### PR TITLE
LibWeb: Use separate structure to represent fragments in paintable tree

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 500x100 positioned [BFC] children: not-inline
       BlockContainer <div.image-container> at (261,11) content-size 248x28.46875 positioned [BFC] children: inline
-        line 0 width: 250, height: 28.46875, bottom: 28.46875, baseline: 28.46875
-          frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x26.46875]
+        frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x26.46875] baseline: 28.46875
         ImageBox <img> at (262,12) content-size 248x26.46875 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     Box <body> at (9,9) content-size 512.859375x19 positioned flex-container(column) [FFC] children: not-inline
       BlockContainer <div> at (10,10) content-size 510.859375x17 flex-item [BFC] children: inline
-        line 0 width: 510.859375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 60, rect: [10,10 510.859375x17]
+        frag 0 from TextNode start: 0, length: 60, rect: [10,10 510.859375x17] baseline: 13.296875
             "Diese Website nutzt Cookies und vergleichbare Funktionen zur"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/abspos-flexbox-with-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flexbox-with-auto-height.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x0 children: not-inline
       Box <nav> at (11,11) content-size 310.453125x19 positioned flex-container(row) [FFC] children: not-inline
         BlockContainer <div.item> at (12,12) content-size 308.453125x17 flex-item [BFC] children: inline
-          line 0 width: 308.453125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 36, rect: [12,12 308.453125x17]
+          frag 0 from TextNode start: 0, length: 36, rect: [12,12 308.453125x17] baseline: 13.296875
               "This should have a green background."
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 500x400 positioned [BFC] children: inline
       BlockContainer <div.one> at (311,211) content-size 28.6875x17 positioned [BFC] children: inline
-        line 0 width: 28.6875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [311,211 28.6875x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [311,211 28.6875x17] baseline: 13.296875
             "one"
         TextNode <#text>
       BlockContainer <div.two> at (330.5625,352) content-size 28.4375x17 positioned [BFC] children: inline
-        line 0 width: 28.4375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [330.5625,352 28.4375x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [330.5625,352 28.4375x17] baseline: 13.296875
             "two"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <dl> at (25,25) content-size 470x0 children: inline
         TextNode <#text>
         BlockContainer <dt> at (40,40) content-size 49.984375x280 floating [BFC] children: inline
-          line 0 width: 28.3125, height: 10, bottom: 10, baseline: 8
-            frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.3125x10]
+          frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.3125x10] baseline: 8
               "toggle"
           TextNode <#text>
         TextNode <#text>
@@ -19,8 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <ul> at (135,45) content-size 340x0 children: inline
             TextNode <#text>
             BlockContainer <li> at (150,60) content-size 50x90 floating [BFC] children: inline
-              line 0 width: 37.875, height: 10, bottom: 10, baseline: 8
-                frag 0 from TextNode start: 0, length: 7, rect: [150,60 37.875x10]
+              frag 0 from TextNode start: 0, length: 7, rect: [150,60 37.875x10] baseline: 8
                   "the way"
               TextNode <#text>
             TextNode <#text>
@@ -28,8 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (235,55) content-size 139.96875x0 children: inline
                 TextNode <#text>
               BlockContainer <p> at (235,55) content-size 139.96875x10 children: inline
-                line 0 width: 74.3125, height: 10, bottom: 10, baseline: 8
-                  frag 0 from TextNode start: 0, length: 14, rect: [235,55 74.3125x10]
+                frag 0 from TextNode start: 0, length: 14, rect: [235,55 74.3125x10] baseline: 8
                     "the world ends"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (235,65) content-size 139.96875x0 children: inline
@@ -39,18 +36,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   TextNode <#text>
                   TextNode <#text>
               BlockContainer <p> at (235,65) content-size 139.96875x19 children: inline
-                line 0 width: 39.484375, height: 19, bottom: 19, baseline: 12.5
-                  frag 0 from TextNode start: 1, length: 5, rect: [235,65 27.484375x19]
+                frag 0 from TextNode start: 1, length: 5, rect: [235,65 27.484375x19] baseline: 12.5
                     "bang "
-                  frag 1 from RadioButton start: 0, length: 0, rect: [262,65 12x12]
+                frag 1 from RadioButton start: 0, length: 0, rect: [262,65 12x12] baseline: 12
                 TextNode <#text>
                 RadioButton <input> at (262,65) content-size 12x12 inline-block children: not-inline
                 TextNode <#text>
               BlockContainer <p> at (235,84) content-size 139.96875x19 children: inline
-                line 0 width: 57.15625, height: 19, bottom: 19, baseline: 12.5
-                  frag 0 from TextNode start: 1, length: 8, rect: [235,84 45.15625x19]
+                frag 0 from TextNode start: 1, length: 8, rect: [235,84 45.15625x19] baseline: 12.5
                     "whimper "
-                  frag 1 from RadioButton start: 0, length: 0, rect: [280,84 12x12]
+                frag 1 from RadioButton start: 0, length: 0, rect: [280,84 12x12] baseline: 12
                 TextNode <#text>
                 RadioButton <input> at (280,84) content-size 12x12 inline-block children: not-inline
                 TextNode <#text>
@@ -58,17 +53,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             TextNode <#text>
             BlockContainer <li> at (409.96875,60) content-size 50x90 floating [BFC] children: inline
-              line 0 width: 31.578125, height: 10, bottom: 10, baseline: 8
-                frag 0 from TextNode start: 0, length: 6, rect: [409.96875,60 31.578125x10]
+              frag 0 from TextNode start: 0, length: 6, rect: [409.96875,60 31.578125x10] baseline: 8
                   "i grow"
-              line 1 width: 14.03125, height: 10, bottom: 20, baseline: 8
-                frag 0 from TextNode start: 7, length: 3, rect: [409.96875,70 14.03125x10]
+              frag 1 from TextNode start: 7, length: 3, rect: [409.96875,70 14.03125x10] baseline: 8
                   "old"
               TextNode <#text>
             TextNode <#text>
             BlockContainer <li#baz> at (145,185) content-size 100x100 floating [BFC] children: inline
-              line 0 width: 29.421875, height: 10, bottom: 10, baseline: 8
-                frag 0 from TextNode start: 0, length: 6, rect: [145,185 29.421875x10]
+              frag 0 from TextNode start: 0, length: 6, rect: [145,185 29.421875x10] baseline: 8
                   "pluot?"
               TextNode <#text>
             TextNode <#text>
@@ -78,22 +70,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (280,195) content-size 50x0 children: inline
                 TextNode <#text>
               BlockContainer <address> at (280,195) content-size 50x20 children: inline
-                line 0 width: 17.28125, height: 10, bottom: 10, baseline: 8
-                  frag 0 from TextNode start: 0, length: 3, rect: [280,195 17.28125x10]
+                frag 0 from TextNode start: 0, length: 3, rect: [280,195 17.28125x10] baseline: 8
                     "bar"
-                line 1 width: 30.21875, height: 10, bottom: 20, baseline: 8
-                  frag 0 from TextNode start: 4, length: 6, rect: [280,205 30.21875x10]
+                frag 1 from TextNode start: 4, length: 6, rect: [280,205 30.21875x10] baseline: 8
                     "maids,"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (280,215) content-size 50x0 children: inline
                 TextNode <#text>
             TextNode <#text>
             BlockContainer <h1> at (365,185) content-size 100x100 floating [BFC] children: inline
-              line 0 width: 56.421875, height: 10, bottom: 10, baseline: 8
-                frag 0 from TextNode start: 0, length: 11, rect: [365,185 56.421875x10]
+              frag 0 from TextNode start: 0, length: 11, rect: [365,185 56.421875x10] baseline: 8
                   "sing to me,"
-              line 1 width: 65.4375, height: 10, bottom: 20, baseline: 8
-                frag 0 from TextNode start: 12, length: 12, rect: [365,195 65.4375x10]
+              frag 1 from TextNode start: 12, length: 12, rect: [365,195 65.4375x10] baseline: 8
                   "erbarme dich"
               TextNode <#text>
             TextNode <#text>
@@ -101,28 +89,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (20,30) content-size 480x0 children: inline
         TextNode <#text>
       BlockContainer <p> at (20,335) content-size 480x65 children: inline
-        line 0 width: 473.625, height: 13, bottom: 13, baseline: 9.5
-          frag 0 from TextNode start: 1, length: 90, rect: [20,335 473.625x13]
+        frag 0 from TextNode start: 1, length: 90, rect: [20,335 473.625x13] baseline: 9.5
             "This is a nonsensical document, but syntactically valid HTML 4.0. All 100%-conformant CSS1"
-        line 1 width: 396.96875, height: 13, bottom: 26, baseline: 9.5
-          frag 0 from TextNode start: 92, length: 74, rect: [20,348 396.96875x13]
+        frag 1 from TextNode start: 92, length: 74, rect: [20,348 396.96875x13] baseline: 9.5
             "agents should be able to render the document elements above this paragraph"
-        line 2 width: 470.578125, height: 13, bottom: 39, baseline: 9.5
-          frag 0 from TextNode start: 167, length: 43, rect: [20,361 207.890625x13]
+        frag 2 from TextNode start: 167, length: 43, rect: [20,361 207.890625x13] baseline: 9.5
             "indistinguishably (to the pixel) from this "
-          frag 1 from TextNode start: 0, length: 20, rect: [228,361 103.015625x13]
+        frag 3 from TextNode start: 0, length: 20, rect: [228,361 103.015625x13] baseline: 9.5
             "reference rendering,"
-          frag 2 from TextNode start: 0, length: 31, rect: [331,361 159.671875x13]
+        frag 4 from TextNode start: 0, length: 31, rect: [331,361 159.671875x13] baseline: 9.5
             " (except font rasterization and"
-        line 3 width: 465.015625, height: 13, bottom: 52, baseline: 9.5
-          frag 0 from TextNode start: 32, length: 89, rect: [20,374 465.015625x13]
+        frag 5 from TextNode start: 32, length: 89, rect: [20,374 465.015625x13] baseline: 9.5
             "form widgets). All discrepancies should be traceable to CSS1 implementation shortcomings."
-        line 4 width: 408.15625, height: 13, bottom: 65, baseline: 9.5
-          frag 0 from TextNode start: 122, length: 67, rect: [20,387 345.546875x13]
+        frag 6 from TextNode start: 122, length: 67, rect: [20,387 345.546875x13] baseline: 9.5
             "Once you have finished evaluating this test, you can return to the "
-          frag 1 from TextNode start: 0, length: 11, rect: [366,387 59.890625x13]
+        frag 7 from TextNode start: 0, length: 11, rect: [366,387 59.890625x13] baseline: 9.5
             "parent page"
-          frag 2 from TextNode start: 0, length: 1, rect: [425,387 2.71875x13]
+        frag 8 from TextNode start: 0, length: 1, rect: [425,387 2.71875x13] baseline: 9.5
             "."
         TextNode <#text>
         InlineNode <a>

--- a/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
+++ b/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x89.4375 [BFC] children: not-inline
     BlockContainer <body> at (8,21.4375) content-size 784x73.4375 children: not-inline
       BlockContainer <h1> at (8,21.4375) content-size 784x35 children: inline
-        line 0 width: 105.53125, height: 35, bottom: 35, baseline: 27.09375
-          frag 0 from TextNode start: 0, length: 6, rect: [8,21.4375 105.53125x35]
+        frag 0 from TextNode start: 0, length: 6, rect: [8,21.4375 105.53125x35] baseline: 27.09375
             "header"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,77.875) content-size 784x17 children: inline
-        line 0 width: 212.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 24, rect: [8,77.875 212.125x17]
+        frag 0 from TextNode start: 0, length: 24, rect: [8,77.875 212.125x17] baseline: 13.296875
             "anonymously wrapped text"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x304 children: not-inline
       BlockContainer <div> at (9,9) content-size 200x100 children: not-inline
       BlockContainer <(anonymous)> at (8,110) content-size 784x202 children: inline
-        line 0 width: 202, height: 202, bottom: 202, baseline: 202
-          frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x200]
+        frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x200] baseline: 202
         ImageBox <img> at (9,111) content-size 200x200 children: not-inline
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       BlockContainer <div> at (9,9) content-size 200x0 children: not-inline
       BlockContainer <(anonymous)> at (8,10) content-size 784x202 children: inline
-        line 0 width: 202, height: 202, bottom: 202, baseline: 202
-          frag 0 from ImageBox start: 0, length: 0, rect: [9,11 200x200]
+        frag 0 from ImageBox start: 0, length: 0, rect: [9,11 200x200] baseline: 202
         ImageBox <img> at (9,11) content-size 200x200 children: not-inline
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       BlockContainer <div> at (9,9) content-size 200x100 children: not-inline
       BlockContainer <(anonymous)> at (8,110) content-size 784x102 children: inline
-        line 0 width: 202, height: 102, bottom: 102, baseline: 102
-          frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x100]
+        frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x100] baseline: 102
         ImageBox <img> at (9,111) content-size 200x100 children: not-inline
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-grid-with-definite-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-grid-with-definite-width.txt
@@ -3,17 +3,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x0 children: not-inline
       Box <div.box> at (1,11) content-size 200x68 positioned [GFC] children: not-inline
         BlockContainer <(anonymous)> at (1,11) content-size 200x68 [BFC] children: inline
-          line 0 width: 181.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 21, rect: [1,11 181.78125x17]
+          frag 0 from TextNode start: 0, length: 21, rect: [1,11 181.78125x17] baseline: 13.296875
               "Giveaways in Channels"
-          line 1 width: 149.4375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 22, length: 16, rect: [1,28 149.4375x17]
+          frag 1 from TextNode start: 22, length: 16, rect: [1,28 149.4375x17] baseline: 13.296875
               "and Free Premium"
-          line 2 width: 181.78125, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 39, length: 21, rect: [1,45 181.78125x17]
+          frag 2 from TextNode start: 39, length: 21, rect: [1,45 181.78125x17] baseline: 13.296875
               "Giveaways in Channels"
-          line 3 width: 149.4375, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 61, length: 16, rect: [1,62 149.4375x17]
+          frag 3 from TextNode start: 61, length: 16, rect: [1,62 149.4375x17] baseline: 13.296875
               "and Free Premium"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
@@ -1,10 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x62.59375 [BFC] children: not-inline
     BlockContainer <body> at (2,2) content-size 796x60.59375 children: inline
-      line 0 width: 34, height: 28.59375, bottom: 28.59375, baseline: 28.59375
-        frag 0 from BlockContainer start: 0, length: 0, rect: [4,3 30x30]
-      line 1 width: 32, height: 28.59375, bottom: 60.59375, baseline: 28.59375
-        frag 0 from BlockContainer start: 0, length: 0, rect: [3,35 30x30]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [4,3 30x30] baseline: 32
+      frag 1 from BlockContainer start: 0, length: 0, rect: [3,35 30x30] baseline: 32
       BlockContainer <div.clump> at (4,3) content-size 30x30 inline-block [BFC] children: not-inline
       BreakNode <br>
       BlockContainer <div.clump> at (3,35) content-size 30x30 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-white-space-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-white-space-nowrap.txt
@@ -2,10 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 37.15625x17 children: not-inline
       BlockContainer <div> at (8,8) content-size 37.15625x17 children: inline
-        line 0 width: 37.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from ImageBox start: 0, length: 0, rect: [35,11 10x10]
+        frag 1 from ImageBox start: 0, length: 0, rect: [35,11 10x10] baseline: 10
         TextNode <#text>
         ImageBox <img> at (35,11) content-size 10x10 children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
@@ -5,24 +5,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       BlockContainer <div.big-float> at (8,8) content-size 100x100 floating [BFC] children: not-inline
       BlockContainer <div.xxx> at (108,8) content-size 29.109375x17 floating [BFC] children: inline
-        line 0 width: 29.109375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [108,8 29.109375x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [108,8 29.109375x17] baseline: 13.296875
             "xxx"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
-        line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 3, rect: [137,8 27.640625x17]
+        frag 0 from TextNode start: 1, length: 3, rect: [137,8 27.640625x17] baseline: 13.296875
             "bar"
         TextNode <#text>
         TextNode <#text>
       BlockContainer <div> at (8,25) content-size 784x17 children: inline
-        line 0 width: 27.203125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 3, rect: [130,25 27.203125x17]
+        frag 0 from TextNode start: 1, length: 3, rect: [130,25 27.203125x17] baseline: 13.296875
             "baz"
         TextNode <#text>
         BlockContainer <div.yyy> at (108,25) content-size 21.515625x17 floating [BFC] children: inline
-          line 0 width: 21.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [108,25 21.515625x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [108,25 21.515625x17] baseline: 13.296875
               "yyy"
           TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-level-floating-box-with-clearance.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-level-floating-box-with-clearance.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 600x960 children: not-inline
       BlockContainer <div.normal> at (18,18) content-size 300x300 children: not-inline
       BlockContainer <div#top> at (8,328) content-size 100x100 floating [BFC] children: inline
-        line 0 width: 26.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,328 26.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,328 26.640625x17] baseline: 13.296875
             "top"
         TextNode <#text>
       BlockContainer <div#left> at (8,428) content-size 100x100 floating [BFC] children: inline
-        line 0 width: 26.25, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 4, rect: [8,428 26.25x17]
+        frag 0 from TextNode start: 0, length: 4, rect: [8,428 26.25x17] baseline: 13.296875
             "left"
         TextNode <#text>
       BlockContainer <div#right> at (108,428) content-size 100x100 floating [BFC] children: inline
-        line 0 width: 37.109375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [108,428 37.109375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [108,428 37.109375x17] baseline: 13.296875
             "right"
         TextNode <#text>
       BlockContainer <div.normal> at (18,338) content-size 300x300 children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x56 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x38 children: not-inline
       BlockContainer <div.box> at (11,11) content-size 138.28125x17 children: inline
-        line 0 width: 138.28125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 18, rect: [11,11 138.28125x17]
+        frag 0 from TextNode start: 0, length: 18, rect: [11,11 138.28125x17] baseline: 13.296875
             "Well hello friends"
         TextNode <#text>
       BlockContainer <div.box2> at (11,30) content-size 138.28125x17 children: inline
-        line 0 width: 138.28125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 18, rect: [11,30 138.28125x17]
+        frag 0 from TextNode start: 0, length: 18, rect: [11,30 138.28125x17] baseline: 13.296875
             "Well hello friends"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,48) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19 children: not-inline
       BlockContainer <div.box> at (11,11) content-size 138.28125x17 children: inline
-        line 0 width: 138.28125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 18, rect: [11,11 138.28125x17]
+        frag 0 from TextNode start: 0, length: 18, rect: [11,11 138.28125x17] baseline: 13.296875
             "Well hello friends"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,29) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
@@ -11,16 +11,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (108,8) content-size 684x0 children: inline
           TextNode <#text>
           BlockContainer <div.a> at (108,8) content-size 14.265625x17 floating [BFC] children: inline
-            line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [108,8 14.265625x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [108,8 14.265625x17] baseline: 13.296875
                 "A"
             TextNode <#text>
           TextNode <#text>
         BlockContainer <(anonymous)> at (108,8) content-size 684x0 children: inline
           TextNode <#text>
         BlockContainer <div.b> at (122.265625,8) content-size 669.734375x17 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [122.265625,8 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [122.265625,8 9.34375x17] baseline: 13.296875
               "B"
           TextNode <#text>
         BlockContainer <(anonymous)> at (108,25) content-size 684x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
@@ -10,15 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> at (8,8) content-size 57.0625x0 children: inline
               TextNode <#text>
             BlockContainer <div.a4> at (8,8) content-size 57.0625x17 children: inline
-              line 0 width: 57.0625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 4, rect: [8,8 57.0625x17]
+              frag 0 from TextNode start: 0, length: 4, rect: [8,8 57.0625x17] baseline: 13.296875
                   "AAAA"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,25) content-size 57.0625x0 children: inline
               TextNode <#text>
             BlockContainer <div> at (8,25) content-size 57.0625x17 children: inline
-              line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [8,25 14.265625x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [8,25 14.265625x17] baseline: 13.296875
                   "A"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,42) content-size 57.0625x0 children: inline
@@ -30,15 +28,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> at (108,8) content-size 684x0 children: inline
             TextNode <#text>
           BlockContainer <div> at (108,8) content-size 684x17 children: inline
-            line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [108,8 9.34375x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [108,8 9.34375x17] baseline: 13.296875
                 "B"
             TextNode <#text>
           BlockContainer <(anonymous)> at (108,25) content-size 684x0 children: inline
             TextNode <#text>
           BlockContainer <div.c> at (108,25) content-size 684x17 [BFC] children: inline
-            line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [108,25 10.3125x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [108,25 10.3125x17] baseline: 13.296875
                 "C"
             TextNode <#text>
           BlockContainer <(anonymous)> at (108,42) content-size 684x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
@@ -2,22 +2,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x75 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x57 children: not-inline
       BlockContainer <div.foo> at (11,11) content-size 150.21875x17 children: inline
-        line 0 width: 150.21875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 18, rect: [11,11 150.21875x17]
+        frag 0 from TextNode start: 0, length: 18, rect: [11,11 150.21875x17] baseline: 13.296875
             "width: max-content"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,29) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.bar> at (11,30) content-size 187.953125x17 children: inline
-        line 0 width: 187.953125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 22, rect: [11,30 187.953125x17]
+        frag 0 from TextNode start: 0, length: 22, rect: [11,30 187.953125x17] baseline: 13.296875
             "max-width: max-content"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,48) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.baz> at (11,49) content-size 183.078125x17 children: inline
-        line 0 width: 183.078125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 22, rect: [11,49 183.078125x17]
+        frag 0 from TextNode start: 0, length: 22, rect: [11,49 183.078125x17] baseline: 13.296875
             "min-width: max-content"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,67) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
@@ -2,31 +2,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x126 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x108 children: not-inline
       BlockContainer <div.foo> at (11,11) content-size 93.765625x34 children: inline
-        line 0 width: 43.578125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [11,11 43.578125x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [11,11 43.578125x17] baseline: 13.296875
             "width:"
-        line 1 width: 93.765625, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 7, length: 11, rect: [11,28 93.765625x17]
+        frag 1 from TextNode start: 7, length: 11, rect: [11,28 93.765625x17] baseline: 13.296875
             "min-content"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,46) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.bar> at (11,47) content-size 93.765625x34 children: inline
-        line 0 width: 81.3125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 10, rect: [11,47 81.3125x17]
+        frag 0 from TextNode start: 0, length: 10, rect: [11,47 81.3125x17] baseline: 13.296875
             "max-width:"
-        line 1 width: 93.765625, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 11, length: 11, rect: [11,64 93.765625x17]
+        frag 1 from TextNode start: 11, length: 11, rect: [11,64 93.765625x17] baseline: 13.296875
             "min-content"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,82) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.baz> at (11,83) content-size 93.765625x34 children: inline
-        line 0 width: 76.4375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 10, rect: [11,83 76.4375x17]
+        frag 0 from TextNode start: 0, length: 10, rect: [11,83 76.4375x17] baseline: 13.296875
             "min-width:"
-        line 1 width: 93.765625, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 11, length: 11, rect: [11,100 93.765625x17]
+        frag 1 from TextNode start: 11, length: 11, rect: [11,100 93.765625x17] baseline: 13.296875
             "min-content"
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,118) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
@@ -2,11 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x54 [BFC] children: not-inline
     BlockContainer <body> at (110,10) content-size 300x36 positioned children: not-inline
       BlockContainer <div> at (61,11) content-size 200x34 children: inline
-        line 0 width: 159.859375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 19, rect: [61,11 159.859375x17]
+        frag 0 from TextNode start: 0, length: 19, rect: [61,11 159.859375x17] baseline: 13.296875
             "there are no floats"
-        line 1 width: 163.875, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 20, length: 21, rect: [61,28 163.875x17]
+        frag 1 from TextNode start: 20, length: 21, rect: [61,28 163.875x17] baseline: 13.296875
             "intruding on this div"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-baseline-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-baseline-align.txt
@@ -1,26 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x48 children: inline
-      line 0 width: 61.1875, height: 48, bottom: 48, baseline: 34
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x48]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x48] baseline: 34
       BlockContainer <div.ib> at (8,8) content-size 61.1875x48 inline-block [BFC] children: inline
-        line 0 width: 61.1875, height: 48, bottom: 48, baseline: 34
-          frag 0 from BlockContainer start: 0, length: 0, rect: [9,25 17.828125x22]
-          frag 1 from TextNode start: 0, length: 1, rect: [28,28 8x17]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,25 17.828125x22] baseline: 18
+        frag 1 from TextNode start: 0, length: 1, rect: [28,28 8x17] baseline: 13.296875
             " "
-          frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x44]
+        frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x44] baseline: 34
         TextNode <#text>
         BlockContainer <div.label> at (9,25) content-size 17.828125x22 inline-block [BFC] children: inline
-          line 0 width: 17.828125, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 1, rect: [9,25 17.828125x22]
+          frag 0 from TextNode start: 0, length: 1, rect: [9,25 17.828125x22] baseline: 17
               "A"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <button> at (41,10) content-size 23.359375x44 inline-block [BFC] children: not-inline
           BlockContainer <(anonymous)> at (41,10) content-size 23.359375x44 flex-container(column) [FFC] children: not-inline
             BlockContainer <(anonymous)> at (41,10) content-size 23.359375x44 flex-item [BFC] children: inline
-              line 0 width: 23.359375, height: 44, bottom: 44, baseline: 34
-                frag 0 from TextNode start: 0, length: 1, rect: [41,10 23.359375x44]
+              frag 0 from TextNode start: 0, length: 1, rect: [41,10 23.359375x44] baseline: 34
                   "B"
               TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-image-only.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-image-only.txt
@@ -1,13 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x424 children: inline
-      line 0 width: 430, height: 424, bottom: 424, baseline: 420
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 420x420]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 420x420] baseline: 420
       BlockContainer <button> at (13,10) content-size 420x420 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 420x420 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 420x420 flex-item [BFC] children: inline
-            line 0 width: 420, height: 420, bottom: 420, baseline: 420
-              frag 0 from ImageBox start: 0, length: 0, rect: [13,10 420x420]
+            frag 0 from ImageBox start: 0, length: 0, rect: [13,10 420x420] baseline: 420
             TextNode <#text>
             ImageBox <img> at (13,10) content-size 420x420 children: not-inline
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-should-have-vertically-aligned-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-should-have-vertically-aligned-content.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: inline
-      line 0 width: 76.6875, height: 200, bottom: 200, baseline: 70.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [22,19 48.6875x178]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [22,19 48.6875x178] baseline: 70.296875
       TextNode <#text>
       BlockContainer <button.button.border-black> at (22,19) content-size 48.6875x178 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (22,19) content-size 48.6875x178 flex-container(column) [FFC] children: not-inline
@@ -10,15 +9,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> at (22,29.5) content-size 48.6875x0 children: inline
               TextNode <#text>
             BlockContainer <div.border-black> at (32,39.5) content-size 28.6875x17 children: inline
-              line 0 width: 28.6875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 1, length: 3, rect: [32,39.5 28.6875x17]
+              frag 0 from TextNode start: 1, length: 3, rect: [32,39.5 28.6875x17] baseline: 13.296875
                   "one"
               TextNode <#text>
             BlockContainer <(anonymous)> at (22,66.5) content-size 48.6875x0 children: inline
               TextNode <#text>
             BlockContainer <div.border-black> at (32,76.5) content-size 28.6875x100 children: inline
-              line 0 width: 28.4375, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 1, length: 3, rect: [32,76.5 28.4375x17]
+              frag 0 from TextNode start: 1, length: 3, rect: [32,76.5 28.4375x17] baseline: 13.296875
                   "two"
               TextNode <#text>
             BlockContainer <(anonymous)> at (22,186.5) content-size 48.6875x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-width.txt
@@ -4,15 +4,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <button.btn.fixed-width> at (13,10) content-size 190x17 children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 190x17 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 190x17 flex-item [BFC] children: inline
-            line 0 width: 94.921875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 11, rect: [61,10 94.921875x17]
+            frag 0 from TextNode start: 0, length: 11, rect: [61,10 94.921875x17] baseline: 13.296875
                 "200px width"
             TextNode <#text>
       BlockContainer <button.btn> at (13,31) content-size 324.671875x17 children: not-inline
         BlockContainer <(anonymous)> at (13,31) content-size 324.671875x17 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,31) content-size 324.671875x17 flex-item [BFC] children: inline
-            line 0 width: 324.671875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 39, rect: [13,31 324.671875x17]
+            frag 0 from TextNode start: 0, length: 39, rect: [13,31 324.671875x17] baseline: 13.296875
                 "auto width should behave as fit-content"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x58 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x42 children: inline
-      line 0 width: 42, height: 42, bottom: 42, baseline: 42
-        frag 0 from BlockContainer start: 0, length: 0, rect: [29,29 0x0]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [29,29 0x0] baseline: 42
       BlockContainer <button> at (29,29) content-size 0x0 positioned inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (29,29) content-size 0x0 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (29,29) content-size 0x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
@@ -1,13 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x75 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x59 children: inline
-      line 0 width: 424.640625, height: 59, bottom: 59, baseline: 42.484375
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.640625x55]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.640625x55] baseline: 42.484375
       BlockContainer <button.button_button___eDCW> at (13,10) content-size 414.640625x55 positioned inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 414.640625x55 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 414.640625x55 flex-item [BFC] children: inline
-            line 0 width: 414.640625, height: 55, bottom: 55, baseline: 42.484375
-              frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.640625x55]
+            frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.640625x55] baseline: 42.484375
                 "See more games"
             TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 422.640625x57 positioned [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
@@ -1,15 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x75 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x59 children: inline
-      line 0 width: 424.640625, height: 59, bottom: 59, baseline: 42.484375
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.640625x55]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.640625x55] baseline: 42.484375
       BlockContainer <button.button_button___eDCW> at (13,10) content-size 414.640625x55 positioned inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (9,9) content-size 422.640625x57 positioned [BFC] children: inline
           TextNode <#text>
         BlockContainer <(anonymous)> at (13,10) content-size 414.640625x55 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 414.640625x55 flex-item [BFC] children: inline
-            line 0 width: 414.640625, height: 55, bottom: 55, baseline: 42.484375
-              frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.640625x55]
+            frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.640625x55] baseline: 42.484375
                 "See more games"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-block-content-baseline-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-block-content-baseline-align.txt
@@ -1,18 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x48 children: inline
-      line 0 width: 61.1875, height: 48, bottom: 48, baseline: 34
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x48]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x48] baseline: 34
       BlockContainer <div.ib> at (8,8) content-size 61.1875x48 inline-block [BFC] children: inline
-        line 0 width: 61.1875, height: 48, bottom: 48, baseline: 34
-          frag 0 from BlockContainer start: 0, length: 0, rect: [9,25 17.828125x22]
-          frag 1 from TextNode start: 0, length: 1, rect: [28,28 8x17]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,25 17.828125x22] baseline: 18
+        frag 1 from TextNode start: 0, length: 1, rect: [28,28 8x17] baseline: 13.296875
             " "
-          frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x44]
+        frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x44] baseline: 34
         TextNode <#text>
         BlockContainer <div.label> at (9,25) content-size 17.828125x22 inline-block [BFC] children: inline
-          line 0 width: 17.828125, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 1, rect: [9,25 17.828125x22]
+          frag 0 from TextNode start: 0, length: 1, rect: [9,25 17.828125x22] baseline: 17
               "A"
           TextNode <#text>
         TextNode <#text>
@@ -22,8 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (41,10) content-size 23.359375x0 children: inline
                 TextNode <#text>
               BlockContainer <div> at (41,10) content-size 23.359375x44 children: inline
-                line 0 width: 23.359375, height: 44, bottom: 44, baseline: 34
-                  frag 0 from TextNode start: 0, length: 1, rect: [41,10 23.359375x44]
+                frag 0 from TextNode start: 0, length: 1, rect: [41,10 23.359375x44] baseline: 34
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (41,54) content-size 23.359375x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-multiple-words-text-node-label.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-multiple-words-text-node-label.txt
@@ -1,13 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21 children: inline
-      line 0 width: 59.921875, height: 21, bottom: 21, baseline: 13.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 49.921875x17]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 49.921875x17] baseline: 13.296875
       BlockContainer <button> at (13,10) content-size 49.921875x17 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 49.921875x17 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 49.921875x17 flex-item [BFC] children: inline
-            line 0 width: 49.921875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 5, rect: [13,10 49.921875x17]
+            frag 0 from TextNode start: 0, length: 5, rect: [13,10 49.921875x17] baseline: 13.296875
                 "A B C"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label-and-font-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label-and-font-size.txt
@@ -1,13 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x56 children: inline
-      line 0 width: 121.65625, height: 56, bottom: 56, baseline: 40.390625
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 111.65625x52]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 111.65625x52] baseline: 40.390625
       BlockContainer <button> at (13,10) content-size 111.65625x52 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 111.65625x52 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 111.65625x52 flex-item [BFC] children: inline
-            line 0 width: 111.65625, height: 52, bottom: 52, baseline: 40.390625
-              frag 0 from TextNode start: 0, length: 4, rect: [13,10 111.65625x52]
+            frag 0 from TextNode start: 0, length: 4, rect: [13,10 111.65625x52] baseline: 40.390625
                 "Test"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label.txt
@@ -1,13 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21 children: inline
-      line 0 width: 47.21875, height: 21, bottom: 21, baseline: 13.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 37.21875x17]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 37.21875x17] baseline: 13.296875
       BlockContainer <button> at (13,10) content-size 37.21875x17 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 37.21875x17 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 37.21875x17 flex-item [BFC] children: inline
-            line 0 width: 37.21875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 4, rect: [13,10 37.21875x17]
+            frag 0 from TextNode start: 0, length: 4, rect: [13,10 37.21875x17] baseline: 13.296875
                 "Test"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-from-inline-formatting-context.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-from-inline-formatting-context.txt
@@ -4,20 +4,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
         BlockContainer <h1.left> at (8,29.4375) content-size 28.53125x35 floating [BFC] children: inline
-          line 0 width: 28.53125, height: 35, bottom: 35, baseline: 27.09375
-            frag 0 from TextNode start: 0, length: 1, rect: [8,29.4375 28.53125x35]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,29.4375 28.53125x35] baseline: 27.09375
               "A"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <h1.right> at (773.3125,29.4375) content-size 18.6875x35 floating [BFC] children: inline
-          line 0 width: 18.6875, height: 35, bottom: 35, baseline: 27.09375
-            frag 0 from TextNode start: 0, length: 1, rect: [773.3125,29.4375 18.6875x35]
+          frag 0 from TextNode start: 0, length: 1, rect: [773.3125,29.4375 18.6875x35] baseline: 27.09375
               "B"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <div.c> at (8,155.875) content-size 11.5625x17 floating [BFC] children: inline
-          line 0 width: 11.5625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,155.875 11.5625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,155.875 11.5625x17] baseline: 13.296875
               "X"
           TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
@@ -2,14 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x125 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x109 children: not-inline
       BlockContainer <div.upper> at (8,8) content-size 784x17 children: inline
-        line 0 width: 46.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [8,8 46.15625x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 46.15625x17] baseline: 13.296875
             "upper"
         TextNode <#text>
       BlockContainer <div.mystery> at (8,100) content-size 784x0 children: not-inline
       BlockContainer <div.lower> at (8,100) content-size 784x17 children: inline
-        line 0 width: 43.359375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [8,100 43.359375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [8,100 43.359375x17] baseline: 13.296875
             "lower"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/columns-33-percent-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/columns-33-percent-width.txt
@@ -1,10 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 620x100 children: inline
-      line 0 width: 619.96875, height: 100, bottom: 100, baseline: 100
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 206.65625x100]
-        frag 1 from BlockContainer start: 0, length: 0, rect: [215,8 206.65625x100]
-        frag 2 from BlockContainer start: 0, length: 0, rect: [421,8 206.65625x100]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 206.65625x100] baseline: 100
+      frag 1 from BlockContainer start: 0, length: 0, rect: [215,8 206.65625x100] baseline: 100
+      frag 2 from BlockContainer start: 0, length: 0, rect: [421,8 206.65625x100] baseline: 100
       BlockContainer <div> at (8,8) content-size 206.65625x100 inline-block [BFC] children: not-inline
       BlockContainer <div> at (215,8) content-size 206.65625x100 inline-block [BFC] children: not-inline
       BlockContainer <div> at (421,8) content-size 206.65625x100 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/flex-container-should-avoid-overlapping-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/flex-container-should-avoid-overlapping-floats.txt
@@ -2,14 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 400x50 children: not-inline
       BlockContainer <div.right> at (370.890625,8) content-size 37.109375x17 floating [BFC] children: inline
-        line 0 width: 37.109375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [370.890625,8 37.109375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [370.890625,8 37.109375x17] baseline: 13.296875
             "right"
         TextNode <#text>
       Box <div.flex> at (8,8) content-size 362.890625x50 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 32.34375x50 flex-item [BFC] children: inline
-          line 0 width: 32.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,8 32.34375x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,8 32.34375x17] baseline: 13.296875
               "item"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
@@ -6,14 +6,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
         BlockContainer <div#lefty> at (8,8) content-size 100x100 floating [BFC] children: inline
-          line 0 width: 10.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 10.859375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 10.859375x17] baseline: 13.296875
               "L"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <div#righty> at (742,8) content-size 50x50 floating [BFC] children: inline
-          line 0 width: 13.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [742,8 13.6875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [742,8 13.6875x17] baseline: 13.296875
               "R"
           TextNode <#text>
         TextNode <#text>
@@ -22,14 +20,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
         BlockContainer <div#lefty2> at (108,8) content-size 80x80 floating [BFC] children: inline
-          line 0 width: 19.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 2, rect: [108,8 19.671875x17]
+          frag 0 from TextNode start: 0, length: 2, rect: [108,8 19.671875x17] baseline: 13.296875
               "L2"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <div#righty2> at (712,8) content-size 30x30 floating [BFC] children: inline
-          line 0 width: 22.5, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 2, rect: [712,8 22.5x17]
+          frag 0 from TextNode start: 0, length: 2, rect: [712,8 22.5x17] baseline: 13.296875
               "R2"
           TextNode <#text>
         TextNode <#text>
@@ -38,76 +34,55 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
         BlockContainer <div#lefty3> at (188,8) content-size 40x40 floating [BFC] children: inline
-          line 0 width: 19.953125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 2, rect: [188,8 19.953125x17]
+          frag 0 from TextNode start: 0, length: 2, rect: [188,8 19.953125x17] baseline: 13.296875
               "L3"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <div#righty3> at (692,8) content-size 20x20 floating [BFC] children: inline
-          line 0 width: 22.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 2, rect: [692,8 22.78125x17]
+          frag 0 from TextNode start: 0, length: 2, rect: [692,8 22.78125x17] baseline: 13.296875
               "R3"
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (8,8) content-size 784x323 children: inline
-        line 0 width: 414.5625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 47, rect: [228,8 414.5625x17]
+        frag 0 from TextNode start: 1, length: 47, rect: [228,8 414.5625x17] baseline: 13.296875
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 1 width: 414.5625, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 49, length: 47, rect: [228,25 414.5625x17]
+        frag 1 from TextNode start: 49, length: 47, rect: [228,25 414.5625x17] baseline: 13.296875
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 2 width: 466.90625, height: 17, bottom: 51, baseline: 13.296875
-          frag 0 from TextNode start: 97, length: 53, rect: [228,42 466.90625x17]
+        frag 2 from TextNode start: 97, length: 53, rect: [228,42 466.90625x17] baseline: 13.296875
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 3 width: 573.5, height: 17, bottom: 68, baseline: 13.296875
-          frag 0 from TextNode start: 151, length: 65, rect: [188,59 573.5x17]
+        frag 3 from TextNode start: 151, length: 65, rect: [188,59 573.5x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 4 width: 572.546875, height: 17, bottom: 85, baseline: 13.296875
-          frag 0 from TextNode start: 217, length: 65, rect: [188,76 572.546875x17]
+        frag 4 from TextNode start: 217, length: 65, rect: [188,76 572.546875x17] baseline: 13.296875
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 5 width: 679.140625, height: 17, bottom: 102, baseline: 13.296875
-          frag 0 from TextNode start: 283, length: 77, rect: [108,93 679.140625x17]
+        frag 5 from TextNode start: 283, length: 77, rect: [108,93 679.140625x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 6 width: 783.828125, height: 17, bottom: 119, baseline: 13.296875
-          frag 0 from TextNode start: 361, length: 89, rect: [8,110 783.828125x17]
+        frag 6 from TextNode start: 361, length: 89, rect: [8,110 783.828125x17] baseline: 13.296875
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 7 width: 731.484375, height: 17, bottom: 136, baseline: 13.296875
-          frag 0 from TextNode start: 451, length: 83, rect: [8,127 731.484375x17]
+        frag 7 from TextNode start: 451, length: 83, rect: [8,127 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 8 width: 731.484375, height: 17, bottom: 153, baseline: 13.296875
-          frag 0 from TextNode start: 535, length: 83, rect: [8,144 731.484375x17]
+        frag 8 from TextNode start: 535, length: 83, rect: [8,144 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 9 width: 731.484375, height: 17, bottom: 170, baseline: 13.296875
-          frag 0 from TextNode start: 619, length: 83, rect: [8,161 731.484375x17]
+        frag 9 from TextNode start: 619, length: 83, rect: [8,161 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 10 width: 731.484375, height: 17, bottom: 187, baseline: 13.296875
-          frag 0 from TextNode start: 703, length: 83, rect: [8,178 731.484375x17]
+        frag 10 from TextNode start: 703, length: 83, rect: [8,178 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 11 width: 731.484375, height: 17, bottom: 204, baseline: 13.296875
-          frag 0 from TextNode start: 787, length: 83, rect: [8,195 731.484375x17]
+        frag 11 from TextNode start: 787, length: 83, rect: [8,195 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 12 width: 731.484375, height: 17, bottom: 221, baseline: 13.296875
-          frag 0 from TextNode start: 871, length: 83, rect: [8,212 731.484375x17]
+        frag 12 from TextNode start: 871, length: 83, rect: [8,212 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 13 width: 731.484375, height: 17, bottom: 238, baseline: 13.296875
-          frag 0 from TextNode start: 955, length: 83, rect: [8,229 731.484375x17]
+        frag 13 from TextNode start: 955, length: 83, rect: [8,229 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 14 width: 731.484375, height: 17, bottom: 255, baseline: 13.296875
-          frag 0 from TextNode start: 1039, length: 83, rect: [8,246 731.484375x17]
+        frag 14 from TextNode start: 1039, length: 83, rect: [8,246 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 15 width: 731.484375, height: 17, bottom: 272, baseline: 13.296875
-          frag 0 from TextNode start: 1123, length: 83, rect: [8,263 731.484375x17]
+        frag 15 from TextNode start: 1123, length: 83, rect: [8,263 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 16 width: 731.484375, height: 17, bottom: 289, baseline: 13.296875
-          frag 0 from TextNode start: 1207, length: 83, rect: [8,280 731.484375x17]
+        frag 16 from TextNode start: 1207, length: 83, rect: [8,280 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 17 width: 731.484375, height: 17, bottom: 306, baseline: 13.296875
-          frag 0 from TextNode start: 1291, length: 83, rect: [8,297 731.484375x17]
+        frag 17 from TextNode start: 1291, length: 83, rect: [8,297 731.484375x17] baseline: 13.296875
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 18 width: 45.296875, height: 17, bottom: 323, baseline: 13.296875
-          frag 0 from TextNode start: 1375, length: 5, rect: [8,314 45.296875x17]
+        frag 18 from TextNode start: 1375, length: 5, rect: [8,314 45.296875x17] baseline: 13.296875
             "ipsum"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,331) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         TextNode <#text>
       BlockContainer <div#a> at (8,8) content-size 784x17 children: inline
-        line 0 width: 37.578125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 4, rect: [60,8 37.578125x17]
+        frag 0 from TextNode start: 0, length: 4, rect: [60,8 37.578125x17] baseline: 13.296875
             "Text"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
@@ -16,8 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
           TextNode <#text>
         BlockContainer <div#text> at (9,109) content-size 778x17 children: inline
-          line 0 width: 54.796875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [371,109 54.796875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [371,109 54.796875x17] baseline: 13.296875
               "foobar"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,126) content-size 778x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
@@ -5,26 +5,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 780x0 children: inline
       TextNode <#text>
       BlockContainer <div.left> at (9,9) content-size 50x50 floating [BFC] children: inline
-        line 0 width: 39.21875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [14,9 39.21875x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [14,9 39.21875x17] baseline: 13.296875
             "Left1"
         TextNode <#text>
       TextNode <#text>
       BlockContainer <div.right> at (737,9) content-size 50x50 floating [BFC] children: inline
-        line 0 width: 48.3125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [738,9 48.3125x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [738,9 48.3125x17] baseline: 13.296875
             "Right1"
         TextNode <#text>
       TextNode <#text>
       BlockContainer <div.left> at (61,9) content-size 50x50 floating [BFC] children: inline
-        line 0 width: 41.6875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [65,9 41.6875x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [65,9 41.6875x17] baseline: 13.296875
             "Left2"
         TextNode <#text>
       TextNode <#text>
       BlockContainer <div.right> at (685,9) content-size 50x50 floating [BFC] children: inline
-        line 0 width: 50.78125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [685,9 50.78125x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [685,9 50.78125x17] baseline: 13.296875
             "Right2"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
@@ -1,15 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: inline
-      line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 1, rect: [108,8 6.34375x17]
+      frag 0 from TextNode start: 0, length: 1, rect: [108,8 6.34375x17] baseline: 13.296875
           "1"
-      line 1 width: 8.8125, height: 17, bottom: 34, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 1, rect: [108,25 8.8125x17]
+      frag 1 from TextNode start: 0, length: 1, rect: [108,25 8.8125x17] baseline: 13.296875
           "2"
       BlockContainer <span.a> at (8,8) content-size 100x17 floating [BFC] children: inline
-        line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
             "A"
         TextNode <#text>
       InlineNode <span>
@@ -18,8 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BreakNode <br>
       TextNode <#text>
       BlockContainer <span.a> at (8,25) content-size 100x17 floating [BFC] children: inline
-        line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [8,25 9.34375x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [8,25 9.34375x17] baseline: 13.296875
             "B"
         TextNode <#text>
       InlineNode <span>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
@@ -1,200 +1,181 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (252,10) content-size 538x400 children: inline
-      line 0 width: 228.34375, height: 22, bottom: 22, baseline: 17
-        frag 0 from TextNode start: 1, length: 5, rect: [554,10 63.71875x22]
+      frag 0 from TextNode start: 1, length: 5, rect: [554,10 63.71875x22] baseline: 17
           "Lorem"
-        frag 1 from TextNode start: 6, length: 1, rect: [618,10 12.546875x22]
+      frag 1 from TextNode start: 6, length: 1, rect: [618,10 12.546875x22] baseline: 17
           " "
-        frag 2 from TextNode start: 7, length: 5, rect: [630.546875,10 56.625x22]
+      frag 2 from TextNode start: 7, length: 5, rect: [630.546875,10 56.625x22] baseline: 17
           "ipsum"
-        frag 3 from TextNode start: 12, length: 1, rect: [686.546875,10 12.546875x22]
+      frag 3 from TextNode start: 12, length: 1, rect: [686.546875,10 12.546875x22] baseline: 17
           " "
-        frag 4 from TextNode start: 13, length: 5, rect: [699.09375,10 52.046875x22]
+      frag 4 from TextNode start: 13, length: 5, rect: [699.09375,10 52.046875x22] baseline: 17
           "dolor"
-        frag 5 from TextNode start: 18, length: 1, rect: [751.09375,10 12.546875x22]
+      frag 5 from TextNode start: 18, length: 1, rect: [751.09375,10 12.546875x22] baseline: 17
           " "
-        frag 6 from TextNode start: 19, length: 3, rect: [763.640625,10 25.953125x22]
+      frag 6 from TextNode start: 19, length: 3, rect: [763.640625,10 25.953125x22] baseline: 17
           "sit"
-      line 1 width: 183.78125, height: 22, bottom: 44, baseline: 17
-        frag 0 from TextNode start: 23, length: 5, rect: [554,32 52.71875x22]
+      frag 7 from TextNode start: 23, length: 5, rect: [554,32 52.71875x22] baseline: 17
           "amet,"
-        frag 1 from TextNode start: 28, length: 1, rect: [607,32 62.21875x22]
+      frag 8 from TextNode start: 28, length: 1, rect: [607,32 62.21875x22] baseline: 17
           " "
-        frag 2 from TextNode start: 29, length: 11, rect: [669.21875,32 121.0625x22]
+      frag 9 from TextNode start: 29, length: 11, rect: [669.21875,32 121.0625x22] baseline: 17
           "consectetur"
-      line 2 width: 140.5625, height: 22, bottom: 66, baseline: 17
-        frag 0 from TextNode start: 41, length: 10, rect: [554,54 94.65625x22]
+      frag 10 from TextNode start: 41, length: 10, rect: [554,54 94.65625x22] baseline: 17
           "adipiscing"
-        frag 1 from TextNode start: 51, length: 1, rect: [649,54 105.4375x22]
+      frag 11 from TextNode start: 51, length: 1, rect: [649,54 105.4375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 52, length: 5, rect: [754.4375,54 35.90625x22]
+      frag 12 from TextNode start: 52, length: 5, rect: [754.4375,54 35.90625x22] baseline: 17
           "elit."
-      line 3 width: 145, height: 22, bottom: 88, baseline: 17
-        frag 0 from TextNode start: 58, length: 11, rect: [554,76 123.3125x22]
+      frag 13 from TextNode start: 58, length: 11, rect: [554,76 123.3125x22] baseline: 17
           "Suspendisse"
-        frag 1 from TextNode start: 69, length: 1, rect: [677,76 101x22]
+      frag 14 from TextNode start: 69, length: 1, rect: [677,76 101x22] baseline: 17
           " "
-        frag 2 from TextNode start: 70, length: 1, rect: [778,76 11.6875x22]
+      frag 15 from TextNode start: 70, length: 1, rect: [778,76 11.6875x22] baseline: 17
           "a"
-      line 4 width: 196.703125, height: 22, bottom: 110, baseline: 17
-        frag 0 from TextNode start: 72, length: 8, rect: [554,98 82.046875x22]
+      frag 16 from TextNode start: 72, length: 8, rect: [554,98 82.046875x22] baseline: 17
           "placerat"
-        frag 1 from TextNode start: 80, length: 1, rect: [636,98 29.640625x22]
+      frag 17 from TextNode start: 80, length: 1, rect: [636,98 29.640625x22] baseline: 17
           " "
-        frag 2 from TextNode start: 81, length: 7, rect: [665.640625,98 73.875x22]
+      frag 18 from TextNode start: 81, length: 7, rect: [665.640625,98 73.875x22] baseline: 17
           "mauris,"
-        frag 3 from TextNode start: 88, length: 1, rect: [739.640625,98 29.640625x22]
+      frag 19 from TextNode start: 88, length: 1, rect: [739.640625,98 29.640625x22] baseline: 17
           " "
-        frag 4 from TextNode start: 89, length: 2, rect: [769.28125,98 20.78125x22]
+      frag 20 from TextNode start: 89, length: 2, rect: [769.28125,98 20.78125x22] baseline: 17
           "ut"
-      line 5 width: 234.6875, height: 22, bottom: 132, baseline: 17
-        frag 0 from TextNode start: 92, length: 9, rect: [554,120 101.28125x22]
+      frag 21 from TextNode start: 92, length: 9, rect: [554,120 101.28125x22] baseline: 17
           "elementum"
-        frag 1 from TextNode start: 101, length: 1, rect: [655,120 10.4375x22]
+      frag 22 from TextNode start: 101, length: 1, rect: [655,120 10.4375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 102, length: 3, rect: [665.4375,120 26.390625x22]
+      frag 23 from TextNode start: 102, length: 3, rect: [665.4375,120 26.390625x22] baseline: 17
           "mi."
-        frag 3 from TextNode start: 105, length: 1, rect: [692.4375,120 10.4375x22]
+      frag 24 from TextNode start: 105, length: 1, rect: [692.4375,120 10.4375x22] baseline: 17
           " "
-        frag 4 from TextNode start: 106, length: 5, rect: [702.875,120 56.234375x22]
+      frag 25 from TextNode start: 106, length: 5, rect: [702.875,120 56.234375x22] baseline: 17
           "Morbi"
-        frag 5 from TextNode start: 111, length: 1, rect: [758.875,120 10.4375x22]
+      frag 26 from TextNode start: 111, length: 1, rect: [758.875,120 10.4375x22] baseline: 17
           " "
-        frag 6 from TextNode start: 112, length: 2, rect: [769.3125,120 20.78125x22]
+      frag 27 from TextNode start: 112, length: 2, rect: [769.3125,120 20.78125x22] baseline: 17
           "ut"
-      line 6 width: 201.53125, height: 22, bottom: 154, baseline: 17
-        frag 0 from TextNode start: 115, length: 8, rect: [554,142 78.765625x22]
+      frag 28 from TextNode start: 115, length: 8, rect: [554,142 78.765625x22] baseline: 17
           "vehicula"
-        frag 1 from TextNode start: 123, length: 1, rect: [633,142 27.234375x22]
+      frag 29 from TextNode start: 123, length: 1, rect: [633,142 27.234375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 124, length: 6, rect: [660.234375,142 62.9375x22]
+      frag 30 from TextNode start: 124, length: 6, rect: [660.234375,142 62.9375x22] baseline: 17
           "ipsum,"
-        frag 3 from TextNode start: 130, length: 1, rect: [723.234375,142 27.234375x22]
+      frag 31 from TextNode start: 130, length: 1, rect: [723.234375,142 27.234375x22] baseline: 17
           " "
-        frag 4 from TextNode start: 131, length: 4, rect: [750.46875,142 39.828125x22]
+      frag 32 from TextNode start: 131, length: 4, rect: [750.46875,142 39.828125x22] baseline: 17
           "eget"
-      line 7 width: 232.53125, height: 22, bottom: 176, baseline: 17
-        frag 0 from TextNode start: 136, length: 8, rect: [554,164 82.046875x22]
+      frag 33 from TextNode start: 136, length: 8, rect: [554,164 82.046875x22] baseline: 17
           "placerat"
-        frag 1 from TextNode start: 144, length: 1, rect: [636,164 11.734375x22]
+      frag 34 from TextNode start: 144, length: 1, rect: [636,164 11.734375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 145, length: 6, rect: [647.734375,164 61.875x22]
+      frag 35 from TextNode start: 145, length: 6, rect: [647.734375,164 61.875x22] baseline: 17
           "augue."
-        frag 3 from TextNode start: 151, length: 1, rect: [709.734375,164 11.734375x22]
+      frag 36 from TextNode start: 151, length: 1, rect: [709.734375,164 11.734375x22] baseline: 17
           " "
-        frag 4 from TextNode start: 152, length: 7, rect: [721.46875,164 68.609375x22]
+      frag 37 from TextNode start: 152, length: 7, rect: [721.46875,164 68.609375x22] baseline: 17
           "Integer"
-      line 8 width: 202.96875, height: 22, bottom: 198, baseline: 17
-        frag 0 from TextNode start: 160, length: 6, rect: [554,186 70.3125x22]
+      frag 38 from TextNode start: 160, length: 6, rect: [554,186 70.3125x22] baseline: 17
           "rutrum"
-        frag 1 from TextNode start: 166, length: 1, rect: [624,186 21x22]
+      frag 39 from TextNode start: 166, length: 1, rect: [624,186 21x22] baseline: 17
           " "
-        frag 2 from TextNode start: 167, length: 4, rect: [645,186 35.09375x22]
+      frag 40 from TextNode start: 167, length: 4, rect: [645,186 35.09375x22] baseline: 17
           "nisi"
-        frag 3 from TextNode start: 171, length: 1, rect: [680,186 21x22]
+      frag 41 from TextNode start: 171, length: 1, rect: [680,186 21x22] baseline: 17
           " "
-        frag 4 from TextNode start: 172, length: 4, rect: [701,186 39.828125x22]
+      frag 42 from TextNode start: 172, length: 4, rect: [701,186 39.828125x22] baseline: 17
           "eget"
-        frag 5 from TextNode start: 176, length: 1, rect: [741,186 21x22]
+      frag 43 from TextNode start: 176, length: 1, rect: [741,186 21x22] baseline: 17
           " "
-        frag 6 from TextNode start: 177, length: 3, rect: [762,186 27.734375x22]
+      frag 44 from TextNode start: 177, length: 3, rect: [762,186 27.734375x22] baseline: 17
           "dui"
-      line 9 width: 0, height: 0, bottom: 0, baseline: 0
-      line 10 width: 208.828125, height: 22, bottom: 224, baseline: 17
-        frag 0 from TextNode start: 181, length: 7, rect: [252,212 68.984375x22]
+      frag 45 from TextNode start: 181, length: 7, rect: [252,212 68.984375x22] baseline: 17
           "dictum,"
-        frag 1 from TextNode start: 188, length: 1, rect: [321,212 23.578125x22]
+      frag 46 from TextNode start: 188, length: 1, rect: [321,212 23.578125x22] baseline: 17
           " "
-        frag 2 from TextNode start: 189, length: 2, rect: [344.578125,212 23.109375x22]
+      frag 47 from TextNode start: 189, length: 2, rect: [344.578125,212 23.109375x22] baseline: 17
           "eu"
-        frag 3 from TextNode start: 191, length: 1, rect: [367.578125,212 23.578125x22]
+      frag 48 from TextNode start: 191, length: 1, rect: [367.578125,212 23.578125x22] baseline: 17
           " "
-        frag 4 from TextNode start: 192, length: 8, rect: [391.15625,212 96.734375x22]
+      frag 49 from TextNode start: 192, length: 8, rect: [391.15625,212 96.734375x22] baseline: 17
           "accumsan"
-      line 11 width: 180.1875, height: 22, bottom: 246, baseline: 17
-        frag 0 from TextNode start: 201, length: 4, rect: [252,234 43.875x22]
+      frag 50 from TextNode start: 201, length: 4, rect: [252,234 43.875x22] baseline: 17
           "enim"
-        frag 1 from TextNode start: 205, length: 1, rect: [296,234 37.90625x22]
+      frag 51 from TextNode start: 205, length: 1, rect: [296,234 37.90625x22] baseline: 17
           " "
-        frag 2 from TextNode start: 206, length: 10, rect: [333.90625,234 93.625x22]
+      frag 52 from TextNode start: 206, length: 10, rect: [333.90625,234 93.625x22] baseline: 17
           "tristique."
-        frag 3 from TextNode start: 216, length: 1, rect: [427.90625,234 37.90625x22]
+      frag 53 from TextNode start: 216, length: 1, rect: [427.90625,234 37.90625x22] baseline: 17
           " "
-        frag 4 from TextNode start: 217, length: 2, rect: [465.8125,234 22.6875x22]
+      frag 54 from TextNode start: 217, length: 2, rect: [465.8125,234 22.6875x22] baseline: 17
           "Ut"
-      line 12 width: 195.28125, height: 22, bottom: 268, baseline: 17
-        frag 0 from TextNode start: 220, length: 8, rect: [252,256 80.015625x22]
+      frag 55 from TextNode start: 220, length: 8, rect: [252,256 80.015625x22] baseline: 17
           "lobortis"
-        frag 1 from TextNode start: 228, length: 1, rect: [332,256 30.359375x22]
+      frag 56 from TextNode start: 228, length: 1, rect: [332,256 30.359375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 229, length: 5, rect: [362.359375,256 55.4375x22]
+      frag 57 from TextNode start: 229, length: 5, rect: [362.359375,256 55.4375x22] baseline: 17
           "lorem"
-        frag 3 from TextNode start: 234, length: 1, rect: [417.359375,256 30.359375x22]
+      frag 58 from TextNode start: 234, length: 1, rect: [417.359375,256 30.359375x22] baseline: 17
           " "
-        frag 4 from TextNode start: 235, length: 4, rect: [447.71875,256 39.828125x22]
+      frag 59 from TextNode start: 235, length: 4, rect: [447.71875,256 39.828125x22] baseline: 17
           "eget"
-      line 13 width: 222.921875, height: 22, bottom: 290, baseline: 17
-        frag 0 from TextNode start: 240, length: 3, rect: [252,278 31.15625x22]
+      frag 60 from TextNode start: 240, length: 3, rect: [252,278 31.15625x22] baseline: 17
           "est"
-        frag 1 from TextNode start: 243, length: 1, rect: [283,278 16.53125x22]
+      frag 61 from TextNode start: 243, length: 1, rect: [283,278 16.53125x22] baseline: 17
           " "
-        frag 2 from TextNode start: 244, length: 9, rect: [299.53125,278 91.46875x22]
+      frag 62 from TextNode start: 244, length: 9, rect: [299.53125,278 91.46875x22] baseline: 17
           "vulputate"
-        frag 3 from TextNode start: 253, length: 1, rect: [391.53125,278 16.53125x22]
+      frag 63 from TextNode start: 253, length: 1, rect: [391.53125,278 16.53125x22] baseline: 17
           " "
-        frag 4 from TextNode start: 254, length: 8, rect: [408.0625,278 80.296875x22]
+      frag 64 from TextNode start: 254, length: 8, rect: [408.0625,278 80.296875x22] baseline: 17
           "egestas."
-      line 14 width: 223.125, height: 22, bottom: 312, baseline: 17
-        frag 0 from TextNode start: 263, length: 7, rect: [252,300 68.609375x22]
+      frag 65 from TextNode start: 263, length: 7, rect: [252,300 68.609375x22] baseline: 17
           "Integer"
-        frag 1 from TextNode start: 270, length: 1, rect: [321,300 16.4375x22]
+      frag 66 from TextNode start: 270, length: 1, rect: [321,300 16.4375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 271, length: 7, rect: [337.4375,300 71.328125x22]
+      frag 67 from TextNode start: 271, length: 7, rect: [337.4375,300 71.328125x22] baseline: 17
           "laoreet"
-        frag 3 from TextNode start: 278, length: 1, rect: [408.4375,300 16.4375x22]
+      frag 68 from TextNode start: 278, length: 1, rect: [408.4375,300 16.4375x22] baseline: 17
           " "
-        frag 4 from TextNode start: 279, length: 7, rect: [424.875,300 63.1875x22]
+      frag 69 from TextNode start: 279, length: 7, rect: [424.875,300 63.1875x22] baseline: 17
           "lacinia"
-      line 15 width: 222.609375, height: 22, bottom: 334, baseline: 17
-        frag 0 from TextNode start: 287, length: 4, rect: [252,322 43.15625x22]
+      frag 70 from TextNode start: 287, length: 4, rect: [252,322 43.15625x22] baseline: 17
           "ante"
-        frag 1 from TextNode start: 291, length: 1, rect: [295,322 16.6875x22]
+      frag 71 from TextNode start: 291, length: 1, rect: [295,322 16.6875x22] baseline: 17
           " "
-        frag 2 from TextNode start: 292, length: 7, rect: [311.6875,322 74x22]
+      frag 72 from TextNode start: 292, length: 7, rect: [311.6875,322 74x22] baseline: 17
           "sodales"
-        frag 3 from TextNode start: 299, length: 1, rect: [385.6875,322 16.6875x22]
+      frag 73 from TextNode start: 299, length: 1, rect: [385.6875,322 16.6875x22] baseline: 17
           " "
-        frag 4 from TextNode start: 300, length: 9, rect: [402.375,322 85.453125x22]
+      frag 74 from TextNode start: 300, length: 9, rect: [402.375,322 85.453125x22] baseline: 17
           "lobortis."
-      line 16 width: 178.3125, height: 22, bottom: 356, baseline: 17
-        frag 0 from TextNode start: 310, length: 5, rect: [252,344 60.90625x22]
+      frag 75 from TextNode start: 310, length: 5, rect: [252,344 60.90625x22] baseline: 17
           "Donec"
-        frag 1 from TextNode start: 315, length: 1, rect: [313,344 38.84375x22]
+      frag 76 from TextNode start: 315, length: 1, rect: [313,344 38.84375x22] baseline: 17
           " "
-        frag 2 from TextNode start: 316, length: 1, rect: [351.84375,344 11.6875x22]
+      frag 77 from TextNode start: 316, length: 1, rect: [351.84375,344 11.6875x22] baseline: 17
           "a"
-        frag 3 from TextNode start: 317, length: 1, rect: [363.84375,344 38.84375x22]
+      frag 78 from TextNode start: 317, length: 1, rect: [363.84375,344 38.84375x22] baseline: 17
           " "
-        frag 4 from TextNode start: 318, length: 9, rect: [402.6875,344 85.71875x22]
+      frag 79 from TextNode start: 318, length: 9, rect: [402.6875,344 85.71875x22] baseline: 17
           "tincidunt"
-      line 17 width: 231.078125, height: 22, bottom: 378, baseline: 17
-        frag 0 from TextNode start: 328, length: 5, rect: [252,366 48.59375x22]
+      frag 80 from TextNode start: 328, length: 5, rect: [252,366 48.59375x22] baseline: 17
           "ante."
-        frag 1 from TextNode start: 333, length: 1, rect: [301,366 11.640625x22]
+      frag 81 from TextNode start: 333, length: 1, rect: [301,366 11.640625x22] baseline: 17
           " "
-        frag 2 from TextNode start: 334, length: 9, rect: [312.640625,366 94.765625x22]
+      frag 82 from TextNode start: 334, length: 9, rect: [312.640625,366 94.765625x22] baseline: 17
           "Phasellus"
-        frag 3 from TextNode start: 343, length: 1, rect: [406.640625,366 11.640625x22]
+      frag 83 from TextNode start: 343, length: 1, rect: [406.640625,366 11.640625x22] baseline: 17
           " "
-        frag 4 from TextNode start: 344, length: 1, rect: [418.28125,366 11.6875x22]
+      frag 84 from TextNode start: 344, length: 1, rect: [418.28125,366 11.6875x22] baseline: 17
           "a"
-        frag 5 from TextNode start: 345, length: 1, rect: [430.28125,366 11.640625x22]
+      frag 85 from TextNode start: 345, length: 1, rect: [430.28125,366 11.640625x22] baseline: 17
           " "
-        frag 6 from TextNode start: 346, length: 4, rect: [441.921875,366 46.03125x22]
+      frag 86 from TextNode start: 346, length: 4, rect: [441.921875,366 46.03125x22] baseline: 17
           "arcu"
-      line 18 width: 70.546875, height: 22, bottom: 400, baseline: 17
-        frag 0 from TextNode start: 351, length: 7, rect: [252,388 70.546875x22]
+      frag 87 from TextNode start: 351, length: 7, rect: [252,388 70.546875x22] baseline: 17
           "tortor."
       BlockContainer <div.left> at (253,11) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
@@ -1,60 +1,41 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (252,10) content-size 538x400 children: inline
-      line 0 width: 228.34375, height: 22, bottom: 22, baseline: 17
-        frag 0 from TextNode start: 1, length: 21, rect: [554,10 228.34375x22]
+      frag 0 from TextNode start: 1, length: 21, rect: [554,10 228.34375x22] baseline: 17
           "Lorem ipsum dolor sit"
-      line 1 width: 183.78125, height: 22, bottom: 44, baseline: 17
-        frag 0 from TextNode start: 23, length: 17, rect: [554,32 183.78125x22]
+      frag 1 from TextNode start: 23, length: 17, rect: [554,32 183.78125x22] baseline: 17
           "amet, consectetur"
-      line 2 width: 140.5625, height: 22, bottom: 66, baseline: 17
-        frag 0 from TextNode start: 41, length: 16, rect: [554,54 140.5625x22]
+      frag 2 from TextNode start: 41, length: 16, rect: [554,54 140.5625x22] baseline: 17
           "adipiscing elit."
-      line 3 width: 145, height: 22, bottom: 88, baseline: 17
-        frag 0 from TextNode start: 58, length: 13, rect: [554,76 145x22]
+      frag 3 from TextNode start: 58, length: 13, rect: [554,76 145x22] baseline: 17
           "Suspendisse a"
-      line 4 width: 196.703125, height: 22, bottom: 110, baseline: 17
-        frag 0 from TextNode start: 72, length: 19, rect: [554,98 196.703125x22]
+      frag 4 from TextNode start: 72, length: 19, rect: [554,98 196.703125x22] baseline: 17
           "placerat mauris, ut"
-      line 5 width: 234.6875, height: 22, bottom: 132, baseline: 17
-        frag 0 from TextNode start: 92, length: 22, rect: [554,120 234.6875x22]
+      frag 5 from TextNode start: 92, length: 22, rect: [554,120 234.6875x22] baseline: 17
           "elementum mi. Morbi ut"
-      line 6 width: 201.53125, height: 22, bottom: 154, baseline: 17
-        frag 0 from TextNode start: 115, length: 20, rect: [554,142 201.53125x22]
+      frag 6 from TextNode start: 115, length: 20, rect: [554,142 201.53125x22] baseline: 17
           "vehicula ipsum, eget"
-      line 7 width: 232.53125, height: 22, bottom: 176, baseline: 17
-        frag 0 from TextNode start: 136, length: 23, rect: [554,164 232.53125x22]
+      frag 7 from TextNode start: 136, length: 23, rect: [554,164 232.53125x22] baseline: 17
           "placerat augue. Integer"
-      line 8 width: 202.96875, height: 22, bottom: 198, baseline: 17
-        frag 0 from TextNode start: 160, length: 20, rect: [554,186 202.96875x22]
+      frag 8 from TextNode start: 160, length: 20, rect: [554,186 202.96875x22] baseline: 17
           "rutrum nisi eget dui"
-      line 9 width: 0, height: 0, bottom: 0, baseline: 0
-      line 10 width: 208.828125, height: 22, bottom: 224, baseline: 17
-        frag 0 from TextNode start: 181, length: 19, rect: [252,212 208.828125x22]
+      frag 9 from TextNode start: 181, length: 19, rect: [252,212 208.828125x22] baseline: 17
           "dictum, eu accumsan"
-      line 11 width: 180.1875, height: 22, bottom: 246, baseline: 17
-        frag 0 from TextNode start: 201, length: 18, rect: [252,234 180.1875x22]
+      frag 10 from TextNode start: 201, length: 18, rect: [252,234 180.1875x22] baseline: 17
           "enim tristique. Ut"
-      line 12 width: 195.28125, height: 22, bottom: 268, baseline: 17
-        frag 0 from TextNode start: 220, length: 19, rect: [252,256 195.28125x22]
+      frag 11 from TextNode start: 220, length: 19, rect: [252,256 195.28125x22] baseline: 17
           "lobortis lorem eget"
-      line 13 width: 222.921875, height: 22, bottom: 290, baseline: 17
-        frag 0 from TextNode start: 240, length: 22, rect: [252,278 222.921875x22]
+      frag 12 from TextNode start: 240, length: 22, rect: [252,278 222.921875x22] baseline: 17
           "est vulputate egestas."
-      line 14 width: 223.125, height: 22, bottom: 312, baseline: 17
-        frag 0 from TextNode start: 263, length: 23, rect: [252,300 223.125x22]
+      frag 13 from TextNode start: 263, length: 23, rect: [252,300 223.125x22] baseline: 17
           "Integer laoreet lacinia"
-      line 15 width: 222.609375, height: 22, bottom: 334, baseline: 17
-        frag 0 from TextNode start: 287, length: 22, rect: [252,322 222.609375x22]
+      frag 14 from TextNode start: 287, length: 22, rect: [252,322 222.609375x22] baseline: 17
           "ante sodales lobortis."
-      line 16 width: 178.3125, height: 22, bottom: 356, baseline: 17
-        frag 0 from TextNode start: 310, length: 17, rect: [252,344 178.3125x22]
+      frag 15 from TextNode start: 310, length: 17, rect: [252,344 178.3125x22] baseline: 17
           "Donec a tincidunt"
-      line 17 width: 231.078125, height: 22, bottom: 378, baseline: 17
-        frag 0 from TextNode start: 328, length: 22, rect: [252,366 231.078125x22]
+      frag 16 from TextNode start: 328, length: 22, rect: [252,366 231.078125x22] baseline: 17
           "ante. Phasellus a arcu"
-      line 18 width: 70.546875, height: 22, bottom: 400, baseline: 17
-        frag 0 from TextNode start: 351, length: 7, rect: [252,388 70.546875x22]
+      frag 17 from TextNode start: 351, length: 7, rect: [252,388 70.546875x22] baseline: 17
           "tortor."
       BlockContainer <div.left> at (253,11) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block-flex-display.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block-flex-display.txt
@@ -5,13 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (8,8) content-size 23.609375x17 flex-item [BFC] children: not-inline
           BlockContainer <div> at (8,8) content-size 23.609375x17 floating [BFC] children: not-inline
             BlockContainer <span> at (8,8) content-size 14.265625x17 floating [BFC] children: inline
-              line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
                   "A"
               TextNode <#text>
             BlockContainer <span> at (22.265625,8) content-size 9.34375x17 floating [BFC] children: inline
-              line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [22.265625,8 9.34375x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [22.265625,8 9.34375x17] baseline: 13.296875
                   "B"
               TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 23.609375x17 floating [BFC] children: not-inline
         BlockContainer <span> at (8,8) content-size 14.265625x17 floating [BFC] children: inline
-          line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
               "A"
           TextNode <#text>
         BlockContainer <span> at (22.265625,8) content-size 9.34375x17 floating [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [22.265625,8 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [22.265625,8 9.34375x17] baseline: 13.296875
               "B"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-should-avoid-inline-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-should-avoid-inline-block.txt
@@ -2,19 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x249 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21 children: not-inline
       BlockContainer <div.Layout-sidebar> at (11,11) content-size 220x19 children: inline
-        line 0 width: 102, height: 19, bottom: 19, baseline: 14.296875
-          frag 0 from BlockContainer start: 0, length: 0, rect: [12,12 100x17]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [12,12 100x17] baseline: 14.296875
         BlockContainer <div.d-inline-block> at (12,12) content-size 100x17 inline-block [BFC] children: inline
-          line 0 width: 69.734375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [12,12 69.734375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [12,12 69.734375x17] baseline: 13.296875
               "floats!!!!!!"
           TextNode <#text>
         BlockContainer <div.float-left> at (12,31) content-size 232.71875x218 floating [BFC] children: inline
-          line 0 width: 232.71875, height: 109, bottom: 109, baseline: 84.484375
-            frag 0 from TextNode start: 0, length: 5, rect: [12,31 232.71875x109]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,31 232.71875x109] baseline: 84.484375
               "float"
-          line 1 width: 164.0625, height: 109, bottom: 218, baseline: 84.484375
-            frag 0 from TextNode start: 6, length: 4, rect: [12,140 164.0625x109]
+          frag 1 from TextNode start: 6, length: 4, rect: [12,140 164.0625x109] baseline: 84.484375
               "left"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
@@ -4,63 +4,45 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.outer> at (9,9) content-size 300x250 children: inline
-        line 0 width: 239.15625, height: 16, bottom: 16, baseline: 12.796875
-          frag 0 from TextNode start: 1, length: 24, rect: [61,9 212x16]
+        frag 0 from TextNode start: 1, length: 24, rect: [61,9 212x16] baseline: 12.796875
             "foo bar baz foo bar baz "
-          frag 1 from TextNode start: 1, length: 3, rect: [273,9 27.15625x16]
+        frag 1 from TextNode start: 1, length: 3, rect: [273,9 27.15625x16] baseline: 12.796875
             "foo"
-        line 1 width: 27.640625, height: 16, bottom: 32, baseline: 12.796875
-          frag 0 from TextNode start: 5, length: 3, rect: [263,25 27.640625x16]
+        frag 2 from TextNode start: 5, length: 3, rect: [263,25 27.640625x16] baseline: 12.796875
             "bar"
-        line 2 width: 27.203125, height: 16, bottom: 48, baseline: 12.796875
-          frag 0 from TextNode start: 9, length: 3, rect: [263,41 27.203125x16]
+        frag 3 from TextNode start: 9, length: 3, rect: [263,41 27.203125x16] baseline: 12.796875
             "baz"
-        line 3 width: 27.15625, height: 16, bottom: 64, baseline: 12.796875
-          frag 0 from TextNode start: 13, length: 3, rect: [263,57 27.15625x16]
+        frag 4 from TextNode start: 13, length: 3, rect: [263,57 27.15625x16] baseline: 12.796875
             "foo"
-        line 4 width: 0, height: 0, bottom: 0, baseline: 0
-        line 5 width: 62.84375, height: 16, bottom: 84, baseline: 12.796875
-          frag 0 from TextNode start: 17, length: 7, rect: [9,77 62.84375x16]
+        frag 5 from TextNode start: 17, length: 7, rect: [9,77 62.84375x16] baseline: 12.796875
             "bar baz"
-        line 6 width: 62.796875, height: 16, bottom: 100, baseline: 12.796875
-          frag 0 from TextNode start: 25, length: 7, rect: [9,93 62.796875x16]
+        frag 6 from TextNode start: 25, length: 7, rect: [9,93 62.796875x16] baseline: 12.796875
             "foo bar"
-        line 7 width: 62.359375, height: 16, bottom: 116, baseline: 12.796875
-          frag 0 from TextNode start: 33, length: 7, rect: [9,109 62.359375x16]
+        frag 7 from TextNode start: 33, length: 7, rect: [9,109 62.359375x16] baseline: 12.796875
             "baz foo"
-        line 8 width: 62.84375, height: 16, bottom: 132, baseline: 12.796875
-          frag 0 from TextNode start: 41, length: 7, rect: [9,125 62.84375x16]
+        frag 8 from TextNode start: 41, length: 7, rect: [9,125 62.84375x16] baseline: 12.796875
             "bar baz"
-        line 9 width: 239.15625, height: 16, bottom: 148, baseline: 12.796875
-          frag 0 from TextNode start: 1, length: 27, rect: [9,141 239.15625x16]
+        frag 9 from TextNode start: 1, length: 27, rect: [9,141 239.15625x16] baseline: 12.796875
             "foo bar baz foo bar baz foo"
-        line 10 width: 239.640625, height: 16, bottom: 164, baseline: 12.796875
-          frag 0 from TextNode start: 29, length: 27, rect: [9,157 239.640625x16]
+        frag 10 from TextNode start: 29, length: 27, rect: [9,157 239.640625x16] baseline: 12.796875
             "bar baz foo bar baz foo bar"
-        line 11 width: 239.203125, height: 16, bottom: 180, baseline: 12.796875
-          frag 0 from TextNode start: 57, length: 16, rect: [61,173 141.203125x16]
+        frag 11 from TextNode start: 57, length: 16, rect: [61,173 141.203125x16] baseline: 12.796875
             "baz foo bar baz "
-          frag 1 from TextNode start: 1, length: 11, rect: [202,173 98x16]
+        frag 12 from TextNode start: 1, length: 11, rect: [202,173 98x16] baseline: 12.796875
             "foo bar baz"
-        line 12 width: 204, height: 16, bottom: 196, baseline: 12.796875
-          frag 0 from TextNode start: 13, length: 12, rect: [61,189 106x16]
+        frag 13 from TextNode start: 13, length: 12, rect: [61,189 106x16] baseline: 12.796875
             "foo bar baz "
-          frag 1 from TextNode start: 1, length: 11, rect: [167,189 98x16]
+        frag 14 from TextNode start: 1, length: 11, rect: [167,189 98x16] baseline: 12.796875
             "foo bar baz"
-        line 13 width: 204, height: 16, bottom: 212, baseline: 12.796875
-          frag 0 from TextNode start: 13, length: 23, rect: [61,205 204x16]
+        frag 15 from TextNode start: 13, length: 23, rect: [61,205 204x16] baseline: 12.796875
             "foo bar baz foo bar baz"
-        line 14 width: 239.15625, height: 16, bottom: 228, baseline: 12.796875
-          frag 0 from TextNode start: 37, length: 27, rect: [61,221 239.15625x16]
+        frag 16 from TextNode start: 37, length: 27, rect: [61,221 239.15625x16] baseline: 12.796875
             "foo bar baz foo bar baz foo"
-        line 15 width: 274.84375, height: 16, bottom: 244, baseline: 12.796875
-          frag 0 from TextNode start: 65, length: 31, rect: [9,237 274.84375x16]
+        frag 17 from TextNode start: 65, length: 31, rect: [9,237 274.84375x16] baseline: 12.796875
             "bar baz foo bar baz foo bar baz"
-        line 16 width: 274.796875, height: 16, bottom: 260, baseline: 12.796875
-          frag 0 from TextNode start: 97, length: 31, rect: [9,253 274.796875x16]
+        frag 18 from TextNode start: 97, length: 31, rect: [9,253 274.796875x16] baseline: 12.796875
             "foo bar baz foo bar baz foo bar"
-        line 17 width: 133.203125, height: 16, bottom: 276, baseline: 12.796875
-          frag 0 from TextNode start: 129, length: 15, rect: [9,269 133.203125x16]
+        frag 19 from TextNode start: 129, length: 15, rect: [9,269 133.203125x16] baseline: 12.796875
             "baz foo bar baz"
         TextNode <#text>
         BlockContainer <div.lefty> at (10,10) content-size 50x50 floating [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
@@ -4,13 +4,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#page> at (50,50) content-size 750x0 children: not-inline
         BlockContainer <div#content_box> at (50,50) content-size 400x150 floating [BFC] children: inline
           BlockContainer <article.first> at (50,50) content-size 300x100 floating [BFC] children: inline
-            line 0 width: 36.03125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 5, rect: [50,50 36.03125x17]
+            frag 0 from TextNode start: 0, length: 5, rect: [50,50 36.03125x17] baseline: 13.296875
                 "first"
             TextNode <#text>
           BlockContainer <article.second> at (50,150) content-size 200x50 floating [BFC] children: inline
-            line 0 width: 54.78125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 6, rect: [50,150 54.78125x17]
+            frag 0 from TextNode start: 0, length: 6, rect: [50,150 54.78125x17] baseline: 13.296875
                 "second"
             TextNode <#text>
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.outer> at (9,9) content-size 300x250 children: inline
-        line 0 width: 204, height: 16, bottom: 16, baseline: 12.796875
-          frag 0 from TextNode start: 1, length: 23, rect: [61,9 204x16]
+        frag 0 from TextNode start: 1, length: 23, rect: [61,9 204x16] baseline: 12.796875
             "foo bar baz foo bar baz"
         TextNode <#text>
         BlockContainer <div.lefty> at (10,10) content-size 50x50 floating [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/floats-and-negative-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/floats-and-negative-margins.txt
@@ -3,14 +3,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (100,8) content-size 200x200 children: not-inline
       BlockContainer <div.row> at (50,8) content-size 250x200 children: inline
         BlockContainer <div.item> at (50,8) content-size 125x17 floating [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 1, rect: [50,8 9.34375x17]
+          frag 0 from TextNode start: 1, length: 1, rect: [50,8 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         TextNode <#text>
         BlockContainer <div.item> at (175,8) content-size 125x17 floating [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 1, rect: [175,8 9.46875x17]
+          frag 0 from TextNode start: 1, length: 1, rect: [175,8 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/floats-with-negative-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/floats-with-negative-percentage-margins.txt
@@ -2,18 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x208 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 600x0 children: not-inline
       BlockContainer <div#top> at (8,8) content-size 100x100 floating [BFC] children: inline
-        line 0 width: 26.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.640625x17] baseline: 13.296875
             "top"
         TextNode <#text>
       BlockContainer <div#left> at (8,108) content-size 100x100 floating [BFC] children: inline
-        line 0 width: 26.25, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 4, rect: [8,108 26.25x17]
+        frag 0 from TextNode start: 0, length: 4, rect: [8,108 26.25x17] baseline: 13.296875
             "left"
         TextNode <#text>
       BlockContainer <div#right> at (208,108) content-size 100x100 floating [BFC] children: inline
-        line 0 width: 37.109375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [208,108 37.109375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [208,108 37.109375x17] baseline: 13.296875
             "right"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x19 children: not-inline
       BlockContainer <pre> at (9,17) content-size 782x17 children: inline
-        line 0 width: 8, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17] baseline: 13.296875
             " "
         InlineNode <span>
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/grid-container-should-avoid-overlapping-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/grid-container-should-avoid-overlapping-floats.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 400x50 children: not-inline
       BlockContainer <div.right> at (370.890625,8) content-size 37.109375x17 floating [BFC] children: inline
-        line 0 width: 37.109375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [370.890625,8 37.109375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [370.890625,8 37.109375x17] baseline: 13.296875
             "right"
         TextNode <#text>
       Box <div.grid> at (8,8) content-size 362.890625x50 [GFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19 children: not-inline
       BlockContainer <div.thumbnail> at (11,11) content-size 50x50 floating [BFC] children: not-inline
       BlockContainer <div.title> at (91,11) content-size 698x17 children: inline
-        line 0 width: 125.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 14, rect: [91,11 125.125x17]
+        frag 0 from TextNode start: 0, length: 14, rect: [91,11 125.125x17] baseline: 13.296875
             "Chrono Trigger"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-1.txt
@@ -1,20 +1,17 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x92 children: inline
-      line 0 width: 307.140625, height: 92, bottom: 92, baseline: 34.296875
-        frag 0 from TextNode start: 0, length: 13, rect: [10,31 103.140625x17]
+      frag 0 from TextNode start: 0, length: 13, rect: [10,31 103.140625x17] baseline: 13.296875
           "Hello friends"
-        frag 1 from BlockContainer start: 0, length: 0, rect: [114,11 202x90]
+      frag 1 from BlockContainer start: 0, length: 0, rect: [114,11 202x90] baseline: 34.296875
       TextNode <#text>
       BlockContainer <div.ib> at (114,11) content-size 202x90 inline-block [BFC] children: not-inline
         BlockContainer <div> at (115,12) content-size 200x17 children: inline
-          line 0 width: 22.546875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [115,12 22.546875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [115,12 22.546875x17] baseline: 13.296875
               "1st"
           TextNode <#text>
         BlockContainer <div> at (115,31) content-size 200x17 children: inline
-          line 0 width: 26.28125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [115,31 26.28125x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [115,31 26.28125x17] baseline: 13.296875
               "2nd"
           TextNode <#text>
         BlockContainer <div.whee> at (115,50) content-size 200x50 children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-2.txt
@@ -1,25 +1,21 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x59 children: inline
-      line 0 width: 144.375, height: 59, bottom: 59, baseline: 34.296875
-        frag 0 from TextNode start: 0, length: 13, rect: [10,31 103.140625x17]
+      frag 0 from TextNode start: 0, length: 13, rect: [10,31 103.140625x17] baseline: 13.296875
           "Hello friends"
-        frag 1 from BlockContainer start: 0, length: 0, rect: [114,11 39.234375x57]
+      frag 1 from BlockContainer start: 0, length: 0, rect: [114,11 39.234375x57] baseline: 34.296875
       TextNode <#text>
       BlockContainer <div.ib> at (114,11) content-size 39.234375x57 inline-block [BFC] children: not-inline
         BlockContainer <div> at (115,12) content-size 37.234375x17 children: inline
-          line 0 width: 22.546875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [115,12 22.546875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [115,12 22.546875x17] baseline: 13.296875
               "1st"
           TextNode <#text>
         BlockContainer <div> at (115,31) content-size 37.234375x17 children: inline
-          line 0 width: 26.28125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [115,31 26.28125x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [115,31 26.28125x17] baseline: 13.296875
               "2nd"
           TextNode <#text>
         BlockContainer <div.float> at (115,50) content-size 37.234375x17 floating [BFC] children: inline
-          line 0 width: 37.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [115,50 37.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [115,50 37.234375x17] baseline: 13.296875
               "float"
           TextNode <#text>
         BlockContainer <(anonymous)> at (114,49) content-size 39.234375x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-contained-by-abspos-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-contained-by-abspos-element.txt
@@ -3,26 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x2 children: not-inline
       BlockContainer <div> at (11,11) content-size 500x0 positioned children: not-inline
         BlockContainer <h1> at (12,45.5) content-size 498x332 positioned [BFC] children: inline
-          line 0 width: 498, height: 332, bottom: 332, baseline: 43.484375
-            frag 0 from BlockContainer start: 0, length: 0, rect: [13,46.5 496x330]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [13,46.5 496x330] baseline: 43.484375
           BlockContainer <span> at (13,46.5) content-size 496x330 inline-block [BFC] children: inline
-            line 0 width: 246.484375, height: 55, bottom: 55, baseline: 42.484375
-              frag 0 from TextNode start: 0, length: 9, rect: [13,46.5 246.484375x55]
+            frag 0 from TextNode start: 0, length: 9, rect: [13,46.5 246.484375x55] baseline: 42.484375
                 "Skew is a"
-            line 1 width: 240.53125, height: 55, bottom: 110, baseline: 42.484375
-              frag 0 from TextNode start: 10, length: 10, rect: [13,101.5 240.53125x55]
+            frag 1 from TextNode start: 10, length: 10, rect: [13,101.5 240.53125x55] baseline: 42.484375
                 "web-first,"
-            line 2 width: 377.9375, height: 55, bottom: 165, baseline: 42.484375
-              frag 0 from TextNode start: 21, length: 14, rect: [13,156.5 377.9375x55]
+            frag 2 from TextNode start: 21, length: 14, rect: [13,156.5 377.9375x55] baseline: 42.484375
                 "cross-platform"
-            line 3 width: 314.015625, height: 55, bottom: 220, baseline: 42.484375
-              frag 0 from TextNode start: 36, length: 11, rect: [13,211.5 314.015625x55]
+            frag 3 from TextNode start: 36, length: 11, rect: [13,211.5 314.015625x55] baseline: 42.484375
                 "programming"
-            line 4 width: 415.734375, height: 55, bottom: 275, baseline: 42.484375
-              frag 0 from TextNode start: 48, length: 16, rect: [13,266.5 415.734375x55]
+            frag 4 from TextNode start: 48, length: 16, rect: [13,266.5 415.734375x55] baseline: 42.484375
                 "language with an"
-            line 5 width: 492.671875, height: 55, bottom: 330, baseline: 42.484375
-              frag 0 from TextNode start: 65, length: 20, rect: [13,321.5 492.671875x55]
+            frag 5 from TextNode start: 65, length: 20, rect: [13,321.5 492.671875x55] baseline: 42.484375
                 "optimizing compiler."
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-percentage-max-width.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x113 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x97 children: inline
-      line 0 width: 134.109375, height: 97, bottom: 97, baseline: 53.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [48,48 54.109375x17]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [48,48 54.109375x17] baseline: 53.296875
       BlockContainer <div> at (48,48) content-size 54.109375x17 inline-block [BFC] children: inline
-        line 0 width: 54.109375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [48,48 54.109375x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [48,48 54.109375x17] baseline: 13.296875
             "New UI"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x35 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x19 children: inline
-      line 0 width: 102.203125, height: 19, bottom: 19, baseline: 14.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 100.203125x17]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 100.203125x17] baseline: 14.296875
       BlockContainer <span> at (9,9) content-size 100.203125x17 inline-block [BFC] children: inline
-        line 0 width: 100.203125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 13, rect: [9,9 100.203125x17]
+        frag 0 from TextNode start: 0, length: 13, rect: [9,9 100.203125x17] baseline: 13.296875
             "hello friends"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-negative-margin-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-negative-margin-left.txt
@@ -1,9 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (5,5) content-size 150x50 children: inline
-      line 0 width: 150, height: 50, bottom: 50, baseline: 50
-        frag 0 from BlockContainer start: 0, length: 0, rect: [5,5 100x50]
-        frag 1 from BlockContainer start: 0, length: 0, rect: [55,5 100x50]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [5,5 100x50] baseline: 50
+      frag 1 from BlockContainer start: 0, length: 0, rect: [55,5 100x50] baseline: 50
       BlockContainer <div.foo> at (5,5) content-size 100x50 inline-block [BFC] children: not-inline
       BlockContainer <div.bar> at (55,5) content-size 100x50 inline-block [BFC] children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-negative-margin-right.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-negative-margin-right.txt
@@ -1,9 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (5,5) content-size 150x50 children: inline
-      line 0 width: 150, height: 50, bottom: 50, baseline: 50
-        frag 0 from BlockContainer start: 0, length: 0, rect: [5,5 100x50]
-        frag 1 from BlockContainer start: 0, length: 0, rect: [105,5 100x50]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [5,5 100x50] baseline: 50
+      frag 1 from BlockContainer start: 0, length: 0, rect: [105,5 100x50] baseline: 50
       BlockContainer <div.foo> at (5,5) content-size 100x50 inline-block [BFC] children: not-inline
       BlockContainer <div.bar> at (105,5) content-size 100x50 inline-block [BFC] children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-percentage-height-and-auto-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-percentage-height-and-auto-height-of-containing-block.txt
@@ -2,11 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       BlockContainer <div.pure-menu-list> at (8,8) content-size 784x17 children: inline
-        line 0 width: 36.453125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 36.453125x17]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 36.453125x17] baseline: 13.296875
         BlockContainer <div.pure-menu-item> at (8,8) content-size 36.453125x17 inline-block [BFC] children: inline
-          line 0 width: 36.453125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,8 36.453125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,8 36.453125x17] baseline: 13.296875
               "docs"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
@@ -1,16 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x20 children: inline
-      line 0 width: 352.34375, height: 20, bottom: 20, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 14, rect: [8,8 112.421875x17]
+      frag 0 from TextNode start: 0, length: 14, rect: [8,8 112.421875x17] baseline: 13.296875
           "text text text"
-        frag 1 from BlockContainer start: 0, length: 0, rect: [120,8 110.375x20]
-        frag 2 from TextNode start: 0, length: 16, rect: [231,8 129.546875x17]
+      frag 1 from BlockContainer start: 0, length: 0, rect: [120,8 110.375x20] baseline: 13.296875
+      frag 2 from TextNode start: 0, length: 16, rect: [231,8 129.546875x17] baseline: 13.296875
           "more inline text"
       TextNode <#text>
       BlockContainer <span.displaced_text> at (150,48) content-size 110.375x20 positioned inline-block [BFC] children: inline
-        line 0 width: 110.375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 14, rect: [150,48 110.375x17]
+        frag 0 from TextNode start: 0, length: 14, rect: [150,48 110.375x17] baseline: 13.296875
             "displaced text"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
@@ -1,11 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x175 children: inline
-      line 0 width: 210.828125, height: 175, bottom: 175, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 6, rect: [8,8 43.125x17]
+      frag 0 from TextNode start: 0, length: 6, rect: [8,8 43.125x17] baseline: 13.296875
           "Well, "
-        frag 1 from BlockContainer start: 0, length: 0, rect: [51,58 100x100]
-        frag 2 from TextNode start: 0, length: 9, rect: [151,8 67.703125x17]
+      frag 1 from BlockContainer start: 0, length: 0, rect: [51,58 100x100] baseline: 0
+      frag 2 from TextNode start: 0, length: 9, rect: [151,8 67.703125x17] baseline: 13.296875
           " friends."
       TextNode <#text>
       BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
@@ -1,11 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x178 children: inline
-      line 0 width: 210.828125, height: 178, bottom: 178, baseline: 175
-        frag 0 from TextNode start: 0, length: 6, rect: [8,169 43.125x17]
+      frag 0 from TextNode start: 0, length: 6, rect: [8,169 43.125x17] baseline: 13.296875
           "Well, "
-        frag 1 from BlockContainer start: 0, length: 0, rect: [51,58 100x100]
-        frag 2 from TextNode start: 0, length: 9, rect: [151,169 67.703125x17]
+      frag 1 from BlockContainer start: 0, length: 0, rect: [51,58 100x100] baseline: 175
+      frag 2 from TextNode start: 0, length: 9, rect: [151,169 67.703125x17] baseline: 13.296875
           " friends."
       TextNode <#text>
       BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-node-not-inserted-into-generated-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-node-not-inserted-into-generated-box.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x50 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
-        line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17] baseline: 13.296875
             "foo"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,25) content-size 784x17 children: inline
-        line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,25 27.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,25 27.640625x17] baseline: 13.296875
             "bar"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x60 children: not-inline
       BlockContainer <div.banner> at (8,8) content-size 200x30 children: not-inline
       BlockContainer <(anonymous)> at (8,38) content-size 784x30 children: inline
-        line 0 width: 200, height: 30, bottom: 30, baseline: 30
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 200x30]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 200x30] baseline: 30
         BlockContainer <div.tab> at (8,38) content-size 200x30 inline-block [BFC] children: not-inline
         BlockContainer <div.timeline> at (592,38) content-size 200x30 floating [BFC] children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/list-markers-intruded-by-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/list-markers-intruded-by-float.txt
@@ -4,38 +4,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.box> at (18,26) content-size 200x100 floating [BFC] children: not-inline
       BlockContainer <ul> at (48,16) content-size 744x102 children: not-inline
         ListItemBox <li> at (48,16) content-size 744x17 children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [328,16 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [328,16 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (304,16) content-size 12x17 children: not-inline
         ListItemBox <li> at (48,33) content-size 744x17 children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [328,33 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [328,33 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (304,33) content-size 12x17 children: not-inline
         ListItemBox <li> at (48,50) content-size 744x17 children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [328,50 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [328,50 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (304,50) content-size 12x17 children: not-inline
         ListItemBox <li> at (48,67) content-size 744x17 children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [328,67 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [328,67 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (304,67) content-size 12x17 children: not-inline
         ListItemBox <li> at (48,84) content-size 744x17 children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [328,84 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [328,84 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (304,84) content-size 12x17 children: not-inline
         ListItemBox <li> at (48,101) content-size 744x17 children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [328,101 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [328,101 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (304,101) content-size 12x17 children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
@@ -2,15 +2,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,25) content-size 784x229 children: not-inline
       BlockContainer <div#foo> at (34,26) content-size 100x100 children: inline
-        line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [34,26 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [34,26 27.15625x17] baseline: 13.296875
             "foo"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,152) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div#bar> at (34,153) content-size 100x100 children: inline
-        line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [34,153 27.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [34,153 27.640625x17] baseline: 13.296875
             "bar"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,279) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
@@ -2,22 +2,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x336 children: not-inline
       BlockContainer <div#foo> at (9,9) content-size 100x100 children: inline
-        line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [9,9 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [9,9 27.15625x17] baseline: 13.296875
             "foo"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,135) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div#bar> at (9,136) content-size 100x100 children: inline
-        line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [9,136 27.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [9,136 27.640625x17] baseline: 13.296875
             "bar"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,262) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div#baz> at (9,243) content-size 100x100 children: inline
-        line 0 width: 27.203125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [9,243 27.203125x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [9,243 27.203125x17] baseline: 13.296875
             "baz"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,344) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x121 [BFC] children: inline
-    line 0 width: 170.96875, height: 121, bottom: 121, baseline: 15.296875
-      frag 0 from BlockContainer start: 0, length: 0, rect: [2,2 168.96875x119]
+    frag 0 from BlockContainer start: 0, length: 0, rect: [2,2 168.96875x119] baseline: 15.296875
     BlockContainer <body> at (2,2) content-size 168.96875x119 inline-block [BFC] children: not-inline
       BlockContainer <div.hmm> at (3,3) content-size 166.96875x17 children: inline
-        line 0 width: 166.96875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 21, rect: [3,3 166.96875x17]
+        frag 0 from TextNode start: 0, length: 21, rect: [3,3 166.96875x17] baseline: 13.296875
             "suspiciously tall box"
         TextNode <#text>
       BlockContainer <(anonymous)> at (2,121) content-size 168.96875x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 500x81 children: not-inline
       BlockContainer <div.a> at (51,21) content-size 413x49 children: not-inline
         BlockContainer <div.b> at (92,32) content-size 326x17 children: inline
-          line 0 width: 41.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [93,32 39.78125x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [93,32 39.78125x17] baseline: 13.296875
               "Hello"
           InlineNode <span>
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 500x101 children: not-inline
       BlockContainer <div.a> at (31,21) content-size 458x79 children: not-inline
         BlockContainer <div.b> at (72,52) content-size 376x17 children: inline
-          line 0 width: 41.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [73,52 39.78125x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [73,52 39.78125x17] baseline: 13.296875
               "Hello"
           InlineNode <span>
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-for-box-with-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-for-box-with-inline-children.txt
@@ -3,14 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 204x169 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 202x167 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 200x165 children: inline
-          line 0 width: 88.765625, height: 55, bottom: 55, baseline: 42.484375
-            frag 0 from TextNode start: 0, length: 4, rect: [12,12 88.765625x55]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,12 88.765625x55] baseline: 42.484375
               "well"
-          line 1 width: 115.140625, height: 55, bottom: 110, baseline: 42.484375
-            frag 0 from TextNode start: 5, length: 5, rect: [12,67 115.140625x55]
+          frag 1 from TextNode start: 5, length: 5, rect: [12,67 115.140625x55] baseline: 42.484375
               "hello"
-          line 2 width: 173, height: 55, bottom: 165, baseline: 42.484375
-            frag 0 from TextNode start: 11, length: 7, rect: [12,122 173x55]
+          frag 2 from TextNode start: 11, length: 7, rect: [12,122 173x55] baseline: 42.484375
               "friends"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body.outer> at (10,10) content-size 780x21 flex-container(row) [FFC] children: not-inline
       BlockContainer <div.middle> at (11,11) content-size 202x19 flex-item [BFC] children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 200x17 children: inline
-          line 0 width: 45.15625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12,12 45.15625x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,12 45.15625x17] baseline: 13.296875
               "OPEN"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100-border-box.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 93.59375x19 positioned [BFC] children: not-inline
       BlockContainer <nav> at (11,11) content-size 91.59375x17 children: inline
-        line 0 width: 91.59375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 10, rect: [11,11 91.59375x17]
+        frag 0 from TextNode start: 0, length: 10, rect: [11,11 91.59375x17] baseline: 13.296875
             "border box"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 138.609375x19 positioned [BFC] children: not-inline
       BlockContainer <div> at (11,11) content-size 136.609375x17 children: inline
-        line 0 width: 136.609375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 18, rect: [11,11 136.609375x17]
+        frag 0 from TextNode start: 0, length: 18, rect: [11,11 136.609375x17] baseline: 13.296875
             "well hello friends"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-containing-block.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19 children: not-inline
       BlockContainer <span.text> at (11,11) content-size 66.671875x17 children: inline
-        line 0 width: 66.671875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 7, rect: [11,11 66.671875x17]
+        frag 0 from TextNode start: 0, length: 7, rect: [11,11 66.671875x17] baseline: 13.296875
             "Trimmed"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-wrapped-in-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-wrapped-in-max-content.txt
@@ -4,23 +4,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.wrapper> at (8,8) content-size 270x102 children: not-inline
         BlockContainer <div.constrained> at (8,8) content-size 270x102 children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 270x102 children: inline
-            line 0 width: 261.0625, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 35, rect: [8,8 261.0625x17]
+            frag 0 from TextNode start: 1, length: 35, rect: [8,8 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 1 width: 261.0625, height: 17, bottom: 34, baseline: 13.296875
-              frag 0 from TextNode start: 37, length: 35, rect: [8,25 261.0625x17]
+            frag 1 from TextNode start: 37, length: 35, rect: [8,25 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 2 width: 261.0625, height: 17, bottom: 51, baseline: 13.296875
-              frag 0 from TextNode start: 73, length: 35, rect: [8,42 261.0625x17]
+            frag 2 from TextNode start: 73, length: 35, rect: [8,42 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 3 width: 261.0625, height: 17, bottom: 68, baseline: 13.296875
-              frag 0 from TextNode start: 109, length: 35, rect: [8,59 261.0625x17]
+            frag 3 from TextNode start: 109, length: 35, rect: [8,59 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 4 width: 261.0625, height: 17, bottom: 85, baseline: 13.296875
-              frag 0 from TextNode start: 145, length: 35, rect: [8,76 261.0625x17]
+            frag 4 from TextNode start: 145, length: 35, rect: [8,76 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 5 width: 81.6875, height: 17, bottom: 102, baseline: 13.296875
-              frag 0 from TextNode start: 181, length: 11, rect: [8,93 81.6875x17]
+            frag 5 from TextNode start: 181, length: 11, rect: [8,93 81.6875x17] baseline: 13.296875
                 "hello hello"
             TextNode <#text>
           BlockContainer <div> at (8,110) content-size 270x0 children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/min-width-for-box-with-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/min-width-for-box-with-inline-children.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 604x59 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 602x57 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 600x55 children: inline
-          line 0 width: 426.90625, height: 55, bottom: 55, baseline: 42.484375
-            frag 0 from TextNode start: 0, length: 18, rect: [12,12 426.90625x55]
+          frag 0 from TextNode start: 0, length: 18, rect: [12,12 426.90625x55] baseline: 42.484375
               "well hello friends"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
@@ -4,20 +4,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.wrapper> at (8,8) content-size 784x105 children: not-inline
         BlockContainer <div.float> at (592,8) content-size 200x1000 floating [BFC] children: not-inline
         BlockContainer <div.bfc> at (18,18) content-size 564x85 [BFC] children: inline
-          line 0 width: 458.125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 56, rect: [18,18 458.125x17]
+          frag 0 from TextNode start: 0, length: 56, rect: [18,18 458.125x17] baseline: 13.296875
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-          line 1 width: 511.796875, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 57, length: 60, rect: [18,35 511.796875x17]
+          frag 1 from TextNode start: 57, length: 60, rect: [18,35 511.796875x17] baseline: 13.296875
               "Pellentesque vitae neque nunc. Nam fermentum libero a lectus"
-          line 2 width: 537.078125, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 118, length: 67, rect: [18,52 537.078125x17]
+          frag 2 from TextNode start: 118, length: 67, rect: [18,52 537.078125x17] baseline: 13.296875
               "vulputate eleifend. Nam sagittis tristique augue, id sodales mauris"
-          line 3 width: 537.34375, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 186, length: 65, rect: [18,69 537.34375x17]
+          frag 3 from TextNode start: 186, length: 65, rect: [18,69 537.34375x17] baseline: 13.296875
               "suscipit at. Vivamus eget placerat ex. Suspendisse potenti. Morbi"
-          line 4 width: 455.375, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 252, length: 57, rect: [18,86 455.375x17]
+          frag 4 from TextNode start: 252, length: 57, rect: [18,86 455.375x17] baseline: 13.296875
               "pulvinar ipsum eget nulla dapibus, ac varius mi eleifend."
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height-with-containing-block-padding.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height-with-containing-block-padding.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
       BlockContainer <div.container> at (8,108) content-size 784x500 children: not-inline
         BlockContainer <div.hmm> at (18,118) content-size 764x250 children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [18,118 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [18,118 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x53 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x37 children: not-inline
       BlockContainer <div.hmm> at (18,18) content-size 764x17 children: inline
-        line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [18,18 36.84375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [18,18 36.84375x17] baseline: 13.296875
             "hello"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 200x17 children: not-inline
       BlockContainer <div> at (8,8) content-size 200x17 children: inline
-        line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
             "hello"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 0x17 children: inline
-      line 0 width: 0, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 0x0]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 0x0] baseline: 0
       BlockContainer <div> at (8,21) content-size 0x0 inline-block [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (2,2) content-size 796x62 [BFC] children: not-inline
     BlockContainer <body> at (12,12) content-size 600x42 children: not-inline
       BlockContainer <div.exekiller> at (14,14) content-size 200x17 positioned children: inline
-        line 0 width: 65.4375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17]
+        frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17] baseline: 13.296875
             "exekiller"
         TextNode <#text>
       BlockContainer <div.athena> at (24,25) content-size 200x17 positioned children: inline
-        line 0 width: 53.171875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [24,25 53.171875x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [24,25 53.171875x17] baseline: 13.296875
             "athena"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (2,2) content-size 796x31 [BFC] children: not-inline
     BlockContainer <body> at (12,12) content-size 600x0 children: not-inline
       BlockContainer <div.exekiller> at (14,14) content-size 200x17 positioned floating [BFC] children: inline
-        line 0 width: 65.4375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17]
+        frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17] baseline: 13.296875
             "exekiller"
         TextNode <#text>
       BlockContainer <div.athena> at (18,18) content-size 200x17 positioned floating [BFC] children: inline
-        line 0 width: 53.171875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17] baseline: 13.296875
             "athena"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -2,12 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x152 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
-        line 0 width: 136.609375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17] baseline: 13.296875
             "well "
-          frag 1 from TextNode start: 0, length: 6, rect: [44,33 44.84375x17]
+        frag 1 from TextNode start: 0, length: 6, rect: [44,33 44.84375x17] baseline: 13.296875
             "hello "
-          frag 2 from TextNode start: 0, length: 7, rect: [89,58 55.359375x17]
+        frag 2 from TextNode start: 0, length: 7, rect: [89,58 55.359375x17] baseline: 13.296875
             "friends"
         InlineNode <span>
           TextNode <#text>
@@ -18,23 +17,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,25) content-size 784x135 children: not-inline
         BlockContainer <(anonymous)> at (8,25) content-size 784x68 children: inline
-          line 0 width: 0, height: 17, bottom: 17, baseline: 13.296875
-          line 1 width: 0, height: 17, bottom: 34, baseline: 13.296875
-          line 2 width: 0, height: 17, bottom: 51, baseline: 13.296875
-          line 3 width: 0, height: 17, bottom: 68, baseline: 13.296875
           BreakNode <br>
           BreakNode <br>
           BreakNode <br>
           BreakNode <br>
         BlockContainer <pre#out> at (8,109) content-size 784x51 children: inline
-          line 0 width: 72.421875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [8,109 72.421875x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [8,109 72.421875x17] baseline: 13.296875
               "well: 0, 0"
-          line 1 width: 96.765625, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 11, length: 13, rect: [8,126 96.765625x17]
+          frag 1 from TextNode start: 11, length: 13, rect: [8,126 96.765625x17] baseline: 13.296875
               "hello: 36, 25"
-          line 2 width: 113.65625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 25, length: 15, rect: [8,143 113.65625x17]
+          frag 2 from TextNode start: 25, length: 15, rect: [8,143 113.65625x17] baseline: 13.296875
               "friends: 45, 25"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,176) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
@@ -1,14 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      line 0 width: 98, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 4, rect: [8,8 35.15625x17]
+      frag 0 from TextNode start: 0, length: 4, rect: [8,8 35.15625x17] baseline: 13.296875
           "foo "
-        frag 1 from TextNode start: 0, length: 3, rect: [43,33 27.640625x17]
+      frag 1 from TextNode start: 0, length: 3, rect: [43,33 27.640625x17] baseline: 13.296875
           "bar"
-        frag 2 from TextNode start: 0, length: 1, rect: [71,8 8x17]
+      frag 2 from TextNode start: 0, length: 1, rect: [71,8 8x17] baseline: 13.296875
           " "
-        frag 3 from TextNode start: 0, length: 3, rect: [54,58 27.203125x17]
+      frag 3 from TextNode start: 0, length: 3, rect: [54,58 27.203125x17] baseline: 13.296875
           "baz"
       TextNode <#text>
       InlineNode <b>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
@@ -3,7 +3,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21 children: not-inline
       BlockContainer <div#begin> at (8,8) content-size 784x2 children: not-inline
       BlockContainer <(anonymous)> at (8,10) content-size 784x17 children: inline
-        line 0 width: 0, height: 17, bottom: 17, baseline: 13.296875
         BreakNode <br>
       BlockContainer <div#end> at (8,27) content-size 784x2 children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/small-percentage-margin.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/small-percentage-margin.txt
@@ -2,23 +2,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x208 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (15.828125,8) content-size 376.3125x100 floating [BFC] children: inline
-        line 0 width: 27.703125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [15.828125,8 27.703125x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [15.828125,8 27.703125x17] baseline: 13.296875
             "abc"
         TextNode <#text>
       BlockContainer <div> at (407.796875,8) content-size 376.3125x100 floating [BFC] children: inline
-        line 0 width: 23.015625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [407.796875,8 23.015625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [407.796875,8 23.015625x17] baseline: 13.296875
             "def"
         TextNode <#text>
       BlockContainer <div> at (15.828125,108) content-size 376.3125x100 floating [BFC] children: inline
-        line 0 width: 21.421875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [15.828125,108 21.421875x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [15.828125,108 21.421875x17] baseline: 13.296875
             "ghi"
         TextNode <#text>
       BlockContainer <div> at (407.796875,108) content-size 376.3125x100 floating [BFC] children: inline
-        line 0 width: 18.40625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [407.796875,108 18.40625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [407.796875,108 18.40625x17] baseline: 13.296875
             "jkl"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
@@ -3,14 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 102x55 positioned [BFC] children: not-inline
       BlockContainer <div#container> at (11,11) content-size 100x53 children: not-inline
         BlockContainer <div#child> at (72,12) content-size 50x51 children: inline
-          line 0 width: 28.40625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [72,12 28.40625x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [72,12 28.40625x17] baseline: 13.296875
               "well"
-          line 1 width: 36.84375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 5, length: 5, rect: [72,29 36.84375x17]
+          frag 1 from TextNode start: 5, length: 5, rect: [72,29 36.84375x17] baseline: 13.296875
               "hello"
-          line 2 width: 55.359375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 11, length: 7, rect: [72,46 55.359375x17]
+          frag 2 from TextNode start: 11, length: 7, rect: [72,46 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
+++ b/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
@@ -1,12 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x67 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x51 children: inline
-      line 0 width: 89.71875, height: 51, bottom: 51, baseline: 17
-        frag 0 from Box start: 0, length: 0, rect: [28,39 49.71875x0]
+      frag 0 from Box start: 0, length: 0, rect: [28,39 49.71875x0] baseline: 6
       Box <div.button> at (28,39) content-size 49.71875x0 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (28,28) content-size 49.71875x22 flex-item [BFC] children: inline
-          line 0 width: 49.71875, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 5, rect: [28,28 49.71875x22]
+          frag 0 from TextNode start: 0, length: 5, rect: [28,28 49.71875x22] baseline: 17
               "Hello"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
+++ b/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
@@ -2,18 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x83 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x67 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x17 children: inline
-        line 0 width: 310.625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [8,16 10.625x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [8,16 10.625x17] baseline: 13.296875
             "+"
-          frag 1 from TextNode start: 0, length: 36, rect: [19,16 300x17]
+        frag 1 from TextNode start: 0, length: 36, rect: [19,16 300x17] baseline: 13.296875
             "P should generate a ::before pseudo."
         InlineNode <(anonymous)>
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49) content-size 784x34 children: inline
-        line 0 width: 0, height: 17, bottom: 17, baseline: 13.296875
-        line 1 width: 120.578125, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 14, rect: [8,66 120.578125x17]
+        frag 0 from TextNode start: 0, length: 14, rect: [8,66 120.578125x17] baseline: 13.296875
             "BR should not!"
         BreakNode <br>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/calc-font-size-with-percentages.txt
+++ b/Tests/LibWeb/Layout/expected/calc-font-size-with-percentages.txt
@@ -2,11 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
       BlockContainer <div.test> at (8,8) content-size 784x104 children: inline
-        line 0 width: 500.8125, height: 52, bottom: 52, baseline: 40.390625
-          frag 0 from TextNode start: 0, length: 20, rect: [8,8 500.8125x52]
+        frag 0 from TextNode start: 0, length: 20, rect: [8,8 500.8125x52] baseline: 40.390625
             "i resolved enough of"
-        line 1 width: 406.40625, height: 52, bottom: 104, baseline: 40.390625
-          frag 0 from TextNode start: 21, length: 16, rect: [8,60 406.40625x52]
+        frag 1 from TextNode start: 21, length: 16, rect: [8,60 406.40625x52] baseline: 40.390625
             "percentages, no?"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/calc-with-fr.txt
+++ b/Tests/LibWeb/Layout/expected/calc-with-fr.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
       Box <div.container> at (8,8) content-size 784x51 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 784x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div> at (8,25) content-size 784x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,25 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,25 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <div> at (8,42) content-size 784x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,42 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,42 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: inline
-  line 0 width: 238.125, height: 17, bottom: 17, baseline: 13.296875
-    frag 0 from TextNode start: 1, length: 18, rect: [0,0 134.984375x17]
+  frag 0 from TextNode start: 1, length: 18, rect: [0,0 134.984375x17] baseline: 13.296875
       "* { all: unset; } "
-    frag 1 from TextNode start: 0, length: 13, rect: [135,0 103.140625x17]
+  frag 1 from TextNode start: 0, length: 13, rect: [135,0 103.140625x17] baseline: 13.296875
       "Hello friends"
   InlineNode <html>
     InlineNode <head>

--- a/Tests/LibWeb/Layout/expected/css-dir-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-dir-selector.txt
@@ -2,81 +2,65 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (100,0) content-size 700x832 [BFC] children: not-inline
     BlockContainer <body> at (200,8) content-size 592x816 children: not-inline
       BlockContainer <div> at (301,9) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 11, rect: [301,9 79.96875x17]
+        frag 0 from TextNode start: 0, length: 11, rect: [301,9 79.96875x17] baseline: 13.296875
             "Well, hello"
-        line 1 width: 59.21875, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 12, length: 8, rect: [301,26 59.21875x17]
+        frag 1 from TextNode start: 12, length: 8, rect: [301,26 59.21875x17] baseline: 13.296875
             "friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,110) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,111) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 11, rect: [301,111 79.96875x17]
+        frag 0 from TextNode start: 0, length: 11, rect: [301,111 79.96875x17] baseline: 13.296875
             "Well, hello"
-        line 1 width: 59.21875, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 12, length: 8, rect: [301,128 59.21875x17]
+        frag 1 from TextNode start: 12, length: 8, rect: [301,128 59.21875x17] baseline: 13.296875
             "friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,212) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,213) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 11, rect: [401,213 79.96875x17]
+        frag 0 from TextNode start: 0, length: 11, rect: [401,213 79.96875x17] baseline: 13.296875
             "Well, hello"
-        line 1 width: 59.21875, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 12, length: 8, rect: [401,230 59.21875x17]
+        frag 1 from TextNode start: 12, length: 8, rect: [401,230 59.21875x17] baseline: 13.296875
             "friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,314) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,315) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 11, rect: [301,315 79.96875x17]
+        frag 0 from TextNode start: 0, length: 11, rect: [301,315 79.96875x17] baseline: 13.296875
             "Well, hello"
-        line 1 width: 59.21875, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 12, length: 8, rect: [301,332 59.21875x17]
+        frag 1 from TextNode start: 12, length: 8, rect: [301,332 59.21875x17] baseline: 13.296875
             "friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,416) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,417) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 26, rect: [301,417 86.125x17]
+        frag 0 from TextNode start: 0, length: 26, rect: [301,417 86.125x17] baseline: 13.296875
             "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 27, length: 25, rect: [301,434 78.125x17]
+        frag 1 from TextNode start: 27, length: 25, rect: [301,434 78.125x17] baseline: 13.296875
             "أيها الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,518) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,519) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 26, rect: [301,519 86.125x17]
+        frag 0 from TextNode start: 0, length: 26, rect: [301,519 86.125x17] baseline: 13.296875
             "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 27, length: 25, rect: [301,536 78.125x17]
+        frag 1 from TextNode start: 27, length: 25, rect: [301,536 78.125x17] baseline: 13.296875
             "أيها الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,620) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,621) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 26, rect: [401,621 86.125x17]
+        frag 0 from TextNode start: 0, length: 26, rect: [401,621 86.125x17] baseline: 13.296875
             "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 27, length: 25, rect: [401,638 78.125x17]
+        frag 1 from TextNode start: 27, length: 25, rect: [401,638 78.125x17] baseline: 13.296875
             "أيها الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,722) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,723) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 26, rect: [401,723 86.125x17]
+        frag 0 from TextNode start: 0, length: 26, rect: [401,723 86.125x17] baseline: 13.296875
             "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 27, length: 25, rect: [401,740 78.125x17]
+        frag 1 from TextNode start: 27, length: 25, rect: [401,740 78.125x17] baseline: 13.296875
             "أيها الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,824) content-size 592x0 children: inline

--- a/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x125 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x109 children: inline
-      line 0 width: 644.625, height: 109, bottom: 109, baseline: 84.484375
-        frag 0 from TextNode start: 0, length: 13, rect: [8,8 644.625x109]
+      frag 0 from TextNode start: 0, length: 13, rect: [8,8 644.625x109] baseline: 84.484375
           "Hello friends"
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-font-size-math.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-math.txt
@@ -1,16 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x79 children: inline
-      line 0 width: 78.9375, height: 79, bottom: 79, baseline: 61.09375
-        frag 0 from TextNode start: 0, length: 1, rect: [8,25 39.09375x56]
+      frag 0 from TextNode start: 0, length: 1, rect: [8,25 39.09375x56] baseline: 43.328125
           "H"
-        frag 1 from TextNode start: 0, length: 1, rect: [47,38 19.78125x40]
+      frag 1 from TextNode start: 0, length: 1, rect: [47,38 19.78125x40] baseline: 30.875
           "e"
-        frag 2 from TextNode start: 0, length: 1, rect: [67,47 6.8125x28]
+      frag 2 from TextNode start: 0, length: 1, rect: [67,47 6.8125x28] baseline: 21.71875
           "l"
-        frag 3 from TextNode start: 0, length: 1, rect: [74,53 4.84375x20]
+      frag 3 from TextNode start: 0, length: 1, rect: [74,53 4.84375x20] baseline: 15.484375
           "l"
-        frag 4 from TextNode start: 0, length: 1, rect: [79,58 8.40625x14]
+      frag 4 from TextNode start: 0, length: 1, rect: [79,58 8.40625x14] baseline: 10.890625
           "o"
       InlineNode <span>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-host-selector-gets-parsed.txt
+++ b/Tests/LibWeb/Layout/expected/css-host-selector-gets-parsed.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       BlockContainer <div> at (8,8) content-size 100x100 children: inline
-        line 0 width: 26.953125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17] baseline: 13.296875
             "whf"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-import-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-import-rule.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x55 children: inline
-      line 0 width: 137.640625, height: 55, bottom: 55, baseline: 42.484375
-        frag 0 from TextNode start: 0, length: 5, rect: [8,8 137.640625x55]
+      frag 0 from TextNode start: 0, length: 5, rect: [8,8 137.640625x55] baseline: 42.484375
           "Crazy"
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x109 children: inline
-      line 0 width: 275.296875, height: 109, bottom: 109, baseline: 84.484375
-        frag 0 from TextNode start: 0, length: 5, rect: [8,8 275.296875x109]
+      frag 0 from TextNode start: 0, length: 5, rect: [8,8 275.296875x109] baseline: 84.484375
           "Crazy"
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x52 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x34 children: not-inline
       BlockContainer <div> at (11,11) content-size 778x32 children: inline
-        line 0 width: 552.125, height: 32, bottom: 32, baseline: 28
-          frag 0 from TextNode start: 0, length: 25, rect: [11,11 552.125x32]
+        frag 0 from TextNode start: 0, length: 25, rect: [11,11 552.125x32] baseline: 28
             "The Linux Kernel Archives"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,20) content-size 784x22 children: not-inline
       BlockContainer <p> at (8,20) content-size 784x22 children: inline
-        line 0 width: 183.890625, height: 22, bottom: 22, baseline: 17
-          frag 0 from TextNode start: 0, length: 15, rect: [18,20 163.890625x22]
+        frag 0 from TextNode start: 0, length: 15, rect: [18,20 163.890625x22] baseline: 17
             "Should be green"
         TextNode <#text>
         InlineNode <a>

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,20) content-size 784x22 children: not-inline
       BlockContainer <p> at (8,20) content-size 784x22 children: inline
-        line 0 width: 151.34375, height: 22, bottom: 22, baseline: 17
-          frag 0 from TextNode start: 0, length: 13, rect: [13,20 141.34375x22]
+        frag 0 from TextNode start: 0, length: 13, rect: [13,20 141.34375x22] baseline: 17
             "Should be red"
         TextNode <#text>
         InlineNode <a>

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -2,11 +2,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x201 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x155 children: inline
-        line 0 width: 312, height: 155, bottom: 155, baseline: 152
-          frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 300x150]
-          frag 1 from TextNode start: 0, length: 1, rect: [310,146 8x17]
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 300x150] baseline: 152
+        frag 1 from TextNode start: 0, length: 1, rect: [310,146 8x17] baseline: 13.296875
             " "
-          frag 2 from Box start: 0, length: 0, rect: [319,51 0x108]
+        frag 2 from Box start: 0, length: 0, rect: [319,51 0x108] baseline: 110
         SVGSVGBox <svg> at (9,9) content-size 300x150 [SVG] children: inline
           InlineNode <a>
             SVGTextBox <text> at (29,25.015625) content-size 193.59375x67.578125 children: inline
@@ -17,8 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
         TextNode <#text>
       BlockContainer <div> at (9,164) content-size 782x44 children: inline
-        line 0 width: 101.453125, height: 44, bottom: 44, baseline: 34
-          frag 0 from TextNode start: 0, length: 5, rect: [10,164 99.453125x44]
+        frag 0 from TextNode start: 0, length: 5, rect: [10,164 99.453125x44] baseline: 34
             "Hello"
         InlineNode <a>
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.foo> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 28.40625x17 flex-item [BFC] children: inline
-          line 0 width: 28.40625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,8 28.40625x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,8 28.40625x17] baseline: 13.296875
               "well"
           TextNode <#text>
         BlockContainer <(anonymous)> at (46,8) content-size 36.84375x17 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [46,8 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [46,8 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         BlockContainer <(anonymous)> at (92.4375,8) content-size 55.359375x17 flex-item [BFC] children: inline
-          line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [92.4375,8 55.359375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [92.4375,8 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-quotes-nesting.txt
+++ b/Tests/LibWeb/Layout/expected/css-quotes-nesting.txt
@@ -2,24 +2,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x67 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
       BlockContainer <div.a> at (8,8) content-size 784x17 children: inline
-        line 0 width: 72.140625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
             "a"
-          frag 1 from TextNode start: 0, length: 1, rect: [17,8 9.46875x17]
+        frag 1 from TextNode start: 0, length: 1, rect: [17,8 9.46875x17] baseline: 13.296875
             "b"
-          frag 2 from TextNode start: 0, length: 1, rect: [27,8 8.890625x17]
+        frag 2 from TextNode start: 0, length: 1, rect: [27,8 8.890625x17] baseline: 13.296875
             "c"
-          frag 3 from TextNode start: 0, length: 1, rect: [36,8 7.859375x17]
+        frag 3 from TextNode start: 0, length: 1, rect: [36,8 7.859375x17] baseline: 13.296875
             "d"
-          frag 4 from TextNode start: 0, length: 1, rect: [44,8 8.71875x17]
+        frag 4 from TextNode start: 0, length: 1, rect: [44,8 8.71875x17] baseline: 13.296875
             "e"
-          frag 5 from TextNode start: 0, length: 1, rect: [52,8 6.4375x17]
+        frag 5 from TextNode start: 0, length: 1, rect: [52,8 6.4375x17] baseline: 13.296875
             "f"
-          frag 6 from TextNode start: 0, length: 1, rect: [59,8 7.5625x17]
+        frag 6 from TextNode start: 0, length: 1, rect: [59,8 7.5625x17] baseline: 13.296875
             "g"
-          frag 7 from TextNode start: 0, length: 1, rect: [66,8 9.296875x17]
+        frag 7 from TextNode start: 0, length: 1, rect: [66,8 9.296875x17] baseline: 13.296875
             "h"
-          frag 8 from TextNode start: 0, length: 1, rect: [76,8 4.5625x17]
+        frag 8 from TextNode start: 0, length: 1, rect: [76,8 4.5625x17] baseline: 13.296875
             "i"
         InlineNode <span>
           InlineNode <(anonymous)>
@@ -58,44 +57,43 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.b> at (8,25) content-size 784x17 children: inline
-        line 0 width: 130.578125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,25 5.84375x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,25 5.84375x17] baseline: 13.296875
             "“"
-          frag 1 from TextNode start: 0, length: 1, rect: [14,25 9.34375x17]
+        frag 1 from TextNode start: 0, length: 1, rect: [14,25 9.34375x17] baseline: 13.296875
             "a"
-          frag 2 from TextNode start: 0, length: 3, rect: [23,25 5.84375x17]
+        frag 2 from TextNode start: 0, length: 3, rect: [23,25 5.84375x17] baseline: 13.296875
             "‘"
-          frag 3 from TextNode start: 0, length: 1, rect: [29,25 9.46875x17]
+        frag 3 from TextNode start: 0, length: 1, rect: [29,25 9.46875x17] baseline: 13.296875
             "b"
-          frag 4 from TextNode start: 0, length: 3, rect: [39,25 5.84375x17]
+        frag 4 from TextNode start: 0, length: 3, rect: [39,25 5.84375x17] baseline: 13.296875
             "‘"
-          frag 5 from TextNode start: 0, length: 1, rect: [44,25 8.890625x17]
+        frag 5 from TextNode start: 0, length: 1, rect: [44,25 8.890625x17] baseline: 13.296875
             "c"
-          frag 6 from TextNode start: 0, length: 3, rect: [53,25 5.84375x17]
+        frag 6 from TextNode start: 0, length: 3, rect: [53,25 5.84375x17] baseline: 13.296875
             "‘"
-          frag 7 from TextNode start: 0, length: 1, rect: [59,25 7.859375x17]
+        frag 7 from TextNode start: 0, length: 1, rect: [59,25 7.859375x17] baseline: 13.296875
             "d"
-          frag 8 from TextNode start: 0, length: 3, rect: [67,25 5.84375x17]
+        frag 8 from TextNode start: 0, length: 3, rect: [67,25 5.84375x17] baseline: 13.296875
             "‘"
-          frag 9 from TextNode start: 0, length: 1, rect: [73,25 8.71875x17]
+        frag 9 from TextNode start: 0, length: 1, rect: [73,25 8.71875x17] baseline: 13.296875
             "e"
-          frag 10 from TextNode start: 0, length: 3, rect: [82,25 5.84375x17]
+        frag 10 from TextNode start: 0, length: 3, rect: [82,25 5.84375x17] baseline: 13.296875
             "’"
-          frag 11 from TextNode start: 0, length: 1, rect: [87,25 6.4375x17]
+        frag 11 from TextNode start: 0, length: 1, rect: [87,25 6.4375x17] baseline: 13.296875
             "f"
-          frag 12 from TextNode start: 0, length: 3, rect: [94,25 5.84375x17]
+        frag 12 from TextNode start: 0, length: 3, rect: [94,25 5.84375x17] baseline: 13.296875
             "’"
-          frag 13 from TextNode start: 0, length: 1, rect: [100,25 7.5625x17]
+        frag 13 from TextNode start: 0, length: 1, rect: [100,25 7.5625x17] baseline: 13.296875
             "g"
-          frag 14 from TextNode start: 0, length: 3, rect: [107,25 5.84375x17]
+        frag 14 from TextNode start: 0, length: 3, rect: [107,25 5.84375x17] baseline: 13.296875
             "’"
-          frag 15 from TextNode start: 0, length: 1, rect: [113,25 9.296875x17]
+        frag 15 from TextNode start: 0, length: 1, rect: [113,25 9.296875x17] baseline: 13.296875
             "h"
-          frag 16 from TextNode start: 0, length: 3, rect: [122,25 5.84375x17]
+        frag 16 from TextNode start: 0, length: 3, rect: [122,25 5.84375x17] baseline: 13.296875
             "’"
-          frag 17 from TextNode start: 0, length: 1, rect: [128,25 4.5625x17]
+        frag 17 from TextNode start: 0, length: 1, rect: [128,25 4.5625x17] baseline: 13.296875
             "i"
-          frag 18 from TextNode start: 0, length: 3, rect: [133,25 5.84375x17]
+        frag 18 from TextNode start: 0, length: 3, rect: [133,25 5.84375x17] baseline: 13.296875
             "”"
         InlineNode <span>
           InlineNode <(anonymous)>
@@ -134,44 +132,43 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.c> at (8,42) content-size 784x17 children: inline
-        line 0 width: 140.234375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [8,42 5.484375x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [8,42 5.484375x17] baseline: 13.296875
             "("
-          frag 1 from TextNode start: 0, length: 1, rect: [13,42 9.34375x17]
+        frag 1 from TextNode start: 0, length: 1, rect: [13,42 9.34375x17] baseline: 13.296875
             "a"
-          frag 2 from TextNode start: 0, length: 1, rect: [23,42 7.625x17]
+        frag 2 from TextNode start: 0, length: 1, rect: [23,42 7.625x17] baseline: 13.296875
             "{"
-          frag 3 from TextNode start: 0, length: 1, rect: [30,42 9.46875x17]
+        frag 3 from TextNode start: 0, length: 1, rect: [30,42 9.46875x17] baseline: 13.296875
             "b"
-          frag 4 from TextNode start: 0, length: 1, rect: [40,42 6.953125x17]
+        frag 4 from TextNode start: 0, length: 1, rect: [40,42 6.953125x17] baseline: 13.296875
             "["
-          frag 5 from TextNode start: 0, length: 1, rect: [47,42 8.890625x17]
+        frag 5 from TextNode start: 0, length: 1, rect: [47,42 8.890625x17] baseline: 13.296875
             "c"
-          frag 6 from TextNode start: 0, length: 1, rect: [56,42 6.953125x17]
+        frag 6 from TextNode start: 0, length: 1, rect: [56,42 6.953125x17] baseline: 13.296875
             "["
-          frag 7 from TextNode start: 0, length: 1, rect: [63,42 7.859375x17]
+        frag 7 from TextNode start: 0, length: 1, rect: [63,42 7.859375x17] baseline: 13.296875
             "d"
-          frag 8 from TextNode start: 0, length: 1, rect: [71,42 6.953125x17]
+        frag 8 from TextNode start: 0, length: 1, rect: [71,42 6.953125x17] baseline: 13.296875
             "["
-          frag 9 from TextNode start: 0, length: 1, rect: [78,42 8.71875x17]
+        frag 9 from TextNode start: 0, length: 1, rect: [78,42 8.71875x17] baseline: 13.296875
             "e"
-          frag 10 from TextNode start: 0, length: 1, rect: [86,42 7.21875x17]
+        frag 10 from TextNode start: 0, length: 1, rect: [86,42 7.21875x17] baseline: 13.296875
             "]"
-          frag 11 from TextNode start: 0, length: 1, rect: [93,42 6.4375x17]
+        frag 11 from TextNode start: 0, length: 1, rect: [93,42 6.4375x17] baseline: 13.296875
             "f"
-          frag 12 from TextNode start: 0, length: 1, rect: [100,42 7.21875x17]
+        frag 12 from TextNode start: 0, length: 1, rect: [100,42 7.21875x17] baseline: 13.296875
             "]"
-          frag 13 from TextNode start: 0, length: 1, rect: [107,42 7.5625x17]
+        frag 13 from TextNode start: 0, length: 1, rect: [107,42 7.5625x17] baseline: 13.296875
             "g"
-          frag 14 from TextNode start: 0, length: 1, rect: [115,42 7.21875x17]
+        frag 14 from TextNode start: 0, length: 1, rect: [115,42 7.21875x17] baseline: 13.296875
             "]"
-          frag 15 from TextNode start: 0, length: 1, rect: [122,42 9.296875x17]
+        frag 15 from TextNode start: 0, length: 1, rect: [122,42 9.296875x17] baseline: 13.296875
             "h"
-          frag 16 from TextNode start: 0, length: 1, rect: [131,42 7.65625x17]
+        frag 16 from TextNode start: 0, length: 1, rect: [131,42 7.65625x17] baseline: 13.296875
             "}"
-          frag 17 from TextNode start: 0, length: 1, rect: [139,42 4.5625x17]
+        frag 17 from TextNode start: 0, length: 1, rect: [139,42 4.5625x17] baseline: 13.296875
             "i"
-          frag 18 from TextNode start: 0, length: 1, rect: [143,42 4.8125x17]
+        frag 18 from TextNode start: 0, length: 1, rect: [143,42 4.8125x17] baseline: 13.296875
             ")"
         InlineNode <span>
           InlineNode <(anonymous)>

--- a/Tests/LibWeb/Layout/expected/css-revert.txt
+++ b/Tests/LibWeb/Layout/expected/css-revert.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x17 [BFC] children: not-inline
     BlockContainer <body> at (0,0) content-size 800x17 children: inline
-      line 0 width: 103.140625, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 13, rect: [0,0 103.140625x17]
+      frag 0 from TextNode start: 0, length: 13, rect: [0,0 103.140625x17] baseline: 13.296875
           "Hello friends"
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-text-transform-math-auto.txt
+++ b/Tests/LibWeb/Layout/expected/css-text-transform-math-auto.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x17 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x17 children: inline
-        line 0 width: 118.40625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 67, rect: [8,16 118.40625x17]
+        frag 0 from TextNode start: 0, length: 67, rect: [8,16 118.40625x17] baseline: 13.296875
             "𝑊𝑒𝑙𝑙, ℎ𝑒𝑙𝑙𝑜 𝑓𝑟𝑖𝑒𝑛𝑑𝑠!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/details-closed.txt
+++ b/Tests/LibWeb/Layout/expected/details-closed.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         InlineNode <details>
       ListItemBox <summary> at (32,8) content-size 760x17 children: inline
-        line 0 width: 114.625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17]
+        frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17] baseline: 13.296875
             "I'm a summary"
         TextNode <#text>
         ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline

--- a/Tests/LibWeb/Layout/expected/details-open.txt
+++ b/Tests/LibWeb/Layout/expected/details-open.txt
@@ -4,14 +4,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         InlineNode <details>
       ListItemBox <summary> at (32,8) content-size 760x17 children: inline
-        line 0 width: 114.625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17]
+        frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17] baseline: 13.296875
             "I'm a summary"
         TextNode <#text>
         ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline
       BlockContainer <slot> at (8,25) content-size 784x17 children: inline
-        line 0 width: 82.3125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 10, rect: [8,25 82.3125x17]
+        frag 0 from TextNode start: 0, length: 10, rect: [8,25 82.3125x17] baseline: 13.296875
             "I'm a node"
         TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
@@ -1,7 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x17 [BFC] children: inline
-    line 0 width: 51.75, height: 17, bottom: 17, baseline: 13.296875
-      frag 0 from TextNode start: 0, length: 7, rect: [0,0 51.75x17]
+    frag 0 from TextNode start: 0, length: 7, rect: [0,0 51.75x17] baseline: 13.296875
         "whf :^)"
     InlineNode <span>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
@@ -9,8 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.aligncenter.block-image> at (8,8) content-size 1200x600 table-box [TFC] children: inline
           Box <(anonymous)> at (8,8) content-size 1200x600 table-row children: inline
             BlockContainer <(anonymous)> at (8,8) content-size 1200x600 table-cell [BFC] children: inline
-              line 0 width: 1200, height: 600, bottom: 600, baseline: 600
-                frag 0 from ImageBox start: 0, length: 0, rect: [8,8 1200x600]
+              frag 0 from ImageBox start: 0, length: 0, rect: [8,8 1200x600] baseline: 600
               TextNode <#text>
               InlineNode <a>
                 TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/div_align.txt
+++ b/Tests/LibWeb/Layout/expected/div_align.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x608 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x137 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
-          line 0 width: 436.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 53, rect: [8,8 436.625x17]
+          frag 0 from TextNode start: 0, length: 53, rect: [8,8 436.625x17] baseline: 13.296875
               "This text and the green square are both left aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (28,45) content-size 100x100 children: not-inline
@@ -12,8 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,165) content-size 784x137 children: not-inline
         BlockContainer <(anonymous)> at (8,165) content-size 784x17 children: inline
-          line 0 width: 418.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 49, rect: [191,165 418.6875x17]
+          frag 0 from TextNode start: 0, length: 49, rect: [191,165 418.6875x17] baseline: 13.296875
               "This text and the green square are both centered:"
           TextNode <#text>
         BlockContainer <div.square> at (350,202) content-size 100x100 children: not-inline
@@ -21,8 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,322) content-size 784x137 children: not-inline
         BlockContainer <(anonymous)> at (8,322) content-size 784x17 children: inline
-          line 0 width: 447.484375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 54, rect: [345,322 447.484375x17]
+          frag 0 from TextNode start: 0, length: 54, rect: [345,322 447.484375x17] baseline: 13.296875
               "This text and the green square are both right aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (672,359) content-size 100x100 children: not-inline
@@ -30,48 +27,47 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,479) content-size 784x137 children: not-inline
         BlockContainer <(anonymous)> at (8,479) content-size 784x17 children: inline
-          line 0 width: 512.53125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,479 35.5x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,479 35.5x17] baseline: 13.296875
               "This"
-            frag 1 from TextNode start: 4, length: 1, rect: [44,479 8x17]
+          frag 1 from TextNode start: 4, length: 1, rect: [44,479 8x17] baseline: 13.296875
               " "
-            frag 2 from TextNode start: 5, length: 4, rect: [52,479 32.140625x17]
+          frag 2 from TextNode start: 5, length: 4, rect: [52,479 32.140625x17] baseline: 13.296875
               "text"
-            frag 3 from TextNode start: 9, length: 1, rect: [84,479 8x17]
+          frag 3 from TextNode start: 9, length: 1, rect: [84,479 8x17] baseline: 13.296875
               " "
-            frag 4 from TextNode start: 10, length: 2, rect: [92,479 13.90625x17]
+          frag 4 from TextNode start: 10, length: 2, rect: [92,479 13.90625x17] baseline: 13.296875
               "is"
-            frag 5 from TextNode start: 12, length: 1, rect: [106,479 8x17]
+          frag 5 from TextNode start: 12, length: 1, rect: [106,479 8x17] baseline: 13.296875
               " "
-            frag 6 from TextNode start: 13, length: 16, rect: [114,479 102.96875x17]
+          frag 6 from TextNode start: 13, length: 16, rect: [114,479 102.96875x17] baseline: 13.296875
               "'full-justified'"
-            frag 7 from TextNode start: 29, length: 1, rect: [217,479 8x17]
+          frag 7 from TextNode start: 29, length: 1, rect: [217,479 8x17] baseline: 13.296875
               " "
-            frag 8 from TextNode start: 30, length: 3, rect: [225,479 26.8125x17]
+          frag 8 from TextNode start: 30, length: 3, rect: [225,479 26.8125x17] baseline: 13.296875
               "and"
-            frag 9 from TextNode start: 33, length: 1, rect: [251,479 8x17]
+          frag 9 from TextNode start: 33, length: 1, rect: [251,479 8x17] baseline: 13.296875
               " "
-            frag 10 from TextNode start: 34, length: 3, rect: [259,479 24.875x17]
+          frag 10 from TextNode start: 34, length: 3, rect: [259,479 24.875x17] baseline: 13.296875
               "the"
-            frag 11 from TextNode start: 37, length: 1, rect: [284,479 8x17]
+          frag 11 from TextNode start: 37, length: 1, rect: [284,479 8x17] baseline: 13.296875
               " "
-            frag 12 from TextNode start: 38, length: 5, rect: [292,479 43.4375x17]
+          frag 12 from TextNode start: 38, length: 5, rect: [292,479 43.4375x17] baseline: 13.296875
               "green"
-            frag 13 from TextNode start: 43, length: 1, rect: [336,479 8x17]
+          frag 13 from TextNode start: 43, length: 1, rect: [336,479 8x17] baseline: 13.296875
               " "
-            frag 14 from TextNode start: 44, length: 6, rect: [344,479 57.0625x17]
+          frag 14 from TextNode start: 44, length: 6, rect: [344,479 57.0625x17] baseline: 13.296875
               "square"
-            frag 15 from TextNode start: 50, length: 1, rect: [401,479 8x17]
+          frag 15 from TextNode start: 50, length: 1, rect: [401,479 8x17] baseline: 13.296875
               " "
-            frag 16 from TextNode start: 51, length: 2, rect: [409,479 13.90625x17]
+          frag 16 from TextNode start: 51, length: 2, rect: [409,479 13.90625x17] baseline: 13.296875
               "is"
-            frag 17 from TextNode start: 53, length: 1, rect: [423,479 8x17]
+          frag 17 from TextNode start: 53, length: 1, rect: [423,479 8x17] baseline: 13.296875
               " "
-            frag 18 from TextNode start: 54, length: 4, rect: [431,479 26.25x17]
+          frag 18 from TextNode start: 54, length: 4, rect: [431,479 26.25x17] baseline: 13.296875
               "left"
-            frag 19 from TextNode start: 58, length: 1, rect: [457,479 8x17]
+          frag 19 from TextNode start: 58, length: 1, rect: [457,479 8x17] baseline: 13.296875
               " "
-            frag 20 from TextNode start: 59, length: 8, rect: [465,479 55.671875x17]
+          frag 20 from TextNode start: 59, length: 8, rect: [465,479 55.671875x17] baseline: 13.296875
               "aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (28,516) content-size 100x100 children: not-inline

--- a/Tests/LibWeb/Layout/expected/div_align_nested.txt
+++ b/Tests/LibWeb/Layout/expected/div_align_nested.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x251 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x251 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
-          line 0 width: 447.484375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 54, rect: [345,8 447.484375x17]
+          frag 0 from TextNode start: 0, length: 54, rect: [345,8 447.484375x17] baseline: 13.296875
               "This text and the green square are both right aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (692,25) content-size 100x100 children: not-inline
@@ -12,11 +11,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <div> at (8,125) content-size 784x134 children: not-inline
           BlockContainer <(anonymous)> at (8,125) content-size 784x34 children: inline
-            line 0 width: 711.4375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 87, rect: [8,125 711.4375x17]
+            frag 0 from TextNode start: 1, length: 87, rect: [8,125 711.4375x17] baseline: 13.296875
                 "This text and the green square are both left aligned despite being nested in a div with"
-            line 1 width: 94.296875, height: 17, bottom: 34, baseline: 13.296875
-              frag 0 from TextNode start: 89, length: 14, rect: [8,142 94.296875x17]
+            frag 1 from TextNode start: 89, length: 14, rect: [8,142 94.296875x17] baseline: 13.296875
                 "align="right":"
             TextNode <#text>
           BlockContainer <div.square> at (8,159) content-size 100x100 children: inline

--- a/Tests/LibWeb/Layout/expected/dont-crash-on-relayout-that-rewraps-text.txt
+++ b/Tests/LibWeb/Layout/expected/dont-crash-on-relayout-that-rewraps-text.txt
@@ -1,19 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x56 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 200x38 children: inline
-      line 0 width: 196.0625, height: 19, bottom: 19, baseline: 14.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 194.0625x17]
-      line 1 width: 138.265625, height: 19, bottom: 38, baseline: 14.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,30 136.265625x17]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 194.0625x17] baseline: 14.296875
+      frag 1 from BlockContainer start: 0, length: 0, rect: [11,30 136.265625x17] baseline: 14.296875
       BlockContainer <div> at (11,11) content-size 194.0625x17 inline-block [BFC] children: inline
-        line 0 width: 194.0625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 20, rect: [11,11 194.0625x17]
+        frag 0 from TextNode start: 0, length: 20, rect: [11,11 194.0625x17] baseline: 13.296875
             "xxxxxxxxxxxxxxxxxxxx"
         TextNode <#text>
       TextNode <#text>
       BlockContainer <div> at (11,30) content-size 136.265625x17 inline-block [BFC] children: inline
-        line 0 width: 136.265625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 19, rect: [11,30 136.265625x17]
+        frag 0 from TextNode start: 0, length: 19, rect: [11,30 136.265625x17] baseline: 13.296875
             "yyyyyyyyyyyyyyyyyyy"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/element-use-pseudo-element.txt
+++ b/Tests/LibWeb/Layout/expected/element-use-pseudo-element.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x22 children: inline
-      line 0 width: 300, height: 22, bottom: 22, baseline: 17
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,13 300x12]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,13 300x12] baseline: 12
       BlockContainer <progress#a> at (8,13) content-size 300x12 inline-block [BFC] children: not-inline
         BlockContainer <div> at (9,14) content-size 298x12 children: not-inline
           BlockContainer <div> at (9,14) content-size 298x12 children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex-auto.txt
+++ b/Tests/LibWeb/Layout/expected/flex-auto.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 164.671875x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (176.671875,10) content-size 164.671875x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [176.671875,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [176.671875,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (343.34375,10) content-size 164.671875x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [343.34375,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [343.34375,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,112) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (135,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [135,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [135,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,93.328125) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,93.328125 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,93.328125 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,176.65625) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,176.65625 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,176.65625 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,93.328125) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,93.328125 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,93.328125 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,176.65625) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,176.65625 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,176.65625 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,93.328125) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,93.328125 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,93.328125 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,176.65625) content-size 100x81.328125 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,176.65625 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,176.65625 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,112) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,214) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,214 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,214 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
@@ -2,20 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x89 [BFC] children: not-inline
     Box <body> at (2,2) content-size 796x87 flex-container(column) [FFC] children: not-inline
       BlockContainer <main> at (3,3) content-size 400x85 flex-item [BFC] children: inline
-        line 0 width: 346.984375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 41, rect: [3,3 346.984375x17]
+        frag 0 from TextNode start: 0, length: 41, rect: [3,3 346.984375x17] baseline: 13.296875
             "For my day job I'm currently working as a"
-        line 1 width: 337.59375, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 42, length: 39, rect: [3,20 337.59375x17]
+        frag 1 from TextNode start: 42, length: 39, rect: [3,20 337.59375x17] baseline: 13.296875
             "Software Engineer at For my day job I'm"
-        line 2 width: 368.203125, height: 17, bottom: 51, baseline: 13.296875
-          frag 0 from TextNode start: 82, length: 43, rect: [3,37 368.203125x17]
+        frag 2 from TextNode start: 82, length: 43, rect: [3,37 368.203125x17] baseline: 13.296875
             "currently working as a Software Engineer at"
-        line 3 width: 346.984375, height: 17, bottom: 68, baseline: 13.296875
-          frag 0 from TextNode start: 126, length: 41, rect: [3,54 346.984375x17]
+        frag 3 from TextNode start: 126, length: 41, rect: [3,54 346.984375x17] baseline: 13.296875
             "For my day job I'm currently working as a"
-        line 4 width: 175.40625, height: 17, bottom: 85, baseline: 13.296875
-          frag 0 from TextNode start: 168, length: 20, rect: [3,71 175.40625x17]
+        frag 4 from TextNode start: 168, length: 20, rect: [3,71 175.40625x17] baseline: 13.296875
             "Software Engineer at"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
@@ -2,20 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x334 [BFC] children: not-inline
     Box <body.hero> at (2,2) content-size 600x332 flex-container(column) [FFC] children: not-inline
       BlockContainer <div.header> at (102,3) content-size 400x330 flex-item [BFC] children: inline
-        line 0 width: 340.484375, height: 66, bottom: 66, baseline: 50.984375
-          frag 0 from TextNode start: 0, length: 11, rect: [102,3 340.484375x66]
+        frag 0 from TextNode start: 0, length: 11, rect: [102,3 340.484375x66] baseline: 50.984375
             "This entire"
-        line 1 width: 341.25, height: 66, bottom: 132, baseline: 50.984375
-          frag 0 from TextNode start: 12, length: 11, rect: [102,69 341.25x66]
+        frag 1 from TextNode start: 12, length: 11, rect: [102,69 341.25x66] baseline: 50.984375
             "text should"
-        line 2 width: 274.15625, height: 66, bottom: 198, baseline: 50.984375
-          frag 0 from TextNode start: 24, length: 8, rect: [102,135 274.15625x66]
+        frag 2 from TextNode start: 24, length: 8, rect: [102,135 274.15625x66] baseline: 50.984375
             "be on an"
-        line 3 width: 204.078125, height: 66, bottom: 264, baseline: 50.984375
-          frag 0 from TextNode start: 33, length: 6, rect: [102,201 204.078125x66]
+        frag 3 from TextNode start: 33, length: 6, rect: [102,201 204.078125x66] baseline: 50.984375
             "orange"
-        line 4 width: 351.5625, height: 66, bottom: 330, baseline: 50.984375
-          frag 0 from TextNode start: 40, length: 11, rect: [102,267 351.5625x66]
+        frag 4 from TextNode start: 40, length: 11, rect: [102,267 351.5625x66] baseline: 50.984375
             "background."
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
@@ -2,20 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x455 [BFC] children: not-inline
     Box <body.hero> at (10,10) content-size 500x437 flex-container(column) [FFC] children: not-inline
       BlockContainer <div.upper> at (10,11) content-size 500x435 flex-item [BFC] children: inline
-        line 0 width: 453.984375, height: 87, bottom: 87, baseline: 67.484375
-          frag 0 from TextNode start: 0, length: 11, rect: [10,11 453.984375x87]
+        frag 0 from TextNode start: 0, length: 11, rect: [10,11 453.984375x87] baseline: 67.484375
             "This entire"
-        line 1 width: 455, height: 87, bottom: 174, baseline: 67.484375
-          frag 0 from TextNode start: 12, length: 11, rect: [10,98 455x87]
+        frag 1 from TextNode start: 12, length: 11, rect: [10,98 455x87] baseline: 67.484375
             "text should"
-        line 2 width: 230.78125, height: 87, bottom: 261, baseline: 67.484375
-          frag 0 from TextNode start: 24, length: 5, rect: [10,185 230.78125x87]
+        frag 2 from TextNode start: 24, length: 5, rect: [10,185 230.78125x87] baseline: 67.484375
             "be on"
-        line 3 width: 272.109375, height: 87, bottom: 348, baseline: 67.484375
-          frag 0 from TextNode start: 30, length: 6, rect: [10,272 272.109375x87]
+        frag 3 from TextNode start: 30, length: 6, rect: [10,272 272.109375x87] baseline: 67.484375
             "orange"
-        line 4 width: 468.75, height: 87, bottom: 435, baseline: 67.484375
-          frag 0 from TextNode start: 37, length: 11, rect: [10,359 468.75x87]
+        frag 4 from TextNode start: 37, length: 11, rect: [10,359 468.75x87] baseline: 67.484375
             "background."
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (93.328125,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [93.328125,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [93.328125,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (176.65625,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [176.65625,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [176.65625,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (112,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,112) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,112 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,112 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (93.328125,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [93.328125,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [93.328125,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (176.65625,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [176.65625,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [176.65625,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
+++ b/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
@@ -3,28 +3,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x52 children: not-inline
       Box <div.flexbox> at (11,11) content-size 778x50 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 136.3125x48 flex-item [BFC] children: inline
-          line 0 width: 136.3125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 15, rect: [12,12 136.3125x17]
+          frag 0 from TextNode start: 0, length: 15, rect: [12,12 136.3125x17] baseline: 13.296875
               "LongPieceOfText"
           TextNode <#text>
         BlockContainer <div> at (150.3125,12) content-size 136.3125x48 flex-item [BFC] children: inline
-          line 0 width: 136.3125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 15, rect: [150.3125,12 136.3125x17]
+          frag 0 from TextNode start: 0, length: 15, rect: [150.3125,12 136.3125x17] baseline: 13.296875
               "LongPieceOfText"
           TextNode <#text>
         BlockContainer <div> at (288.625,12) content-size 136.3125x48 flex-item [BFC] children: inline
-          line 0 width: 136.3125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 15, rect: [288.625,12 136.3125x17]
+          frag 0 from TextNode start: 0, length: 15, rect: [288.625,12 136.3125x17] baseline: 13.296875
               "LongPieceOfText"
           TextNode <#text>
         BlockContainer <div> at (426.9375,12) content-size 136.3125x48 flex-item [BFC] children: inline
-          line 0 width: 136.3125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 15, rect: [426.9375,12 136.3125x17]
+          frag 0 from TextNode start: 0, length: 15, rect: [426.9375,12 136.3125x17] baseline: 13.296875
               "LongPieceOfText"
           TextNode <#text>
         BlockContainer <div.last.item> at (565.25,12) content-size 222.75x48 flex-item [BFC] children: inline
-          line 0 width: 136.3125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 15, rect: [565.25,12 136.3125x17]
+          frag 0 from TextNode start: 0, length: 15, rect: [565.25,12 136.3125x17] baseline: 13.296875
               "LongPieceOfText"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x17 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,29) content-size 100x17 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,29 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,29 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,48) content-size 100x17 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,48 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,48 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-grow-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-1.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 229.328125x100 flex-item [BFC] children: inline
-          line 0 width: 144.546875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 17, rect: [10,10 144.546875x17]
+          frag 0 from TextNode start: 0, length: 17, rect: [10,10 144.546875x17] baseline: 13.296875
               "1 I grow the most"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (241.328125,10) content-size 164.671875x100 flex-item [BFC] children: inline
-          line 0 width: 67.375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [241.328125,10 67.375x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [241.328125,10 67.375x17] baseline: 13.296875
               "2 I grow"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (408,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 68, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [408,10 68x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [408,10 68x17] baseline: 13.296875
               "3 I don't"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-grow-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-2.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 82.328125x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (94.328125,10) content-size 164.671875x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [94.328125,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [94.328125,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (261,10) content-size 247x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [261,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [261,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body.outer> at (8,8) content-size 400x100 flex-container(column) [FFC] children: not-inline
       Box <div.inner> at (8,8) content-size 400x17 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 348.609375x17 flex-item [BFC] children: inline
-          line 0 width: 348.609375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 40, rect: [8,8 348.609375x17]
+          frag 0 from TextNode start: 0, length: 40, rect: [8,8 348.609375x17] baseline: 13.296875
               "The orange box should have a snug height"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
@@ -7,8 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.flex-item> at (12,72) content-size 27.15625x18 flex-item [BFC] children: inline
-          line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17] baseline: 13.296875
               "foo"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.flexrow> at (11,11) content-size 778x19 flex-container(row) [FFC] children: not-inline
         Box <div.project> at (12,12) content-size 44.03125x19 flex-container(column) flex-item [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,12) content-size 44.03125x17 flex-item [BFC] children: inline
-            line 0 width: 44.03125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 6, rect: [12,12 44.03125x17]
+            frag 0 from TextNode start: 0, length: 6, rect: [12,12 44.03125x17] baseline: 13.296875
                 "pillow"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x54 children: not-inline
       Box <div.container> at (9,9) content-size 600x52 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.box> at (20,10) content-size 150x50 flex-item [BFC] children: inline
-          line 0 width: 86.359375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 11, rect: [20,10 86.359375x17]
+          frag 0 from TextNode start: 0, length: 11, rect: [20,10 86.359375x17] baseline: 13.296875
               "left margin"
           TextNode <#text>
         BlockContainer <div.box> at (172,10) content-size 150x50 flex-item [BFC] children: inline
-          line 0 width: 141.28125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 18, rect: [172,10 141.28125x17]
+          frag 0 from TextNode start: 0, length: 18, rect: [172,10 141.28125x17] baseline: 13.296875
               "follow immediately"
           TextNode <#text>
         BlockContainer <div.box> at (458,10) content-size 150x50 flex-item [BFC] children: inline
-          line 0 width: 138.296875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 17, rect: [458,10 138.296875x17]
+          frag 0 from TextNode start: 0, length: 17, rect: [458,10 138.296875x17] baseline: 13.296875
               "over at the right"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,62) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/flex-row.txt
+++ b/Tests/LibWeb/Layout/expected/flex-row.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (112,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (214,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [214,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [214,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
@@ -5,31 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 62.671875x100 flex-item [BFC] children: inline
-          line 0 width: 18.9375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [10,10 18.9375x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [10,10 18.9375x17] baseline: 13.296875
               "1 I"
-          line 1 width: 49.359375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 4, length: 6, rect: [10,27 49.359375x17]
+          frag 1 from TextNode start: 4, length: 6, rect: [10,27 49.359375x17] baseline: 13.296875
               "shrink"
-          line 2 width: 24.875, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 11, length: 3, rect: [10,44 24.875x17]
+          frag 2 from TextNode start: 11, length: 3, rect: [10,44 24.875x17] baseline: 13.296875
               "the"
-          line 3 width: 38.765625, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 15, length: 4, rect: [10,61 38.765625x17]
+          frag 3 from TextNode start: 15, length: 4, rect: [10,61 38.765625x17] baseline: 13.296875
               "most"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (74.671875,10) content-size 81.328125x100 flex-item [BFC] children: inline
-          line 0 width: 78.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [74.671875,10 78.765625x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [74.671875,10 78.765625x17] baseline: 13.296875
               "2 I shrink"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (158,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 68, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [158,10 68x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [158,10 68x17] baseline: 13.296875
               "3 I don't"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 47x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (59,10) content-size 164.671875x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [59,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [59,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (225.671875,10) content-size 282.328125x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [225.671875,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [225.671875,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (112,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.box> at (214,10) content-size 100x100 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [214,10 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [214,10 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -5,72 +5,63 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.outer.normal> at (38,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (48,48) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 54.578125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [48,48 54.578125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [48,48 54.578125x17] baseline: 13.296875
               "normal"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.stretch> at (208,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (218,48) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 58.796875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [218,48 58.796875x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [218,48 58.796875x17] baseline: 13.296875
               "stretch"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.start> at (378,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (388,48) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [388,48 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [388,48 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.flex-start> at (548,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (558,48) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [558,48 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [558,48 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.end> at (38,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (48,308) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [48,308 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [48,308 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.flex-end> at (208,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (218,308) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [218,308 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [218,308 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.center> at (378,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (388,258) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [388,258 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [388,258 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.self-start> at (548,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (558,218) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.453125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [558,218 76.453125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [558,218 76.453125x17] baseline: 13.296875
               "self-start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.self-end> at (38,378) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div> at (48,478) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.40625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [48,478 61.40625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [48,478 61.40625x17] baseline: 13.296875
               "self-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -5,256 +5,224 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.row.outer.start> at (53,53) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (68,68) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [68,68 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [68,68 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,128) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-start> at (53,143) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (68,158) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [68,158 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [68,158 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,218) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.end> at (53,233) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (188,248) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [188,248 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [188,248 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,308) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-end> at (53,323) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (188,338) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [188,338 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [188,338 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,398) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.center> at (53,413) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (128,428) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [128,428 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [128,428 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,488) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-around> at (53,503) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (128,518) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [128,518 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [128,518 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,578) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-between> at (53,593) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (68,608) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [68,608 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [68,608 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,668) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-evenly> at (53,683) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (128,698) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [128,698 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [128,698 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,758) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.start> at (53,773) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,788) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [68,788 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [68,788 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,848) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-start> at (53,863) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (188,878) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [188,878 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [188,878 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,938) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.end> at (53,953) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (188,968) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [188,968 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [188,968 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1028) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-end> at (53,1043) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,1058) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [68,1058 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [68,1058 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1118) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.center> at (53,1133) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (128,1148) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [128,1148 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [128,1148 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1208) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-around> at (53,1223) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (128,1238) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [128,1238 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [128,1238 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1298) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-between> at (53,1313) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (188,1328) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [188,1328 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [188,1328 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1388) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-evenly> at (53,1403) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (128,1418) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [128,1418 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [128,1418 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1478) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.start> at (53,1493) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,1508) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [68,1508 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [68,1508 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1568) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-start> at (53,1583) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,1598) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [68,1598 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [68,1598 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1658) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.end> at (53,1673) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,1668) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [68,1668 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [68,1668 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1748) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-end> at (53,1763) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,1758) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [68,1758 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [68,1758 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1838) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.center> at (53,1853) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,1858) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [68,1858 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [68,1858 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1928) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-around> at (53,1943) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,1948) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [68,1948 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [68,1948 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2018) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-between> at (53,2033) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,2048) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [68,2048 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [68,2048 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2108) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-evenly> at (53,2123) content-size 300x60 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (68,2128) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [68,2128 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [68,2128 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2198) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.start> at (53,2213) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2228) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [68,2228 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [68,2228 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2288) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-start> at (53,2303) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2298) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [68,2298 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [68,2298 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2378) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.end> at (53,2393) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2388) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [68,2388 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [68,2388 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2468) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-end> at (53,2483) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2498) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [68,2498 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [68,2498 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2558) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.center> at (53,2573) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2578) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [68,2578 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [68,2578 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2648) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-around> at (53,2663) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2668) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [68,2668 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [68,2668 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2738) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-between> at (53,2753) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2748) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [68,2748 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [68,2748 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2828) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-evenly> at (53,2843) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (68,2848) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [68,2848 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [68,2848 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2918) content-size 724x0 children: inline

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-padding-on-flex-container.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-padding-on-flex-container.txt
@@ -5,8 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#absolute> at (18,18) content-size 50x50 positioned [BFC] children: not-inline
           BlockContainer <div#orange> at (18,18) content-size 50x50 children: not-inline
         BlockContainer <div#red> at (18,18) content-size 9.703125x17 flex-item [BFC] children: inline
-          line 0 width: 9.703125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,18 9.703125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,18 9.703125x17] baseline: 13.296875
               "x"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/align-keywords-start-and-end.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-keywords-start-and-end.txt
@@ -3,28 +3,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x265 children: not-inline
       Box <div.flex.row.align-start> at (11,11) content-size 500x200 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 136.5x17 flex-item [BFC] children: inline
-          line 0 width: 136.5, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 18, rect: [12,12 136.5x17]
+          frag 0 from TextNode start: 0, length: 18, rect: [12,12 136.5x17] baseline: 13.296875
               "align-items: start"
           TextNode <#text>
       Box <div.flex.align-end> at (11,213) content-size 500x19 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,214) content-size 121.453125x17 flex-item [BFC] children: inline
-          line 0 width: 121.453125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 16, rect: [12,214 121.453125x17]
+          frag 0 from TextNode start: 0, length: 16, rect: [12,214 121.453125x17] baseline: 13.296875
               "align-items: end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,233) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.flex.align-start> at (11,234) content-size 500x19 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,235) content-size 136.5x17 flex-item [BFC] children: inline
-          line 0 width: 136.5, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 18, rect: [12,235 136.5x17]
+          frag 0 from TextNode start: 0, length: 18, rect: [12,235 136.5x17] baseline: 13.296875
               "align-items: start"
           TextNode <#text>
       Box <div.flex.column.align-end> at (11,255) content-size 500x19 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (388.546875,256) content-size 121.453125x17 flex-item [BFC] children: inline
-          line 0 width: 121.453125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 16, rect: [388.546875,256 121.453125x17]
+          frag 0 from TextNode start: 0, length: 16, rect: [388.546875,256 121.453125x17] baseline: 13.296875
               "align-items: end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,275) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/flex/automatic-minimum-size-with-explicit-flex-basis-and-flex-container-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/automatic-minimum-size-with-explicit-flex-basis-and-flex-container-with-max-content-main-size.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x68 [BFC] children: not-inline
     Box <body.flex> at (10,10) content-size 38.84375x50 flex-container(row) [FFC] children: not-inline
       BlockContainer <div.item> at (11,11) content-size 36.84375x48 flex-item [BFC] children: inline
-        line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17] baseline: 13.296875
             "hello"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x42 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x24 children: not-inline
       BlockContainer <div.first> at (11,11) content-size 778x22 children: inline
-        line 0 width: 22, height: 22, bottom: 22, baseline: 22
-          frag 0 from Box start: 0, length: 0, rect: [22,22 0x0]
+        frag 0 from Box start: 0, length: 0, rect: [22,22 0x0] baseline: 22
         Box <span.second> at (22,22) content-size 0x0 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (22,22) content-size 0x0 [BFC] children: inline
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/br-element-does-not-get-blockified-by-itself.txt
+++ b/Tests/LibWeb/Layout/expected/flex/br-element-does-not-get-blockified-by-itself.txt
@@ -3,14 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
       Box <div> at (8,8) content-size 784x51 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 55.359375x51 flex-item [BFC] children: inline
-          line 0 width: 28.40625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 4, rect: [8,8 28.40625x17]
+          frag 0 from TextNode start: 1, length: 4, rect: [8,8 28.40625x17] baseline: 13.296875
               "well"
-          line 1 width: 36.84375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 5, rect: [8,25 36.84375x17]
+          frag 1 from TextNode start: 1, length: 5, rect: [8,25 36.84375x17] baseline: 13.296875
               "hello"
-          line 2 width: 55.359375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 7, rect: [8,42 55.359375x17]
+          frag 2 from TextNode start: 1, length: 7, rect: [8,42 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
           BreakNode <br>

--- a/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
@@ -3,23 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x62 children: not-inline
       Box <div.flex-container> at (11,11) content-size 778x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.flex-item> at (12,12) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 58.40625, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 6, rect: [12,12 58.40625x22]
+          frag 0 from TextNode start: 0, length: 6, rect: [12,12 58.40625x22] baseline: 17
               "Item 1"
           TextNode <#text>
         BlockContainer <div.flex-item> at (401,12) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 61.484375, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 6, rect: [401,12 61.484375x22]
+          frag 0 from TextNode start: 0, length: 6, rect: [401,12 61.484375x22] baseline: 17
               "Item 2"
           TextNode <#text>
         BlockContainer <div.flex-item> at (12,42) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 61.84375, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 6, rect: [12,42 61.84375x22]
+          frag 0 from TextNode start: 0, length: 6, rect: [12,42 61.84375x22] baseline: 17
               "Item 3"
           TextNode <#text>
         BlockContainer <div.flex-item> at (401,42) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 60.15625, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 6, rect: [401,42 60.15625x22]
+          frag 0 from TextNode start: 0, length: 6, rect: [401,42 60.15625x22] baseline: 17
               "Item 4"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
+++ b/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
@@ -3,26 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x223 children: not-inline
       Box <div.outer.flex.flex-wrap> at (11,11) content-size 778x221 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.inner> at (12,62) content-size 776x119 flex-item [BFC] children: inline
-          line 0 width: 741.640625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 90, rect: [12,62 741.640625x17]
+          frag 0 from TextNode start: 0, length: 90, rect: [12,62 741.640625x17] baseline: 13.296875
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus interdum libero et urna"
-          line 1 width: 765.03125, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 91, length: 95, rect: [12,79 765.03125x17]
+          frag 1 from TextNode start: 91, length: 95, rect: [12,79 765.03125x17] baseline: 13.296875
               "sodales auctor. Nullam sodales bibendum turpis quis blandit. Ut fringilla erat et erat laoreet,"
-          line 2 width: 747.5625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 187, length: 90, rect: [12,96 747.5625x17]
+          frag 2 from TextNode start: 187, length: 90, rect: [12,96 747.5625x17] baseline: 13.296875
               "faucibus rhoncus orci hendrerit. Etiam at sagittis diam. Etiam nec neque non dolor iaculis"
-          line 3 width: 732.109375, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 278, length: 90, rect: [12,113 732.109375x17]
+          frag 3 from TextNode start: 278, length: 90, rect: [12,113 732.109375x17] baseline: 13.296875
               "finibus euismod eget erat. Pellentesque vitae purus vitae nisi vehicula vestibulum quis ut"
-          line 4 width: 759.453125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 369, length: 95, rect: [12,130 759.453125x17]
+          frag 4 from TextNode start: 369, length: 95, rect: [12,130 759.453125x17] baseline: 13.296875
               "diam. Integer convallis, justo ullamcorper sollicitudin varius, enim enim pellentesque erat, eu"
-          line 5 width: 767.1875, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 465, length: 94, rect: [12,147 767.1875x17]
+          frag 5 from TextNode start: 465, length: 94, rect: [12,147 767.1875x17] baseline: 13.296875
               "pellentesque sem arcu eu purus. Phasellus id erat sed felis luctus mollis eget sit amet dolor."
-          line 6 width: 765.578125, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 560, length: 95, rect: [12,164 765.578125x17]
+          frag 6 from TextNode start: 560, length: 95, rect: [12,164 765.578125x17] baseline: 13.296875
               "Pellentesque eget justo nulla. Duis consectetur imperdiet nisi, ac tincidunt urna blandit quis."
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-percentage-max-width.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 54x102 children: not-inline
       Box <div.flex> at (11,11) content-size 52x100 flex-container(column) [FFC] children: not-inline
         BlockContainer <div.hmm> at (12,12) content-size 50x17 flex-item [BFC] children: inline
-          line 0 width: 39.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17] baseline: 13.296875
               "Hello"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body.outer> at (18,18) content-size 280.84375x17 children: not-inline
       Box <div.inner> at (18,18) content-size 280.84375x17 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (18,18) content-size 280.84375x17 flex-item [BFC] children: inline
-          line 0 width: 280.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 35, rect: [18,18 280.84375x17]
+          frag 0 from TextNode start: 0, length: 35, rect: [18,18 280.84375x17] baseline: 13.296875
               "this text should be all on one line"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
@@ -7,17 +7,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       BlockContainer <div.buttons> at (394.625,11) content-size 114.375x50 flex-item [BFC] children: inline
-        line 0 width: 114.375, height: 19, bottom: 19, baseline: 14.296875
-          frag 0 from BlockContainer start: 0, length: 0, rect: [395.625,12 57.046875x17]
-          frag 1 from BlockContainer start: 0, length: 0, rect: [454.625,12 53.328125x17]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [395.625,12 57.046875x17] baseline: 14.296875
+        frag 1 from BlockContainer start: 0, length: 0, rect: [454.625,12 53.328125x17] baseline: 14.296875
         BlockContainer <div.button> at (395.625,12) content-size 57.046875x17 inline-block [BFC] children: inline
-          line 0 width: 57.046875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [395.625,12 57.046875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [395.625,12 57.046875x17] baseline: 13.296875
               "Accept"
           TextNode <#text>
         BlockContainer <div.button> at (454.625,12) content-size 53.328125x17 inline-block [BFC] children: inline
-          line 0 width: 53.328125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [454.625,12 53.328125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [454.625,12 53.328125x17] baseline: 13.296875
               "Reject"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
@@ -3,14 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body.pink> at (8,8) content-size 784x51 flex-container(row) [FFC] children: not-inline
       Box <div.orange> at (8,8) content-size 194.71875x51 flex-container(row) flex-item [FFC] children: not-inline
         BlockContainer <div.lime> at (8,8) content-size 87.359375x51 flex-item [BFC] children: inline
-          line 0 width: 74.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,8 74.75x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,8 74.75x17] baseline: 13.296875
               "This is a"
-          line 1 width: 71.828125, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 10, length: 8, rect: [8,25 71.828125x17]
+          frag 1 from TextNode start: 10, length: 8, rect: [8,25 71.828125x17] baseline: 13.296875
               "bunch of"
-          line 2 width: 32.140625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 19, length: 4, rect: [8,42 32.140625x17]
+          frag 2 from TextNode start: 19, length: 4, rect: [8,42 32.140625x17] baseline: 13.296875
               "text"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-with-centered-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-with-centered-content.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
       Box <div.flex> at (8,8) content-size 784x50 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (425,8) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [425,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [425,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div> at (375,8) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [375,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [375,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <div> at (325,8) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [325,8 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [325,8 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/flex-shorthand-flex-basis-zero-percent.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-shorthand-flex-basis-zero-percent.txt
@@ -3,28 +3,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x108 children: not-inline
       Box <div.flex> at (11,11) content-size 500x52 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 36.84375x52 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         Box <div.item.one> at (48.84375,12) content-size 461.15625x50 flex-container(row) flex-item [FFC] children: not-inline
           BlockContainer <(anonymous)> at (48.84375,12) content-size 55.359375x50 flex-item [BFC] children: inline
-            line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 7, rect: [48.84375,12 55.359375x17]
+            frag 0 from TextNode start: 0, length: 7, rect: [48.84375,12 55.359375x17] baseline: 13.296875
                 "friends"
             TextNode <#text>
       BlockContainer <(anonymous)> at (10,64) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.flex> at (11,65) content-size 500x52 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (11,65) content-size 36.84375x52 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [11,65 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [11,65 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         Box <div.item.two> at (48.84375,66) content-size 461.15625x50 flex-container(row) flex-item [FFC] children: not-inline
           BlockContainer <(anonymous)> at (48.84375,66) content-size 55.359375x50 flex-item [BFC] children: inline
-            line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 7, rect: [48.84375,66 55.359375x17]
+            frag 0 from TextNode start: 0, length: 7, rect: [48.84375,66 55.359375x17] baseline: 13.296875
                 "friends"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     Box <body> at (8,8) content-size 784x17 flex-container(column) [FFC] children: not-inline
       BlockContainer <main> at (8,8) content-size 784x17 flex-item [BFC] children: inline
-        line 0 width: 153.984375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 13, rect: [8,8 153.984375x17]
+        frag 0 from TextNode start: 0, length: 13, rect: [8,8 153.984375x17] baseline: 13.296875
             "hmmMMMMmmmmmm"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 500x37 [BFC] children: inline
-    line 0 width: 272.40625, height: 37, bottom: 37, baseline: 15.296875
-      frag 0 from Box start: 0, length: 0, rect: [10,10 162.40625x19]
+    frag 0 from Box start: 0, length: 0, rect: [10,10 162.40625x19] baseline: 15.296875
     Box <body> at (10,10) content-size 162.40625x19 flex-container(row) [FFC] children: not-inline
       BlockContainer <div> at (11,11) content-size 160.40625x17 flex-item [BFC] children: inline
-        line 0 width: 160.40625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 20, rect: [11,11 160.40625x17]
+        frag 0 from TextNode start: 0, length: 20, rect: [11,11 160.40625x17] baseline: 13.296875
             "Immobilie inserieren"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-column-items-with-different-kinds-of-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-column-items-with-different-kinds-of-width.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.px> at (11,11) content-size 200x19 flex-item [BFC] children: not-inline
         Box <div.inner> at (12,12) content-size 198x17 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,12) content-size 19.125x17 flex-item [BFC] children: inline
-            line 0 width: 19.125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 2, rect: [12,12 19.125x17]
+            frag 0 from TextNode start: 0, length: 2, rect: [12,12 19.125x17] baseline: 13.296875
                 "px"
             TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -15,8 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.percentage> at (11,32) content-size 50x19 flex-item [BFC] children: not-inline
         Box <div.inner> at (12,33) content-size 48x17 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,33) content-size 86.671875x17 flex-item [BFC] children: inline
-            line 0 width: 86.671875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 10, rect: [12,33 86.671875x17]
+            frag 0 from TextNode start: 0, length: 10, rect: [12,33 86.671875x17] baseline: 13.296875
                 "percentage"
             TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -24,8 +22,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.fit-content> at (11,53) content-size 88.765625x19 flex-item [BFC] children: not-inline
         Box <div.inner> at (12,54) content-size 86.765625x17 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,54) content-size 86.765625x17 flex-item [BFC] children: inline
-            line 0 width: 86.765625, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 11, rect: [12,54 86.765625x17]
+            frag 0 from TextNode start: 0, length: 11, rect: [12,54 86.765625x17] baseline: 13.296875
                 "fit content"
             TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -33,8 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.max-content> at (11,74) content-size 102.15625x19 flex-item [BFC] children: not-inline
         Box <div.inner> at (12,75) content-size 100.15625x17 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,75) content-size 100.15625x17 flex-item [BFC] children: inline
-            line 0 width: 100.15625, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 11, rect: [12,75 100.15625x17]
+            frag 0 from TextNode start: 0, length: 11, rect: [12,75 100.15625x17] baseline: 13.296875
                 "max content"
             TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -42,11 +38,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.min-content> at (11,95) content-size 62.90625x36 flex-item [BFC] children: not-inline
         Box <div.inner> at (12,96) content-size 60.90625x34 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,96) content-size 60.90625x34 flex-item [BFC] children: inline
-            line 0 width: 26.375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 3, rect: [12,96 26.375x17]
+            frag 0 from TextNode start: 0, length: 3, rect: [12,96 26.375x17] baseline: 13.296875
                 "min"
-            line 1 width: 60.90625, height: 17, bottom: 34, baseline: 13.296875
-              frag 0 from TextNode start: 4, length: 7, rect: [12,113 60.90625x17]
+            frag 1 from TextNode start: 4, length: 7, rect: [12,113 60.90625x17] baseline: 13.296875
                 "content"
             TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
@@ -5,576 +5,480 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.row.outer.start> at (11,11) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [12,12 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,12 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (64,12) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [64,12 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [64,12 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (116,12) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [116,12 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [116,12 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,72) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-start> at (11,73) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,74) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [12,74 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [12,74 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (64,74) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [64,74 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [64,74 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (116,74) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [116,74 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [116,74 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,134) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.end> at (11,135) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (156,136) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [156,136 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [156,136 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (208,136) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [208,136 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [208,136 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (260,136) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [260,136 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [260,136 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,196) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-end> at (11,197) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (156,198) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [156,198 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [156,198 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (208,198) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [208,198 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [208,198 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (260,198) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [260,198 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [260,198 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,258) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.center> at (11,259) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (84,260) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [84,260 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [84,260 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
         BlockContainer <div> at (136,260) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,260 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,260 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (188,260) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [188,260 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [188,260 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,320) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-around> at (11,321) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (36,322) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [36,322 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [36,322 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
         BlockContainer <div> at (136,322) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,322 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,322 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (236,322) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [236,322 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [236,322 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,382) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-between> at (11,383) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,384) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [12,384 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [12,384 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
         BlockContainer <div> at (136,384) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,384 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,384 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (260,384) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [260,384 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [260,384 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,444) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-evenly> at (11,445) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (48,446) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [48,446 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [48,446 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
         BlockContainer <div> at (136,446) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,446 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,446 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (224,446) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [224,446 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [224,446 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,506) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.start> at (11,507) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (116,508) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [116,508 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [116,508 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (64,508) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [64,508 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [64,508 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,508) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,508 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,508 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,568) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-start> at (11,569) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (260,570) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [260,570 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [260,570 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (208,570) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [208,570 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [208,570 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (156,570) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [156,570 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [156,570 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,630) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.end> at (11,631) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (260,632) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [260,632 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [260,632 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (208,632) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [208,632 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [208,632 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (156,632) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [156,632 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [156,632 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,692) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-end> at (11,693) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (116,694) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [116,694 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [116,694 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (64,694) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [64,694 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [64,694 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,694) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,694 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,694 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,754) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.center> at (11,755) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (188,756) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [188,756 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [188,756 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
         BlockContainer <div> at (136,756) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,756 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,756 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (84,756) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [84,756 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [84,756 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,816) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-around> at (11,817) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (236,818) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [236,818 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [236,818 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
         BlockContainer <div> at (136,818) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,818 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,818 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (36,818) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [36,818 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [36,818 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,878) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-between> at (11,879) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (260,880) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [260,880 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [260,880 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
         BlockContainer <div> at (136,880) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,880 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,880 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,880) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,880 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,880 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,940) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-evenly> at (11,941) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (224,942) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [224,942 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [224,942 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
         BlockContainer <div> at (136,942) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [136,942 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [136,942 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (48,942) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [48,942 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [48,942 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1002) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.start> at (11,1003) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,1004) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [12,1004 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,1004 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (12,1056) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1056 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1056 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,1108) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1108 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1108 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1304) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-start> at (11,1305) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,1306) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [12,1306 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [12,1306 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (12,1358) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1358 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1358 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,1410) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1410 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1410 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1606) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.end> at (11,1607) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,1752) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,1752 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,1752 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (12,1804) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1804 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1804 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,1856) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1856 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1856 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1908) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-end> at (11,1909) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,2054) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [12,2054 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [12,2054 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (12,2106) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2106 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2106 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,2158) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2158 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2158 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2210) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.center> at (11,2211) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,2284) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [12,2284 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [12,2284 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
         BlockContainer <div> at (12,2336) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2336 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2336 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,2388) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2388 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2388 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2512) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-around> at (11,2513) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,2538) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [12,2538 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [12,2538 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
         BlockContainer <div> at (12,2638) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2638 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2638 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,2738) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2738 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2738 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2814) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-between> at (11,2815) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,2816) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [12,2816 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [12,2816 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
         BlockContainer <div> at (12,2940) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2940 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2940 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,3064) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3064 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3064 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,3116) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-evenly> at (11,3117) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,3154) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [12,3154 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [12,3154 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
         BlockContainer <div> at (12,3242) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3242 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3242 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,3330) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3330 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3330 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,3418) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.start> at (11,3419) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,3524) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [12,3524 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,3524 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (12,3472) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3472 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3472 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,3420) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3420 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3420 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,3720) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-start> at (11,3721) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,3970) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [12,3970 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [12,3970 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (12,3918) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3918 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3918 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,3866) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,3866 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,3866 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,4022) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.end> at (11,4023) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,4272) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,4272 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,4272 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (12,4220) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4220 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4220 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,4168) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4168 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4168 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,4324) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-end> at (11,4325) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,4430) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [12,4430 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [12,4430 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (12,4378) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4378 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4378 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,4326) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4326 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4326 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,4626) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.center> at (11,4627) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,4804) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [12,4804 51.625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [12,4804 51.625x17] baseline: 13.296875
               "center"
           TextNode <#text>
         BlockContainer <div> at (12,4752) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4752 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4752 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,4700) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4700 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4700 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,4928) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-around> at (11,4929) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,5154) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 107.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [12,5154 107.96875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [12,5154 107.96875x17] baseline: 13.296875
               "space-around"
           TextNode <#text>
         BlockContainer <div> at (12,5054) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,5054 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,5054 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,4954) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,4954 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,4954 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,5230) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-between> at (11,5231) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,5480) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 115.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [12,5480 115.515625x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [12,5480 115.515625x17] baseline: 13.296875
               "space-between"
           TextNode <#text>
         BlockContainer <div> at (12,5356) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,5356 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,5356 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,5232) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,5232 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,5232 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,5532) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-evenly> at (11,5533) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,5746) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 98.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [12,5746 98.859375x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [12,5746 98.859375x17] baseline: 13.296875
               "space-evenly"
           TextNode <#text>
         BlockContainer <div> at (12,5658) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,5658 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,5658 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,5570) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,5570 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,5570 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,5834) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 14.265625x17 flex-item [BFC] children: inline
-          line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
               "A"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-with-margin-auto-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-with-margin-auto-child.txt
@@ -5,288 +5,240 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.row.outer.start> at (11,11) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (60,12) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [60,12 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [60,12 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (160,12) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [160,12 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [160,12 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (260,12) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [260,12 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [260,12 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,72) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-start> at (11,73) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (60,74) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [60,74 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [60,74 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (160,74) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [160,74 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [160,74 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (260,74) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [260,74 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [260,74 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,134) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.end> at (11,135) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,136) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,136 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,136 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (112,136) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,136 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,136 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (212,136) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [212,136 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [212,136 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,196) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-end> at (11,197) content-size 300x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,198) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [12,198 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [12,198 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (112,198) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,198 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,198 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (212,198) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [212,198 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [212,198 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,258) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.start> at (11,259) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (260,260) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [260,260 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [260,260 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (160,260) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [160,260 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [160,260 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (60,260) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [60,260 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [60,260 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,320) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-start> at (11,321) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (260,322) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [260,322 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [260,322 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (160,322) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [160,322 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [160,322 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (60,322) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [60,322 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [60,322 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,382) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.end> at (11,383) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (212,384) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [212,384 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [212,384 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (112,384) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,384 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,384 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,384) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,384 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,384 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,444) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-end> at (11,445) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (212,446) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [212,446 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [212,446 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (112,446) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [112,446 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [112,446 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,446) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,446 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,446 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,506) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.start> at (11,507) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (20,508) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [20,508 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [20,508 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (20,560) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,560 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,560 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (20,612) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,612 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,612 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,808) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-start> at (11,809) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (20,810) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [20,810 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [20,810 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (20,862) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,862 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,862 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (20,914) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,914 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,914 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1110) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.end> at (11,1111) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,1256) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,1256 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,1256 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (12,1308) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1308 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1308 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,1360) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1360 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1360 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1412) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-end> at (11,1413) content-size 60x300 flex-container(column) [FFC] children: not-inline
         BlockContainer <div> at (12,1558) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [12,1558 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [12,1558 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (12,1610) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1610 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1610 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,1662) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,1662 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,1662 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1714) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.start> at (11,1715) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (20,1820) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 41.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [20,1820 41.234375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [20,1820 41.234375x17] baseline: 13.296875
               "start"
           TextNode <#text>
         BlockContainer <div> at (20,1768) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,1768 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,1768 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (20,1716) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,1716 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,1716 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2016) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-start> at (11,2017) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (20,2266) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 76.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [20,2266 76.8125x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [20,2266 76.8125x17] baseline: 13.296875
               "flex-start"
           TextNode <#text>
         BlockContainer <div> at (20,2214) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,2214 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,2214 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (20,2162) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [20,2162 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,2162 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2318) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.end> at (11,2319) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,2568) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 26.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,2568 26.1875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,2568 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
         BlockContainer <div> at (12,2516) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2516 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2516 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,2464) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2464 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2464 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2620) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-end> at (11,2621) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,2726) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 61.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 8, rect: [12,2726 61.765625x17]
+          frag 0 from TextNode start: 0, length: 8, rect: [12,2726 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
         BlockContainer <div> at (12,2674) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2674 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2674 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (12,2622) content-size 50x50 flex-item [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,2622 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,2622 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2922) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
+++ b/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,16) content-size 784x17 children: not-inline
       Box <ul.globalnav-list> at (48,16) content-size 744x17 flex-container(row) [FFC] children: not-inline
         BlockContainer <div#item-1> at (48,16) content-size 46.734375x17 flex-item [BFC] children: inline
-          line 0 width: 46.734375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [48,16 46.734375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [48,16 46.734375x17] baseline: 13.296875
               "Store"
           TextNode <#text>
         BlockContainer <div#item-2> at (762,16) content-size 30x17 flex-item [BFC] children: inline
-          line 0 width: 30, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [762,16 30x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [762,16 30x17] baseline: 13.296875
               "Mac"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body.outer> at (8,8) content-size 200x17 flex-container(column) [FFC] children: not-inline
       BlockContainer <div.middle> at (8,8) content-size 200x17 flex-item [BFC] children: not-inline
         BlockContainer <div.inner> at (8,8) content-size 200x17 children: inline
-          line 0 width: 174.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 20, rect: [8,8 174.234375x17]
+          frag 0 from TextNode start: 0, length: 20, rect: [8,8 174.234375x17] baseline: 13.296875
               "percentages are hard"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (2,2) content-size 796x41 [BFC] children: not-inline
     Box <body> at (12,12) content-size 600x21 flex-container(row) [FFC] children: not-inline
       BlockContainer <div.exekiller> at (14,14) content-size 200x17 positioned flex-item [BFC] children: inline
-        line 0 width: 65.4375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17]
+        frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17] baseline: 13.296875
             "exekiller"
         TextNode <#text>
       BlockContainer <div.athena> at (18,18) content-size 200x17 positioned flex-item [BFC] children: inline
-        line 0 width: 53.171875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17] baseline: 13.296875
             "athena"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
+++ b/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
@@ -3,72 +3,60 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
       Box <div.outer.row> at (8,8) content-size 150x150 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.inner> at (12.609375,8) content-size 30.078125x150 flex-item [BFC] children: inline
-          line 0 width: 30.078125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12.609375,8 30.078125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12.609375,8 30.078125x17] baseline: 13.296875
               "Well"
           TextNode <#text>
         BlockContainer <div.inner> at (51.921875,8) content-size 36.84375x150 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [51.921875,8 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [51.921875,8 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         BlockContainer <div.inner> at (98,8) content-size 55.359375x150 flex-item [BFC] children: inline
-          line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [98,8 55.359375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [98,8 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.outer.row-reverse> at (8,158) content-size 150x150 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div.inner> at (123.3125,158) content-size 30.078125x150 flex-item [BFC] children: inline
-          line 0 width: 30.078125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [123.3125,158 30.078125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [123.3125,158 30.078125x17] baseline: 13.296875
               "Well"
           TextNode <#text>
         BlockContainer <div.inner> at (77.234375,158) content-size 36.84375x150 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [77.234375,158 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [77.234375,158 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         BlockContainer <div.inner> at (12.640625,158) content-size 55.359375x150 flex-item [BFC] children: inline
-          line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [12.640625,158 55.359375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [12.640625,158 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,308) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.outer.column> at (8,308) content-size 150x150 flex-container(column) [FFC] children: not-inline
         BlockContainer <div.inner> at (8,324.5) content-size 150x17 flex-item [BFC] children: inline
-          line 0 width: 30.078125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,324.5 30.078125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,324.5 30.078125x17] baseline: 13.296875
               "Well"
           TextNode <#text>
         BlockContainer <div.inner> at (8,374.5) content-size 150x17 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [8,374.5 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [8,374.5 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         BlockContainer <div.inner> at (8,424.5) content-size 150x17 flex-item [BFC] children: inline
-          line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [8,424.5 55.359375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [8,424.5 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,458) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.outer.column-reverse> at (8,458) content-size 150x150 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div.inner> at (8,574.5) content-size 150x17 flex-item [BFC] children: inline
-          line 0 width: 30.078125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,574.5 30.078125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,574.5 30.078125x17] baseline: 13.296875
               "Well"
           TextNode <#text>
         BlockContainer <div.inner> at (8,524.5) content-size 150x17 flex-item [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [8,524.5 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [8,524.5 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
         BlockContainer <div.inner> at (8,474.5) content-size 150x17 flex-item [BFC] children: inline
-          line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [8,474.5 55.359375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [8,474.5 55.359375x17] baseline: 13.296875
               "friends"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/font-fractional-size.txt
+++ b/Tests/LibWeb/Layout/expected/font-fractional-size.txt
@@ -1,16 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x39 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: inline
-      line 0 width: 54.203125, height: 23, bottom: 23, baseline: 17.953125
-        frag 0 from TextNode start: 0, length: 1, rect: [8,8 12.4375x22]
+      frag 0 from TextNode start: 0, length: 1, rect: [8,8 12.4375x22] baseline: 17.140625
           "x"
-        frag 1 from TextNode start: 0, length: 1, rect: [20,12 8x17]
+      frag 1 from TextNode start: 0, length: 1, rect: [20,12 8x17] baseline: 13.296875
           " "
-        frag 2 from TextNode start: 0, length: 1, rect: [28,8 12.734375x23]
+      frag 2 from TextNode start: 0, length: 1, rect: [28,8 12.734375x23] baseline: 17.796875
           "x"
-        frag 3 from TextNode start: 0, length: 1, rect: [41,12 8x17]
+      frag 3 from TextNode start: 0, length: 1, rect: [41,12 8x17] baseline: 13.296875
           " "
-        frag 4 from TextNode start: 0, length: 1, rect: [49,8 13.03125x23]
+      frag 4 from TextNode start: 0, length: 1, rect: [49,8 13.03125x23] baseline: 17.953125
           "x"
       InlineNode <span.a>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/font-size-legacy.txt
+++ b/Tests/LibWeb/Layout/expected/font-size-legacy.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      line 0 width: 24.109375, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 4, rect: [8,11 24.109375x13]
+      frag 0 from TextNode start: 0, length: 4, rect: [8,11 24.109375x13] baseline: 10.09375
           "text"
       InlineNode <font>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/font-size-zero.txt
+++ b/Tests/LibWeb/Layout/expected/font-size-zero.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
-        line 0 width: 0, height: 0, bottom: 0, baseline: 0
-          frag 0 from TextNode start: 0, length: 21, rect: [8,8 0x0]
+        frag 0 from TextNode start: 0, length: 21, rect: [8,8 0x0] baseline: 0
             "should not be visible"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -1,20 +1,19 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: inline
-      line 0 width: 424, height: 200, bottom: 200, baseline: 159.96875
-        frag 0 from TextNode start: 0, length: 1, rect: [8,8 79.296875x200]
+      frag 0 from TextNode start: 0, length: 1, rect: [8,8 79.296875x200] baseline: 159.96875
           "1"
-        frag 1 from TextNode start: 0, length: 1, rect: [87,154 8x17]
+      frag 1 from TextNode start: 0, length: 1, rect: [87,154 8x17] baseline: 13.296875
           " "
-        frag 2 from TextNode start: 0, length: 1, rect: [95,8 110.15625x200]
+      frag 2 from TextNode start: 0, length: 1, rect: [95,8 110.15625x200] baseline: 159.96875
           "2"
-        frag 3 from TextNode start: 0, length: 1, rect: [205,154 8x17]
+      frag 3 from TextNode start: 0, length: 1, rect: [205,154 8x17] baseline: 13.296875
           " "
-        frag 4 from TextNode start: 0, length: 1, rect: [213,8 113.671875x200]
+      frag 4 from TextNode start: 0, length: 1, rect: [213,8 113.671875x200] baseline: 159.96875
           "3"
-        frag 5 from TextNode start: 0, length: 1, rect: [327,154 8x17]
+      frag 5 from TextNode start: 0, length: 1, rect: [327,154 8x17] baseline: 13.296875
           " "
-        frag 6 from TextNode start: 0, length: 1, rect: [335,8 96.875x200]
+      frag 6 from TextNode start: 0, length: 1, rect: [335,8 96.875x200] baseline: 159.96875
           "4"
       InlineNode <span.one>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
+++ b/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x38 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x22 children: inline
-      line 0 width: 362.609375, height: 22, bottom: 22, baseline: 17
-        frag 0 from TextNode start: 0, length: 35, rect: [8,8 362.609375x22]
+      frag 0 from TextNode start: 0, length: 35, rect: [8,8 362.609375x22] baseline: 17
           "This test passes if we don't crash."
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.outer-grid> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.inner-absolute-block> at (8,8) content-size 80.765625x17 positioned [BFC] children: inline
-          line 0 width: 80.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,8 80.765625x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,8 80.765625x17] baseline: 13.296875
               "some text"
           TextNode <#text>
         BlockContainer <div> at (8,8) content-size 784x17 [BFC] children: inline
-          line 0 width: 80.25, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,8 80.25x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,8 80.25x17] baseline: 13.296875
               "more text"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/align-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/align-items.txt
@@ -5,39 +5,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.grid.start> at (31,31) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div> at (32,32) content-size 367x17 [BFC] children: inline
-          line 0 width: 50.203125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [32,32 50.203125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [32,32 50.203125x17] baseline: 13.296875
               "Start1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,42) content-size 347x17 [BFC] children: inline
-          line 0 width: 52.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [411,42 52.671875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [411,42 52.671875x17] baseline: 13.296875
               "Start2"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,91) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.center> at (31,112) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div> at (32,123) content-size 367x17 [BFC] children: inline
-          line 0 width: 59.390625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [32,123 59.390625x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [32,123 59.390625x17] baseline: 13.296875
               "Center1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,123) content-size 347x17 [BFC] children: inline
-          line 0 width: 61.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [411,123 61.859375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [411,123 61.859375x17] baseline: 13.296875
               "Center2"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,172) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.end> at (31,193) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div> at (32,214) content-size 367x17 [BFC] children: inline
-          line 0 width: 35.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [32,214 35.671875x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [32,214 35.671875x17] baseline: 13.296875
               "End1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,204) content-size 347x17 [BFC] children: inline
-          line 0 width: 38.140625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [411,204 38.140625x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [411,204 38.140625x17] baseline: 13.296875
               "End2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/align-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/align-self.txt
@@ -5,39 +5,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.grid> at (31,31) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div.start> at (32,32) content-size 367x17 [BFC] children: inline
-          line 0 width: 50.203125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [32,32 50.203125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [32,32 50.203125x17] baseline: 13.296875
               "Start1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,42) content-size 347x17 [BFC] children: inline
-          line 0 width: 52.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [411,42 52.671875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [411,42 52.671875x17] baseline: 13.296875
               "Start2"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,91) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid> at (31,112) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div.center> at (32,123) content-size 367x17 [BFC] children: inline
-          line 0 width: 59.390625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [32,123 59.390625x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [32,123 59.390625x17] baseline: 13.296875
               "Center1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,123) content-size 347x17 [BFC] children: inline
-          line 0 width: 61.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [411,123 61.859375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [411,123 61.859375x17] baseline: 13.296875
               "Center2"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,172) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid> at (31,193) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div.end> at (32,214) content-size 367x17 [BFC] children: inline
-          line 0 width: 35.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [32,214 35.671875x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [32,214 35.671875x17] baseline: 13.296875
               "End1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,204) content-size 347x17 [BFC] children: inline
-          line 0 width: 38.140625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [411,204 38.140625x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [411,204 38.140625x17] baseline: 13.296875
               "End2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
@@ -5,29 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 392x100 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,8) content-size 392x100 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,108) content-size 392x100 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,108) content-size 392x100 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,108 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,108 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
+++ b/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.grid> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 784x17 [BFC] children: inline
-          line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
               "hello"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill-and-named-line-placement.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill-and-named-line-placement.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x57 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x57 [GFC] children: not-inline
         BlockContainer <div.grid-item> at (28,28) content-size 744x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [397,28 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [397,28 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill-rows.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x234 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x234 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 784x200 [BFC] children: inline
-          line 0 width: 46.71875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [8,8 46.71875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,8 46.71875x17] baseline: 13.296875
               "Item 1"
           TextNode <#text>
         BlockContainer <div> at (8,208) content-size 784x17 [BFC] children: inline
-          line 0 width: 49.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [8,208 49.1875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,208 49.1875x17] baseline: 13.296875
               "Item 2"
           TextNode <#text>
         BlockContainer <div> at (8,225) content-size 784x17 [BFC] children: inline
-          line 0 width: 49.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [8,225 49.46875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,225 49.46875x17] baseline: 13.296875
               "Item 3"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (269.328125,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (530.65625,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x97 children: not-inline
       Box <div.container> at (18,18) content-size 764x77 [GFC] children: not-inline
         BlockContainer <div.item> at (48,48) content-size 704x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [48,48 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [48,48 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (269.328125,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (530.65625,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/auto-flow-column-spanning-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-flow-column-spanning-item.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (8,8) content-size 784x17 [GFC] children: not-inline
       BlockContainer <div> at (8,8) content-size 156.796875x17 [BFC] children: not-inline
       BlockContainer <div.item> at (164.796875,8) content-size 627.1875x17 [BFC] children: inline
-        line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [164.796875,8 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [164.796875,8 27.15625x17] baseline: 13.296875
             "foo"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/auto-flow-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-flow-column.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37 [BFC] children: not-inline
     Box <body> at (10,10) content-size 200x19 [GFC] children: not-inline
       BlockContainer <div> at (11,11) content-size 98x17 [BFC] children: inline
-        line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17] baseline: 13.296875
             "hello"
         TextNode <#text>
       BlockContainer <div> at (111,11) content-size 98x17 [BFC] children: inline
-        line 0 width: 55.359375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 7, rect: [111,11 55.359375x17]
+        frag 0 from TextNode start: 0, length: 7, rect: [111,11 55.359375x17] baseline: 13.296875
             "friends"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/basic-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div#grid> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div#title> at (8,8) content-size 88.171875x17 [BFC] children: inline
-          line 0 width: 88.171875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [8,8 88.171875x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [8,8 88.171875x17] baseline: 13.296875
               "Game Title"
           TextNode <#text>
         BlockContainer <div#board> at (96.171875,8) content-size 695.828125x17 [BFC] children: inline
-          line 0 width: 45.734375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [96.171875,8 45.734375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [96.171875,8 45.734375x17] baseline: 13.296875
               "Board"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/basic.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic.txt
@@ -5,29 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,25) content-size 392x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,25 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,25 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,25) content-size 392x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,25 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,25 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -5,29 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,18) content-size 372x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,18 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,18 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (410,18) content-size 372x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [410,18 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [410,18 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,55) content-size 372x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,55 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,55 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (410,55) content-size 372x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [410,55 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [410,55 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -38,29 +34,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,92) content-size 372x50 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,92 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,92 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (410,92) content-size 372x50 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [410,92 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [410,92 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,162) content-size 372x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,162 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,162 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (410,162) content-size 372x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [410,162 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [410,162 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -71,29 +63,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,199) content-size 347x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,199 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,199 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (435,199) content-size 347x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [435,199 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [435,199 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,246) content-size 347x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,246 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,246 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (435,246) content-size 347x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [435,246 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [435,246 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -104,15 +92,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (444.203125,283) content-size 337.796875x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [444.203125,283 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [444.203125,283 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,336) content-size 337.796875x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,336 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,336 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -123,29 +109,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,373) content-size 280x5 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,373 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,373 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (318,373) content-size 280x5 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [318,373 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [318,373 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,398) content-size 280x5 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,398 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,398 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (318,398) content-size 280x5 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [318,398 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [318,398 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -156,8 +138,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (18,423) content-size 764x0 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [18,423 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [18,423 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.grid-item> at (8,8) content-size 200x17 [BFC] children: inline
-          line 0 width: 31.265625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [8,8 31.265625x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 31.265625x17] baseline: 13.296875
               "Uno"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/grid/columns-auto-fill-with-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/columns-auto-fill-with-gap-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.grid> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 367x17 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (425,8) content-size 367x17 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [425,8 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [425,8 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/container-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/container-min-height.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x202 children: not-inline
       Box <div.container> at (11,11) content-size 778x200 [GFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 776x98 [BFC] children: inline
-          line 0 width: 311.21875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 35, rect: [12,12 311.21875x17]
+          frag 0 from TextNode start: 0, length: 35, rect: [12,12 311.21875x17] baseline: 13.296875
               "Making Commerce Better for Everyone"
           TextNode <#text>
         BlockContainer <div> at (12,112) content-size 776x98 [BFC] children: inline
-          line 0 width: 311.21875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 35, rect: [12,112 311.21875x17]
+          frag 0 from TextNode start: 0, length: 35, rect: [12,112 311.21875x17] baseline: 13.296875
               "Making Commerce Better for Everyone"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
@@ -5,29 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 50x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (58,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [58,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [58,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,25) content-size 50x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,25 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,25 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (58,25) content-size 392x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [58,25 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [58,25 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
@@ -5,8 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.right> at (400,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,8 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -15,8 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 392x0 children: inline
             TextNode <#text>
           BlockContainer <div.inner> at (8,8) content-size 392x17 children: inline
-            line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.46875x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.46875x17] baseline: 13.296875
                 "b"
             TextNode <#text>
           BlockContainer <(anonymous)> at (8,25) content-size 392x0 children: inline

--- a/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
@@ -3,23 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div.container> at (8,8) content-size 203.28125x34 floating [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 101.640625x17 [BFC] children: inline
-          line 0 width: 79.25, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,8 79.25x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,8 79.25x17] baseline: 13.296875
               "some-text"
           TextNode <#text>
         BlockContainer <div.item> at (109.640625,8) content-size 101.640625x17 [BFC] children: inline
-          line 0 width: 78.03125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [109.640625,8 78.03125x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [109.640625,8 78.03125x17] baseline: 13.296875
               "goes-here"
           TextNode <#text>
         BlockContainer <div.item> at (8,25) content-size 101.640625x17 [BFC] children: inline
-          line 0 width: 101.640625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [8,25 101.640625x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [8,25 101.640625x17] baseline: 13.296875
               "another-text"
           TextNode <#text>
         BlockContainer <div.item> at (109.640625,25) content-size 101.640625x17 [BFC] children: inline
-          line 0 width: 84.890625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [109.640625,25 84.890625x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [109.640625,25 84.890625x17] baseline: 13.296875
               "goes-there"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid> at (8,8) content-size 784x27 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 784x27 [BFC] children: not-inline
           BlockContainer <div.left> at (8,8) content-size 6.34375x17 floating [BFC] children: inline
-            line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
                 "1"
             TextNode <#text>
           TableWrapper <(anonymous)> at (14.34375,8) content-size 156.796875x27 floating [BFC] children: not-inline
@@ -13,18 +12,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               Box <tbody> at (15.34375,9) content-size 148.796875x21 table-row-group children: not-inline
                 Box <tr> at (17.34375,11) content-size 148.796875x21 table-row children: not-inline
                   BlockContainer <td> at (19.34375,13) content-size 69.59375x17 table-cell [BFC] children: inline
-                    line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x17] baseline: 13.296875
                         "2"
                     TextNode <#text>
                   BlockContainer <td> at (94.9375,13) content-size 71.203125x17 table-cell [BFC] children: inline
-                    line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x17] baseline: 13.296875
                         "3"
                     TextNode <#text>
           BlockContainer <div.right> at (171.140625,8) content-size 7.75x17 floating [BFC] children: inline
-            line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [171.140625,8 7.75x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [171.140625,8 7.75x17] baseline: 13.296875
                 "4"
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,35) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
@@ -3,23 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x84 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x84 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 342x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.two> at (450,8) content-size 342x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [450,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [450,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <div.three> at (8,75) content-size 342x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,75 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,75 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <div.four> at (450,75) content-size 342x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [450,75 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [450,75 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
       Box <div.container> at (8,8) content-size 784x50 [GFC] children: not-inline
         BlockContainer <div.item> at (434.203125,8) content-size 357.796875x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [434.203125,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [434.203125,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.item> at (8,41) content-size 357.796875x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,41 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,41 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.item> at (410,8) content-size 382x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [410,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [410,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
@@ -5,29 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (68,68) content-size 17.046875x33 [BFC] children: inline
-          line 0 width: 11.890625, height: 33, bottom: 33, baseline: 25.5
-            frag 0 from TextNode start: 0, length: 1, rect: [71,68 11.890625x33]
+          frag 0 from TextNode start: 0, length: 1, rect: [71,68 11.890625x33] baseline: 25.5
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (255.046875,68) content-size 16.53125x33 [BFC] children: inline
-          line 0 width: 16.53125, height: 33, bottom: 33, baseline: 25.5
-            frag 0 from TextNode start: 0, length: 1, rect: [255.046875,68 16.53125x33]
+          frag 0 from TextNode start: 0, length: 1, rect: [255.046875,68 16.53125x33] baseline: 25.5
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (68,271) content-size 17.046875x33 [BFC] children: inline
-          line 0 width: 17.046875, height: 33, bottom: 33, baseline: 25.5
-            frag 0 from TextNode start: 0, length: 1, rect: [68,271 17.046875x33]
+          frag 0 from TextNode start: 0, length: 1, rect: [68,271 17.046875x33] baseline: 25.5
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (255.046875,271) content-size 16.53125x33 [BFC] children: inline
-          line 0 width: 14.53125, height: 33, bottom: 33, baseline: 25.5
-            frag 0 from TextNode start: 0, length: 1, rect: [256.046875,271 14.53125x33]
+          frag 0 from TextNode start: 0, length: 1, rect: [256.046875,271 14.53125x33] baseline: 25.5
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x200 [GFC] children: not-inline
         BlockContainer <div.first> at (8,8) content-size 100x200 [BFC] children: inline
-          line 0 width: 42.140625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17] baseline: 13.296875
               "First"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
@@ -5,109 +5,85 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto.right-margin-auto> at (99.71875,12) content-size 322.5625x17 [BFC] children: inline
-          line 0 width: 322.5625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 38, rect: [99.71875,12 322.5625x17]
+          frag 0 from TextNode start: 0, length: 38, rect: [99.71875,12 322.5625x17] baseline: 13.296875
               "auto horizontal margins and auto width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto> at (252.375,31) content-size 257.625x17 [BFC] children: inline
-          line 0 width: 257.625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 31, rect: [252.375,31 257.625x17]
+          frag 0 from TextNode start: 0, length: 31, rect: [252.375,31 257.625x17] baseline: 13.296875
               "auto left margin and auto width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.right-margin-auto> at (12,50) content-size 268.484375x17 [BFC] children: inline
-          line 0 width: 268.484375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 32, rect: [12,50 268.484375x17]
+          frag 0 from TextNode start: 0, length: 32, rect: [12,50 268.484375x17] baseline: 13.296875
               "auto right margin and auto width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto.right-margin-auto.fit-content-width> at (75.25,69) content-size 371.484375x17 [BFC] children: inline
-          line 0 width: 371.484375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 45, rect: [75.25,69 371.484375x17]
+          frag 0 from TextNode start: 0, length: 45, rect: [75.25,69 371.484375x17] baseline: 13.296875
               "auto horizontal margins and fit-content width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto.fit-content-width> at (203.453125,88) content-size 306.546875x17 [BFC] children: inline
-          line 0 width: 306.546875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 38, rect: [203.453125,88 306.546875x17]
+          frag 0 from TextNode start: 0, length: 38, rect: [203.453125,88 306.546875x17] baseline: 13.296875
               "auto left margin and fit-content width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.right-margin-auto.fit-content-width> at (12,107) content-size 317.40625x17 [BFC] children: inline
-          line 0 width: 317.40625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 39, rect: [12,107 317.40625x17]
+          frag 0 from TextNode start: 0, length: 39, rect: [12,107 317.40625x17] baseline: 13.296875
               "auto right margin and fit-content width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto.right-margin-auto.fixed-width> at (236,126) content-size 50x102 [BFC] children: inline
-          line 0 width: 36.328125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [236,126 36.328125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [236,126 36.328125x17] baseline: 13.296875
               "auto"
-          line 1 width: 81.84375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 5, length: 10, rect: [236,143 81.84375x17]
+          frag 1 from TextNode start: 5, length: 10, rect: [236,143 81.84375x17] baseline: 13.296875
               "horizontal"
-          line 2 width: 61.453125, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 16, length: 7, rect: [236,160 61.453125x17]
+          frag 2 from TextNode start: 16, length: 7, rect: [236,160 61.453125x17] baseline: 13.296875
               "margins"
-          line 3 width: 26.8125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 24, length: 3, rect: [236,177 26.8125x17]
+          frag 3 from TextNode start: 24, length: 3, rect: [236,177 26.8125x17] baseline: 13.296875
               "and"
-          line 4 width: 37.28125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 28, length: 5, rect: [236,194 37.28125x17]
+          frag 4 from TextNode start: 28, length: 5, rect: [236,194 37.28125x17] baseline: 13.296875
               "fixed"
-          line 5 width: 39.796875, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 34, length: 5, rect: [236,211 39.796875x17]
+          frag 5 from TextNode start: 34, length: 5, rect: [236,211 39.796875x17] baseline: 13.296875
               "width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto.fixed-width> at (460,230) content-size 50x102 [BFC] children: inline
-          line 0 width: 36.328125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [460,230 36.328125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [460,230 36.328125x17] baseline: 13.296875
               "auto"
-          line 1 width: 26.25, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 5, length: 4, rect: [460,247 26.25x17]
+          frag 1 from TextNode start: 5, length: 4, rect: [460,247 26.25x17] baseline: 13.296875
               "left"
-          line 2 width: 52.109375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 10, length: 6, rect: [460,264 52.109375x17]
+          frag 2 from TextNode start: 10, length: 6, rect: [460,264 52.109375x17] baseline: 13.296875
               "margin"
-          line 3 width: 26.8125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 17, length: 3, rect: [460,281 26.8125x17]
+          frag 3 from TextNode start: 17, length: 3, rect: [460,281 26.8125x17] baseline: 13.296875
               "and"
-          line 4 width: 37.28125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 21, length: 5, rect: [460,298 37.28125x17]
+          frag 4 from TextNode start: 21, length: 5, rect: [460,298 37.28125x17] baseline: 13.296875
               "fixed"
-          line 5 width: 39.796875, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 27, length: 5, rect: [460,315 39.796875x17]
+          frag 5 from TextNode start: 27, length: 5, rect: [460,315 39.796875x17] baseline: 13.296875
               "width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.right-margin-auto.fixed-width> at (12,334) content-size 50x102 [BFC] children: inline
-          line 0 width: 36.328125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12,334 36.328125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,334 36.328125x17] baseline: 13.296875
               "auto"
-          line 1 width: 37.109375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 5, length: 5, rect: [12,351 37.109375x17]
+          frag 1 from TextNode start: 5, length: 5, rect: [12,351 37.109375x17] baseline: 13.296875
               "right"
-          line 2 width: 52.109375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 11, length: 6, rect: [12,368 52.109375x17]
+          frag 2 from TextNode start: 11, length: 6, rect: [12,368 52.109375x17] baseline: 13.296875
               "margin"
-          line 3 width: 26.8125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 18, length: 3, rect: [12,385 26.8125x17]
+          frag 3 from TextNode start: 18, length: 3, rect: [12,385 26.8125x17] baseline: 13.296875
               "and"
-          line 4 width: 37.28125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 22, length: 5, rect: [12,402 37.28125x17]
+          frag 4 from TextNode start: 22, length: 5, rect: [12,402 37.28125x17] baseline: 13.296875
               "fixed"
-          line 5 width: 39.796875, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 28, length: 5, rect: [12,419 39.796875x17]
+          frag 5 from TextNode start: 28, length: 5, rect: [12,419 39.796875x17] baseline: 13.296875
               "width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div.grid> at (8,8) content-size 102x204 floating [GFC] children: not-inline
         BlockContainer <div.first> at (9,9) content-size 100x100 [BFC] children: inline
-          line 0 width: 36.03125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [9,9 36.03125x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [9,9 36.03125x17] baseline: 13.296875
               "first"
           TextNode <#text>
         BlockContainer <div.second> at (9,111) content-size 100x100 [BFC] children: inline
-          line 0 width: 54.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [9,111 54.78125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [9,111 54.78125x17] baseline: 13.296875
               "second"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x17 children: not-inline
         Box <div.grid> at (8,8) content-size 784x17 [GFC] children: not-inline
           BlockContainer <div.item> at (243.1875,8) content-size 313.625x17 [BFC] children: inline
-            line 0 width: 121.0625, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 16, rect: [243.1875,8 121.0625x17]
+            frag 0 from TextNode start: 0, length: 16, rect: [243.1875,8 121.0625x17] baseline: 13.296875
                 "A filthy t-shirt"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
@@ -3,59 +3,41 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div.container> at (8,8) content-size 200x306 floating [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 100x306 [BFC] children: inline
-          line 0 width: 50.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 5, rect: [8,8 50.96875x17]
+          frag 0 from TextNode start: 1, length: 5, rect: [8,8 50.96875x17] baseline: 13.296875
               "Lorem"
-          line 1 width: 94.9375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 7, length: 11, rect: [8,25 94.9375x17]
+          frag 1 from TextNode start: 7, length: 11, rect: [8,25 94.9375x17] baseline: 13.296875
               "ipsum dolor"
-          line 2 width: 70.9375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 19, length: 9, rect: [8,42 70.9375x17]
+          frag 2 from TextNode start: 19, length: 9, rect: [8,42 70.9375x17] baseline: 13.296875
               "sit amet,"
-          line 3 width: 96.84375, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 29, length: 11, rect: [8,59 96.84375x17]
+          frag 3 from TextNode start: 29, length: 11, rect: [8,59 96.84375x17] baseline: 13.296875
               "consectetur"
-          line 4 width: 75.71875, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 41, length: 10, rect: [8,76 75.71875x17]
+          frag 4 from TextNode start: 41, length: 10, rect: [8,76 75.71875x17] baseline: 13.296875
               "adipiscing"
-          line 5 width: 28.71875, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 52, length: 5, rect: [8,93 28.71875x17]
+          frag 5 from TextNode start: 52, length: 5, rect: [8,93 28.71875x17] baseline: 13.296875
               "elit."
-          line 6 width: 65.40625, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 58, length: 7, rect: [8,110 65.40625x17]
+          frag 6 from TextNode start: 58, length: 7, rect: [8,110 65.40625x17] baseline: 13.296875
               "Vivamus"
-          line 7 width: 88.640625, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 66, length: 11, rect: [8,127 88.640625x17]
+          frag 7 from TextNode start: 66, length: 11, rect: [8,127 88.640625x17] baseline: 13.296875
               "eget turpis"
-          line 8 width: 77.40625, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 78, length: 9, rect: [8,144 77.40625x17]
+          frag 8 from TextNode start: 78, length: 9, rect: [8,144 77.40625x17] baseline: 13.296875
               "eget urna"
-          line 9 width: 53.25, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 88, length: 7, rect: [8,161 53.25x17]
+          frag 9 from TextNode start: 88, length: 7, rect: [8,161 53.25x17] baseline: 13.296875
               "feugiat"
-          line 10 width: 84.984375, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 96, length: 10, rect: [8,178 84.984375x17]
+          frag 10 from TextNode start: 96, length: 10, rect: [8,178 84.984375x17] baseline: 13.296875
               "pretium ut"
-          line 11 width: 65.359375, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 107, length: 8, rect: [8,195 65.359375x17]
+          frag 11 from TextNode start: 107, length: 8, rect: [8,195 65.359375x17] baseline: 13.296875
               "eu ante."
-          line 12 width: 72.46875, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 116, length: 8, rect: [8,212 72.46875x17]
+          frag 12 from TextNode start: 116, length: 8, rect: [8,212 72.46875x17] baseline: 13.296875
               "Nunc sed"
-          line 13 width: 70.640625, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 125, length: 8, rect: [8,229 70.640625x17]
+          frag 13 from TextNode start: 125, length: 8, rect: [8,229 70.640625x17] baseline: 13.296875
               "pharetra"
-          line 14 width: 39.015625, height: 17, bottom: 255, baseline: 13.296875
-            frag 0 from TextNode start: 134, length: 5, rect: [8,246 39.015625x17]
+          frag 14 from TextNode start: 134, length: 5, rect: [8,246 39.015625x17] baseline: 13.296875
               "diam,"
-          line 15 width: 56.25, height: 17, bottom: 272, baseline: 13.296875
-            frag 0 from TextNode start: 140, length: 6, rect: [8,263 56.25x17]
+          frag 15 from TextNode start: 140, length: 6, rect: [8,263 56.25x17] baseline: 13.296875
               "rutrum"
-          line 16 width: 50.546875, height: 17, bottom: 289, baseline: 13.296875
-            frag 0 from TextNode start: 147, length: 7, rect: [8,280 50.546875x17]
+          frag 16 from TextNode start: 147, length: 7, rect: [8,280 50.546875x17] baseline: 13.296875
               "lacinia"
-          line 17 width: 47.5, height: 17, bottom: 306, baseline: 13.296875
-            frag 0 from TextNode start: 155, length: 7, rect: [8,297 47.5x17]
+          frag 17 from TextNode start: 155, length: 7, rect: [8,297 47.5x17] baseline: 13.296875
               "tellus."
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.first> at (8,8) content-size 313.59375x17 [BFC] children: inline
-          line 0 width: 42.140625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17] baseline: 13.296875
               "First"
           TextNode <#text>
         BlockContainer <div.second> at (400,8) content-size 78.390625x17 [BFC] children: inline
-          line 0 width: 57.40625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [400,8 57.40625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [400,8 57.40625x17] baseline: 13.296875
               "Second"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x19 [GFC] children: not-inline
       BlockContainer <div.inner> at (11,11) content-size 132.828125x17 [BFC] children: inline
-        line 0 width: 132.828125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 15, rect: [11,11 132.828125x17]
+        frag 0 from TextNode start: 0, length: 15, rect: [11,11 132.828125x17] baseline: 13.296875
             "Press and Media"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x97.875 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x79.875 [GFC] children: not-inline
       BlockContainer <h1> at (55.5,32.4375) content-size 689x35 [BFC] children: inline
-        line 0 width: 492.96875, height: 35, bottom: 35, baseline: 27.09375
-          frag 0 from TextNode start: 0, length: 31, rect: [55.5,32.4375 492.96875x35]
+        frag 0 from TextNode start: 0, length: 31, rect: [55.5,32.4375 492.96875x35] baseline: 27.09375
             "Null publishes fine indie games"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-span-4.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-span-4.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x66 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x48 [GFC] children: not-inline
       BlockContainer <div.foo> at (11,11) content-size 778x22 [BFC] children: inline
-        line 0 width: 33.9375, height: 22, bottom: 22, baseline: 17
-          frag 0 from TextNode start: 0, length: 3, rect: [11,11 33.9375x22]
+        frag 0 from TextNode start: 0, length: 3, rect: [11,11 33.9375x22] baseline: 17
             "foo"
         TextNode <#text>
       BlockContainer <div.bar> at (11,35) content-size 778x22 [BFC] children: inline
-        line 0 width: 34.546875, height: 22, bottom: 22, baseline: 17
-          frag 0 from TextNode start: 0, length: 3, rect: [11,35 34.546875x22]
+        frag 0 from TextNode start: 0, length: 3, rect: [11,35 34.546875x22] baseline: 17
             "bar"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       Box <div.container> at (8,8) content-size 784x34 [GFC] children: not-inline
         BlockContainer <div.item.right-bottom> at (400,25) content-size 392x17 [BFC] children: inline
-          line 0 width: 99.703125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [400,25 99.703125x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [400,25 99.703125x17] baseline: 13.296875
               "right-bottom"
           TextNode <#text>
         BlockContainer <div.item.left> at (8,8) content-size 392x34 [BFC] children: inline
-          line 0 width: 26.25, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [8,8 26.25x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [8,8 26.25x17] baseline: 13.296875
               "left"
           TextNode <#text>
         BlockContainer <div.item.right-top> at (400,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 70.234375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [400,8 70.234375x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [400,8 70.234375x17] baseline: 13.296875
               "right-top"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x55 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x37 [GFC] children: not-inline
       BlockContainer <h1> at (55.5,11) content-size 689x35 [BFC] children: inline
-        line 0 width: 200.40625, height: 35, bottom: 35, baseline: 27.09375
-          frag 0 from TextNode start: 0, length: 13, rect: [55.5,11 200.40625x35]
+        frag 0 from TextNode start: 0, length: 13, rect: [55.5,11 200.40625x35] baseline: 27.09375
             "hello friends"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/grid-template.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template.txt
@@ -23,29 +23,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <header> at (8,8) content-size 784x30 [BFC] children: inline
-          line 0 width: 55.703125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [8,8 55.703125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,8 55.703125x17] baseline: 13.296875
               "Header"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <nav> at (8,38) content-size 120x170 [BFC] children: inline
-          line 0 width: 80.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 10, rect: [8,38 80.6875x17]
+          frag 0 from TextNode start: 0, length: 10, rect: [8,38 80.6875x17] baseline: 13.296875
               "Navigation"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <main> at (128,38) content-size 664x140 [BFC] children: inline
-          line 0 width: 79.515625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [128,38 79.515625x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [128,38 79.515625x17] baseline: 13.296875
               "Main area"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <footer> at (128,178) content-size 664x30 [BFC] children: inline
-          line 0 width: 57.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [128,178 57.671875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [128,178 57.671875x17] baseline: 13.296875
               "Footer"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/grow-beyond-limits.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grow-beyond-limits.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 28.6875x17 [BFC] children: inline
-          line 0 width: 28.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [8,8 28.6875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 28.6875x17] baseline: 13.296875
               "one"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -5,8 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.wrapper> at (8,8) content-size 64.03125x24 [BFC] children: inline
-          line 0 width: 64.03125, height: 24, bottom: 24, baseline: 24
-            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.03125x24]
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.03125x24] baseline: 24
           TextNode <#text>
           ImageBox <img> at (8,8) content-size 64.03125x24 children: not-inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/implicit-lines.txt
+++ b/Tests/LibWeb/Layout/expected/grid/implicit-lines.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x220 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x220 [GFC] children: not-inline
         BlockContainer <div.item2> at (405,8) content-size 387x100 [BFC] children: inline
-          line 0 width: 49.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [405,8 49.1875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [405,8 49.1875x17] baseline: 13.296875
               "Item 2"
           TextNode <#text>
         BlockContainer <div.item1> at (8,8) content-size 387x210 [BFC] children: inline
-          line 0 width: 46.71875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [8,8 46.71875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,8 46.71875x17] baseline: 13.296875
               "Item 1"
           TextNode <#text>
         BlockContainer <div.item3> at (405,118) content-size 387x100 [BFC] children: inline
-          line 0 width: 49.1875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [405,118 49.1875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [405,118 49.1875x17] baseline: 13.296875
               "Item 2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
+++ b/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: inline
-    line 0 width: 42.953125, height: 33, bottom: 33, baseline: 13.296875
-      frag 0 from Box start: 0, length: 0, rect: [8,8 26.953125x17]
+    frag 0 from Box start: 0, length: 0, rect: [8,8 26.953125x17] baseline: 13.296875
     Box <body> at (8,8) content-size 26.953125x17 [GFC] children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 26.953125x17 [BFC] children: inline
-        line 0 width: 26.953125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17] baseline: 13.296875
             "whf"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.whee> at (9,9) content-size 18x17 [BFC] children: inline
-          line 0 width: 37.953125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [9,9 37.953125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [9,9 37.953125x17] baseline: 13.296875
               "whee"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x0 children: not-inline
       Box <div.grid> at (11,11) content-size 96.421875x19 floating [GFC] children: not-inline
         BlockContainer <div.whee> at (12,12) content-size 37.953125x17 [BFC] children: inline
-          line 0 width: 37.953125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17] baseline: 13.296875
               "whee"
           TextNode <#text>
         BlockContainer <div.yeehaw> at (51.953125,12) content-size 54.46875x17 [BFC] children: inline
-          line 0 width: 54.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [51.953125,12 54.46875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [51.953125,12 54.46875x17] baseline: 13.296875
               "yeehaw"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 41.953125x21 floating [BFC] children: not-inline
       Box <div.grid> at (11,11) content-size 39.953125x19 [GFC] children: not-inline
         BlockContainer <div.whee> at (12,12) content-size 37.953125x17 [BFC] children: inline
-          line 0 width: 37.953125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17] baseline: 13.296875
               "whee"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/item-align-self-center-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-align-self-center-and-max-height.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x100 [GFC] children: not-inline
         BlockContainer <div#max-height-item.grid-item> at (12,11) content-size 776x100 [BFC] children: inline
-          line 0 width: 166.84375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 20, rect: [12,11 166.84375x17]
+          frag 0 from TextNode start: 0, length: 20, rect: [12,11 166.84375x17] baseline: 13.296875
               "Item with Max-Height"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/item-align-self-center-and-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-align-self-center-and-min-height.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x304 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x302 [GFC] children: not-inline
         BlockContainer <div#min-height-item.grid-item> at (12,12) content-size 776x300 [BFC] children: inline
-          line 0 width: 161.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 20, rect: [12,12 161.96875x17]
+          frag 0 from TextNode start: 0, length: 20, rect: [12,12 161.96875x17] baseline: 13.296875
               "Item with Min-Height"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
@@ -8,11 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.item-right> at (108.03125,8) content-size 683.96875x34 [BFC] children: inline
-          line 0 width: 625.953125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 77, rect: [108.03125,8 625.953125x17]
+          frag 0 from TextNode start: 0, length: 77, rect: [108.03125,8 625.953125x17] baseline: 13.296875
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut iaculis venenatis"
-          line 1 width: 304.0625, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 78, length: 39, rect: [108.03125,25 304.0625x17]
+          frag 1 from TextNode start: 78, length: 39, rect: [108.03125,25 304.0625x17] baseline: 13.296875
               "purus, eget blandit velit venenatis at."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/item-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-fit-content-width.txt
@@ -4,13 +4,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.flex> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
         Box <div.grid> at (8,8) content-size 67.4375x17 flex-item [GFC] children: not-inline
           BlockContainer <div.w-fit> at (8,8) content-size 31.25x17 [BFC] children: inline
-            line 0 width: 31.25, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 4, rect: [8,8 31.25x17]
+            frag 0 from TextNode start: 0, length: 4, rect: [8,8 31.25x17] baseline: 13.296875
                 "Col1"
             TextNode <#text>
           BlockContainer <div.w-fit> at (41.71875,8) content-size 33.71875x17 [BFC] children: inline
-            line 0 width: 33.71875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 4, rect: [41.71875,8 33.71875x17]
+            frag 0 from TextNode start: 0, length: 4, rect: [41.71875,8 33.71875x17] baseline: 13.296875
                 "Col2"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/item-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-with-box-sizing-border-box.txt
@@ -4,14 +4,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid> at (11,11) content-size 778x21 [GFC] children: not-inline
         BlockContainer <div.item> at (112,12) content-size 187x19 [BFC] children: not-inline
           BlockContainer <div> at (113,13) content-size 185x17 children: inline
-            line 0 width: 29.8125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 3, rect: [113,13 29.8125x17]
+            frag 0 from TextNode start: 0, length: 3, rect: [113,13 29.8125x17] baseline: 13.296875
                 "One"
             TextNode <#text>
         BlockContainer <div.item> at (501,12) content-size 187x19 [BFC] children: not-inline
           BlockContainer <div> at (502,13) content-size 185x17 children: inline
-            line 0 width: 33.875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 3, rect: [502,13 33.875x17]
+            frag 0 from TextNode start: 0, length: 3, rect: [502,13 33.875x17] baseline: 13.296875
                 "Two"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/items-min-content-size-should-account-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/items-min-content-size-should-account-paddings.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.cta-banner> at (8,8) content-size 784x117 flex-container(row) [FFC] children: not-inline
         Box <div.w-layout-grid> at (8,8) content-size 470.4375x117 flex-item [GFC] children: not-inline
           BlockContainer <div.button> at (58,58) content-size 135.21875x17 [BFC] children: inline
-            line 0 width: 135.21875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 16, rect: [58,58 135.21875x17]
+            frag 0 from TextNode start: 0, length: 16, rect: [58,58 135.21875x17] baseline: 13.296875
                 "Sign up for free"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-content.txt
@@ -3,65 +3,55 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x85 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,8 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,8 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
         BlockContainer <div> at (400,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [400,8 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [400,8 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.container> at (8,25) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div> at (8,25) content-size 392x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,25 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,25 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
         BlockContainer <div> at (400,25) content-size 392x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [400,25 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [400,25 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.container> at (8,42) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div> at (8,42) content-size 67.96875x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [8,42 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [8,42 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
         BlockContainer <div> at (75.96875,42) content-size 67.96875x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [75.96875,42 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [75.96875,42 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.container> at (8,59) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div> at (332.03125,59) content-size 67.96875x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [332.03125,59 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [332.03125,59 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
         BlockContainer <div> at (400,59) content-size 67.96875x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [400,59 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [400,59 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,76) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.container> at (8,76) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div> at (656.0625,76) content-size 67.96875x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [656.0625,76 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [656.0625,76 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
         BlockContainer <div> at (724.03125,76) content-size 67.96875x17 [BFC] children: inline
-          line 0 width: 67.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 9, rect: [724.03125,76 67.96875x17]
+          frag 0 from TextNode start: 0, length: 9, rect: [724.03125,76 67.96875x17] baseline: 13.296875
               "wikipedia"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/justify-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-items.txt
@@ -5,24 +5,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.grid.start> at (11,11) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 43.859375x17 [BFC] children: inline
-          line 0 width: 43.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [12,12 43.859375x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,12 43.859375x17] baseline: 13.296875
               "Start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,31) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.center> at (11,32) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div> at (373.46875,33) content-size 53.046875x17 [BFC] children: inline
-          line 0 width: 53.046875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [373.46875,33 53.046875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [373.46875,33 53.046875x17] baseline: 13.296875
               "Center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,52) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.end> at (11,53) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div> at (758.671875,54) content-size 29.328125x17 [BFC] children: inline
-          line 0 width: 29.328125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [758.671875,54 29.328125x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [758.671875,54 29.328125x17] baseline: 13.296875
               "End"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/justify-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-self.txt
@@ -4,22 +4,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       BlockContainer <div> at (11,11) content-size 43.859375x17 [BFC] children: inline
-        line 0 width: 43.859375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [11,11 43.859375x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [11,11 43.859375x17] baseline: 13.296875
             "Start"
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       BlockContainer <div> at (373.46875,30) content-size 53.046875x17 [BFC] children: inline
-        line 0 width: 53.046875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [373.46875,30 53.046875x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [373.46875,30 53.046875x17] baseline: 13.296875
             "Center"
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       BlockContainer <div> at (759.671875,49) content-size 29.328125x17 [BFC] children: inline
-        line 0 width: 29.328125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [759.671875,49 29.328125x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [759.671875,49 29.328125x17] baseline: 13.296875
             "End"
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/justify-start-min-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-start-min-width.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div#grid> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <a#box> at (8,8) content-size 288x17 [BFC] children: inline
-          line 0 width: 102.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 13, rect: [8,8 102.75x17]
+          frag 0 from TextNode start: 0, length: 13, rect: [8,8 102.75x17] baseline: 13.296875
               "Start Selling"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/line-placement-with-repeat.txt
+++ b/Tests/LibWeb/Layout/expected/grid/line-placement-with-repeat.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 480x17 [BFC] children: not-inline
           BlockContainer <div.box> at (8,8) content-size 480x17 children: inline
-            line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
                 "1"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/max-width-grid-container-wrapper-in-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/max-width-grid-container-wrapper-in-max-content.txt
@@ -4,23 +4,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.wrapper> at (8,8) content-size 270x102 children: not-inline
         Box <div.constrained> at (8,8) content-size 270x102 [GFC] children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 270x102 [BFC] children: inline
-            line 0 width: 261.0625, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 35, rect: [8,8 261.0625x17]
+            frag 0 from TextNode start: 1, length: 35, rect: [8,8 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 1 width: 261.0625, height: 17, bottom: 34, baseline: 13.296875
-              frag 0 from TextNode start: 37, length: 35, rect: [8,25 261.0625x17]
+            frag 1 from TextNode start: 37, length: 35, rect: [8,25 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 2 width: 261.0625, height: 17, bottom: 51, baseline: 13.296875
-              frag 0 from TextNode start: 73, length: 35, rect: [8,42 261.0625x17]
+            frag 2 from TextNode start: 73, length: 35, rect: [8,42 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 3 width: 261.0625, height: 17, bottom: 68, baseline: 13.296875
-              frag 0 from TextNode start: 109, length: 35, rect: [8,59 261.0625x17]
+            frag 3 from TextNode start: 109, length: 35, rect: [8,59 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 4 width: 261.0625, height: 17, bottom: 85, baseline: 13.296875
-              frag 0 from TextNode start: 145, length: 35, rect: [8,76 261.0625x17]
+            frag 4 from TextNode start: 145, length: 35, rect: [8,76 261.0625x17] baseline: 13.296875
                 "hello hello hello hello hello hello"
-            line 5 width: 81.6875, height: 17, bottom: 102, baseline: 13.296875
-              frag 0 from TextNode start: 181, length: 11, rect: [8,93 81.6875x17]
+            frag 5 from TextNode start: 181, length: 11, rect: [8,93 81.6875x17] baseline: 13.296875
                 "hello hello"
             TextNode <#text>
           BlockContainer <div> at (8,110) content-size 270x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 196x17 [BFC] children: inline
-          line 0 width: 93.765625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17]
+          frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17] baseline: 13.296875
               "min-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (204,8) content-size 98.640625x17 [BFC] children: inline
-          line 0 width: 98.640625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 11, rect: [204,8 98.640625x17]
+          frag 0 from TextNode start: 0, length: 11, rect: [204,8 98.640625x17] baseline: 13.296875
               "max-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (302.640625,8) content-size 489.359375x17 [BFC] children: inline
-          line 0 width: 21.609375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [302.640625,8 21.609375x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [302.640625,8 21.609375x17] baseline: 13.296875
               "1fr"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 300x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.two> at (308,8) content-size 300x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.container> at (8,8) content-size 784x100 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 300x50 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.two> at (308,8) content-size 300x50 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
@@ -3,18 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 292x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.two> at (300,8) content-size 200x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [300,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [300,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <div.three> at (500,8) content-size 292x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [500,8 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [500,8 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       Box <div.container> at (8,8) content-size 784x34 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 784x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.two> at (8,25) content-size 784x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,25 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,25 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
@@ -3,23 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       Box <div.grid> at (8,8) content-size 784x34 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div> at (269.328125,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
         BlockContainer <div> at (530.65625,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 8.890625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 8.890625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 8.890625x17] baseline: 13.296875
               "c"
           TextNode <#text>
         BlockContainer <div> at (8,25) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 7.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,25 7.859375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,25 7.859375x17] baseline: 13.296875
               "d"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
+++ b/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
@@ -5,64 +5,55 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.a> at (8,8) content-size 196x17 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.c> at (204,8) content-size 196x17 [BFC] children: inline
-          line 0 width: 8.890625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [204,8 8.890625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [204,8 8.890625x17] baseline: 13.296875
               "c"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.b> at (400,8) content-size 196x17 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,8 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.b> at (400,25) content-size 196x17 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,25 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,25 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.d> at (596,25) content-size 196x17 [BFC] children: inline
-          line 0 width: 7.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [596,25 7.859375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [596,25 7.859375x17] baseline: 13.296875
               "d"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.c> at (204,42) content-size 196x17 [BFC] children: inline
-          line 0 width: 8.890625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [204,42 8.890625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [204,42 8.890625x17] baseline: 13.296875
               "c"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.d> at (596,42) content-size 196x17 [BFC] children: inline
-          line 0 width: 7.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [596,42 7.859375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [596,42 7.859375x17] baseline: 13.296875
               "d"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.e> at (8,59) content-size 196x17 [BFC] children: inline
-          line 0 width: 8.71875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,59 8.71875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,59 8.71875x17] baseline: 13.296875
               "e"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.f> at (204,59) content-size 196x17 [BFC] children: inline
-          line 0 width: 6.4375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [204,59 6.4375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [204,59 6.4375x17] baseline: 13.296875
               "f"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/order.txt
+++ b/Tests/LibWeb/Layout/expected/grid/order.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-1> at (271.328125,12) content-size 100x100 [BFC] children: inline
-          line 0 width: 7.9375, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 1, rect: [271.328125,12 7.9375x22]
+          frag 0 from TextNode start: 0, length: 1, rect: [271.328125,12 7.9375x22] baseline: 17
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-2> at (530.65625,12) content-size 100x100 [BFC] children: inline
-          line 0 width: 11.015625, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,12 11.015625x22]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,12 11.015625x22] baseline: 17
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-3> at (12,12) content-size 100x100 [BFC] children: inline
-          line 0 width: 11.375, height: 22, bottom: 22, baseline: 17
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 11.375x22]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 11.375x22] baseline: 17
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/place-items-center-nested-grids.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-items-center-nested-grids.txt
@@ -3,20 +3,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (8,8) content-size 784x85 [GFC] children: not-inline
       Box <div> at (8,8) content-size 784x85 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 65.328125x85 [BFC] children: inline
-          line 0 width: 50.5625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [8,8 50.5625x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,8 50.5625x17] baseline: 13.296875
               "Making"
-          line 1 width: 80.234375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 7, length: 8, rect: [8,25 80.234375x17]
+          frag 1 from TextNode start: 7, length: 8, rect: [8,25 80.234375x17] baseline: 13.296875
               "Commerce"
-          line 2 width: 49.328125, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 16, length: 6, rect: [8,42 49.328125x17]
+          frag 2 from TextNode start: 16, length: 6, rect: [8,42 49.328125x17] baseline: 13.296875
               "Better"
-          line 3 width: 25.625, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 23, length: 3, rect: [8,59 25.625x17]
+          frag 3 from TextNode start: 23, length: 3, rect: [8,59 25.625x17] baseline: 13.296875
               "for"
-          line 4 width: 73.46875, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 27, length: 8, rect: [8,76 73.46875x17]
+          frag 4 from TextNode start: 27, length: 8, rect: [8,76 73.46875x17] baseline: 13.296875
               "Everyone"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/place-items-center.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-items-center.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x19 [GFC] children: not-inline
       BlockContainer <div> at (362.9375,11) content-size 74.125x17 [BFC] children: inline
-        line 0 width: 74.125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 8, rect: [362.9375,11 74.125x17]
+        frag 0 from TextNode start: 0, length: 8, rect: [362.9375,11 74.125x17] baseline: 13.296875
             "Download"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/place-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-self.txt
@@ -3,39 +3,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x243 children: not-inline
       Box <div.grid> at (31,31) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div.start> at (32,32) content-size 50.203125x17 [BFC] children: inline
-          line 0 width: 50.203125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [32,32 50.203125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [32,32 50.203125x17] baseline: 13.296875
               "Start1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,42) content-size 347x17 [BFC] children: inline
-          line 0 width: 52.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [411,42 52.671875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [411,42 52.671875x17] baseline: 13.296875
               "Start2"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,91) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid> at (31,112) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div.center> at (185.796875,123) content-size 59.390625x17 [BFC] children: inline
-          line 0 width: 59.390625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [185.796875,123 59.390625x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [185.796875,123 59.390625x17] baseline: 13.296875
               "Center1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,123) content-size 347x17 [BFC] children: inline
-          line 0 width: 61.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [411,123 61.859375x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [411,123 61.859375x17] baseline: 13.296875
               "Center2"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,172) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid> at (31,193) content-size 738x39 [GFC] children: not-inline
         BlockContainer <div.end> at (363.328125,214) content-size 35.671875x17 [BFC] children: inline
-          line 0 width: 35.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [363.328125,214 35.671875x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [363.328125,214 35.671875x17] baseline: 13.296875
               "End1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,204) content-size 347x17 [BFC] children: inline
-          line 0 width: 38.140625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [411,204 38.140625x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [411,204 38.140625x17] baseline: 13.296875
               "End2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-1.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 516.625x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.b> at (530.625,12) content-size 257.3125x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.625,12 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.625,12 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div.grid-item.a> at (12,12) content-size 257.3125x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.grid-item.b> at (271.3125,12) content-size 516.625x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [271.3125,12 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [271.3125,12 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-3.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x100 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 776x38 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.b> at (12,52) content-size 776x58 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,52 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,52 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-4.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-4.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x40 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x38 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 776x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div> at (12,31) content-size 387x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,31 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,31 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-1.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 387x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.b> at (401,12) content-size 387x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [401,12 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [401,12 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-2.txt
@@ -3,23 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x77 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x75 [GFC] children: not-inline
         BlockContainer <div.grid-item.a> at (12,12) content-size 257.328125x73 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div.grid-item.b> at (530.65625,12) content-size 257.328125x48 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,12 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,12 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <div.grid-item.c> at (271.328125,12) content-size 257.328125x23 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [271.328125,12 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [271.328125,12 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <div.grid-item.d> at (271.328125,62) content-size 516.65625x23 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [271.328125,62 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [271.328125,62 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-3.txt
@@ -3,23 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x40 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x38 [GFC] children: not-inline
         BlockContainer <div.a> at (62,12) content-size 98x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [62,12 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [62,12 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <div> at (162,12) content-size 48x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [162,12 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [162,12 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <div> at (212,12) content-size 98x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [212,12 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [212,12 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <div> at (12,31) content-size 48x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,31 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,31 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (2,2) content-size 796x62 [BFC] children: not-inline
     Box <body> at (12,12) content-size 600x42 [GFC] children: not-inline
       BlockContainer <div.exekiller> at (14,14) content-size 200x17 positioned [BFC] children: inline
-        line 0 width: 65.4375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17]
+        frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17] baseline: 13.296875
             "exekiller"
         TextNode <#text>
       BlockContainer <div.athena> at (24,25) content-size 200x17 positioned [BFC] children: inline
-        line 0 width: 53.171875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [24,25 53.171875x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [24,25 53.171875x17] baseline: 13.296875
             "athena"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/repeat.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat.txt
@@ -5,43 +5,37 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 392x200 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,8) content-size 392x100 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,108) content-size 196x50 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,108 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,108 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (596,108) content-size 196x50 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [596,108 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [596,108 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,158) content-size 196x50 [BFC] children: inline
-          line 0 width: 8.453125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,158 8.453125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,158 8.453125x17] baseline: 13.296875
               "5"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (596,158) content-size 196x50 [BFC] children: inline
-          line 0 width: 8.734375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [596,158 8.734375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [596,158 8.734375x17] baseline: 13.296875
               "6"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -54,29 +48,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,208) content-size 50x17 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,208 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,208 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (58,208) content-size 50x17 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [58,208 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [58,208 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (108,208) content-size 100x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [108,208 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [108,208 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (208,208) content-size 100x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [208,208 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [208,208 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-height.txt
@@ -5,29 +5,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 392x50 [BFC] children: inline
-          line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,8) content-size 392x50 [BFC] children: inline
-          line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17] baseline: 13.296875
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,58) content-size 392x17 [BFC] children: inline
-          line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [8,58 9.09375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,58 9.09375x17] baseline: 13.296875
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (400,58) content-size 392x17 [BFC] children: inline
-          line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [400,58 7.75x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [400,58 7.75x17] baseline: 13.296875
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
@@ -5,100 +5,71 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-one> at (401.46875,8) content-size 392x127.5 [BFC] children: inline
-          line 0 width: 319.171875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 40, rect: [401.46875,8 319.171875x17]
+          frag 0 from TextNode start: 1, length: 40, rect: [401.46875,8 319.171875x17] baseline: 13.296875
               "In a sollicitudin augue. Sed ante augue,"
-          line 1 width: 335.125, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 42, length: 42, rect: [401.46875,25 335.125x17]
+          frag 1 from TextNode start: 42, length: 42, rect: [401.46875,25 335.125x17] baseline: 13.296875
               "rhoncus nec porttitor id, lacinia et nibh."
-          line 2 width: 378.625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 85, length: 48, rect: [401.46875,42 378.625x17]
+          frag 2 from TextNode start: 85, length: 48, rect: [401.46875,42 378.625x17] baseline: 13.296875
               "Pellentesque diam libero, ultrices eget eleifend"
-          line 3 width: 182.8125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 134, length: 22, rect: [401.46875,59 182.8125x17]
+          frag 3 from TextNode start: 134, length: 22, rect: [401.46875,59 182.8125x17] baseline: 13.296875
               "at, consequat ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-two> at (401.46875,135.5) content-size 392x178.5 [BFC] children: inline
-          line 0 width: 359.15625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 43, rect: [401.46875,135.5 359.15625x17]
+          frag 0 from TextNode start: 1, length: 43, rect: [401.46875,135.5 359.15625x17] baseline: 13.296875
               "Suspendisse potenti. Pellentesque at varius"
-          line 1 width: 318.5625, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 45, length: 41, rect: [401.46875,152.5 318.5625x17]
+          frag 1 from TextNode start: 45, length: 41, rect: [401.46875,152.5 318.5625x17] baseline: 13.296875
               "lacus, sed sollicitudin leo. Pellentesque"
-          line 2 width: 377.640625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 87, length: 44, rect: [401.46875,169.5 377.640625x17]
+          frag 2 from TextNode start: 87, length: 44, rect: [401.46875,169.5 377.640625x17] baseline: 13.296875
               "malesuada mi eget pellentesque tempor. Donec"
-          line 3 width: 378.03125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 132, length: 47, rect: [401.46875,186.5 378.03125x17]
+          frag 3 from TextNode start: 132, length: 47, rect: [401.46875,186.5 378.03125x17] baseline: 13.296875
               "egestas mauris est, ut lobortis nisi luctus at."
-          line 4 width: 345.953125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 180, length: 41, rect: [401.46875,203.5 345.953125x17]
+          frag 4 from TextNode start: 180, length: 41, rect: [401.46875,203.5 345.953125x17] baseline: 13.296875
               "Vivamus eleifend, lorem vulputate maximus"
-          line 5 width: 312.765625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 222, length: 37, rect: [401.46875,220.5 312.765625x17]
+          frag 5 from TextNode start: 222, length: 37, rect: [401.46875,220.5 312.765625x17] baseline: 13.296875
               "porta, nunc metus porttitor nibh, nec"
-          line 6 width: 242.921875, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 260, length: 31, rect: [401.46875,237.5 242.921875x17]
+          frag 6 from TextNode start: 260, length: 31, rect: [401.46875,237.5 242.921875x17] baseline: 13.296875
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 393.46875x306 [BFC] children: inline
-          line 0 width: 337.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17]
+          frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17] baseline: 13.296875
               "Lorem ipsum dolor sit amet, consectetur"
-          line 1 width: 376.34375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17]
+          frag 1 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17] baseline: 13.296875
               "adipiscing elit. Sed vitae condimentum erat, ac"
-          line 2 width: 365.84375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17]
+          frag 2 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17] baseline: 13.296875
               "posuere arcu. Aenean tincidunt mi ligula, vel"
-          line 3 width: 381.96875, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 135, length: 46, rect: [8,59 381.96875x17]
+          frag 3 from TextNode start: 135, length: 46, rect: [8,59 381.96875x17] baseline: 13.296875
               "semper dolor aliquet at. Phasellus scelerisque"
-          line 4 width: 377.203125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 182, length: 45, rect: [8,76 377.203125x17]
+          frag 4 from TextNode start: 182, length: 45, rect: [8,76 377.203125x17] baseline: 13.296875
               "dapibus diam sed rhoncus. Proin sed orci leo."
-          line 5 width: 375.390625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 228, length: 45, rect: [8,93 375.390625x17]
+          frag 5 from TextNode start: 228, length: 45, rect: [8,93 375.390625x17] baseline: 13.296875
               "Praesent pellentesque mi eu nunc gravida, vel"
-          line 6 width: 383.53125, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 274, length: 46, rect: [8,110 383.53125x17]
+          frag 6 from TextNode start: 274, length: 46, rect: [8,110 383.53125x17] baseline: 13.296875
               "consectetur nulla malesuada. Sed pellentesque,"
-          line 7 width: 344.8125, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 321, length: 47, rect: [8,127 344.8125x17]
+          frag 7 from TextNode start: 321, length: 47, rect: [8,127 344.8125x17] baseline: 13.296875
               "elit sit amet sollicitudin sollicitudin, lectus"
-          line 8 width: 374.703125, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 369, length: 46, rect: [8,144 374.703125x17]
+          frag 8 from TextNode start: 369, length: 46, rect: [8,144 374.703125x17] baseline: 13.296875
               "justo facilisis lacus, ac vehicula metus neque"
-          line 9 width: 384.125, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 416, length: 45, rect: [8,161 384.125x17]
+          frag 9 from TextNode start: 416, length: 45, rect: [8,161 384.125x17] baseline: 13.296875
               "ac mi. In in augue et massa maximus venenatis"
-          line 10 width: 373.25, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 462, length: 44, rect: [8,178 373.25x17]
+          frag 10 from TextNode start: 462, length: 44, rect: [8,178 373.25x17] baseline: 13.296875
               "auctor fermentum dui. Aliquam dictum finibus"
-          line 11 width: 288.203125, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 507, length: 35, rect: [8,195 288.203125x17]
+          frag 11 from TextNode start: 507, length: 35, rect: [8,195 288.203125x17] baseline: 13.296875
               "urna, quis lacinia massa laoreet a."
-          line 12 width: 316.296875, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 543, length: 36, rect: [8,212 316.296875x17]
+          frag 12 from TextNode start: 543, length: 36, rect: [8,212 316.296875x17] baseline: 13.296875
               "Suspendisse elementum non lectus nec"
-          line 13 width: 388.78125, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 580, length: 48, rect: [8,229 388.78125x17]
+          frag 13 from TextNode start: 580, length: 48, rect: [8,229 388.78125x17] baseline: 13.296875
               "elementum. Quisque ultricies suscipit porttitor."
-          line 14 width: 373.828125, height: 17, bottom: 255, baseline: 13.296875
-            frag 0 from TextNode start: 629, length: 45, rect: [8,246 373.828125x17]
+          frag 14 from TextNode start: 629, length: 45, rect: [8,246 373.828125x17] baseline: 13.296875
               "Sed non urna rutrum, mattis nulla at, feugiat"
-          line 15 width: 368.75, height: 17, bottom: 272, baseline: 13.296875
-            frag 0 from TextNode start: 675, length: 48, rect: [8,263 368.75x17]
+          frag 15 from TextNode start: 675, length: 48, rect: [8,263 368.75x17] baseline: 13.296875
               "erat. Duis orci elit, vehicula sed blandit eget,"
-          line 16 width: 390.625, height: 17, bottom: 289, baseline: 13.296875
-            frag 0 from TextNode start: 724, length: 46, rect: [8,280 390.625x17]
+          frag 16 from TextNode start: 724, length: 46, rect: [8,280 390.625x17] baseline: 13.296875
               "auctor in arcu. Ut cursus magna sit amet nulla"
-          line 17 width: 294.90625, height: 17, bottom: 306, baseline: 13.296875
-            frag 0 from TextNode start: 771, length: 36, rect: [8,297 294.90625x17]
+          frag 17 from TextNode start: 771, length: 36, rect: [8,297 294.90625x17] baseline: 13.296875
               "cursus, vitae gravida mauris dictum."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
@@ -5,181 +5,125 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-one> at (108.640625,8) content-size 101.515625x238 [BFC] children: inline
-          line 0 width: 31.546875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 4, rect: [108.640625,8 31.546875x17]
+          frag 0 from TextNode start: 1, length: 4, rect: [108.640625,8 31.546875x17] baseline: 13.296875
               "In a"
-          line 1 width: 84.84375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 6, length: 12, rect: [108.640625,25 84.84375x17]
+          frag 1 from TextNode start: 6, length: 12, rect: [108.640625,25 84.84375x17] baseline: 13.296875
               "sollicitudin"
-          line 2 width: 86.046875, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 19, length: 10, rect: [108.640625,42 86.046875x17]
+          frag 2 from TextNode start: 19, length: 10, rect: [108.640625,42 86.046875x17] baseline: 13.296875
               "augue. Sed"
-          line 3 width: 92.734375, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 30, length: 11, rect: [108.640625,59 92.734375x17]
+          frag 3 from TextNode start: 30, length: 11, rect: [108.640625,59 92.734375x17] baseline: 13.296875
               "ante augue,"
-          line 4 width: 101.3125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 42, length: 11, rect: [108.640625,76 101.3125x17]
+          frag 4 from TextNode start: 42, length: 11, rect: [108.640625,76 101.3125x17] baseline: 13.296875
               "rhoncus nec"
-          line 5 width: 98.40625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 54, length: 13, rect: [108.640625,93 98.40625x17]
+          frag 5 from TextNode start: 54, length: 13, rect: [108.640625,93 98.40625x17] baseline: 13.296875
               "porttitor id,"
-          line 6 width: 74.125, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 68, length: 10, rect: [108.640625,110 74.125x17]
+          frag 6 from TextNode start: 68, length: 10, rect: [108.640625,110 74.125x17] baseline: 13.296875
               "lacinia et"
-          line 7 width: 37.28125, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 79, length: 5, rect: [108.640625,127 37.28125x17]
+          frag 7 from TextNode start: 79, length: 5, rect: [108.640625,127 37.28125x17] baseline: 13.296875
               "nibh."
-          line 8 width: 101.515625, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 85, length: 12, rect: [108.640625,144 101.515625x17]
+          frag 8 from TextNode start: 85, length: 12, rect: [108.640625,144 101.515625x17] baseline: 13.296875
               "Pellentesque"
-          line 9 width: 93.1875, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 98, length: 12, rect: [108.640625,161 93.1875x17]
+          frag 9 from TextNode start: 98, length: 12, rect: [108.640625,161 93.1875x17] baseline: 13.296875
               "diam libero,"
-          line 10 width: 101.0625, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 111, length: 13, rect: [108.640625,178 101.0625x17]
+          frag 10 from TextNode start: 111, length: 13, rect: [108.640625,178 101.0625x17] baseline: 13.296875
               "ultrices eget"
-          line 11 width: 88.109375, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 125, length: 12, rect: [108.640625,195 88.109375x17]
+          frag 11 from TextNode start: 125, length: 12, rect: [108.640625,195 88.109375x17] baseline: 13.296875
               "eleifend at,"
-          line 12 width: 83.953125, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 138, length: 9, rect: [108.640625,212 83.953125x17]
+          frag 12 from TextNode start: 138, length: 9, rect: [108.640625,212 83.953125x17] baseline: 13.296875
               "consequat"
-          line 13 width: 61.609375, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 148, length: 8, rect: [108.640625,229 61.609375x17]
+          frag 13 from TextNode start: 148, length: 8, rect: [108.640625,229 61.609375x17] baseline: 13.296875
               "ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-two> at (108.640625,246) content-size 101.515625x306 [BFC] children: inline
-          line 0 width: 98.65625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 11, rect: [108.640625,246 98.65625x17]
+          frag 0 from TextNode start: 1, length: 11, rect: [108.640625,246 98.65625x17] baseline: 13.296875
               "Suspendisse"
-          line 1 width: 60.734375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 13, length: 8, rect: [108.640625,263 60.734375x17]
+          frag 1 from TextNode start: 13, length: 8, rect: [108.640625,263 60.734375x17] baseline: 13.296875
               "potenti."
-          line 2 width: 101.515625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 22, length: 12, rect: [108.640625,280 101.515625x17]
+          frag 2 from TextNode start: 22, length: 12, rect: [108.640625,280 101.515625x17] baseline: 13.296875
               "Pellentesque"
-          line 3 width: 74.25, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 35, length: 9, rect: [108.640625,297 74.25x17]
+          frag 3 from TextNode start: 35, length: 9, rect: [108.640625,297 74.25x17] baseline: 13.296875
               "at varius"
-          line 4 width: 80.546875, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 45, length: 10, rect: [108.640625,314 80.546875x17]
+          frag 4 from TextNode start: 45, length: 10, rect: [108.640625,314 80.546875x17] baseline: 13.296875
               "lacus, sed"
-          line 5 width: 84.84375, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 56, length: 12, rect: [108.640625,331 84.84375x17]
+          frag 5 from TextNode start: 56, length: 12, rect: [108.640625,331 84.84375x17] baseline: 13.296875
               "sollicitudin"
-          line 6 width: 27.65625, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 69, length: 4, rect: [108.640625,348 27.65625x17]
+          frag 6 from TextNode start: 69, length: 4, rect: [108.640625,348 27.65625x17] baseline: 13.296875
               "leo."
-          line 7 width: 101.515625, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 74, length: 12, rect: [108.640625,365 101.515625x17]
+          frag 7 from TextNode start: 74, length: 12, rect: [108.640625,365 101.515625x17] baseline: 13.296875
               "Pellentesque"
-          line 8 width: 80.15625, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 87, length: 9, rect: [108.640625,382 80.15625x17]
+          frag 8 from TextNode start: 87, length: 9, rect: [108.640625,382 80.15625x17] baseline: 13.296875
               "malesuada"
-          line 9 width: 56.625, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 97, length: 7, rect: [108.640625,399 56.625x17]
+          frag 9 from TextNode start: 97, length: 7, rect: [108.640625,399 56.625x17] baseline: 13.296875
               "mi eget"
-          line 10 width: 99.40625, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 105, length: 12, rect: [108.640625,416 99.40625x17]
+          frag 10 from TextNode start: 105, length: 12, rect: [108.640625,416 99.40625x17] baseline: 13.296875
               "pellentesque"
-          line 11 width: 60.734375, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 118, length: 7, rect: [108.640625,433 60.734375x17]
+          frag 11 from TextNode start: 118, length: 7, rect: [108.640625,433 60.734375x17] baseline: 13.296875
               "tempor."
-          line 12 width: 48.71875, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 126, length: 5, rect: [108.640625,450 48.71875x17]
+          frag 12 from TextNode start: 126, length: 5, rect: [108.640625,450 48.71875x17] baseline: 13.296875
               "Donec"
-          line 13 width: 59.890625, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 132, length: 7, rect: [108.640625,467 59.890625x17]
+          frag 13 from TextNode start: 132, length: 7, rect: [108.640625,467 59.890625x17] baseline: 13.296875
               "egestas"
-          line 14 width: 92.015625, height: 17, bottom: 255, baseline: 13.296875
-            frag 0 from TextNode start: 140, length: 11, rect: [108.640625,484 92.015625x17]
+          frag 14 from TextNode start: 140, length: 11, rect: [108.640625,484 92.015625x17] baseline: 13.296875
               "mauris est,"
-          line 15 width: 88.640625, height: 17, bottom: 272, baseline: 13.296875
-            frag 0 from TextNode start: 152, length: 11, rect: [108.640625,501 88.640625x17]
+          frag 15 from TextNode start: 152, length: 11, rect: [108.640625,501 88.640625x17] baseline: 13.296875
               "ut lobortis"
-          line 16 width: 84.9375, height: 17, bottom: 289, baseline: 13.296875
-            frag 0 from TextNode start: 164, length: 11, rect: [108.640625,518 84.9375x17]
+          frag 16 from TextNode start: 164, length: 11, rect: [108.640625,518 84.9375x17] baseline: 13.296875
               "nisi luctus"
-          line 17 width: 20.546875, height: 17, bottom: 306, baseline: 13.296875
-            frag 0 from TextNode start: 176, length: 3, rect: [108.640625,535 20.546875x17]
+          frag 17 from TextNode start: 176, length: 3, rect: [108.640625,535 20.546875x17] baseline: 13.296875
               "at."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 100.640625x544 [BFC] children: inline
-          line 0 width: 50.96875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 5, rect: [8,8 50.96875x17]
+          frag 0 from TextNode start: 1, length: 5, rect: [8,8 50.96875x17] baseline: 13.296875
               "Lorem"
-          line 1 width: 94.9375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 7, length: 11, rect: [8,25 94.9375x17]
+          frag 1 from TextNode start: 7, length: 11, rect: [8,25 94.9375x17] baseline: 13.296875
               "ipsum dolor"
-          line 2 width: 70.9375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 19, length: 9, rect: [8,42 70.9375x17]
+          frag 2 from TextNode start: 19, length: 9, rect: [8,42 70.9375x17] baseline: 13.296875
               "sit amet,"
-          line 3 width: 96.84375, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 29, length: 11, rect: [8,59 96.84375x17]
+          frag 3 from TextNode start: 29, length: 11, rect: [8,59 96.84375x17] baseline: 13.296875
               "consectetur"
-          line 4 width: 75.71875, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 41, length: 10, rect: [8,76 75.71875x17]
+          frag 4 from TextNode start: 41, length: 10, rect: [8,76 75.71875x17] baseline: 13.296875
               "adipiscing"
-          line 5 width: 65.265625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 52, length: 9, rect: [8,93 65.265625x17]
+          frag 5 from TextNode start: 52, length: 9, rect: [8,93 65.265625x17] baseline: 13.296875
               "elit. Sed"
-          line 6 width: 37.6875, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 62, length: 5, rect: [8,110 37.6875x17]
+          frag 6 from TextNode start: 62, length: 5, rect: [8,110 37.6875x17] baseline: 13.296875
               "vitae"
-          line 7 width: 100.640625, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 68, length: 11, rect: [8,127 100.640625x17]
+          frag 7 from TextNode start: 68, length: 11, rect: [8,127 100.640625x17] baseline: 13.296875
               "condimentum"
-          line 8 width: 65.03125, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 80, length: 8, rect: [8,144 65.03125x17]
+          frag 8 from TextNode start: 80, length: 8, rect: [8,144 65.03125x17] baseline: 13.296875
               "erat, ac"
-          line 9 width: 65.15625, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 89, length: 7, rect: [8,161 65.15625x17]
+          frag 9 from TextNode start: 89, length: 7, rect: [8,161 65.15625x17] baseline: 13.296875
               "posuere"
-          line 10 width: 41.171875, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 97, length: 5, rect: [8,178 41.171875x17]
+          frag 10 from TextNode start: 97, length: 5, rect: [8,178 41.171875x17] baseline: 13.296875
               "arcu."
-          line 11 width: 60.265625, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 103, length: 6, rect: [8,195 60.265625x17]
+          frag 11 from TextNode start: 103, length: 6, rect: [8,195 60.265625x17] baseline: 13.296875
               "Aenean"
-          line 12 width: 93.34375, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 110, length: 12, rect: [8,212 93.34375x17]
+          frag 12 from TextNode start: 110, length: 12, rect: [8,212 93.34375x17] baseline: 13.296875
               "tincidunt mi"
-          line 13 width: 73.90625, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 123, length: 11, rect: [8,229 73.90625x17]
+          frag 13 from TextNode start: 123, length: 11, rect: [8,229 73.90625x17] baseline: 13.296875
               "ligula, vel"
-          line 14 width: 57.234375, height: 17, bottom: 255, baseline: 13.296875
-            frag 0 from TextNode start: 135, length: 6, rect: [8,246 57.234375x17]
+          frag 14 from TextNode start: 135, length: 6, rect: [8,246 57.234375x17] baseline: 13.296875
               "semper"
-          line 15 width: 41.640625, height: 17, bottom: 272, baseline: 13.296875
-            frag 0 from TextNode start: 142, length: 5, rect: [8,263 41.640625x17]
+          frag 15 from TextNode start: 142, length: 5, rect: [8,263 41.640625x17] baseline: 13.296875
               "dolor"
-          line 16 width: 83.09375, height: 17, bottom: 289, baseline: 13.296875
-            frag 0 from TextNode start: 148, length: 11, rect: [8,280 83.09375x17]
+          frag 16 from TextNode start: 148, length: 11, rect: [8,280 83.09375x17] baseline: 13.296875
               "aliquet at."
-          line 17 width: 75.8125, height: 17, bottom: 306, baseline: 13.296875
-            frag 0 from TextNode start: 160, length: 9, rect: [8,297 75.8125x17]
+          frag 17 from TextNode start: 160, length: 9, rect: [8,297 75.8125x17] baseline: 13.296875
               "Phasellus"
-          line 18 width: 92.1875, height: 17, bottom: 323, baseline: 13.296875
-            frag 0 from TextNode start: 170, length: 11, rect: [8,314 92.1875x17]
+          frag 18 from TextNode start: 170, length: 11, rect: [8,314 92.1875x17] baseline: 13.296875
               "scelerisque"
-          line 19 width: 59.765625, height: 17, bottom: 340, baseline: 13.296875
-            frag 0 from TextNode start: 182, length: 7, rect: [8,331 59.765625x17]
+          frag 19 from TextNode start: 182, length: 7, rect: [8,331 59.765625x17] baseline: 13.296875
               "dapibus"
-          line 20 width: 67.890625, height: 17, bottom: 357, baseline: 13.296875
-            frag 0 from TextNode start: 190, length: 8, rect: [8,348 67.890625x17]
+          frag 20 from TextNode start: 190, length: 8, rect: [8,348 67.890625x17] baseline: 13.296875
               "diam sed"
-          line 21 width: 70.4375, height: 17, bottom: 374, baseline: 13.296875
-            frag 0 from TextNode start: 199, length: 8, rect: [8,365 70.4375x17]
+          frag 21 from TextNode start: 199, length: 8, rect: [8,365 70.4375x17] baseline: 13.296875
               "rhoncus."
-          line 22 width: 78.8125, height: 17, bottom: 391, baseline: 13.296875
-            frag 0 from TextNode start: 208, length: 9, rect: [8,382 78.8125x17]
+          frag 22 from TextNode start: 208, length: 9, rect: [8,382 78.8125x17] baseline: 13.296875
               "Proin sed"
-          line 23 width: 68.296875, height: 17, bottom: 408, baseline: 13.296875
-            frag 0 from TextNode start: 218, length: 9, rect: [8,399 68.296875x17]
+          frag 23 from TextNode start: 218, length: 9, rect: [8,399 68.296875x17] baseline: 13.296875
               "orci leo."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
@@ -5,103 +5,73 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-one> at (411.46875,8) content-size 382x126 [BFC] children: inline
-          line 0 width: 319.171875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 40, rect: [411.46875,8 319.171875x17]
+          frag 0 from TextNode start: 1, length: 40, rect: [411.46875,8 319.171875x17] baseline: 13.296875
               "In a sollicitudin augue. Sed ante augue,"
-          line 1 width: 335.125, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 42, length: 42, rect: [411.46875,25 335.125x17]
+          frag 1 from TextNode start: 42, length: 42, rect: [411.46875,25 335.125x17] baseline: 13.296875
               "rhoncus nec porttitor id, lacinia et nibh."
-          line 2 width: 378.625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 85, length: 48, rect: [411.46875,42 378.625x17]
+          frag 2 from TextNode start: 85, length: 48, rect: [411.46875,42 378.625x17] baseline: 13.296875
               "Pellentesque diam libero, ultrices eget eleifend"
-          line 3 width: 182.8125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 134, length: 22, rect: [411.46875,59 182.8125x17]
+          frag 3 from TextNode start: 134, length: 22, rect: [411.46875,59 182.8125x17] baseline: 13.296875
               "at, consequat ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-two> at (411.46875,154) content-size 382x177 [BFC] children: inline
-          line 0 width: 359.15625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 43, rect: [411.46875,154 359.15625x17]
+          frag 0 from TextNode start: 1, length: 43, rect: [411.46875,154 359.15625x17] baseline: 13.296875
               "Suspendisse potenti. Pellentesque at varius"
-          line 1 width: 318.5625, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 45, length: 41, rect: [411.46875,171 318.5625x17]
+          frag 1 from TextNode start: 45, length: 41, rect: [411.46875,171 318.5625x17] baseline: 13.296875
               "lacus, sed sollicitudin leo. Pellentesque"
-          line 2 width: 377.640625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 87, length: 44, rect: [411.46875,188 377.640625x17]
+          frag 2 from TextNode start: 87, length: 44, rect: [411.46875,188 377.640625x17] baseline: 13.296875
               "malesuada mi eget pellentesque tempor. Donec"
-          line 3 width: 378.03125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 132, length: 47, rect: [411.46875,205 378.03125x17]
+          frag 3 from TextNode start: 132, length: 47, rect: [411.46875,205 378.03125x17] baseline: 13.296875
               "egestas mauris est, ut lobortis nisi luctus at."
-          line 4 width: 345.953125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 180, length: 41, rect: [411.46875,222 345.953125x17]
+          frag 4 from TextNode start: 180, length: 41, rect: [411.46875,222 345.953125x17] baseline: 13.296875
               "Vivamus eleifend, lorem vulputate maximus"
-          line 5 width: 312.765625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 222, length: 37, rect: [411.46875,239 312.765625x17]
+          frag 5 from TextNode start: 222, length: 37, rect: [411.46875,239 312.765625x17] baseline: 13.296875
               "porta, nunc metus porttitor nibh, nec"
-          line 6 width: 242.921875, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 260, length: 31, rect: [411.46875,256 242.921875x17]
+          frag 6 from TextNode start: 260, length: 31, rect: [411.46875,256 242.921875x17] baseline: 13.296875
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 383.46875x323 [BFC] children: inline
-          line 0 width: 337.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17]
+          frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17] baseline: 13.296875
               "Lorem ipsum dolor sit amet, consectetur"
-          line 1 width: 376.34375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17]
+          frag 1 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17] baseline: 13.296875
               "adipiscing elit. Sed vitae condimentum erat, ac"
-          line 2 width: 365.84375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17]
+          frag 2 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17] baseline: 13.296875
               "posuere arcu. Aenean tincidunt mi ligula, vel"
-          line 3 width: 381.96875, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 135, length: 46, rect: [8,59 381.96875x17]
+          frag 3 from TextNode start: 135, length: 46, rect: [8,59 381.96875x17] baseline: 13.296875
               "semper dolor aliquet at. Phasellus scelerisque"
-          line 4 width: 377.203125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 182, length: 45, rect: [8,76 377.203125x17]
+          frag 4 from TextNode start: 182, length: 45, rect: [8,76 377.203125x17] baseline: 13.296875
               "dapibus diam sed rhoncus. Proin sed orci leo."
-          line 5 width: 375.390625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 228, length: 45, rect: [8,93 375.390625x17]
+          frag 5 from TextNode start: 228, length: 45, rect: [8,93 375.390625x17] baseline: 13.296875
               "Praesent pellentesque mi eu nunc gravida, vel"
-          line 6 width: 271.078125, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 274, length: 32, rect: [8,110 271.078125x17]
+          frag 6 from TextNode start: 274, length: 32, rect: [8,110 271.078125x17] baseline: 13.296875
               "consectetur nulla malesuada. Sed"
-          line 7 width: 303.5625, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 307, length: 40, rect: [8,127 303.5625x17]
+          frag 7 from TextNode start: 307, length: 40, rect: [8,127 303.5625x17] baseline: 13.296875
               "pellentesque, elit sit amet sollicitudin"
-          line 8 width: 346.625, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 348, length: 46, rect: [8,144 346.625x17]
+          frag 8 from TextNode start: 348, length: 46, rect: [8,144 346.625x17] baseline: 13.296875
               "sollicitudin, lectus justo facilisis lacus, ac"
-          line 9 width: 350.234375, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 395, length: 42, rect: [8,161 350.234375x17]
+          frag 9 from TextNode start: 395, length: 42, rect: [8,161 350.234375x17] baseline: 13.296875
               "vehicula metus neque ac mi. In in augue et"
-          line 10 width: 361.0625, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 438, length: 40, rect: [8,178 361.0625x17]
+          frag 10 from TextNode start: 438, length: 40, rect: [8,178 361.0625x17] baseline: 13.296875
               "massa maximus venenatis auctor fermentum"
-          line 11 width: 371.734375, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 479, length: 46, rect: [8,195 371.734375x17]
+          frag 11 from TextNode start: 479, length: 46, rect: [8,195 371.734375x17] baseline: 13.296875
               "dui. Aliquam dictum finibus urna, quis lacinia"
-          line 12 width: 369.59375, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 526, length: 42, rect: [8,212 369.59375x17]
+          frag 12 from TextNode start: 526, length: 42, rect: [8,212 369.59375x17] baseline: 13.296875
               "massa laoreet a. Suspendisse elementum non"
-          line 13 width: 323.78125, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 569, length: 39, rect: [8,229 323.78125x17]
+          frag 13 from TextNode start: 569, length: 39, rect: [8,229 323.78125x17] baseline: 13.296875
               "lectus nec elementum. Quisque ultricies"
-          line 14 width: 337, height: 17, bottom: 255, baseline: 13.296875
-            frag 0 from TextNode start: 609, length: 40, rect: [8,246 337x17]
+          frag 14 from TextNode start: 609, length: 40, rect: [8,246 337x17] baseline: 13.296875
               "suscipit porttitor. Sed non urna rutrum,"
-          line 15 width: 351.828125, height: 17, bottom: 272, baseline: 13.296875
-            frag 0 from TextNode start: 650, length: 46, rect: [8,263 351.828125x17]
+          frag 15 from TextNode start: 650, length: 46, rect: [8,263 351.828125x17] baseline: 13.296875
               "mattis nulla at, feugiat erat. Duis orci elit,"
-          line 16 width: 361.328125, height: 17, bottom: 289, baseline: 13.296875
-            frag 0 from TextNode start: 697, length: 45, rect: [8,280 361.328125x17]
+          frag 16 from TextNode start: 697, length: 45, rect: [8,280 361.328125x17] baseline: 13.296875
               "vehicula sed blandit eget, auctor in arcu. Ut"
-          line 17 width: 345.75, height: 17, bottom: 306, baseline: 13.296875
-            frag 0 from TextNode start: 743, length: 41, rect: [8,297 345.75x17]
+          frag 17 from TextNode start: 743, length: 41, rect: [8,297 345.75x17] baseline: 13.296875
               "cursus magna sit amet nulla cursus, vitae"
-          line 18 width: 180.234375, height: 17, bottom: 323, baseline: 13.296875
-            frag 0 from TextNode start: 785, length: 22, rect: [8,314 180.234375x17]
+          frag 18 from TextNode start: 785, length: 22, rect: [8,314 180.234375x17] baseline: 13.296875
               "gravida mauris dictum."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
@@ -5,100 +5,71 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-one> at (401.46875,8) content-size 392x127.5 [BFC] children: inline
-          line 0 width: 319.171875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 40, rect: [401.46875,8 319.171875x17]
+          frag 0 from TextNode start: 1, length: 40, rect: [401.46875,8 319.171875x17] baseline: 13.296875
               "In a sollicitudin augue. Sed ante augue,"
-          line 1 width: 335.125, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 42, length: 42, rect: [401.46875,25 335.125x17]
+          frag 1 from TextNode start: 42, length: 42, rect: [401.46875,25 335.125x17] baseline: 13.296875
               "rhoncus nec porttitor id, lacinia et nibh."
-          line 2 width: 378.625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 85, length: 48, rect: [401.46875,42 378.625x17]
+          frag 2 from TextNode start: 85, length: 48, rect: [401.46875,42 378.625x17] baseline: 13.296875
               "Pellentesque diam libero, ultrices eget eleifend"
-          line 3 width: 182.8125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 134, length: 22, rect: [401.46875,59 182.8125x17]
+          frag 3 from TextNode start: 134, length: 22, rect: [401.46875,59 182.8125x17] baseline: 13.296875
               "at, consequat ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-one-two> at (401.46875,135.5) content-size 392x178.5 [BFC] children: inline
-          line 0 width: 359.15625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 43, rect: [401.46875,135.5 359.15625x17]
+          frag 0 from TextNode start: 1, length: 43, rect: [401.46875,135.5 359.15625x17] baseline: 13.296875
               "Suspendisse potenti. Pellentesque at varius"
-          line 1 width: 318.5625, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 45, length: 41, rect: [401.46875,152.5 318.5625x17]
+          frag 1 from TextNode start: 45, length: 41, rect: [401.46875,152.5 318.5625x17] baseline: 13.296875
               "lacus, sed sollicitudin leo. Pellentesque"
-          line 2 width: 377.640625, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 87, length: 44, rect: [401.46875,169.5 377.640625x17]
+          frag 2 from TextNode start: 87, length: 44, rect: [401.46875,169.5 377.640625x17] baseline: 13.296875
               "malesuada mi eget pellentesque tempor. Donec"
-          line 3 width: 378.03125, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 132, length: 47, rect: [401.46875,186.5 378.03125x17]
+          frag 3 from TextNode start: 132, length: 47, rect: [401.46875,186.5 378.03125x17] baseline: 13.296875
               "egestas mauris est, ut lobortis nisi luctus at."
-          line 4 width: 345.953125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 180, length: 41, rect: [401.46875,203.5 345.953125x17]
+          frag 4 from TextNode start: 180, length: 41, rect: [401.46875,203.5 345.953125x17] baseline: 13.296875
               "Vivamus eleifend, lorem vulputate maximus"
-          line 5 width: 312.765625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 222, length: 37, rect: [401.46875,220.5 312.765625x17]
+          frag 5 from TextNode start: 222, length: 37, rect: [401.46875,220.5 312.765625x17] baseline: 13.296875
               "porta, nunc metus porttitor nibh, nec"
-          line 6 width: 242.921875, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 260, length: 31, rect: [401.46875,237.5 242.921875x17]
+          frag 6 from TextNode start: 260, length: 31, rect: [401.46875,237.5 242.921875x17] baseline: 13.296875
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 393.46875x306 [BFC] children: inline
-          line 0 width: 337.6875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17]
+          frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17] baseline: 13.296875
               "Lorem ipsum dolor sit amet, consectetur"
-          line 1 width: 376.34375, height: 17, bottom: 34, baseline: 13.296875
-            frag 0 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17]
+          frag 1 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17] baseline: 13.296875
               "adipiscing elit. Sed vitae condimentum erat, ac"
-          line 2 width: 365.84375, height: 17, bottom: 51, baseline: 13.296875
-            frag 0 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17]
+          frag 2 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17] baseline: 13.296875
               "posuere arcu. Aenean tincidunt mi ligula, vel"
-          line 3 width: 381.96875, height: 17, bottom: 68, baseline: 13.296875
-            frag 0 from TextNode start: 135, length: 46, rect: [8,59 381.96875x17]
+          frag 3 from TextNode start: 135, length: 46, rect: [8,59 381.96875x17] baseline: 13.296875
               "semper dolor aliquet at. Phasellus scelerisque"
-          line 4 width: 377.203125, height: 17, bottom: 85, baseline: 13.296875
-            frag 0 from TextNode start: 182, length: 45, rect: [8,76 377.203125x17]
+          frag 4 from TextNode start: 182, length: 45, rect: [8,76 377.203125x17] baseline: 13.296875
               "dapibus diam sed rhoncus. Proin sed orci leo."
-          line 5 width: 375.390625, height: 17, bottom: 102, baseline: 13.296875
-            frag 0 from TextNode start: 228, length: 45, rect: [8,93 375.390625x17]
+          frag 5 from TextNode start: 228, length: 45, rect: [8,93 375.390625x17] baseline: 13.296875
               "Praesent pellentesque mi eu nunc gravida, vel"
-          line 6 width: 383.53125, height: 17, bottom: 119, baseline: 13.296875
-            frag 0 from TextNode start: 274, length: 46, rect: [8,110 383.53125x17]
+          frag 6 from TextNode start: 274, length: 46, rect: [8,110 383.53125x17] baseline: 13.296875
               "consectetur nulla malesuada. Sed pellentesque,"
-          line 7 width: 344.8125, height: 17, bottom: 136, baseline: 13.296875
-            frag 0 from TextNode start: 321, length: 47, rect: [8,127 344.8125x17]
+          frag 7 from TextNode start: 321, length: 47, rect: [8,127 344.8125x17] baseline: 13.296875
               "elit sit amet sollicitudin sollicitudin, lectus"
-          line 8 width: 374.703125, height: 17, bottom: 153, baseline: 13.296875
-            frag 0 from TextNode start: 369, length: 46, rect: [8,144 374.703125x17]
+          frag 8 from TextNode start: 369, length: 46, rect: [8,144 374.703125x17] baseline: 13.296875
               "justo facilisis lacus, ac vehicula metus neque"
-          line 9 width: 384.125, height: 17, bottom: 170, baseline: 13.296875
-            frag 0 from TextNode start: 416, length: 45, rect: [8,161 384.125x17]
+          frag 9 from TextNode start: 416, length: 45, rect: [8,161 384.125x17] baseline: 13.296875
               "ac mi. In in augue et massa maximus venenatis"
-          line 10 width: 373.25, height: 17, bottom: 187, baseline: 13.296875
-            frag 0 from TextNode start: 462, length: 44, rect: [8,178 373.25x17]
+          frag 10 from TextNode start: 462, length: 44, rect: [8,178 373.25x17] baseline: 13.296875
               "auctor fermentum dui. Aliquam dictum finibus"
-          line 11 width: 288.203125, height: 17, bottom: 204, baseline: 13.296875
-            frag 0 from TextNode start: 507, length: 35, rect: [8,195 288.203125x17]
+          frag 11 from TextNode start: 507, length: 35, rect: [8,195 288.203125x17] baseline: 13.296875
               "urna, quis lacinia massa laoreet a."
-          line 12 width: 316.296875, height: 17, bottom: 221, baseline: 13.296875
-            frag 0 from TextNode start: 543, length: 36, rect: [8,212 316.296875x17]
+          frag 12 from TextNode start: 543, length: 36, rect: [8,212 316.296875x17] baseline: 13.296875
               "Suspendisse elementum non lectus nec"
-          line 13 width: 388.78125, height: 17, bottom: 238, baseline: 13.296875
-            frag 0 from TextNode start: 580, length: 48, rect: [8,229 388.78125x17]
+          frag 13 from TextNode start: 580, length: 48, rect: [8,229 388.78125x17] baseline: 13.296875
               "elementum. Quisque ultricies suscipit porttitor."
-          line 14 width: 373.828125, height: 17, bottom: 255, baseline: 13.296875
-            frag 0 from TextNode start: 629, length: 45, rect: [8,246 373.828125x17]
+          frag 14 from TextNode start: 629, length: 45, rect: [8,246 373.828125x17] baseline: 13.296875
               "Sed non urna rutrum, mattis nulla at, feugiat"
-          line 15 width: 368.75, height: 17, bottom: 272, baseline: 13.296875
-            frag 0 from TextNode start: 675, length: 48, rect: [8,263 368.75x17]
+          frag 15 from TextNode start: 675, length: 48, rect: [8,263 368.75x17] baseline: 13.296875
               "erat. Duis orci elit, vehicula sed blandit eget,"
-          line 16 width: 390.625, height: 17, bottom: 289, baseline: 13.296875
-            frag 0 from TextNode start: 724, length: 46, rect: [8,280 390.625x17]
+          frag 16 from TextNode start: 724, length: 46, rect: [8,280 390.625x17] baseline: 13.296875
               "auctor in arcu. Ut cursus magna sit amet nulla"
-          line 17 width: 294.90625, height: 17, bottom: 306, baseline: 13.296875
-            frag 0 from TextNode start: 771, length: 36, rect: [8,297 294.90625x17]
+          frag 17 from TextNode start: 771, length: 36, rect: [8,297 294.90625x17] baseline: 13.296875
               "cursus, vitae gravida mauris dictum."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       Box <div.container> at (8,8) content-size 784x34 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 784x17 [BFC] children: inline
-          line 0 width: 31.265625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [8,8 31.265625x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 31.265625x17] baseline: 13.296875
               "Uno"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/grid/should-not-cause-infinite-spinning-in-space-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/should-not-cause-infinite-spinning-in-space-distribution.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x56 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x38 [GFC] children: not-inline
       BlockContainer <div.foo> at (11,11) content-size 778x17 [BFC] children: inline
-        line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.15625x17] baseline: 13.296875
             "foo"
         TextNode <#text>
       BlockContainer <div.bar> at (11,30) content-size 778x17 [BFC] children: inline
-        line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [11,30 27.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [11,30 27.640625x17] baseline: 13.296875
             "bar"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/should-not-hang-in-size-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/should-not-hang-in-size-distribution.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (8,8) content-size 784x17 [GFC] children: not-inline
       BlockContainer <div#item> at (8,8) content-size 784x17 [BFC] children: not-inline
         BlockContainer <div#block> at (8,8) content-size 784x17 children: inline
-          line 0 width: 210.484375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 26, rect: [8,8 210.484375x17]
+          frag 0 from TextNode start: 0, length: 26, rect: [8,8 210.484375x17] baseline: 13.296875
               "Taika Waititi's Best Roles"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/template-areas-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-areas-1.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x302 children: not-inline
       Box <div.grid> at (11,11) content-size 778x300 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 298x198 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div.b> at (12,212) content-size 298x98 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,212 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,212 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/template-areas-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-areas-2.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x302 children: not-inline
       Box <div.grid> at (11,11) content-size 778x300 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 198x298 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div.b> at (212,12) content-size 98x298 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [212,12 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [212,12 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/template-areas-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-areas-3.txt
@@ -3,28 +3,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x674 children: not-inline
       Box <div.grid> at (11,11) content-size 778x672 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 775.984375x334 [BFC] children: inline
-          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.34375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.34375x17] baseline: 13.296875
               "a"
           TextNode <#text>
         BlockContainer <div.b> at (12,348) content-size 257.328125x334 [BFC] children: inline
-          line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [12,348 9.46875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [12,348 9.46875x17] baseline: 13.296875
               "b"
           TextNode <#text>
         BlockContainer <div.c> at (271.328125,348) content-size 257.328125x334 [BFC] children: inline
-          line 0 width: 8.890625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [271.328125,348 8.890625x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [271.328125,348 8.890625x17] baseline: 13.296875
               "c"
           TextNode <#text>
         BlockContainer <div.d> at (530.65625,348) content-size 257.328125x166 [BFC] children: inline
-          line 0 width: 7.859375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,348 7.859375x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,348 7.859375x17] baseline: 13.296875
               "d"
           TextNode <#text>
         BlockContainer <div.e> at (530.65625,516) content-size 257.328125x166 [BFC] children: inline
-          line 0 width: 8.71875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,516 8.71875x17]
+          frag 0 from TextNode start: 0, length: 1, rect: [530.65625,516 8.71875x17] baseline: 13.296875
               "e"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
@@ -3,13 +3,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.grid> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.item-left> at (8,8) content-size 261.328125x17 [BFC] children: inline
-          line 0 width: 21.609375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17] baseline: 13.296875
               "1fr"
           TextNode <#text>
         BlockContainer <div.item-right> at (269.328125,8) content-size 522.65625x17 [BFC] children: inline
-          line 0 width: 21.609375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [269.328125,8 21.609375x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [269.328125,8 21.609375x17] baseline: 13.296875
               "1fr"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.ipc-page-grid> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
         Box <div.ipc-sub-grid> at (8,8) content-size 401.28125x17 flex-item [GFC] children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 401.28125x17 [BFC] children: inline
-            line 0 width: 401.28125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 45, rect: [8,8 401.28125x17]
+            frag 0 from TextNode start: 0, length: 45, rect: [8,8 401.28125x17] baseline: 13.296875
                 "The 10 Most Anticipated Summer Movies of 2023"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/two-items-spanning-one-1fr-row.txt
+++ b/Tests/LibWeb/Layout/expected/grid/two-items-spanning-one-1fr-row.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x120 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x102 [GFC] children: not-inline
       BlockContainer <div.foo> at (11,11) content-size 100x100 [BFC] children: inline
-        line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.15625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.15625x17] baseline: 13.296875
             "foo"
         TextNode <#text>
       BlockContainer <div.bar> at (11,11) content-size 778x100 [BFC] children: inline
-        line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.640625x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.640625x17] baseline: 13.296875
             "bar"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
+++ b/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.ipc-page-grid> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
         Box <div.ipc-sub-grid> at (8,8) content-size 36.84375x17 flex-item [GFC] children: not-inline
           BlockContainer <div> at (8,8) content-size 36.84375x17 [BFC] children: inline
-            line 0 width: 36.84375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17]
+            frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
                 "hello"
             TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17 [GFC] children: not-inline
         BlockContainer <div.grid-item> at (8,8) content-size 392x17 [BFC] children: inline
-          line 0 width: 21.609375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17] baseline: 13.296875
               "1fr"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/grid/vertical-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/vertical-margins-auto.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x502 children: not-inline
       Box <div.container> at (11,11) content-size 500x500 [GFC] children: not-inline
         BlockContainer <div.item> at (244.828125,252.5) content-size 32.34375x17 [BFC] children: inline
-          line 0 width: 32.34375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [244.828125,252.5 32.34375x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [244.828125,252.5 32.34375x17] baseline: 13.296875
               "item"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/height-min-max-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/height-min-max-fit-content.txt
@@ -1,14 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x139 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x123 children: inline
-      line 0 width: 376, height: 123, bottom: 123, baseline: 120
-        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
-        frag 1 from TextNode start: 0, length: 1, rect: [128,114 8x17]
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120] baseline: 120
+      frag 1 from TextNode start: 0, length: 1, rect: [128,114 8x17] baseline: 13.296875
           " "
-        frag 2 from ImageBox start: 0, length: 0, rect: [136,8 120x120]
-        frag 3 from TextNode start: 0, length: 1, rect: [256,114 8x17]
+      frag 2 from ImageBox start: 0, length: 0, rect: [136,8 120x120] baseline: 120
+      frag 3 from TextNode start: 0, length: 1, rect: [256,114 8x17] baseline: 13.296875
           " "
-        frag 4 from ImageBox start: 0, length: 0, rect: [264,8 120x120]
+      frag 4 from ImageBox start: 0, length: 0, rect: [264,8 120x120] baseline: 120
       ImageBox <img.min> at (8,8) content-size 120x120 children: not-inline
       TextNode <#text>
       ImageBox <img.max> at (136,8) content-size 120x120 children: not-inline

--- a/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
@@ -5,8 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       TextNode <#text>
       BlockContainer <h1> at (76.59375,103.765625) content-size 126x38 positioned [BFC] children: inline
-        line 0 width: 46.53125, height: 22, bottom: 22, baseline: 17
-          frag 0 from TextNode start: 0, length: 4, rect: [116.59375,103.765625 46.53125x22]
+        frag 0 from TextNode start: 0, length: 4, rect: [116.59375,103.765625 46.53125x22] baseline: 17
             "Test"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
+++ b/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x80 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x62 children: inline
-      line 0 width: 82, height: 62, bottom: 62, baseline: 62
-        frag 0 from ImageBox start: 0, length: 0, rect: [11,11 80x60]
+      frag 0 from ImageBox start: 0, length: 0, rect: [11,11 80x60] baseline: 62
       ImageBox <img> at (11,11) content-size 80x60 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/img-with-box-sizing-border-box-and-padding.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-box-sizing-border-box-and-padding.txt
@@ -1,9 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
-      line 0 width: 200, height: 100, bottom: 100, baseline: 100
-        frag 0 from ImageBox start: 0, length: 0, rect: [29,29 58x58]
-        frag 1 from ImageBox start: 0, length: 0, rect: [129,29 58x58]
+      frag 0 from ImageBox start: 0, length: 0, rect: [29,29 58x58] baseline: 100
+      frag 1 from ImageBox start: 0, length: 0, rect: [129,29 58x58] baseline: 100
       ImageBox <img.with-height> at (29,29) content-size 58x58 children: not-inline
       ImageBox <img.with-width> at (129,29) content-size 58x58 children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x136 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 120x120 children: not-inline
       BlockContainer <div> at (8,8) content-size 120x120 children: inline
-        line 0 width: 120, height: 120, bottom: 120, baseline: 120
-          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120] baseline: 120
         ImageBox <img> at (8,8) content-size 120x120 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 0x17 children: inline
-      line 0 width: 0, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0]
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0] baseline: 0
       ImageBox <img> at (8,21) content-size 0x0 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/incomplete-input-no-newline-at-eof-should-not-crash.txt
+++ b/Tests/LibWeb/Layout/expected/incomplete-input-no-newline-at-eof-should-not-crash.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      line 0 width: 14.65625, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 2, rect: [8,8 14.65625x17]
+      frag 0 from TextNode start: 0, length: 2, rect: [8,8 14.65625x17] baseline: 13.296875
           "</"
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/inline-block-treat-100pct-width-as-auto.txt
+++ b/Tests/LibWeb/Layout/expected/inline-block-treat-100pct-width-as-auto.txt
@@ -3,11 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x0 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 102.484375x71 floating [BFC] children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 102.484375x19 children: inline
-          line 0 width: 104.484375, height: 19, bottom: 19, baseline: 14.296875
-            frag 0 from BlockContainer start: 0, length: 0, rect: [12,12 102.484375x17]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [12,12 102.484375x17] baseline: 14.296875
           BlockContainer <div.first> at (12,12) content-size 102.484375x17 inline-block [BFC] children: inline
-            line 0 width: 100.484375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 11, rect: [12,12 100.484375x17]
+            frag 0 from TextNode start: 0, length: 11, rect: [12,12 100.484375x17] baseline: 13.296875
                 "programming"
             TextNode <#text>
         BlockContainer <div.second> at (12,31) content-size 50x50 children: not-inline

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -2,18 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x570 [BFC] children: not-inline
     BlockContainer <body> at (8,70) content-size 784x492 children: not-inline
       BlockContainer <p.min-inline-test> at (8,70) content-size 784x200 children: inline
-        line 0 width: 85.859375, height: 76, bottom: 76, baseline: 58.984375
-          frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76]
+        frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76] baseline: 58.984375
             "KK"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,340) content-size 784x76 children: inline
-        line 0 width: 0, height: 76, bottom: 76, baseline: 58.984375
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
       BlockContainer <p.max-inline-test> at (8,486) content-size 100x76 children: inline
-        line 0 width: 85.859375, height: 76, bottom: 76, baseline: 58.984375
-          frag 0 from TextNode start: 0, length: 2, rect: [8,486 85.859375x76]
+        frag 0 from TextNode start: 0, length: 2, rect: [8,486 85.859375x76] baseline: 58.984375
             "KK"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,632) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x46 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x28 children: inline
-      line 0 width: 202, height: 28, bottom: 28, baseline: 28
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x26]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x26] baseline: 28
       BlockContainer <input> at (11,11) content-size 200x26 inline-block [BFC] children: not-inline
         Box <div> at (13,12) content-size 196x24 flex-container(row) [FFC] children: not-inline
           BlockContainer <div> at (14,13) content-size 194x22 flex-item [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/input-text-node-invalidation-on-value-change.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-node-invalidation-on-value-change.txt
@@ -1,13 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x42 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x26 children: inline
-      line 0 width: 202, height: 26, bottom: 26, baseline: 17
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 200x24]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 200x24] baseline: 17
       BlockContainer <input#foo> at (9,9) content-size 200x24 inline-block [BFC] children: not-inline
         Box <div> at (11,10) content-size 196x22 flex-container(row) [FFC] children: not-inline
           BlockContainer <div> at (11,10) content-size 196x22 flex-item [BFC] children: inline
-            line 0 width: 62.171875, height: 22, bottom: 22, baseline: 17
-              frag 0 from TextNode start: 0, length: 4, rect: [11,10 62.171875x22]
+            frag 0 from TextNode start: 0, length: 4, rect: [11,10 62.171875x22] baseline: 17
                 "PASS"
             TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.parent> at (8,8) content-size 200x200 positioned children: inline
         TextNode <#text>
         BlockContainer <div.bad> at (38,18) content-size 150x150 positioned [BFC] children: inline
-          line 0 width: 26.546875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [38,18 26.546875x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [38,18 26.546875x17] baseline: 13.296875
               "Bad"
           TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
+++ b/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x80 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x64 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x64 children: inline
-        line 0 width: 100.203125, height: 64, bottom: 64, baseline: 36.796875
-          frag 0 from TextNode start: 0, length: 13, rect: [8,8 100.203125x64]
+        frag 0 from TextNode start: 0, length: 13, rect: [8,8 100.203125x64] baseline: 36.796875
             "hello friends"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/media-query-resolution.txt
+++ b/Tests/LibWeb/Layout/expected/media-query-resolution.txt
@@ -2,18 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x67 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x34 children: inline
-        line 0 width: 746.890625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 88, rect: [8,16 746.890625x17]
+        frag 0 from TextNode start: 0, length: 88, rect: [8,16 746.890625x17] baseline: 13.296875
             "NOTE: This test assumes that you're running with 1x pixels (which our test runner always"
-        line 1 width: 40.625, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 89, length: 5, rect: [8,33 40.625x17]
+        frag 1 from TextNode start: 89, length: 5, rect: [8,33 40.625x17] baseline: 13.296875
             "does."
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,66) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.pass> at (8,66) content-size 784x17 children: inline
-        line 0 width: 49.734375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 4, rect: [8,66 49.734375x17]
+        frag 0 from TextNode start: 0, length: 4, rect: [8,66 49.734375x17] baseline: 13.296875
             "PASS"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,83) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/negative-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/negative-max-size.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x35 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x19 children: not-inline
       BlockContainer <div> at (9,9) content-size 782x17 children: inline
-        line 0 width: 147.1875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 20, rect: [9,9 147.1875x17]
+        frag 0 from TextNode start: 0, length: 20, rect: [9,9 147.1875x17] baseline: 13.296875
             "Well, hello friends!"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
@@ -2,12 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x19 children: not-inline
       BlockContainer <div.fixed_width> at (9,9) content-size 50x17 children: inline
-        line 0 width: 79.40625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17] baseline: 13.296875
             "ABC"
-          frag 1 from TextNode start: 0, length: 1, rect: [43,9 11.5625x17]
+        frag 1 from TextNode start: 0, length: 1, rect: [43,9 11.5625x17] baseline: 13.296875
             "X"
-          frag 2 from TextNode start: 0, length: 3, rect: [54,9 33.921875x17]
+        frag 2 from TextNode start: 0, length: 3, rect: [54,9 33.921875x17] baseline: 13.296875
             "ABC"
         TextNode <#text>
         InlineNode <span.nowrap>

--- a/Tests/LibWeb/Layout/expected/ordered-list.txt
+++ b/Tests/LibWeb/Layout/expected/ordered-list.txt
@@ -5,24 +5,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (48,16) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,16) content-size 744x17 children: inline
-          line 0 width: 58.78125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [48,16 58.78125x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [48,16 58.78125x17] baseline: 13.296875
               "Item 20"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (13.25,16) content-size 22.75x17 children: not-inline
         BlockContainer <(anonymous)> at (48,33) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,33) content-size 744x17 children: inline
-          line 0 width: 55.53125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [48,33 55.53125x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [48,33 55.53125x17] baseline: 13.296875
               "Item 21"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (16.5,33) content-size 19.5x17 children: not-inline
         BlockContainer <(anonymous)> at (48,50) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,50) content-size 744x17 children: inline
-          line 0 width: 58, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 7, rect: [48,50 58x17]
+          frag 0 from TextNode start: 0, length: 7, rect: [48,50 58x17] baseline: 13.296875
               "Item 22"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (14.03125,50) content-size 21.96875x17 children: not-inline
@@ -34,32 +31,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (48,83) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,83) content-size 744x17 children: inline
-          line 0 width: 46.71875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [48,83 46.71875x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [48,83 46.71875x17] baseline: 13.296875
               "Item 1"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (25.3125,83) content-size 10.6875x17 children: not-inline
         BlockContainer <(anonymous)> at (48,100) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,100) content-size 744x17 children: inline
-          line 0 width: 48.828125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [48,100 48.828125x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [48,100 48.828125x17] baseline: 13.296875
               "Item 5"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (23.203125,100) content-size 12.796875x17 children: not-inline
         BlockContainer <(anonymous)> at (48,117) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,117) content-size 744x17 children: inline
-          line 0 width: 49.109375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [48,117 49.109375x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [48,117 49.109375x17] baseline: 13.296875
               "Item 6"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (22.921875,117) content-size 13.078125x17 children: not-inline
         BlockContainer <(anonymous)> at (48,134) content-size 744x0 children: inline
           TextNode <#text>
         ListItemBox <li> at (48,134) content-size 744x17 children: inline
-          line 0 width: 49.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 6, rect: [48,134 49.09375x17]
+          frag 0 from TextNode start: 0, length: 6, rect: [48,134 49.09375x17] baseline: 13.296875
               "Item 7"
           TextNode <#text>
           ListItemMarkerBox <(anonymous)> at (22.9375,134) content-size 13.0625x17 children: not-inline

--- a/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
+++ b/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
@@ -3,15 +3,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x103 children: not-inline
       BlockContainer <div.block.formatting-context> at (11,11) content-size 778x19 [BFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 776x17 children: inline
-          line 0 width: 40.671875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 5, rect: [12,12 40.671875x17]
+          frag 0 from TextNode start: 0, length: 5, rect: [12,12 40.671875x17] baseline: 13.296875
               "block"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,31) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.inline.formatting-context> at (11,32) content-size 778x17 [BFC] children: inline
-        line 0 width: 43.296875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 6, rect: [12,32 41.296875x17]
+        frag 0 from TextNode start: 0, length: 6, rect: [12,32 41.296875x17] baseline: 13.296875
             "inline"
         InlineNode <div>
           TextNode <#text>
@@ -19,16 +17,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       Box <div.flex.formatting-context> at (11,51) content-size 778x19 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,52) content-size 29.09375x17 flex-item [BFC] children: inline
-          line 0 width: 29.09375, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12,52 29.09375x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,52 29.09375x17] baseline: 13.296875
               "flex"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,71) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.formatting-context> at (11,72) content-size 778x19 [GFC] children: not-inline
         BlockContainer <div> at (12,73) content-size 776x17 [BFC] children: inline
-          line 0 width: 28.8125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [12,73 28.8125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [12,73 28.8125x17] baseline: 13.296875
               "grid"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,92) content-size 780x0 children: inline
@@ -38,8 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <(anonymous)> at (11,93) content-size 40.625x19 table-row children: not-inline
             BlockContainer <(anonymous)> at (11,93) content-size 40.625x19 table-cell [BFC] children: not-inline
               BlockContainer <div> at (12,94) content-size 38.625x17 children: inline
-                line 0 width: 38.625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 5, rect: [12,94 38.625x17]
+                frag 0 from TextNode start: 0, length: 5, rect: [12,94 38.625x17] baseline: 13.296875
                     "table"
                 TextNode <#text>
       BlockContainer <(anonymous)> at (10,113) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
+++ b/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x416 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x400 children: inline
-      line 0 width: 400, height: 400, bottom: 400, baseline: 400
-        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 400x400]
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 400x400] baseline: 400
       TextNode <#text>
       InlineNode <picture>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19 children: not-inline
       Box <div.container> at (11,11) content-size 800x17 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (392.203125,11) content-size 37.578125x17 flex-item [BFC] children: inline
-          line 0 width: 37.578125, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 4, rect: [392.203125,11 37.578125x17]
+          frag 0 from TextNode start: 0, length: 4, rect: [392.203125,11 37.578125x17] baseline: 13.296875
               "Text"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      line 0 width: 21.875, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17]
+      frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17] baseline: 13.296875
           " | "
       InlineNode <pre>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -2,22 +2,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x470 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x454 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x22 children: inline
-        line 0 width: 391.65625, height: 22, bottom: 22, baseline: 17
-          frag 0 from TextNode start: 0, length: 40, rect: [8,8 391.65625x22]
+        frag 0 from TextNode start: 0, length: 40, rect: [8,8 391.65625x22] baseline: 17
             "Variable set by inline style of element:"
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
       BlockContainer <div.a> at (8,30) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 100
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,30 200x100]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,30 200x100] baseline: 100
         BlockContainer <(anonymous)> at (8,30) content-size 200x100 inline-block [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,130) content-size 784x66 children: inline
-        line 0 width: 0, height: 22, bottom: 22, baseline: 17
-        line 1 width: 0, height: 22, bottom: 44, baseline: 17
-        line 2 width: 441.28125, height: 22, bottom: 66, baseline: 17
-          frag 0 from TextNode start: 1, length: 42, rect: [8,174 441.28125x22]
+        frag 0 from TextNode start: 1, length: 42, rect: [8,174 441.28125x22] baseline: 17
             "Variable set by CSS rule matching element:"
         TextNode <#text>
         BreakNode <br>
@@ -26,15 +21,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
         TextNode <#text>
       BlockContainer <div.b> at (8,196) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 100
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,196 200x100]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,196 200x100] baseline: 100
         BlockContainer <(anonymous)> at (8,196) content-size 200x100 inline-block [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,296) content-size 784x66 children: inline
-        line 0 width: 0, height: 22, bottom: 22, baseline: 17
-        line 1 width: 0, height: 22, bottom: 44, baseline: 17
-        line 2 width: 520.625, height: 22, bottom: 66, baseline: 17
-          frag 0 from TextNode start: 1, length: 49, rect: [8,340 520.625x22]
+        frag 0 from TextNode start: 1, length: 49, rect: [8,340 520.625x22] baseline: 17
             "Variable set by CSS rule matching pseudo element:"
         TextNode <#text>
         BreakNode <br>
@@ -43,8 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
         TextNode <#text>
       BlockContainer <div.c> at (8,362) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 100
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,362 200x100]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,362 200x100] baseline: 100
         BlockContainer <(anonymous)> at (8,362) content-size 200x100 inline-block [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,462) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
@@ -1,11 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x216 children: inline
-      line 0 width: 174.828125, height: 216, bottom: 216, baseline: 213
-        frag 0 from TextNode start: 0, length: 6, rect: [8,207 43.125x17]
+      frag 0 from TextNode start: 0, length: 6, rect: [8,207 43.125x17] baseline: 13.296875
           "Well, "
-        frag 1 from ImageBox start: 0, length: 0, rect: [51,33 64x138]
-        frag 2 from TextNode start: 0, length: 9, rect: [115,207 67.703125x17]
+      frag 1 from ImageBox start: 0, length: 0, rect: [51,33 64x138] baseline: 213
+      frag 2 from TextNode start: 0, length: 9, rect: [115,207 67.703125x17] baseline: 13.296875
           " friends."
       TextNode <#text>
       ImageBox <img#image> at (51,33) content-size 64x138 children: not-inline

--- a/Tests/LibWeb/Layout/expected/replaced-within-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-within-max-content.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
       BlockContainer <div.container> at (8,8) content-size 150x150 children: inline
-        line 0 width: 150, height: 150, bottom: 150, baseline: 150
-          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 150x150]
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 150x150] baseline: 150
         ImageBox <img.replaced> at (8,8) content-size 150x150 children: not-inline
           (SVG-as-image isolated context)
           Viewport <#document> at (0,0) content-size 150x150 [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
@@ -2,26 +2,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x1251 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x1233 children: not-inline
       BlockContainer <div.w.min> at (11,11) content-size 2x17 children: inline
-        line 0 width: 4, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from ImageBox start: 0, length: 0, rect: [12,21 2x2]
+        frag 0 from ImageBox start: 0, length: 0, rect: [12,21 2x2] baseline: 4
         ImageBox <img> at (12,21) content-size 2x2 children: not-inline
       BlockContainer <(anonymous)> at (10,29) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.w.max> at (11,30) content-size 402x404 children: inline
-        line 0 width: 404, height: 404, bottom: 404, baseline: 404
-          frag 0 from ImageBox start: 0, length: 0, rect: [12,31 402x402]
+        frag 0 from ImageBox start: 0, length: 0, rect: [12,31 402x402] baseline: 404
         ImageBox <img> at (12,31) content-size 402x402 children: not-inline
       BlockContainer <(anonymous)> at (10,435) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.h.min> at (11,436) content-size 778x402 children: inline
-        line 0 width: 402, height: 402, bottom: 402, baseline: 402
-          frag 0 from ImageBox start: 0, length: 0, rect: [12,437 400x400]
+        frag 0 from ImageBox start: 0, length: 0, rect: [12,437 400x400] baseline: 402
         ImageBox <img> at (12,437) content-size 400x400 children: not-inline
       BlockContainer <(anonymous)> at (10,839) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.h.max> at (11,840) content-size 778x402 children: inline
-        line 0 width: 402, height: 402, bottom: 402, baseline: 402
-          frag 0 from ImageBox start: 0, length: 0, rect: [12,841 400x400]
+        frag 0 from ImageBox start: 0, length: 0, rect: [12,841 400x400] baseline: 402
         ImageBox <img> at (12,841) content-size 400x400 children: not-inline
       BlockContainer <(anonymous)> at (10,1243) content-size 780x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
@@ -14,8 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
             TextNode <#text>
           BlockContainer <p> at (8,16) content-size 1280x17 children: inline
-            line 0 width: 37.21875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 0, length: 4, rect: [8,16 37.21875x17]
+            frag 0 from TextNode start: 0, length: 4, rect: [8,16 37.21875x17] baseline: 13.296875
                 "Test"
             TextNode <#text>
           BlockContainer <(anonymous)> at (8,49) content-size 1280x0 children: inline

--- a/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
+++ b/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         TextNode <#text>
       BlockContainer <p> at (8,16) content-size 784x17 children: inline
-        line 0 width: 37.21875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 4, rect: [228,16 37.21875x17]
+        frag 0 from TextNode start: 0, length: 4, rect: [228,16 37.21875x17] baseline: 13.296875
             "Test"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
+++ b/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       BlockContainer <div#container> at (8,8) content-size 784x17 children: inline
-        line 0 width: 43.421875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 5, rect: [8,8 43.421875x17]
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 43.421875x17] baseline: 13.296875
             "Pass!"
         InlineNode <span>
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
@@ -2,11 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       BlockContainer <div.fixed_width> at (9,9) content-size 50x34 children: inline
-        line 0 width: 33.921875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17] baseline: 13.296875
             "ABC"
-        line 1 width: 33.921875, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [9,26 33.921875x17]
+        frag 1 from TextNode start: 0, length: 3, rect: [9,26 33.921875x17] baseline: 13.296875
             "ABC"
         TextNode <#text>
         InlineNode <span.nowrap>

--- a/Tests/LibWeb/Layout/expected/style-invalidation-line-height-propagation.txt
+++ b/Tests/LibWeb/Layout/expected/style-invalidation-line-height-propagation.txt
@@ -2,13 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x36 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x20 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x10 children: inline
-        line 0 width: 98, height: 10, bottom: 10, baseline: 9.796875
-          frag 0 from TextNode start: 0, length: 11, rect: [8,8 98x10]
+        frag 0 from TextNode start: 0, length: 11, rect: [8,8 98x10] baseline: 9.796875
             "foo bar baz"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,18) content-size 784x10 children: inline
-        line 0 width: 98, height: 10, bottom: 10, baseline: 9.796875
-          frag 0 from TextNode start: 0, length: 11, rect: [8,18 98x10]
+        frag 0 from TextNode start: 0, length: 11, rect: [8,18 98x10] baseline: 9.796875
             "foo bar baz"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -1,43 +1,41 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x257 children: inline
-      line 0 width: 772, height: 130, bottom: 130, baseline: 127
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,84 100x50]
-        frag 1 from TextNode start: 0, length: 1, rect: [110,121 8x17]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,84 100x50] baseline: 52
+      frag 1 from TextNode start: 0, length: 1, rect: [110,121 8x17] baseline: 13.296875
           " "
-        frag 2 from SVGSVGBox start: 0, length: 0, rect: [119,84 100x50]
-        frag 3 from TextNode start: 0, length: 1, rect: [220,121 8x17]
+      frag 2 from SVGSVGBox start: 0, length: 0, rect: [119,84 100x50] baseline: 52
+      frag 3 from TextNode start: 0, length: 1, rect: [220,121 8x17] baseline: 13.296875
           " "
-        frag 4 from SVGSVGBox start: 0, length: 0, rect: [229,84 100x50]
-        frag 5 from TextNode start: 0, length: 1, rect: [330,121 8x17]
+      frag 4 from SVGSVGBox start: 0, length: 0, rect: [229,84 100x50] baseline: 52
+      frag 5 from TextNode start: 0, length: 1, rect: [330,121 8x17] baseline: 13.296875
           " "
-        frag 6 from SVGSVGBox start: 0, length: 0, rect: [339,84 100x50]
-        frag 7 from TextNode start: 0, length: 1, rect: [440,121 8x17]
+      frag 6 from SVGSVGBox start: 0, length: 0, rect: [339,84 100x50] baseline: 52
+      frag 7 from TextNode start: 0, length: 1, rect: [440,121 8x17] baseline: 13.296875
           " "
-        frag 8 from SVGSVGBox start: 0, length: 0, rect: [449,84 100x50]
-        frag 9 from TextNode start: 0, length: 1, rect: [550,121 8x17]
+      frag 8 from SVGSVGBox start: 0, length: 0, rect: [449,84 100x50] baseline: 52
+      frag 9 from TextNode start: 0, length: 1, rect: [550,121 8x17] baseline: 13.296875
           " "
-        frag 10 from SVGSVGBox start: 0, length: 0, rect: [559,84 100x50]
-        frag 11 from TextNode start: 0, length: 1, rect: [660,121 8x17]
+      frag 10 from SVGSVGBox start: 0, length: 0, rect: [559,84 100x50] baseline: 52
+      frag 11 from TextNode start: 0, length: 1, rect: [660,121 8x17] baseline: 13.296875
           " "
-        frag 12 from SVGSVGBox start: 0, length: 0, rect: [669,9 50x125]
-        frag 13 from TextNode start: 0, length: 1, rect: [720,121 8x17]
+      frag 12 from SVGSVGBox start: 0, length: 0, rect: [669,9 50x125] baseline: 127
+      frag 13 from TextNode start: 0, length: 1, rect: [720,121 8x17] baseline: 13.296875
           " "
-        frag 14 from SVGSVGBox start: 0, length: 0, rect: [729,9 50x125]
-      line 1 width: 402, height: 130, bottom: 257, baseline: 127
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,136 50x125]
-        frag 1 from TextNode start: 0, length: 1, rect: [60,248 8x17]
+      frag 14 from SVGSVGBox start: 0, length: 0, rect: [729,9 50x125] baseline: 127
+      frag 15 from SVGSVGBox start: 0, length: 0, rect: [9,136 50x125] baseline: 127
+      frag 16 from TextNode start: 0, length: 1, rect: [60,248 8x17] baseline: 13.296875
           " "
-        frag 2 from SVGSVGBox start: 0, length: 0, rect: [69,136 50x125]
-        frag 3 from TextNode start: 0, length: 1, rect: [120,248 8x17]
+      frag 17 from SVGSVGBox start: 0, length: 0, rect: [69,136 50x125] baseline: 127
+      frag 18 from TextNode start: 0, length: 1, rect: [120,248 8x17] baseline: 13.296875
           " "
-        frag 4 from SVGSVGBox start: 0, length: 0, rect: [129,136 50x125]
-        frag 5 from TextNode start: 0, length: 1, rect: [180,248 8x17]
+      frag 19 from SVGSVGBox start: 0, length: 0, rect: [129,136 50x125] baseline: 127
+      frag 20 from TextNode start: 0, length: 1, rect: [180,248 8x17] baseline: 13.296875
           " "
-        frag 6 from SVGSVGBox start: 0, length: 0, rect: [189,136 50x125]
-        frag 7 from TextNode start: 0, length: 1, rect: [240,248 8x17]
+      frag 21 from SVGSVGBox start: 0, length: 0, rect: [189,136 50x125] baseline: 127
+      frag 22 from TextNode start: 0, length: 1, rect: [240,248 8x17] baseline: 13.296875
           " "
-        frag 8 from SVGSVGBox start: 0, length: 0, rect: [249,201 160x60]
+      frag 23 from SVGSVGBox start: 0, length: 0, rect: [249,201 160x60] baseline: 62
       SVGSVGBox <svg> at (9,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (34,84) content-size 50x50 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg-text-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg-text-with-viewbox.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x261.328125 children: inline
-      line 0 width: 784, height: 261.328125, bottom: 261.328125, baseline: 261.328125
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x261.328125]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x261.328125] baseline: 261.328125
       SVGSVGBox <svg> at (8,8) content-size 784x261.328125 [SVG] children: inline
         TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -1,24 +1,21 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x700 [BFC] children: not-inline
     BlockContainer <body> at (50,50) content-size 700x600 children: inline
-      line 0 width: 616, height: 203, bottom: 203, baseline: 200
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,150 200x100]
-        frag 1 from TextNode start: 0, length: 1, rect: [250,236 8x17]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,150 200x100] baseline: 100
+      frag 1 from TextNode start: 0, length: 1, rect: [250,236 8x17] baseline: 13.296875
           " "
-        frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,50 200x200]
-        frag 3 from TextNode start: 0, length: 1, rect: [458,236 8x17]
+      frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,50 200x200] baseline: 200
+      frag 3 from TextNode start: 0, length: 1, rect: [458,236 8x17] baseline: 13.296875
           " "
-        frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,50 200x200]
-      line 1 width: 616, height: 203, bottom: 403, baseline: 200
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,250 200x200]
-        frag 1 from TextNode start: 0, length: 1, rect: [250,436 8x17]
+      frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,50 200x200] baseline: 200
+      frag 5 from SVGSVGBox start: 0, length: 0, rect: [50,250 200x200] baseline: 200
+      frag 6 from TextNode start: 0, length: 1, rect: [250,436 8x17] baseline: 13.296875
           " "
-        frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,250 200x200]
-        frag 3 from TextNode start: 0, length: 1, rect: [458,436 8x17]
+      frag 7 from SVGSVGBox start: 0, length: 0, rect: [258,250 200x200] baseline: 200
+      frag 8 from TextNode start: 0, length: 1, rect: [458,436 8x17] baseline: 13.296875
           " "
-        frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,250 200x200]
-      line 2 width: 200, height: 200, bottom: 600, baseline: 200
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,450 200x200]
+      frag 9 from SVGSVGBox start: 0, length: 0, rect: [466,250 200x200] baseline: 200
+      frag 10 from SVGSVGBox start: 0, length: 0, rect: [50,450 200x200] baseline: 200
       SVGSVGBox <svg> at (50,150) content-size 200x100 [SVG] children: inline
         TextNode <#text>
         SVGGraphicsBox <g> at (45.6875,199.828125) content-size 118.78125x47.453125 children: inline

--- a/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 0x17 children: inline
-      line 0 width: 0, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 0x0]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 0x0] baseline: 0
       SVGSVGBox <svg> at (8,21) content-size 0x0 [SVG] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
+++ b/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: inline
-      line 0 width: 200, height: 200, bottom: 200, baseline: 200
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
       SVGSVGBox <svg> at (8,8) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         SVGGraphicsBox <mask#myMask> at (8,8) content-size 1x1 children: inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: inline
-      line 0 width: 784, height: 784, bottom: 784, baseline: 784
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784] baseline: 784
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (47.203125,47.203125) content-size 548.796875x548.796875 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: inline
-      line 0 width: 784, height: 784, bottom: 784, baseline: 784
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784] baseline: 784
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: inline
-      line 0 width: 784, height: 784, bottom: 784, baseline: 784
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784] baseline: 784
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
         TextNode <#text>
         SVGGraphicsBox <g> at (121.671875,121.671875) content-size 556.65625x556.65625 children: inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x40 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x24 children: inline
-      line 0 width: 24, height: 24, bottom: 24, baseline: 24
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 24x24]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 24x24] baseline: 24
       SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: inline
         SVGGraphicsBox <g> at (8,8) content-size 24x24 children: inline
           SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
-      line 0 width: 100, height: 100, bottom: 100, baseline: 100
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (8,10) content-size 100x48 children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
-      line 0 width: 100, height: 100, bottom: 100, baseline: 100
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (28,28) content-size 60x60 children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -5,8 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         TextNode <#text>
       BlockContainer <div> at (8,8) content-size 784x150 children: inline
-        line 0 width: 300, height: 150, bottom: 150, baseline: 150
-          frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150]
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
         TextNode <#text>
         SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x102 children: inline
-      line 0 width: 102, height: 102, bottom: 102, baseline: 102
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100] baseline: 102
       SVGSVGBox <svg> at (9,9) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <rect> at (29,29) content-size 60x60 children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -1,11 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      line 0 width: 8, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0]
-        frag 1 from TextNode start: 0, length: 1, rect: [8,8 8x17]
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0] baseline: 0
+      frag 1 from TextNode start: 0, length: 1, rect: [8,8 8x17] baseline: 13.296875
           " "
-        frag 2 from SVGSVGBox start: 0, length: 0, rect: [16,21 0x0]
+      frag 2 from SVGSVGBox start: 0, length: 0, rect: [16,21 0x0] baseline: 0
       ImageBox <img> at (8,21) content-size 0x0 children: not-inline
         (SVG-as-image isolated context)
         Viewport <#document> at (0,0) content-size 0x0 [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
-      line 0 width: 100, height: 100, bottom: 100, baseline: 100
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
         TextNode <#text>
         SVGTextBox <text> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: inline
-      line 0 width: 300, height: 150, bottom: 150, baseline: 150
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150]
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: not-inline
         SVGTextBox <text> at (8,8) content-size 0x0 children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -10,22 +10,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (25,25) content-size 32.078125x17 table-cell [BFC] children: inline
-                line 0 width: 32.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x17] baseline: 13.296875
                     "Top"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (89.078125,74) content-size 55.984375x17 table-cell [BFC] children: inline
-                line 0 width: 55.984375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [89.078125,74 55.984375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [89.078125,74 55.984375x17] baseline: 13.296875
                     "Bottom"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (177.0625,25) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,8 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (177.0625,74) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,74 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [177.0625,74 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-height.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <(anonymous)> at (11,11) content-size 29.15625x19 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,11) content-size 29.15625x19 table-row children: not-inline
               BlockContainer <span> at (12,12) content-size 27.15625x17 table-cell [BFC] children: inline
-                line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x17] baseline: 13.296875
                     "foo"
                 TextNode <#text>
       BlockContainer <div> at (11,32) content-size 778x19 children: not-inline
@@ -15,8 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <(anonymous)> at (11,32) content-size 29.640625x19 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,32) content-size 29.640625x19 table-row children: not-inline
               BlockContainer <span> at (12,33) content-size 27.640625x17 table-cell [BFC] children: inline
-                line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [12,33 27.640625x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [12,33 27.640625x17] baseline: 13.296875
                     "bar"
                 TextNode <#text>
       BlockContainer <(anonymous)> at (10,52) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/table/auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-margins.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.box> at (235.265625,8) content-size 329.46875x17 table-box [TFC] children: not-inline
             Box <(anonymous)> at (235.265625,8) content-size 329.46875x17 table-row children: not-inline
               BlockContainer <div.cell> at (235.265625,8) content-size 329.46875x17 table-cell [BFC] children: inline
-                line 0 width: 329.46875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x17]
+                frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x17] baseline: 13.296875
                     "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
                 TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -12,8 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 0x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -11,8 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
           BlockContainer <caption> at (8,10) content-size 82.734375x17 [BFC] children: inline
-            line 0 width: 82.734375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 9, rect: [16,10 82.734375x17]
+            frag 0 from TextNode start: 1, length: 9, rect: [16,10 82.734375x17] baseline: 13.296875
                 "A Caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -24,8 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,30) content-size 93.171875x17 table-cell [BFC] children: inline
-                line 0 width: 73.65625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,30 73.65625x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [11,30 73.65625x17] baseline: 13.296875
                     "Head Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,8 +39,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,51) content-size 93.171875x17 table-cell [BFC] children: inline
-                line 0 width: 70.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,51 70.234375x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [11,51 70.234375x17] baseline: 13.296875
                     "Body Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -58,8 +55,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,72) content-size 93.171875x17 table-cell [BFC] children: inline
-                line 0 width: 93.171875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,72 93.171875x17]
+                frag 0 from TextNode start: 0, length: 11, rect: [11,72 93.171875x17] baseline: 13.296875
                     "Footer Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (18,18) content-size 18.265625x21 table-row-group children: not-inline
             Box <tr> at (20,20) content-size 18.265625x21 table-row children: not-inline
               BlockContainer <td> at (22,22) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/border-attribute.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (13,13) content-size 18.265625x21 table-row-group children: not-inline
             Box <tr> at (15,15) content-size 18.265625x21 table-row children: not-inline
               BlockContainer <td> at (17,17) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.horizontal> at (8,8) content-size 784x197 children: inline
-        line 0 width: 163.90625, height: 197, bottom: 197, baseline: 191.296875
-          frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 161.90625x195]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 161.90625x195] baseline: 191.296875
         TextNode <#text>
         BlockContainer <table> at (9,9) content-size 161.90625x195 inline-block [BFC] children: not-inline
           BlockContainer <(anonymous)> at (9,9) content-size 161.90625x0 children: inline
@@ -21,22 +20,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (30,20) content-size 14.265625x17 table-cell [BFC] children: inline
-                    line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x17] baseline: 13.296875
                         "A"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (86.265625,20) content-size 12.546875x17 table-cell [BFC] children: inline
-                    line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [88.265625,20 9.34375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [88.265625,20 9.34375x17] baseline: 13.296875
                         "B"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (140.8125,20) content-size 9.09375x17 table-cell [BFC] children: inline
-                    line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [141.8125,20 6.34375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [141.8125,20 6.34375x17] baseline: 13.296875
                         "1"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
@@ -47,22 +43,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (30,59) content-size 14.265625x17 table-cell [BFC] children: inline
-                    line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [32,59 10.3125x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [32,59 10.3125x17] baseline: 13.296875
                         "C"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (86.265625,59) content-size 12.546875x17 table-cell [BFC] children: inline
-                    line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [87.265625,59 11.140625x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [87.265625,59 11.140625x17] baseline: 13.296875
                         "D"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (140.8125,59) content-size 9.09375x17 table-cell [BFC] children: inline
-                    line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,59 8.8125x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [140.8125,59 8.8125x17] baseline: 13.296875
                         "2"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
@@ -73,22 +66,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (30,98) content-size 14.265625x17 table-cell [BFC] children: inline
-                    line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [31,98 11.859375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [31,98 11.859375x17] baseline: 13.296875
                         "E"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (86.265625,98) content-size 12.546875x17 table-cell [BFC] children: inline
-                    line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.265625,98 12.546875x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [86.265625,98 12.546875x17] baseline: 13.296875
                         "F"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (140.8125,98) content-size 9.09375x17 table-cell [BFC] children: inline
-                    line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,98 9.09375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [140.8125,98 9.09375x17] baseline: 13.296875
                         "3"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
@@ -99,22 +89,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (30,137) content-size 14.265625x17 table-cell [BFC] children: inline
-                    line 0 width: 13.234375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [31,137 13.234375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [31,137 13.234375x17] baseline: 13.296875
                         "G"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (86.265625,137) content-size 12.546875x17 table-cell [BFC] children: inline
-                    line 0 width: 12.234375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.265625,137 12.234375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [86.265625,137 12.234375x17] baseline: 13.296875
                         "H"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (140.8125,137) content-size 9.09375x17 table-cell [BFC] children: inline
-                    line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [141.8125,137 7.75x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [141.8125,137 7.75x17] baseline: 13.296875
                         "4"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
@@ -125,22 +112,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (30,176) content-size 14.265625x17 table-cell [BFC] children: inline
-                    line 0 width: 4.59375, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [35,176 4.59375x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [35,176 4.59375x17] baseline: 13.296875
                         "I"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (86.265625,176) content-size 12.546875x17 table-cell [BFC] children: inline
-                    line 0 width: 8.90625, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [88.265625,176 8.90625x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [88.265625,176 8.90625x17] baseline: 13.296875
                         "J"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                   BlockContainer <td> at (140.8125,176) content-size 9.09375x17 table-cell [BFC] children: inline
-                    line 0 width: 8.453125, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,176 8.453125x17]
+                    frag 0 from TextNode start: 0, length: 1, rect: [140.8125,176 8.453125x17] baseline: 13.296875
                         "5"
                     TextNode <#text>
                   BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -12,22 +12,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (29,21) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td.td-thick-border> at (89.265625,21) content-size 9.859375x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (145.125,20) content-size 14.546875x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,22 +35,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (29,64) content-size 16.265625x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,64 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [29,64 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,65) content-size 11.859375x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td.td-thick-border> at (145.125,64) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,64 12.546875x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [145.125,64 12.546875x17] baseline: 13.296875
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -20,8 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,21) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,8 +31,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,60) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,60 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,60 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -44,8 +42,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,99) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,99 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,99 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -56,8 +53,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,138) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,138 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,138 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -12,15 +12,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,21) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,21) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -31,15 +29,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (29,64) content-size 16.265625x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,64 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [29,64 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,64) content-size 14.546875x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,64 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,64 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -50,15 +46,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,107) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,107 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,107 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,107) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,107 12.546875x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,107 12.546875x17] baseline: 13.296875
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -10,15 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
             Box <tr> at (8,8) content-size 113.40625x41 table-row children: not-inline
               BlockContainer <td> at (29,19) content-size 16.265625x17 table-cell [BFC] children: inline
-                line 0 width: 9.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x17] baseline: 13.296875
                     "0"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,19) content-size 13.140625x17 table-cell [BFC] children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,15 +30,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,62) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,62 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,62 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,62) content-size 11.140625x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,62 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,62 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -51,15 +47,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (31,101) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,101 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [31,101 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.265625,101) content-size 11.140625x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,101 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,101 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -10,15 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (48,38) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (102.265625,38) content-size 9.34375x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -16,22 +16,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,15 +39,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,79) content-size 88.8125x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [89,79 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [89,79 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79 8.8125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79 8.8125x17] baseline: 13.296875
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -61,22 +56,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,128 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51,128 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -87,22 +79,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 13.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,177 13.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51,177 13.234375x17] baseline: 13.296875
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,177 12.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,177 12.234375x17] baseline: 13.296875
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,177 7.75x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [201.8125,177 7.75x17] baseline: 13.296875
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -113,22 +102,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 4.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [55,226 4.59375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [55,226 4.59375x17] baseline: 13.296875
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 8.90625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,226 8.90625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.265625,226 8.90625x17] baseline: 13.296875
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 8.453125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,226 8.453125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,226 8.453125x17] baseline: 13.296875
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -16,22 +16,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,54.5) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,54.5 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [50,54.5 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,15 +39,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.265625,79 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [127.265625,79 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79 8.8125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79 8.8125x17] baseline: 13.296875
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -61,22 +56,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,128 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51,128 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -87,22 +79,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 13.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,177 13.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51,177 13.234375x17] baseline: 13.296875
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,177 12.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,177 12.234375x17] baseline: 13.296875
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,177 7.75x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [201.8125,177 7.75x17] baseline: 13.296875
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -113,22 +102,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 4.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [55,226 4.59375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [55,226 4.59375x17] baseline: 13.296875
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 8.90625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,226 8.90625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.265625,226 8.90625x17] baseline: 13.296875
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 8.453125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,226 8.453125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,226 8.453125x17] baseline: 13.296875
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       BlockContainer <div.left> at (8,8) content-size 117.59375x17 floating [BFC] children: inline
-        line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17]
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
             "A"
         TextNode <#text>
       TextNode <#text>
@@ -18,8 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (128.59375,11) content-size 472.234375x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -30,8 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       TextNode <#text>
       BlockContainer <div.right> at (603.828125,8) content-size 188.15625x17 floating [BFC] children: inline
-        line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 1, rect: [603.828125,8 10.3125x17]
+        frag 0 from TextNode start: 1, length: 1, rect: [603.828125,8 10.3125x17] baseline: 13.296875
             "C"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -16,22 +16,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,22 +39,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,79) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [52,79 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [52,79 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.265625,79 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [127.265625,79 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79 8.8125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79 8.8125x17] baseline: 13.296875
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -68,22 +62,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,128 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51,128 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -94,22 +85,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 13.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,177 13.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51,177 13.234375x17] baseline: 13.296875
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 12.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,177 12.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,177 12.234375x17] baseline: 13.296875
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,177 7.75x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [201.8125,177 7.75x17] baseline: 13.296875
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -120,22 +108,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 4.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [55,226 4.59375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [55,226 4.59375x17] baseline: 13.296875
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: inline
-                line 0 width: 8.90625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,226 8.90625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [128.265625,226 8.90625x17] baseline: 13.296875
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 8.453125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,226 8.453125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,226 8.453125x17] baseline: 13.296875
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -10,15 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 82.015625x17 table-cell [BFC] children: inline
-                line 0 width: 82.015625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x17] baseline: 13.296875
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (101.015625,13) content-size 76.28125x17 table-cell [BFC] children: inline
-                line 0 width: 76.28125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x17] baseline: 13.296875
                     "Lastname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -29,15 +27,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,36) content-size 82.015625x17 table-cell [BFC] children: inline
-                line 0 width: 44.65625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 5, rect: [13,36 44.65625x17]
+                frag 0 from TextNode start: 0, length: 5, rect: [13,36 44.65625x17] baseline: 13.296875
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (101.015625,36) content-size 76.28125x17 table-cell [BFC] children: inline
-                line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,36 53.671875x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [101.015625,36 53.671875x17] baseline: 13.296875
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,15 +44,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,59) content-size 82.015625x17 table-cell [BFC] children: inline
-                line 0 width: 35.125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [13,59 35.125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [13,59 35.125x17] baseline: 13.296875
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (101.015625,59) content-size 76.28125x17 table-cell [BFC] children: inline
-                line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59 53.671875x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59 53.671875x17] baseline: 13.296875
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -75,15 +69,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (9,82) content-size 82.015625x17 table-cell [BFC] children: inline
-                line 0 width: 82.015625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [9,82 82.015625x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [9,82 82.015625x17] baseline: 13.296875
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (95.015625,82) content-size 76.28125x17 table-cell [BFC] children: inline
-                line 0 width: 76.28125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [95.015625,82 76.28125x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [95.015625,82 76.28125x17] baseline: 13.296875
                     "Lastname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -94,15 +86,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (9,103) content-size 82.015625x17 table-cell [BFC] children: inline
-                line 0 width: 44.65625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 5, rect: [9,103 44.65625x17]
+                frag 0 from TextNode start: 0, length: 5, rect: [9,103 44.65625x17] baseline: 13.296875
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (95.015625,103) content-size 76.28125x17 table-cell [BFC] children: inline
-                line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,103 53.671875x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [95.015625,103 53.671875x17] baseline: 13.296875
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -113,15 +103,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (9,124) content-size 82.015625x17 table-cell [BFC] children: inline
-                line 0 width: 35.125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [9,124 35.125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [9,124 35.125x17] baseline: 13.296875
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (95.015625,124) content-size 76.28125x17 table-cell [BFC] children: inline
-                line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,124 53.671875x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [95.015625,124 53.671875x17] baseline: 13.296875
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -139,15 +127,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (8,142) content-size 82.015625x17 table-cell [BFC] children: inline
-              line 0 width: 82.015625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 9, rect: [8,142 82.015625x17]
+              frag 0 from TextNode start: 0, length: 9, rect: [8,142 82.015625x17] baseline: 13.296875
                   "Firstname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (92.015625,142) content-size 76.28125x17 table-cell [BFC] children: inline
-              line 0 width: 76.28125, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 8, rect: [92.015625,142 76.28125x17]
+              frag 0 from TextNode start: 0, length: 8, rect: [92.015625,142 76.28125x17] baseline: 13.296875
                   "Lastname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -158,15 +144,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (8,161) content-size 82.015625x17 table-cell [BFC] children: inline
-              line 0 width: 44.65625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 5, rect: [8,161 44.65625x17]
+              frag 0 from TextNode start: 0, length: 5, rect: [8,161 44.65625x17] baseline: 13.296875
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (92.015625,161) content-size 76.28125x17 table-cell [BFC] children: inline
-              line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,161 53.671875x17]
+              frag 0 from TextNode start: 0, length: 7, rect: [92.015625,161 53.671875x17] baseline: 13.296875
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -177,15 +161,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (8,180) content-size 82.015625x17 table-cell [BFC] children: inline
-              line 0 width: 35.125, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 4, rect: [8,180 35.125x17]
+              frag 0 from TextNode start: 0, length: 4, rect: [8,180 35.125x17] baseline: 13.296875
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (92.015625,180) content-size 76.28125x17 table-cell [BFC] children: inline
-              line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,180 53.671875x17]
+              frag 0 from TextNode start: 0, length: 7, rect: [92.015625,180 53.671875x17] baseline: 13.296875
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -203,15 +185,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (8,197) content-size 82.015625x17 table-cell [BFC] children: inline
-              line 0 width: 82.015625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 9, rect: [8,197 82.015625x17]
+              frag 0 from TextNode start: 0, length: 9, rect: [8,197 82.015625x17] baseline: 13.296875
                   "Firstname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (100.015625,197) content-size 76.28125x17 table-cell [BFC] children: inline
-              line 0 width: 76.28125, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 8, rect: [100.015625,197 76.28125x17]
+              frag 0 from TextNode start: 0, length: 8, rect: [100.015625,197 76.28125x17] baseline: 13.296875
                   "Lastname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -222,15 +202,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (8,224) content-size 82.015625x17 table-cell [BFC] children: inline
-              line 0 width: 44.65625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 5, rect: [8,224 44.65625x17]
+              frag 0 from TextNode start: 0, length: 5, rect: [8,224 44.65625x17] baseline: 13.296875
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (100.015625,224) content-size 76.28125x17 table-cell [BFC] children: inline
-              line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,224 53.671875x17]
+              frag 0 from TextNode start: 0, length: 7, rect: [100.015625,224 53.671875x17] baseline: 13.296875
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -241,15 +219,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (8,251) content-size 82.015625x17 table-cell [BFC] children: inline
-              line 0 width: 35.125, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 4, rect: [8,251 35.125x17]
+              frag 0 from TextNode start: 0, length: 4, rect: [8,251 35.125x17] baseline: 13.296875
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (100.015625,251) content-size 76.28125x17 table-cell [BFC] children: inline
-              line 0 width: 53.671875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,251 53.671875x17]
+              frag 0 from TextNode start: 0, length: 7, rect: [100.015625,251 53.671875x17] baseline: 13.296875
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
           BlockContainer <caption> at (8,73) content-size 82.734375x17 [BFC] children: inline
-            line 0 width: 82.734375, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 9, rect: [16,73 82.734375x17]
+            frag 0 from TextNode start: 1, length: 9, rect: [16,73 82.734375x17] baseline: 13.296875
                 "A Caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -21,8 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 93.171875x17 table-cell [BFC] children: inline
-                line 0 width: 73.65625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x17] baseline: 13.296875
                     "Head Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,8 +36,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 93.171875x17 table-cell [BFC] children: inline
-                line 0 width: 70.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,32 70.234375x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [11,32 70.234375x17] baseline: 13.296875
                     "Body Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,8 +52,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,53) content-size 93.171875x17 table-cell [BFC] children: inline
-                line 0 width: 93.171875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,53 93.171875x17]
+                frag 0 from TextNode start: 0, length: 11, rect: [11,53 93.171875x17] baseline: 13.296875
                     "Footer Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -15,22 +15,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
                 BlockContainer <td> at (11,11) content-size 17.828125x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
                 BlockContainer <td> at (32.828125,11) content-size 11.828125x17 table-cell [BFC] children: inline
-                  line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x17] baseline: 13.296875
                       "B"
                   TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
                 BlockContainer <td> at (48.65625,11) content-size 36.34375x17 table-cell [BFC] children: inline
-                  line 0 width: 29.453125, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x17]
+                  frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x17] baseline: 13.296875
                       "C D"
                   TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -12,22 +12,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (11,11) content-size 300.640625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [154,11 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [154,11 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (315.640625,11) content-size 168.71875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [395.640625,11 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [395.640625,11 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (488.359375,11) content-size 300.640625x17 table-cell [BFC] children: inline
-                line 0 width: 29.453125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [624.359375,11 29.453125x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [624.359375,11 29.453125x17] baseline: 13.296875
                     "C D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,22 +35,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 300.640625x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [155,32 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [155,32 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (315.640625,32) content-size 168.71875x17 table-cell [BFC] children: inline
-                line 0 width: 12.546875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [393.640625,32 12.546875x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [393.640625,32 12.546875x17] baseline: 13.296875
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (488.359375,32) content-size 300.640625x17 table-cell [BFC] children: inline
-                line 0 width: 13.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [632.359375,32 13.234375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [632.359375,32 13.234375x17] baseline: 13.296875
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/cell-with-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-with-max-width.txt
@@ -8,23 +8,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <td> at (11,11) content-size 270x102 table-cell [BFC] children: not-inline
                 BlockContainer <div> at (11,11) content-size 270x102 children: not-inline
                   BlockContainer <(anonymous)> at (11,11) content-size 270x102 children: inline
-                    line 0 width: 261.0625, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 1, length: 35, rect: [11,11 261.0625x17]
+                    frag 0 from TextNode start: 1, length: 35, rect: [11,11 261.0625x17] baseline: 13.296875
                         "hello hello hello hello hello hello"
-                    line 1 width: 261.0625, height: 17, bottom: 34, baseline: 13.296875
-                      frag 0 from TextNode start: 37, length: 35, rect: [11,28 261.0625x17]
+                    frag 1 from TextNode start: 37, length: 35, rect: [11,28 261.0625x17] baseline: 13.296875
                         "hello hello hello hello hello hello"
-                    line 2 width: 261.0625, height: 17, bottom: 51, baseline: 13.296875
-                      frag 0 from TextNode start: 73, length: 35, rect: [11,45 261.0625x17]
+                    frag 2 from TextNode start: 73, length: 35, rect: [11,45 261.0625x17] baseline: 13.296875
                         "hello hello hello hello hello hello"
-                    line 3 width: 261.0625, height: 17, bottom: 68, baseline: 13.296875
-                      frag 0 from TextNode start: 109, length: 35, rect: [11,62 261.0625x17]
+                    frag 3 from TextNode start: 109, length: 35, rect: [11,62 261.0625x17] baseline: 13.296875
                         "hello hello hello hello hello hello"
-                    line 4 width: 261.0625, height: 17, bottom: 85, baseline: 13.296875
-                      frag 0 from TextNode start: 145, length: 35, rect: [11,79 261.0625x17]
+                    frag 4 from TextNode start: 145, length: 35, rect: [11,79 261.0625x17] baseline: 13.296875
                         "hello hello hello hello hello hello"
-                    line 5 width: 81.6875, height: 17, bottom: 102, baseline: 13.296875
-                      frag 0 from TextNode start: 181, length: 11, rect: [11,96 81.6875x17]
+                    frag 5 from TextNode start: 181, length: 11, rect: [11,96 81.6875x17] baseline: 13.296875
                         "hello hello"
                     TextNode <#text>
                   BlockContainer <div> at (11,113) content-size 270x0 children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -10,22 +10,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (19,19) content-size 8.453125x17 table-cell [BFC] children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (49.453125,19) content-size 8.8125x17 table-cell [BFC] children: inline
-                line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x17] baseline: 13.296875
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (80.265625,19) content-size 9.09375x17 table-cell [BFC] children: inline
-                line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x17] baseline: 13.296875
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,15 +33,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (19,58) content-size 8.453125x17 table-cell [BFC] children: inline
-                line 0 width: 7.75, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,58 7.75x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [19,58 7.75x17] baseline: 13.296875
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (49.453125,77.5) content-size 39.90625x17 table-cell [BFC] children: inline
-                line 0 width: 24.046875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [49.453125,77.5 24.046875x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [49.453125,77.5 24.046875x17] baseline: 13.296875
                     "6-9"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,8 +50,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (19,97) content-size 8.453125x17 table-cell [BFC] children: inline
-                line 0 width: 8.453125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,97 8.453125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [19,97 8.453125x17] baseline: 13.296875
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -10,22 +10,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 79.59375x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [44,11 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [44,11 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (94.59375,11) content-size 157.328125x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [168.59375,11 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [168.59375,11 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (255.921875,11) content-size 169.078125x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [334.921875,11 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [334.921875,11 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,15 +33,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 79.59375x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [45,32 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [45,32 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (94.59375,32) content-size 330.40625x17 table-cell [BFC] children: inline
-                line 0 width: 11.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [253.59375,32 11.859375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [253.59375,32 11.859375x17] baseline: 13.296875
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -10,15 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 180x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [94,11 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [94,11 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (195,11) content-size 20x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [200,11 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [200,11 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -29,8 +27,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 204x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [108,32 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [108,32 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -14,15 +14,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 17.5625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,11 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [13,11 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (32.5625,11) content-size 11.75x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.5625,11 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [33.5625,11 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -33,8 +31,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 33.3125x17 table-cell [BFC] children: inline
-                line 0 width: 33.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [11,32 33.3125x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [11,32 33.3125x17] baseline: 13.296875
                     "CDE"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
@@ -14,22 +14,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 70.046875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
                     "Header 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 72.515625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
                     "Header 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 72.796875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
                     "Header 3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -40,8 +37,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 223.359375x17 table-cell [BFC] children: inline
-                line 0 width: 41.84375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [102,32 41.84375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [102,32 41.84375x17] baseline: 13.296875
                     "Cell 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -52,8 +48,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,53) content-size 223.359375x17 table-cell [BFC] children: inline
-                line 0 width: 44.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [101,53 44.3125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [101,53 44.3125x17] baseline: 13.296875
                     "Cell 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -64,22 +59,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 44.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [24,74 44.59375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [24,74 44.59375x17] baseline: 13.296875
                     "Cell 3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 43.25, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [100.046875,74 43.25x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [100.046875,74 43.25x17] baseline: 13.296875
                     "Cell 4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 43.953125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [175.5625,74 43.953125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [175.5625,74 43.953125x17] baseline: 13.296875
                     "Cell 5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -10,23 +10,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <td.mbox-image> at (12,38) content-size 50x50 table-cell [BFC] children: not-inline
                 BlockContainer <div.mbox-image-div> at (12,38) content-size 50x50 children: not-inline
               BlockContainer <td.mbox-text> at (66,12) content-size 722x102 table-cell [BFC] children: inline
-                line 0 width: 689.640625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17]
+                frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17] baseline: 13.296875
                     "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
-                line 1 width: 695.5625, height: 17, bottom: 34, baseline: 13.296875
-                  frag 0 from TextNode start: 86, length: 84, rect: [66,29 695.5625x17]
+                frag 1 from TextNode start: 86, length: 84, rect: [66,29 695.5625x17] baseline: 13.296875
                     "against the wall. They receive a call from their assistant who expresses frustration"
-                line 2 width: 703.125, height: 17, bottom: 51, baseline: 13.296875
-                  frag 0 from TextNode start: 171, length: 85, rect: [66,46 703.125x17]
+                frag 2 from TextNode start: 171, length: 85, rect: [66,46 703.125x17] baseline: 13.296875
                     "over a packed waiting room and the lawyer's lack of clients. The lawyer then looks at"
-                line 3 width: 695.90625, height: 17, bottom: 68, baseline: 13.296875
-                  frag 0 from TextNode start: 257, length: 81, rect: [66,63 695.90625x17]
+                frag 3 from TextNode start: 257, length: 81, rect: [66,63 695.90625x17] baseline: 13.296875
                     "some papers from a large envelope, which turn out to be divorce papers from their"
-                line 4 width: 670.515625, height: 17, bottom: 85, baseline: 13.296875
-                  frag 0 from TextNode start: 339, length: 84, rect: [66,80 670.515625x17]
+                frag 4 from TextNode start: 339, length: 84, rect: [66,80 670.515625x17] baseline: 13.296875
                     "significant other. Finally, the lawyer instructs their assistant to send in the next"
-                line 5 width: 47.21875, height: 17, bottom: 102, baseline: 13.296875
-                  frag 0 from TextNode start: 424, length: 7, rect: [66,97 47.21875x17]
+                frag 5 from TextNode start: 424, length: 7, rect: [66,97 47.21875x17] baseline: 13.296875
                     "client."
                 TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -10,29 +10,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 62.4375x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (77.4375,11) content-size 62.4375x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (143.875,11) content-size 128.890625x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (276.765625,11) content-size 328.234375x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,29 +39,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 62.4375x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (77.4375,32) content-size 62.4375x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [77.4375,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (143.875,32) content-size 128.890625x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [143.875,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [143.875,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (276.765625,32) content-size 328.234375x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [276.765625,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -10,29 +10,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 95.65625x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (110.65625,11) content-size 95.65625x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (210.3125,11) content-size 95.65625x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (309.96875,11) content-size 295x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,29 +39,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 95.65625x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (110.65625,32) content-size 95.65625x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (210.3125,32) content-size 95.65625x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (309.96875,32) content-size 295x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
@@ -10,29 +10,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 58.578125x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (73.578125,11) content-size 58.578125x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [73.578125,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [73.578125,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (136.15625,11) content-size 116.53125x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [136.15625,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [136.15625,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (256.6875,11) content-size 348.3125x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,29 +39,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 58.578125x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (73.578125,32) content-size 58.578125x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [73.578125,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [73.578125,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (136.15625,32) content-size 116.53125x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [136.15625,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [136.15625,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (256.6875,32) content-size 348.3125x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [256.6875,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [256.6875,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
@@ -10,32 +10,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,19.5) content-size 94x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,19.5 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,19.5 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (109,19.5) content-size 94x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [109,19.5 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [109,19.5 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (207,11) content-size 94x34 table-cell [BFC] children: inline
-                line 0 width: 60.890625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x17] baseline: 13.296875
                     "A table"
-                line 1 width: 26.078125, height: 17, bottom: 34, baseline: 13.296875
-                  frag 0 from TextNode start: 8, length: 4, rect: [207,28 26.078125x17]
+                frag 1 from TextNode start: 8, length: 4, rect: [207,28 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (305,19.5) content-size 300x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [305,19.5 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [305,19.5 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -46,32 +41,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,57.5) content-size 94x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,57.5 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,57.5 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (109,57.5) content-size 94x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [109,57.5 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [109,57.5 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (207,49) content-size 94x34 table-cell [BFC] children: inline
-                line 0 width: 60.890625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [207,49 60.890625x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [207,49 60.890625x17] baseline: 13.296875
                     "A table"
-                line 1 width: 26.078125, height: 17, bottom: 34, baseline: 13.296875
-                  frag 0 from TextNode start: 8, length: 4, rect: [207,66 26.078125x17]
+                frag 1 from TextNode start: 8, length: 4, rect: [207,66 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (305,57.5) content-size 300x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [305,57.5 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [305,57.5 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
@@ -10,29 +10,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (160.5,11) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [160.5,11 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [160.5,11 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (310,11) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [310,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [310,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (459.5,11) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,29 +39,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (160.5,32) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 26.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [160.5,32 26.078125x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [160.5,32 26.078125x17] baseline: 13.296875
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (310,32) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [310,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [310,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (459.5,32) content-size 145.5x17 table-cell [BFC] children: inline
-                line 0 width: 94.96875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 12, rect: [459.5,32 94.96875x17]
+                frag 0 from TextNode start: 0, length: 12, rect: [459.5,32 94.96875x17] baseline: 13.296875
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -6,11 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.box> at (108,8) content-size 584x34 table-box [TFC] children: not-inline
             Box <(anonymous)> at (108,8) content-size 584x34 table-row children: not-inline
               BlockContainer <div.cell> at (108,8) content-size 584x34 table-cell [BFC] children: inline
-                line 0 width: 569.859375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x17]
+                frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x17] baseline: 13.296875
                     "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"
-                line 1 width: 399.9375, height: 17, bottom: 34, baseline: 13.296875
-                  frag 0 from TextNode start: 59, length: 40, rect: [108,25 399.9375x17]
+                frag 1 from TextNode start: 59, length: 40, rect: [108,25 399.9375x17] baseline: 13.296875
                     "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
                 TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <(anonymous)> at (11,11) content-size 41.78125x19 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,11) content-size 41.78125x19 table-row children: not-inline
               BlockContainer <div.cell> at (12,12) content-size 39.78125x17 table-cell [BFC] children: inline
-                line 0 width: 39.78125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17]
+                frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17] baseline: 13.296875
                     "Hello"
                 TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -1,32 +1,27 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x46 children: inline
-      line 0 width: 137.984375, height: 46, bottom: 46, baseline: 38.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44] baseline: 38.296875
       BlockContainer <table> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
         TableWrapper <(anonymous)> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
           Box <(anonymous)> at (9,9) content-size 135.984375x44 inline-table table-box [TFC] children: not-inline
             Box <tbody> at (9,9) content-size 129.984375x38 table-row-group children: not-inline
               Box <tr> at (11,11) content-size 129.984375x19 table-row children: not-inline
                 BlockContainer <td> at (12,12) content-size 87.90625x17 table-cell [BFC] children: inline
-                  line 0 width: 15.734375, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x17]
+                  frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x17] baseline: 13.296875
                       "ID"
                   TextNode <#text>
                 BlockContainer <td> at (103.90625,12) content-size 38.078125x17 table-cell [BFC] children: inline
-                  line 0 width: 27.84375, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17]
+                  frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17] baseline: 13.296875
                       "null"
                   TextNode <#text>
               Box <tr> at (11,32) content-size 129.984375x19 table-row children: not-inline
                 BlockContainer <td> at (12,33) content-size 87.90625x17 table-cell [BFC] children: inline
-                  line 0 width: 87.90625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 11, rect: [12,33 87.90625x17]
+                  frag 0 from TextNode start: 0, length: 11, rect: [12,33 87.90625x17] baseline: 13.296875
                       "Is Selected"
                   TextNode <#text>
                 BlockContainer <td> at (103.90625,33) content-size 38.078125x17 table-cell [BFC] children: inline
-                  line 0 width: 38.078125, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 5, rect: [103.90625,33 38.078125x17]
+                  frag 0 from TextNode start: 0, length: 5, rect: [103.90625,33 38.078125x17] baseline: 13.296875
                       "false"
                   TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/internal-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/internal-alignment.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               Box <tr> at (303,11) content-size 194x198 table-row children: not-inline
                 BlockContainer <td> at (304,85.5) content-size 192x49 table-cell [BFC] children: not-inline
                   BlockContainer <p> at (304,101.5) content-size 192x17 children: inline
-                    line 0 width: 26.25, height: 17, bottom: 17, baseline: 13.296875
-                      frag 0 from TextNode start: 0, length: 4, rect: [304,101.5 26.25x17]
+                    frag 0 from TextNode start: 0, length: 4, rect: [304,101.5 26.25x17] baseline: 13.296875
                         "left"
                     TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
+++ b/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (8,8) content-size 33.609375x19 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 33.609375x19 table-row children: not-inline
               BlockContainer <td.ab> at (11,11) content-size 31.609375x17 table-cell [BFC] children: inline
-                line 0 width: 31.609375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x17] baseline: 13.296875
                     "A B"
                 TextNode <#text>
       BlockContainer <(anonymous)> at (8,31) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
@@ -12,18 +12,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (10,18.5) content-size 14.296875x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [10,18.5 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [10,18.5 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (28.296875,10) content-size 20.40625x34 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x17]
+                frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x17] baseline: 13.296875
                     "B"
-                line 1 width: 10.3125, height: 17, bottom: 34, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [28.296875,27 10.3125x17]
+                frag 1 from TextNode start: 0, length: 1, rect: [28.296875,27 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
                 BreakNode <br>
@@ -31,8 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (52.703125,18.5) content-size 14.296875x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 1, length: 1, rect: [52.703125,18.5 11.140625x17]
+                frag 0 from TextNode start: 1, length: 1, rect: [52.703125,18.5 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -8,11 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
           BlockContainer <caption> at (8,8) content-size 59.046875x34 [BFC] children: inline
-            line 0 width: 54.03125, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 6, rect: [11,8 54.03125x17]
+            frag 0 from TextNode start: 1, length: 6, rect: [11,8 54.03125x17] baseline: 13.296875
                 "A long"
-            line 1 width: 59.046875, height: 17, bottom: 34, baseline: 13.296875
-              frag 0 from TextNode start: 8, length: 7, rect: [8,25 59.046875x17]
+            frag 1 from TextNode start: 8, length: 7, rect: [8,25 59.046875x17] baseline: 13.296875
                 "caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -24,15 +22,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,46) content-size 21.25x17 table-cell [BFC] children: inline
-                line 0 width: 20.609375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,46 20.609375x17]
+                frag 0 from TextNode start: 0, length: 2, rect: [14,46 20.609375x17] baseline: 13.296875
                     "A1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (41.25,46) content-size 23.796875x17 table-cell [BFC] children: inline
-                line 0 width: 23.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,46 23.078125x17]
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,46 23.078125x17] baseline: 13.296875
                     "A2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,15 +44,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,69) content-size 21.25x17 table-cell [BFC] children: inline
-                line 0 width: 15.6875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,69 15.6875x17]
+                frag 0 from TextNode start: 0, length: 2, rect: [14,69 15.6875x17] baseline: 13.296875
                     "B1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (41.25,69) content-size 23.796875x17 table-cell [BFC] children: inline
-                line 0 width: 18.15625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,69 18.15625x17]
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,69 18.15625x17] baseline: 13.296875
                     "B2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -72,15 +66,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,92) content-size 21.25x17 table-cell [BFC] children: inline
-                line 0 width: 18.890625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,92 18.890625x17]
+                frag 0 from TextNode start: 0, length: 2, rect: [14,92 18.890625x17] baseline: 13.296875
                     "F1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (41.25,92) content-size 23.796875x17 table-cell [BFC] children: inline
-                line 0 width: 21.359375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,92 21.359375x17]
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,92 21.359375x17] baseline: 13.296875
                     "F2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
@@ -7,27 +7,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tbody> at (9,9) content-size 98x117 table-row-group children: not-inline
               Box <tr> at (9,9) content-size 98x39 table-row children: not-inline
                 BlockContainer <td> at (20,20) content-size 30.5625x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <td> at (72.5625,20) content-size 23.4375x17 table-cell [BFC] children: inline
-                  line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17] baseline: 13.296875
                       "B"
                   TextNode <#text>
               Box <tr> at (9,48) content-size 98x39 table-row children: not-inline
                 BlockContainer <td> at (20,59) content-size 30.5625x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,68) content-size 21.71875x0 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (84.28125,67.5) content-size 21.71875x0 table-cell [BFC] children: not-inline
               Box <tr> at (9,87) content-size 98x39 table-row children: not-inline
                 BlockContainer <td> at (20,98) content-size 30.5625x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,106) content-size 21.71875x0 table-cell [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/missing-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells.txt
@@ -7,26 +7,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tbody> at (9,9) content-size 98x117 table-row-group children: not-inline
               Box <tr> at (9,9) content-size 98x39 table-row children: not-inline
                 BlockContainer <td> at (20,20) content-size 30.5625x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <td> at (72.5625,20) content-size 23.4375x17 table-cell [BFC] children: inline
-                  line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17] baseline: 13.296875
                       "B"
                   TextNode <#text>
               Box <tr> at (9,48) content-size 98x39 table-row children: not-inline
                 BlockContainer <td> at (20,59) content-size 30.5625x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,68) content-size 43.4375x0 table-cell [BFC] children: not-inline
               Box <tr> at (9,87) content-size 98x39 table-row children: not-inline
                 BlockContainer <td> at (20,98) content-size 30.5625x17 table-cell [BFC] children: inline
-                  line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17]
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17] baseline: 13.296875
                       "A"
                   TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,106) content-size 43.4375x0 table-cell [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -8,19 +8,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (9,9) content-size 75.4375x59 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 75.4375x21 table-row children: not-inline
               BlockContainer <td> at (13,13) content-size 71.4375x17 table-cell [BFC] children: inline
-                line 0 width: 7.9375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x17] baseline: 13.296875
                     "*"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (11,34) content-size 75.4375x38 table-row children: not-inline
               BlockContainer <td> at (13,36) content-size 71.4375x34 table-cell [BFC] children: inline
-                line 0 width: 71.4375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,36 71.4375x17]
+                frag 0 from TextNode start: 0, length: 9, rect: [13,36 71.4375x17] baseline: 13.296875
                     "*********"
-                line 1 width: 63.5625, height: 17, bottom: 34, baseline: 13.296875
-                  frag 0 from TextNode start: 10, length: 8, rect: [13,53 63.5625x17]
+                frag 1 from TextNode start: 10, length: 8, rect: [13,53 63.5625x17] baseline: 13.296875
                     "***** **"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
@@ -11,8 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     Box <tbody> at (159.890625,13) content-size 39.109375x198 table-row-group children: not-inline
                       Box <tr> at (161.890625,15) content-size 39.109375x198 table-row children: not-inline
                         BlockContainer <td> at (162.890625,105.5) content-size 37.109375x17 table-cell [BFC] children: inline
-                          line 0 width: 37.109375, height: 17, bottom: 17, baseline: 13.296875
-                            frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105.5 37.109375x17]
+                          frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105.5 37.109375x17] baseline: 13.296875
                               "right"
                           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -16,8 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (25,33.5) content-size 11.5625x17 table-cell [BFC] children: inline
-                line 0 width: 11.5625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x17] baseline: 13.296875
                     "X"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,8 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (75.5625,42) content-size 14.265625x17 table-cell [BFC] children: inline
-                          line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                            frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x17]
+                          frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x17] baseline: 13.296875
                               "A"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,8 +46,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (75.5625,81) content-size 14.265625x17 table-cell [BFC] children: inline
-                          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                            frag 0 from TextNode start: 0, length: 1, rect: [75.5625,81 9.34375x17]
+                          frag 0 from TextNode start: 0, length: 1, rect: [75.5625,81 9.34375x17] baseline: 13.296875
                               "B"
                           TextNode <#text>
                         BlockContainer <(anonymous)> at (58.5625,25) content-size 0x0 children: inline
@@ -68,8 +65,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (25,89.5) content-size 11.5625x17 table-cell [BFC] children: inline
-                line 0 width: 11.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [25,89.5 11.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [25,89.5 11.09375x17] baseline: 13.296875
                     "Y"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -12,22 +12,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 14.40625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (29.40625,11) content-size 51.1875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.40625,11 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [50.40625,11 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (84.59375,11) content-size 14.40625x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [86.59375,11 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [86.59375,11 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -13,8 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         Box <tbody> at (12,12) content-size 188x19 table-row-group children: not-inline
                           Box <tr> at (14,14) content-size 188x19 table-row children: not-inline
                             BlockContainer <td> at (15,15) content-size 186x17 table-cell [BFC] children: inline
-                              line 0 width: 36.53125, height: 17, bottom: 17, baseline: 13.296875
-                                frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x17]
+                              frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x17] baseline: 13.296875
                                   "A A"
                               TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
@@ -10,22 +10,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (10,10) content-size 31.703125x17 table-cell [BFC] children: inline
-                line 0 width: 31.609375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x17] baseline: 13.296875
                     "A B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (45.703125,10) content-size 43.59375x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [45.703125,10 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [45.703125,10 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (93.296875,10) content-size 31.703125x17 table-cell [BFC] children: inline
-                line 0 width: 11.140625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x17] baseline: 13.296875
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -13,8 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (16,12) content-size 37.21875x17 table-cell [BFC] children: inline
-                line 0 width: 37.21875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x17] baseline: 13.296875
                     "Test"
                 TextNode <#text>
                 InlineNode <a>

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -16,8 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,29.25) content-size 11.5625x17 table-cell [BFC] children: inline
-                line 0 width: 11.5625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.25 11.5625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [17,29.25 11.5625x17] baseline: 13.296875
                     "X"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,8 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (51.5625,26) content-size 14.265625x17 table-cell [BFC] children: inline
-                          line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x17]
+                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x17] baseline: 13.296875
                               "A"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,8 +46,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (51.5625,57) content-size 14.265625x17 table-cell [BFC] children: inline
-                          line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,57 9.34375x17]
+                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,57 9.34375x17] baseline: 13.296875
                               "B"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
@@ -60,8 +57,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (51.5625,88) content-size 14.265625x17 table-cell [BFC] children: inline
-                          line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,88 10.3125x17]
+                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,88 10.3125x17] baseline: 13.296875
                               "C"
                           TextNode <#text>
                         BlockContainer <(anonymous)> at (42.5625,17) content-size 0x0 children: inline
@@ -80,8 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,84.75) content-size 11.5625x17 table-cell [BFC] children: inline
-                line 0 width: 11.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,84.75 11.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [17,84.75 11.09375x17] baseline: 13.296875
                     "Y"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -5,14 +5,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
           Box <div.row.a> at (8,8) content-size 200x150 table-row children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x17 table-cell [BFC] children: inline
-              line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
                   "a"
               TextNode <#text>
           Box <div.row.b> at (8,158) content-size 200x150 table-row children: not-inline
             BlockContainer <div.cell> at (8,158) content-size 200x17 table-cell [BFC] children: inline
-              line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x17] baseline: 13.296875
                   "b"
               TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -5,14 +5,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
           Box <div.row.a> at (8,8) content-size 200x100 table-row children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x17 table-cell [BFC] children: inline
-              line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
                   "a"
               TextNode <#text>
           Box <div.row.b> at (8,108) content-size 200x200 table-row children: not-inline
             BlockContainer <div.cell> at (8,108) content-size 200x17 table-cell [BFC] children: inline
-              line 0 width: 9.46875, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x17]
+              frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x17] baseline: 13.296875
                   "b"
               TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
@@ -14,22 +14,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 70.046875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
                     "Header 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 72.515625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
                     "Header 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 72.796875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
                     "Header 3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -40,22 +37,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 41.84375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [25,32 41.84375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [25,32 41.84375x17] baseline: 13.296875
                     "Cell 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,32) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 44.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.046875,32 44.3125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [99.046875,32 44.3125x17] baseline: 13.296875
                     "Cell 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,42.5) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 44.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [175.5625,42.5 44.59375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [175.5625,42.5 44.59375x17] baseline: 13.296875
                     "Cell 3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -66,15 +60,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,53) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 43.25, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [24,53 43.25x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [24,53 43.25x17] baseline: 13.296875
                     "Cell 4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 43.953125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.046875,53 43.953125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [99.046875,53 43.953125x17] baseline: 13.296875
                     "Cell 5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -85,22 +77,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 44.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [24,74 44.234375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [24,74 44.234375x17] baseline: 13.296875
                     "Cell 6"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 44.21875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.046875,74 44.21875x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [99.046875,74 44.21875x17] baseline: 13.296875
                     "Cell 7"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 44.984375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [175.5625,74 44.984375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [175.5625,74 44.984375x17] baseline: 13.296875
                     "Cell 8"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -111,22 +100,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,95) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 44.328125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [24,95 44.328125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [24,95 44.328125x17] baseline: 13.296875
                     "Cell 9"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,95) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 51.4375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [96.046875,95 51.4375x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [96.046875,95 51.4375x17] baseline: 13.296875
                     "Cell 10"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,105.5) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 48.1875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [173.5625,105.5 48.1875x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [173.5625,105.5 48.1875x17] baseline: 13.296875
                     "Cell 11"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -137,15 +123,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,116) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 50.65625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [21,116 50.65625x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [21,116 50.65625x17] baseline: 13.296875
                     "Cell 12"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,116) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 50.9375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 7, rect: [96.046875,116 50.9375x17]
+                frag 0 from TextNode start: 0, length: 7, rect: [96.046875,116 50.9375x17] baseline: 13.296875
                     "Cell 13"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -14,22 +14,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 70.046875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
                     "Header 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 72.515625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
                     "Header 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 72.796875, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17]
+                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
                     "Header 3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -40,22 +37,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,42.5) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 49.609375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 5, rect: [11,42.5 49.609375x17]
+                frag 0 from TextNode start: 0, length: 5, rect: [11,42.5 49.609375x17] baseline: 13.296875
                     "Row 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,32) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 41.84375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,32 41.84375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,32 41.84375x17] baseline: 13.296875
                     "Cell 1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,32) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 44.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,32 44.3125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,32 44.3125x17] baseline: 13.296875
                     "Cell 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -66,15 +60,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 44.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,53 44.59375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,53 44.59375x17] baseline: 13.296875
                     "Cell 3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,53) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 43.25, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,53 43.25x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,53 43.25x17] baseline: 13.296875
                     "Cell 4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -85,22 +77,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
-                line 0 width: 52.078125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 5, rect: [11,74 52.078125x17]
+                frag 0 from TextNode start: 0, length: 5, rect: [11,74 52.078125x17] baseline: 13.296875
                     "Row 2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: inline
-                line 0 width: 43.953125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,74 43.953125x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,74 43.953125x17] baseline: 13.296875
                     "Cell 5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: inline
-                line 0 width: 44.234375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,74 44.234375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,74 44.234375x17] baseline: 13.296875
                     "Cell 6"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/size.txt
+++ b/Tests/LibWeb/Layout/expected/table/size.txt
@@ -8,8 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (350,8) content-size 100x0 children: inline
                 TextNode <#text>
               BlockContainer <div> at (350,8) content-size 2000x17 children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [350,8 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [350,8 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (350,25) content-size 100x0 children: inline

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -10,22 +10,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 19x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (38,13) content-size 41.984375x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.984375,13) content-size 19x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (109,101) content-size 83.34375x198 table-row-group children: not-inline
             Box <tr> at (111,103) content-size 83.34375x198 table-row children: not-inline
               BlockContainer <td> at (112,193.5) content-size 81.34375x17 table-cell [BFC] children: inline
-                line 0 width: 81.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 10, rect: [112,193.5 81.34375x17]
+                frag 0 from TextNode start: 0, length: 10, rect: [112,193.5 81.34375x17] baseline: 13.296875
                     "off-center"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (371.1875,9) content-size 53.625x198 table-row-group children: not-inline
             Box <tr> at (373.1875,11) content-size 53.625x198 table-row children: not-inline
               BlockContainer <td> at (374.1875,101.5) content-size 51.625x17 table-cell [BFC] children: inline
-                line 0 width: 51.625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101.5 51.625x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101.5 51.625x17] baseline: 13.296875
                     "center"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
@@ -1,8 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      line 0 width: 10, height: 17, bottom: 17, baseline: 13.296875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,19 0x0]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,19 0x0] baseline: 4
       BlockContainer <button> at (13,19) content-size 0x0 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,19) content-size 0x0 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,19) content-size 0x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
@@ -6,18 +6,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (9,9) content-size 488.1875x198 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 488.1875x198 table-row children: not-inline
               BlockContainer <td> at (71,71) content-size 26.640625x17 table-cell [BFC] children: inline
-                line 0 width: 26.640625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x17] baseline: 13.296875
                     "top"
                 TextNode <#text>
               BlockContainer <td> at (219.640625,101.5) content-size 45.4375x17 table-cell [BFC] children: inline
-                line 0 width: 45.4375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101.5 45.4375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101.5 45.4375x17] baseline: 13.296875
                     "middle"
                 TextNode <#text>
               BlockContainer <td> at (387.078125,132) content-size 56.109375x17 table-cell [BFC] children: inline
-                line 0 width: 56.109375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [387.078125,132 56.109375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [387.078125,132 56.109375x17] baseline: 13.296875
                     "bottom"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-fixup-font-size-and-line-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-fixup-font-size-and-line-height.txt
@@ -5,8 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div> at (8,8) content-size 69.078125x100 table-box [TFC] children: inline
           Box <(anonymous)> at (8,8) content-size 69.078125x100 table-row children: inline
             BlockContainer <(anonymous)> at (8,8) content-size 69.078125x100 table-cell [BFC] children: inline
-              line 0 width: 69.078125, height: 100, bottom: 100, baseline: 59
-                frag 0 from TextNode start: 0, length: 5, rect: [8,8 69.078125x100]
+              frag 0 from TextNode start: 0, length: 5, rect: [8,8 69.078125x100] baseline: 59
                   "hello"
               TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -10,22 +10,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (20,20) content-size 9.59375x17 table-cell [BFC] children: inline
-                line 0 width: 9.59375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x17] baseline: 13.296875
                     "0"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (51.59375,39.5) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,39.5 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51.59375,39.5 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.859375,59) content-size 11.5625x17 table-cell [BFC] children: inline
-                line 0 width: 11.5625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,59 11.5625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.859375,59 11.5625x17] baseline: 13.296875
                     "X"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,8 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (20,59) content-size 9.59375x17 table-cell [BFC] children: inline
-                line 0 width: 6.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,59 6.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [20,59 6.34375x17] baseline: 13.296875
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,15 +44,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (20,98) content-size 9.59375x17 table-cell [BFC] children: inline
-                line 0 width: 8.8125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,98 8.8125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [20,98 8.8125x17] baseline: 13.296875
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (51.59375,117.5) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,117.5 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [51.59375,117.5 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -67,15 +61,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (20,137) content-size 9.59375x17 table-cell [BFC] children: inline
-                line 0 width: 9.09375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,137 9.09375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [20,137 9.09375x17] baseline: 13.296875
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (87.859375,137) content-size 11.5625x17 table-cell [BFC] children: inline
-                line 0 width: 10.3125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,137 10.3125x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [87.859375,137 10.3125x17] baseline: 13.296875
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
@@ -5,15 +5,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.bottom> at (10,10) content-size 298x99 table-footer-group children: inline
           Box <(anonymous)> at (10,10) content-size 298x99 table-row children: inline
             BlockContainer <(anonymous)> at (10,10) content-size 298x17 table-cell [BFC] children: inline
-              line 0 width: 56.109375, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 6, rect: [10,10 56.109375x17]
+              frag 0 from TextNode start: 0, length: 6, rect: [10,10 56.109375x17] baseline: 13.296875
                   "bottom"
               TextNode <#text>
         Box <div.top> at (10,109) content-size 298x99 table-header-group children: inline
           Box <(anonymous)> at (10,109) content-size 298x99 table-row children: inline
             BlockContainer <(anonymous)> at (10,109) content-size 298x17 table-cell [BFC] children: inline
-              line 0 width: 26.640625, height: 17, bottom: 17, baseline: 13.296875
-                frag 0 from TextNode start: 0, length: 3, rect: [10,109 26.640625x17]
+              frag 0 from TextNode start: 0, length: 3, rect: [10,109 26.640625x17] baseline: 13.296875
                   "top"
               TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -6,18 +6,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (9,9) content-size 134.1875x198 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 134.1875x198 table-row children: not-inline
               BlockContainer <td> at (12,12) content-size 26.640625x17 table-cell [BFC] children: inline
-                line 0 width: 26.640625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x17]
+                frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x17] baseline: 13.296875
                     "top"
                 TextNode <#text>
               BlockContainer <td> at (42.640625,101.5) content-size 45.4375x17 table-cell [BFC] children: inline
-                line 0 width: 45.4375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101.5 45.4375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101.5 45.4375x17] baseline: 13.296875
                     "middle"
                 TextNode <#text>
               BlockContainer <td> at (92.078125,191) content-size 56.109375x17 table-cell [BFC] children: inline
-                line 0 width: 56.109375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 6, rect: [92.078125,191 56.109375x17]
+                frag 0 from TextNode start: 0, length: 6, rect: [92.078125,191 56.109375x17] baseline: 13.296875
                     "bottom"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -6,8 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
           BlockContainer <caption> at (8,8) content-size 60.46875x17 [BFC] children: inline
-            line 0 width: 60.46875, height: 17, bottom: 17, baseline: 13.296875
-              frag 0 from TextNode start: 1, length: 7, rect: [8,8 60.46875x17]
+            frag 0 from TextNode start: 1, length: 7, rect: [8,8 60.46875x17] baseline: 13.296875
                 "Caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -17,8 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,38) content-size 54.46875x17 table-cell [BFC] children: inline
-                line 0 width: 27.5, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,38 27.5x17]
+                frag 0 from TextNode start: 0, length: 4, rect: [11,38 27.5x17] baseline: 13.296875
                     "Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -15,15 +15,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 46x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (65,13) content-size 358x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -15,15 +15,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (33.265625,13) content-size 389.734375x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -10,15 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (33.265625,13) content-size 389.734375x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17]
+                frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -12,22 +12,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (10,10) content-size 216.09375x17 table-cell [BFC] children: inline
-                line 0 width: 14.265625, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x17]
+                frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x17] baseline: 13.296875
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (230.09375,10) content-size 156.796875x17 table-cell [BFC] children: inline
-                line 0 width: 9.34375, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 1, length: 1, rect: [230.09375,10 9.34375x17]
+                frag 0 from TextNode start: 1, length: 1, rect: [230.09375,10 9.34375x17] baseline: 13.296875
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (390.890625,10) content-size 399.109375x17 table-cell [BFC] children: inline
-                line 0 width: 29.453125, height: 17, bottom: 17, baseline: 13.296875
-                  frag 0 from TextNode start: 1, length: 3, rect: [390.890625,10 29.453125x17]
+                frag 0 from TextNode start: 1, length: 3, rect: [390.890625,10 29.453125x17] baseline: 13.296875
                     "C D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
@@ -2,71 +2,65 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x102 children: not-inline
       BlockContainer <div> at (9,9) content-size 100x100 children: inline
-        line 0 width: 98, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 3, rect: [9,9 27.15625x17]
+        frag 0 from TextNode start: 1, length: 3, rect: [9,9 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from TextNode start: 4, length: 1, rect: [36,9 9x17]
+        frag 1 from TextNode start: 4, length: 1, rect: [36,9 9x17] baseline: 13.296875
             " "
-          frag 2 from TextNode start: 5, length: 3, rect: [45,9 27.640625x17]
+        frag 2 from TextNode start: 5, length: 3, rect: [45,9 27.640625x17] baseline: 13.296875
             "bar"
-          frag 3 from TextNode start: 8, length: 1, rect: [73,9 9x17]
+        frag 3 from TextNode start: 8, length: 1, rect: [73,9 9x17] baseline: 13.296875
             " "
-          frag 4 from TextNode start: 9, length: 3, rect: [82,9 27.203125x17]
+        frag 4 from TextNode start: 9, length: 3, rect: [82,9 27.203125x17] baseline: 13.296875
             "baz"
-        line 1 width: 98, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 13, length: 3, rect: [9,26 27.15625x17]
+        frag 5 from TextNode start: 13, length: 3, rect: [9,26 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from TextNode start: 16, length: 1, rect: [36,26 8x17]
+        frag 6 from TextNode start: 16, length: 1, rect: [36,26 8x17] baseline: 13.296875
             " "
-          frag 2 from TextNode start: 17, length: 3, rect: [44,26 27.640625x17]
+        frag 7 from TextNode start: 17, length: 3, rect: [44,26 27.640625x17] baseline: 13.296875
             "bar"
-          frag 3 from TextNode start: 20, length: 1, rect: [72,26 8x17]
+        frag 8 from TextNode start: 20, length: 1, rect: [72,26 8x17] baseline: 13.296875
             " "
-          frag 4 from TextNode start: 21, length: 3, rect: [80,26 27.203125x17]
+        frag 9 from TextNode start: 21, length: 3, rect: [80,26 27.203125x17] baseline: 13.296875
             "baz"
-        line 2 width: 98, height: 17, bottom: 51, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 3, rect: [9,43 27.15625x17]
+        frag 10 from TextNode start: 1, length: 3, rect: [9,43 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from TextNode start: 4, length: 1, rect: [36,43 9x17]
+        frag 11 from TextNode start: 4, length: 1, rect: [36,43 9x17] baseline: 13.296875
             " "
-          frag 2 from TextNode start: 5, length: 3, rect: [45,43 27.640625x17]
+        frag 12 from TextNode start: 5, length: 3, rect: [45,43 27.640625x17] baseline: 13.296875
             "bar"
-          frag 3 from TextNode start: 8, length: 1, rect: [73,43 9x17]
+        frag 13 from TextNode start: 8, length: 1, rect: [73,43 9x17] baseline: 13.296875
             " "
-          frag 4 from TextNode start: 9, length: 3, rect: [82,43 27.203125x17]
+        frag 14 from TextNode start: 9, length: 3, rect: [82,43 27.203125x17] baseline: 13.296875
             "baz"
-        line 3 width: 98, height: 17, bottom: 68, baseline: 13.296875
-          frag 0 from TextNode start: 13, length: 3, rect: [9,60 27.15625x17]
+        frag 15 from TextNode start: 13, length: 3, rect: [9,60 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from TextNode start: 16, length: 1, rect: [36,60 9x17]
+        frag 16 from TextNode start: 16, length: 1, rect: [36,60 9x17] baseline: 13.296875
             " "
-          frag 2 from TextNode start: 17, length: 3, rect: [45,60 27.640625x17]
+        frag 17 from TextNode start: 17, length: 3, rect: [45,60 27.640625x17] baseline: 13.296875
             "bar"
-          frag 3 from TextNode start: 20, length: 1, rect: [73,60 9x17]
+        frag 18 from TextNode start: 20, length: 1, rect: [73,60 9x17] baseline: 13.296875
             " "
-          frag 4 from TextNode start: 21, length: 3, rect: [82,60 27.203125x17]
+        frag 19 from TextNode start: 21, length: 3, rect: [82,60 27.203125x17] baseline: 13.296875
             "baz"
-        line 4 width: 98, height: 17, bottom: 85, baseline: 13.296875
-          frag 0 from TextNode start: 25, length: 3, rect: [9,77 27.15625x17]
+        frag 20 from TextNode start: 25, length: 3, rect: [9,77 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from TextNode start: 28, length: 1, rect: [36,77 8x17]
+        frag 21 from TextNode start: 28, length: 1, rect: [36,77 8x17] baseline: 13.296875
             " "
-          frag 2 from TextNode start: 29, length: 3, rect: [44,77 27.640625x17]
+        frag 22 from TextNode start: 29, length: 3, rect: [44,77 27.640625x17] baseline: 13.296875
             "bar"
-          frag 3 from TextNode start: 32, length: 1, rect: [72,77 8x17]
+        frag 23 from TextNode start: 32, length: 1, rect: [72,77 8x17] baseline: 13.296875
             " "
-          frag 4 from TextNode start: 33, length: 3, rect: [80,77 27.203125x17]
+        frag 24 from TextNode start: 33, length: 3, rect: [80,77 27.203125x17] baseline: 13.296875
             "baz"
-        line 5 width: 98, height: 17, bottom: 102, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 3, rect: [9,94 27.15625x17]
+        frag 25 from TextNode start: 1, length: 3, rect: [9,94 27.15625x17] baseline: 13.296875
             "foo"
-          frag 1 from TextNode start: 4, length: 1, rect: [36,94 8x17]
+        frag 26 from TextNode start: 4, length: 1, rect: [36,94 8x17] baseline: 13.296875
             " "
-          frag 2 from TextNode start: 5, length: 3, rect: [44,94 27.640625x17]
+        frag 27 from TextNode start: 5, length: 3, rect: [44,94 27.640625x17] baseline: 13.296875
             "bar"
-          frag 3 from TextNode start: 8, length: 1, rect: [72,94 8x17]
+        frag 28 from TextNode start: 8, length: 1, rect: [72,94 8x17] baseline: 13.296875
             " "
-          frag 4 from TextNode start: 9, length: 3, rect: [80,94 27.203125x17]
+        frag 29 from TextNode start: 9, length: 3, rect: [80,94 27.203125x17] baseline: 13.296875
             "baz"
         TextNode <#text>
         BreakNode <br>

--- a/Tests/LibWeb/Layout/expected/text-align-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-overflow.txt
@@ -3,8 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       BlockContainer <div.outer> at (18,8) content-size 80x17 children: not-inline
         BlockContainer <span.text> at (18,8) content-size 80x17 [BFC] children: inline
-          line 0 width: 189.875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 22, rect: [18,8 189.875x17]
+          frag 0 from TextNode start: 0, length: 22, rect: [18,8 189.875x17] baseline: 13.296875
               "My super long message!"
           TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/text-indent.txt
+++ b/Tests/LibWeb/Layout/expected/text-indent.txt
@@ -3,27 +3,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x140 children: not-inline
       BlockContainer <div.px-indent> at (11,11) content-size 778x68 children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 778x17 children: inline
-          line 0 width: 142.390625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 11, rect: [61,11 92.390625x17]
+          frag 0 from TextNode start: 0, length: 11, rect: [61,11 92.390625x17] baseline: 13.296875
               "50px indent"
           TextNode <#text>
         BlockContainer <p> at (12,45) content-size 776x17 children: inline
-          line 0 width: 140.921875, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 12, rect: [62,45 90.921875x17]
+          frag 0 from TextNode start: 0, length: 12, rect: [62,45 90.921875x17] baseline: 13.296875
               "is inherited"
           TextNode <#text>
       BlockContainer <div.pct-indent> at (11,81) content-size 100x68 children: inline
-        line 0 width: 80.34375, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 0, length: 3, rect: [61,81 30.34375x17]
+        frag 0 from TextNode start: 0, length: 3, rect: [61,81 30.34375x17] baseline: 13.296875
             "50%"
-        line 1 width: 88.15625, height: 17, bottom: 34, baseline: 13.296875
-          frag 0 from TextNode start: 4, length: 11, rect: [11,98 88.15625x17]
+        frag 1 from TextNode start: 4, length: 11, rect: [11,98 88.15625x17] baseline: 13.296875
             "indent snip"
-        line 2 width: 78.703125, height: 17, bottom: 51, baseline: 13.296875
-          frag 0 from TextNode start: 16, length: 9, rect: [11,115 78.703125x17]
+        frag 2 from TextNode start: 16, length: 9, rect: [11,115 78.703125x17] baseline: 13.296875
             "snap snib"
-        line 3 width: 37.765625, height: 17, bottom: 68, baseline: 13.296875
-          frag 0 from TextNode start: 26, length: 4, rect: [11,132 37.765625x17]
+        frag 3 from TextNode start: 26, length: 4, rect: [11,132 37.765625x17] baseline: 13.296875
             "snab"
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/textarea-content.txt
+++ b/Tests/LibWeb/Layout/expected/textarea-content.txt
@@ -1,25 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50 children: inline
-      line 0 width: 502, height: 50, bottom: 50, baseline: 17
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 240x44]
-        frag 1 from TextNode start: 0, length: 1, rect: [254,8 10x22]
+      frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 240x44] baseline: 17
+      frag 1 from TextNode start: 0, length: 1, rect: [254,8 10x22] baseline: 17
           " "
-        frag 2 from BlockContainer start: 0, length: 0, rect: [267,11 240x44]
+      frag 2 from BlockContainer start: 0, length: 0, rect: [267,11 240x44] baseline: 17
       TextNode <#text>
       BlockContainer <textarea> at (11,11) content-size 240x44 inline-block [BFC] children: not-inline
         BlockContainer <div> at (11,11) content-size 240x22 children: not-inline
           BlockContainer <div> at (11,11) content-size 240x22 children: inline
-            line 0 width: 190.265625, height: 22, bottom: 22, baseline: 17
-              frag 0 from TextNode start: 0, length: 17, rect: [11,11 190.265625x22]
+            frag 0 from TextNode start: 0, length: 17, rect: [11,11 190.265625x22] baseline: 17
                 "Bonjour mon amis!"
             TextNode <#text>
       TextNode <#text>
       BlockContainer <textarea> at (267,11) content-size 240x44 inline-block [BFC] children: not-inline
         BlockContainer <div> at (267,11) content-size 240x22 children: not-inline
           BlockContainer <div> at (267,11) content-size 240x22 children: inline
-            line 0 width: 177.6875, height: 22, bottom: 22, baseline: 17
-              frag 0 from TextNode start: 0, length: 19, rect: [267,11 177.6875x22]
+            frag 0 from TextNode start: 0, length: 19, rect: [267,11 177.6875x22] baseline: 17
                 "Well hello friends!"
             TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/textnode-width-bitmap-font.txt
+++ b/Tests/LibWeb/Layout/expected/textnode-width-bitmap-font.txt
@@ -2,8 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x38 [BFC] children: not-inline
     BlockContainer <body> at (8,13) content-size 784x17 children: not-inline
       BlockContainer <p> at (8,13) content-size 784x17 children: inline
-        line 0 width: 102, height: 17, bottom: 17, baseline: 11
-          frag 0 from TextNode start: 0, length: 18, rect: [8,13 102x17]
+        frag 0 from TextNode start: 0, length: 18, rect: [8,13 102x17] baseline: 11
             "This is some text."
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,43) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/utf-16-be-xhtml-file-should-decode-correctly.txt
+++ b/Tests/LibWeb/Layout/expected/utf-16-be-xhtml-file-should-decode-correctly.txt
@@ -4,8 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <p> at (8,16) content-size 784x17 children: inline
-        line 0 width: 29.21875, height: 17, bottom: 17, baseline: 13.296875
-          frag 0 from TextNode start: 1, length: 15, rect: [8,16 29.21875x17]
+        frag 0 from TextNode start: 1, length: 15, rect: [8,16 29.21875x17] baseline: 13.296875
             "好啦朋友們"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
@@ -7,13 +7,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 600x0 children: inline
           TextNode <#text>
         BlockContainer <div.foo> at (12,72) content-size 598x18 children: inline
-          line 0 width: 27.15625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17]
+          frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17] baseline: 13.296875
               "foo"
           TextNode <#text>
         BlockContainer <(anonymous)> at (11,211) content-size 600x17 children: inline
-          line 0 width: 27.640625, height: 17, bottom: 17, baseline: 13.296875
-            frag 0 from TextNode start: 1, length: 3, rect: [11,211 27.640625x17]
+          frag 0 from TextNode start: 1, length: 3, rect: [11,211 27.640625x17] baseline: 13.296875
               "bar"
           TextNode <#text>
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -500,6 +500,7 @@ set(SOURCES
     Painting/PaintContext.cpp
     Painting/Paintable.cpp
     Painting/PaintableBox.cpp
+    Painting/PaintableFragment.cpp
     Painting/PaintingCommandExecutorCPU.cpp
     Painting/RadioButtonPaintable.cpp
     Painting/RecordingPainter.cpp

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -7,8 +7,6 @@
 #include <AK/Utf8View.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/Layout/LayoutState.h>
-#include <LibWeb/Layout/LineBoxFragment.h>
-#include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <ctype.h>
 
@@ -40,113 +38,6 @@ CSSPixelRect const LineBoxFragment::absolute_rect() const
     rect.set_location(m_layout_node->containing_block()->paintable_box()->absolute_position());
     rect.translate_by(offset());
     return rect;
-}
-
-int LineBoxFragment::text_index_at(CSSPixels x) const
-{
-    if (!is<TextNode>(layout_node()))
-        return 0;
-    auto& layout_text = verify_cast<TextNode>(layout_node());
-    auto& font = layout_text.first_available_font();
-    Utf8View view(text());
-
-    CSSPixels relative_x = x - absolute_x();
-    CSSPixels glyph_spacing = font.glyph_spacing();
-
-    if (relative_x < 0)
-        return 0;
-
-    CSSPixels width_so_far = 0;
-    for (auto it = view.begin(); it != view.end(); ++it) {
-        auto previous_it = it;
-        CSSPixels glyph_width = CSSPixels::nearest_value_for(font.glyph_or_emoji_width(it));
-
-        if ((width_so_far + glyph_width + glyph_spacing / 2) > relative_x)
-            return m_start + view.byte_offset_of(previous_it);
-
-        width_so_far += glyph_width + glyph_spacing;
-    }
-
-    return m_start + m_length;
-}
-
-CSSPixelRect LineBoxFragment::selection_rect(Gfx::Font const& font) const
-{
-    if (layout_node().selection_state() == Node::SelectionState::None)
-        return {};
-
-    if (layout_node().selection_state() == Node::SelectionState::Full)
-        return absolute_rect();
-
-    if (!is<TextNode>(layout_node()))
-        return {};
-
-    auto selection = layout_node().root().selection();
-    if (!selection)
-        return {};
-    auto range = selection->range();
-    if (!range)
-        return {};
-
-    // FIXME: m_start and m_length should be unsigned and then we won't need these casts.
-    auto const start_index = static_cast<unsigned>(m_start);
-    auto const end_index = static_cast<unsigned>(m_start) + static_cast<unsigned>(m_length);
-    auto text = this->text();
-
-    if (layout_node().selection_state() == Node::SelectionState::StartAndEnd) {
-        // we are in the start/end node (both the same)
-        if (start_index > range->end_offset())
-            return {};
-        if (end_index < range->start_offset())
-            return {};
-
-        if (range->start_offset() == range->end_offset())
-            return {};
-
-        auto selection_start_in_this_fragment = max(0, range->start_offset() - m_start);
-        auto selection_end_in_this_fragment = min(m_length, range->end_offset() - m_start);
-        auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
-        auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
-
-        auto rect = absolute_rect();
-        rect.set_x(rect.x() + pixel_distance_to_first_selected_character);
-        rect.set_width(pixel_width_of_selection);
-
-        return rect;
-    }
-    if (layout_node().selection_state() == Node::SelectionState::Start) {
-        // we are in the start node
-        if (end_index < range->start_offset())
-            return {};
-
-        auto selection_start_in_this_fragment = max(0, range->start_offset() - m_start);
-        auto selection_end_in_this_fragment = m_length;
-        auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
-        auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
-
-        auto rect = absolute_rect();
-        rect.set_x(rect.x() + pixel_distance_to_first_selected_character);
-        rect.set_width(pixel_width_of_selection);
-
-        return rect;
-    }
-    if (layout_node().selection_state() == Node::SelectionState::End) {
-        // we are in the end node
-        if (start_index > range->end_offset())
-            return {};
-
-        auto selection_start_in_this_fragment = 0;
-        auto selection_end_in_this_fragment = min(range->end_offset() - m_start, m_length);
-        auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
-        auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
-
-        auto rect = absolute_rect();
-        rect.set_x(rect.x() + pixel_distance_to_first_selected_character);
-        rect.set_width(pixel_width_of_selection);
-
-        return rect;
-    }
-    return {};
 }
 
 bool LineBoxFragment::is_atomic_inline() const

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -36,10 +36,7 @@ public:
     int length() const { return m_length; }
     CSSPixelRect const absolute_rect() const;
 
-    CSSPixelPoint offset() const
-    {
-        return m_offset;
-    }
+    CSSPixelPoint offset() const { return m_offset; }
     void set_offset(CSSPixelPoint offset) { m_offset = offset; }
 
     // The baseline of a fragment is the number of pixels from the top to the text baseline.
@@ -55,32 +52,15 @@ public:
     CSSPixels width() const { return m_size.width(); }
     CSSPixels height() const { return m_size.height(); }
 
-    CSSPixels border_box_height() const
-    {
-        return m_border_box_top + height() + m_border_box_bottom;
-    }
     CSSPixels border_box_top() const { return m_border_box_top; }
-    CSSPixels border_box_bottom() const { return m_border_box_bottom; }
-
-    CSSPixels absolute_x() const { return absolute_rect().x(); }
 
     bool ends_in_whitespace() const;
     bool is_justifiable_whitespace() const;
     StringView text() const;
 
-    int text_index_at(CSSPixels x) const;
-
-    CSSPixelRect selection_rect(Gfx::Font const&) const;
-
     bool is_atomic_inline() const;
 
     Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run() const { return m_glyph_run; }
-
-    Painting::BorderRadiiData const& border_radii_data() const { return m_border_radii_data; }
-    void set_border_radii_data(Painting::BorderRadiiData const& border_radii_data) { m_border_radii_data = border_radii_data; }
-
-    bool contained_by_inline_node() const { return m_contained_by_inline_node; }
-    void set_contained_by_inline_node() { m_contained_by_inline_node = true; }
 
 private:
     JS::NonnullGCPtr<Node const> m_layout_node;
@@ -92,8 +72,6 @@ private:
     CSSPixels m_border_box_bottom { 0 };
     CSSPixels m_baseline { 0 };
     Vector<Gfx::DrawGlyphOrEmoji> m_glyph_run;
-    Painting::BorderRadiiData m_border_radii_data;
-    bool m_contained_by_inline_node { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -7,10 +7,8 @@
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/BlockContainer.h>
-#include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/InlinePaintable.h>
-#include <LibWeb/Painting/ShadowPainting.h>
 
 namespace Web::Painting {
 
@@ -168,7 +166,7 @@ template<typename Callback>
 void InlinePaintable::for_each_fragment(Callback callback) const
 {
     // FIXME: This will be slow if the containing block has a lot of fragments!
-    Vector<Layout::LineBoxFragment const&> fragments;
+    Vector<PaintableFragment const&> fragments;
     verify_cast<PaintableWithLines>(*containing_block()->paintable_box()).for_each_fragment([&](auto& fragment) {
         if (layout_node().is_inclusive_ancestor_of(fragment.layout_node()))
             fragments.append(fragment);
@@ -184,7 +182,7 @@ void InlinePaintable::mark_contained_fragments()
 {
     verify_cast<PaintableWithLines>(*containing_block()->paintable_box()).for_each_fragment([&](auto& fragment) {
         if (layout_node().is_inclusive_ancestor_of(fragment.layout_node()))
-            const_cast<Layout::LineBoxFragment&>(fragment).set_contained_by_inline_node();
+            const_cast<PaintableFragment&>(fragment).set_contained_by_inline_node();
         return IterationDecision::Continue;
     });
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Range.h>
+#include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/PaintableBox.h>
+
+namespace Web::Painting {
+
+PaintableFragment::PaintableFragment(Layout::LineBoxFragment const& fragment)
+    : m_layout_node(fragment.layout_node())
+    , m_offset(fragment.offset())
+    , m_size(fragment.size())
+    , m_baseline(fragment.baseline())
+    , m_start(fragment.start())
+    , m_length(fragment.length())
+    , m_glyph_run(fragment.glyph_run())
+{
+}
+
+CSSPixelRect const PaintableFragment::absolute_rect() const
+{
+    CSSPixelRect rect { {}, size() };
+    rect.set_location(m_layout_node->containing_block()->paintable_box()->absolute_position());
+    rect.translate_by(offset());
+    return rect;
+}
+
+int PaintableFragment::text_index_at(CSSPixels x) const
+{
+    if (!is<Layout::TextNode>(*m_layout_node))
+        return 0;
+    auto& layout_text = verify_cast<Layout::TextNode>(layout_node());
+    auto& font = layout_text.first_available_font();
+    Utf8View view(layout_text.text_for_rendering().bytes_as_string_view().substring_view(m_start, m_length));
+
+    CSSPixels relative_x = x - absolute_rect().x();
+    CSSPixels glyph_spacing = font.glyph_spacing();
+
+    if (relative_x < 0)
+        return 0;
+
+    CSSPixels width_so_far = 0;
+    for (auto it = view.begin(); it != view.end(); ++it) {
+        auto previous_it = it;
+        CSSPixels glyph_width = CSSPixels::nearest_value_for(font.glyph_or_emoji_width(it));
+
+        if ((width_so_far + glyph_width + glyph_spacing / 2) > relative_x)
+            return m_start + view.byte_offset_of(previous_it);
+
+        width_so_far += glyph_width + glyph_spacing;
+    }
+
+    return m_start + m_length;
+}
+
+CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
+{
+    if (layout_node().selection_state() == Layout::Node::SelectionState::None)
+        return {};
+
+    if (layout_node().selection_state() == Layout::Node::SelectionState::Full)
+        return absolute_rect();
+
+    if (!is<Layout::TextNode>(layout_node()))
+        return {};
+
+    auto selection = layout_node().root().selection();
+    if (!selection)
+        return {};
+    auto range = selection->range();
+    if (!range)
+        return {};
+
+    // FIXME: m_start and m_length should be unsigned and then we won't need these casts.
+    auto const start_index = static_cast<unsigned>(m_start);
+    auto const end_index = static_cast<unsigned>(m_start) + static_cast<unsigned>(m_length);
+
+    auto& layout_text = verify_cast<Layout::TextNode>(layout_node());
+    auto text = layout_text.text_for_rendering().bytes_as_string_view().substring_view(m_start, m_length);
+
+    if (layout_node().selection_state() == Layout::Node::SelectionState::StartAndEnd) {
+        // we are in the start/end node (both the same)
+        if (start_index > range->end_offset())
+            return {};
+        if (end_index < range->start_offset())
+            return {};
+
+        if (range->start_offset() == range->end_offset())
+            return {};
+
+        auto selection_start_in_this_fragment = max(0, range->start_offset() - m_start);
+        auto selection_end_in_this_fragment = min(m_length, range->end_offset() - m_start);
+        auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
+        auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
+
+        auto rect = absolute_rect();
+        rect.set_x(rect.x() + pixel_distance_to_first_selected_character);
+        rect.set_width(pixel_width_of_selection);
+
+        return rect;
+    }
+    if (layout_node().selection_state() == Layout::Node::SelectionState::Start) {
+        // we are in the start node
+        if (end_index < range->start_offset())
+            return {};
+
+        auto selection_start_in_this_fragment = max(0, range->start_offset() - m_start);
+        auto selection_end_in_this_fragment = m_length;
+        auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
+        auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
+
+        auto rect = absolute_rect();
+        rect.set_x(rect.x() + pixel_distance_to_first_selected_character);
+        rect.set_width(pixel_width_of_selection);
+
+        return rect;
+    }
+    if (layout_node().selection_state() == Layout::Node::SelectionState::End) {
+        // we are in the end node
+        if (start_index > range->end_offset())
+            return {};
+
+        auto selection_start_in_this_fragment = 0;
+        auto selection_end_in_this_fragment = min(range->end_offset() - m_start, m_length);
+        auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
+        auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
+
+        auto rect = absolute_rect();
+        rect.set_x(rect.x() + pixel_distance_to_first_selected_character);
+        rect.set_width(pixel_width_of_selection);
+
+        return rect;
+    }
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Layout/LineBoxFragment.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BorderRadiiData.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::Painting {
+
+class PaintableFragment {
+public:
+    explicit PaintableFragment(Layout::LineBoxFragment const&);
+
+    Layout::Node const& layout_node() const { return m_layout_node; }
+
+    int start() const { return m_start; }
+    int length() const { return m_length; }
+
+    CSSPixels baseline() const { return m_baseline; }
+    CSSPixelPoint offset() const { return m_offset; }
+    void set_offset(CSSPixelPoint offset) { m_offset = offset; }
+    CSSPixelSize size() const { return m_size; }
+
+    BorderRadiiData const& border_radii_data() const { return m_border_radii_data; }
+    void set_border_radii_data(BorderRadiiData const& border_radii_data) { m_border_radii_data = border_radii_data; }
+
+    CSSPixelRect const absolute_rect() const;
+
+    Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run() const { return m_glyph_run; }
+
+    CSSPixelRect selection_rect(Gfx::Font const&) const;
+
+    bool contained_by_inline_node() const { return m_contained_by_inline_node; }
+    void set_contained_by_inline_node() { m_contained_by_inline_node = true; }
+
+    CSSPixels width() const { return m_size.width(); }
+    CSSPixels height() const { return m_size.height(); }
+
+    int text_index_at(CSSPixels) const;
+
+private:
+    JS::NonnullGCPtr<Layout::Node const> m_layout_node;
+    CSSPixelPoint m_offset;
+    CSSPixelSize m_size;
+    CSSPixels m_baseline;
+    int m_start;
+    int m_length;
+    Painting::BorderRadiiData m_border_radii_data;
+    Vector<Gfx::DrawGlyphOrEmoji> m_glyph_run;
+    bool m_contained_by_inline_node { false };
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
+#include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ShadowPainting.h>
 
 namespace Web::Painting {
@@ -578,9 +579,9 @@ void paint_box_shadow(PaintContext& context,
     }
 }
 
-void paint_text_shadow(PaintContext& context, Layout::LineBoxFragment const& fragment, Vector<ShadowData> const& shadow_layers)
+void paint_text_shadow(PaintContext& context, PaintableFragment const& fragment, Vector<ShadowData> const& shadow_layers)
 {
-    if (shadow_layers.is_empty() || fragment.text().is_empty())
+    if (shadow_layers.is_empty() || fragment.glyph_run().is_empty())
         return;
 
     auto fragment_width = context.enclosing_device_pixels(fragment.width()).value();

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
@@ -10,6 +10,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
+#include <LibWeb/Painting/PaintableFragment.h>
 #include <LibWeb/Painting/ShadowData.h>
 
 namespace Web::Painting {
@@ -26,6 +27,6 @@ void paint_box_shadow(
     BordersData const& borders_data,
     BorderRadiiData const&,
     Vector<ShadowData> const&);
-void paint_text_shadow(PaintContext&, Layout::LineBoxFragment const&, Vector<ShadowData> const&);
+void paint_text_shadow(PaintContext&, PaintableFragment const&, Vector<ShadowData> const&);
 
 }


### PR DESCRIPTION
This is a part of refactoring towards making the paintable tree independent of the layout tree. Now, instead of transferring text fragments from the layout tree to the paintable tree during the layout commit phase, we allocate separate PaintableFragments that contain only the information necessary for painting. Doing this also allows us to get rid LineBoxes, as they are used only during layout.