### PR TITLE
AK+Everywhere: Better JsonValue numeric API

### DIFF
--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -138,16 +138,16 @@ Optional<JsonArray const&> JsonObject::get_array(StringView key) const
 Optional<double> JsonObject::get_double_with_precision_loss(StringView key) const
 {
     auto maybe_value = get(key);
-    if (maybe_value.has_value() && maybe_value->is_number())
-        return maybe_value->to_number<double>();
+    if (maybe_value.has_value())
+        return maybe_value->get_double_with_precision_loss();
     return {};
 }
 
 Optional<float> JsonObject::get_float_with_precision_loss(StringView key) const
 {
     auto maybe_value = get(key);
-    if (maybe_value.has_value() && maybe_value->is_number())
-        return maybe_value->to_number<float>();
+    if (maybe_value.has_value())
+        return maybe_value->get_float_with_precision_loss();
     return {};
 }
 #endif

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -241,14 +241,6 @@ bool JsonObject::has_object(StringView key) const
     return value.has_value() && value->is_object();
 }
 
-#ifndef KERNEL
-bool JsonObject::has_double(StringView key) const
-{
-    auto value = get(key);
-    return value.has_value() && value->is_double();
-}
-#endif
-
 void JsonObject::set(ByteString const& key, JsonValue value)
 {
     m_members.set(key, move(value));

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -51,9 +51,6 @@ public:
     [[nodiscard]] bool has_number(StringView key) const;
     [[nodiscard]] bool has_array(StringView key) const;
     [[nodiscard]] bool has_object(StringView key) const;
-#ifndef KERNEL
-    [[nodiscard]] bool has_double(StringView key) const;
-#endif
 
     Optional<JsonValue const&> get(StringView key) const;
 

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -162,16 +162,16 @@ inline void JsonValue::serialize(Builder& builder) const
         break;
 #endif
     case Type::Int32:
-        builder.appendff("{}", as_i32());
+        builder.appendff("{}", m_value.as_i32);
         break;
     case Type::Int64:
-        builder.appendff("{}", as_i64());
+        builder.appendff("{}", m_value.as_i64);
         break;
     case Type::UnsignedInt32:
-        builder.appendff("{}", as_u32());
+        builder.appendff("{}", m_value.as_u32);
         break;
     case Type::UnsignedInt64:
-        builder.appendff("{}", as_u64());
+        builder.appendff("{}", m_value.as_u64);
         break;
     case Type::Null:
         builder.append("null"sv);

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -154,10 +154,24 @@ public:
         return *m_value.as_array;
     }
 
-    double as_double() const
+    Variant<u64, i64, double> as_number() const
     {
-        VERIFY(is_double());
-        return m_value.as_double;
+        VERIFY(is_number());
+
+        switch (m_type) {
+        case Type::Int32:
+            return static_cast<i64>(m_value.as_i32);
+        case Type::UnsignedInt32:
+            return static_cast<i64>(m_value.as_u32);
+        case Type::Int64:
+            return m_value.as_i64;
+        case Type::UnsignedInt64:
+            return m_value.as_u64;
+        case Type::Double:
+            return m_value.as_double;
+        default:
+            VERIFY_NOT_REACHED();
+        }
     }
 
     Type type() const

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -182,11 +182,6 @@ public:
     bool is_null() const { return m_type == Type::Null; }
     bool is_bool() const { return m_type == Type::Bool; }
     bool is_string() const { return m_type == Type::String; }
-    bool is_i32() const { return m_type == Type::Int32; }
-    bool is_u32() const { return m_type == Type::UnsignedInt32; }
-    bool is_i64() const { return m_type == Type::Int64; }
-    bool is_u64() const { return m_type == Type::UnsignedInt64; }
-    bool is_double() const { return m_type == Type::Double; }
     bool is_array() const { return m_type == Type::Array; }
     bool is_object() const { return m_type == Type::Object; }
     bool is_number() const
@@ -206,7 +201,7 @@ public:
     template<typename T>
     T to_number(T default_value = 0) const
     {
-        if (is_double())
+        if (type() == Type::Double)
             return (T)m_value.as_double;
         if (type() == Type::Int32)
             return (T)m_value.as_i32;

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -118,30 +118,6 @@ public:
         return as_bool();
     }
 
-    i32 as_i32() const
-    {
-        VERIFY(is_i32());
-        return m_value.as_i32;
-    }
-
-    u32 as_u32() const
-    {
-        VERIFY(is_u32());
-        return m_value.as_u32;
-    }
-
-    i64 as_i64() const
-    {
-        VERIFY(is_i64());
-        return m_value.as_i64;
-    }
-
-    u64 as_u64() const
-    {
-        VERIFY(is_u64());
-        return m_value.as_u64;
-    }
-
     bool as_bool() const
     {
         VERIFY(is_bool());
@@ -217,15 +193,15 @@ public:
     T to_number(T default_value = 0) const
     {
         if (is_double())
-            return (T)as_double();
+            return (T)m_value.as_double;
         if (type() == Type::Int32)
-            return (T)as_i32();
+            return (T)m_value.as_i32;
         if (type() == Type::UnsignedInt32)
-            return (T)as_u32();
+            return (T)m_value.as_u32;
         if (type() == Type::Int64)
-            return (T)as_i64();
+            return (T)m_value.as_i64;
         if (type() == Type::UnsignedInt64)
-            return (T)as_u64();
+            return (T)m_value.as_u64;
         return default_value;
     }
 

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -211,15 +211,15 @@ static ErrorOr<String> generate_initializer_for(Optional<StringView> property_na
 
         return String::formatted(R"~~~("{}"_string)~~~", TRY(escape_string(value)));
     }
-    // No need to handle the smaller integer types separately.
-    if (value.is_integer<i64>())
-        return String::formatted("static_cast<i64>({})", value.as_integer<i64>());
-    if (value.is_integer<u64>())
-        return String::formatted("static_cast<u64>({})", value.as_integer<u64>());
     if (value.is_bool())
         return String::formatted("{}", value.as_bool());
-    if (value.is_double())
-        return String::formatted("static_cast<double>({})", value.as_double());
+    if (value.is_number()) {
+        return value.as_number().visit(
+            // NOTE: Passing by mutable reference here in order to disallow implicit casts.
+            [](u64& value) { return String::formatted("static_cast<u64>({})", value); },
+            [](i64& value) { return String::formatted("static_cast<i64>({})", value); },
+            [](double& value) { return String::formatted("static_cast<double>({})", value); });
+    }
     if (value.is_array()) {
         auto const& array = value.as_array();
         auto child_type = Optional<StringView> {};

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -236,7 +236,8 @@ static ErrorOr<String> generate_initializer_for(Optional<StringView> property_na
             HANDLE_TYPE(i64, is_integer<i64>)
             HANDLE_TYPE(u64, is_integer<u64>)
             HANDLE_TYPE(bool, is_bool)
-            HANDLE_TYPE(double, is_double)
+            // FIXME: Do we want to allow precision loss when C++ compiler parses these doubles?
+            HANDLE_TYPE(double, is_number)
             return Error::from_string_view("Inconsistent contained type in JSON array"sv);
 #undef HANDLE_TYPE
         }

--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -170,7 +170,7 @@ Variants read_variants_settings(JsonObject const& variants_obj)
     if (variants_obj.has_array("argument_counts"sv)) {
         variants.argument_counts.clear_with_capacity();
         variants_obj.get_array("argument_counts"sv)->for_each([&](auto const& argument_count_value) {
-            variants.argument_counts.append(argument_count_value.to_u32());
+            variants.argument_counts.append(argument_count_value.get_u32().value());
         });
     }
     if (variants_obj.has_array("argument_defaults"sv)) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -764,11 +764,11 @@ size_t property_maximum_value_count(PropertyID property_id)
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
         if (value.as_object().has("max-values"sv)) {
-            auto max_values = value.as_object().get("max-values"sv);
-            VERIFY(max_values.has_value() && max_values->is_number() && !max_values->is_double());
+            JsonValue max_values = value.as_object().get("max-values"sv).release_value();
+            VERIFY(max_values.is_integer<size_t>());
             auto property_generator = generator.fork();
             property_generator.set("name:titlecase", title_casify(name));
-            property_generator.set("max_values", max_values->template serialized<StringBuilder>());
+            property_generator.set("max_values", MUST(String::formatted("{}", max_values.as_integer<size_t>())));
             property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
         return @max_values@;

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -99,8 +99,11 @@ TEST_CASE(json_64_bit_value)
 {
     auto big_value = 0x12345678aabbccddull;
     JsonValue big_json_value(big_value);
+    EXPECT(big_json_value.is_integer<u64>());
+    EXPECT_EQ(big_json_value.as_integer<u64>(), big_value);
+
     JsonValue big_json_value_copy = big_json_value;
-    EXPECT_EQ(big_json_value.as_u64(), big_json_value_copy.as_u64());
+    EXPECT(big_json_value.equals(big_json_value_copy));
 }
 
 TEST_CASE(json_duplicate_keys)
@@ -118,7 +121,7 @@ TEST_CASE(json_u64_roundtrip)
     auto json = JsonValue(big_value).serialized<StringBuilder>();
     auto value = JsonValue::from_string(json);
     EXPECT_EQ_FORCE(value.is_error(), false);
-    EXPECT_EQ(value.value().as_u64(), big_value);
+    EXPECT_EQ(value.value().as_integer<u64>(), big_value);
 }
 
 TEST_CASE(json_parse_empty_string)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -133,16 +133,16 @@ TEST_CASE(json_parse_empty_string)
 TEST_CASE(json_parse_long_decimals)
 {
     auto value = JsonValue::from_string("1644452550.6489999294281"sv);
-    EXPECT_EQ(value.value().as_double(), 1644452550.6489999294281);
+    EXPECT_EQ(value.value().to_number<double>(), 1644452550.6489999294281);
 }
 
 TEST_CASE(json_parse_number_with_exponent)
 {
     auto value_without_fraction = JsonValue::from_string("10e5"sv);
-    EXPECT_EQ(value_without_fraction.value().as_double(), 1000000.0);
+    EXPECT_EQ(value_without_fraction.value().to_number<double>(), 1000000.0);
 
     auto value_with_fraction = JsonValue::from_string("10.5e5"sv);
-    EXPECT_EQ(value_with_fraction.value().as_double(), 1050000.0);
+    EXPECT_EQ(value_with_fraction.value().to_number<double>(), 1050000.0);
 }
 
 TEST_CASE(json_parse_special_numbers)

--- a/Userland/Applications/Maps/UsersMapWidget.cpp
+++ b/Userland/Applications/Maps/UsersMapWidget.cpp
@@ -47,10 +47,11 @@ void UsersMapWidget::get_users()
         auto json_users = result.release_value().as_array();
         for (size_t i = 0; i < json_users.size(); i++) {
             auto const& json_user = json_users.at(i).as_object();
+            auto const& coordinates = json_user.get_array("coordinates"sv).release_value();
             User user {
                 MUST(String::from_byte_string(json_user.get_byte_string("nick"sv).release_value())),
-                { json_user.get_array("coordinates"sv).release_value().at(0).to_double(),
-                    json_user.get_array("coordinates"sv).release_value().at(1).to_double() },
+                { coordinates[0].get_double_with_precision_loss().value(),
+                    coordinates[1].get_double_with_precision_loss().value() },
                 json_user.has_bool("contributor"sv),
             };
             m_users.value().append(user);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1469,7 +1469,7 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
             else
                 return;
 
-            image_editor.add_guide(PixelPaint::Guide::construct(orientation, offset_value->to_number<float>()));
+            image_editor.add_guide(PixelPaint::Guide::construct(orientation, offset_value->get_float_with_precision_loss().value_or(0)));
         });
     }
 

--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -149,7 +149,7 @@ ErrorOr<Gfx::IntSize> Presentation::parse_presentation_size(JsonObject const& me
         return Error::from_string_view("Width or aspect in incorrect format"sv);
 
     // We intentionally discard floating-point data here. If you need more resolution, just use a larger width.
-    auto const width = maybe_width->to_number<int>();
+    auto const width = maybe_width->get_number_with_precision_loss<int>().value();
     auto const aspect_parts = maybe_aspect->split_view(':');
     if (aspect_parts.size() != 2)
         return Error::from_string_view("Aspect specification must have the exact format `width:height`"sv);

--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -8,6 +8,7 @@
 #include "Presentation.h"
 #include <AK/JsonObject.h>
 #include <AK/URL.h>
+#include <LibGUI/PropertyDeserializer.h>
 #include <LibGfx/Font/FontStyleMapping.h>
 #include <LibGfx/Rect.h>
 
@@ -42,16 +43,8 @@ ErrorOr<NonnullRefPtr<SlideObject>> SlideObject::parse_slide_object(JsonObject c
 
 void SlideObject::set_property(StringView name, JsonValue value)
 {
-    if (name == "rect"sv) {
-        if (value.is_array() && value.as_array().size() == 4) {
-            Gfx::IntRect rect;
-            rect.set_x(value.as_array()[0].to_i32());
-            rect.set_y(value.as_array()[1].to_i32());
-            rect.set_width(value.as_array()[2].to_i32());
-            rect.set_height(value.as_array()[3].to_i32());
-            m_rect = rect;
-        }
-    }
+    if (name == "rect"sv)
+        m_rect = GUI::PropertyDeserializer<Gfx::IntRect> {}(value).release_value_but_fixme_should_propagate_errors();
     m_properties.set(name, move(value));
 }
 
@@ -74,7 +67,7 @@ void Text::set_property(StringView name, JsonValue value)
     } else if (name == "font-weight"sv) {
         m_font_weight = Gfx::name_to_weight(value.as_string());
     } else if (name == "font-size"sv) {
-        m_font_size_in_pt = value.to_float();
+        m_font_size_in_pt = value.get_float_with_precision_loss().value();
     } else if (name == "text-alignment"sv) {
         m_text_align = value.as_string();
     }

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -479,7 +479,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
         auto const& stack_array = stack.value();
         for (ssize_t i = stack_array.values().size() - 1; i >= 0; --i) {
             auto const& frame = stack_array.at(i);
-            auto ptr = frame.to_number<u64>();
+            auto ptr = frame.as_integer<u64>();
             u32 offset = 0;
             DeprecatedFlyString object_name;
             ByteString symbol;

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -137,7 +137,7 @@ Variant JsonArrayModel::data(ModelIndex const& index, ModelRole role) const
         if (!data.has_value())
             return "";
         if (data->is_number())
-            return data.value();
+            return data->serialized<StringBuilder>();
         return data->as_string();
     }
 

--- a/Userland/Libraries/LibGUI/PropertyDeserializer.cpp
+++ b/Userland/Libraries/LibGUI/PropertyDeserializer.cpp
@@ -66,16 +66,10 @@ ErrorOr<Gfx::IntRect> PropertyDeserializer<Gfx::IntRect>::operator()(JsonValue c
     } else {
         auto const& array = value.as_array();
 
-        auto get_i32 = [](JsonValue const& value) -> Optional<int> {
-            if (value.is_integer<i32>())
-                return value.to_i32();
-            return {};
-        };
-
-        x = get_i32(array[0]);
-        y = get_i32(array[1]);
-        width = get_i32(array[2]);
-        height = get_i32(array[3]);
+        x = array[0].get_i32();
+        y = array[1].get_i32();
+        width = array[2].get_i32();
+        height = array[3].get_i32();
     }
 
     if (!x.has_value())
@@ -103,16 +97,16 @@ ErrorOr<Gfx::IntSize> PropertyDeserializer<Gfx::IntSize>::operator()(JsonValue c
 
     auto const& array = value.as_array();
 
-    auto const& width = array[0];
-    if (!width.is_integer<i32>())
+    auto const& width = array[0].get_i32();
+    if (!width.has_value())
         return Error::from_string_literal("Width must be an integer");
-    auto const& height = array[1];
-    if (!height.is_integer<i32>())
+    auto const& height = array[1].get_i32();
+    if (!height.has_value())
         return Error::from_string_literal("Height must be an integer");
 
     Gfx::IntSize size;
-    size.set_width(width.to_i32());
-    size.set_height(height.to_i32());
+    size.set_width(width.value());
+    size.set_height(height.value());
 
     return size;
 }
@@ -129,10 +123,10 @@ ErrorOr<GUI::Margins> PropertyDeserializer<GUI::Margins>::operator()(JsonValue c
     int m[4];
 
     for (size_t i = 0; i < size; ++i) {
-        auto const& margin = array[i];
-        if (!margin.is_integer<i32>())
+        auto const& margin = array[i].get_i32();
+        if (!margin.has_value())
             return Error::from_string_literal("Margin value should be an integer");
-        m[i] = margin.to_i32();
+        m[i] = margin.value();
     }
 
     if (size == 1)

--- a/Userland/Libraries/LibGUI/PropertyDeserializer.h
+++ b/Userland/Libraries/LibGUI/PropertyDeserializer.h
@@ -23,7 +23,7 @@ struct PropertyDeserializer<T> {
     {
         if (!value.is_integer<T>())
             return Error::from_string_literal("Value is either not an integer or out of range for requested type");
-        return value.to_number<T>();
+        return value.as_integer<T>();
     }
 };
 

--- a/Userland/Libraries/LibGUI/Variant.cpp
+++ b/Userland/Libraries/LibGUI/Variant.cpp
@@ -13,54 +13,6 @@
 
 namespace GUI {
 
-Variant::Variant(JsonValue const& value)
-{
-    *this = value;
-}
-
-Variant& Variant::operator=(JsonValue const& value)
-{
-    if (value.is_null())
-        return *this;
-
-    if (value.is_i32()) {
-        set(value.as_i32());
-        return *this;
-    }
-
-    if (value.is_u32()) {
-        set(value.as_u32());
-        return *this;
-    }
-
-    if (value.is_i64()) {
-        set(value.as_i64());
-        return *this;
-    }
-
-    if (value.is_u64()) {
-        set(value.as_u64());
-        return *this;
-    }
-
-    if (value.is_double()) {
-        set(value.as_double());
-        return *this;
-    }
-
-    if (value.is_string()) {
-        set(value.as_string());
-        return *this;
-    }
-
-    if (value.is_bool()) {
-        set(Detail::Boolean { value.as_bool() });
-        return *this;
-    }
-
-    VERIFY_NOT_REACHED();
-}
-
 bool Variant::operator==(Variant const& other) const
 {
     return visit([&]<typename T>(T const& own_value) {

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -29,8 +29,6 @@ public:
     using Detail::VariantUnderlyingType::Variant;
     using Detail::VariantUnderlyingType::operator=;
 
-    Variant(JsonValue const&);
-    Variant& operator=(JsonValue const&);
     Variant(bool v)
         : Variant(Detail::Boolean { v })
     {

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -434,8 +434,6 @@ Value JSONObject::parse_json_value(VM& vm, JsonValue const& value)
         return Value(parse_json_array(vm, value.as_array()));
     if (value.is_null())
         return js_null();
-    if (value.is_i32())
-        return Value(value.as_i32());
     if (value.is_number())
         return Value(value.to_double(0));
     if (value.is_string())

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -434,8 +434,8 @@ Value JSONObject::parse_json_value(VM& vm, JsonValue const& value)
         return Value(parse_json_array(vm, value.as_array()));
     if (value.is_null())
         return js_null();
-    if (value.is_number())
-        return Value(value.to_double(0));
+    if (auto double_value = value.get_double_with_precision_loss(); double_value.has_value())
+        return Value(double_value.value());
     if (value.is_string())
         return PrimitiveString::create(vm, value.as_string());
     if (value.is_bool())

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -175,7 +175,7 @@ Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid, IncludeSourcePosition in
 
         stack.ensure_capacity(json.value().as_array().size());
         for (auto& value : json.value().as_array().values()) {
-            stack.append(value.to_addr());
+            stack.append(value.get_addr().value());
         }
     }
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -247,9 +247,9 @@ static ErrorOr<PropertyType, Web::WebDriver::Error> get_property(JsonValue const
             return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a Boolean", key));
         return property->as_bool();
     } else if constexpr (IsSame<PropertyType, u32>) {
-        if (!property->is_u32())
+        if (!property->is_integer<u32>())
             return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a Number", key));
-        return property->as_u32();
+        return property->to_u32();
     } else if constexpr (IsSame<PropertyType, JsonArray const*>) {
         if (!property->is_array())
             return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not an Array", key));


### PR DESCRIPTION
These patches almost completely remove the ability to introspect how `AK::JsonValue` stores its numeric value. They also replace `to_X` functions which have implicit default value with the newly created `get_X` functions that return `Optional<X>`. Anything that is not explicitly marked `_with_precision_loss` will not truncate stored value but instead panic / return empty optional. In the result, we get much more intuitive and explicit interface which is also consistent with `JsonObject`.

The relevant parts of JsonValue interface with the changes from PR look like this:
- `Optional<X> get_X()` where X is one of `int`, `i32`, `i64`, `uint`, `u32`, `u64`. Empty optional if not a number or value is outside of T's domain.
- `Optional<T> get_integer<T>()`. Empty optional if not a number or value is outside of T's domain.
- `Optional<X> get_X_with_precision_loss()` where X is `float` or `double`. Empty optional if not a number, `static_cast`s otherwise.
- `Optional<T> get_number_with_precision_loss<T>()`. Empty optional if not a number, `static_cast`s otherwise.
- `bool is_number()`. Returns true if stored value is a number.
- `bool is_integer<T>()`. Returns true if stored value is a number and is in the T's domain.
- `T as_integer<T>()`. Asserting version of `get_integer`.
- `Variant<u64, i64, double> as_number()`. Asserts number is stored and losslessly returns it.

The "almost" in "almost completely" comes from inconsistent handling of integers stored as floating point numbers. They are not always treated as valid integers. I plan to address this in a future PR.

-----

While I was doing the above refactoring, it didn't occur to me that I should introduce above APIs first. So, the first five commits removes introspecting APIs (like `is_i32`) and ports users to equivalent old APIs and then the last commit actually adds new APIs and removes old ones.