### PR TITLE
LibWeb: Port some more of Element from ByteString, add caching of Element::name

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1250,7 +1250,7 @@ void Document::set_hovered_node(Node* node)
     }
 }
 
-JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_name(String const& name)
+JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_name(FlyString const& name)
 {
     return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [name](Element const& element) {
         return element.name() == name;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1285,7 +1285,7 @@ JS::NonnullGCPtr<HTMLCollection> Document::anchors()
 {
     if (!m_anchors) {
         m_anchors = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLAnchorElement>(element) && element.has_attribute(HTML::AttributeNames::name);
+            return is<HTML::HTMLAnchorElement>(element) && element.name().has_value();
         });
     }
     return *m_anchors;
@@ -1833,7 +1833,7 @@ Element* Document::find_a_potential_indicated_element(FlyString const& fragment)
     //    whose value is equal to fragment, then return the first such element in tree order.
     Element* element_with_name = nullptr;
     root().for_each_in_subtree_of_type<Element>([&](Element const& element) {
-        if (element.attribute(HTML::AttributeNames::name) == fragment) {
+        if (element.name() == fragment) {
             element_with_name = const_cast<Element*>(&element);
             return IterationDecision::Break;
         }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1252,9 +1252,8 @@ void Document::set_hovered_node(Node* node)
 
 JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_name(String const& name)
 {
-    auto deprecated_name = name.to_byte_string();
-    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [deprecated_name](Element const& element) {
-        return element.name() == deprecated_name;
+    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [name](Element const& element) {
+        return element.name() == name;
     });
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -219,7 +219,7 @@ public:
     void schedule_style_update();
     void schedule_layout_update();
 
-    JS::NonnullGCPtr<HTMLCollection> get_elements_by_name(String const&);
+    JS::NonnullGCPtr<HTMLCollection> get_elements_by_name(FlyString const&);
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(StringView);
 
     JS::NonnullGCPtr<HTMLCollection> applets();

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -58,7 +58,7 @@ interface Document : Node {
     readonly attribute Element? activeElement;
 
     Element? getElementById(DOMString id);
-    HTMLCollection getElementsByName(DOMString name);
+    HTMLCollection getElementsByName([FlyString] DOMString name);
     HTMLCollection getElementsByTagName(DOMString tagName);
     HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
     HTMLCollection getElementsByClassName(DOMString className);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1454,7 +1454,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
 }
 
 // https://dom.spec.whatwg.org/#insert-adjacent
-WebIDL::ExceptionOr<JS::GCPtr<Node>> Element::insert_adjacent(ByteString const& where, JS::NonnullGCPtr<Node> node)
+WebIDL::ExceptionOr<JS::GCPtr<Node>> Element::insert_adjacent(StringView where, JS::NonnullGCPtr<Node> node)
 {
     // To insert adjacent, given an element element, string where, and a node node, run the steps associated with the first ASCII case-insensitive match for where:
     if (Infra::is_ascii_case_insensitive_match(where, "beforebegin"sv)) {
@@ -1498,7 +1498,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Node>> Element::insert_adjacent(ByteString const& 
 WebIDL::ExceptionOr<JS::GCPtr<Element>> Element::insert_adjacent_element(String const& where, JS::NonnullGCPtr<Element> element)
 {
     // The insertAdjacentElement(where, element) method steps are to return the result of running insert adjacent, give this, where, and element.
-    auto returned_node = TRY(insert_adjacent(where.to_byte_string(), move(element)));
+    auto returned_node = TRY(insert_adjacent(where, element));
     if (!returned_node)
         return JS::GCPtr<Element> { nullptr };
     return JS::GCPtr<Element> { verify_cast<Element>(*returned_node) };
@@ -1512,7 +1512,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_text(String const& where, Str
 
     // 2. Run insert adjacent, given this, where, and text.
     // Spec Note: This method returns nothing because it existed before we had a chance to design it.
-    (void)TRY(insert_adjacent(where.to_byte_string(), text));
+    (void)TRY(insert_adjacent(where, text));
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -445,6 +445,11 @@ void Element::attribute_changed(FlyString const& name, Optional<String> const& v
             m_id = {};
         else
             m_id = value_or_empty;
+    } else if (name == HTML::AttributeNames::name) {
+        if (!value.has_value())
+            m_name = {};
+        else
+            m_name = value_or_empty;
     } else if (name == HTML::AttributeNames::class_) {
         auto new_classes = value_or_empty.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
         m_classes.clear();

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -173,8 +173,6 @@ public:
     Layout::NodeWithStyle* layout_node();
     Layout::NodeWithStyle const* layout_node() const;
 
-    ByteString name() const { return deprecated_attribute(HTML::AttributeNames::name); }
-
     CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }
     void set_computed_css_values(RefPtr<CSS::StyleProperties>);
@@ -367,6 +365,7 @@ public:
     Directionality directionality() const;
 
     Optional<FlyString> const& id() const { return m_id; }
+    Optional<FlyString> const& name() const { return m_name; }
 
     virtual JS::GCPtr<JS::HeapFunction<void()>> take_lazy_load_resumption_steps(Badge<DOM::Document>)
     {
@@ -416,6 +415,7 @@ private:
     Optional<Dir> m_dir;
 
     Optional<FlyString> m_id;
+    Optional<FlyString> m_name;
 
     using PseudoElementLayoutNodes = Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)>;
     OwnPtr<PseudoElementLayoutNodes> m_pseudo_element_nodes;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -390,7 +390,7 @@ private:
 
     void invalidate_style_after_attribute_change(FlyString const& attribute_name);
 
-    WebIDL::ExceptionOr<JS::GCPtr<Node>> insert_adjacent(ByteString const& where, JS::NonnullGCPtr<Node> node);
+    WebIDL::ExceptionOr<JS::GCPtr<Node>> insert_adjacent(StringView where, JS::NonnullGCPtr<Node> node);
 
     void enqueue_an_element_on_the_appropriate_element_queue();
 

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -84,17 +84,15 @@ Element* HTMLCollection::item(size_t index) const
 }
 
 // https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem-key
-Element* HTMLCollection::named_item(FlyString const& name_) const
+Element* HTMLCollection::named_item(FlyString const& name) const
 {
-    auto name = name_.to_deprecated_fly_string();
-
     // 1. If key is the empty string, return null.
     if (name.is_empty())
         return nullptr;
     auto elements = collect_matching_elements();
     // 2. Return the first element in the collection for which at least one of the following is true:
     //      - it has an ID which is key;
-    if (auto it = elements.find_if([&](auto& entry) { return entry->id().has_value() && entry->id().value() == name_; }); it != elements.end())
+    if (auto it = elements.find_if([&](auto& entry) { return entry->id().has_value() && entry->id().value() == name; }); it != elements.end())
         return *it;
     //      - it is in the HTML namespace and has a name attribute whose value is key;
     if (auto it = elements.find_if([&](auto& entry) { return entry->namespace_uri() == Namespace::HTML && entry->name() == name; }); it != elements.end())

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -118,12 +118,10 @@ Vector<FlyString> HTMLCollection::supported_property_names() const
         }
 
         // 2. If element is in the HTML namespace and has a name attribute whose value is neither the empty string nor is in result, append element’s name attribute value to result.
-        if (element->namespace_uri() == Namespace::HTML) {
-            if (auto maybe_name = element->attribute(HTML::AttributeNames::name); maybe_name.has_value()) {
-                auto name = maybe_name.release_value();
-                if (!name.is_empty() && !result.contains_slow(name))
-                    result.append(name);
-            }
+        if (element->namespace_uri() == Namespace::HTML && element->name().has_value()) {
+            auto name = element->name().value();
+            if (!name.is_empty() && !result.contains_slow(name))
+                result.append(move(name));
         }
     }
 

--- a/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
@@ -39,8 +39,6 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
     if (name.is_empty())
         return {};
 
-    auto const deprecated_name = name.to_deprecated_fly_string();
-
     // 2. If, at the time the method is called, there is exactly one node in the collection that has either an id attribute or a name attribute equal to name, then return that node and stop the algorithm.
     // 3. Otherwise, if there are no nodes in the collection that have either an id attribute or a name attribute equal to name, then return null and stop the algorithm.
     Element* matching_element = nullptr;
@@ -48,7 +46,7 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
 
     auto collection = collect_matching_elements();
     for (auto const& element : collection) {
-        if (element->id() != name && element->name() != deprecated_name)
+        if (element->id() != name && element->name() != name)
             continue;
 
         if (matching_element) {
@@ -68,12 +66,12 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
     // 4. Otherwise, create a new RadioNodeList object representing a live view of the HTMLFormControlsCollection object, further filtered so that the only nodes in the
     //    RadioNodeList object are those that have either an id attribute or a name attribute equal to name. The nodes in the RadioNodeList object must be sorted in tree
     //    order. Return that RadioNodeList object.
-    return JS::make_handle(RadioNodeList::create(realm(), root(), LiveNodeList::Scope::Descendants, [name, deprecated_name](Node const& node) {
+    return JS::make_handle(RadioNodeList::create(realm(), root(), LiveNodeList::Scope::Descendants, [name](Node const& node) {
         if (!is<Element>(node))
             return false;
 
         auto const& element = verify_cast<Element>(node);
-        return element.id() == name || element.name() == deprecated_name;
+        return element.id() == name || element.name() == name;
     }));
 }
 

--- a/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
@@ -48,7 +48,7 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
 
     auto collection = collect_matching_elements();
     for (auto const& element : collection) {
-        if (element->deprecated_attribute(HTML::AttributeNames::id) != deprecated_name && element->name() != deprecated_name)
+        if (element->id() != name && element->name() != deprecated_name)
             continue;
 
         if (matching_element) {
@@ -68,12 +68,12 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
     // 4. Otherwise, create a new RadioNodeList object representing a live view of the HTMLFormControlsCollection object, further filtered so that the only nodes in the
     //    RadioNodeList object are those that have either an id attribute or a name attribute equal to name. The nodes in the RadioNodeList object must be sorted in tree
     //    order. Return that RadioNodeList object.
-    return JS::make_handle(RadioNodeList::create(realm(), root(), LiveNodeList::Scope::Descendants, [deprecated_name](Node const& node) {
+    return JS::make_handle(RadioNodeList::create(realm(), root(), LiveNodeList::Scope::Descendants, [name, deprecated_name](Node const& node) {
         if (!is<Element>(node))
             return false;
 
         auto const& element = verify_cast<Element>(node);
-        return element.deprecated_attribute(HTML::AttributeNames::id) == deprecated_name || element.name() == deprecated_name;
+        return element.id() == name || element.name() == deprecated_name;
     }));
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1476,8 +1476,8 @@ String Node::debug_description() const
     builder.append(node_name().to_deprecated_fly_string().to_lowercase());
     if (is_element()) {
         auto const& element = static_cast<DOM::Element const&>(*this);
-        if (auto id = element.get_attribute(HTML::AttributeNames::id); id.has_value())
-            builder.appendff("#{}", id.value());
+        if (element.id().has_value())
+            builder.appendff("#{}", element.id().value());
         for (auto const& class_name : element.class_names())
             builder.appendff(".{}", class_name);
     }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -150,10 +150,9 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     if (layout_node.dom_node() && is<DOM::Element>(*layout_node.dom_node())) {
         auto& element = verify_cast<DOM::Element>(*layout_node.dom_node());
         StringBuilder builder;
-        auto id = element.deprecated_attribute(HTML::AttributeNames::id);
-        if (!id.is_empty()) {
+        if (element.id().has_value() && !element.id()->is_empty()) {
             builder.append('#');
-            builder.append(id);
+            builder.append(*element.id());
         }
         for (auto& class_name : element.class_names()) {
             builder.append('.');

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -104,7 +104,7 @@ void FormAssociatedElement::reset_form_owner()
         // 1. If the first element in element's tree, in tree order, to have an ID that is identical to element's form content attribute's value, is a form element, then associate the element with that form element.
         auto form_value = html_element.attribute(HTML::AttributeNames::form);
         html_element.root().for_each_in_inclusive_subtree_of_type<HTMLFormElement>([this, &form_value](HTMLFormElement& form_element) {
-            if (form_element.attribute(HTML::AttributeNames::id) == form_value) {
+            if (form_element.id() == form_value) {
                 set_form(&form_element);
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -125,8 +125,8 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
                 value = "on"_string;
 
             // 2. Create an entry with name and value, and append it to entry list.
-            auto checkbox_or_radio_element_name = TRY_OR_THROW_OOM(vm, String::from_byte_string(checkbox_or_radio_element->name()));
-            entry_list.append(XHR::FormDataEntry { .name = move(checkbox_or_radio_element_name), .value = move(value) });
+            auto checkbox_or_radio_element_name = checkbox_or_radio_element->name();
+            entry_list.append(XHR::FormDataEntry { .name = checkbox_or_radio_element_name->to_string(), .value = move(value) });
         }
         // 8. Otherwise, if the field element is an input element whose type attribute is in the File Upload state, then:
         else if (auto* file_element = dynamic_cast<HTML::HTMLInputElement*>(control.ptr()); file_element && file_element->type_state() == HTMLInputElement::TypeAttributeState::FileUpload) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -902,8 +902,8 @@ Vector<FlyString> HTMLFormElement::supported_property_names() const
 
         // 2. If candidate has a name attribute, add an entry to sourced names with that name attribute's value as the
         //    string, candidate as the element, and name as the source.
-        if (auto maybe_name = candidate->attribute(HTML::AttributeNames::name); maybe_name.has_value())
-            sourced_names.append(SourcedName { maybe_name.value(), candidate, SourcedName::Source::Name, {} });
+        if (candidate->name().has_value())
+            sourced_names.append(SourcedName { candidate->name().value(), candidate, SourcedName::Source::Name, {} });
     }
 
     // 3. For each img element candidate whose form owner is the form element:
@@ -920,8 +920,8 @@ Vector<FlyString> HTMLFormElement::supported_property_names() const
 
         // 2. If candidate has a name attribute, add an entry to sourced names with that name attribute's value as the
         //    string, candidate as the element, and name as the source.
-        if (auto maybe_name = candidate->attribute(HTML::AttributeNames::name); maybe_name.has_value())
-            sourced_names.append(SourcedName { maybe_name.value(), candidate, SourcedName::Source::Name, {} });
+        if (candidate->name().has_value())
+            sourced_names.append(SourcedName { candidate->name().value(), candidate, SourcedName::Source::Name, {} });
     }
 
     // 4. For each entry past entry in the past names map add an entry to sourced names with the past entry's name as
@@ -984,8 +984,7 @@ WebIDL::ExceptionOr<JS::Value> HTMLFormElement::named_item_value(FlyString const
         if (!is_form_control(element, *this))
             return false;
 
-        // FIXME: DOM::Element::name() isn't cached
-        return name == element.id() || name == element.attribute(HTML::AttributeNames::name);
+        return name == element.id() || name == element.name();
     });
 
     // 2. If candidates is empty, let candidates be a live RadioNodeList object containing all the img elements,
@@ -1000,8 +999,7 @@ WebIDL::ExceptionOr<JS::Value> HTMLFormElement::named_item_value(FlyString const
             if (element.form() != this)
                 return false;
 
-            // FIXME: DOM::Element::name() isn't cached
-            return name == element.id() || name == element.attribute(HTML::AttributeNames::name);
+            return name == element.id() || name == element.name();
         });
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -965,9 +965,9 @@ static bool is_in_same_radio_button_group(HTML::HTMLInputElement const& a, HTML:
         && a.form() == b.form()
         // - They both have a name attribute, their name attributes are not empty, and the
         // value of a's name attribute equals the value of b's name attribute.
-        && a.has_attribute(HTML::AttributeNames::name)
-        && b.has_attribute(HTML::AttributeNames::name)
-        && non_empty_equals(a.name(), b.name()));
+        && a.name().has_value()
+        && b.name().has_value()
+        && non_empty_equals(a.name().value(), b.name().value()));
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
@@ -979,8 +979,7 @@ void HTMLInputElement::set_checked_within_group()
     set_checked(true, ChangeSource::User);
 
     // No point iterating the tree if we have an empty name.
-    auto name = this->name();
-    if (name.is_empty())
+    if (!name().has_value() || name()->is_empty())
         return;
 
     document().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
@@ -1010,8 +1009,6 @@ void HTMLInputElement::legacy_pre_activation_behavior()
     // has its checkedness set to true, if any, and then set this element's
     // checkedness to true.
     if (type_state() == TypeAttributeState::RadioButton) {
-        ByteString name = this->name();
-
         document().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
             if (element.checked() && is_in_same_radio_button_group(*this, element)) {
                 m_legacy_pre_activation_behavior_checked_element_in_group = &element;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -65,7 +65,6 @@ public:
     WebIDL::ExceptionOr<void> set_type(String const&);
 
     ByteString default_value() const { return deprecated_attribute(HTML::AttributeNames::value); }
-    ByteString name() const { return deprecated_attribute(HTML::AttributeNames::name); }
 
     virtual String value() const override;
     WebIDL::ExceptionOr<void> set_value(String const&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -54,9 +54,8 @@ void HTMLMetaElement::inserted()
     //     * The element is in a document tree
     //     * The element has a name attribute, whose value is an ASCII case-insensitive match for theme-color
     //     * The element has a content attribute
-    auto name = attribute(AttributeNames::name);
     auto content = attribute(AttributeNames::content);
-    if (name.has_value() && name->bytes_as_string_view().equals_ignoring_ascii_case("theme-color"sv) && content.has_value()) {
+    if (name().has_value() && name()->equals_ignoring_ascii_case("theme-color"sv) && content.has_value()) {
         auto context = CSS::Parser::ParsingContext { document() };
 
         // 2. For each element in candidate elements:

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -76,8 +76,8 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable()
     Optional<String> target_name;
 
     // 5. If element has a name content attribute, then set targetName to the value of that attribute.
-    if (auto value = attribute(HTML::AttributeNames::name); value.has_value())
-        target_name = move(value);
+    if (name().has_value())
+        target_name = name().value().to_string();
 
     // 6. Let documentState be a new document state, with
     //  - document: document

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1587,8 +1587,8 @@ Vector<FlyString> Window::supported_property_names() const
     //   and are in a document tree with window's associated Document as their root.
     associated_document().for_each_in_subtree_of_type<DOM::Element>([&property_names](auto& element) -> IterationDecision {
         if (is<HTMLEmbedElement>(element) || is<HTMLFormElement>(element) || is<HTMLImageElement>(element) || is<HTMLObjectElement>(element)) {
-            if (auto const& name = element.attribute(AttributeNames::name); name.has_value())
-                property_names.set(name.value(), AK::HashSetExistingEntryBehavior::Keep);
+            if (element.name().has_value())
+                property_names.set(element.name().value(), AK::HashSetExistingEntryBehavior::Keep);
         }
         if (auto const& name = element.id(); name.has_value())
             property_names.set(name.value().to_string(), AK::HashSetExistingEntryBehavior::Keep);
@@ -1636,9 +1636,9 @@ WebIDL::ExceptionOr<JS::Value> Window::named_item_value(FlyString const& name) c
     //    whose filter matches only named objects of window with the name name. (By definition, these will all be elements.)
     return DOM::HTMLCollection::create(mutable_this.associated_document(), DOM::HTMLCollection::Scope::Descendants, [name](auto& element) -> bool {
         if ((is<HTMLEmbedElement>(element) || is<HTMLFormElement>(element) || is<HTMLImageElement>(element) || is<HTMLObjectElement>(element))
-            && (element.attribute(AttributeNames::name) == name))
+            && (element.name() == name))
             return true;
-        return element.attribute(AttributeNames::id) == name;
+        return element.id() == name;
     });
 }
 
@@ -1664,9 +1664,9 @@ Window::NamedObjects Window::named_objects(StringView name)
     // HTML elements that have an id content attribute whose value is name and are in a document tree with window's associated Document as their root.
     associated_document().for_each_in_subtree_of_type<DOM::Element>([&objects, &name](auto& element) -> IterationDecision {
         if ((is<HTMLEmbedElement>(element) || is<HTMLFormElement>(element) || is<HTMLImageElement>(element) || is<HTMLObjectElement>(element))
-            && (element.attribute(AttributeNames::name) == name))
+            && (element.name() == name))
             objects.elements.append(element);
-        else if (element.attribute(AttributeNames::id) == name)
+        else if (element.id() == name)
             objects.elements.append(element);
         return IterationDecision::Continue;
     });

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -93,7 +93,7 @@ Label const* Label::label_for_control_node(LabelableNode const& control)
     // same tree as the label element. If the attribute is specified and there is an element in the tree
     // whose ID is equal to the value of the for attribute, and the first such element in tree order is
     // a labelable element, then that element is the label element's labeled control.
-    if (auto id = control.dom_node().attribute(HTML::AttributeNames::id); id.has_value() && !id->is_empty()) {
+    if (auto const& id = control.dom_node().id(); id.has_value() && !id->is_empty()) {
         Label const* label = nullptr;
 
         control.document().layout_node()->for_each_in_inclusive_subtree_of_type<Label>([&](auto& node) {
@@ -128,7 +128,7 @@ LabelableNode* Label::labeled_control()
     // a labelable element, then that element is the label element's labeled control.
     if (auto for_ = dom_node().for_(); for_.has_value()) {
         document().layout_node()->for_each_in_inclusive_subtree_of_type<LabelableNode>([&](auto& node) {
-            if (node.dom_node().attribute(HTML::AttributeNames::id) == for_) {
+            if (node.dom_node().id() == for_) {
                 control = &node;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -899,8 +899,8 @@ ByteString Node::debug_description() const
         builder.appendff("<{}>", dom_node()->node_name());
         if (dom_node()->is_element()) {
             auto& element = static_cast<DOM::Element const&>(*dom_node());
-            if (auto id = element.get_attribute(HTML::AttributeNames::id); id.has_value())
-                builder.appendff("#{}", id.value());
+            if (element.id().has_value())
+                builder.appendff("#{}", element.id().value());
             for (auto const& class_name : element.class_names())
                 builder.appendff(".{}", class_name);
         }


### PR DESCRIPTION
This MR gets Element pretty close to finally being rid of ByteString, and introduces caching of Element::name.

We also use the cached name and id in more places.