### PR TITLE
LibWeb: Resolve text shadows in LayoutState::commit()

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -188,6 +188,7 @@ private:
     void resolve_relative_positions(Vector<Painting::PaintableWithLines&> const&);
     void resolve_border_radii();
     void resolve_box_shadow_data();
+    void resolve_text_shadows(Vector<Painting::PaintableWithLines&> const& paintables_with_lines);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -662,24 +662,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
         for (auto& fragment : fragments()) {
             if (fragment.contained_by_inline_node())
                 continue;
-            if (is<Layout::TextNode>(fragment.layout_node())) {
-                auto& text_shadow = fragment.layout_node().computed_values().text_shadow();
-                if (!text_shadow.is_empty()) {
-                    Vector<ShadowData> resolved_shadow_data;
-                    resolved_shadow_data.ensure_capacity(text_shadow.size());
-                    for (auto const& layer : text_shadow) {
-                        resolved_shadow_data.empend(
-                            layer.color,
-                            layer.offset_x.to_px(layout_box()),
-                            layer.offset_y.to_px(layout_box()),
-                            layer.blur_radius.to_px(layout_box()),
-                            layer.spread_distance.to_px(layout_box()),
-                            ShadowPlacement::Outer);
-                    }
-                    context.recording_painter().set_font(fragment.layout_node().first_available_font());
-                    paint_text_shadow(context, fragment, resolved_shadow_data);
-                }
-            }
+            paint_text_shadow(context, fragment, fragment.shadows());
         }
     }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -14,6 +14,8 @@
 namespace Web::Painting {
 
 class PaintableFragment {
+    friend struct Layout::LayoutState;
+
 public:
     explicit PaintableFragment(Layout::LineBoxFragment const&);
 
@@ -29,6 +31,9 @@ public:
 
     BorderRadiiData const& border_radii_data() const { return m_border_radii_data; }
     void set_border_radii_data(BorderRadiiData const& border_radii_data) { m_border_radii_data = border_radii_data; }
+
+    Vector<ShadowData> const& shadows() const { return m_shadows; }
+    void set_shadows(Vector<ShadowData>&& shadows) { m_shadows = shadows; }
 
     CSSPixelRect const absolute_rect() const;
 
@@ -53,6 +58,7 @@ private:
     int m_length;
     Painting::BorderRadiiData m_border_radii_data;
     Vector<Gfx::DrawGlyphOrEmoji> m_glyph_run;
+    Vector<ShadowData> m_shadows;
     bool m_contained_by_inline_node { false };
 };
 

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -587,14 +587,13 @@ void paint_text_shadow(PaintContext& context, PaintableFragment const& fragment,
     auto fragment_width = context.enclosing_device_pixels(fragment.width()).value();
     auto fragment_height = context.enclosing_device_pixels(fragment.height()).value();
     auto draw_rect = context.enclosing_device_rect(fragment.absolute_rect()).to_type<int>();
-    auto const& scaled_font = fragment.layout_node().scaled_font(context);
     auto fragment_baseline = context.rounded_device_pixels(fragment.baseline()).value();
 
     Vector<Gfx::DrawGlyphOrEmoji> scaled_glyph_run;
     scaled_glyph_run.ensure_capacity(fragment.glyph_run().size());
     for (auto glyph : fragment.glyph_run()) {
         glyph.visit([&](auto& glyph) {
-            glyph.font = scaled_font;
+            glyph.font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(context.device_pixels_per_css_pixel()));
             glyph.position = glyph.position.scaled(context.device_pixels_per_css_pixel());
         });
         scaled_glyph_run.append(move(glyph));


### PR DESCRIPTION
Rather than resolving the text-shadow each time painting commands are
recorded, we can resolve it once during the layout commit and save the
resolved values in paintable fragments. This is also step towards
getting rid of layout node pointer in paintable fragment.
