### PR TITLE
LibWeb: Set box-shadow for inline paintables in LayoutState::commit()

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -335,24 +335,31 @@ void LayoutState::resolve_box_shadow_data()
     for (auto& it : used_values_per_layout_node) {
         auto& used_values = *it.value;
         auto& node = const_cast<NodeWithStyle&>(used_values.node());
+
+        auto const& box_shadow_data = node.computed_values().box_shadow();
+        if (box_shadow_data.is_empty())
+            continue;
+        Vector<Painting::ShadowData> resolved_box_shadow_data;
+        resolved_box_shadow_data.ensure_capacity(box_shadow_data.size());
+        for (auto const& layer : box_shadow_data) {
+            resolved_box_shadow_data.empend(
+                layer.color,
+                layer.offset_x.to_px(node),
+                layer.offset_y.to_px(node),
+                layer.blur_radius.to_px(node),
+                layer.spread_distance.to_px(node),
+                layer.placement == CSS::ShadowPlacement::Outer ? Painting::ShadowPlacement::Outer : Painting::ShadowPlacement::Inner);
+        }
+
         auto* paintable = node.paintable();
         if (paintable && is<Painting::PaintableBox>(*paintable)) {
-            auto box_shadow_data = node.computed_values().box_shadow();
-            if (box_shadow_data.is_empty())
-                continue;
             auto& paintable_box = static_cast<Painting::PaintableBox&>(*paintable);
-            Vector<Painting::ShadowData> resolved_box_shadow_data;
-            resolved_box_shadow_data.ensure_capacity(box_shadow_data.size());
-            for (auto const& layer : box_shadow_data) {
-                resolved_box_shadow_data.empend(
-                    layer.color,
-                    layer.offset_x.to_px(node),
-                    layer.offset_y.to_px(node),
-                    layer.blur_radius.to_px(node),
-                    layer.spread_distance.to_px(node),
-                    layer.placement == CSS::ShadowPlacement::Outer ? Painting::ShadowPlacement::Outer : Painting::ShadowPlacement::Inner);
-            }
             paintable_box.set_box_shadow_data(move(resolved_box_shadow_data));
+        } else if (paintable && is<Painting::InlinePaintable>(*paintable)) {
+            auto& inline_paintable = static_cast<Painting::InlinePaintable&>(*paintable);
+            inline_paintable.set_box_shadow_data(move(resolved_box_shadow_data));
+        } else {
+            VERIFY_NOT_REACHED();
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -51,18 +51,7 @@ void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
             auto const& border_radii_data = fragment.border_radii_data();
             paint_background(context, layout_node(), absolute_fragment_rect, computed_values().background_color(), computed_values().image_rendering(), &computed_values().background_layers(), border_radii_data);
 
-            if (auto computed_box_shadow = computed_values().box_shadow(); !computed_box_shadow.is_empty()) {
-                Vector<ShadowData> resolved_box_shadow_data;
-                resolved_box_shadow_data.ensure_capacity(computed_box_shadow.size());
-                for (auto const& layer : computed_box_shadow) {
-                    resolved_box_shadow_data.empend(
-                        layer.color,
-                        layer.offset_x.to_px(layout_node()),
-                        layer.offset_y.to_px(layout_node()),
-                        layer.blur_radius.to_px(layout_node()),
-                        layer.spread_distance.to_px(layout_node()),
-                        layer.placement == CSS::ShadowPlacement::Outer ? ShadowPlacement::Outer : ShadowPlacement::Inner);
-                }
+            if (!box_shadow_data().is_empty()) {
                 auto borders_data = BordersData {
                     .top = computed_values().border_top(),
                     .right = computed_values().border_right(),
@@ -73,7 +62,7 @@ void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
                     borders_data.top.width, borders_data.right.width,
                     borders_data.bottom.width, borders_data.left.width);
                 paint_box_shadow(context, absolute_fragment_rect_bordered, absolute_fragment_rect,
-                    borders_data, border_radii_data, resolved_box_shadow_data);
+                    borders_data, border_radii_data, box_shadow_data());
             }
 
             return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -28,11 +28,16 @@ public:
 
     void mark_contained_fragments();
 
+    void set_box_shadow_data(Vector<ShadowData>&& box_shadow_data) { m_box_shadow_data = move(box_shadow_data); }
+    Vector<ShadowData> const& box_shadow_data() const { return m_box_shadow_data; }
+
 private:
     InlinePaintable(Layout::InlineNode const&);
 
     template<typename Callback>
     void for_each_fragment(Callback) const;
+
+    Vector<ShadowData> m_box_shadow_data;
 };
 
 }


### PR DESCRIPTION
This is part of the efforts towards making the paintable tree independent of the layout tree.