### PR TITLE
LibGUI+Applications: Default the SpinBox min/max to the full int range

### DIFF
--- a/Userland/Applications/Calendar/AddEventDialog.gml
+++ b/Userland/Applications/Calendar/AddEventDialog.gml
@@ -120,7 +120,6 @@
             name: "duration_hour"
             fixed_size: [50, 20]
             min: 0
-            max: 999999
         }
 
         @GUI::SpinBox {

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -35,6 +35,7 @@
                 @GUI::SpinBox {
                     name: "glyph_editor_width_spinbox"
                     preferred_width: "fit"
+                    min: 0
                 }
 
                 @GUI::CheckBox {

--- a/Userland/Libraries/LibGUI/FontPickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FontPickerDialog.gml
@@ -48,6 +48,7 @@
 
             @GUI::SpinBox {
                 name: "size_spin_box"
+                min: 0
             }
 
             @GUI::ListView {

--- a/Userland/Libraries/LibGUI/SpinBox.h
+++ b/Userland/Libraries/LibGUI/SpinBox.h
@@ -42,8 +42,8 @@ private:
     RefPtr<Button> m_increment_button;
     RefPtr<Button> m_decrement_button;
 
-    int m_min { 0 };
-    int m_max { 100 };
+    int m_min { NumericLimits<int>::min() };
+    int m_max { NumericLimits<int>::max() };
     int m_value { 0 };
 };
 


### PR DESCRIPTION
By default, a SpinBox's value should be unlimited, (or as close as we can get to that,) and then the GML or code can impose a limit if needed. This saves the developer from entering an arbitrary "big" max value when they want the value to have no maximum.

I've audited the use of SpinBox and added `min: 0`, and removed a `max`, where appropriate. All existing SpinBoxes constructed in code have a range set explicitly as far as I can tell.

(See the discussion here: https://github.com/SerenityOS/serenity/pull/22653#discussion_r1444485508 )