### PR TITLE
LibWeb: Make inline paintables own their fragments

### DIFF
--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -95,23 +95,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "agents should be able to render the document elements above this paragraph"
         frag 2 from TextNode start: 167, length: 43, rect: [20,361 207.890625x13] baseline: 9.5
             "indistinguishably (to the pixel) from this "
-        frag 3 from TextNode start: 0, length: 20, rect: [228,361 103.015625x13] baseline: 9.5
-            "reference rendering,"
-        frag 4 from TextNode start: 0, length: 31, rect: [331,361 159.671875x13] baseline: 9.5
+        frag 3 from TextNode start: 0, length: 31, rect: [331,361 159.671875x13] baseline: 9.5
             " (except font rasterization and"
-        frag 5 from TextNode start: 32, length: 89, rect: [20,374 465.015625x13] baseline: 9.5
+        frag 4 from TextNode start: 32, length: 89, rect: [20,374 465.015625x13] baseline: 9.5
             "form widgets). All discrepancies should be traceable to CSS1 implementation shortcomings."
-        frag 6 from TextNode start: 122, length: 67, rect: [20,387 345.546875x13] baseline: 9.5
+        frag 5 from TextNode start: 122, length: 67, rect: [20,387 345.546875x13] baseline: 9.5
             "Once you have finished evaluating this test, you can return to the "
-        frag 7 from TextNode start: 0, length: 11, rect: [366,387 59.890625x13] baseline: 9.5
-            "parent page"
-        frag 8 from TextNode start: 0, length: 1, rect: [425,387 2.71875x13] baseline: 9.5
+        frag 6 from TextNode start: 0, length: 1, rect: [425,387 2.71875x13] baseline: 9.5
             "."
         TextNode <#text>
         InlineNode <a>
+          frag 0 from TextNode start: 0, length: 20, rect: [228,361 103.015625x13] baseline: 9.5
+              "reference rendering,"
           TextNode <#text>
         TextNode <#text>
         InlineNode <a>
+          frag 0 from TextNode start: 0, length: 11, rect: [366,387 59.890625x13] baseline: 9.5
+              "parent page"
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (20,400) content-size 480x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
@@ -1,15 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: inline
-      frag 0 from TextNode start: 0, length: 1, rect: [108,8 6.34375x17] baseline: 13.296875
-          "1"
-      frag 1 from TextNode start: 0, length: 1, rect: [108,25 8.8125x17] baseline: 13.296875
-          "2"
       BlockContainer <span.a> at (8,8) content-size 100x17 floating [BFC] children: inline
         frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
             "A"
         TextNode <#text>
       InlineNode <span>
+        frag 0 from TextNode start: 0, length: 1, rect: [108,8 6.34375x17] baseline: 13.296875
+            "1"
         TextNode <#text>
       TextNode <#text>
       BreakNode <br>
@@ -19,6 +17,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "B"
         TextNode <#text>
       InlineNode <span>
+        frag 0 from TextNode start: 0, length: 1, rect: [108,25 8.8125x17] baseline: 13.296875
+            "2"
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
@@ -2,9 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x19 children: not-inline
       BlockContainer <pre> at (9,17) content-size 782x17 children: inline
-        frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17] baseline: 13.296875
-            " "
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17] baseline: 13.296875
+              " "
           TextNode <#text>
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
@@ -3,9 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 500x81 children: not-inline
       BlockContainer <div.a> at (51,21) content-size 413x49 children: not-inline
         BlockContainer <div.b> at (92,32) content-size 326x17 children: inline
-          frag 0 from TextNode start: 0, length: 5, rect: [93,32 39.78125x17] baseline: 13.296875
-              "Hello"
           InlineNode <span>
+            frag 0 from TextNode start: 0, length: 5, rect: [93,32 39.78125x17] baseline: 13.296875
+                "Hello"
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
@@ -3,9 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 500x101 children: not-inline
       BlockContainer <div.a> at (31,21) content-size 458x79 children: not-inline
         BlockContainer <div.b> at (72,52) content-size 376x17 children: inline
-          frag 0 from TextNode start: 0, length: 5, rect: [73,52 39.78125x17] baseline: 13.296875
-              "Hello"
           InlineNode <span>
+            frag 0 from TextNode start: 0, length: 5, rect: [73,52 39.78125x17] baseline: 13.296875
+                "Hello"
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -2,17 +2,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x152 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17] baseline: 13.296875
-            "well "
-        frag 1 from TextNode start: 0, length: 6, rect: [44,33 44.84375x17] baseline: 13.296875
-            "hello "
-        frag 2 from TextNode start: 0, length: 7, rect: [89,58 55.359375x17] baseline: 13.296875
-            "friends"
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17] baseline: 13.296875
+              "well "
           TextNode <#text>
           InlineNode <b>
+            frag 0 from TextNode start: 0, length: 6, rect: [44,33 44.84375x17] baseline: 13.296875
+                "hello "
             TextNode <#text>
             InlineNode <i>
+              frag 0 from TextNode start: 0, length: 7, rect: [89,58 55.359375x17] baseline: 13.296875
+                  "friends"
               TextNode <#text>
         TextNode <#text>
       BlockContainer <div> at (8,25) content-size 784x135 children: not-inline
@@ -36,7 +36,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x152] overflow: [8,8 784x168]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17] overflow: [8,8 784x67]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
         InlinePaintable (InlineNode<SPAN>)
           TextPaintable (TextNode<#text>)
           InlinePaintable (InlineNode<B>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
@@ -3,24 +3,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
       frag 0 from TextNode start: 0, length: 4, rect: [8,8 35.15625x17] baseline: 13.296875
           "foo "
-      frag 1 from TextNode start: 0, length: 3, rect: [43,33 27.640625x17] baseline: 13.296875
-          "bar"
-      frag 2 from TextNode start: 0, length: 1, rect: [71,8 8x17] baseline: 13.296875
+      frag 1 from TextNode start: 0, length: 1, rect: [71,8 8x17] baseline: 13.296875
           " "
-      frag 3 from TextNode start: 0, length: 3, rect: [54,58 27.203125x17] baseline: 13.296875
-          "baz"
       TextNode <#text>
       InlineNode <b>
+        frag 0 from TextNode start: 0, length: 3, rect: [43,33 27.640625x17] baseline: 13.296875
+            "bar"
         TextNode <#text>
       TextNode <#text>
       InlineNode <b>
         InlineNode <i>
+          frag 0 from TextNode start: 0, length: 3, rect: [54,58 27.203125x17] baseline: 13.296875
+              "baz"
           TextNode <#text>
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784x67]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784x42]
       TextPaintable (TextNode<#text>)
       InlinePaintable (InlineNode<B>)
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
+++ b/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
@@ -2,11 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x83 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x67 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 1, rect: [8,16 10.625x17] baseline: 13.296875
-            "+"
-        frag 1 from TextNode start: 0, length: 36, rect: [19,16 300x17] baseline: 13.296875
+        frag 0 from TextNode start: 0, length: 36, rect: [19,16 300x17] baseline: 13.296875
             "P should generate a ::before pseudo."
         InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 1, rect: [8,16 10.625x17] baseline: 13.296875
+              "+"
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49) content-size 784x34 children: inline

--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: inline
-  frag 0 from TextNode start: 1, length: 18, rect: [0,0 134.984375x17] baseline: 13.296875
-      "* { all: unset; } "
-  frag 1 from TextNode start: 0, length: 13, rect: [135,0 103.140625x17] baseline: 13.296875
-      "Hello friends"
   InlineNode <html>
     InlineNode <head>
       InlineNode <style>
+        frag 0 from TextNode start: 1, length: 18, rect: [0,0 134.984375x17] baseline: 13.296875
+            "* { all: unset; } "
         TextNode <#text>
     InlineNode <body>
+      frag 0 from TextNode start: 0, length: 13, rect: [135,0 103.140625x17] baseline: 13.296875
+          "Hello friends"
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/css-font-size-math.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-math.txt
@@ -1,25 +1,25 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x79 children: inline
-      frag 0 from TextNode start: 0, length: 1, rect: [8,25 39.09375x56] baseline: 43.328125
-          "H"
-      frag 1 from TextNode start: 0, length: 1, rect: [47,38 19.78125x40] baseline: 30.875
-          "e"
-      frag 2 from TextNode start: 0, length: 1, rect: [67,47 6.8125x28] baseline: 21.71875
-          "l"
-      frag 3 from TextNode start: 0, length: 1, rect: [74,53 4.84375x20] baseline: 15.484375
-          "l"
-      frag 4 from TextNode start: 0, length: 1, rect: [79,58 8.40625x14] baseline: 10.890625
-          "o"
       InlineNode <span>
+        frag 0 from TextNode start: 0, length: 1, rect: [8,25 39.09375x56] baseline: 43.328125
+            "H"
         TextNode <#text>
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 1, rect: [47,38 19.78125x40] baseline: 30.875
+              "e"
           TextNode <#text>
           InlineNode <span>
+            frag 0 from TextNode start: 0, length: 1, rect: [67,47 6.8125x28] baseline: 21.71875
+                "l"
             TextNode <#text>
             InlineNode <span>
+              frag 0 from TextNode start: 0, length: 1, rect: [74,53 4.84375x20] baseline: 15.484375
+                  "l"
               TextNode <#text>
               InlineNode <span>
+                frag 0 from TextNode start: 0, length: 1, rect: [79,58 8.40625x14] baseline: 10.890625
+                    "o"
                 TextNode <#text>
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
@@ -2,10 +2,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,20) content-size 784x22 children: not-inline
       BlockContainer <p> at (8,20) content-size 784x22 children: inline
-        frag 0 from TextNode start: 0, length: 15, rect: [18,20 163.890625x22] baseline: 17
-            "Should be green"
         TextNode <#text>
         InlineNode <a>
+          frag 0 from TextNode start: 0, length: 15, rect: [18,20 163.890625x22] baseline: 17
+              "Should be green"
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,62) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
@@ -2,10 +2,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,20) content-size 784x22 children: not-inline
       BlockContainer <p> at (8,20) content-size 784x22 children: inline
-        frag 0 from TextNode start: 0, length: 13, rect: [13,20 141.34375x22] baseline: 17
-            "Should be red"
         TextNode <#text>
         InlineNode <a>
+          frag 0 from TextNode start: 0, length: 13, rect: [13,20 141.34375x22] baseline: 17
+              "Should be red"
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,62) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -16,9 +16,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
         TextNode <#text>
       BlockContainer <div> at (9,164) content-size 782x44 children: inline
-        frag 0 from TextNode start: 0, length: 5, rect: [10,164 99.453125x44] baseline: 34
-            "Hello"
         InlineNode <a>
+          frag 0 from TextNode start: 0, length: 5, rect: [10,164 99.453125x44] baseline: 34
+              "Hello"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,209) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-quotes-nesting.txt
+++ b/Tests/LibWeb/Layout/expected/css-quotes-nesting.txt
@@ -2,41 +2,41 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x67 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
       BlockContainer <div.a> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
-            "a"
-        frag 1 from TextNode start: 0, length: 1, rect: [17,8 9.46875x17] baseline: 13.296875
-            "b"
-        frag 2 from TextNode start: 0, length: 1, rect: [27,8 8.890625x17] baseline: 13.296875
-            "c"
-        frag 3 from TextNode start: 0, length: 1, rect: [36,8 7.859375x17] baseline: 13.296875
-            "d"
-        frag 4 from TextNode start: 0, length: 1, rect: [44,8 8.71875x17] baseline: 13.296875
-            "e"
-        frag 5 from TextNode start: 0, length: 1, rect: [52,8 6.4375x17] baseline: 13.296875
-            "f"
-        frag 6 from TextNode start: 0, length: 1, rect: [59,8 7.5625x17] baseline: 13.296875
-            "g"
-        frag 7 from TextNode start: 0, length: 1, rect: [66,8 9.296875x17] baseline: 13.296875
-            "h"
-        frag 8 from TextNode start: 0, length: 1, rect: [76,8 4.5625x17] baseline: 13.296875
-            "i"
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
+              "a"
+          frag 1 from TextNode start: 0, length: 1, rect: [76,8 4.5625x17] baseline: 13.296875
+              "i"
           InlineNode <(anonymous)>
             TextNode <#text>
           TextNode <#text>
           InlineNode <span>
+            frag 0 from TextNode start: 0, length: 1, rect: [17,8 9.46875x17] baseline: 13.296875
+                "b"
+            frag 1 from TextNode start: 0, length: 1, rect: [66,8 9.296875x17] baseline: 13.296875
+                "h"
             InlineNode <(anonymous)>
               TextNode <#text>
             TextNode <#text>
             InlineNode <span>
+              frag 0 from TextNode start: 0, length: 1, rect: [27,8 8.890625x17] baseline: 13.296875
+                  "c"
+              frag 1 from TextNode start: 0, length: 1, rect: [59,8 7.5625x17] baseline: 13.296875
+                  "g"
               InlineNode <(anonymous)>
                 TextNode <#text>
               TextNode <#text>
               InlineNode <span>
+                frag 0 from TextNode start: 0, length: 1, rect: [36,8 7.859375x17] baseline: 13.296875
+                    "d"
+                frag 1 from TextNode start: 0, length: 1, rect: [52,8 6.4375x17] baseline: 13.296875
+                    "f"
                 InlineNode <(anonymous)>
                   TextNode <#text>
                 TextNode <#text>
                 InlineNode <span>
+                  frag 0 from TextNode start: 0, length: 1, rect: [44,8 8.71875x17] baseline: 13.296875
+                      "e"
                   InlineNode <(anonymous)>
                     TextNode <#text>
                   TextNode <#text>
@@ -57,152 +57,152 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.b> at (8,25) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 3, rect: [8,25 5.84375x17] baseline: 13.296875
-            "“"
-        frag 1 from TextNode start: 0, length: 1, rect: [14,25 9.34375x17] baseline: 13.296875
-            "a"
-        frag 2 from TextNode start: 0, length: 3, rect: [23,25 5.84375x17] baseline: 13.296875
-            "‘"
-        frag 3 from TextNode start: 0, length: 1, rect: [29,25 9.46875x17] baseline: 13.296875
-            "b"
-        frag 4 from TextNode start: 0, length: 3, rect: [39,25 5.84375x17] baseline: 13.296875
-            "‘"
-        frag 5 from TextNode start: 0, length: 1, rect: [44,25 8.890625x17] baseline: 13.296875
-            "c"
-        frag 6 from TextNode start: 0, length: 3, rect: [53,25 5.84375x17] baseline: 13.296875
-            "‘"
-        frag 7 from TextNode start: 0, length: 1, rect: [59,25 7.859375x17] baseline: 13.296875
-            "d"
-        frag 8 from TextNode start: 0, length: 3, rect: [67,25 5.84375x17] baseline: 13.296875
-            "‘"
-        frag 9 from TextNode start: 0, length: 1, rect: [73,25 8.71875x17] baseline: 13.296875
-            "e"
-        frag 10 from TextNode start: 0, length: 3, rect: [82,25 5.84375x17] baseline: 13.296875
-            "’"
-        frag 11 from TextNode start: 0, length: 1, rect: [87,25 6.4375x17] baseline: 13.296875
-            "f"
-        frag 12 from TextNode start: 0, length: 3, rect: [94,25 5.84375x17] baseline: 13.296875
-            "’"
-        frag 13 from TextNode start: 0, length: 1, rect: [100,25 7.5625x17] baseline: 13.296875
-            "g"
-        frag 14 from TextNode start: 0, length: 3, rect: [107,25 5.84375x17] baseline: 13.296875
-            "’"
-        frag 15 from TextNode start: 0, length: 1, rect: [113,25 9.296875x17] baseline: 13.296875
-            "h"
-        frag 16 from TextNode start: 0, length: 3, rect: [122,25 5.84375x17] baseline: 13.296875
-            "’"
-        frag 17 from TextNode start: 0, length: 1, rect: [128,25 4.5625x17] baseline: 13.296875
-            "i"
-        frag 18 from TextNode start: 0, length: 3, rect: [133,25 5.84375x17] baseline: 13.296875
-            "”"
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 1, rect: [14,25 9.34375x17] baseline: 13.296875
+              "a"
+          frag 1 from TextNode start: 0, length: 1, rect: [128,25 4.5625x17] baseline: 13.296875
+              "i"
           InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [8,25 5.84375x17] baseline: 13.296875
+                "“"
             TextNode <#text>
           TextNode <#text>
           InlineNode <span>
+            frag 0 from TextNode start: 0, length: 1, rect: [29,25 9.46875x17] baseline: 13.296875
+                "b"
+            frag 1 from TextNode start: 0, length: 1, rect: [113,25 9.296875x17] baseline: 13.296875
+                "h"
             InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 3, rect: [23,25 5.84375x17] baseline: 13.296875
+                  "‘"
               TextNode <#text>
             TextNode <#text>
             InlineNode <span>
+              frag 0 from TextNode start: 0, length: 1, rect: [44,25 8.890625x17] baseline: 13.296875
+                  "c"
+              frag 1 from TextNode start: 0, length: 1, rect: [100,25 7.5625x17] baseline: 13.296875
+                  "g"
               InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 3, rect: [39,25 5.84375x17] baseline: 13.296875
+                    "‘"
                 TextNode <#text>
               TextNode <#text>
               InlineNode <span>
+                frag 0 from TextNode start: 0, length: 1, rect: [59,25 7.859375x17] baseline: 13.296875
+                    "d"
+                frag 1 from TextNode start: 0, length: 1, rect: [87,25 6.4375x17] baseline: 13.296875
+                    "f"
                 InlineNode <(anonymous)>
+                  frag 0 from TextNode start: 0, length: 3, rect: [53,25 5.84375x17] baseline: 13.296875
+                      "‘"
                   TextNode <#text>
                 TextNode <#text>
                 InlineNode <span>
+                  frag 0 from TextNode start: 0, length: 1, rect: [73,25 8.71875x17] baseline: 13.296875
+                      "e"
                   InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 3, rect: [67,25 5.84375x17] baseline: 13.296875
+                        "‘"
                     TextNode <#text>
                   TextNode <#text>
                   InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 3, rect: [82,25 5.84375x17] baseline: 13.296875
+                        "’"
                     TextNode <#text>
                 TextNode <#text>
                 InlineNode <(anonymous)>
+                  frag 0 from TextNode start: 0, length: 3, rect: [94,25 5.84375x17] baseline: 13.296875
+                      "’"
                   TextNode <#text>
               TextNode <#text>
               InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 3, rect: [107,25 5.84375x17] baseline: 13.296875
+                    "’"
                 TextNode <#text>
             TextNode <#text>
             InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 3, rect: [122,25 5.84375x17] baseline: 13.296875
+                  "’"
               TextNode <#text>
           TextNode <#text>
           InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [133,25 5.84375x17] baseline: 13.296875
+                "”"
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.c> at (8,42) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 1, rect: [8,42 5.484375x17] baseline: 13.296875
-            "("
-        frag 1 from TextNode start: 0, length: 1, rect: [13,42 9.34375x17] baseline: 13.296875
-            "a"
-        frag 2 from TextNode start: 0, length: 1, rect: [23,42 7.625x17] baseline: 13.296875
-            "{"
-        frag 3 from TextNode start: 0, length: 1, rect: [30,42 9.46875x17] baseline: 13.296875
-            "b"
-        frag 4 from TextNode start: 0, length: 1, rect: [40,42 6.953125x17] baseline: 13.296875
-            "["
-        frag 5 from TextNode start: 0, length: 1, rect: [47,42 8.890625x17] baseline: 13.296875
-            "c"
-        frag 6 from TextNode start: 0, length: 1, rect: [56,42 6.953125x17] baseline: 13.296875
-            "["
-        frag 7 from TextNode start: 0, length: 1, rect: [63,42 7.859375x17] baseline: 13.296875
-            "d"
-        frag 8 from TextNode start: 0, length: 1, rect: [71,42 6.953125x17] baseline: 13.296875
-            "["
-        frag 9 from TextNode start: 0, length: 1, rect: [78,42 8.71875x17] baseline: 13.296875
-            "e"
-        frag 10 from TextNode start: 0, length: 1, rect: [86,42 7.21875x17] baseline: 13.296875
-            "]"
-        frag 11 from TextNode start: 0, length: 1, rect: [93,42 6.4375x17] baseline: 13.296875
-            "f"
-        frag 12 from TextNode start: 0, length: 1, rect: [100,42 7.21875x17] baseline: 13.296875
-            "]"
-        frag 13 from TextNode start: 0, length: 1, rect: [107,42 7.5625x17] baseline: 13.296875
-            "g"
-        frag 14 from TextNode start: 0, length: 1, rect: [115,42 7.21875x17] baseline: 13.296875
-            "]"
-        frag 15 from TextNode start: 0, length: 1, rect: [122,42 9.296875x17] baseline: 13.296875
-            "h"
-        frag 16 from TextNode start: 0, length: 1, rect: [131,42 7.65625x17] baseline: 13.296875
-            "}"
-        frag 17 from TextNode start: 0, length: 1, rect: [139,42 4.5625x17] baseline: 13.296875
-            "i"
-        frag 18 from TextNode start: 0, length: 1, rect: [143,42 4.8125x17] baseline: 13.296875
-            ")"
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 1, rect: [13,42 9.34375x17] baseline: 13.296875
+              "a"
+          frag 1 from TextNode start: 0, length: 1, rect: [139,42 4.5625x17] baseline: 13.296875
+              "i"
           InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 1, rect: [8,42 5.484375x17] baseline: 13.296875
+                "("
             TextNode <#text>
           TextNode <#text>
           InlineNode <span>
+            frag 0 from TextNode start: 0, length: 1, rect: [30,42 9.46875x17] baseline: 13.296875
+                "b"
+            frag 1 from TextNode start: 0, length: 1, rect: [122,42 9.296875x17] baseline: 13.296875
+                "h"
             InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 1, rect: [23,42 7.625x17] baseline: 13.296875
+                  "{"
               TextNode <#text>
             TextNode <#text>
             InlineNode <span>
+              frag 0 from TextNode start: 0, length: 1, rect: [47,42 8.890625x17] baseline: 13.296875
+                  "c"
+              frag 1 from TextNode start: 0, length: 1, rect: [107,42 7.5625x17] baseline: 13.296875
+                  "g"
               InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 1, rect: [40,42 6.953125x17] baseline: 13.296875
+                    "["
                 TextNode <#text>
               TextNode <#text>
               InlineNode <span>
+                frag 0 from TextNode start: 0, length: 1, rect: [63,42 7.859375x17] baseline: 13.296875
+                    "d"
+                frag 1 from TextNode start: 0, length: 1, rect: [93,42 6.4375x17] baseline: 13.296875
+                    "f"
                 InlineNode <(anonymous)>
+                  frag 0 from TextNode start: 0, length: 1, rect: [56,42 6.953125x17] baseline: 13.296875
+                      "["
                   TextNode <#text>
                 TextNode <#text>
                 InlineNode <span>
+                  frag 0 from TextNode start: 0, length: 1, rect: [78,42 8.71875x17] baseline: 13.296875
+                      "e"
                   InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 1, rect: [71,42 6.953125x17] baseline: 13.296875
+                        "["
                     TextNode <#text>
                   TextNode <#text>
                   InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 1, rect: [86,42 7.21875x17] baseline: 13.296875
+                        "]"
                     TextNode <#text>
                 TextNode <#text>
                 InlineNode <(anonymous)>
+                  frag 0 from TextNode start: 0, length: 1, rect: [100,42 7.21875x17] baseline: 13.296875
+                      "]"
                   TextNode <#text>
               TextNode <#text>
               InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 1, rect: [115,42 7.21875x17] baseline: 13.296875
+                    "]"
                 TextNode <#text>
             TextNode <#text>
             InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 1, rect: [131,42 7.65625x17] baseline: 13.296875
+                  "}"
               TextNode <#text>
           TextNode <#text>
           InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 1, rect: [143,42 4.8125x17] baseline: 13.296875
+                ")"
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/details-open.txt
+++ b/Tests/LibWeb/Layout/expected/details-open.txt
@@ -9,11 +9,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline
       BlockContainer <slot> at (8,25) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 10, rect: [8,25 82.3125x17] baseline: 13.296875
-            "I'm a node"
         TextNode <#text>
         TextNode <#text>
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 10, rect: [8,25 82.3125x17] baseline: 13.296875
+              "I'm a node"
           TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x17 [BFC] children: inline
-    frag 0 from TextNode start: 0, length: 7, rect: [0,0 51.75x17] baseline: 13.296875
-        "whf :^)"
     InlineNode <span>
+      frag 0 from TextNode start: 0, length: 7, rect: [0,0 51.75x17] baseline: 13.296875
+          "whf :^)"
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
@@ -9,9 +9,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.aligncenter.block-image> at (8,8) content-size 1200x600 table-box [TFC] children: inline
           Box <(anonymous)> at (8,8) content-size 1200x600 table-row children: inline
             BlockContainer <(anonymous)> at (8,8) content-size 1200x600 table-cell [BFC] children: inline
-              frag 0 from ImageBox start: 0, length: 0, rect: [8,8 1200x600] baseline: 600
               TextNode <#text>
               InlineNode <a>
+                frag 0 from ImageBox start: 0, length: 0, rect: [8,8 1200x600] baseline: 600
                 TextNode <#text>
                 ImageBox <img> at (8,8) content-size 1200x600 children: not-inline
                 TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/font-fractional-size.txt
+++ b/Tests/LibWeb/Layout/expected/font-fractional-size.txt
@@ -1,23 +1,23 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x39 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: inline
-      frag 0 from TextNode start: 0, length: 1, rect: [8,8 12.4375x22] baseline: 17.140625
-          "x"
-      frag 1 from TextNode start: 0, length: 1, rect: [20,12 8x17] baseline: 13.296875
+      frag 0 from TextNode start: 0, length: 1, rect: [20,12 8x17] baseline: 13.296875
           " "
-      frag 2 from TextNode start: 0, length: 1, rect: [28,8 12.734375x23] baseline: 17.796875
-          "x"
-      frag 3 from TextNode start: 0, length: 1, rect: [41,12 8x17] baseline: 13.296875
+      frag 1 from TextNode start: 0, length: 1, rect: [41,12 8x17] baseline: 13.296875
           " "
-      frag 4 from TextNode start: 0, length: 1, rect: [49,8 13.03125x23] baseline: 17.953125
-          "x"
       InlineNode <span.a>
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 12.4375x22] baseline: 17.140625
+            "x"
         TextNode <#text>
       TextNode <#text>
       InlineNode <span.b>
+        frag 0 from TextNode start: 0, length: 1, rect: [28,8 12.734375x23] baseline: 17.796875
+            "x"
         TextNode <#text>
       TextNode <#text>
       InlineNode <span.c>
+        frag 0 from TextNode start: 0, length: 1, rect: [49,8 13.03125x23] baseline: 17.953125
+            "x"
         TextNode <#text>
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/font-size-legacy.txt
+++ b/Tests/LibWeb/Layout/expected/font-size-legacy.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      frag 0 from TextNode start: 0, length: 4, rect: [8,11 24.109375x13] baseline: 10.09375
-          "text"
       InlineNode <font>
+        frag 0 from TextNode start: 0, length: 4, rect: [8,11 24.109375x13] baseline: 10.09375
+            "text"
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -1,30 +1,30 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: inline
-      frag 0 from TextNode start: 0, length: 1, rect: [8,8 79.296875x200] baseline: 159.96875
-          "1"
-      frag 1 from TextNode start: 0, length: 1, rect: [87,154 8x17] baseline: 13.296875
+      frag 0 from TextNode start: 0, length: 1, rect: [87,154 8x17] baseline: 13.296875
           " "
-      frag 2 from TextNode start: 0, length: 1, rect: [95,8 110.15625x200] baseline: 159.96875
-          "2"
-      frag 3 from TextNode start: 0, length: 1, rect: [205,154 8x17] baseline: 13.296875
+      frag 1 from TextNode start: 0, length: 1, rect: [205,154 8x17] baseline: 13.296875
           " "
-      frag 4 from TextNode start: 0, length: 1, rect: [213,8 113.671875x200] baseline: 159.96875
-          "3"
-      frag 5 from TextNode start: 0, length: 1, rect: [327,154 8x17] baseline: 13.296875
+      frag 2 from TextNode start: 0, length: 1, rect: [327,154 8x17] baseline: 13.296875
           " "
-      frag 6 from TextNode start: 0, length: 1, rect: [335,8 96.875x200] baseline: 159.96875
-          "4"
       InlineNode <span.one>
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 79.296875x200] baseline: 159.96875
+            "1"
         TextNode <#text>
       TextNode <#text>
       InlineNode <span.two>
+        frag 0 from TextNode start: 0, length: 1, rect: [95,8 110.15625x200] baseline: 159.96875
+            "2"
         TextNode <#text>
       TextNode <#text>
       InlineNode <span.three>
+        frag 0 from TextNode start: 0, length: 1, rect: [213,8 113.671875x200] baseline: 159.96875
+            "3"
         TextNode <#text>
       TextNode <#text>
       InlineNode <span.four>
+        frag 0 from TextNode start: 0, length: 1, rect: [335,8 96.875x200] baseline: 159.96875
+            "4"
         TextNode <#text>
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
@@ -2,18 +2,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x19 children: not-inline
       BlockContainer <div.fixed_width> at (9,9) content-size 50x17 children: inline
-        frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17] baseline: 13.296875
-            "ABC"
-        frag 1 from TextNode start: 0, length: 1, rect: [43,9 11.5625x17] baseline: 13.296875
-            "X"
-        frag 2 from TextNode start: 0, length: 3, rect: [54,9 33.921875x17] baseline: 13.296875
-            "ABC"
         TextNode <#text>
         InlineNode <span.nowrap>
+          frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17] baseline: 13.296875
+              "ABC"
           TextNode <#text>
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 1, rect: [43,9 11.5625x17] baseline: 13.296875
+              "X"
           TextNode <#text>
         InlineNode <span.nowrap>
+          frag 0 from TextNode start: 0, length: 3, rect: [54,9 33.921875x17] baseline: 13.296875
+              "ABC"
           TextNode <#text>
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
+++ b/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
@@ -9,9 +9,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,31) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.inline.formatting-context> at (11,32) content-size 778x17 [BFC] children: inline
-        frag 0 from TextNode start: 0, length: 6, rect: [12,32 41.296875x17] baseline: 13.296875
-            "inline"
         InlineNode <div>
+          frag 0 from TextNode start: 0, length: 6, rect: [12,32 41.296875x17] baseline: 13.296875
+              "inline"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,50) content-size 780x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
+++ b/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x416 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x400 children: inline
-      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 400x400] baseline: 400
       TextNode <#text>
       InlineNode <picture>
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 400x400] baseline: 400
         TextNode <#text>
         InlineNode <source>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17] baseline: 13.296875
-          " | "
       InlineNode <pre>
+        frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17] baseline: 13.296875
+            " | "
         TextNode <#text>
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
+++ b/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
@@ -2,9 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       BlockContainer <div#container> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 5, rect: [8,8 43.421875x17] baseline: 13.296875
-            "Pass!"
         InlineNode <span>
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 43.421875x17] baseline: 13.296875
+              "Pass!"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
@@ -2,16 +2,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       BlockContainer <div.fixed_width> at (9,9) content-size 50x34 children: inline
-        frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17] baseline: 13.296875
-            "ABC"
-        frag 1 from TextNode start: 0, length: 3, rect: [9,26 33.921875x17] baseline: 13.296875
-            "ABC"
         TextNode <#text>
         InlineNode <span.nowrap>
+          frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17] baseline: 13.296875
+              "ABC"
           TextNode <#text>
         InlineNode <span>
           TextNode <#text>
         InlineNode <span.nowrap>
+          frag 0 from TextNode start: 0, length: 3, rect: [9,26 33.921875x17] baseline: 13.296875
+              "ABC"
           TextNode <#text>
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -13,10 +13,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (16,12) content-size 37.21875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x17] baseline: 13.296875
-                    "Test"
                 TextNode <#text>
                 InlineNode <a>
+                  frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x17] baseline: 13.296875
+                      "Test"
                   TextNode <#text>
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/PaintableFragment.h>
 
 namespace Web::Painting {
 
@@ -23,10 +24,12 @@ public:
     auto const& box_model() const { return layout_node().box_model(); }
 
     CSSPixelRect bounding_rect() const;
+    Vector<PaintableFragment> const& fragments() const { return m_fragments; }
+    Vector<PaintableFragment>& fragments() { return m_fragments; }
 
     virtual bool is_inline_paintable() const override { return true; }
 
-    void mark_contained_fragments();
+    virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
 
     void set_box_shadow_data(Vector<ShadowData>&& box_shadow_data) { m_box_shadow_data = move(box_shadow_data); }
     Vector<ShadowData> const& box_shadow_data() const { return m_box_shadow_data; }
@@ -38,6 +41,7 @@ private:
     void for_each_fragment(Callback) const;
 
     Vector<ShadowData> m_box_shadow_data;
+    Vector<PaintableFragment> m_fragments;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -741,6 +741,15 @@ Optional<HitTestResult> PaintableWithLines::hit_test(CSSPixelPoint position, Hit
     if (!layout_box().children_are_inline() || m_fragments.is_empty())
         return PaintableBox::hit_test(position, type);
 
+    for (auto* child = first_child(); child; child = child->next_sibling()) {
+        auto result = child->hit_test(position, type);
+        if (!result.has_value())
+            continue;
+        if (!result->paintable->visible_for_hit_testing())
+            continue;
+        return result;
+    }
+
     Optional<HitTestResult> last_good_candidate;
     for (auto const& fragment : fragments()) {
         if (is<Layout::Box>(fragment.layout_node()) && static_cast<Layout::Box const&>(fragment.layout_node()).paintable_box()->stacking_context())

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -230,11 +230,14 @@ public:
     Layout::BlockContainer& layout_box();
 
     Vector<PaintableFragment> const& fragments() const { return m_fragments; }
+    Vector<PaintableFragment>& fragments() { return m_fragments; }
 
     void add_fragment(Layout::LineBoxFragment const& fragment)
     {
         m_fragments.append(PaintableFragment { fragment });
     }
+
+    void set_fragments(Vector<PaintableFragment>&& fragments) { m_fragments = move(fragments); }
 
     template<typename Callback>
     void for_each_fragment(Callback callback) const


### PR DESCRIPTION
The paintable tree structure more closely matches the painting order when fragments are owned by corresponding inline paintables. This change does not affect the layout tree, as it is more convenient for layout purposes to have all fragments owned by a block container in one place.

Additionally, this improves performance significantly on pages with many fragments, as we no longer have to walk the ancestor chain up to the closest block container to determine if a fragment belongs to an inline paintable.