### PR TITLE
LibCrypto: Parse negative input correctly in `BigFraction::from_string()`

### DIFF
--- a/Tests/LibCrypto/CMakeLists.txt
+++ b/Tests/LibCrypto/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestAES.cpp
     TestASN1.cpp
+    TestBigFraction.cpp
     TestBigInteger.cpp
     TestChecksum.cpp
     TestChaCha20.cpp

--- a/Tests/LibCrypto/TestBigFraction.cpp
+++ b/Tests/LibCrypto/TestBigFraction.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCrypto/BigFraction/BigFraction.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(roundtrip_from_string)
+{
+    Array valid_number_strings {
+        "0.1"sv,
+        "-0.1"sv,
+        "0.9"sv,
+        "-0.9"sv,
+        "1.2"sv,
+        "-1.2"sv,
+        "610888968122787804679.305596150292503043363"sv,
+        "-610888968122787804679.305596150292503043363"sv
+    };
+
+    for (auto valid_number_string : valid_number_strings) {
+        auto result = TRY_OR_FAIL(Crypto::BigFraction::from_string(valid_number_string));
+        auto precision = valid_number_string.length() - valid_number_string.find('.').value();
+        EXPECT_EQ(result.to_byte_string(precision), valid_number_string);
+    }
+}

--- a/Userland/Libraries/LibCrypto/BigFraction/BigFraction.cpp
+++ b/Userland/Libraries/LibCrypto/BigFraction/BigFraction.cpp
@@ -36,6 +36,9 @@ ErrorOr<BigFraction> BigFraction::from_string(StringView sv)
     auto fractional_part = TRY(SignedBigInteger::from_base(10, fraction_part_view));
     auto fraction_length = UnsignedBigInteger(static_cast<u64>(fraction_part_view.length()));
 
+    if (!sv.is_empty() && sv[0] == '-')
+        fractional_part.negate();
+
     return BigFraction(move(integer_part)) + BigFraction(move(fractional_part), NumberTheory::Power("10"_bigint, move(fraction_length)));
 }
 


### PR DESCRIPTION
Previously, when calling `BigFraction::from_string()`, the fractional part of the number was always treated as positive. This led to an incorrect result if the input string was negative.

I found this issue when attempting to paste a negative decimal value into the calculator.