### PR TITLE
LibWeb: Implement Element.getAttributeNodeNS and Element.removeAttributeNS

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Element-getAttributeNodeNS.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-getAttributeNodeNS.txt
@@ -1,0 +1,4 @@
+     xlink:href getAttributeNode = 'null'
+xlink:href getAttributeNodeNS = 'Attr': name = xlink:href value = test
+href getAttributeNode = 'Attr': name = href value = test
+href getAttributeNodeNS = 'null'

--- a/Tests/LibWeb/Text/expected/DOM/Element-removeAttributeNS.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-removeAttributeNS.txt
@@ -1,0 +1,12 @@
+     Original values
+xlink:href getAttributeNS = 'test'
+href getAttribute = 'test'
+Non-matching namespace
+xlink:href getAttributeNS = 'test'
+href getAttribute = 'test'
+Non-matching name
+xlink:href getAttributeNS = 'test'
+href getAttribute = 'test'
+Matching
+xlink:href getAttributeNS = 'null'
+href getAttribute = 'null'

--- a/Tests/LibWeb/Text/input/DOM/Element-getAttributeNodeNS.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-getAttributeNodeNS.html
@@ -1,0 +1,23 @@
+<script src="../include.js"></script>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <script id="with-xlink-href" xlink:href="test"></script>
+    <script id="no-xlink-href" href="test"></script>
+</svg>
+<script id="svg-script-element">
+    function dumpAttr(description, attr) {
+        if (attr === null) {
+            println(`${description} = 'null'`);
+            return;
+        }
+        println(`${description} = '${attr.constructor.name}': name = ${attr.name} value = ${attr.value}`);
+    }
+    test(() => {
+        const xlinkNS = document.getElementById("with-xlink-href");
+        dumpAttr('xlink:href getAttributeNode', xlinkNS.getAttributeNode("href"));
+        dumpAttr('xlink:href getAttributeNodeNS', xlinkNS.getAttributeNodeNS("http://www.w3.org/1999/xlink", "href"));
+
+        const noNS = document.getElementById("no-xlink-href");
+        dumpAttr('href getAttributeNode', noNS.getAttributeNode("href"));
+        dumpAttr('href getAttributeNodeNS', noNS.getAttributeNodeNS("http://www.w3.org/1999/xlink", "href"));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/Element-removeAttributeNS.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-removeAttributeNS.html
@@ -1,0 +1,37 @@
+<script src="../include.js"></script>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <script id="with-xlink-href" xlink:href="test"></script>
+    <script id="no-xlink-href" href="test"></script>
+</svg>
+<script id="svg-script-element">
+    test(() => {
+        const namespace = "http://www.w3.org/1999/xlink"
+        const xlinkNS = document.getElementById("with-xlink-href");
+        const noNS = document.getElementById("no-xlink-href");
+
+        println("Original values");
+        println(`xlink:href getAttributeNS = '${xlinkNS.getAttributeNS(namespace, "href")}'`);
+        println(`href getAttribute = '${noNS.getAttribute("href")}'`);
+
+        println("Non-matching namespace");
+        xlinkNS.removeAttributeNS(null, "href");
+        noNS.removeAttributeNS(namespace, "href");
+
+        println(`xlink:href getAttributeNS = '${xlinkNS.getAttributeNS(namespace, "href")}'`);
+        println(`href getAttribute = '${noNS.getAttribute("href")}'`);
+
+        println("Non-matching name");
+        xlinkNS.removeAttributeNS(namespace, "thing");
+        noNS.removeAttributeNS(null, "thing");
+
+        println(`xlink:href getAttributeNS = '${xlinkNS.getAttributeNS(namespace, "href")}'`);
+        println(`href getAttribute = '${noNS.getAttribute("href")}'`);
+
+        println("Matching");
+        xlinkNS.removeAttributeNS(namespace, "href");
+        noNS.removeAttributeNS(null, "href");
+
+        println(`xlink:href getAttributeNS = '${xlinkNS.getAttributeNS(namespace, "href")}'`);
+        println(`href getAttribute = '${noNS.getAttribute("href")}'`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -164,6 +164,13 @@ JS::GCPtr<Attr> Element::get_attribute_node(FlyString const& name) const
     return m_attributes->get_attribute(name);
 }
 
+// https://dom.spec.whatwg.org/#dom-element-getattributenodens
+JS::GCPtr<Attr> Element::get_attribute_node_ns(Optional<FlyString> const& namespace_, FlyString const& name) const
+{
+    // The getAttributeNodeNS(namespace, localName) method steps are to return the result of getting an attribute given namespace, localName, and this.
+    return m_attributes->get_attribute_ns(namespace_, name);
+}
+
 // https://dom.spec.whatwg.org/#dom-element-setattribute
 WebIDL::ExceptionOr<void> Element::set_attribute(FlyString const& name, String const& value)
 {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -305,6 +305,13 @@ void Element::remove_attribute(FlyString const& name)
     m_attributes->remove_attribute(name);
 }
 
+// https://dom.spec.whatwg.org/#dom-element-removeattributens
+void Element::remove_attribute_ns(Optional<FlyString> const& namespace_, FlyString const& name)
+{
+    // The removeAttributeNS(namespace, localName) method steps are to remove an attribute given namespace, localName, and this, and then return undefined.
+    m_attributes->remove_attribute_ns(namespace_, name);
+}
+
 // https://dom.spec.whatwg.org/#dom-element-hasattribute
 bool Element::has_attribute(FlyString const& name) const
 {

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -112,6 +112,7 @@ public:
 
     void append_attribute(Attr&);
     void remove_attribute(FlyString const& name);
+    void remove_attribute_ns(Optional<FlyString> const& namespace_, FlyString const& name);
 
     WebIDL::ExceptionOr<bool> toggle_attribute(FlyString const& name, Optional<bool> force);
     size_t attribute_list_size() const;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -119,6 +119,7 @@ public:
     Vector<String> get_attribute_names() const;
 
     JS::GCPtr<Attr> get_attribute_node(FlyString const& name) const;
+    JS::GCPtr<Attr> get_attribute_node_ns(Optional<FlyString> const& namespace_, FlyString const& name) const;
 
     DOMTokenList* class_list();
 

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -35,7 +35,8 @@ interface Element : Node {
     [CEReactions] Attr? setAttributeNode(Attr attr);
     [CEReactions] Attr? setAttributeNodeNS(Attr attr);
 
-    [CEReactions] undefined removeAttribute(DOMString qualifiedName);
+    [CEReactions] undefined removeAttribute([FlyString] DOMString qualifiedName);
+    [CEReactions] undefined removeAttributeNS([FlyString] DOMString? namespace, [FlyString] DOMString localName);
     [CEReactions] boolean toggleAttribute(DOMString qualifiedName, optional boolean force);
     boolean hasAttribute(DOMString qualifiedName);
     boolean hasAttributeNS([FlyString] DOMString? namespace, [FlyString] DOMString localName);

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -43,7 +43,8 @@ interface Element : Node {
     [SameObject] readonly attribute NamedNodeMap attributes;
     sequence<DOMString> getAttributeNames();
 
-    Attr? getAttributeNode(DOMString qualifiedName);
+    Attr? getAttributeNode([FlyString] DOMString qualifiedName);
+    Attr? getAttributeNodeNS([FlyString] DOMString? namespace, [FlyString] DOMString localName);
 
     HTMLCollection getElementsByTagName(DOMString tagName);
     HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);


### PR DESCRIPTION
Continue fleshing out support for attributes with namespaces