### PR TITLE
LibWeb: Use paintable to represent event tracking node

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1177,14 +1177,14 @@ void Document::set_inspected_node(Node* node, Optional<CSS::Selector::PseudoElem
     if (m_inspected_node.ptr() == node && m_inspected_pseudo_element == pseudo_element)
         return;
 
-    if (auto layout_node = inspected_layout_node())
-        layout_node->set_needs_display();
+    if (auto layout_node = inspected_layout_node(); layout_node && layout_node->paintable())
+        layout_node->paintable()->set_needs_display();
 
     m_inspected_node = node;
     m_inspected_pseudo_element = pseudo_element;
 
-    if (auto layout_node = inspected_layout_node())
-        layout_node->set_needs_display();
+    if (auto layout_node = inspected_layout_node(); layout_node && layout_node->paintable())
+        layout_node->paintable()->set_needs_display();
 }
 
 Layout::Node* Document::inspected_layout_node()
@@ -1736,8 +1736,8 @@ void Document::set_focused_element(Element* element)
         m_focused_element->set_needs_style_update(true);
     }
 
-    if (m_layout_root)
-        m_layout_root->set_needs_display();
+    if (paintable())
+        paintable()->set_needs_display();
 
     // Scroll the viewport if necessary to make the newly focused element visible.
     if (m_focused_element) {
@@ -1755,8 +1755,8 @@ void Document::set_active_element(Element* element)
 
     m_active_element = element;
 
-    if (m_layout_root)
-        m_layout_root->set_needs_display();
+    if (paintable())
+        paintable()->set_needs_display();
 }
 
 void Document::set_target_element(Element* element)
@@ -1772,8 +1772,8 @@ void Document::set_target_element(Element* element)
     if (m_target_element)
         m_target_element->set_needs_style_update(true);
 
-    if (m_layout_root)
-        m_layout_root->set_needs_display();
+    if (paintable())
+        paintable()->set_needs_display();
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -588,8 +588,8 @@ Element::RequiredInvalidationAfterStyleChange Element::recompute_style()
     if (!invalidation.rebuild_layout_tree && layout_node()) {
         // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
         layout_node()->apply_style(*m_computed_css_values);
-        if (invalidation.repaint)
-            layout_node()->set_needs_display();
+        if (invalidation.repaint && paintable())
+            paintable()->set_needs_display();
     }
 
     return invalidation;

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Namespace.h>
+#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::DOM {
 
@@ -94,9 +95,9 @@ void Range::update_associated_selection()
 {
     if (!m_associated_selection)
         return;
-    if (auto* layout_root = m_associated_selection->document()->layout_node()) {
+    if (auto* layout_root = m_associated_selection->document()->layout_node(); layout_root && layout_root->paintable()) {
         layout_root->recompute_selection_states();
-        layout_root->set_needs_display();
+        layout_root->paintable()->set_needs_display();
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Platform/AudioCodecPlugin.h>
 
 namespace Web::HTML {
@@ -30,8 +31,8 @@ AudioTrack::AudioTrack(JS::Realm& realm, JS::NonnullGCPtr<HTMLMediaElement> medi
     , m_audio_plugin(Platform::AudioCodecPlugin::create(move(loader)).release_value_but_fixme_should_propagate_errors())
 {
     m_audio_plugin->on_playback_position_updated = [this](auto position) {
-        if (auto* layout_node = m_media_element->layout_node())
-            layout_node->set_needs_display();
+        if (auto const* paintable = m_media_element->paintable())
+            paintable->set_needs_display();
 
         auto playback_position = static_cast<double>(position.to_milliseconds()) / 1000.0;
         m_media_element->set_current_playback_position(playback_position);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -297,6 +297,8 @@ void BrowsingContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_last_child);
     visitor.visit(m_next_sibling);
     visitor.visit(m_previous_sibling);
+
+    m_event_handler.visit_edges(visitor);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#bc-traversable

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -273,9 +273,9 @@ BrowsingContext::BrowsingContext(JS::NonnullGCPtr<Page> page, HTML::NavigableCon
     m_cursor_blink_timer = Core::Timer::create_repeating(500, [this] {
         if (!is_focused_context())
             return;
-        if (m_cursor_position && m_cursor_position->node()->layout_node()) {
+        if (m_cursor_position && m_cursor_position->node()->layout_node() && m_cursor_position->node()->layout_node()->paintable()) {
             m_cursor_blink_state = !m_cursor_blink_state;
-            m_cursor_position->node()->layout_node()->set_needs_display();
+            m_cursor_position->node()->paintable()->set_needs_display();
         }
     }).release_value_but_fixme_should_propagate_errors();
 }
@@ -327,8 +327,8 @@ void BrowsingContext::reset_cursor_blink_cycle()
 {
     m_cursor_blink_state = true;
     m_cursor_blink_timer->restart();
-    if (m_cursor_position && m_cursor_position->node()->layout_node())
-        m_cursor_position->node()->layout_node()->set_needs_display();
+    if (m_cursor_position && m_cursor_position->node()->paintable())
+        m_cursor_position->node()->paintable()->set_needs_display();
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context
@@ -404,13 +404,13 @@ void BrowsingContext::set_cursor_position(JS::NonnullGCPtr<DOM::Position> positi
     if (m_cursor_position && m_cursor_position->equals(position))
         return;
 
-    if (m_cursor_position && m_cursor_position->node()->layout_node())
-        m_cursor_position->node()->layout_node()->set_needs_display();
+    if (m_cursor_position && m_cursor_position->node()->paintable())
+        m_cursor_position->node()->paintable()->set_needs_display();
 
     m_cursor_position = position;
 
-    if (m_cursor_position && m_cursor_position->node()->layout_node())
-        m_cursor_position->node()->layout_node()->set_needs_display();
+    if (m_cursor_position && m_cursor_position->node()->paintable())
+        m_cursor_position->node()->paintable()->set_needs_display();
 
     reset_cursor_blink_cycle();
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/URL/URL.h>
 
 namespace Web::HTML {
@@ -391,9 +392,9 @@ CSSPixelPoint BrowsingContext::to_top_level_position(CSSPixelPoint a_position)
             break;
         if (!ancestor->container())
             return {};
-        if (!ancestor->container()->layout_node())
+        if (!ancestor->container()->paintable())
             return {};
-        position.translate_by(ancestor->container()->layout_node()->box_type_agnostic_position());
+        position.translate_by(ancestor->container()->paintable()->box_type_agnostic_position());
     }
     return position;
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/TextMetrics.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Layout/TextNode.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Platform/FontPlugin.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -174,9 +175,9 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
 void CanvasRenderingContext2D::did_draw(Gfx::FloatRect const&)
 {
     // FIXME: Make use of the rect to reduce the invalidated area when possible.
-    if (!canvas_element().layout_node())
+    if (!canvas_element().paintable())
         return;
-    canvas_element().layout_node()->set_needs_display();
+    canvas_element().paintable()->set_needs_display();
 }
 
 Gfx::Painter* CanvasRenderingContext2D::painter()

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::HTML {
 
@@ -78,8 +79,8 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> 
     } else if (name.equals_ignoring_ascii_case("background"sv)) {
         m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value.value_or(String {})));
         m_background_style_value->on_animate = [this] {
-            if (layout_node()) {
-                layout_node()->set_needs_display();
+            if (paintable()) {
+                paintable()->set_needs_display();
             }
         };
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -215,7 +215,7 @@ int HTMLElement::offset_top() const
     //    ignoring any transforms that apply to the element and its ancestors, and terminate this algorithm.
     auto offset_parent = this->offset_parent();
     if (!offset_parent || !offset_parent->layout_node()) {
-        auto position = layout_node()->box_type_agnostic_position();
+        auto position = paintable()->box_type_agnostic_position();
         return position.y().to_int();
     }
 
@@ -224,8 +224,8 @@ int HTMLElement::offset_top() const
     //    from the y-coordinate of the top border edge of the first box associated with the element,
     //    relative to the initial containing block origin,
     //    ignoring any transforms that apply to the element and its ancestors.
-    auto offset_parent_position = offset_parent->layout_node()->box_type_agnostic_position();
-    auto position = layout_node()->box_type_agnostic_position();
+    auto offset_parent_position = offset_parent->paintable()->box_type_agnostic_position();
+    auto position = paintable()->box_type_agnostic_position();
     return position.y().to_int() - offset_parent_position.y().to_int();
 }
 
@@ -248,7 +248,7 @@ int HTMLElement::offset_left() const
     //    ignoring any transforms that apply to the element and its ancestors, and terminate this algorithm.
     auto offset_parent = this->offset_parent();
     if (!offset_parent || !offset_parent->layout_node()) {
-        auto position = layout_node()->box_type_agnostic_position();
+        auto position = paintable()->box_type_agnostic_position();
         return position.x().to_int();
     }
 
@@ -257,8 +257,8 @@ int HTMLElement::offset_left() const
     //    from the x-coordinate of the left border edge of the first CSS layout box associated with the element,
     //    relative to the initial containing block origin,
     //    ignoring any transforms that apply to the element and its ancestors.
-    auto offset_parent_position = offset_parent->layout_node()->box_type_agnostic_position();
-    auto position = layout_node()->box_type_agnostic_position();
+    auto offset_parent_position = offset_parent->paintable()->box_type_agnostic_position();
+    auto position = paintable()->box_type_agnostic_position();
     return position.x().to_int() - offset_parent_position.x().to_int();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1005,8 +1005,8 @@ void HTMLImageElement::animate()
         }
     }
 
-    if (layout_node())
-        layout_node()->set_needs_display();
+    if (paintable())
+        paintable()->set_needs_display();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -35,6 +35,7 @@
 #include <LibWeb/HTML/VideoTrackList.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/MimeSniff/MimeType.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::HTML {
@@ -325,8 +326,8 @@ void HTMLMediaElement::set_duration(double duration)
 
     m_duration = duration;
 
-    if (auto* layout_node = this->layout_node())
-        layout_node->set_needs_display();
+    if (auto* paintable = this->paintable())
+        paintable->set_needs_display();
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLMediaElement::play()
@@ -424,8 +425,8 @@ void HTMLMediaElement::volume_or_muted_attribute_changed()
 
     // FIXME: Then, if the media element is not allowed to play, the user agent must run the internal pause steps for the media element.
 
-    if (auto* layout_node = this->layout_node())
-        layout_node->set_needs_display();
+    if (auto* paintable = this->paintable())
+        paintable->set_needs_display();
 
     on_volume_change();
 }
@@ -1586,8 +1587,8 @@ void HTMLMediaElement::set_show_poster(bool show_poster)
 
     m_show_poster = show_poster;
 
-    if (auto* layout_node = this->layout_node())
-        layout_node->set_needs_display();
+    if (auto* paintable = this->paintable())
+        paintable->set_needs_display();
 }
 
 void HTMLMediaElement::set_paused(bool paused)
@@ -1600,8 +1601,8 @@ void HTMLMediaElement::set_paused(bool paused)
     if (m_paused)
         on_paused();
 
-    if (auto* layout_node = this->layout_node())
-        layout_node->set_needs_display();
+    if (auto* paintable = this->paintable())
+        paintable->set_needs_display();
     set_needs_style_update(true);
 }
 
@@ -1928,8 +1929,8 @@ void HTMLMediaElement::set_layout_display_time(Badge<Painting::MediaPaintable>, 
 
     m_display_time = move(display_time);
 
-    if (auto* layout_node = this->layout_node())
-        layout_node->set_needs_display();
+    if (auto* paintable = this->paintable())
+        paintable->set_needs_display();
 }
 
 double HTMLMediaElement::layout_display_time(Badge<Painting::MediaPaintable>) const

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/VideoTrack.h>
 #include <LibWeb/Layout/VideoBox.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
 
 namespace Web::HTML {
@@ -102,8 +103,8 @@ void HTMLVideoElement::set_video_track(JS::GCPtr<HTML::VideoTrack> video_track)
 void HTMLVideoElement::set_current_frame(Badge<VideoTrack>, RefPtr<Gfx::Bitmap> frame, double position)
 {
     m_current_frame = { move(frame), position };
-    if (layout_node())
-        layout_node()->set_needs_display();
+    if (paintable())
+        paintable()->set_needs_display();
 }
 
 void HTMLVideoElement::on_playing()

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1990,8 +1990,8 @@ void Navigable::set_needs_display(CSSPixelRect const& rect)
         return;
     }
 
-    if (container() && container()->layout_node())
-        container()->layout_node()->set_needs_display();
+    if (container() && container()->paintable())
+        container()->paintable()->set_needs_display();
 }
 
 // https://html.spec.whatwg.org/#rendering-opportunity

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -31,6 +31,7 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/XHR/FormData.h>
 
@@ -1920,9 +1921,9 @@ CSSPixelPoint Navigable::to_top_level_position(CSSPixelPoint a_position)
             break;
         if (!ancestor->container())
             return {};
-        if (!ancestor->container()->layout_node())
+        if (!ancestor->container()->paintable())
             return {};
-        position.translate_by(ancestor->container()->layout_node()->box_type_agnostic_position());
+        position.translate_by(ancestor->container()->paintable()->box_type_agnostic_position());
     }
     return position;
 }

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -60,15 +60,6 @@ bool Box::is_user_scrollable() const
     return computed_values().overflow_y() == CSS::Overflow::Scroll || computed_values().overflow_y() == CSS::Overflow::Auto;
 }
 
-void Box::set_needs_display()
-{
-    if (!navigable())
-        return;
-
-    if (paintable_box())
-        navigable()->set_needs_display(paintable_box()->absolute_rect());
-}
-
 bool Box::is_body() const
 {
     return dom_node() && dom_node() == document().body();

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -25,8 +25,6 @@ public:
     Painting::PaintableBox const* paintable_box() const;
     Painting::PaintableBox* paintable_box();
 
-    virtual void set_needs_display() override;
-
     bool is_body() const;
 
     // https://www.w3.org/TR/css-images-3/#natural-dimensions

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -226,31 +226,6 @@ Viewport& Node::root()
     return *document().layout_node();
 }
 
-void Node::set_needs_display()
-{
-    auto* containing_block = this->containing_block();
-    if (!containing_block)
-        return;
-    if (!containing_block->paintable_box())
-        return;
-    auto navigable = this->navigable();
-    if (!navigable)
-        return;
-
-    if (this->paintable() && is<Painting::InlinePaintable>(this->paintable())) {
-        auto const& fragments = static_cast<Painting::InlinePaintable*>(this->paintable())->fragments();
-        for (auto const& fragment : fragments)
-            navigable->set_needs_display(fragment.absolute_rect());
-    }
-
-    if (!is<Painting::PaintableWithLines>(*containing_block->paintable_box()))
-        return;
-    static_cast<Painting::PaintableWithLines const&>(*containing_block->paintable_box()).for_each_fragment([&](auto& fragment) {
-        navigable->set_needs_display(fragment.absolute_rect());
-        return IterationDecision::Continue;
-    });
-}
-
 bool Node::is_floating() const
 {
     if (!has_style())

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -251,29 +251,6 @@ void Node::set_needs_display()
     });
 }
 
-CSSPixelPoint Node::box_type_agnostic_position() const
-{
-    if (is<Box>(*this))
-        return verify_cast<Box>(*this).paintable_box()->absolute_position();
-    VERIFY(is_inline());
-
-    if (paintable() && paintable()->is_inline_paintable()) {
-        auto const& inline_paintable = static_cast<Painting::InlinePaintable const&>(*paintable());
-        if (!inline_paintable.fragments().is_empty())
-            return inline_paintable.fragments().first().absolute_rect().location();
-        VERIFY_NOT_REACHED();
-    }
-
-    CSSPixelPoint position;
-    if (auto const* block = containing_block(); block && block->paintable() && is<Painting::PaintableWithLines>(*block->paintable())) {
-        static_cast<Painting::PaintableWithLines const&>(*block->paintable_box()).for_each_fragment([&](auto& fragment) {
-            position = fragment.absolute_rect().location();
-            return IterationDecision::Break;
-        });
-    }
-    return position;
-}
-
 bool Node::is_floating() const
 {
     if (!has_style())

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -160,8 +160,6 @@ public:
     bool children_are_inline() const { return m_children_are_inline; }
     void set_children_are_inline(bool value) { m_children_are_inline = value; }
 
-    CSSPixelPoint box_type_agnostic_position() const;
-
     enum class SelectionState {
         None,        // No selection
         Start,       // Selection starts in this Node

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -155,8 +155,6 @@ public:
     void removed_from(Node&) { }
     void children_changed() { }
 
-    virtual void set_needs_display();
-
     bool children_are_inline() const { return m_children_are_inline; }
     void set_children_are_inline(bool value) { m_children_are_inline = value; }
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -116,7 +116,7 @@ static Gfx::StandardCursor cursor_css_to_gfx(Optional<CSS::Cursor> cursor)
 
 static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Layout::Node const& layout_node)
 {
-    auto top_left_of_layout_node = layout_node.box_type_agnostic_position();
+    auto top_left_of_layout_node = layout_node.paintable()->box_type_agnostic_position();
     return {
         position.x() - top_left_of_layout_node.x(),
         position.y() - top_left_of_layout_node.y()

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -12,6 +12,7 @@
 #include <Kernel/API/KeyCode.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>
+#include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/EditEventHandler.h>
@@ -33,9 +34,11 @@ public:
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);
 
-    void set_mouse_event_tracking_layout_node(Layout::Node*);
+    void set_mouse_event_tracking_paintable(Painting::Paintable*);
 
     void set_edit_event_handler(NonnullOwnPtr<EditEventHandler> value) { m_edit_event_handler = move(value); }
+
+    void visit_edges(JS::Cell::Visitor& visitor) const;
 
 private:
     bool focus_next_element();
@@ -59,7 +62,7 @@ private:
 
     bool m_in_mouse_selection { false };
 
-    WeakPtr<Layout::Node> m_mouse_event_tracking_layout_node;
+    JS::GCPtr<Painting::Paintable> m_mouse_event_tracking_paintable;
 
     NonnullOwnPtr<EditEventHandler> m_edit_event_handler;
 

--- a/Userland/Libraries/LibWeb/Painting/LabelablePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/LabelablePaintable.cpp
@@ -42,7 +42,7 @@ LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousedown
 
     set_being_pressed(true);
     m_tracking_mouse = true;
-    browsing_context().event_handler().set_mouse_event_tracking_layout_node(&layout_box());
+    browsing_context().event_handler().set_mouse_event_tracking_paintable(this);
     return DispatchEventOfSameName::Yes;
 }
 
@@ -57,7 +57,7 @@ LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mouseup(B
 
     set_being_pressed(false);
     m_tracking_mouse = false;
-    browsing_context().event_handler().set_mouse_event_tracking_layout_node(nullptr);
+    browsing_context().event_handler().set_mouse_event_tracking_paintable(nullptr);
     return DispatchEventOfSameName::Yes;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -284,7 +284,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousedown(Badge<E
     }
 
     if (media_element.layout_mouse_tracking_component({}).has_value())
-        const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_layout_node(&layout_node());
+        const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_paintable(this);
 
     return DispatchEventOfSameName::Yes;
 }
@@ -306,7 +306,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<Eve
             break;
         }
 
-        const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_layout_node(nullptr);
+        const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_paintable(nullptr);
         media_element.set_layout_mouse_tracking_component({}, {});
 
         return DispatchEventOfSameName::Yes;

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -73,6 +73,11 @@ HTML::BrowsingContext& Paintable::browsing_context()
     return m_browsing_context;
 }
 
+JS::GCPtr<HTML::Navigable> Paintable::navigable() const
+{
+    return document().navigable();
+}
+
 Paintable::DispatchEventOfSameName Paintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned)
 {
     return DispatchEventOfSameName::Yes;
@@ -116,6 +121,31 @@ void Paintable::set_stacking_context(NonnullOwnPtr<StackingContext> stacking_con
 void Paintable::invalidate_stacking_context()
 {
     m_stacking_context = nullptr;
+}
+
+void Paintable::set_needs_display() const
+{
+    auto* containing_block = this->containing_block();
+    if (!containing_block)
+        return;
+    if (!containing_block->paintable_box())
+        return;
+    auto navigable = this->navigable();
+    if (!navigable)
+        return;
+
+    if (is<Painting::InlinePaintable>(*this)) {
+        auto const& fragments = static_cast<Painting::InlinePaintable const*>(this)->fragments();
+        for (auto const& fragment : fragments)
+            navigable->set_needs_display(fragment.absolute_rect());
+    }
+
+    if (!is<Painting::PaintableWithLines>(*containing_block->paintable_box()))
+        return;
+    static_cast<Painting::PaintableWithLines const&>(*containing_block->paintable_box()).for_each_fragment([&](auto& fragment) {
+        navigable->set_needs_display(fragment.absolute_rect());
+        return IterationDecision::Continue;
+    });
 }
 
 PaintableBox const* Paintable::nearest_scrollable_ancestor_within_stacking_context() const

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -186,6 +186,8 @@ public:
 
     PaintableBox const* nearest_scrollable_ancestor_within_stacking_context() const;
 
+    CSSPixelPoint box_type_agnostic_position() const;
+
 protected:
     explicit Paintable(Layout::Node const&);
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -165,7 +165,9 @@ public:
     [[nodiscard]] HTML::BrowsingContext const& browsing_context() const;
     [[nodiscard]] HTML::BrowsingContext& browsing_context();
 
-    void set_needs_display() const { const_cast<Layout::Node&>(*m_layout_node).set_needs_display(); }
+    JS::GCPtr<HTML::Navigable> navigable() const;
+
+    virtual void set_needs_display() const;
 
     Layout::Box const* containing_block() const
     {

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -80,7 +80,7 @@ void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
         return;
     }
 
-    node.set_needs_display();
+    set_needs_display();
 }
 
 void PaintableBox::scroll_by(int delta_x, int delta_y)
@@ -788,6 +788,12 @@ Optional<HitTestResult> PaintableWithLines::hit_test(CSSPixelPoint position, Hit
     if (is_visible() && absolute_border_box_rect().contains(position.x(), position.y()))
         return HitTestResult { const_cast<PaintableWithLines&>(*this) };
     return {};
+}
+
+void PaintableBox::set_needs_display() const
+{
+    if (auto navigable = this->navigable())
+        navigable->set_needs_display(absolute_rect());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -124,6 +124,8 @@ public:
     DOM::Node const* dom_node() const { return layout_box().dom_node(); }
     DOM::Node* dom_node() { return layout_box().dom_node(); }
 
+    virtual void set_needs_display() const override;
+
     virtual void apply_scroll_offset(PaintContext&, PaintPhase) const override;
     virtual void reset_scroll_offset(PaintContext&, PaintPhase) const override;
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -24,7 +24,8 @@ PaintableFragment::PaintableFragment(Layout::LineBoxFragment const& fragment)
 CSSPixelRect const PaintableFragment::absolute_rect() const
 {
     CSSPixelRect rect { {}, size() };
-    rect.set_location(m_layout_node->containing_block()->paintable_box()->absolute_position());
+    if (m_layout_node->containing_block() && m_layout_node->containing_block()->paintable_box())
+        rect.set_location(m_layout_node->containing_block()->paintable_box()->absolute_position());
     rect.translate_by(offset());
     return rect;
 }

--- a/Userland/Libraries/LibWeb/Painting/TextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/TextPaintable.cpp
@@ -42,7 +42,7 @@ TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousedown(Badge<Eve
     if (!label)
         return DispatchEventOfSameName::No;
     const_cast<Layout::Label*>(label)->handle_mousedown_on_label({}, position, button);
-    const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_layout_node(&const_cast<Layout::TextNode&>(layout_node()));
+    const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_paintable(this);
     return DispatchEventOfSameName::Yes;
 }
 
@@ -53,7 +53,7 @@ TextPaintable::DispatchEventOfSameName TextPaintable::handle_mouseup(Badge<Event
         return DispatchEventOfSameName::No;
 
     const_cast<Layout::Label*>(label)->handle_mouseup_on_label({}, position, button);
-    const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_layout_node(nullptr);
+    const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_paintable(nullptr);
     return DispatchEventOfSameName::Yes;
 }
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -8,6 +8,7 @@
 #include <LibGL/GLContext.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
 namespace Web::WebGL {
@@ -99,9 +100,9 @@ void WebGLRenderingContextBase::needs_to_present()
 {
     m_should_present = true;
 
-    if (!canvas_element().layout_node())
+    if (!canvas_element().paintable())
         return;
-    canvas_element().layout_node()->set_needs_display();
+    canvas_element().paintable()->set_needs_display();
 }
 
 void WebGLRenderingContextBase::set_error(GLenum error)


### PR DESCRIPTION
The use of layout nodes likely predated the paintable tree, but now there is no point in introducing another level of indirection.