### PR TITLE
More tiny Hurd fixes

### DIFF
--- a/Userland/Libraries/LibJIT/GDBElf.cpp
+++ b/Userland/Libraries/LibJIT/GDBElf.cpp
@@ -26,7 +26,7 @@ Optional<FixedArray<u8>> build_gdb_image(ReadonlyBytes code, StringView file_sym
     auto const text = sections.build_nobits([&](Elf64_Shdr& text) {
         text.sh_name = section_names.insert(".text"sv);
         text.sh_flags = SHF_EXECINSTR | SHF_ALLOC;
-        text.sh_addr = bit_cast<u64>(code.offset(0));
+        text.sh_addr = bit_cast<uintptr_t>(code.offset(0));
         text.sh_size = code.size();
         text.sh_link = 0;
         text.sh_info = 0;

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
@@ -16,7 +16,7 @@
 #endif
 
 // FIXME: Implement MADV_FREE and/or MADV_DONTNEED on SerenityOS.
-#if defined(AK_OS_SERENITY) || (!defined(MADV_FREE) && !defined(MADV_DONTNEED))
+#if defined(AK_OS_SERENITY) || defined(AK_OS_GNU_HURD) || (!defined(MADV_FREE) && !defined(MADV_DONTNEED))
 #    define USE_FALLBACK_BLOCK_DEALLOCATION
 #endif
 

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -39,7 +39,7 @@ static ErrorOr<int> create_database_socket(ByteString const& socket_path)
     TRY(Core::System::fcntl(socket_fd, F_SETFD, FD_CLOEXEC));
 #    endif
 
-#    if !defined(AK_OS_BSD_GENERIC)
+#    if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_GNU_HURD)
     TRY(Core::System::fchmod(socket_fd, 0600));
 #    endif
 


### PR DESCRIPTION
More tiny fixes for regressions on GNU/Hurd introduced since https://github.com/SerenityOS/serenity/pull/21780.

<details>
<summary>I'm still building with this additional patch on top</summary>
<pre><code>diff --git a/Meta/CMake/lagom_compile_options.cmake b/Meta/CMake/lagom_compile_options.cmake
index 2f7ba5213e..02cda3a33c 100644
--- a/Meta/CMake/lagom_compile_options.cmake
+++ b/Meta/CMake/lagom_compile_options.cmake
@@ -4,6 +4,8 @@ add_compile_options(-Wno-maybe-uninitialized)
 add_compile_options(-Wno-shorten-64-to-32)
 add_compile_options(-fsigned-char)
 add_compile_options(-ggnu-pubnames)
+add_compile_options(-O2)
+add_compile_options(-mstack-alignment=16)
 if (NOT WIN32)
     add_compile_options(-fPIC)
 endif()
diff --git a/Userland/Libraries/LibCore/System.cpp b/Userland/Libraries/LibCore/System.cpp
index ab49f2cadf..cadb675358 100644
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -519,6 +519,20 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
+#elif defined(__GNU__)
+    file_t dir = file_name_lookup("/tmp", O_DIRECTORY, 0);
+    VERIFY(dir);
+    file_t file;
+    int err = dir_mkfile(dir, O_RDWR, 0777, &file);
+    VERIFY(err == 0);
+    err = mach_port_deallocate(mach_task_self(), dir);
+    VERIFY(err == 0);
+    fd = openport(file, O_CLOEXEC | O_IGNORE_CTTY);
+    if (::ftruncate(fd, size) < 0) {
+        auto saved_errno = errno;
+        TRY(close(fd));
+        return Error::from_errno(saved_errno);
+    }
 #elif defined(SHM_ANON)
     fd = shm_open(SHM_ANON, O_RDWR | O_CREAT | options, 0600);
     if (fd < 0)</code></pre></details>

![Screenshot from 2024-01-14 17-26-26](https://github.com/SerenityOS/serenity/assets/10091584/3225882d-3f64-454f-87d7-b53878d32b06)