### PR TITLE
Kernel+Ports: Restore and improve SDL2 keyboard mapping

### DIFF
--- a/Kernel/API/KeyCode.h
+++ b/Kernel/API/KeyCode.h
@@ -152,7 +152,7 @@ enum KeyCode : u8 {
         Key_Shift
     = Key_LeftShift,
 };
-int const key_code_count = Key_Menu;
+size_t const key_code_count = Key_Menu + 1;
 
 enum KeyModifier {
     Mod_None = 0x00,

--- a/Kernel/Devices/HID/PS2/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2/KeyboardDevice.cpp
@@ -50,7 +50,7 @@ static constexpr KeyCodeEntry unshifted_scan_code_set1_key_map[0x80] = {
 
 // clang-format off
 static constexpr KeyCodeEntry shifted_scan_code_set1_key_map[0x100] = {
-    { Key_Invalid, 0xFF },        { Key_Escape, 1 },                    { Key_Escape, 2 },                { Key_AtSign, 3 },
+    { Key_Invalid, 0xFF },        { Key_Escape, 1 },                    { Key_ExclamationPoint, 2 },      { Key_AtSign, 3 },
     { Key_Hashtag, 4 },           { Key_Dollar, 5 },                    { Key_Percent, 6 },               { Key_Circumflex, 7 },
     { Key_Ampersand, 8 },         { Key_Asterisk, 9 },                  { Key_LeftParen, 0x0A },          { Key_RightParen, 0x0B },
     { Key_Underscore, 0xC },      { Key_Plus, 0x4E },                   { Key_Backspace, 0x0E },          { Key_Tab, 0x0F },

--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -31,19 +31,19 @@ Co-Authored-By: Tim Ledbetter <timledbetter@gmail.com>
  src/audio/SDL_audio.c                         |   3 +
  src/audio/SDL_sysaudio.h                      |   1 +
  src/audio/serenity/SDL_serenityaudio.cpp      | 166 +++++
- src/audio/serenity/SDL_serenityaudio.h        |  38 ++
+ src/audio/serenity/SDL_serenityaudio.h        |  38 +
  src/stdlib/SDL_stdlib.c                       |   2 +-
  src/video/SDL_sysvideo.h                      |   1 +
  src/video/SDL_video.c                         |  13 +
  src/video/serenity/SDL_serenityevents.cpp     |  52 ++
  src/video/serenity/SDL_serenityevents_c.h     |  33 +
  src/video/serenity/SDL_serenitymessagebox.cpp |  40 ++
- src/video/serenity/SDL_serenitymessagebox.h   |  38 ++
+ src/video/serenity/SDL_serenitymessagebox.h   |  38 +
  src/video/serenity/SDL_serenitymouse.cpp      | 142 ++++
  src/video/serenity/SDL_serenitymouse.h        |  39 ++
- src/video/serenity/SDL_serenityvideo.cpp      | 617 ++++++++++++++++++
+ src/video/serenity/SDL_serenityvideo.cpp      | 655 ++++++++++++++++++
  src/video/serenity/SDL_serenityvideo.h        | 101 +++
- 21 files changed, 1320 insertions(+), 26 deletions(-)
+ 21 files changed, 1358 insertions(+), 26 deletions(-)
  create mode 100644 src/audio/serenity/SDL_serenityaudio.cpp
  create mode 100644 src/audio/serenity/SDL_serenityaudio.h
  create mode 100644 src/video/serenity/SDL_serenityevents.cpp
@@ -889,10 +889,10 @@ index 0000000000000000000000000000000000000000..039f0361b3d1b248e218ea69495f58e5
 +/* vi: set ts=4 sw=4 expandtab: */
 diff --git a/src/video/serenity/SDL_serenityvideo.cpp b/src/video/serenity/SDL_serenityvideo.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..411deb26028567d753b8335e606d59d05e004caa
+index 0000000000000000000000000000000000000000..26ff18b1c878f7a14c32554859bd088522806b91
 --- /dev/null
 +++ b/src/video/serenity/SDL_serenityvideo.cpp
-@@ -0,0 +1,617 @@
+@@ -0,0 +1,655 @@
 +/*
 +  Simple DirectMedia Layer
 +  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
@@ -932,6 +932,8 @@ index 0000000000000000000000000000000000000000..411deb26028567d753b8335e606d59d0
 +#    include "SDL_serenitymouse.h"
 +#    include "SDL_serenityvideo.h"
 +
++#    include <AK/Array.h>
++#    include <Kernel/API/KeyCode.h>
 +#    include <LibCore/EventLoop.h>
 +#    include <LibGUI/Application.h>
 +#    include <LibGUI/Desktop.h>
@@ -942,114 +944,150 @@ index 0000000000000000000000000000000000000000..411deb26028567d753b8335e606d59d0
 +#    include <LibMain/Main.h>
 +#    include <dlfcn.h>
 +
-+static SDL_Scancode scancode_map[] = {
-+    SDL_SCANCODE_UNKNOWN,
-+    SDL_SCANCODE_ESCAPE,
-+    SDL_SCANCODE_TAB,
-+    SDL_SCANCODE_BACKSPACE,
-+    SDL_SCANCODE_RETURN,
-+    SDL_SCANCODE_INSERT,
-+    SDL_SCANCODE_DELETE,
-+    SDL_SCANCODE_PRINTSCREEN,
-+    SDL_SCANCODE_SYSREQ,
-+    SDL_SCANCODE_HOME,
-+    SDL_SCANCODE_END,
-+    SDL_SCANCODE_LEFT,
-+    SDL_SCANCODE_UP,
-+    SDL_SCANCODE_RIGHT,
-+    SDL_SCANCODE_DOWN,
-+    SDL_SCANCODE_PAGEUP,
-+    SDL_SCANCODE_PAGEDOWN,
-+    SDL_SCANCODE_LSHIFT,
-+    SDL_SCANCODE_RSHIFT,
-+    SDL_SCANCODE_LCTRL,
-+    SDL_SCANCODE_LALT,
-+    SDL_SCANCODE_CAPSLOCK,
-+    SDL_SCANCODE_NUMLOCKCLEAR,
-+    SDL_SCANCODE_SCROLLLOCK,
-+    SDL_SCANCODE_F1,
-+    SDL_SCANCODE_F2,
-+    SDL_SCANCODE_F3,
-+    SDL_SCANCODE_F4,
-+    SDL_SCANCODE_F5,
-+    SDL_SCANCODE_F6,
-+    SDL_SCANCODE_F7,
-+    SDL_SCANCODE_F8,
-+    SDL_SCANCODE_F9,
-+    SDL_SCANCODE_F10,
-+    SDL_SCANCODE_F11,
-+    SDL_SCANCODE_F12,
-+    SDL_SCANCODE_SPACE,
-+    SDL_SCANCODE_1,
-+    SDL_SCANCODE_APOSTROPHE,
-+    SDL_SCANCODE_3,
-+    SDL_SCANCODE_4,
-+    SDL_SCANCODE_5,
-+    SDL_SCANCODE_7,
-+    SDL_SCANCODE_APOSTROPHE,
-+    SDL_SCANCODE_9,
-+    SDL_SCANCODE_0,
-+    SDL_SCANCODE_8,
-+    SDL_SCANCODE_EQUALS,
-+    SDL_SCANCODE_COMMA,
-+    SDL_SCANCODE_MINUS,
-+    SDL_SCANCODE_PERIOD,
-+    SDL_SCANCODE_SLASH,
-+    SDL_SCANCODE_0,
-+    SDL_SCANCODE_1,
-+    SDL_SCANCODE_2,
-+    SDL_SCANCODE_3,
-+    SDL_SCANCODE_4,
-+    SDL_SCANCODE_5,
-+    SDL_SCANCODE_6,
-+    SDL_SCANCODE_7,
-+    SDL_SCANCODE_8,
-+    SDL_SCANCODE_9,
-+    SDL_SCANCODE_SEMICOLON,
-+    SDL_SCANCODE_SEMICOLON,
-+    SDL_SCANCODE_COMMA,
-+    SDL_SCANCODE_EQUALS,
-+    SDL_SCANCODE_PERIOD,
-+    SDL_SCANCODE_SLASH,
-+    SDL_SCANCODE_2,
-+    SDL_SCANCODE_A,
-+    SDL_SCANCODE_B,
-+    SDL_SCANCODE_C,
-+    SDL_SCANCODE_D,
-+    SDL_SCANCODE_E,
-+    SDL_SCANCODE_F,
-+    SDL_SCANCODE_G,
-+    SDL_SCANCODE_H,
-+    SDL_SCANCODE_I,
-+    SDL_SCANCODE_J,
-+    SDL_SCANCODE_K,
-+    SDL_SCANCODE_L,
-+    SDL_SCANCODE_M,
-+    SDL_SCANCODE_N,
-+    SDL_SCANCODE_O,
-+    SDL_SCANCODE_P,
-+    SDL_SCANCODE_Q,
-+    SDL_SCANCODE_R,
-+    SDL_SCANCODE_S,
-+    SDL_SCANCODE_T,
-+    SDL_SCANCODE_U,
-+    SDL_SCANCODE_V,
-+    SDL_SCANCODE_W,
-+    SDL_SCANCODE_X,
-+    SDL_SCANCODE_Y,
-+    SDL_SCANCODE_Z,
-+    SDL_SCANCODE_LEFTBRACKET,
-+    SDL_SCANCODE_RIGHTBRACKET,
-+    SDL_SCANCODE_BACKSLASH,
-+    SDL_SCANCODE_6,
-+    SDL_SCANCODE_MINUS,
-+    SDL_SCANCODE_LEFTBRACKET,
-+    SDL_SCANCODE_RIGHTBRACKET,
-+    SDL_SCANCODE_BACKSLASH,
-+    SDL_SCANCODE_GRAVE,
-+    SDL_SCANCODE_GRAVE,
-+    SDL_SCANCODE_UNKNOWN,
-+};
++static consteval AK::Array<SDL_Scancode, key_code_count> generate_scancode_map()
++{
++    auto map = AK::Array<SDL_Scancode, key_code_count>::from_repeated_value(SDL_SCANCODE_UNKNOWN);
++
++    // Below list is in order of Kernel/API/KeyCode.h; the shift modifier is applied by SDL
++    // and as such, unshifted scancodes must be used (e.g. dollar sign => 4).
++#   define MAP_KEYCODE(A,B) map[to_underlying(KeyCode::Key_##A)] = SDL_SCANCODE_##B;
++    MAP_KEYCODE(Escape, ESCAPE);
++    MAP_KEYCODE(Tab, TAB);
++    MAP_KEYCODE(Backspace, BACKSPACE);
++    MAP_KEYCODE(Return, RETURN);
++    MAP_KEYCODE(Insert, INSERT);
++    MAP_KEYCODE(Delete, DELETE);
++    MAP_KEYCODE(PrintScreen, PRINTSCREEN);
++    MAP_KEYCODE(PauseBreak, PAUSE);
++    MAP_KEYCODE(SysRq, SYSREQ);
++    MAP_KEYCODE(Home, HOME);
++    MAP_KEYCODE(End, END);
++    MAP_KEYCODE(Left, LEFT);
++    MAP_KEYCODE(Up, UP);
++    MAP_KEYCODE(Right, RIGHT);
++    MAP_KEYCODE(Down, DOWN);
++    MAP_KEYCODE(PageUp, PAGEUP);
++    MAP_KEYCODE(PageDown, PAGEDOWN);
++    MAP_KEYCODE(LeftShift, LSHIFT);
++    MAP_KEYCODE(RightShift, RSHIFT);
++    MAP_KEYCODE(Control, LCTRL);
++    MAP_KEYCODE(RightControl, RCTRL);
++    MAP_KEYCODE(Alt, LALT);
++    MAP_KEYCODE(RightAlt, RALT);
++    MAP_KEYCODE(CapsLock, CAPSLOCK);
++    MAP_KEYCODE(NumLock, NUMLOCKCLEAR);
++    MAP_KEYCODE(ScrollLock, SCROLLLOCK);
++    MAP_KEYCODE(F1, F1);
++    MAP_KEYCODE(F2, F2);
++    MAP_KEYCODE(F3, F3);
++    MAP_KEYCODE(F4, F4);
++    MAP_KEYCODE(F5, F5);
++    MAP_KEYCODE(F6, F6);
++    MAP_KEYCODE(F7, F7);
++    MAP_KEYCODE(F8, F8);
++    MAP_KEYCODE(F9, F9);
++    MAP_KEYCODE(F10, F10);
++    MAP_KEYCODE(F11, F11);
++    MAP_KEYCODE(F12, F12);
++    MAP_KEYCODE(Space, SPACE);
++    MAP_KEYCODE(ExclamationPoint, 1);
++    MAP_KEYCODE(DoubleQuote, APOSTROPHE);
++    MAP_KEYCODE(Hashtag, 3);
++    MAP_KEYCODE(Dollar, 4);
++    MAP_KEYCODE(Percent, 5);
++    MAP_KEYCODE(Ampersand, 7);
++    MAP_KEYCODE(Apostrophe, APOSTROPHE);
++    MAP_KEYCODE(LeftParen, 9);
++    MAP_KEYCODE(RightParen, 0);
++    MAP_KEYCODE(Asterisk, 8);
++    MAP_KEYCODE(Plus, EQUALS);
++    MAP_KEYCODE(Comma, COMMA);
++    MAP_KEYCODE(Minus, MINUS);
++    MAP_KEYCODE(Period, PERIOD);
++    MAP_KEYCODE(Slash, SLASH);
++    MAP_KEYCODE(0, 0);
++    MAP_KEYCODE(1, 1);
++    MAP_KEYCODE(2, 2);
++    MAP_KEYCODE(3, 3);
++    MAP_KEYCODE(4, 4);
++    MAP_KEYCODE(5, 5);
++    MAP_KEYCODE(6, 6);
++    MAP_KEYCODE(7, 7);
++    MAP_KEYCODE(8, 8);
++    MAP_KEYCODE(9, 9);
++    MAP_KEYCODE(Colon, SEMICOLON);
++    MAP_KEYCODE(Semicolon, SEMICOLON);
++    MAP_KEYCODE(LessThan, COMMA);
++    MAP_KEYCODE(Equal, EQUALS);
++    MAP_KEYCODE(GreaterThan, PERIOD);
++    MAP_KEYCODE(QuestionMark, SLASH);
++    MAP_KEYCODE(A, A);
++    MAP_KEYCODE(B, B);
++    MAP_KEYCODE(C, C);
++    MAP_KEYCODE(D, D);
++    MAP_KEYCODE(E, E);
++    MAP_KEYCODE(F, F);
++    MAP_KEYCODE(G, G);
++    MAP_KEYCODE(H, H);
++    MAP_KEYCODE(I, I);
++    MAP_KEYCODE(J, J);
++    MAP_KEYCODE(K, K);
++    MAP_KEYCODE(L, L);
++    MAP_KEYCODE(M, M);
++    MAP_KEYCODE(N, N);
++    MAP_KEYCODE(O, O);
++    MAP_KEYCODE(P, P);
++    MAP_KEYCODE(Q, Q);
++    MAP_KEYCODE(R, R);
++    MAP_KEYCODE(S, S);
++    MAP_KEYCODE(T, T);
++    MAP_KEYCODE(U, U);
++    MAP_KEYCODE(V, V);
++    MAP_KEYCODE(W, W);
++    MAP_KEYCODE(X, X);
++    MAP_KEYCODE(Y, Y);
++    MAP_KEYCODE(Z, Z);
++    MAP_KEYCODE(LeftBracket, LEFTBRACKET);
++    MAP_KEYCODE(RightBracket, RIGHTBRACKET);
++    MAP_KEYCODE(Backslash, BACKSLASH);
++    MAP_KEYCODE(Circumflex, 6);
++    MAP_KEYCODE(Underscore, MINUS);
++    MAP_KEYCODE(LeftBrace, LEFTBRACKET);
++    MAP_KEYCODE(RightBrace, RIGHTBRACKET);
++    MAP_KEYCODE(Pipe, BACKSLASH);
++    MAP_KEYCODE(Tilde, GRAVE);
++    MAP_KEYCODE(Backtick, GRAVE);
++    MAP_KEYCODE(Super, LGUI);
++    MAP_KEYCODE(BrowserSearch, AC_SEARCH);
++    MAP_KEYCODE(BrowserFavorites, AC_BOOKMARKS);
++    MAP_KEYCODE(BrowserHome, AC_HOME);
++    MAP_KEYCODE(PreviousTrack, AUDIOPREV);
++    MAP_KEYCODE(BrowserBack, AC_BACK);
++    MAP_KEYCODE(BrowserForward, AC_FORWARD);
++    MAP_KEYCODE(BrowserRefresh, AC_REFRESH);
++    MAP_KEYCODE(BrowserStop, AC_STOP);
++    MAP_KEYCODE(VolumeDown, VOLUMEDOWN);
++    MAP_KEYCODE(VolumeUp, VOLUMEUP);
++    // Unmapped: Wake
++    MAP_KEYCODE(Sleep, SLEEP);
++    MAP_KEYCODE(NextTrack, AUDIONEXT);
++    MAP_KEYCODE(MediaSelect, MEDIASELECT);
++    MAP_KEYCODE(Email, MAIL);
++    MAP_KEYCODE(MyComputer, COMPUTER);
++    MAP_KEYCODE(Power, POWER);
++    MAP_KEYCODE(Stop, STOP);
++    MAP_KEYCODE(LeftGUI, LGUI);
++    MAP_KEYCODE(Mute, MUTE);
++    MAP_KEYCODE(RightGUI, RGUI);
++    MAP_KEYCODE(Calculator, CALCULATOR);
++    // Unmapped: Apps
++    MAP_KEYCODE(PlayPause, AUDIOPLAY);
++    MAP_KEYCODE(Menu, APPLICATION);
++
++    return map;
++}
++
++static constexpr auto scancode_map = generate_scancode_map();
 +
 +/* Initialization/Query functions */
 +static int SERENITY_VideoInit(_THIS);

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -189,7 +189,7 @@ void MainWidget::turn_off_pressed_keys()
 {
     if (m_keys_widget->mouse_note() != -1)
         m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), DSP::Keyboard::Switch::Off);
-    for (int i = 0; i < key_code_count; ++i) {
+    for (size_t i = 0u; i < key_code_count; ++i) {
         if (m_keys_pressed[i])
             note_key_action(i, DSP::Keyboard::Switch::Off);
     }
@@ -199,7 +199,7 @@ void MainWidget::turn_on_pressed_keys()
 {
     if (m_keys_widget->mouse_note() != -1)
         m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), DSP::Keyboard::Switch::On);
-    for (int i = 0; i < key_code_count; ++i) {
+    for (size_t i = 0u; i < key_code_count; ++i) {
         if (m_keys_pressed[i])
             note_key_action(i, DSP::Keyboard::Switch::On);
     }


### PR DESCRIPTION
I noticed SDL2 applications no longer had a working arrow key mapping, so let's fix that :^)

CC @supercomputer7 