### PR TITLE
LibGUI: Use BoxSampling to draw thumbnails

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -732,7 +732,7 @@ static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_thumbnail(StringView path)
     auto destination = Gfx::IntRect(0, 0, (int)(bitmap->width() * scale), (int)(bitmap->height() * scale)).centered_within(thumbnail->rect());
 
     Painter painter(thumbnail);
-    painter.draw_scaled_bitmap(destination, *bitmap, bitmap->rect());
+    painter.draw_scaled_bitmap(destination, *bitmap, bitmap->rect(), 1.f, Painter::ScalingMode::BoxSampling);
     return thumbnail;
 }
 


### PR DESCRIPTION
Some examples from the libtiff test suite.

Before:
![image](https://github.com/SerenityOS/serenity/assets/26030965/f378a8f6-9794-45c3-b5df-4f95811a7971)

After:
![image](https://github.com/SerenityOS/serenity/assets/26030965/587cfb28-beb8-49cd-85a7-01eb924f84bf)
