### PR TITLE
LibGfx/JPEG: Allow decoding more subsampling factors 

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -314,7 +314,7 @@ TEST_CASE(test_jpeg_ycck)
 {
     Array test_inputs = {
         TEST_INPUT("jpg/ycck-1111.jpg"sv),
-        // TEST_INPUT("jpg/ycck-2111.jpg"sv), // FIXME: Enable once this decodes correctly
+        TEST_INPUT("jpg/ycck-2111.jpg"sv),
         TEST_INPUT("jpg/ycck-2112.jpg"sv),
     };
 


### PR DESCRIPTION
We now allow all subsampling factors where the subsampling factors
of follow-on components evenly decode the ones of the first component.

In practice, this allows YCCK 2111, CMYK 2112, and CMYK 2111.