### PR TITLE
LibPDF: Mark text rendering matrix as dirty after TJ numbers

### DIFF
--- a/Tests/LibPDF/text.pdf
+++ b/Tests/LibPDF/text.pdf
@@ -2,77 +2,51 @@
 %µ¶
 
 1 0 obj
-<<
-  /Type /Catalog
-  /Pages 2 0 R
->>
+<</Type/Catalog/Pages 2 0 R>>
 endobj
 
 2 0 obj
-<<
-  /Type /Pages
-  /Kids [ 3 0 R ]
-  /Count 1
->>
+<</Type/Pages/Kids[3 0 R]/Count 1>>
 endobj
 
 3 0 obj
-<<
-  /Type /Page
-  /Parent 2 0 R
-  /MediaBox [ 0 0 525 250 ]
-  /Contents 4 0 R
-  /Resources <<
-    /Font <<
-      /F1 5 0 R
-    >>
-  >>
->>
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 525 250]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>
 endobj
 
 4 0 obj
-<<
-  /Length 236
->>
+<</Length 291>>
 stream
 BT
-/F1 24 Tf
+/F1 25 Tf
 -30 TL
 40 40 Td
 [ (Hello) -2000 (World) ] TJ T*
 [ (Hello) -1000 -1000 (World) ] TJ T*
 [ (Hello) -1000 ] TJ [ -1000 ] TJ [ (World) ] TJ T*
+1 0 0 1 45 130 Tm [ 200 (Hello) -2000 (World) ] TJ T*
 (should be the same on all lines:) '
 (The distance between "Hello" and "World") '
 ET
+
 
 endstream
 endobj
 
 5 0 obj
-<<
-  /Type /Font
-  /Subtype /Type1
-  /Name /F1
-  /BaseFont /Helvetica
-  /Encoding /MacRomanEncoding
->>
+<</Type/Font/Subtype/Type1/Name/F1/BaseFont/Helvetica/Encoding/MacRomanEncoding>>
 endobj
 
 xref
 0 6
 0000000000 65536 f 
 0000000016 00000 n 
-0000000070 00000 n 
-0000000136 00000 n 
-0000000291 00000 n 
-0000000581 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000227 00000 n 
+0000000568 00000 n 
 
 trailer
-<<
-  /Size 6
-  /Root 1 0 R
->>
+<</Size 6/Root 1 0 R>>
 startxref
-700
+666
 %%EOF

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -571,9 +571,11 @@ RENDERER_HANDLER(text_show_string_array)
         if (element.has<int>()) {
             float shift = (float)element.get<int>() / 1000.0f;
             m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
+            m_text_rendering_matrix_is_dirty = true;
         } else if (element.has<float>()) {
             float shift = element.get<float>() / 1000.0f;
             m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
+            m_text_rendering_matrix_is_dirty = true;
         } else {
             auto str = element.get<NonnullRefPtr<Object>>()->cast<StringObject>()->string();
             TRY(show_text(str));


### PR DESCRIPTION
Mostly because I audited all places that assigned to `m_text_matrix` after #22760.

This one is very difficult to trigger in practice.

`show_text()` marks the text rendering matrix dirty already, so this only has an effect if the `TJ` array starts with a number, and the matrix isn't marked dirty going in.

`Tm` caches the text rendering matrix, so I changed text.pdf to contain:

```
1 0 0 1 45 130 Tm
[ 200 (Hello) -2000 (World) ] TJ T*
```

This first sets an x offset of 5 (on top of the normal 40), and then undoes it (`200` is multiplied by font size (25) / -1000, and `200 * 25 / -1000` is -5). Before this change, the topmost "Hello World" ended up slightly indented.

Likely no behavior change in practice, but makes the code easier to understand, and maybe it helps in the wild somewhere.