### PR TITLE
LibWeb: Treat flex item cross axis max-size as "none" in more cases

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-percentage-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-percentage-max-size.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x100 flex-container(row) [FFC] children: not-inline
+      Box <div> at (8,8) content-size 100x100 flex-container(row) flex-item [FFC] children: not-inline
+        SVGSVGBox <svg.c-ico> at (8,8) content-size 100x100 flex-item [SVG] children: inline
+          Box <use> at (8,8) content-size 100x100 children: inline
+            Box <symbol#icon-cart> at (8,8) content-size 100x100 [BFC] children: not-inline
+              SVGGeometryBox <rect> at (8,8) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>) [8,8 100x100]
+        SVGSVGPaintable (SVGSVGBox<svg>.c-ico) [8,8 100x100]
+          PaintableBox (Box<use>) [8,8 100x100]
+            PaintableBox (Box<symbol>#icon-cart) [8,8 100x100]
+              SVGPathPaintable (SVGGeometryBox<rect>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/flex/svg-flex-item-with-percentage-max-size.html
+++ b/Tests/LibWeb/Layout/input/flex/svg-flex-item-with-percentage-max-size.html
@@ -1,0 +1,17 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black !important;
+    }
+    svg {
+        max-height: 100%;
+        max-width: 100%;
+        height: 100px;
+        width: 100px;
+    }
+    body {
+        display: flex;
+    }
+    div {
+        display: flex;
+    }
+</style><body><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: none"><symbol id="icon-cart" viewBox="0 0 10 10"><rect x=0 y=0 width=10 height=10 fill=green></symbol></svg><div><svg class="c-ico"><use xlink:href="#icon-cart"></use></svg>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -30,6 +30,9 @@ private:
     [[nodiscard]] bool should_treat_main_size_as_auto(Box const&) const;
     [[nodiscard]] bool should_treat_cross_size_as_auto(Box const&) const;
 
+    [[nodiscard]] bool should_treat_main_max_size_as_none(Box const&) const;
+    [[nodiscard]] bool should_treat_cross_max_size_as_none(Box const&) const;
+
     [[nodiscard]] CSSPixels adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const&, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const;
     [[nodiscard]] CSSPixels calculate_main_size_from_cross_size_and_aspect_ratio(CSSPixels cross_size, CSSPixelFraction aspect_ratio) const;
     [[nodiscard]] CSSPixels calculate_cross_size_from_main_size_and_aspect_ratio(CSSPixels main_size, CSSPixelFraction aspect_ratio) const;


### PR DESCRIPTION
There are a bunch of situations where we need to treat cross axis max-size properties as "none", notably percentage values when the reference containing block size is an intrinsic sizing constraint.

This fixes an issue where flex items with definite width would get shrunk to 0px by "max-width: 100%" in case the item itself is an SVG with no natural width or height.

For consistency, we now use the should_treat_max_width/height_as_none helpers throughout FFC.

This makes the search/account/cart icons show up in the top right on https://twinings.co.uk :^)

![twiningsicons](https://github.com/SerenityOS/serenity/assets/5954907/3afc8699-066a-4909-8ccc-13ebdbf83525)
