### PR TITLE
LibWeb: Check if corners have radius after converting to device pixels

### DIFF
--- a/Tests/LibWeb/Layout/expected/misc/corner-radius.txt
+++ b/Tests/LibWeb/Layout/expected/misc/corner-radius.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x48 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 1x32 children: not-inline
+      BlockContainer <div> at (8,8) content-size 1x32 [BFC] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 16x32] baseline: 32
+        ImageBox <img> at (8,8) content-size 16x32 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 1x32]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 1x32] overflow: [8,8 16x32]
+        ImagePaintable (ImageBox<IMG>) [8,8 16x32]

--- a/Tests/LibWeb/Layout/input/misc/corner-radius.html
+++ b/Tests/LibWeb/Layout/input/misc/corner-radius.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+    body {
+        width: 1px;
+    }
+    div {           
+        border-radius: 8px;
+        overflow: hidden;
+    }
+    /* Test passes if it renders without crashing. */
+</style><body><div><img>

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -63,7 +63,7 @@ public:
 
         inline operator bool() const
         {
-            return horizontal_radius > 0 && vertical_radius > 0;
+            return horizontal_radius > 0 || vertical_radius > 0;
         }
 
         Gfx::IntRect as_rect() const

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
@@ -21,7 +21,7 @@ struct BorderRadiusData {
 
     inline operator bool() const
     {
-        return horizontal_radius > 0 && vertical_radius > 0;
+        return horizontal_radius > 0 || vertical_radius > 0;
     }
 
     inline void shrink(CSSPixels horizontal, CSSPixels vertical)

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -111,17 +111,17 @@ void BorderRadiusCornerClipper::blit_corner_clipping(Gfx::Painter& painter)
 ScopedCornerRadiusClip::ScopedCornerRadiusClip(PaintContext& context, DevicePixelRect const& border_rect, BorderRadiiData const& border_radii, CornerClip corner_clip)
     : m_context(context)
     , m_id(context.allocate_corner_clipper_id())
-    , m_has_radius(border_radii.has_any_radius())
     , m_border_rect(border_rect)
 {
-    if (!m_has_radius)
-        return;
     CornerRadii const corner_radii {
         .top_left = border_radii.top_left.as_corner(context),
         .top_right = border_radii.top_right.as_corner(context),
         .bottom_right = border_radii.bottom_right.as_corner(context),
         .bottom_left = border_radii.bottom_left.as_corner(context)
     };
+    m_has_radius = corner_radii.has_any_radius();
+    if (!m_has_radius)
+        return;
     m_context.recording_painter().sample_under_corners(m_id, corner_radii, border_rect.to_type<int>(), corner_clip);
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -438,7 +438,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
             .bottom_right = border_radii_data.bottom_right.as_corner(context),
             .bottom_left = border_radii_data.bottom_left.as_corner(context)
         };
-        if (border_radii_data.has_any_radius()) {
+        if (corner_radii.has_any_radius()) {
             VERIFY(!m_corner_clipper_id.has_value());
             m_corner_clipper_id = context.allocate_corner_clipper_id();
             context.recording_painter().sample_under_corners(*m_corner_clipper_id, corner_radii, context.rounded_device_rect(*clip_rect).to_type<int>(), CornerClip::Outside);
@@ -648,7 +648,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             .bottom_right = border_radii.bottom_right.as_corner(context),
             .bottom_left = border_radii.bottom_left.as_corner(context)
         };
-        if (border_radii.has_any_radius()) {
+        if (corner_radii.has_any_radius()) {
             corner_clip_id = context.allocate_corner_clipper_id();
             context.recording_painter().sample_under_corners(*corner_clip_id, corner_radii, clip_box.to_type<int>(), CornerClip::Outside);
         }


### PR DESCRIPTION
Check needs to happen after conversion because non-zero radius in CSSPixels could turn into zero in device pixels.

Fixes https://github.com/SerenityOS/serenity/issues/22765