### PR TITLE
MacPDF: Add a "Debug" menu with a "Show Clipping Paths" entry

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
@@ -26,4 +26,6 @@
 - (IBAction)goToNextPage:(id)sender;
 - (IBAction)goToPreviousPage:(id)sender;
 
+- (IBAction)toggleShowClippingPaths:(id)sender;
+
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
+++ b/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -660,26 +660,39 @@
                         </items>
                     </menu>
                 </menuItem>
-                <menuItem title="Window" id="aUF-d1-5bR">
+                <menuItem title="Debug" id="jWy-In-lcG">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                    <menu key="submenu" title="Debug" id="9JC-3n-6oc">
                         <items>
-                            <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
-                                <connections>
-                                    <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Zoom" id="R4o-n2-Eq4">
+                            <menuItem title="Show Clipping Paths" id="mNt-xL-mVw">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
+                                    <action selector="toggleShowClippingPaths:" target="-1" id="ZXz-gM-52n"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
-                            <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Window" id="rRF-Br-Pu3">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Window" systemMenu="window" id="ipJ-MA-vaP">
+                        <items>
+                            <menuItem title="Minimize" keyEquivalent="m" id="iQm-go-526">
+                                <connections>
+                                    <action selector="performMiniaturize:" target="-1" id="ysV-jh-lhh"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom" id="3fA-VK-sIE">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="arrangeInFront:" target="-1" id="DRN-fu-gQh"/>
+                                    <action selector="performZoom:" target="-1" id="3eR-Yk-WOl"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="fk3-NL-Gg9"/>
+                            <menuItem title="Bring All to Front" id="q3x-yl-EEv">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="arrangeInFront:" target="-1" id="9GN-Lx-lIK"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
...and hook it up.

I opened MainMenu.xib in Xcode, added a new "Submenu Menu Item" from the Library (cmd-shift-l), added a User Defined "toggleShowClippingPaths:" action on First Responder and connected the menu item's action to that action.

(I first tried duplicating the existing Window menu and editing that, but the Window menu is marked as `systemMenu="window"` in the xib and I couldn't find a way to undo that in Xcode. So the Debug menu first acted as a second Window menu.)

I made "Debug" a toplevel menu to make it consistent with Ladybird.app for now, but I'll probably make it a submenu of "View" in the future.