### PR TITLE
LibGfx/JPEG: Simplify loops walking all pixels in all macroblocks

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -447,7 +447,7 @@ struct JPEGLoadingContext {
     Array<Optional<Array<u16, 64>>, 4> quantization_tables {};
 
     StartOfFrame frame;
-    SamplingFactors sampling_factors { 0 };
+    SamplingFactors sampling_factors {};
 
     Optional<Scan> current_scan {};
 


### PR DESCRIPTION
When we want to walk everything, we can just do a linear walk.

No behavior change.

---

A tiny separate simplification too.

It has no behavior change, it just simplifies some loops. I think it should be a no-op for real this time, and it might help the compiler vectorize these loops better.