### PR TITLE
Ladybird/AppKit/CMake: Use a more civilized way of finding Cocoa

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -99,8 +99,6 @@ if (ENABLE_QT)
     set(CMAKE_AUTORCC ON)
     set(CMAKE_AUTOUIC ON)
     find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
-elseif (APPLE)
-    find_library(COCOA_LIBRARY Cocoa)
 endif()
 
 set(SOURCES
@@ -151,7 +149,7 @@ elseif (APPLE)
         AppKit/Utilities/Conversions.mm
     )
     target_include_directories(ladybird PRIVATE AppKit)
-    target_link_libraries(ladybird PRIVATE ${COCOA_LIBRARY} LibUnicode)
+    target_link_libraries(ladybird PRIVATE "-framework Cocoa" LibUnicode)
     target_compile_options(ladybird PRIVATE
         -fobjc-arc
         -Wno-deprecated-anon-enum-enum-conversion # Required for CGImageCreate


### PR DESCRIPTION
Finding Cocoa.framework is the linker's job, not CMake's.

No behavior change.