### PR TITLE
LibFileSystem: Return ByteString from FileSystem functions

### DIFF
--- a/Meta/Lagom/Tools/ConfigureComponents/main.cpp
+++ b/Meta/Lagom/Tools/ConfigureComponents/main.cpp
@@ -234,7 +234,7 @@ int main()
     auto current_working_directory = FileSystem::current_working_directory();
     if (current_working_directory.is_error())
         return 1;
-    auto lexical_cwd = LexicalPath(current_working_directory.release_value().to_byte_string());
+    auto lexical_cwd = LexicalPath(current_working_directory.release_value());
     auto& parts = lexical_cwd.parts_view();
     if (parts.size() < 2 || parts[parts.size() - 2] != "Build") {
         warnln("\e[31mError:\e[0m This program needs to be executed from inside 'Build/*'.");

--- a/Tests/Kernel/TestKernelFilePermissions.cpp
+++ b/Tests/Kernel/TestKernelFilePermissions.cpp
@@ -81,9 +81,7 @@ TEST_CASE(test_change_file_location)
     ftruncate(fd, 0);
     EXPECT(fchmod(fd, 06755) != -1);
 
-    auto suid_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-
-    auto suid_path = suid_path_string.to_byte_string();
+    auto suid_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
     EXPECT(suid_path.characters());
     auto new_path = ByteString::formatted("{}.renamed", suid_path);
 

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -218,7 +218,7 @@ TEST_CASE(unlink_symlink)
     }
 
     auto target = TRY_OR_FAIL(FileSystem::read_link("/tmp/linky"sv));
-    EXPECT_EQ(target.bytes_as_string_view(), "/proc/2/foo"sv);
+    EXPECT_EQ(target, "/proc/2/foo"sv);
 
     rc = unlink("/tmp/linky");
     EXPECT(rc >= 0);

--- a/Tests/LibC/TestLibCMkTemp.cpp
+++ b/Tests/LibC/TestLibCMkTemp.cpp
@@ -86,8 +86,7 @@ TEST_CASE(test_mkstemp_unique_filename)
         auto fd = mkstemp(path);
         EXPECT_NE(fd, -1);
 
-        auto temp_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-        auto temp_path = temp_path_string.to_byte_string();
+        auto temp_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
         EXPECT(temp_path.characters());
 
         close(fd);
@@ -105,8 +104,7 @@ TEST_CASE(test_mkstemp_unique_filename)
         auto fd = mkstemp(path);
         EXPECT(fd != -1);
 
-        auto path2_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-        auto path2 = path2_string.to_byte_string();
+        auto path2 = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
         EXPECT(path2.characters());
 
         close(fd);
@@ -128,8 +126,7 @@ TEST_CASE(test_mkstemps_unique_filename)
         auto fd = mkstemps(path, 6);
         EXPECT_NE(fd, -1);
 
-        auto temp_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-        auto temp_path = temp_path_string.to_byte_string();
+        auto temp_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
         EXPECT(temp_path.characters());
 
         close(fd);
@@ -151,8 +148,7 @@ TEST_CASE(test_mkstemps_unique_filename)
         auto fd = mkstemps(path, 6);
         EXPECT(fd != -1);
 
-        auto path2_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-        auto path2 = path2_string.to_byte_string();
+        auto path2 = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
         EXPECT(path2.characters());
 
         close(fd);

--- a/Tests/LibELF/test-elf.cpp
+++ b/Tests/LibELF/test-elf.cpp
@@ -58,8 +58,7 @@ TEST_CASE(test_interp_header_tiny_p_filesz)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-    auto elf_path = elf_path_string.to_byte_string();
+    auto elf_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -113,8 +112,7 @@ TEST_CASE(test_interp_header_p_filesz_larger_than_p_memsz)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-    auto elf_path = elf_path_string.to_byte_string();
+    auto elf_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -172,8 +170,7 @@ TEST_CASE(test_interp_header_p_filesz_plus_p_offset_overflow_p_memsz)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-    auto elf_path = elf_path_string.to_byte_string();
+    auto elf_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -228,8 +225,7 @@ TEST_CASE(test_load_header_p_memsz_zero)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-    auto elf_path = elf_path_string.to_byte_string();
+    auto elf_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -284,8 +280,7 @@ TEST_CASE(test_load_header_p_memsz_not_equal_to_p_align)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
-    auto elf_path = elf_path_string.to_byte_string();
+    auto elf_path = TRY_OR_FAIL(FileSystem::read_link(ByteString::formatted("/proc/{}/fd/{}", getpid(), fd)));
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -413,11 +413,11 @@ bool DirectoryView::open(ByteString const& path)
         warnln("Failed to open '{}': {}", real_path, result.error());
     }
 
-    if (model().root_path() == real_path.to_byte_string()) {
+    if (model().root_path() == real_path) {
         refresh();
     } else {
         set_active_widget(&current_view());
-        model().set_root_path(real_path.to_byte_string());
+        model().set_root_path(real_path);
     }
     return true;
 }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -170,9 +170,11 @@ ErrorOr<void> PropertiesWindow::create_general_tab(GUI::TabWidget& tab_widget, b
         } else {
             auto link_destination = link_destination_or_error.release_value();
             auto* link_location = general_tab.find_descendant_of_type_named<GUI::LinkLabel>("link_location");
-            link_location->set_text(link_destination);
+            // FIXME: How do we safely display some text that might not be utf8?
+            auto link_destination_string = TRY(String::from_byte_string(link_destination));
+            link_location->set_text(link_destination_string);
             link_location->on_click = [link_destination] {
-                auto link_directory = LexicalPath(link_destination.to_byte_string());
+                auto link_directory = LexicalPath(link_destination);
                 Desktop::Launcher::open(URL::create_with_file_scheme(link_directory.dirname(), link_directory.basename()));
             };
         }

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -142,7 +142,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (auto error_or_cwd = FileSystem::current_working_directory(); initial_location.is_empty() && !error_or_cwd.is_error())
-        initial_location = error_or_cwd.release_value().to_byte_string();
+        initial_location = error_or_cwd.release_value();
 
     if (initial_location.is_empty())
         initial_location = Core::StandardPaths::home_directory();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -109,7 +109,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     LexicalPath path(initial_location);
     if (!initial_location.is_empty()) {
         if (auto error_or_path = FileSystem::real_path(initial_location); !ignore_path_resolution && !error_or_path.is_error())
-            initial_location = error_or_path.release_value().to_byte_string();
+            initial_location = error_or_path.release_value();
 
         if (!FileSystem::is_directory(initial_location)) {
             // We want to extract zips to a temporary directory when FileManager is launched with a .zip file as its first argument

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -147,7 +147,7 @@ bool RunWindow::run_via_launch(ByteString const& run_input)
             warnln("Failed to launch '{}': {}", file_path, real_path_or_error.error());
             return false;
         }
-        url = URL::create_with_url_or_path(real_path_or_error.release_value().to_byte_string());
+        url = URL::create_with_url_or_path(real_path_or_error.release_value());
     }
 
     if (!Desktop::Launcher::open(url)) {

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.add_positional_argument(file_to_edit, "Theme file to edit", "file", Core::ArgsParser::Required::No);
     parser.parse(arguments);
 
-    Optional<String> path = {};
+    Optional<ByteString> path = {};
 
     if (auto error_or_path = FileSystem::absolute_path(file_to_edit); !file_to_edit.is_empty() && !error_or_path.is_error())
         path = error_or_path.release_value();
@@ -57,7 +57,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         // Note: This is deferred to ensure that the window has already popped and any error dialog boxes would show up correctly.
         app->event_loop().deferred_invoke(
             [&window, &path, &main_widget]() {
-                auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, path.value().to_byte_string());
+                auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, path.value());
                 if (!response.is_error()) {
                     auto load_from_file_result = main_widget->load_from_file(response.value().filename(), response.value().release_stream());
                     if (load_from_file_result.is_error())

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -228,7 +228,7 @@ static ErrorOr<NonnullRefPtr<HackStudioWidget>> create_hack_studio_widget(bool m
     else if (auto last_path = last_opened_project_path(); last_path.has_value())
         project_path = last_path.release_value();
     else
-        project_path = TRY(FileSystem::real_path("."sv)).to_byte_string();
+        project_path = TRY(FileSystem::real_path("."sv));
 
     return HackStudioWidget::create(project_path);
 }

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -23,10 +23,9 @@
 
 namespace FileSystem {
 
-ErrorOr<String> current_working_directory()
+ErrorOr<ByteString> current_working_directory()
 {
-    auto cwd = TRY(Core::System::getcwd());
-    return TRY(String::from_byte_string({ cwd }));
+    return Core::System::getcwd();
 }
 
 ErrorOr<String> absolute_path(StringView path)

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -28,18 +28,16 @@ ErrorOr<ByteString> current_working_directory()
     return Core::System::getcwd();
 }
 
-ErrorOr<String> absolute_path(StringView path)
+ErrorOr<ByteString> absolute_path(StringView path)
 {
     if (exists(path))
-        return TRY(real_path(path));
+        return TRY(real_path(path)).to_byte_string();
 
     if (path.starts_with("/"sv))
-        return TRY(String::from_byte_string(LexicalPath::canonicalized_path(path)));
+        return LexicalPath::canonicalized_path(path);
 
     auto working_directory = TRY(current_working_directory());
-    auto full_path = LexicalPath::join(working_directory, path).string();
-
-    return TRY(String::from_byte_string(LexicalPath::canonicalized_path(full_path)));
+    return LexicalPath::absolute_path(working_directory, path);
 }
 
 ErrorOr<String> real_path(StringView path)

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -20,7 +20,7 @@ namespace FileSystem {
 
 ErrorOr<ByteString> current_working_directory();
 ErrorOr<ByteString> absolute_path(StringView path);
-ErrorOr<String> real_path(StringView path);
+ErrorOr<ByteString> real_path(StringView path);
 
 bool exists(StringView path);
 bool exists(int fd);

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/Error.h>
-#include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibCore/File.h>
 #include <sys/stat.h>
@@ -74,7 +74,7 @@ ErrorOr<void> remove(StringView path, RecursionMode);
 ErrorOr<size_t> size(StringView path);
 bool can_delete_or_move(StringView path);
 
-ErrorOr<String> read_link(StringView link_path);
+ErrorOr<ByteString> read_link(StringView link_path);
 ErrorOr<void> link_file(StringView destination_path, StringView source_path);
 
 bool looks_like_shared_library(StringView path);

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -18,7 +18,7 @@ namespace FileSystem {
 #define DEFAULT_PATH "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 #define DEFAULT_PATH_SV "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv
 
-ErrorOr<String> current_working_directory();
+ErrorOr<ByteString> current_working_directory();
 ErrorOr<String> absolute_path(StringView path);
 ErrorOr<String> real_path(StringView path);
 

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -19,7 +19,7 @@ namespace FileSystem {
 #define DEFAULT_PATH_SV "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv
 
 ErrorOr<ByteString> current_working_directory();
-ErrorOr<String> absolute_path(StringView path);
+ErrorOr<ByteString> absolute_path(StringView path);
 ErrorOr<String> real_path(StringView path);
 
 bool exists(StringView path);

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -259,7 +259,7 @@ Icon FileIconProvider::icon_for_path(StringView path, mode_t mode)
         auto raw_symlink_target_or_error = FileSystem::read_link(path);
         if (raw_symlink_target_or_error.is_error())
             return s_symlink_icon;
-        auto raw_symlink_target = raw_symlink_target_or_error.release_value().to_byte_string();
+        auto raw_symlink_target = raw_symlink_target_or_error.release_value();
 
         ByteString target_path;
         if (raw_symlink_target.starts_with('/')) {

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -259,9 +259,9 @@ Icon FileIconProvider::icon_for_path(StringView path, mode_t mode)
         auto raw_symlink_target_or_error = FileSystem::read_link(path);
         if (raw_symlink_target_or_error.is_error())
             return s_symlink_icon;
-        auto raw_symlink_target = raw_symlink_target_or_error.release_value();
+        auto raw_symlink_target = raw_symlink_target_or_error.release_value().to_byte_string();
 
-        String target_path;
+        ByteString target_path;
         if (raw_symlink_target.starts_with('/')) {
             target_path = raw_symlink_target;
         } else {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -68,7 +68,7 @@ bool FileSystemModel::Node::fetch_data(ByteString const& full_path, bool is_root
         if (sym_link_target_or_error.is_error())
             perror("readlink");
         else {
-            symlink_target = sym_link_target_or_error.release_value().to_byte_string();
+            symlink_target = sym_link_target_or_error.release_value();
             if (symlink_target.is_empty())
                 perror("readlink");
         }

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -144,7 +144,7 @@ Optional<Interface&> Parser::resolve_import(auto path)
     auto real_path_error_or = FileSystem::real_path(include_path);
     if (real_path_error_or.is_error())
         report_parsing_error(ByteString::formatted("Failed to resolve path {}: {}", include_path, real_path_error_or.error()), filename, input, lexer.tell());
-    auto real_path = real_path_error_or.release_value().to_byte_string();
+    auto real_path = real_path_error_or.release_value();
 
     if (top_level_resolved_imports().contains(real_path))
         return *top_level_resolved_imports().find(real_path)->value;
@@ -966,7 +966,7 @@ Interface& Parser::parse()
         report_parsing_error(ByteString::formatted("Failed to resolve path '{}': {}", filename, this_module_or_error.error()), filename, input, 0);
         VERIFY_NOT_REACHED();
     }
-    auto this_module = this_module_or_error.release_value().to_byte_string();
+    auto this_module = this_module_or_error.release_value();
 
     auto interface_ptr = make<Interface>();
     auto& interface = *interface_ptr;

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -174,14 +174,14 @@ int main(int argc, char** argv)
         warnln("Failed to resolve test root: {}", test_root_or_error.error());
         return 1;
     }
-    test_root = test_root_or_error.release_value().to_byte_string();
+    test_root = test_root_or_error.release_value();
 
     auto common_path_or_error = FileSystem::real_path(common_path);
     if (common_path_or_error.is_error()) {
         warnln("Failed to resolve common path: {}", common_path_or_error.error());
         return 1;
     }
-    common_path = common_path_or_error.release_value().to_byte_string();
+    common_path = common_path_or_error.release_value();
 
     if (chdir(test_root.characters()) < 0) {
         auto saved_errno = errno;

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -88,7 +88,7 @@ Optional<URL> sanitize_url(StringView url, Optional<StringView> search_engine, A
         if (path.is_error())
             return {};
 
-        return URL::create_with_file_scheme(path.value().to_byte_string());
+        return URL::create_with_file_scheme(path.value());
     }
 
     auto format_search_engine = [&]() -> Optional<URL> {

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -56,7 +56,7 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
 
         if (prompt == ShouldPrompt::Yes) {
             VERIFY(window_server_client_id != -1 && parent_window_id != -1);
-            auto exe_name = LexicalPath::basename(exe_path.to_byte_string());
+            auto exe_name = LexicalPath::basename(exe_path);
             auto text = String::formatted("Allow {} ({}) to {} \"{}\"?", exe_name, pid, access_string, path).release_value_but_fixme_should_propagate_errors();
             auto result = GUI::MessageBox::try_show({}, window_server_client_id, parent_window_id, text, "File Permissions Requested"sv).release_value_but_fixme_should_propagate_errors();
             approved = result == GUI::MessageBox::ExecResult::Yes;

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -318,7 +318,7 @@ void Launcher::for_each_handler_for_path(ByteString const& path, Function<bool(H
         }
         auto real_path = real_path_or_error.release_value();
 
-        return for_each_handler_for_path(real_path.to_byte_string(), [&](auto const& handler) -> bool {
+        return for_each_handler_for_path(real_path, [&](auto const& handler) -> bool {
             return f(handler);
         });
     }

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -309,7 +309,7 @@ void Launcher::for_each_handler_for_path(ByteString const& path, Function<bool(H
             return;
         }
 
-        auto link_target = LexicalPath { link_target_or_error.release_value().to_byte_string() };
+        auto link_target = LexicalPath { link_target_or_error.release_value() };
         LexicalPath absolute_link_target = link_target.is_absolute() ? link_target : LexicalPath::join(LexicalPath::dirname(path), link_target.string());
         auto real_path_or_error = FileSystem::real_path(absolute_link_target.string());
         if (real_path_or_error.is_error()) {

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -68,7 +68,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!username.is_empty() && !password.is_empty())
         credentials = HTTP::HttpRequest::BasicAuthenticationCredentials { username, password };
 
-    WebServer::Configuration configuration(real_document_root_path, credentials);
+    // FIXME: This should accept a ByteString for the path instead.
+    WebServer::Configuration configuration(TRY(String::from_byte_string(real_document_root_path)), credentials);
 
     Core::EventLoop loop;
 

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -54,7 +54,7 @@ enum FollowSymlinks {
     No
 };
 
-static Vector<String> find_matching_executables_in_path(StringView filename, FollowSymlinks follow_symlinks = FollowSymlinks::No)
+static Vector<ByteString> find_matching_executables_in_path(StringView filename, FollowSymlinks follow_symlinks = FollowSymlinks::No)
 {
     // Edge cases in which there are guaranteed no solutions
     if (filename.is_empty() || filename.contains('/'))
@@ -65,10 +65,10 @@ static Vector<String> find_matching_executables_in_path(StringView filename, Fol
     if (path_str != nullptr) // maybe && *path_str
         path = { path_str, strlen(path_str) };
 
-    Vector<String> executables;
+    Vector<ByteString> executables;
     auto directories = path.split_view(':');
     for (auto directory : directories) {
-        auto file = String::formatted("{}/{}", directory, filename).release_value_but_fixme_should_propagate_errors();
+        auto file = ByteString::formatted("{}/{}", directory, filename);
 
         if (follow_symlinks == FollowSymlinks::Yes) {
             auto path_or_error = FileSystem::read_link(file);

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -454,7 +454,7 @@ ErrorOr<int> Shell::builtin_cd(Main::Arguments arguments)
         warnln("Invalid path '{}'", new_path);
         return 1;
     }
-    auto real_path = real_path_or_error.release_value().to_byte_string();
+    auto real_path = real_path_or_error.release_value();
 
     if (cd_history.is_empty() || cd_history.last() != real_path)
         cd_history.enqueue(real_path);

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -394,7 +394,7 @@ ByteString Shell::resolve_path(ByteString path) const
     if (!path.starts_with('/'))
         path = ByteString::formatted("{}/{}", cwd, path);
 
-    return FileSystem::real_path(path).release_value_but_fixme_should_propagate_errors().to_byte_string();
+    return FileSystem::real_path(path).release_value_but_fixme_should_propagate_errors();
 }
 
 Shell::LocalFrame* Shell::find_frame_containing_local_variable(StringView name)

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -579,7 +579,7 @@ private:
             auto full_path_or_error = FileSystem::real_path(file_data.full_path());
             if (!full_path_or_error.is_error()) {
                 auto fullpath = full_path_or_error.release_value();
-                auto url = URL::create_with_file_scheme(fullpath.to_byte_string());
+                auto url = URL::create_with_file_scheme(fullpath);
                 out("\033]8;;{}\033\\{}{}\033]8;;\033\\", url.serialize(), file_data.full_path(), m_terminator);
                 printed = true;
             }

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -88,7 +88,7 @@ static void append_formatted_path(StringBuilder& builder, StringView path, Optio
         auto full_path_or_error = FileSystem::real_path(path);
         if (!full_path_or_error.is_error()) {
             auto fullpath = full_path_or_error.release_value();
-            auto url = URL::create_with_file_scheme(fullpath.to_byte_string(), {}, hostname());
+            auto url = URL::create_with_file_scheme(fullpath, {}, hostname());
             if (has_flag(print_type, PrintType::LineNumbers) && line_number.has_value())
                 url.set_query(MUST(String::formatted("line_number={}", *line_number)));
             builder.appendff("\033]8;;{}\033\\", url.serialize());

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -264,7 +264,7 @@ static ErrorOr<TestResult> run_dump_test(HeadlessWebContentView& view, StringVie
         loop.quit(0);
     }));
 
-    auto url = URL::create_with_file_scheme(TRY(FileSystem::real_path(input_path)).to_byte_string());
+    auto url = URL::create_with_file_scheme(TRY(FileSystem::real_path(input_path)));
 
     String result;
     auto did_finish_test = false;
@@ -359,7 +359,7 @@ static ErrorOr<TestResult> run_ref_test(HeadlessWebContentView& view, StringView
         loop.quit(0);
     }));
 
-    view.load(URL::create_with_file_scheme(TRY(FileSystem::real_path(input_path)).to_byte_string()));
+    view.load(URL::create_with_file_scheme(TRY(FileSystem::real_path(input_path))));
 
     RefPtr<Gfx::Bitmap> actual_screenshot, expectation_screenshot;
     view.on_load_finish = [&](auto const&) {
@@ -478,7 +478,8 @@ static ErrorOr<void> collect_dump_tests(Vector<Test>& tests, StringView path, St
         auto basename = LexicalPath::title(name);
         auto expectation_path = TRY(String::formatted("{}/expected/{}/{}.txt", path, trail, basename));
 
-        tests.append({ move(input_path), move(expectation_path), mode, {} });
+        // FIXME: Test paths should be ByteString
+        tests.append({ TRY(String::from_byte_string(input_path)), move(expectation_path), mode, {} });
     }
     return {};
 }
@@ -489,7 +490,8 @@ static ErrorOr<void> collect_ref_tests(Vector<Test>& tests, StringView path)
         if (entry.type == Core::DirectoryEntry::Type::Directory)
             return IterationDecision::Continue;
         auto input_path = TRY(FileSystem::real_path(TRY(String::formatted("{}/{}", path, entry.name))));
-        tests.append({ move(input_path), {}, TestMode::Ref, {} });
+        // FIXME: Test paths should be ByteString
+        tests.append({ TRY(String::from_byte_string(input_path)), {}, TestMode::Ref, {} });
         return IterationDecision::Continue;
     }));
 

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -35,8 +35,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     ByteString destination_dir = (sources.size() > 1 ? ByteString { destination } : LexicalPath::dirname(destination));
 
     if (create_leading_dest_components) {
-        String destination_dir_absolute = TRY(FileSystem::absolute_path(destination_dir));
-        MUST(Core::Directory::create(destination_dir_absolute.to_byte_string(), Core::Directory::CreateDirectories::Yes));
+        auto destination_dir_absolute = TRY(FileSystem::absolute_path(destination_dir));
+        MUST(Core::Directory::create(destination_dir_absolute, Core::Directory::CreateDirectories::Yes));
     }
 
     for (auto const& source : sources) {

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -267,7 +267,7 @@ static size_t print_name(const struct stat& st, ByteString const& name, Optional
         auto full_path_or_error = FileSystem::real_path(path_for_hyperlink);
         if (!full_path_or_error.is_error()) {
             auto fullpath = full_path_or_error.release_value();
-            auto url = URL::create_with_file_scheme(fullpath.to_byte_string(), {}, hostname());
+            auto url = URL::create_with_file_scheme(fullpath, {}, hostname());
             out("\033]8;;{}\033\\", url.serialize());
         }
     }

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -301,6 +301,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (verbose_output)
         outln("Reading and parsing Markdown files ...");
+    // FIXME: Use ByteString for file paths
     HashMap<String, MarkdownLinkage> files;
     for (auto path : file_paths) {
         auto file_or_error = Core::File::open(path, Core::File::OpenMode::Read);
@@ -326,7 +327,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             // Since this should never happen anyway, fail early.
             return 1;
         }
-        files.set(TRY(FileSystem::real_path(path)), MarkdownLinkage::analyze(*document, verbose_output));
+        files.set(TRY(String::from_byte_string(TRY(FileSystem::real_path(path)))), MarkdownLinkage::analyze(*document, verbose_output));
     }
 
     if (verbose_output)

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -71,33 +71,33 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(target_directory, "Create TEMPLATE relative to DIR", "tmpdir", 'p', "DIR");
     args_parser.parse(arguments);
 
-    Optional<String> final_file_template;
-    Optional<String> final_target_directory;
+    Optional<ByteString> final_file_template;
+    Optional<ByteString> final_target_directory;
 
     if (target_directory.is_empty()) {
         if (!file_template.is_empty()) {
             auto resolved_path = LexicalPath(TRY(FileSystem::absolute_path(file_template)));
-            final_target_directory = TRY(String::from_utf8(resolved_path.dirname()));
-            final_file_template = TRY(String::from_utf8(resolved_path.basename()));
+            final_target_directory = resolved_path.dirname();
+            final_file_template = resolved_path.basename();
         } else {
-            final_target_directory = "/tmp"_string;
+            final_target_directory = "/tmp";
             auto const* env_directory = getenv("TMPDIR");
             if (env_directory != nullptr && *env_directory != 0)
-                final_target_directory = TRY(String::from_utf8({ env_directory, strlen(env_directory) }));
+                final_target_directory = ByteString { env_directory, strlen(env_directory) };
         }
     }
 
     if (!final_file_template.has_value()) {
-        final_file_template = "tmp.XXXXXXXXXX"_string;
+        final_file_template = "tmp.XXXXXXXXXX";
     }
 
-    if (!final_file_template->find_byte_offset("XXX"sv).has_value()) {
+    if (!final_file_template->find("XXX"sv).has_value()) {
         if (!quiet)
             warnln("Too few X's in template {}", final_file_template);
         return 1;
     }
 
-    auto target_path = LexicalPath::join(final_target_directory->to_byte_string(), final_file_template->to_byte_string()).string();
+    auto target_path = LexicalPath::join(final_target_directory.value(), final_file_template.value()).string();
 
     auto final_path = TRY(make_temp(target_path, create_directory, dry_run));
     if (!final_path.has_value()) {

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (target_directory.is_empty()) {
         if (!file_template.is_empty()) {
-            auto resolved_path = LexicalPath(TRY(FileSystem::absolute_path(file_template)).to_byte_string());
+            auto resolved_path = LexicalPath(TRY(FileSystem::absolute_path(file_template)));
             final_target_directory = TRY(String::from_utf8(resolved_path.dirname()));
             final_file_template = TRY(String::from_utf8(resolved_path.basename()));
         } else {

--- a/Userland/Utilities/open.cpp
+++ b/Userland/Utilities/open.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 continue;
             }
         } else {
-            url = URL::create_with_url_or_path(path_or_error.value().to_byte_string());
+            url = URL::create_with_url_or_path(path_or_error.value());
         }
 
         if (!Desktop::Launcher::open(url)) {

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -382,7 +382,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    test_root = TRY(FileSystem::real_path(test_root)).to_byte_string();
+    test_root = TRY(FileSystem::real_path(test_root));
 
     auto void_or_error = Core::System::chdir(test_root);
     if (void_or_error.is_error()) {

--- a/Userland/Utilities/sed.cpp
+++ b/Userland/Utilities/sed.cpp
@@ -952,7 +952,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         pos_args.remove(0);
     }
 
-    HashMap<String, String> paths_to_unveil;
+    HashMap<ByteString, String> paths_to_unveil;
 
     for (auto const& input_filename : TRY(script.input_filenames())) {
         TRY(paths_to_unveil.try_set(TRY(FileSystem::absolute_path(input_filename)), edit_in_place ? "rwc"_string : "r"_string));

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -179,7 +179,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             char hostname[HOST_NAME_MAX];
             VERIFY(gethostname(hostname, sizeof(hostname)) == 0);
 
-            auto url = URL::create_with_file_scheme(full_path_or_error.value().to_byte_string(), {}, hostname);
+            auto url = URL::create_with_file_scheme(full_path_or_error.value(), {}, hostname);
             out("\033]8;;{}\033\\", url.serialize());
             printed_hyperlink = true;
         }

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -167,7 +167,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 outln("{}", filename);
 
             if (extract) {
-                ByteString absolute_path = TRY(FileSystem::absolute_path(filename)).to_byte_string();
+                auto absolute_path = TRY(FileSystem::absolute_path(filename));
                 auto parent_path = LexicalPath(absolute_path).parent();
                 auto header_mode = TRY(header.mode());
 

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -388,11 +388,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     for (auto& string : wasi_preopened_mappings) {
                         auto split_index = string.find(':');
                         if (split_index.has_value()) {
-                            LexicalPath host_path { FileSystem::real_path(string.substring_view(0, *split_index)).release_value_but_fixme_should_propagate_errors().to_byte_string() };
+                            LexicalPath host_path { FileSystem::real_path(string.substring_view(0, *split_index)).release_value_but_fixme_should_propagate_errors() };
                             LexicalPath mapped_path { string.substring_view(*split_index + 1) };
                             paths.append({move(host_path), move(mapped_path)});
                         } else {
-                            LexicalPath host_path { FileSystem::real_path(string).release_value_but_fixme_should_propagate_errors().to_byte_string() };
+                            LexicalPath host_path { FileSystem::real_path(string).release_value_but_fixme_should_propagate_errors() };
                             LexicalPath mapped_path { string };
                             paths.append({move(host_path), move(mapped_path)});
                         }

--- a/Userland/Utilities/xml.cpp
+++ b/Userland/Utilities/xml.cpp
@@ -355,7 +355,7 @@ static void dump(XML::Document& document)
     dump(document.root());
 }
 
-static String s_path;
+static ByteString s_path;
 static auto parse(StringView contents)
 {
     return XML::Parser {
@@ -363,7 +363,7 @@ static auto parse(StringView contents)
         {
             .preserve_comments = true,
             .resolve_external_resource = [&](XML::SystemID const& system_id, Optional<XML::PublicID> const&) -> ErrorOr<ByteString> {
-                auto base = URL::create_with_file_scheme(s_path.to_byte_string());
+                auto base = URL::create_with_file_scheme(s_path);
                 auto url = URLParser::basic_parse(system_id.system_literal, base);
                 if (!url.is_valid())
                     return Error::from_string_literal("Invalid URL");
@@ -402,7 +402,7 @@ static void do_run_tests(XML::Document& document)
 
     dump_cases(root);
 
-    auto base_path = LexicalPath::dirname(s_path.to_byte_string());
+    auto base_path = LexicalPath::dirname(s_path);
 
     while (!suites.is_empty()) {
         auto& node = *suites.dequeue();


### PR DESCRIPTION
Paths need to use ByteString because we can't guarantee they're utf-8, or any other encoding.

The `mktemp` commit snuck in here because it relied on the transient `AK/String.h` include from `FileSystem.h`, so it seemed I might as well make that correct instead of just adding the include.