### PR TITLE
HackStudio: Fix launching with a relative project path

### DIFF
--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -18,6 +18,7 @@ Project::Project(ByteString const& root_path)
 
 OwnPtr<Project> Project::open_with_root_path(ByteString const& root_path)
 {
+    VERIFY(LexicalPath(root_path).is_absolute());
     if (!FileSystem::is_directory(root_path))
         return {};
     return adopt_own(*new Project(root_path));

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -223,8 +223,7 @@ static ErrorOr<NonnullRefPtr<HackStudioWidget>> create_hack_studio_widget(bool m
     if (pid_to_debug != -1 || mode_coredump)
         project_path = "/usr/src/serenity";
     else if (!raw_path_argument.is_null())
-        // FIXME: Validation is unintentional, and should be removed when migrating to String.
-        project_path = TRY(ByteString::from_utf8(raw_path_argument));
+        project_path = raw_path_argument;
     else if (auto last_path = last_opened_project_path(); last_path.has_value())
         project_path = last_path.release_value();
     else


### PR DESCRIPTION
Relies on #22775. Only the last 2 commits are really this PR.

Before, trying to launch HackStudio with a relative project path (eg, `HackStudio Source/little`) would crash, and now it doesn't, and generally works as you would expect. (As far as I can tell anyway!)

cc: @ADKaster