### PR TITLE
LibGfx/PNG: Spec comment for PNGImageDecoderPlugin::unfilter_scanline()

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -291,6 +291,8 @@ static_assert(AssertSize<Pixel, 4>());
 
 void PNGImageDecoderPlugin::unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, ReadonlyBytes previous_scanlines_data, u8 bytes_per_complete_pixel)
 {
+    // https://www.w3.org/TR/png-3/#9Filter-types
+    // "Filters are applied to bytes, not to pixels, regardless of the bit depth or colour type of the image."
     switch (filter) {
     case PNG::FilterType::None:
         break;


### PR DESCRIPTION
Every time I read this, I'm like "wait, this does the wrong thing for images with bpp != 8". It doesn't, though.