### PR TITLE
LibGfx/TIFF: Add support for Float and Double types

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -475,9 +475,12 @@ private:
             return read_every_values.template operator()<Rational<u32>>();
         case Type::SignedLong:
             return read_every_values.template operator()<i32>();
-            ;
         case Type::SignedRational:
             return read_every_values.template operator()<Rational<i32>>();
+        case Type::Float:
+            return read_every_values.template operator()<float>();
+        case Type::Double:
+            return read_every_values.template operator()<double>();
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -211,6 +211,8 @@ def export_tag_related_enums(tags: List[Tag]) -> str:
 def promote_type(t: TIFFType) -> TIFFType:
     if t == TIFFType.UnsignedShort:
         return TIFFType.UnsignedLong
+    if t == TIFFType.Float:
+        return TIFFType.Double
     return t
 
 
@@ -229,6 +231,10 @@ def tiff_type_to_cpp(t: TIFFType, with_promotion: bool = True) -> str:
         return 'u32'
     if t == TIFFType.UnsignedRational:
         return 'TIFF::Rational<u32>'
+    if t == TIFFType.Float:
+        return 'float'
+    if t == TIFFType.Double:
+        return 'double'
     raise RuntimeError(f'Type "{t}" not recognized, please update tiff_type_to_read_only_cpp()')
 
 
@@ -394,7 +400,7 @@ struct Rational {{
 {export_promoter()}
 
 // Note that u16 is not include on purpose
-using Value = Variant<ByteBuffer, String, u32, Rational<u32>, i32, Rational<i32>>;
+using Value = Variant<ByteBuffer, String, u32, Rational<u32>, i32, Rational<i32>, double>;
 
 {export_tag_related_enums(known_tags)}
 
@@ -484,7 +490,6 @@ def generate_tag_handler(tag: Tag) -> str:
 
 
 def generate_tag_handler_file(tags: List[Tag]) -> str:
-
     formatter_for_tag_with_enum = '\n'.join([fR"""        case {tag.id}:
             return MUST(String::from_utf8(
                 name_for_enum_tag_value(static_cast<{tag.associated_enum.export_name()}>(v.get<u32>()))));"""


### PR DESCRIPTION
We previously were considering Float and Doubles as non-supported types. But this was done in a sneaky way, by letting them hit the default case in the `read_type` method. So, when I ported this function to the generator we started to make this types flow into the system without a proper support there. Since 3124c161, we would have crashes on images containing tags with a floating point value.