### PR TITLE
LibPDF: Make `pdf --dump-contents` handle \r line endings better

### DIFF
--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -137,11 +137,17 @@ ByteString StreamObject::to_byte_string(int indent) const
     bool is_mostly_text = percentage_ascii > 95;
 
     if (is_mostly_text) {
-        for (auto c : bytes()) {
-            if (c < 128)
-                builder.append(c);
-            else
+        for (size_t i = 0; i < bytes().size(); ++i) {
+            auto c = bytes()[i];
+            if (c < 128) {
+                bool next_is_newline = i + 1 < bytes().size() && bytes()[i + 1] == '\n';
+                if (c == '\r' && !next_is_newline)
+                    builder.append('\n');
+                else
+                    builder.append(c);
+            } else {
                 builder.appendff("\\{:03o}", c);
+            }
         }
     } else {
         auto string = encode_hex(bytes());


### PR DESCRIPTION
Previously, all page contents ended up overprinting a single line over and over for PDFs that used only `\r` as line ending.

This is for example useful for 0000364.pdf.

---

I've locally added this many times. Might as well send it upstream.