### PR TITLE
cksum: Consider empty file operand when printing

### DIFF
--- a/Userland/Utilities/cksum.cpp
+++ b/Userland/Utilities/cksum.cpp
@@ -92,7 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto file = file_or_error.release_value();
         auto data = build_checksum_data_using_file(file.ptr(), filepath);
 
-        outln("{:08x} {}", data.checksum, data.file_size);
+        outln("{} {}", data.checksum, data.file_size);
 
         // We return fail here since build_checksum_data_using_file() may set it to true, indicating problems have occurred.
         return fail;
@@ -110,7 +110,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto file = file_or_error.release_value();
         auto data = build_checksum_data_using_file(file.ptr(), path);
 
-        outln("{:08x} {} {}", data.checksum, data.file_size, path);
+        outln("{} {} {}", data.checksum, data.file_size, path);
     }
 
     return fail;


### PR DESCRIPTION
This PR exists to handle an edge case where no file operands are given (so something like `echo "hello friends" | cksum`). I felt the need to make a couple touch-ups and other changes along the way :^)

An example:

Before:
![Screenshot 2024-01-15 203415](https://github.com/SerenityOS/serenity/assets/60799661/2cd86061-fb3b-45cd-a803-ee845949a133)

After (while also having the checksum as a decimal instead of hexadecimal as the spec expects):
![Screenshot 2024-01-15 203252](https://github.com/SerenityOS/serenity/assets/60799661/3cfbbb9c-21de-4932-ade8-fb0f855fe1f5)


I tested this branch manually by comparing some commands run on my local master branch. After executing the following on my master branch (note that I just written these results while looking at Serenity's terminal printout since I haven't taken the time to figure out how to get the SpiceAgent to work):
```console
# Note that I changed the checksum printout to use decimal instead of hexadecimal to compare
# against my changes and other OS implementations

echo "well hello friends" | cksum -
33291047 19 -

echo "well hello friends" | cksum
33291047 19 -

cksum README.md
2483135952 10777 README.md

echo "well hello friends" | cksum --algorithm adler32 -
1213859582 19 -

cksum --algorithm adler32 README.md
1432197557 10777 README.md
```

... it appears the results while running `cksum` on this PR branch appear to match with these.

However, I did try also run the Ubuntu and MacOS implementation of cksum and saw that these results don't match with what we have here. So I'm not sure whether the implementation of this utility might have a flaw or if the `LibCrypto/Checksum/CRC32.cpp` might have a flaw somewhere; it might be a good idea for me to open an issue about this