### PR TITLE
Ladybird+WebContent: Add chrome command line and exe path passing

### DIFF
--- a/Base/res/ladybird/templates/version.html
+++ b/Base/res/ladybird/templates/version.html
@@ -25,7 +25,7 @@
     <table>
         <tr>
             <th>Version:</th>
-            <td>@browser_version@ <!-- FIXME: Add build commit hash --></td>
+            <td>@browser_version@</td>
         </tr>
         <tr>
             <th>Arch:</th>
@@ -39,15 +39,14 @@
             <th>User Agent:</th>
             <td>@user_agent@</td>
         </tr>
-        <!-- FIXME: Add these fields
         <tr>
             <th>Command Line:</th>
-            <td></td>
+            <td>@command_line@</td>
         </tr>
         <tr>
             <th>Executable Path:</th>
-            <td></td>
-        </tr> -->
+            <td>@executable_path@</td>
+        </tr>
     </table>
 </body>
 </html>

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -68,7 +68,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (initial_urls.is_empty())
         initial_urls.append(new_tab_page_url);
 
+    StringBuilder command_line_builder;
+    command_line_builder.join(' ', arguments.strings);
     Ladybird::WebContentOptions web_content_options {
+        .command_line = MUST(command_line_builder.to_string()),
+        .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
         .enable_gpu_painting = use_gpu_painting ? Ladybird::EnableGPUPainting::Yes : Ladybird::EnableGPUPainting::No,
         .use_lagom_networking = Ladybird::UseLagomNetworking::Yes,
         .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -44,6 +44,10 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
                 "--tool=callgrind"sv,
                 "--instr-atstart=no"sv,
                 path.bytes_as_string_view(),
+                "--command-line"sv,
+                web_content_options.command_line,
+                "--executable-path"sv,
+                web_content_options.executable_path,
                 "--webcontent-fd-passing-socket"sv,
                 webcontent_fd_passing_socket_string
             };

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -143,7 +143,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         initial_urls.append(ak_string_from_qstring(new_tab_page));
     }
 
+    StringBuilder command_line_builder;
+    command_line_builder.join(' ', arguments.strings);
     Ladybird::WebContentOptions web_content_options {
+        .command_line = MUST(command_line_builder.to_string()),
+        .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
         .enable_callgrind_profiling = enable_callgrind_profiling ? Ladybird::EnableCallgrindProfiling::Yes : Ladybird::EnableCallgrindProfiling::No,
         .enable_gpu_painting = use_gpu_painting ? Ladybird::EnableGPUPainting::Yes : Ladybird::EnableGPUPainting::No,
         .use_lagom_networking = enable_qt_networking ? Ladybird::UseLagomNetworking::No : Ladybird::UseLagomNetworking::Yes,

--- a/Ladybird/Types.h
+++ b/Ladybird/Types.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/String.h>
+
 namespace Ladybird {
 
 enum class EnableCallgrindProfiling {
@@ -34,6 +36,8 @@ enum class WaitForDebugger {
 };
 
 struct WebContentOptions {
+    String command_line;
+    String executable_path;
     EnableCallgrindProfiling enable_callgrind_profiling { EnableCallgrindProfiling::No };
     EnableGPUPainting enable_gpu_painting { EnableGPUPainting::No };
     IsLayoutTestMode is_layout_test_mode { IsLayoutTestMode::No };

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -76,6 +76,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #endif
     });
 
+    StringView command_line {};
+    StringView executable_path {};
     int webcontent_fd_passing_socket { -1 };
     bool is_layout_test_mode = false;
     bool use_lagom_networking = false;
@@ -83,6 +85,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool wait_for_debugger = false;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(command_line, "Chrome process command line", "command-line", 0, "command_line");
+    args_parser.add_option(executable_path, "Chrome process executable path", "executable-path", 0, "executable_path");
     args_parser.add_option(webcontent_fd_passing_socket, "File descriptor of the passing socket for the WebContent connection", "webcontent-fd-passing-socket", 'c', "webcontent_fd_passing_socket");
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking", 0);
@@ -95,6 +99,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         Core::Process::wait_for_debugger_and_break();
     }
 
+    Web::set_chrome_process_command_line(command_line);
+    Web::set_chrome_process_executable_path(executable_path);
     if (use_gpu_painting) {
         WebContent::PageClient::set_use_gpu_painter();
     }

--- a/Userland/Applications/BrowserSettings/Defaults.h
+++ b/Userland/Applications/BrowserSettings/Defaults.h
@@ -11,7 +11,7 @@
 namespace Browser {
 
 static constexpr StringView default_homepage_url = "resource://html/misc/welcome.html"sv;
-static constexpr StringView default_new_tab_url = "resource://ladybird/newtab.html"sv;
+static constexpr StringView default_new_tab_url = "about:newtab"sv;
 static constexpr StringView default_color_scheme = "auto"sv;
 static constexpr bool default_enable_content_filters = true;
 static constexpr bool default_show_bookmarks_bar = true;

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -16,6 +16,16 @@
 
 namespace Web {
 
+void set_chrome_process_command_line(StringView command_line)
+{
+    s_chrome_process_command_line = MUST(String::from_utf8(command_line));
+}
+
+void set_chrome_process_executable_path(StringView executable_path)
+{
+    s_chrome_process_executable_path = MUST(String::from_utf8(executable_path));
+}
+
 ErrorOr<String> load_error_page(AK::URL const& url)
 {
     // Generate HTML error page from error template file
@@ -81,6 +91,8 @@ ErrorOr<String> load_about_version_page()
     generator.set("arch_name", CPU_STRING);
     generator.set("os_name", OS_STRING);
     generator.set("user_agent", default_user_agent);
+    generator.set("command_line", s_chrome_process_command_line);
+    generator.set("executable_path", s_chrome_process_executable_path);
     generator.append(template_file->data());
     return TRY(String::from_utf8(generator.as_string_view()));
 }

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -11,6 +11,12 @@
 
 namespace Web {
 
+static String s_chrome_process_command_line {};
+static String s_chrome_process_executable_path {};
+
+void set_chrome_process_command_line(StringView command_line);
+void set_chrome_process_executable_path(StringView executable_path);
+
 ErrorOr<String> load_error_page(AK::URL const&);
 
 ErrorOr<String> load_file_directory_page(AK::URL const&);


### PR DESCRIPTION
This pr adds two new arguments to the `WebContent` process, so that the chrome can pass its complete command line and executable path. This information is then displayed in the `about:version` page.

This currently only works in Ladybird chromes outside SerenityOS but I'll fix this in the future.

I also change the default new tab URL to `about:newtab`, I forget to add this back when fixing my previous pr 😆 