### PR TITLE
LibWeb: Use correct max-size in intrinsic sizing of column flex layout

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/column-layout-intrinsic-main-size-with-cross-max-size-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex/column-layout-intrinsic-main-size-with-cross-max-size-constraint.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x100 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x100 flex-item [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 16, rect: [8,8 126.390625x17] baseline: 13.296875
+            "Start free trial"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x100]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/flex/column-layout-intrinsic-main-size-with-cross-max-size-constraint.html
+++ b/Tests/LibWeb/Layout/input/flex/column-layout-intrinsic-main-size-with-cross-max-size-constraint.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><style>
+    * {
+        outline: 1px solid black;
+    }
+    body {
+        display: flex;
+        flex-direction: column;
+    }
+    div {
+        max-width: 100%;
+        height: 100px;
+    }
+</style><body><div>Start free trial

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1686,7 +1686,7 @@ CSSPixels FlexFormattingContext::calculate_intrinsic_main_size_of_flex_container
                 auto const& computed_max_size = this->computed_main_max_size(item.box);
 
                 auto clamp_min = (!computed_min_size.is_auto() && !computed_min_size.contains_percentage()) ? specified_main_min_size(item.box) : automatic_minimum_size(item);
-                auto clamp_max = (!should_treat_cross_max_size_as_none(item.box) && !computed_max_size.contains_percentage()) ? specified_main_max_size(item.box) : CSSPixels::max();
+                auto clamp_max = (!should_treat_main_max_size_as_none(item.box) && !computed_max_size.contains_percentage()) ? specified_main_max_size(item.box) : CSSPixels::max();
 
                 result = css_clamp(result, clamp_min, clamp_max);
 


### PR DESCRIPTION
Regressed in 72dd37438dc7da2150a855b63135afff08994d40

Caught as a visual regression with buttons on https://shopify.com/blog

Broken:
![Screenshot at 2024-01-16 12-06-12](https://github.com/SerenityOS/serenity/assets/5954907/7bea22b5-53db-4401-8c51-54f916303f92)

Fixed:
![Screenshot at 2024-01-16 12-05-23](https://github.com/SerenityOS/serenity/assets/5954907/d40b48b5-48ac-4ee5-b9de-b0031bbd6adb)
