### PR TITLE
HackStudio: Use the Process::spawn() API to spawn processes

### DIFF
--- a/Tests/JSSpecCompiler/test-runner.cpp
+++ b/Tests/JSSpecCompiler/test-runner.cpp
@@ -152,7 +152,7 @@ TEST_CASE(test_regression)
             auto path_to_expectation = LexicalPath::join(path_to_tests_directory.string(), ByteString::formatted("{}.expectation", source));
 
             auto process = MUST(Core::Process::spawn({
-                .path = path_to_compiler_binary.string(),
+                .executable = path_to_compiler_binary.string(),
                 .arguments = build_command_line_arguments(path_to_test, test_description),
                 .file_actions = {
                     Core::FileAction::OpenFile {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -71,7 +71,6 @@
 #include <LibThreading/Thread.h>
 #include <LibVT/TerminalWidget.h>
 #include <fcntl.h>
-#include <spawn.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -29,7 +29,8 @@ struct OpenFile {
 }
 
 struct ProcessSpawnOptions {
-    ByteString path;
+    ByteString executable;
+    bool search_for_executable_in_path { false };
     Vector<ByteString> const& arguments = {};
     Optional<ByteString> working_directory = {};
     Vector<Variant<FileAction::OpenFile>> const& file_actions = {};


### PR DESCRIPTION
Because it's a lot nicer to use than manually calling `posix_spawn_file_actions_FOO()` functions.