### PR TITLE
NotificationServer: Fix the layout for multi-line notifications

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -354,6 +354,7 @@ static ErrorOr<String> generate_cpp(NonnullRefPtr<GUI::GML::GMLFile> gml, Lexica
         TRY(String::from_utf8("<AK/JsonValue.h>"sv)),
         TRY(String::from_utf8("<AK/NonnullRefPtr.h>"sv)),
         TRY(String::from_utf8("<AK/RefPtr.h>"sv)),
+        TRY(String::from_utf8("<LibGfx/Font/FontWeight.h>"sv)),
         // For Gfx::ColorRole
         TRY(String::from_utf8("<LibGfx/SystemTheme.h>"sv)),
         TRY(String::from_utf8("<LibGUI/Widget.h>"sv)),

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -172,19 +172,18 @@ static ErrorOr<Optional<String>> generate_enum_initializer_for(StringView proper
 {
     // The value is the enum's type name.
     static HashMap<StringView, StringView> enum_properties = {
-        { "text_alignment"sv, "Gfx::TextAlignment"sv },
-        { "focus_policy"sv, "GUI::FocusPolicy"sv },
         { "background_role"sv, "Gfx::ColorRole"sv },
+        { "button_style"sv, "Gfx::ButtonStyle"sv },
+        { "checkbox_position"sv, "GUI::CheckBox::CheckBoxPosition"sv },
+        { "focus_policy"sv, "GUI::FocusPolicy"sv },
+        { "font_weight"sv, "Gfx::FontWeight"sv },
         { "foreground_role"sv, "Gfx::ColorRole"sv },
         { "frame_style"sv, "Gfx::FrameStyle"sv },
-        { "text_wrapping"sv, "Gfx::TextWrapping"sv },
-        { "button_style"sv, "Gfx::ButtonStyle"sv },
-        { "opportunistic_resizee"sv, "GUI::Splitter::OpportunisticResizee"sv },
-        { "checkbox_position"sv, "GUI::CheckBox::CheckBoxPosition"sv },
-        { "button_style"sv, "Gfx::ButtonStyle"sv },
         { "mode"sv, "GUI::TextEditor::Mode"sv },
-        { "font_weight"sv, "Gfx::FontWeight"sv },
+        { "opportunistic_resizee"sv, "GUI::Splitter::OpportunisticResizee"sv },
         { "orientation"sv, "Gfx::Orientation"sv },
+        { "text_alignment"sv, "Gfx::TextAlignment"sv },
+        { "text_wrapping"sv, "Gfx::TextWrapping"sv },
     };
 
     auto const& enum_type_name = enum_properties.get(property_name);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -34,8 +34,8 @@
 #include <LibGUI/SeparatorWidget.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGfx/Font/BitmapFont.h>
-#include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/FontStyleMapping.h>
+#include <LibGfx/Font/FontWeight.h>
 #include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/WOFF/Font.h>

--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -12,7 +12,7 @@
 #include <LibGfx/BitmapMixer.h>
 #include <LibGfx/Filters/FastBoxBlurFilter.h>
 #include <LibGfx/Filters/LumaFilter.h>
-#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/FontWeight.h>
 
 namespace PixelPaint::Filters {
 

--- a/Userland/Applications/Presenter/SlideObject.h
+++ b/Userland/Applications/Presenter/SlideObject.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
+#include <AK/HashMap.h>
 #include <LibGfx/Color.h>
-#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/FontWeight.h>
 #include <LibGfx/Rect.h>
 
 class Presentation;

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.h
@@ -11,25 +11,11 @@
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
+#include <LibGfx/Font/FontWeight.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Forward.h>
 
 namespace Gfx {
-
-namespace FontWeight {
-enum {
-    Thin = 100,
-    ExtraLight = 200,
-    Light = 300,
-    Regular = 400,
-    Medium = 500,
-    SemiBold = 600,
-    Bold = 700,
-    ExtraBold = 800,
-    Black = 900,
-    ExtraBlack = 950
-};
-}
 
 class FontDatabase {
 public:

--- a/Userland/Libraries/LibGfx/Font/FontWeight.h
+++ b/Userland/Libraries/LibGfx/Font/FontWeight.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx::FontWeight {
+
+enum {
+    Thin = 100,
+    ExtraLight = 200,
+    Light = 300,
+    Regular = 400,
+    Medium = 500,
+    SemiBold = 600,
+    Bold = 700,
+    ExtraBold = 800,
+    Black = 900,
+    ExtraBlack = 950
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/FontStyleMapping.h>
+#include <LibGfx/Font/FontWeight.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>

--- a/Userland/Services/NotificationServer/CMakeLists.txt
+++ b/Userland/Services/NotificationServer/CMakeLists.txt
@@ -4,12 +4,14 @@ serenity_component(
     TARGETS NotificationServer
 )
 
+compile_gml(NotificationWidget.gml NotificationWidgetGML.cpp)
 compile_ipc(NotificationServer.ipc NotificationServerEndpoint.h)
 compile_ipc(NotificationClient.ipc NotificationClientEndpoint.h)
 
 set(SOURCES
     ConnectionFromClient.cpp
     main.cpp
+    NotificationWidgetGML.cpp
     NotificationWindow.cpp
 )
 

--- a/Userland/Services/NotificationServer/NotificationWidget.gml
+++ b/Userland/Services/NotificationServer/NotificationWidget.gml
@@ -17,11 +17,13 @@
             name: "title"
             font_weight: "Bold"
             text_alignment: "CenterLeft"
+            preferred_height: "shrink"
+            max_height: "shrink"
         }
 
         @GUI::Label {
             name: "text"
-            text_alignment: "CenterLeft"
+            text_alignment: "TopLeft"
         }
     }
 }

--- a/Userland/Services/NotificationServer/NotificationWidget.gml
+++ b/Userland/Services/NotificationServer/NotificationWidget.gml
@@ -1,0 +1,27 @@
+@NotificationServer::NotificationWidget {
+    layout: @GUI::HorizontalBoxLayout {
+        margins: [8]
+        spacing: 6
+    }
+    fill_with_background_color: true
+
+    @GUI::ImageWidget {
+        name: "icon"
+        visible: false
+    }
+
+    @GUI::Widget {
+        layout: @GUI::VerticalBoxLayout {}
+
+        @GUI::Label {
+            name: "title"
+            font_weight: "Bold"
+            text_alignment: "CenterLeft"
+        }
+
+        @GUI::Label {
+            name: "text"
+            text_alignment: "CenterLeft"
+        }
+    }
+}

--- a/Userland/Services/NotificationServer/NotificationWidget.h
+++ b/Userland/Services/NotificationServer/NotificationWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace NotificationServer {
+
+class NotificationWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(NotificationWidget)
+public:
+    static ErrorOr<NonnullRefPtr<NotificationWidget>> try_create();
+    virtual ~NotificationWidget() override = default;
+
+private:
+    NotificationWidget() = default;
+};
+
+}

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "NotificationWindow.h"
+#include "NotificationWidget.h"
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
@@ -65,25 +67,19 @@ NotificationWindow::NotificationWindow(i32 client_id, String const& text, String
 
     set_rect(rect);
 
-    auto widget = set_main_widget<GUI::Widget>();
+    auto widget = NotificationServer::NotificationWidget::try_create().release_value_but_fixme_should_propagate_errors();
+    set_main_widget(widget);
 
-    widget->set_fill_with_background_color(true);
-    widget->set_layout<GUI::HorizontalBoxLayout>(8, 6);
-
-    m_image = &widget->add<GUI::ImageWidget>();
+    m_image = widget->find_descendant_of_type_named<GUI::ImageWidget>("icon"sv);
     m_image->set_visible(icon.is_valid());
     if (icon.is_valid()) {
         m_image->set_bitmap(icon.bitmap());
     }
 
-    auto& left_container = widget->add<GUI::Widget>();
-    left_container.set_layout<GUI::VerticalBoxLayout>();
-
-    m_title_label = &left_container.add<GUI::Label>(title);
-    m_title_label->set_font(Gfx::FontDatabase::default_font().bold_variant());
-    m_title_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    m_text_label = &left_container.add<GUI::Label>(text);
-    m_text_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    m_title_label = widget->find_descendant_of_type_named<GUI::Label>("title");
+    m_title_label->set_text(title);
+    m_text_label = widget->find_descendant_of_type_named<GUI::Label>("text");
+    m_text_label->set_text(text);
 
     // FIXME: There used to be code for setting the tooltip here, but since we
     // expand the notification now we no longer set the tooltip. Should there be


### PR DESCRIPTION
**Before:**

[Peek 2024-01-16 16-15 broken notifications.webm](https://github.com/SerenityOS/serenity/assets/222642/be5dd8c7-ec75-4c5b-aec6-ce1c29d36772)

**After:**

[Peek 2024-01-16 16-06 fixed notifications.webm](https://github.com/SerenityOS/serenity/assets/222642/6522f9ca-5688-44da-b7e6-406478f83bc8)

It's a little hacky to manually calculate the heights here, but it works, until the layout system can handle this better.