### PR TITLE
DisplaySettings+WidgetGallery: Remove quotes around GML boolean values

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -54,7 +54,6 @@
             @GUI::Label {
                 name: "display_dpi"
                 text: "96 dpi"
-                text_alignment: "CenterMiddle"
                 fixed_width: 50
             }
         }

--- a/Userland/Applications/DisplaySettings/ThemesSettings.gml
+++ b/Userland/Applications/DisplaySettings/ThemesSettings.gml
@@ -52,7 +52,7 @@
 
         @GUI::ComboBox {
             name: "color_scheme_combo"
-            enabled: "false"
+            enabled: false
         }
     }
 

--- a/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
@@ -98,7 +98,7 @@
                 @GUI::Button {
                     name: "disabled_normal_button"
                     text: "Disabled"
-                    enabled: "false"
+                    enabled: false
                 }
 
                 @GUI::Layout::Spacer {}
@@ -120,7 +120,7 @@
                 @GUI::Button {
                     name: "disabled_coolbar_button"
                     text: "Disabled"
-                    enabled: "false"
+                    enabled: false
                     button_style: "Coolbar"
                 }
 
@@ -196,7 +196,7 @@
                 @GUI::Button {
                     name: "disabled_icon_button"
                     text: "Disabled"
-                    enabled: "false"
+                    enabled: false
                 }
 
                 @GUI::Layout::Spacer {}


### PR DESCRIPTION
This PR fixes some errors in the GML files for `DisplaySettings` and `WidgetGallery`.  The main cause of these issues was boolean values being put in quotes, which led to the property declaration being ignored.