### PR TITLE
LibPDF: Coordinate transformation nonsense

### DIFF
--- a/Tests/LibPDF/rotate.pdf
+++ b/Tests/LibPDF/rotate.pdf
@@ -1,0 +1,53 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 250 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>
+endobj
+
+4 0 obj
+<</Length 145>>
+stream
+BT
+/F1 25 Tf
+30 TL
+0.7071 0.7071 -0.7071 0.7071 50 50 Tm
+(Rotation) Tj
+5 Ts
+( line 1) Tj
+T*
+40 -20 TD
+(Line 2) Tj T*
+40 -20 Td
+(Line 3) Tj T*
+ET
+
+endstream
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/Name/F1/BaseFont/Helvetica>>
+endobj
+
+xref
+0 6
+0000000000 65536 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000227 00000 n 
+0000000422 00000 n 
+
+trailer
+<</Size 6/Root 1 0 R>>
+startxref
+494
+%%EOF

--- a/Tests/LibPDF/text.pdf
+++ b/Tests/LibPDF/text.pdf
@@ -14,9 +14,10 @@ endobj
 endobj
 
 4 0 obj
-<</Length 291>>
+<</Length 419>>
 stream
 BT
+0.9 0 0 0.9 0 0 cm
 /F1 25 Tf
 -30 TL
 40 40 Td
@@ -24,8 +25,16 @@ BT
 [ (Hello) -1000 -1000 (World) ] TJ T*
 [ (Hello) -1000 ] TJ [ -1000 ] TJ [ (World) ] TJ T*
 1 0 0 1 45 130 Tm [ 200 (Hello) -2000 (World) ] TJ T*
-(should be the same on all lines:) '
-(The distance between "Hello" and "World") '
+0.9 0 0 0.9 40 160 Tm
+80 Tz
+(should be the ) ' (same on all lines:) Tj
+15 Ts /F1 10 Tf ( super) Tj /F1 25 Tf -15 TL
+3 Tc
+5 Tw
+(The distance ) '
+(between "Hello" and "World") Tj
+10 Ts
+(yo) Tj
 ET
 
 
@@ -43,10 +52,10 @@ xref
 0000000062 00000 n 
 0000000114 00000 n 
 0000000227 00000 n 
-0000000568 00000 n 
+0000000696 00000 n 
 
 trailer
 <</Size 6/Root 1 0 R>>
 startxref
-666
+794
 %%EOF

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -48,12 +48,13 @@ PDFErrorOr<void> SimpleFont::initialize(Document* document, NonnullRefPtr<DictOb
 
 PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, ByteString const& string, Renderer const& renderer)
 {
-    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
-    auto font_size = text_rendering_matrix.x_scale() * renderer.text_state().font_size;
-
-    auto character_spacing = text_rendering_matrix.x_scale() * renderer.text_state().character_spacing;
-    auto word_spacing = text_rendering_matrix.x_scale() * renderer.text_state().word_spacing;
     auto horizontal_scaling = renderer.text_state().horizontal_scaling;
+
+    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
+    auto font_size = text_rendering_matrix.x_scale() * renderer.text_state().font_size / horizontal_scaling;
+
+    auto character_spacing = text_rendering_matrix.x_scale() * renderer.text_state().character_spacing / horizontal_scaling;
+    auto word_spacing = text_rendering_matrix.x_scale() * renderer.text_state().word_spacing / horizontal_scaling;
 
     for (auto char_code : string.bytes()) {
         // Use the width specified in the font's dictionary if available,

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1307,6 +1307,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_document(No
 Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
 {
     if (m_text_rendering_matrix_is_dirty) {
+        // PDF 1.7, 5.3.3. Text Space Details
         m_text_rendering_matrix = Gfx::AffineTransform(
             text_state().horizontal_scaling,
             0.0f,

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1308,15 +1308,17 @@ Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
 {
     if (m_text_rendering_matrix_is_dirty) {
         // PDF 1.7, 5.3.3. Text Space Details
-        m_text_rendering_matrix = Gfx::AffineTransform(
+        Gfx::AffineTransform parameter_matrix {
             text_state().horizontal_scaling,
             0.0f,
             0.0f,
             1.0f,
             0.0f,
-            text_state().rise);
-        m_text_rendering_matrix.multiply(state().ctm);
+            text_state().rise
+        };
+        m_text_rendering_matrix = state().ctm;
         m_text_rendering_matrix.multiply(m_text_matrix);
+        m_text_rendering_matrix.multiply(parameter_matrix);
         m_text_rendering_matrix_is_dirty = false;
     }
     return m_text_rendering_matrix;

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1011,15 +1011,13 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
     if (!text_state().font)
         return Error::rendering_unsupported_error("Can't draw text because an invalid font was in use");
 
-    auto const& text_rendering_matrix = calculate_text_rendering_matrix();
-
-    auto start_position = text_rendering_matrix.map(Gfx::FloatPoint { 0.0f, 0.0f });
+    auto start_position = Gfx::FloatPoint { 0.0f, 0.0f };
     auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, *this));
 
-    // Update text matrix
+    // Update text matrix.
     auto delta_x = end_position.x() - start_position.x();
     m_text_rendering_matrix_is_dirty = true;
-    m_text_matrix.translate(delta_x / text_rendering_matrix.x_scale() * text_state().horizontal_scaling, 0.0f);
+    m_text_matrix.translate(delta_x * text_state().horizontal_scaling, 0.0f);
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -487,7 +487,7 @@ RENDERER_HANDLER(text_set_font)
     text_state().font_size = args[1].to_float();
 
     auto& text_rendering_matrix = calculate_text_rendering_matrix();
-    auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
+    auto font_size = text_rendering_matrix.x_scale() * text_state().font_size / text_state().horizontal_scaling;
 
     auto resources = extra_resources.value_or(m_page.resources);
     auto fonts_dictionary = MUST(resources->get_dict(m_document, CommonNames::Font));
@@ -545,7 +545,7 @@ RENDERER_HANDLER(text_set_matrix_and_line_matrix)
     // Settings the text/line matrix retroactively affects fonts
     if (text_state().font) {
         auto new_text_rendering_matrix = calculate_text_rendering_matrix();
-        text_state().font->set_font_size(text_state().font_size * new_text_rendering_matrix.x_scale());
+        text_state().font->set_font_size(text_state().font_size * new_text_rendering_matrix.x_scale() / text_state().horizontal_scaling);
     }
 
     return {};

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1019,7 +1019,7 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
     // Update text matrix
     auto delta_x = end_position.x() - start_position.x();
     m_text_rendering_matrix_is_dirty = true;
-    m_text_matrix.translate(delta_x / text_rendering_matrix.x_scale(), 0.0f);
+    m_text_matrix.translate(delta_x / text_rendering_matrix.x_scale() * text_state().horizontal_scaling, 0.0f);
     return {};
 }
 


### PR DESCRIPTION
The original goal here was to make it so that every glyph is drawn at its final position.

Before this change, when we drew a run of text, we'd have the rigth position for the start of the run of the text, but then draw all glyphs in the run horizontally.

Now, we compute the right position for glyphs in each run. That means that for rotated text, we now put each glyph in the right place. We don't rotate the actual glyph yet, so it doesn't look perfect yet, but it's still a big progression.

However, on the way of getting there, I made `text.pdf` a bit more complicated to make sure I don't break things, only to realize that the existing code didn't handle text offsets and had a whole bunch of bugs. So this PR first tweaks text.pdf, then fixes all the bugs uncovered by the tweaks, and only then adds another test file with rotated text and makes that work.