### PR TITLE
LibPDF: Clip images against clipping path (…bounding box); MacPDF: Add debug toggle to turn off clipping

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
@@ -27,5 +27,7 @@
 - (IBAction)goToPreviousPage:(id)sender;
 
 - (IBAction)toggleShowClippingPaths:(id)sender;
+- (IBAction)toggleClipImages:(id)sender;
+- (IBAction)toggleClipPaths:(id)sender;
 
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -169,6 +169,14 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
         [item setState:_preferences.show_clipping_paths ? NSControlStateValueOn : NSControlStateValueOff];
         return _doc ? YES : NO;
     }
+    if ([item action] == @selector(toggleClipImages:)) {
+        [item setState:_preferences.clip_images ? NSControlStateValueOn : NSControlStateValueOff];
+        return _doc ? YES : NO;
+    }
+    if ([item action] == @selector(toggleClipPaths:)) {
+        [item setState:_preferences.clip_paths ? NSControlStateValueOn : NSControlStateValueOff];
+        return _doc ? YES : NO;
+    }
     return NO;
 }
 
@@ -176,6 +184,22 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
 {
     if (_doc) {
         _preferences.show_clipping_paths = !_preferences.show_clipping_paths;
+        [self invalidateCachedBitmap];
+    }
+}
+
+- (IBAction)toggleClipImages:(id)sender
+{
+    if (_doc) {
+        _preferences.clip_images = !_preferences.clip_images;
+        [self invalidateCachedBitmap];
+    }
+}
+
+- (IBAction)toggleClipPaths:(id)sender
+{
+    if (_doc) {
+        _preferences.clip_paths = !_preferences.clip_paths;
         [self invalidateCachedBitmap];
     }
 }

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)goToNextPage:(id)sender;
 - (IBAction)goToPreviousPage:(id)sender;
 - (IBAction)toggleShowClippingPaths:(id)sender;
+- (IBAction)toggleClipImages:(id)sender;
+- (IBAction)toggleClipPaths:(id)sender;
 - (IBAction)showGoToPageDialog:(id)sender;
 
 - (void)pdfDidInitialize;

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -144,6 +144,16 @@
     [_pdfView toggleShowClippingPaths:sender];
 }
 
+- (IBAction)toggleClipImages:(id)sender
+{
+    [_pdfView toggleClipImages:sender];
+}
+
+- (IBAction)toggleClipPaths:(id)sender
+{
+    [_pdfView toggleClipPaths:sender];
+}
+
 - (IBAction)showGoToPageDialog:(id)sender
 {
     auto alert = [[NSAlert alloc] init];

--- a/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
+++ b/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
@@ -670,6 +670,18 @@
                                     <action selector="toggleShowClippingPaths:" target="-1" id="ZXz-gM-52n"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Clip Images" id="os0-En-UkL">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleClipImages:" target="-1" id="bHz-O3-V8K"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Clip Paths" id="KB8-Ld-jv8">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleClipPaths:" target="-1" id="pZu-tJ-RFh"/>
+                                </connections>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -309,13 +309,15 @@ void Renderer::deactivate_clip()
 
 void Renderer::begin_path_paint()
 {
-    activate_clip();
+    if (m_rendering_preferences.clip_paths)
+        activate_clip();
 }
 
 void Renderer::end_path_paint()
 {
     m_current_path.clear();
-    deactivate_clip();
+    if (m_rendering_preferences.clip_paths)
+        deactivate_clip();
 }
 
 RENDERER_HANDLER(path_stroke)
@@ -1230,7 +1232,9 @@ PDFErrorOr<void> Renderer::show_image(NonnullRefPtr<StreamObject> image)
         Renderer& m_renderer;
     };
 
-    ClipRAII clip_raii(*this);
+    OwnPtr<ClipRAII> clip_raii;
+    if (m_rendering_preferences.clip_images)
+        clip_raii = make<ClipRAII>(*this);
 
     if (!m_rendering_preferences.show_images) {
         show_empty_image(width, height);

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1217,6 +1217,21 @@ PDFErrorOr<void> Renderer::show_image(NonnullRefPtr<StreamObject> image)
     auto width = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::Width)));
     auto height = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::Height)));
 
+    class ClipRAII {
+    public:
+        ClipRAII(Renderer& renderer)
+            : m_renderer(renderer)
+        {
+            m_renderer.activate_clip();
+        }
+        ~ClipRAII() { m_renderer.deactivate_clip(); }
+
+    private:
+        Renderer& m_renderer;
+    };
+
+    ClipRAII clip_raii(*this);
+
     if (!m_rendering_preferences.show_images) {
         show_empty_image(width, height);
         return {};

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -287,11 +287,7 @@ RENDERER_HANDLER(path_append_rect)
     return {};
 }
 
-///
-// Path painting operations
-///
-
-void Renderer::begin_path_paint()
+void Renderer::activate_clip()
 {
     auto bounding_box = state().clipping_paths.current.bounding_box();
     m_painter.clear_clip_rect();
@@ -301,11 +297,25 @@ void Renderer::begin_path_paint()
     m_painter.add_clip_rect(bounding_box.to_type<int>());
 }
 
+void Renderer::deactivate_clip()
+{
+    m_painter.clear_clip_rect();
+    state().clipping_paths.current = state().clipping_paths.next;
+}
+
+///
+// Path painting operations
+///
+
+void Renderer::begin_path_paint()
+{
+    activate_clip();
+}
+
 void Renderer::end_path_paint()
 {
     m_current_path.clear();
-    m_painter.clear_clip_rect();
-    state().clipping_paths.current = state().clipping_paths.next;
+    deactivate_clip();
 }
 
 RENDERER_HANDLER(path_stroke)

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -127,6 +127,9 @@ private:
     PDFErrorOr<void> handle_text_next_line_show_string(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
     PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
 
+    void activate_clip();
+    void deactivate_clip();
+
     void begin_path_paint();
     void end_path_paint();
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -90,6 +90,9 @@ struct RenderingPreferences {
     bool show_clipping_paths { false };
     bool show_images { true };
 
+    bool clip_paths { true };
+    bool clip_images { true };
+
     unsigned hash() const
     {
         return static_cast<unsigned>(show_clipping_paths) | static_cast<unsigned>(show_images) << 1;


### PR DESCRIPTION
This is a dramatic progression for some PDFs.

I'll port the debug toggles to PDFViewer once I'm back at a machine that can build serenity (which will take a couple of days).