### PR TITLE
LibPDF: Tweak vertical position of truetype fonts

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -53,7 +53,8 @@ PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
     auto style = renderer.state().paint_style;
 
     // Account for the reversed font baseline
-    auto position = point.translated(0, -m_font->baseline());
+    auto position = point.translated(0, -m_font->pixel_metrics().descent - m_font->baseline());
+
     if (style.has<Color>()) {
         painter.draw_glyph(position, char_code, *m_font, style.get<Color>());
     } else {

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -71,7 +71,7 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
 
     if (!m_font_program) {
         // Account for the reversed font baseline
-        auto position = point.translated(0, -m_font->baseline());
+        auto position = point.translated(0, -m_font->pixel_metrics().descent - m_font->baseline());
         // FIXME: Bounding box and sample point look to be pretty wrong
         if (style.has<Color>()) {
             painter.draw_glyph(position, char_code, *m_font, style.get<Color>());


### PR DESCRIPTION
The vertical coordinates for truetype fonts are different somehow. We compensated a bit for that; now we compensate some more.

This is still not 100% perfect, but much better than before.

---

Screenshots in a few hours.