### PR TITLE
LibWeb: Reduce the number of UsedValue hash lookups during BFC/IFC layout

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1058,6 +1058,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         auto top_margin_edge = y - box_state.margin_box_top();
         side_data.all_boxes.append(adopt_own(*new FloatingBox {
             .box = box,
+            .used_values = box_state,
             .offset_from_edge = offset_from_edge,
             .top_margin_edge = top_margin_edge,
             .bottom_margin_edge = y + box_state.content_height() + box_state.margin_box_bottom(),

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -993,12 +993,12 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
             // Walk all currently tracked floats on the side we're floating towards.
             // We're looking for the innermost preceding float that intersects vertically with `box`.
             for (auto& preceding_float : side_data.current_boxes.in_reverse()) {
-                auto const preceding_float_rect = margin_box_rect_in_ancestor_coordinate_space(preceding_float.box, root());
+                auto const& preceding_float_state = m_state.get(preceding_float.box);
+                auto const preceding_float_rect = margin_box_rect_in_ancestor_coordinate_space(preceding_float_state, root());
                 if (!preceding_float_rect.contains_vertically(y_in_root))
                     continue;
                 // We found a preceding float that intersects vertically with the current float.
                 // Now we need to find out if there's enough inline-axis space to stack them next to each other.
-                auto const& preceding_float_state = m_state.get(preceding_float.box);
                 CSSPixels tentative_offset_from_edge = 0;
                 bool fits_next_to_preceding_float = false;
                 if (side == FloatSide::Left) {
@@ -1150,12 +1150,11 @@ BlockFormattingContext::SpaceUsedAndContainingMarginForFloats BlockFormattingCon
         auto const& floating_box = *floating_box_ptr;
         auto const& floating_box_state = m_state.get(floating_box.box);
         // NOTE: The floating box is *not* in the final horizontal position yet, but the size and vertical position is valid.
-        auto rect = margin_box_rect_in_ancestor_coordinate_space(floating_box.box, root());
+        auto rect = margin_box_rect_in_ancestor_coordinate_space(floating_box_state, root());
         if (rect.contains_vertically(y)) {
             CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-            for (auto const* containing_block = floating_box.box->containing_block(); containing_block && containing_block != &root(); containing_block = containing_block->containing_block()) {
-                auto const& containing_block_state = m_state.get(*containing_block);
-                offset_from_containing_block_chain_margins_between_here_and_root += containing_block_state.margin_box_left();
+            for (auto const* containing_block = floating_box_state.containing_block_used_values(); containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
+                offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_left();
             }
             space_and_containing_margin.left_used_space = floating_box.offset_from_edge
                 + floating_box_state.content_width()
@@ -1170,12 +1169,11 @@ BlockFormattingContext::SpaceUsedAndContainingMarginForFloats BlockFormattingCon
         auto const& floating_box = *floating_box_ptr;
         auto const& floating_box_state = m_state.get(floating_box.box);
         // NOTE: The floating box is *not* in the final horizontal position yet, but the size and vertical position is valid.
-        auto rect = margin_box_rect_in_ancestor_coordinate_space(floating_box.box, root());
+        auto rect = margin_box_rect_in_ancestor_coordinate_space(floating_box_state, root());
         if (rect.contains_vertically(y)) {
             CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-            for (auto const* containing_block = floating_box.box->containing_block(); containing_block && containing_block != &root(); containing_block = containing_block->containing_block()) {
-                auto const& containing_block_state = m_state.get(*containing_block);
-                offset_from_containing_block_chain_margins_between_here_and_root += containing_block_state.margin_box_right();
+            for (auto const* containing_block = floating_box_state.containing_block_used_values(); containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
+                offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_right();
             }
             space_and_containing_margin.right_used_space = floating_box.offset_from_edge
                 + floating_box_state.margin_box_left();

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -89,6 +89,9 @@ private:
 
     struct FloatingBox {
         JS::NonnullGCPtr<Box const> box;
+
+        LayoutState::UsedValues& used_values;
+
         // Offset from left/right edge to the left content edge of `box`.
         CSSPixels offset_from_edge { 0 };
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -71,12 +71,19 @@ public:
     virtual CSSPixels greatest_child_width(Box const&) const;
 
     [[nodiscard]] CSSPixelRect absolute_content_rect(Box const&) const;
+    [[nodiscard]] CSSPixelRect absolute_content_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect margin_box_rect(Box const&) const;
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
+    [[nodiscard]] CSSPixelRect margin_box_rect(LayoutState::UsedValues const&) const;
+    [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect border_box_rect(Box const&) const;
+    [[nodiscard]] CSSPixelRect border_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect border_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
+    [[nodiscard]] CSSPixelRect border_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect content_box_rect(Box const&) const;
+    [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
+    [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixels box_baseline(Box const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_static_position_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
 

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -39,7 +39,7 @@ BlockFormattingContext const& InlineFormattingContext::parent() const
 CSSPixels InlineFormattingContext::leftmost_x_offset_at(CSSPixels y) const
 {
     // NOTE: Floats are relative to the BFC root box, not necessarily the containing block of this IFC.
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(containing_block(), parent().root());
+    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_containing_block_state, parent().root());
     CSSPixels y_in_root = box_in_root_rect.y() + y;
     auto space_and_containing_margin = parent().space_used_and_containing_margin_for_floats(y_in_root);
     auto left_side_floats_limit_to_right = space_and_containing_margin.left_total_containing_margin + space_and_containing_margin.left_used_space;
@@ -362,7 +362,7 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
 
 bool InlineFormattingContext::any_floats_intrude_at_y(CSSPixels y) const
 {
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(containing_block(), parent().root());
+    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_containing_block_state, parent().root());
     CSSPixels y_in_root = box_in_root_rect.y() + y;
     auto space_and_containing_margin = parent().space_used_and_containing_margin_for_floats(y_in_root);
     return space_and_containing_margin.left_used_space > 0 || space_and_containing_margin.right_used_space > 0;

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -540,6 +540,7 @@ void LayoutState::commit(Box& root)
 void LayoutState::UsedValues::set_node(NodeWithStyle& node, UsedValues const* containing_block_used_values)
 {
     m_node = &node;
+    m_containing_block_used_values = containing_block_used_values;
 
     // NOTE: In the code below, we decide if `node` has definite width and/or height.
     //       This attempts to cover all the *general* cases where CSS considers sizes to be definite.

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -45,6 +45,8 @@ struct LayoutState {
         NodeWithStyle const& node() const { return *m_node; }
         void set_node(NodeWithStyle&, UsedValues const* containing_block_used_values);
 
+        UsedValues const* containing_block_used_values() const { return m_containing_block_used_values; }
+
         CSSPixels content_width() const { return m_content_width; }
         CSSPixels content_height() const { return m_content_height; }
         void set_content_width(CSSPixels);
@@ -142,6 +144,7 @@ struct LayoutState {
         CSSPixels border_bottom_collapsed() const { return use_collapsing_borders_model() ? round(border_bottom / 2) : border_bottom; }
 
         JS::GCPtr<Layout::NodeWithStyle> m_node { nullptr };
+        UsedValues const* m_containing_block_used_values { nullptr };
 
         CSSPixels m_content_width { 0 };
         CSSPixels m_content_height { 0 };


### PR DESCRIPTION
Basically:

1. Give `UsedValues` a pointer to the `UsedValues` of the containing block.
2. Give `BFC::FloatingBox` a pointer to the box's `UsedValues`.
3. Use those in a bunch of hot places to avoid `m_state.get(box)` lookups.

This makes layout *significantly* faster on long Wikipedia articles with many floats.

Time spent in `LayoutState::get()` goes from 37% to 2% on 
https://en.wikipedia.org/wiki/George_Frideric_Handel