### PR TITLE
LibWeb/CSS: Support calc() in grid placement values

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/css-calc-in-grid-position.txt
+++ b/Tests/LibWeb/Layout/expected/grid/css-calc-in-grid-position.txt
@@ -1,0 +1,63 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x50 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 600x34 [GFC] children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div.title> at (8,8) content-size 198.25x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 7, rect: [8,8 45.578125x17] baseline: 13.296875
+            "title 1"
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      BlockContainer <div.text> at (8,25) content-size 198.25x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 6, rect: [8,25 46.484375x17] baseline: 13.296875
+            "text 1"
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+        TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div.title> at (206.25,8) content-size 200.71875x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 7, rect: [206.25,8 48.046875x17] baseline: 13.296875
+            "title 2"
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      BlockContainer <div.text> at (206.25,25) content-size 200.71875x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 6, rect: [206.25,25 48.953125x17] baseline: 13.296875
+            "text 2"
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+        TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div.title> at (406.96875,8) content-size 201x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 7, rect: [406.96875,8 48.328125x17] baseline: 13.296875
+            "title 3"
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      BlockContainer <div.text> at (406.96875,25) content-size 201x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 6, rect: [406.96875,25 49.234375x17] baseline: 13.296875
+            "text 3"
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableBox (Box<BODY>) [8,8 600x34]
+      PaintableWithLines (BlockContainer<DIV>.title) [8,8 198.25x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.text) [8,25 198.25x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.title) [206.25,8 200.71875x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.text) [206.25,25 200.71875x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.title) [406.96875,8 201x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.text) [406.96875,25 201x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/css-calc-in-grid-position.html
+++ b/Tests/LibWeb/Layout/input/grid/css-calc-in-grid-position.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html><style>
+* {
+    outline: 1px solid black;
+}
+body {
+    display: grid;
+    width: 600px;
+}
+.column {
+    display: contents;
+}
+.title {
+    grid-column: var(--column-index);
+    grid-row: calc(3);
+}
+.text {
+    grid-column: var(--column-index);
+    grid-row: calc(4);
+}
+</style>
+<body>
+<div class="column" style="--column-index: 1">
+    <div class="title">title 1</div>
+    <div class="text">text 1</div>
+</div>
+<div class="column" style="--column-index: 2">
+    <div class="title">title 2</div>
+    <div class="text">text 2</div>
+</div>
+<div class="column" style="--column-index: 3">
+    <div class="title">title 3</div>
+    <div class="text">text 3</div>
+</div>
+</body>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5692,6 +5692,10 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(TokenStream<ComponentValue
     //        `parse_grid_area_shorthand_value()` using a single TokenStream.
     if (tokens.remaining_token_count() == 1) {
         auto& token = tokens.next_token();
+        if (auto maybe_calculated = parse_calculated_value(token); maybe_calculated && maybe_calculated->resolves_to_number()) {
+            transaction.commit();
+            return GridTrackPlacementStyleValue::create(GridTrackPlacement::make_line(static_cast<int>(maybe_calculated->resolve_integer().value()), {}));
+        }
         if (token.is_ident("auto"sv)) {
             transaction.commit();
             return GridTrackPlacementStyleValue::create(GridTrackPlacement::make_auto());


### PR DESCRIPTION
Fixes reduction in https://github.com/SerenityOS/serenity/issues/22802 but does not result in visual improvement on https://kotlinlang.org/