### PR TITLE
LibWeb: Fix accounting for gaps in auto-fit count calculation in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/columns-auto-fill-with-gap-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/columns-auto-fill-with-gap-3.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17 [GFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 63.125x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 7, rect: [8,8 63.125x17] baseline: 13.296875
+            "Explore"
+        TextNode <#text>
+      BlockContainer <div> at (121.125,8) content-size 100.0625x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 12, rect: [121.125,8 100.0625x17] baseline: 13.296875
+            "Wiki Content"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableBox (Box<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 63.125x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [121.125,8 100.0625x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/columns-auto-fill-with-gap-3.html
+++ b/Tests/LibWeb/Layout/input/grid/columns-auto-fill-with-gap-3.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><style>
+    * {
+        outline: 1px solid black;
+    }
+    body {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(2ch, max-content));
+        column-gap: 50px;
+    }
+    div {
+        background: pink;
+    }
+</style><body><div>Explore</div><div>Wiki Content</div>


### PR DESCRIPTION
Fixes a bug where gaps between repeated tracks were accounted for only once instead of multiple times, corresponding to the repeat count.

Fixes https://github.com/SerenityOS/serenity/issues/22823