### PR TITLE
LibWeb: Format all .idl files to use four space indentation

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -7,32 +7,31 @@
 interface Animation : EventTarget {
     constructor(optional AnimationEffect? effect = null,
                 optional AnimationTimeline? timeline);
-             attribute DOMString                id;
-             attribute AnimationEffect?         effect;
-             attribute AnimationTimeline?       timeline;
-             attribute double?                  startTime;
-             attribute double?                  currentTime;
-             attribute double                   playbackRate;
-    readonly attribute AnimationPlayState       playState;
-    readonly attribute AnimationReplaceState    replaceState;
-    readonly attribute boolean                  pending;
-    readonly attribute Promise<Animation>       ready;
-    readonly attribute Promise<Animation>       finished;
 
-    // FIXME:
-    //       attribute EventHandler             onfinish;
-    //       attribute EventHandler             oncancel;
-    //       attribute EventHandler             onremove;
+    attribute DOMString id;
+    attribute AnimationEffect? effect;
+    attribute AnimationTimeline? timeline;
+    attribute double? startTime;
+    attribute double? currentTime;
+    attribute double playbackRate;
+    readonly attribute AnimationPlayState playState;
+    readonly attribute AnimationReplaceState replaceState;
+    readonly attribute boolean pending;
+    readonly attribute Promise<Animation> ready;
+    readonly attribute Promise<Animation> finished;
 
-    // undefined cancel();
-    // undefined finish();
-    // undefined play();
-    // undefined pause();
-    // undefined updatePlaybackRate(double playbackRate);
-    // undefined reverse();
-    // undefined persist();
-    // [CEReactions]
-    // undefined commitStyles();
+    // FIXME: attribute EventHandler onfinish;
+    // FIXME: attribute EventHandler oncancel;
+    // FIXME: attribute EventHandler onremove;
+
+    // FIXME: undefined cancel();
+    // FIXME: undefined finish();
+    // FIXME: undefined play();
+    // FIXME: undefined pause();
+    // FIXME: undefined updatePlaybackRate(double playbackRate);
+    // FIXME: undefined reverse();
+    // FIXME: undefined persist();
+    // FIXME: [CEReactions] undefined commitStyles();
 };
 
 // https://www.w3.org/TR/web-animations-1/#the-animationplaystate-enumeration

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.idl
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.idl
@@ -1,25 +1,25 @@
 // https://www.w3.org/TR/web-animations-1/#the-effecttiming-dictionaries
 dictionary EffectTiming {
-    double                             delay = 0;
-    double                             endDelay = 0;
-    FillMode                           fill = "auto";
-    double                             iterationStart = 0.0;
-    unrestricted double                iterations = 1.0;
+    double delay = 0;
+    double endDelay = 0;
+    FillMode fill = "auto";
+    double iterationStart = 0.0;
+    unrestricted double iterations = 1.0;
     (unrestricted double or DOMString) duration = "auto";
-    PlaybackDirection                  direction = "normal";
-    DOMString                          easing = "linear";
+    PlaybackDirection direction = "normal";
+    DOMString easing = "linear";
 };
 
 // https://www.w3.org/TR/web-animations-1/#dictdef-optionaleffecttiming
 dictionary OptionalEffectTiming {
-    double                             delay;
-    double                             endDelay;
-    FillMode                           fill;
-    double                             iterationStart;
-    unrestricted double                iterations;
+    double delay;
+    double endDelay;
+    FillMode fill;
+    double iterationStart;
+    unrestricted double iterations;
     (unrestricted double or DOMString) duration;
-    PlaybackDirection                  direction;
-    DOMString                          easing;
+    PlaybackDirection direction;
+    DOMString easing;
 };
 
 // https://www.w3.org/TR/web-animations-1/#the-fillmode-enumeration
@@ -30,17 +30,17 @@ enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" }
 
 // https://www.w3.org/TR/web-animations-1/#the-computedeffecttiming-dictionary
 dictionary ComputedEffectTiming : EffectTiming {
-    unrestricted double  endTime;
-    unrestricted double  activeDuration;
-    double?              localTime;
-    double?              progress;
+    unrestricted double endTime;
+    unrestricted double activeDuration;
+    double? localTime;
+    double? progress;
     unrestricted double? currentIteration;
 };
 
 // https://www.w3.org/TR/web-animations-1/#the-animationeffect-interface
 [Exposed=Window]
 interface AnimationEffect {
-    EffectTiming         getTiming();
+    EffectTiming getTiming();
     ComputedEffectTiming getComputedTiming();
-    undefined            updateTiming(optional OptionalEffectTiming timing = {});
+    undefined updateTiming(optional OptionalEffectTiming timing = {});
 };

--- a/Userland/Libraries/LibWeb/Animations/DocumentTimeline.idl
+++ b/Userland/Libraries/LibWeb/Animations/DocumentTimeline.idl
@@ -3,11 +3,11 @@
 
 // https://www.w3.org/TR/web-animations-1/#dictdef-documenttimelineoptions
 dictionary DocumentTimelineOptions {
-  DOMHighResTimeStamp originTime = 0;
+    DOMHighResTimeStamp originTime = 0;
 };
 
 // https://www.w3.org/TR/web-animations-1/#documenttimeline
 [Exposed=Window]
 interface DocumentTimeline : AnimationTimeline {
-  constructor(optional DocumentTimelineOptions options = {});
+    constructor(optional DocumentTimelineOptions options = {});
 };

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.idl
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.idl
@@ -10,34 +10,32 @@ enum CompositeOperationOrAuto { "replace", "add", "accumulate", "auto" };
 // https://www.w3.org/TR/web-animations-1/#the-keyframeeffectoptions-dictionary
 dictionary KeyframeEffectOptions : EffectTiming {
     CompositeOperation composite = "replace";
-    CSSOMString?       pseudoElement = null;
+    CSSOMString? pseudoElement = null;
 };
 
 // https://www.w3.org/TR/web-animations-1/#dictdef-basepropertyindexedkeyframe
 dictionary BasePropertyIndexedKeyframe {
-    (double? or sequence<double?>)                         offset = [];
-    (DOMString or sequence<DOMString>)                     easing = [];
+    (double? or sequence<double?>) offset = [];
+    (DOMString or sequence<DOMString>) easing = [];
     (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
 };
 
 // https://www.w3.org/TR/web-animations-1/#dictdef-basekeyframe
 dictionary BaseKeyframe {
-    double?                  offset = null;
-    DOMString                easing = "linear";
+    double? offset = null;
+    DOMString easing = "linear";
     CompositeOperationOrAuto composite = "auto";
 };
 
 // https://www.w3.org/TR/web-animations-1/#the-keyframeeffect-interface
 [Exposed=Window]
 interface KeyframeEffect : AnimationEffect {
-    constructor(Element? target,
-                object? keyframes,
-                optional (unrestricted double or KeyframeEffectOptions) options = {});
+    constructor(Element? target, object? keyframes, optional (unrestricted double or KeyframeEffectOptions) options = {});
     constructor(KeyframeEffect source);
 
-    attribute Element?           target;
-    attribute CSSOMString?       pseudoElement;
+    attribute Element? target;
+    attribute CSSOMString? pseudoElement;
     attribute CompositeOperation composite;
     sequence<object> getKeyframes();
-    undefined        setKeyframes(object? keyframes);
+    undefined setKeyframes(object? keyframes);
 };

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.idl
@@ -3,6 +3,6 @@
 // https://www.w3.org/TR/cssom/#the-cssnamespacerule-interface
 [Exposed=Window]
 interface CSSNamespaceRule : CSSRule {
-  readonly attribute CSSOMString namespaceURI;
-  readonly attribute CSSOMString prefix;
+    readonly attribute CSSOMString namespaceURI;
+    readonly attribute CSSOMString prefix;
 };

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.idl
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.idl
@@ -5,8 +5,8 @@
 // https://w3c.github.io/clipboard-apis/#clipboard
 [SecureContext, Exposed=Window]
 interface Clipboard : EventTarget {
-      // FIXME: Promise<ClipboardItems> read();
-      // FIXME: Promise<DOMString> readText();
-      // FIXME: Promise<undefined> write(ClipboardItems data);
-      Promise<undefined> writeText(DOMString data);
+    // FIXME: Promise<ClipboardItems> read();
+    // FIXME: Promise<DOMString> readText();
+    // FIXME: Promise<undefined> write(ClipboardItems data);
+    Promise<undefined> writeText(DOMString data);
 };

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.idl
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.idl
@@ -1,7 +1,7 @@
 typedef (object or DOMString) AlgorithmIdentifier;
 
 dictionary Algorithm {
-  required DOMString name;
+    required DOMString name;
 };
 
 // https://w3c.github.io/webcrypto/#subtlecrypto-interface

--- a/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.idl
+++ b/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.idl
@@ -4,5 +4,5 @@
 // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlformcontrolscollection
 [Exposed=Window]
 interface HTMLFormControlsCollection : HTMLCollection {
-      [ImplementedAs=named_item_or_radio_node_list] getter (RadioNodeList or Element)? namedItem(DOMString name); // shadows inherited namedItem()
+    [ImplementedAs=named_item_or_radio_node_list] getter (RadioNodeList or Element)? namedItem(DOMString name); // shadows inherited namedItem()
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigateEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigateEvent.idl
@@ -7,50 +7,50 @@
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigateevent-interface
 [Exposed=Window]
 interface NavigateEvent : Event {
-  constructor(DOMString type, NavigateEventInit eventInitDict);
+    constructor(DOMString type, NavigateEventInit eventInitDict);
 
-  readonly attribute NavigationType navigationType;
-  readonly attribute NavigationDestination destination;
-  readonly attribute boolean canIntercept;
-  readonly attribute boolean userInitiated;
-  readonly attribute boolean hashChange;
-  readonly attribute AbortSignal signal;
-  readonly attribute FormData? formData;
-  readonly attribute DOMString? downloadRequest;
-  readonly attribute any info;
-  readonly attribute boolean hasUAVisualTransition;
+    readonly attribute NavigationType navigationType;
+    readonly attribute NavigationDestination destination;
+    readonly attribute boolean canIntercept;
+    readonly attribute boolean userInitiated;
+    readonly attribute boolean hashChange;
+    readonly attribute AbortSignal signal;
+    readonly attribute FormData? formData;
+    readonly attribute DOMString? downloadRequest;
+    readonly attribute any info;
+    readonly attribute boolean hasUAVisualTransition;
 
-  undefined intercept(optional NavigationInterceptOptions options = {});
-  undefined scroll();
+    undefined intercept(optional NavigationInterceptOptions options = {});
+    undefined scroll();
 };
 
 dictionary NavigateEventInit : EventInit {
-  NavigationType navigationType = "push";
-  required NavigationDestination destination;
-  boolean canIntercept = false;
-  boolean userInitiated = false;
-  boolean hashChange = false;
-  required AbortSignal signal;
-  FormData? formData = null;
-  DOMString? downloadRequest = null;
-  any info;
-  boolean hasUAVisualTransition = false;
+    NavigationType navigationType = "push";
+    required NavigationDestination destination;
+    boolean canIntercept = false;
+    boolean userInitiated = false;
+    boolean hashChange = false;
+    required AbortSignal signal;
+    FormData? formData = null;
+    DOMString? downloadRequest = null;
+    any info;
+    boolean hasUAVisualTransition = false;
 };
 
 dictionary NavigationInterceptOptions {
-  NavigationInterceptHandler handler;
-  NavigationFocusReset focusReset;
-  NavigationScrollBehavior scroll;
+    NavigationInterceptHandler handler;
+    NavigationFocusReset focusReset;
+    NavigationScrollBehavior scroll;
 };
 
 enum NavigationFocusReset {
-  "after-transition",
-  "manual"
+    "after-transition",
+    "manual"
 };
 
 enum NavigationScrollBehavior {
-  "after-transition",
-  "manual"
+    "after-transition",
+    "manual"
 };
 
 callback NavigationInterceptHandler = Promise<undefined> ();

--- a/Userland/Libraries/LibWeb/HTML/Navigation.idl
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.idl
@@ -6,51 +6,51 @@
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-interface
 [Exposed=Window]
 interface Navigation : EventTarget {
-  sequence<NavigationHistoryEntry> entries();
-  readonly attribute NavigationHistoryEntry? currentEntry;
-  undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
-  readonly attribute NavigationTransition? transition;
+    sequence<NavigationHistoryEntry> entries();
+    readonly attribute NavigationHistoryEntry? currentEntry;
+    undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
+    readonly attribute NavigationTransition? transition;
 
-  readonly attribute boolean canGoBack;
-  readonly attribute boolean canGoForward;
+    readonly attribute boolean canGoBack;
+    readonly attribute boolean canGoForward;
 
-  NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
-  NavigationResult reload(optional NavigationReloadOptions options = {});
+    NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
+    NavigationResult reload(optional NavigationReloadOptions options = {});
 
-  NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});
-  NavigationResult back(optional NavigationOptions options = {});
-  NavigationResult forward(optional NavigationOptions options = {});
+    NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});
+    NavigationResult back(optional NavigationOptions options = {});
+    NavigationResult forward(optional NavigationOptions options = {});
 
-  attribute EventHandler onnavigate;
-  attribute EventHandler onnavigatesuccess;
-  attribute EventHandler onnavigateerror;
-  attribute EventHandler oncurrententrychange;
+    attribute EventHandler onnavigate;
+    attribute EventHandler onnavigatesuccess;
+    attribute EventHandler onnavigateerror;
+    attribute EventHandler oncurrententrychange;
 };
 
 dictionary NavigationUpdateCurrentEntryOptions {
-  required any state;
+    required any state;
 };
 
 dictionary NavigationOptions {
-  any info;
+    any info;
 };
 
 dictionary NavigationNavigateOptions : NavigationOptions {
-  any state;
-  NavigationHistoryBehavior history = "auto";
+    any state;
+    NavigationHistoryBehavior history = "auto";
 };
 
 dictionary NavigationReloadOptions : NavigationOptions {
-  any state;
+    any state;
 };
 
 dictionary NavigationResult {
-  Promise<NavigationHistoryEntry> committed;
-  Promise<NavigationHistoryEntry> finished;
+    Promise<NavigationHistoryEntry> committed;
+    Promise<NavigationHistoryEntry> finished;
 };
 
 enum NavigationHistoryBehavior {
-  "auto",
-  "push",
-  "replace"
+    "auto",
+    "push",
+    "replace"
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigationDestination.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigationDestination.idl
@@ -1,11 +1,11 @@
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface
 [Exposed=Window]
 interface NavigationDestination {
-  readonly attribute USVString url;
-  readonly attribute DOMString key;
-  readonly attribute DOMString id;
-  readonly attribute long long index;
-  readonly attribute boolean sameDocument;
+    readonly attribute USVString url;
+    readonly attribute DOMString key;
+    readonly attribute DOMString id;
+    readonly attribute long long index;
+    readonly attribute boolean sameDocument;
 
-  any getState();
+    any getState();
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigationHistoryEntry.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigationHistoryEntry.idl
@@ -4,13 +4,13 @@
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationtype
 [Exposed=Window]
 interface NavigationHistoryEntry : EventTarget {
-  readonly attribute USVString? url;
-  readonly attribute DOMString key;
-  readonly attribute DOMString id;
-  readonly attribute long long index;
-  readonly attribute boolean sameDocument;
+    readonly attribute USVString? url;
+    readonly attribute DOMString key;
+    readonly attribute DOMString id;
+    readonly attribute long long index;
+    readonly attribute boolean sameDocument;
 
-  any getState();
+    any getState();
 
-  attribute EventHandler ondispose;
+    attribute EventHandler ondispose;
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigationTransition.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigationTransition.idl
@@ -4,7 +4,7 @@
 // https://html.spec.whatwg.org/#navigationtransition
 [Exposed=Window]
 interface NavigationTransition {
-  readonly attribute NavigationType navigationType;
-  readonly attribute NavigationHistoryEntry from;
-  readonly attribute Promise<undefined> finished;
+    readonly attribute NavigationType navigationType;
+    readonly attribute NavigationHistoryEntry from;
+    readonly attribute Promise<undefined> finished;
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigationType.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigationType.idl
@@ -1,7 +1,7 @@
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationtype
 enum NavigationType {
- "push",
- "replace",
- "reload",
- "traverse"
+    "push",
+    "replace",
+    "reload",
+    "traverse"
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.idl
@@ -1,4 +1,4 @@
 // https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware
 interface mixin NavigatorConcurrentHardware {
-  readonly attribute unsigned long long hardwareConcurrency;
+    readonly attribute unsigned long long hardwareConcurrency;
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigatorID.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorID.idl
@@ -1,12 +1,12 @@
 // https://html.spec.whatwg.org/multipage/system-state.html#navigatorid
 interface mixin NavigatorID {
-  readonly attribute DOMString appCodeName; // constant "Mozilla"
-  readonly attribute DOMString appName; // constant "Netscape"
-  readonly attribute DOMString appVersion;
-  readonly attribute DOMString platform;
-  readonly attribute DOMString product; // constant "Gecko"
-  [Exposed=Window] readonly attribute DOMString productSub;
-  readonly attribute DOMString userAgent;
-  [Exposed=Window] readonly attribute DOMString vendor;
-  [Exposed=Window] readonly attribute DOMString vendorSub; // constant ""
+    readonly attribute DOMString appCodeName; // constant "Mozilla"
+    readonly attribute DOMString appName; // constant "Netscape"
+    readonly attribute DOMString appVersion;
+    readonly attribute DOMString platform;
+    readonly attribute DOMString product; // constant "Gecko"
+    [Exposed=Window] readonly attribute DOMString productSub;
+    readonly attribute DOMString userAgent;
+    [Exposed=Window] readonly attribute DOMString vendor;
+    [Exposed=Window] readonly attribute DOMString vendorSub; // constant ""
 };

--- a/Userland/Libraries/LibWeb/HTML/NavigatorOnLine.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorOnLine.idl
@@ -1,4 +1,4 @@
 // https://html.spec.whatwg.org/multipage/system-state.html#navigatoronline
 interface mixin NavigatorOnLine {
-  readonly attribute boolean onLine;
+    readonly attribute boolean onLine;
 };

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.idl
@@ -10,5 +10,5 @@ interface SubmitEvent : Event {
 };
 
 dictionary SubmitEventInit : EventInit {
-   HTMLElement? submitter = null;
+    HTMLElement? submitter = null;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.idl
@@ -1,6 +1,6 @@
 // https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumber
 [Exposed=Window]
 interface SVGAnimatedNumber {
-           attribute float baseVal;
-  readonly attribute float animVal;
+    attribute float baseVal;
+    readonly attribute float animVal;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedString.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedString.idl
@@ -1,6 +1,6 @@
 // https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString
 [Exposed=Window]
 interface SVGAnimatedString {
-                                      attribute DOMString baseVal;
+    attribute DOMString baseVal;
     [ImplementedAs=base_val] readonly attribute DOMString animVal;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.idl
@@ -4,20 +4,19 @@
 // https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextPathElement
 [Exposed=Window]
 interface SVGTextPathElement : SVGTextContentElement {
+    // textPath Method Types
+    const unsigned short TEXTPATH_METHODTYPE_UNKNOWN = 0;
+    const unsigned short TEXTPATH_METHODTYPE_ALIGN = 1;
+    const unsigned short TEXTPATH_METHODTYPE_STRETCH = 2;
 
-  // textPath Method Types
-  const unsigned short TEXTPATH_METHODTYPE_UNKNOWN = 0;
-  const unsigned short TEXTPATH_METHODTYPE_ALIGN = 1;
-  const unsigned short TEXTPATH_METHODTYPE_STRETCH = 2;
+    // textPath Spacing Types
+    const unsigned short TEXTPATH_SPACINGTYPE_UNKNOWN = 0;
+    const unsigned short TEXTPATH_SPACINGTYPE_AUTO = 1;
+    const unsigned short TEXTPATH_SPACINGTYPE_EXACT = 2;
 
-  // textPath Spacing Types
-  const unsigned short TEXTPATH_SPACINGTYPE_UNKNOWN = 0;
-  const unsigned short TEXTPATH_SPACINGTYPE_AUTO = 1;
-  const unsigned short TEXTPATH_SPACINGTYPE_EXACT = 2;
-
-  // FIXME: [SameObject] readonly attribute SVGAnimatedLength startOffset;
-  // FIXME: [SameObject] readonly attribute SVGAnimatedEnumeration method;
-  // FIXME: [SameObject] readonly attribute SVGAnimatedEnumeration spacing;
+    // FIXME: [SameObject] readonly attribute SVGAnimatedLength startOffset;
+    // FIXME: [SameObject] readonly attribute SVGAnimatedEnumeration method;
+    // FIXME: [SameObject] readonly attribute SVGAnimatedEnumeration spacing;
 };
 
 SVGTextPathElement includes SVGURIReference;


### PR DESCRIPTION
Nitpick pr incoming: I noticed that some `.idl` files where using 2 space indentation, but almost all other use four space indentation like the rest of the project. So let's fix that.

Also the IDL interfaces in the `Animations/` use whitespace differently to align names, this is in the spec but we transform also the whitespace of other specs so I also made that conform the rest of the `.idl` files.