### PR TITLE
Fuzzers: Continue if frame is malformed in GIF fuzzer

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -12,7 +12,9 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    AK::set_debug_enabled(false);
+    if constexpr (!GIF_DEBUG) {
+        AK::set_debug_enabled(false);
+    }
     auto decoder_or_error = Gfx::GIFImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -30,9 +30,14 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
         dbgln_if(GIF_DEBUG, "loop_count: {}", gif_decoder.loop_count());
         dbgln_if(GIF_DEBUG, "frame_count: {}", gif_decoder.frame_count());
         for (size_t i = 0; i < gif_decoder.frame_count(); ++i) {
-            auto ifd = gif_decoder.frame(i).release_value_but_fixme_should_propagate_errors();
-            dbgln_if(GIF_DEBUG, "frame #{} size: {}", i, ifd.image->size());
-            dbgln_if(GIF_DEBUG, "frame #{} duration: {}", i, ifd.duration);
+            auto ifd_or_error = gif_decoder.frame(i);
+            if (ifd_or_error.is_error()) {
+                dbgln_if(GIF_DEBUG, "frame #{} error: {}", i, ifd_or_error.release_error());
+            } else {
+                auto ifd = ifd_or_error.release_value();
+                dbgln_if(GIF_DEBUG, "frame #{} size: {}", i, ifd.image->size());
+                dbgln_if(GIF_DEBUG, "frame #{} duration: {}", i, ifd.duration);
+            }
         }
         dbgln_if(GIF_DEBUG, "Done.");
     }


### PR DESCRIPTION
Fixes oss fuzz issue: [65858](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65858).

I also included a small fix to ensure the conditional logging the fuzzer does is printed when GIF_DEBUG is enabled.