### PR TITLE
base64: Implement -w/--wrap

### DIFF
--- a/Base/usr/share/man/man1/base64.md
+++ b/Base/usr/share/man/man1/base64.md
@@ -5,7 +5,7 @@ base64 - encode and decode to base64
 ## Synopsis
 
 ```**sh
-$ base64 [-d|--decode] [file]
+$ base64 [--decode] [--wrap column] [file]
 ```
 
 ## Description
@@ -15,15 +15,18 @@ file is not specified or file is `-`.
 
 ## Options
 
-* `-d|--decode`: Decode data
+* `-d`, `--decode`: Decode data
+* `-w column`, `--wrap column`: When encoding, wrap output after `column` characters
 
 ## Examples
 
 ```sh
-# base64 encode the text 'foo'
+# base64 encode the text 'A'
 $ echo 'A' | base64
-# base64 encode the content of foo.txt
+# base64 encode the content of hi.txt
 $ base64 hi.txt
+# base64 encode the content of baz.txt and wrap after 4 columns
+$ base64 -w 4 baz.txt
 # base64 decode the text 'Zm9v'
 $ echo 'Zm9v' | base64 -d
 # base64 decode the content of foo.txt

--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -10,15 +10,29 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
+static void print_wrapped_output(size_t column, StringView encoded)
+{
+    VERIFY(column > 0);
+
+    while (!encoded.is_empty()) {
+        auto segment_length = min(column, encoded.length());
+
+        outln("{}", encoded.substring_view(0, segment_length));
+        encoded = encoded.substring_view(segment_length);
+    }
+}
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
     bool decode = false;
+    Optional<size_t> maybe_column;
     StringView filepath = {};
 
     Core::ArgsParser args_parser;
     args_parser.add_option(decode, "Decode data", "decode", 'd');
+    args_parser.add_option(maybe_column, "When encoding, wrap output after column characters", "wrap", 'w', "column");
     args_parser.add_positional_argument(filepath, "", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -34,6 +48,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto encoded = TRY(encode_base64(buffer));
+
+    if (maybe_column.has_value() && *maybe_column > 0) {
+        print_wrapped_output(*maybe_column, encoded);
+        return 0;
+    }
+
     outln("{}", encoded);
     return 0;
 }


### PR DESCRIPTION
This is an option supported by coreutils, so we might as well support it too.

It allows users to wrap their encoded output after the "column" value they provide.

This commit also has the Markdown look more like what we see when running ArgsParser::print_usage_markdown() (and it fixes some of the examples).

Examples:
![Screenshot 2024-01-17 162130](https://github.com/SerenityOS/serenity/assets/60799661/7f0af053-66fa-43af-bbca-b115acff06a8)
