### PR TITLE
nohup: Use return code 127 for errors caught by serenity_main()

### DIFF
--- a/Userland/Utilities/nohup.cpp
+++ b/Userland/Utilities/nohup.cpp
@@ -54,6 +54,7 @@ void dup_out_file(int fd_to_redirect)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    Main::set_return_code_for_errors(127);
     TRY(Core::System::pledge("stdio wpath cpath rpath exec sigaction"));
 
     StringView utility;


### PR DESCRIPTION
For any errors that occur during the runtime of nohup, POSIX uses a 127 return code.

I have actually tried to resolve this in the past (#20537) by manually checking for errors and returning a 127 exit code but the code started to look hard to read. Thanks to `Main::set_return_code_for_errors()`, I don't have to do any of this!