### PR TITLE
LibWeb: Add basic input range user interactivity

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -85,6 +85,7 @@ input[type=range]::-webkit-slider-thumb {
     margin-top: -6px;
     width: 16px;
     height: 16px;
+    transform: translateX(-50%);
     border-radius: 50%;
     background-color: hsl(0, 0%, 96%);
     outline: 1px solid rgba(0, 0, 0, 0.5);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -371,6 +371,19 @@ String HTMLInputElement::value() const
         return get_attribute(AttributeNames::value).value_or(String {});
     }
 
+    // https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range):attr-input-value
+    if (type_state() == TypeAttributeState::Range) {
+        // https://html.spec.whatwg.org/multipage/input.html#concept-input-value-default-range
+        double minimum = *min();
+        double maximum = *max();
+        double default_value = minimum + (maximum - minimum) / 2;
+        if (maximum < minimum)
+            default_value = minimum;
+
+        if (!parse_floating_point_number(m_value).has_value())
+            return MUST(String::number(default_value));
+    }
+
     // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-value
     // Return the current value of the element.
     return m_value;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -223,9 +223,11 @@ private:
     JS::GCPtr<DOM::Text> m_placeholder_text_node;
 
     JS::GCPtr<DOM::Element> m_inner_text_element;
-    JS::GCPtr<DOM::Element> m_color_well_element;
     JS::GCPtr<DOM::Text> m_text_node;
     bool m_checked { false };
+
+    void update_color_well_element();
+    JS::GCPtr<DOM::Element> m_color_well_element;
 
     void update_slider_thumb_element();
     JS::GCPtr<DOM::Element> m_slider_thumb;


### PR DESCRIPTION
To finish some unfinished business with the input range element, here is basic interactivity.

You can use the following methods to adjust the input range like other browsers:
- **Keyboard**: arrows left, right, up, down and page down, up
- **Scrolling**: up and down
- **Mouse**: clicking an dragging

**There is currently no value snapping to the step size!** This is a bug, but I'll fix it in the future.

## Demo video
https://github.com/SerenityOS/serenity/assets/19894029/4ad42b7f-0815-4931-9859-b17833b3646f
