### PR TITLE
LibWeb: Update layout before looking at overflow in window.scroll()

### DIFF
--- a/Tests/LibWeb/Text/expected/window-scroll-while-parsing.txt
+++ b/Tests/LibWeb/Text/expected/window-scroll-while-parsing.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash) 

--- a/Tests/LibWeb/Text/input/window-scroll-while-parsing.html
+++ b/Tests/LibWeb/Text/input/window-scroll-while-parsing.html
@@ -1,0 +1,5 @@
+<body><script>
+    window.scrollTo(200, 200);
+    if (window.internals !== undefined)
+        window.internals.signalTextTestIsDone();
+</script>PASS (didn't crash)

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1273,6 +1273,12 @@ void Window::scroll(ScrollToOptions const& options)
     auto viewport_height = viewport_rect.height();
 
     auto const document = top_level_traversable->active_document();
+    VERIFY(document);
+
+    // Make sure layout is up-to-date before looking at scrollable overflow metrics.
+    document->update_layout();
+
+    VERIFY(document->paintable_box());
     auto scrolling_area = document->paintable_box()->scrollable_overflow_rect()->to_type<float>();
 
     // 7. FIXME: For now we always assume overflow direction is rightward


### PR DESCRIPTION
Fixes a crash seen on https://www.ekioh.com/