### PR TITLE
LibWeb: Correctly categorize Fetch responses as network errors

### DIFF
--- a/Tests/LibWeb/Text/expected/video-failed-load.txt
+++ b/Tests/LibWeb/Text/expected/video-failed-load.txt
@@ -1,0 +1,3 @@
+failed to load: "data:"
+failed to load: "file:///i-do-no-exist-i-swear"
+failed to load: "https://i-do-no-exist-i-swear.net.uk"

--- a/Tests/LibWeb/Text/input/video-failed-load.html
+++ b/Tests/LibWeb/Text/input/video-failed-load.html
@@ -1,0 +1,35 @@
+<script src="include.js"></script>
+<script type="text/javascript">
+    const SOURCES = [
+        "data:",
+        "file:///i-do-no-exist-i-swear",
+        "https://i-do-no-exist-i-swear.net.uk",
+    ];
+
+    const runTest = source => {
+        let video = document.createElement("video");
+
+        return new Promise((resolve, reject) => {
+            video.addEventListener("loadedmetadata", () => {
+                reject(`successfully loaded: "${video.src}"`);
+            });
+
+            video.addEventListener("error", () => {
+                resolve(`failed to load: "${video.src}"`);
+            });
+
+            video.src = source;
+        });
+    };
+
+    asyncTest(done => {
+        let promises = SOURCES.map(source => runTest(source));
+
+        Promise.allSettled(promises)
+            .then(results => {
+                const values = results.map(result => result.value);
+                values.sort().forEach(println);
+            })
+            .finally(done);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -96,7 +96,7 @@ bool Response::is_network_error() const
         return false;
     if (!header_list()->is_empty())
         return false;
-    if (!body())
+    if (body())
         return false;
     if (body_info() != BodyInfo {})
         return false;


### PR DESCRIPTION
The condition here is flipped. From the spec:

     A network error is a response whose ... body is null ...

Fixes #22851