### PR TITLE
LibGfx/TIFF: Rename JPEG to OldJPEG and introduce a new JPEG tag

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
@@ -17,6 +17,10 @@ namespace Gfx {
 // First TIFF Technical notes from 1995
 // https://www.awaresystems.be/imaging/tiff/specification/TIFFPM6.pdf
 
+// Second TIFF Technical notes from 1995
+// The document is the second (and current) specification for embedded JPEGs in TIFF images.
+// https://www.awaresystems.be/imaging/tiff/specification/TIFFTechNote2.txt
+
 // This is also compatible with Exif as it is, basically, another set of TIFF tags:
 // The spec is named "Exchangeable image file format for digital still cameras: Exif Version 3.0"
 // And it can be found at https://www.cipa.jp/e/std/std-sec.html

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -55,7 +55,8 @@ class Compression(EnumWithExportName):
     Group3Fax = 3
     Group4Fax = 4
     LZW = 5
-    JPEG = 6
+    OldJPEG = 6
+    JPEG = 7
     AdobeDeflate = 8
     PackBits = 32773
 


### PR DESCRIPTION
Support for JPEGs embedded in TIFF images was introduced with TIFF 6.0. However, this implementation had major issues. It was so problematic that they decided to reimplement it from scratch in 1995, three years later. The two incarnations are obviously incompatible.

For more details see:
https://www.awaresystems.be/imaging/tiff/specification/TIFFTechNote2.txt