### PR TITLE
LibWeb: Stub Range::get_client_rects()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOMParsing/InnerHTML.h>
 #include <LibWeb/Geometry/DOMRect.h>
+#include <LibWeb/Geometry/DOMRectList.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -1144,6 +1145,13 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
     TRY(set_start(*new_node, new_offset));
     TRY(set_end(*new_node, new_offset));
     return {};
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
+JS::NonnullGCPtr<Geometry::DOMRectList> Range::get_client_rects() const
+{
+    dbgln("(STUBBED) Range::get_client_rects()");
+    return Geometry::DOMRectList::create(realm(), {});
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view/#dom-range-getboundingclientrect

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -85,6 +85,7 @@ public:
 
     static HashTable<Range*>& live_ranges();
 
+    JS::NonnullGCPtr<Geometry::DOMRectList> get_client_rects() const;
     JS::NonnullGCPtr<Geometry::DOMRect> get_bounding_client_rect() const;
 
     bool contains_node(Node const&) const;

--- a/Userland/Libraries/LibWeb/DOM/Range.idl
+++ b/Userland/Libraries/LibWeb/DOM/Range.idl
@@ -40,6 +40,7 @@ interface Range : AbstractRange {
 
     boolean intersectsNode(Node node);
 
+    DOMRectList getClientRects();
     DOMRect getBoundingClientRect();
 
     stringifier;


### PR DESCRIPTION
Fixes "Application error: a client-side exception has occurred (see the browser console for more information)." on https://kotlinlang.org/