### PR TITLE
HackStudio: Make Locator comfier to use

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -319,7 +319,7 @@ bool HackStudioWidget::open_file(ByteString const& full_filename, size_t line, s
 
     if (editor_wrapper_or_none.has_value()) {
         set_current_editor_wrapper(editor_wrapper_or_none.release_value());
-        current_editor().set_cursor(line, column);
+        current_editor().set_cursor_and_focus_line(line, column);
         return true;
     } else if (active_file().is_empty() && !current_editor().document().is_modified() && !full_filename.is_empty()) {
         // Replace "Untitled" blank file since it hasn't been modified
@@ -385,7 +385,7 @@ bool HackStudioWidget::open_file(ByteString const& full_filename, size_t line, s
     current_editor().on_cursor_change = [this] { on_cursor_change(); };
     current_editor().on_change = [this] { update_window_title(); };
     current_editor_wrapper().on_change = [this] { update_gml_preview(); };
-    current_editor().set_cursor(line, column);
+    current_editor().set_cursor_and_focus_line(line, column);
     update_gml_preview();
 
     return true;

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -184,6 +184,7 @@ void Locator::open()
 void Locator::close()
 {
     m_popup_window->hide();
+    m_textbox->set_focus(false);
 }
 
 void Locator::update_suggestions()

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -146,7 +146,7 @@ Locator::Locator(Core::EventReceiver* parent)
     };
 
     m_popup_window = GUI::Window::construct(parent);
-    m_popup_window->set_window_type(GUI::WindowType::Popup);
+    m_popup_window->set_window_type(GUI::WindowType::Autocomplete);
     m_popup_window->set_rect(0, 0, 500, 200);
 
     m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>();


### PR DESCRIPTION
Fixes a couple of issues with the Locator:
- It would lose focus after each character you type in the text box.
- Jumping to a symbol wouldn't scroll to the relevant line, and the Locator would remain focused.