### PR TITLE
GMLCompiler+Applications: Add common user-defined initializer for widgets

### DIFF
--- a/Base/usr/share/man/man5/GML/Usage.md
+++ b/Base/usr/share/man/man5/GML/Usage.md
@@ -50,3 +50,16 @@ From there, you can use `find_descendant_of_type_named` to select widgets from y
 // MyApp::Widget::foo_bar
 m_mem_add_button = *find_descendant_of_type_named<GUI::Button>("mem_add_button");
 ```
+
+### `initialize` Pattern
+
+Initialization, like adding models, attaching callbacks, etc., should be done in a member function with the signature:
+
+```cpp
+// MyApp::Widget
+ErrorOr<void> initialize();
+```
+
+This initializer function, if it exists, will automatically be called after the structure of your widget was set up by the auto-generated GML code.
+
+The only case where this function cannot be used is when your initialization requires additional parameters, like a GUI window. You may still consider moving as much initialization to the canonical function as possible.

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -334,6 +334,8 @@ static ErrorOr<void> generate_loader_for_object(GUI::GML::Object const& gml_obje
         return {};
     }));
 
+    TRY(append(generator, "TRY(::GUI::initialize(*@object_name@));"));
+
     generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)).bytes_as_string_view());
     generator.appendln("}");
 

--- a/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.h
@@ -27,13 +27,13 @@ class AutoplaySettingsWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(AutoplaySettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
-    static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> try_create();
     AutoplaySettingsWidget() = default;
 
     void set_allowlist_model(NonnullRefPtr<AutoplayAllowlistModel> model);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -95,16 +95,7 @@ private:
     Vector<WebView::SearchEngine> m_search_engines;
 };
 
-ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> BrowserSettingsWidget::create()
-{
-    auto widget = TRY(BrowserSettingsWidget::try_create());
-
-    TRY(widget->setup());
-
-    return widget;
-}
-
-ErrorOr<void> BrowserSettingsWidget::setup()
+ErrorOr<void> BrowserSettingsWidget::initialize()
 {
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
     m_homepage_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, Browser::default_homepage_url), GUI::AllowCallback::No);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
@@ -17,17 +17,15 @@ namespace BrowserSettings {
 class BrowserSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(BrowserSettingsWidget)
 public:
-    static ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> try_create();
     virtual ~BrowserSettingsWidget() override = default;
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
+    ErrorOr<void> initialize();
+
 private:
-    static ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> try_create();
-
-    ErrorOr<void> setup();
-
     RefPtr<GUI::TextBox> m_homepage_url_textbox;
     RefPtr<GUI::TextBox> m_new_tab_url_textbox;
     void set_color_scheme(StringView);

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
@@ -37,13 +37,13 @@ class ContentFilterSettingsWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(ContentFilterSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
-    static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> try_create();
     ContentFilterSettingsWidget() = default;
 
     void set_domain_list_model(NonnullRefPtr<DomainListModel>);

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -37,9 +37,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Browser Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    (void)TRY(window->add_tab(TRY(BrowserSettings::BrowserSettingsWidget::create()), "Browser"_string, "browser"sv));
-    (void)TRY(window->add_tab(TRY(BrowserSettings::ContentFilterSettingsWidget::create()), "Content Filtering"_string, "content-filtering"sv));
-    (void)TRY(window->add_tab(TRY(BrowserSettings::AutoplaySettingsWidget::create()), "Autoplay"_string, "autoplay"sv));
+    (void)TRY(window->add_tab<BrowserSettings::BrowserSettingsWidget>("Browser"_string, "browser"sv));
+    (void)TRY(window->add_tab<BrowserSettings::ContentFilterSettingsWidget>("Content Filtering"_string, "content-filtering"sv));
+    (void)TRY(window->add_tab<BrowserSettings::AutoplaySettingsWidget>("Autoplay"_string, "autoplay"sv));
     window->set_active_tab(selected_tab);
 
     window->show();

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -17,89 +17,87 @@
 
 namespace Calculator {
 
-ErrorOr<NonnullRefPtr<CalculatorWidget>> CalculatorWidget::create()
+ErrorOr<void> CalculatorWidget::initialize()
 {
-    auto widget = TRY(CalculatorWidget::try_create());
-
-    widget->m_entry = *widget->find_descendant_of_type_named<GUI::TextBox>("entry_textbox");
+    m_entry = *find_descendant_of_type_named<GUI::TextBox>("entry_textbox");
     // FIXME: Use GML for this.
-    widget->m_entry->set_relative_rect(5, 5, 244, 26);
-    widget->m_entry->set_text_alignment(Gfx::TextAlignment::CenterRight);
+    m_entry->set_relative_rect(5, 5, 244, 26);
+    m_entry->set_text_alignment(Gfx::TextAlignment::CenterRight);
 
     // FIXME: Use GML for this.
-    widget->m_label = *widget->find_descendant_of_type_named<GUI::Label>("label");
-    widget->m_label->set_frame_style(Gfx::FrameStyle::SunkenContainer);
+    m_label = *find_descendant_of_type_named<GUI::Label>("label");
+    m_label->set_frame_style(Gfx::FrameStyle::SunkenContainer);
 
     for (int i = 0; i < 10; i++) {
-        widget->m_digit_button[i] = *widget->find_descendant_of_type_named<GUI::Button>(TRY(String::formatted("{}_button", i)));
-        widget->add_digit_button(*widget->m_digit_button[i], i);
+        m_digit_button[i] = *find_descendant_of_type_named<GUI::Button>(TRY(String::formatted("{}_button", i)));
+        add_digit_button(*m_digit_button[i], i);
     }
 
-    widget->m_mem_add_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_add_button");
-    widget->add_operation_button(*widget->m_mem_add_button, Calculator::Operation::MemAdd);
+    m_mem_add_button = *find_descendant_of_type_named<GUI::Button>("mem_add_button");
+    add_operation_button(*m_mem_add_button, Calculator::Operation::MemAdd);
 
-    widget->m_mem_save_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_save_button");
-    widget->add_operation_button(*widget->m_mem_save_button, Calculator::Operation::MemSave);
+    m_mem_save_button = *find_descendant_of_type_named<GUI::Button>("mem_save_button");
+    add_operation_button(*m_mem_save_button, Calculator::Operation::MemSave);
 
-    widget->m_mem_recall_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_recall_button");
-    widget->add_operation_button(*widget->m_mem_recall_button, Calculator::Operation::MemRecall);
+    m_mem_recall_button = *find_descendant_of_type_named<GUI::Button>("mem_recall_button");
+    add_operation_button(*m_mem_recall_button, Calculator::Operation::MemRecall);
 
-    widget->m_mem_clear_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_clear_button");
-    widget->add_operation_button(*widget->m_mem_clear_button, Calculator::Operation::MemClear);
+    m_mem_clear_button = *find_descendant_of_type_named<GUI::Button>("mem_clear_button");
+    add_operation_button(*m_mem_clear_button, Calculator::Operation::MemClear);
 
-    widget->m_clear_button = *widget->find_descendant_of_type_named<GUI::Button>("clear_button");
-    widget->m_clear_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.set_to_0();
-        self->m_calculator.clear_operation();
-        self->update_display();
+    m_clear_button = *find_descendant_of_type_named<GUI::Button>("clear_button");
+    m_clear_button->on_click = [this](auto) {
+        m_keypad.set_to_0();
+        m_calculator.clear_operation();
+        update_display();
     };
 
-    widget->m_clear_error_button = *widget->find_descendant_of_type_named<GUI::Button>("clear_error_button");
-    widget->m_clear_error_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.set_to_0();
-        self->update_display();
+    m_clear_error_button = *find_descendant_of_type_named<GUI::Button>("clear_error_button");
+    m_clear_error_button->on_click = [this](auto) {
+        m_keypad.set_to_0();
+        update_display();
     };
 
-    widget->m_backspace_button = *widget->find_descendant_of_type_named<GUI::Button>("backspace_button");
-    widget->m_backspace_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.type_backspace();
-        self->update_display();
+    m_backspace_button = *find_descendant_of_type_named<GUI::Button>("backspace_button");
+    m_backspace_button->on_click = [this](auto) {
+        m_keypad.type_backspace();
+        update_display();
     };
 
-    widget->m_decimal_point_button = *widget->find_descendant_of_type_named<GUI::Button>("decimal_button");
-    widget->m_decimal_point_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.type_decimal_point();
-        self->update_display();
+    m_decimal_point_button = *find_descendant_of_type_named<GUI::Button>("decimal_button");
+    m_decimal_point_button->on_click = [this](auto) {
+        m_keypad.type_decimal_point();
+        update_display();
     };
 
-    widget->m_sign_button = *widget->find_descendant_of_type_named<GUI::Button>("sign_button");
-    widget->add_operation_button(*widget->m_sign_button, Calculator::Operation::ToggleSign);
+    m_sign_button = *find_descendant_of_type_named<GUI::Button>("sign_button");
+    add_operation_button(*m_sign_button, Calculator::Operation::ToggleSign);
 
-    widget->m_add_button = *widget->find_descendant_of_type_named<GUI::Button>("add_button");
-    widget->add_operation_button(*widget->m_add_button, Calculator::Operation::Add);
+    m_add_button = *find_descendant_of_type_named<GUI::Button>("add_button");
+    add_operation_button(*m_add_button, Calculator::Operation::Add);
 
-    widget->m_subtract_button = *widget->find_descendant_of_type_named<GUI::Button>("subtract_button");
-    widget->add_operation_button(*widget->m_subtract_button, Calculator::Operation::Subtract);
+    m_subtract_button = *find_descendant_of_type_named<GUI::Button>("subtract_button");
+    add_operation_button(*m_subtract_button, Calculator::Operation::Subtract);
 
-    widget->m_multiply_button = *widget->find_descendant_of_type_named<GUI::Button>("multiply_button");
-    widget->add_operation_button(*widget->m_multiply_button, Calculator::Operation::Multiply);
+    m_multiply_button = *find_descendant_of_type_named<GUI::Button>("multiply_button");
+    add_operation_button(*m_multiply_button, Calculator::Operation::Multiply);
 
-    widget->m_divide_button = *widget->find_descendant_of_type_named<GUI::Button>("divide_button");
-    widget->add_operation_button(*widget->m_divide_button, Calculator::Operation::Divide);
+    m_divide_button = *find_descendant_of_type_named<GUI::Button>("divide_button");
+    add_operation_button(*m_divide_button, Calculator::Operation::Divide);
 
-    widget->m_sqrt_button = *widget->find_descendant_of_type_named<GUI::Button>("sqrt_button");
-    widget->add_operation_button(*widget->m_sqrt_button, Calculator::Operation::Sqrt);
+    m_sqrt_button = *find_descendant_of_type_named<GUI::Button>("sqrt_button");
+    add_operation_button(*m_sqrt_button, Calculator::Operation::Sqrt);
 
-    widget->m_inverse_button = *widget->find_descendant_of_type_named<GUI::Button>("inverse_button");
-    widget->add_operation_button(*widget->m_inverse_button, Calculator::Operation::Inverse);
+    m_inverse_button = *find_descendant_of_type_named<GUI::Button>("inverse_button");
+    add_operation_button(*m_inverse_button, Calculator::Operation::Inverse);
 
-    widget->m_percent_button = *widget->find_descendant_of_type_named<GUI::Button>("mod_button");
-    widget->add_operation_button(*widget->m_percent_button, Calculator::Operation::Percent);
+    m_percent_button = *find_descendant_of_type_named<GUI::Button>("mod_button");
+    add_operation_button(*m_percent_button, Calculator::Operation::Percent);
 
-    widget->m_equals_button = *widget->find_descendant_of_type_named<GUI::Button>("equal_button");
-    widget->add_operation_button(*widget->m_equals_button, Calculator::Operation::Equals);
+    m_equals_button = *find_descendant_of_type_named<GUI::Button>("equal_button");
+    add_operation_button(*m_equals_button, Calculator::Operation::Equals);
 
-    return widget;
+    return {};
 }
 
 void CalculatorWidget::perform_operation(Calculator::Operation operation)

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -20,7 +20,8 @@ namespace Calculator {
 class CalculatorWidget final : public GUI::Widget {
     C_OBJECT(CalculatorWidget)
 public:
-    static ErrorOr<NonnullRefPtr<CalculatorWidget>> create();
+    static ErrorOr<NonnullRefPtr<CalculatorWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual ~CalculatorWidget() override = default;
     String get_entry();
@@ -34,7 +35,6 @@ public:
     void set_rounding_custom(GUI::Action& action, StringView);
 
 private:
-    static ErrorOr<NonnullRefPtr<CalculatorWidget>> try_create();
     CalculatorWidget() = default;
 
     void add_operation_button(GUI::Button&, Calculator::Operation);

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
     window->resize(250, 215);
 
-    auto widget = TRY(Calculator::CalculatorWidget::create());
+    auto widget = TRY(Calculator::CalculatorWidget::try_create());
     window->set_main_widget(widget.ptr());
 
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
@@ -30,14 +30,7 @@ void CalendarSettingsWidget::reset_default_values()
     m_default_view_combobox->set_text("Month");
 }
 
-ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> CalendarSettingsWidget::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> CalendarSettingsWidget::setup()
+ErrorOr<void> CalendarSettingsWidget::initialize()
 {
     m_first_day_of_week_combobox = *find_descendant_of_type_named<GUI::ComboBox>("first_day_of_week");
     m_first_day_of_week_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "FirstDayOfWeek"sv, "Sunday"sv));

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.h
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.h
@@ -15,16 +15,15 @@ class CalendarSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CalendarSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     CalendarSettingsWidget() = default;
-    static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> try_create();
 
-    ErrorOr<void> setup();
     static constexpr Array<StringView, 2> const m_view_modes = { "Month"sv, "Year"sv };
 
     RefPtr<GUI::ComboBox> m_first_day_of_week_combobox;

--- a/Userland/Applications/CalendarSettings/main.cpp
+++ b/Userland/Applications/CalendarSettings/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-calendar"sv);
 
     auto window = TRY(GUI::SettingsWindow::create("Calendar Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab(TRY(CalendarSettings::CalendarSettingsWidget::create()), "Calendar"_string, "Calendar"sv));
+    (void)TRY(window->add_tab<CalendarSettings::CalendarSettingsWidget>("Calendar"_string, "Calendar"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_active_tab(selected_tab);
 

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
@@ -151,13 +151,6 @@ ErrorOr<void> CertificateStoreWidget::export_pem()
     return {};
 }
 
-ErrorOr<NonnullRefPtr<CertificateStoreWidget>> CertificateStoreWidget::create()
-{
-    auto widget = TRY(CertificateStoreWidget::try_create());
-    TRY(widget->initialize());
-    return widget;
-}
-
 ErrorOr<void> CertificateStoreWidget::initialize()
 {
     m_root_ca_tableview = find_descendant_of_type_named<GUI::TableView>("root_ca_tableview");

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
@@ -58,14 +58,13 @@ class CertificateStoreWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CertStoreWidget)
 public:
     virtual ~CertificateStoreWidget() override = default;
-    static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> create();
+    static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> try_create();
+    ErrorOr<void> initialize();
     virtual void apply_settings() override {};
 
 private:
-    static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> try_create();
     CertificateStoreWidget() = default;
 
-    ErrorOr<void> initialize();
     ErrorOr<void> import_pem();
     ErrorOr<void> export_pem();
 

--- a/Userland/Applications/CertificateSettings/main.cpp
+++ b/Userland/Applications/CertificateSettings/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     auto app_icon = GUI::Icon::default_icon("certificate"sv);
     auto window = TRY(GUI::SettingsWindow::create("Certificate Settings", GUI::SettingsWindow::ShowDefaultsButton::No));
-    TRY(window->add_tab(TRY(CertificateSettings::CertificateStoreWidget::create()), "Certificate Store"_string, "certificate"sv));
+    (void)TRY(window->add_tab<CertificateSettings::CertificateStoreWidget>("Certificate Store"_string, "certificate"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -61,13 +61,6 @@ void CardGamePreview::paint_event(GUI::PaintEvent& event)
         stack->paint(painter, background_color);
 }
 
-ErrorOr<NonnullRefPtr<CardSettingsWidget>> CardSettingsWidget::create()
-{
-    auto card_settings_widget = TRY(try_create());
-    TRY(card_settings_widget->initialize());
-    return card_settings_widget;
-}
-
 ErrorOr<void> CardSettingsWidget::initialize()
 {
     auto background_color = Gfx::Color::from_string(Config::read_string("Games"sv, "Cards"sv, "BackgroundColor"sv)).value_or(Gfx::Color::from_rgb(0x008000));

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.h
@@ -21,7 +21,7 @@ class CardSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CardSettingsWidget)
 public:
     static ErrorOr<NonnullRefPtr<CardSettingsWidget>> try_create();
-    static ErrorOr<NonnullRefPtr<CardSettingsWidget>> create();
+    ErrorOr<void> initialize();
     virtual ~CardSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -29,7 +29,6 @@ public:
 
 private:
     CardSettingsWidget() = default;
-    ErrorOr<void> initialize();
 
     bool set_card_back_image_path(StringView);
     String card_back_image_path() const;

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -231,13 +231,6 @@ void ChessGamePreview::paint_event(GUI::PaintEvent& event)
     }
 }
 
-ErrorOr<NonnullRefPtr<ChessSettingsWidget>> ChessSettingsWidget::create()
-{
-    auto chess_settings_widget = TRY(try_create());
-    TRY(chess_settings_widget->initialize());
-    return chess_settings_widget;
-}
-
 ErrorOr<void> ChessSettingsWidget::initialize()
 {
     auto piece_set_name = Config::read_string("Games"sv, "Chess"sv, "PieceSet"sv, "Classic"sv);

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.h
@@ -18,7 +18,7 @@ class ChessSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(ChessSettingsWidget)
 public:
     static ErrorOr<NonnullRefPtr<ChessSettingsWidget>> try_create();
-    static ErrorOr<NonnullRefPtr<ChessSettingsWidget>> create();
+    ErrorOr<void> initialize();
     virtual ~ChessSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -26,7 +26,6 @@ public:
 
 private:
     ChessSettingsWidget() = default;
-    ErrorOr<void> initialize();
 
     Vector<ByteString> m_piece_sets;
 

--- a/Userland/Applications/GamesSettings/main.cpp
+++ b/Userland/Applications/GamesSettings/main.cpp
@@ -35,10 +35,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Games Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto widget_cards = TRY(GamesSettings::CardSettingsWidget::create());
-    auto widget_chess = TRY(GamesSettings::ChessSettingsWidget::create());
-    (void)TRY(window->add_tab(widget_cards, "Cards"_string, "cards"sv));
-    (void)TRY(window->add_tab(widget_chess, "Chess"_string, "chess"sv));
+    (void)TRY(window->add_tab<GamesSettings::CardSettingsWidget>("Cards"_string, "cards"sv));
+    (void)TRY(window->add_tab<GamesSettings::ChessSettingsWidget>("Chess"_string, "chess"sv));
     window->set_active_tab(selected_tab);
 
     window->show();

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -61,7 +61,7 @@ ErrorOr<void> MainWidget::set_start_page(Vector<StringView, 2> query_parameters)
     return {};
 }
 
-ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
+ErrorOr<void> MainWidget::initialize(GUI::Window& window)
 {
     m_toolbar = find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("tab_widget");

--- a/Userland/Applications/Help/MainWidget.h
+++ b/Userland/Applications/Help/MainWidget.h
@@ -21,7 +21,7 @@ public:
 
     static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
 
-    ErrorOr<void> initialize_fallibles(GUI::Window&);
+    ErrorOr<void> initialize(GUI::Window&);
     ErrorOr<void> set_start_page(Vector<StringView, 2> query_parameters);
 
 private:

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -63,7 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto main_widget = TRY(MainWidget::try_create());
     window->set_main_widget(main_widget);
 
-    TRY(main_widget->initialize_fallibles(window));
+    TRY(main_widget->initialize(window));
     TRY(main_widget->set_start_page(query_parameters));
 
     window->show();

--- a/Userland/Applications/Maps/FavoritesPanel.cpp
+++ b/Userland/Applications/Maps/FavoritesPanel.cpp
@@ -15,14 +15,7 @@
 
 namespace Maps {
 
-ErrorOr<NonnullRefPtr<FavoritesPanel>> FavoritesPanel::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> FavoritesPanel::setup()
+ErrorOr<void> FavoritesPanel::initialize()
 {
     m_empty_container = *find_descendant_of_type_named<GUI::Frame>("empty_container");
     m_favorites_list = *find_descendant_of_type_named<GUI::ListView>("favorites_list");

--- a/Userland/Applications/Maps/FavoritesPanel.h
+++ b/Userland/Applications/Maps/FavoritesPanel.h
@@ -22,7 +22,8 @@ public:
         MapWidget::LatLng latlng;
         int zoom;
     };
-    static ErrorOr<NonnullRefPtr<FavoritesPanel>> create();
+    static ErrorOr<NonnullRefPtr<FavoritesPanel>> try_create();
+    ErrorOr<void> initialize();
 
     void load_favorites();
     void reset();
@@ -33,10 +34,6 @@ public:
 
 protected:
     FavoritesPanel() = default;
-
-    static ErrorOr<NonnullRefPtr<FavoritesPanel>> try_create();
-
-    ErrorOr<void> setup();
 
 private:
     ErrorOr<void> edit_favorite(int row);

--- a/Userland/Applications/Maps/SearchPanel.cpp
+++ b/Userland/Applications/Maps/SearchPanel.cpp
@@ -9,14 +9,7 @@
 
 namespace Maps {
 
-ErrorOr<NonnullRefPtr<SearchPanel>> SearchPanel::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> SearchPanel::setup()
+ErrorOr<void> SearchPanel::initialize()
 {
     m_request_client = TRY(Protocol::RequestClient::try_create());
 

--- a/Userland/Applications/Maps/SearchPanel.h
+++ b/Userland/Applications/Maps/SearchPanel.h
@@ -21,7 +21,8 @@ class SearchPanel final : public GUI::Widget {
     C_OBJECT(SearchPanel)
 
 public:
-    static ErrorOr<NonnullRefPtr<SearchPanel>> create();
+    static ErrorOr<NonnullRefPtr<SearchPanel>> try_create();
+    ErrorOr<void> initialize();
 
     void search(StringView query);
     void reset();
@@ -36,10 +37,6 @@ public:
 
 private:
     SearchPanel() = default;
-
-    static ErrorOr<NonnullRefPtr<SearchPanel>> try_create();
-
-    ErrorOr<void> setup();
 
     RefPtr<Protocol::RequestClient> m_request_client;
     RefPtr<Protocol::Request> m_request;

--- a/Userland/Applications/Maps/main.cpp
+++ b/Userland/Applications/Maps/main.cpp
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int panel_width = Config::read_i32("Maps"sv, "Panel"sv, "Width"sv, INT_MIN);
 
     // Search panel
-    auto search_panel = TRY(Maps::SearchPanel::create());
+    auto search_panel = TRY(Maps::SearchPanel::try_create());
     search_panel->on_places_change = [&map_widget](auto) { map_widget.remove_markers_with_name("search"sv); };
     search_panel->on_selected_place_change = [&map_widget](auto const& place) {
         // Remove old search marker
@@ -105,7 +105,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Favorites panel
     auto marker_red_image = TRY(Gfx::Bitmap::load_from_file("/res/graphics/maps/marker-red.png"sv));
-    auto favorites_panel = TRY(Maps::FavoritesPanel::create());
+    auto favorites_panel = TRY(Maps::FavoritesPanel::try_create());
     favorites_panel->on_favorites_change = [&map_widget, marker_red_image](auto const& favorites) {
         // Sync all favorites markers
         map_widget.remove_markers_with_name("favorites"sv);

--- a/Userland/Applications/MapsSettings/MapsSettingsWidget.cpp
+++ b/Userland/Applications/MapsSettings/MapsSettingsWidget.cpp
@@ -14,13 +14,6 @@
 
 namespace MapsSettings {
 
-ErrorOr<NonnullRefPtr<MapsSettingsWidget>> MapsSettingsWidget::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
 void MapsSettingsWidget::apply_settings()
 {
     // Tile Provider
@@ -43,7 +36,7 @@ void MapsSettingsWidget::reset_default_values()
     set_tile_provider(Maps::default_tile_provider_url_format);
 }
 
-ErrorOr<void> MapsSettingsWidget::setup()
+ErrorOr<void> MapsSettingsWidget::initialize()
 {
     // Tile Provider
     Vector<GUI::JsonArrayModel::FieldSpec> tile_provider_fields;

--- a/Userland/Applications/MapsSettings/MapsSettingsWidget.h
+++ b/Userland/Applications/MapsSettings/MapsSettingsWidget.h
@@ -14,16 +14,15 @@ class MapsSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(MapsSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     MapsSettingsWidget() = default;
-    static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> try_create();
 
-    ErrorOr<void> setup();
     void set_tile_provider(StringView url);
 
     RefPtr<GUI::ComboBox> m_tile_provider_combobox;

--- a/Userland/Applications/MapsSettings/main.cpp
+++ b/Userland/Applications/MapsSettings/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Maps Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    (void)TRY(window->add_tab(TRY(MapsSettings::MapsSettingsWidget::create()), "Maps"_string, "maps"sv));
+    (void)TRY(window->add_tab<MapsSettings::MapsSettingsWidget>("Maps"_string, "maps"sv));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -29,14 +29,7 @@ static int netmask_to_cidr(IPv4Address const& address)
     return 32 - count_trailing_zeroes_safe(address_in_host_representation);
 }
 
-ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> NetworkSettingsWidget::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> NetworkSettingsWidget::setup()
+ErrorOr<void> NetworkSettingsWidget::initialize()
 {
     m_adapters_combobox = *find_descendant_of_type_named<GUI::ComboBox>("adapters_combobox");
     m_enabled_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("enabled_checkbox");

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
@@ -16,17 +16,14 @@ class NetworkSettingsWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(NetworkSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     void switch_adapter(ByteString const& adapter);
 
-protected:
-    static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> try_create();
-
 private:
     NetworkSettingsWidget() = default;
-    ErrorOr<void> setup();
 
     struct NetworkAdapterData {
         bool enabled = false;

--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     auto app_icon = GUI::Icon::default_icon("network"sv);
     auto window = TRY(GUI::SettingsWindow::create("Network Settings", GUI::SettingsWindow::ShowDefaultsButton::No));
 
-    auto network_settings_widget = TRY(NetworkSettings::NetworkSettingsWidget::create());
+    auto network_settings_widget = TRY(NetworkSettings::NetworkSettingsWidget::try_create());
     TRY(window->add_tab(network_settings_widget, "Network"_string, "network"sv));
     if (!adapter.is_null()) {
         network_settings_widget->switch_adapter(adapter);

--- a/Userland/Applications/Piano/ExportProgressWindow.cpp
+++ b/Userland/Applications/Piano/ExportProgressWindow.cpp
@@ -18,7 +18,7 @@ ExportProgressWindow::ExportProgressWindow(GUI::Window& parent_window, Atomic<in
 {
 }
 
-ErrorOr<void> ExportProgressWindow::initialize_fallibles()
+ErrorOr<void> ExportProgressWindow::initialize()
 {
     auto main_widget = set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(export_progress_widget));

--- a/Userland/Applications/Piano/ExportProgressWindow.h
+++ b/Userland/Applications/Piano/ExportProgressWindow.h
@@ -17,7 +17,7 @@ class ExportProgressWindow : public GUI::Dialog {
 public:
     virtual ~ExportProgressWindow() override = default;
 
-    ErrorOr<void> initialize_fallibles();
+    ErrorOr<void> initialize();
 
     virtual void timer_event(Core::TimerEvent&) override;
 

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto wav_progress_window = ExportProgressWindow::construct(*window, wav_percent_written);
-    TRY(wav_progress_window->initialize_fallibles());
+    TRY(wav_progress_window->initialize());
 
     auto main_widget_updater = TRY(Core::Timer::create_repeating(static_cast<int>((1 / 30.0) * 1000), [&] {
         if (window->is_active())

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -24,16 +24,7 @@
 
 namespace VideoPlayer {
 
-ErrorOr<NonnullRefPtr<VideoPlayerWidget>> VideoPlayerWidget::create()
-{
-    auto main_widget = TRY(try_create());
-
-    TRY(main_widget->setup_interface());
-
-    return main_widget;
-}
-
-ErrorOr<void> VideoPlayerWidget::setup_interface()
+ErrorOr<void> VideoPlayerWidget::initialize()
 {
     m_video_display = find_descendant_of_type_named<VideoPlayer::VideoFrameWidget>("video_frame");
     m_video_display->on_click = [&]() { toggle_pause(); };

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -25,7 +25,7 @@ class VideoPlayerWidget final : public GUI::Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<VideoPlayerWidget>> try_create();
-    static ErrorOr<NonnullRefPtr<VideoPlayerWidget>> create();
+    ErrorOr<void> initialize();
     virtual ~VideoPlayerWidget() override = default;
     void close_file();
     void open_file(FileSystemAccessClient::File filename);
@@ -43,7 +43,6 @@ public:
 
 private:
     VideoPlayerWidget() = default;
-    ErrorOr<void> setup_interface();
     void update_play_pause_icon();
     void update_seek_slider_max();
     void set_current_timestamp(Duration);

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto main_widget = TRY(VideoPlayer::VideoPlayerWidget::create());
+    auto main_widget = TRY(VideoPlayer::VideoPlayerWidget::try_create());
     window->set_main_widget(main_widget);
     main_widget->update_title();
     TRY(main_widget->initialize_menubar(window));

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -71,6 +71,15 @@ enum class AllowCallback {
     Yes
 };
 
+template<typename T>
+ALWAYS_INLINE ErrorOr<void> initialize(T& object)
+{
+    if constexpr (requires { { object.initialize() } -> SameAs<ErrorOr<void>>; })
+        return object.initialize();
+    else
+        return {};
+}
+
 class Widget : public GUI::Object {
     C_OBJECT(Widget)
 public:


### PR DESCRIPTION
Many widget classes need to run substantial initialization code after
they have been setup from GML. With this change, an
initialize_fallibles() function is called if available, allowing the
initialization to be invoked from the GML setup automatically. This
means that the GML-generated creation function can now be used directly
for many more cases, and reduces code duplication.

Fixes #21401