### PR TITLE
Kernel/riscv64: Don't disable stack protector and sanitizers

### DIFF
--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -45,7 +45,11 @@ public:
         u64* page = m_current;
         m_current += (PAGE_TABLE_SIZE / sizeof(FlatPtr));
 
-        __builtin_memset(page, 0, PAGE_TABLE_SIZE);
+        // We can't use [__builtin_]memset here, as that would call into code which has stack protectors enabled,
+        // resulting in an access to an absolute address.
+        for (u64* p = page; p < page + (PAGE_TABLE_SIZE / sizeof(u64)); p++)
+            *p = 0;
+
         return page;
     }
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -510,8 +510,19 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
     #       by the compiler. The CPU cannot access global variables without the MMU as the kernel is linked for a virtual address in high memory.
     set_source_files_properties(${SOURCES_RUNNING_WITHOUT_MMU} PROPERTIES COMPILE_FLAGS "-fno-stack-protector -fno-sanitize=all")
 elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
+    set(SOURCES_RUNNING_WITHOUT_MMU
+        Arch/riscv64/MMU.cpp
+        Arch/riscv64/pre_init.cpp
+
+        # FIXME: Don't disable stack protectors and sanitizers in SBI.cpp.
+        #        Maybe implement SBI debug console printing directly in pre_init.cpp as well?
+        Arch/riscv64/SBI.cpp
+    )
+
     set(KERNEL_SOURCES
         ${KERNEL_SOURCES}
+        ${SOURCES_RUNNING_WITHOUT_MMU}
+
         Arch/Processor.cpp
         kprintf.cpp
 
@@ -536,7 +547,15 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/Timer.cpp
     )
 
-    add_compile_options(-fno-stack-protector -fno-sanitize=all)
+    # NOTE: These files cannot use a stack protector and sanitizers, as these will cause accesses to global variables to be inserted
+    #       by the compiler. The CPU cannot access global variables without the MMU as the kernel is linked for a virtual address in high memory.
+    #       On GCC, also prevent loops from being optimized into functions like memset, as those might use stack protectors and sanitizers.
+    #       We also have to disable our -ftrivial-auto-var-init=pattern mitigation, as that would cause memsets to be inserted.
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set_source_files_properties(${SOURCES_RUNNING_WITHOUT_MMU} PROPERTIES COMPILE_FLAGS "-fno-stack-protector -fno-sanitize=all -ftrivial-auto-var-init=uninitialized -fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")
+    else()
+        set_source_files_properties(${SOURCES_RUNNING_WITHOUT_MMU} PROPERTIES COMPILE_FLAGS "-fno-stack-protector -fno-sanitize=all -ftrivial-auto-var-init=uninitialized")
+    endif()
 endif()
 
 set(AK_SOURCES


### PR DESCRIPTION
I am not sure why 096cecb95e disabled the stack protector and sanitizers for all files, but this is not necessary.
Only the pre_init code needs to run without them, as that code runs identity mapped.