### PR TITLE
HackStudio+LibGUI: Stop crashing when opening a recent project

### DIFF
--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -167,7 +167,7 @@ ErrorOr<void> MainWidget::create_actions()
         if (auto result = save_file(file.filename(), file.release_stream()); result.is_error())
             show_error(result.release_error(), "Saving"sv, file.filename());
         else
-            GUI::Application::the()->set_most_recently_open_file(file.filename());
+            GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
     });
 
     m_cut_action = GUI::CommonActions::make_cut_action([this](auto&) {
@@ -827,7 +827,7 @@ ErrorOr<void> MainWidget::open_file(StringView path, NonnullOwnPtr<Core::File> f
     auto unmasked_font = TRY(TRY(Gfx::BitmapFont::try_load_from_mapped_file(move(mapped_file)))->unmasked_character_set());
     TRY(initialize(path, move(unmasked_font)));
     if (!path.is_empty())
-        GUI::Application::the()->set_most_recently_open_file(TRY(String::from_utf8(path)));
+        GUI::Application::the()->set_most_recently_open_file(path);
     return {};
 }
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -600,8 +600,9 @@ void HexEditorWidget::open_file(String const& filename, NonnullOwnPtr<Core::File
 {
     window()->set_modified(false);
     m_editor->open_file(move(file));
-    set_path(filename.to_byte_string());
-    GUI::Application::the()->set_most_recently_open_file(filename);
+    auto filename_byte_string = filename.to_byte_string();
+    set_path(filename_byte_string);
+    GUI::Application::the()->set_most_recently_open_file(filename_byte_string);
 }
 
 bool HexEditorWidget::request_close()

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -267,7 +267,7 @@ ErrorOr<void> ViewWidget::try_open_file(String const& path, Core::File& file)
     }
 
     set_path(path);
-    GUI::Application::the()->set_most_recently_open_file(path);
+    GUI::Application::the()->set_most_recently_open_file(path.to_byte_string());
 
     if (on_image_change)
         on_image_change(m_image);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -424,7 +424,7 @@ PDF::PDFErrorOr<void> PDFViewerWidget::try_open_file(StringView path, NonnullOwn
         m_sidebar_open = false;
     }
 
-    GUI::Application::the()->set_most_recently_open_file(TRY(String::from_utf8(path)));
+    GUI::Application::the()->set_most_recently_open_file(path);
 
     return {};
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -208,16 +208,14 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         auto* editor = current_image_editor();
         VERIFY(editor);
         editor->save_project_as();
-        auto path_string = String::from_byte_string(editor->path()).release_value_but_fixme_should_propagate_errors();
-        GUI::Application::the()->set_most_recently_open_file(path_string);
+        GUI::Application::the()->set_most_recently_open_file(editor->path());
     });
 
     m_save_image_action = GUI::CommonActions::make_save_action([&](auto&) {
         auto* editor = current_image_editor();
         VERIFY(editor);
         editor->save_project();
-        auto path_string = String::from_byte_string(editor->path()).release_value_but_fixme_should_propagate_errors();
-        GUI::Application::the()->set_most_recently_open_file(path_string);
+        GUI::Application::the()->set_most_recently_open_file(editor->path());
     });
 
     file_menu->add_action(*m_new_image_action);
@@ -1310,7 +1308,7 @@ void MainWidget::open_image(FileSystemAccessClient::File file)
     editor.set_unmodified();
     m_layer_list_widget->set_image(&image);
     m_toolbox->ensure_tool_selection();
-    GUI::Application::the()->set_most_recently_open_file(file.filename());
+    GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
 }
 
 ErrorOr<void> MainWidget::create_default_image()

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -569,7 +569,7 @@ void SpreadsheetWidget::save(String const& filename, Core::File& file)
     }
     undo_stack().set_current_unmodified();
     window()->set_modified(false);
-    GUI::Application::the()->set_most_recently_open_file(filename);
+    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
 }
 
 void SpreadsheetWidget::load_file(String const& filename, Core::File& file)
@@ -592,7 +592,7 @@ void SpreadsheetWidget::load_file(String const& filename, Core::File& file)
 
     setup_tabs(m_workbook->sheets());
     update_window_title();
-    GUI::Application::the()->set_most_recently_open_file(filename);
+    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
 }
 
 void SpreadsheetWidget::import_sheets(String const& filename, Core::File& file)

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -293,7 +293,7 @@ MainWidget::MainWidget()
         }
 
         set_path(file.filename());
-        GUI::Application::the()->set_most_recently_open_file(file.filename());
+        GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
         dbgln("Wrote document to {}", file.filename());
     });
 
@@ -803,7 +803,7 @@ ErrorOr<void> MainWidget::read_file(String const& filename, Core::File& file)
 {
     m_editor->set_text(TRY(file.read_until_eof()));
     set_path(filename);
-    GUI::Application::the()->set_most_recently_open_file(filename);
+    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
     m_editor->set_focus(true);
     return {};
 }

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -349,9 +349,10 @@ void MainWidget::set_path(ByteString path)
     update_title();
 }
 
-void MainWidget::save_to_file(String const& filename, NonnullOwnPtr<Core::File> file)
+void MainWidget::save_to_file(String const& filename_string, NonnullOwnPtr<Core::File> file)
 {
-    auto theme = Core::ConfigFile::open(filename.to_byte_string(), move(file)).release_value_but_fixme_should_propagate_errors();
+    auto filename = filename_string.to_byte_string();
+    auto theme = Core::ConfigFile::open(filename, move(file)).release_value_but_fixme_should_propagate_errors();
 
 #define __ENUMERATE_ALIGNMENT_ROLE(role) theme->write_entry("Alignments", to_string(Gfx::AlignmentRole::role), to_string(m_current_palette.alignment(Gfx::AlignmentRole::role)));
     ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
@@ -378,7 +379,7 @@ void MainWidget::save_to_file(String const& filename, NonnullOwnPtr<Core::File> 
         GUI::MessageBox::show_error(window(), ByteString::formatted("Failed to save theme file: {}", sync_result.error()));
     } else {
         m_last_modified_time = MonotonicTime::now();
-        set_path(filename.to_byte_string());
+        set_path(filename);
         window()->set_modified(false);
         GUI::Application::the()->set_most_recently_open_file(filename);
     }
@@ -676,7 +677,7 @@ ErrorOr<void> MainWidget::load_from_file(String const& filename, NonnullOwnPtr<C
 
     m_last_modified_time = MonotonicTime::now();
     window()->set_modified(false);
-    GUI::Application::the()->set_most_recently_open_file(filename);
+    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
     return {};
 }
 

--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -129,7 +129,7 @@ void MainWidget::load_file(FileSystemAccessClient::File file)
     m_file_path = file.filename().to_byte_string();
     update_title();
 
-    GUI::Application::the()->set_most_recently_open_file(file.filename());
+    GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
 }
 
 ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
@@ -150,7 +150,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         m_file_path = response.value().filename().to_byte_string();
         update_title();
 
-        GUI::Application::the()->set_most_recently_open_file(response.value().filename());
+        GUI::Application::the()->set_most_recently_open_file(response.value().filename().to_byte_string());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2022, Itamar S. <itamar8910@gmail.com>
  * Copyright (c) 2020-2021, the SerenityOS developers.
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -86,8 +87,6 @@ public:
     void update_window_title();
 
 private:
-    static constexpr size_t recent_projects_history_size = 15;
-
     static ByteString get_full_path_of_serenity_source(ByteString const& file);
     ByteString get_absolute_path(ByteString const&) const;
     Vector<ByteString> selected_file_paths() const;
@@ -149,7 +148,6 @@ private:
     void create_toolbar(GUI::Widget& parent);
     ErrorOr<void> create_action_tab(GUI::Widget& parent);
     ErrorOr<void> create_file_menu(GUI::Window&);
-    void update_recent_projects_submenu();
     ErrorOr<void> create_edit_menu(GUI::Window&);
     void create_build_menu(GUI::Window&);
     ErrorOr<void> create_view_menu(GUI::Window&);

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -41,6 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix fattr thread ptrace"));
 
     auto app = TRY(GUI::Application::create(arguments));
+    app->set_config_domain("HackStudio"_string);
     Config::pledge_domains({ "HackStudio", "Terminal", "FileManager" });
 
     auto window = GUI::Window::construct();

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -399,7 +399,8 @@ void Application::set_most_recently_open_file(ByteString new_path)
             path);
     }
 
-    update_recent_file_actions();
+    if (!m_recent_file_actions.is_empty())
+        update_recent_file_actions();
 }
 
 }

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -371,7 +371,7 @@ void Application::update_recent_file_actions()
     m_recent_file_actions.last()->set_visible(number_of_recently_open_files == 0);
 }
 
-void Application::set_most_recently_open_file(String new_path)
+void Application::set_most_recently_open_file(ByteString new_path)
 {
     Vector<ByteString> new_recent_files_list;
 
@@ -386,7 +386,7 @@ void Application::set_most_recently_open_file(String new_path)
         return existing_path.view() == new_path;
     });
 
-    new_recent_files_list.prepend(new_path.to_byte_string());
+    new_recent_files_list.prepend(new_path);
 
     for (size_t i = 0; i < max_recently_open_files(); ++i) {
         auto& path = new_recent_files_list[i];

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -94,7 +94,7 @@ public:
 
     void set_config_domain(String);
     void update_recent_file_actions();
-    void set_most_recently_open_file(String path);
+    void set_most_recently_open_file(ByteString path);
 
     void register_recent_file_actions(Badge<GUI::Menu>, Vector<NonnullRefPtr<GUI::Action>>);
 

--- a/Userland/Libraries/LibGUI/Menu.cpp
+++ b/Userland/Libraries/LibGUI/Menu.cpp
@@ -224,7 +224,7 @@ void Menu::realize_menu_item(MenuItem& item, int item_id)
     }
 }
 
-void Menu::add_recent_files_list(Function<void(Action&)> callback)
+void Menu::add_recent_files_list(Function<void(Action&)> callback, AddTrailingSeparator add_trailing_separator)
 {
     m_recent_files_callback = move(callback);
 
@@ -244,7 +244,8 @@ void Menu::add_recent_files_list(Function<void(Action&)> callback)
         add_action(action);
     }
 
-    add_separator();
+    if (add_trailing_separator == AddTrailingSeparator::Yes)
+        add_separator();
 }
 
 }

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -46,7 +46,11 @@ public:
     [[nodiscard]] NonnullRefPtr<Menu> add_submenu(String name);
     void remove_all_actions();
 
-    void add_recent_files_list(Function<void(Action&)>);
+    enum class AddTrailingSeparator {
+        No,
+        Yes,
+    };
+    void add_recent_files_list(Function<void(Action&)>, AddTrailingSeparator = AddTrailingSeparator::Yes);
 
     void popup(Gfx::IntPoint screen_position, RefPtr<Action> const& default_action = nullptr, Gfx::IntRect const& button_rect = {});
     void dismiss();


### PR DESCRIPTION
This was motivated by HackStudio crashing every time I clicked a recent project in the list. I noticed it wasn't using the LibGUI built-in way of handling recent files, so now it uses that instead! As a bonus: no crashing. :tada: