### PR TITLE
LibWeb: Add missing EventModifierInit fields and MouseEvent constructor & getModifierState

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -161,6 +161,9 @@ CppType idl_type_name_to_cpp_type(Type const& type, Interface const& interface)
     if (type.name() == "unsigned long" && !type.is_nullable())
         return { .name = "WebIDL::UnsignedLong", .sequence_storage_type = SequenceStorageType::Vector };
 
+    if (type.name() == "short" && !type.is_nullable())
+        return { .name = "WebIDL::Short", .sequence_storage_type = SequenceStorageType::Vector };
+
     if (type.name() == "unsigned short" && !type.is_nullable())
         return { .name = "WebIDL::UnsignedShort", .sequence_storage_type = SequenceStorageType::Vector };
 
@@ -515,6 +518,31 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
             scoped_generator.append(R"~~~(
     else
         @cpp_name@ = @parameter.optional_default_value@UL;
+)~~~");
+        }
+    } else if (parameter.type->name() == "short") {
+        if (!optional || optional_default_value.has_value()) {
+            scoped_generator.append(R"~~~(
+    WebIDL::Short @cpp_name@;
+)~~~");
+        } else {
+            scoped_generator.append(R"~~~(
+    Optional<WebIDL::Short> @cpp_name@;
+)~~~");
+        }
+        if (optional) {
+            scoped_generator.append(R"~~~(
+    if (!@js_name@@js_suffix@.is_undefined())
+)~~~");
+        }
+        // FIXME: pass through [EnforceRange] and [Clamp] extended attributes
+        scoped_generator.append(R"~~~(
+    @cpp_name@ = TRY(WebIDL::convert_to_int<WebIDL::Short>(vm, @js_name@@js_suffix@));
+)~~~");
+        if (optional_default_value.has_value()) {
+            scoped_generator.append(R"~~~(
+    else
+        @cpp_name@ = @parameter.optional_default_value@;
 )~~~");
         }
     } else if (parameter.type->name() == "unsigned short") {

--- a/Tests/LibWeb/Text/expected/UIEvents/custom-keyboard-event.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/custom-keyboard-event.txt
@@ -1,0 +1,4 @@
+1. "W"
+2. true
+3. true
+4. true

--- a/Tests/LibWeb/Text/expected/UIEvents/custom-mouse-event.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/custom-mouse-event.txt
@@ -1,0 +1,4 @@
+1. 10
+2. true
+3. true
+4. true

--- a/Tests/LibWeb/Text/input/UIEvents/custom-keyboard-event.html
+++ b/Tests/LibWeb/Text/input/UIEvents/custom-keyboard-event.html
@@ -1,0 +1,22 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let testCounter = 1;
+        function testPart(part) {
+            println(`${testCounter}. ${JSON.stringify(part())}`);
+            testCounter++;
+        }
+
+        // 1. Creating a KeyboardEvent
+        testPart(() => new KeyboardEvent('keydown', { key: 'W' }).key);
+
+        // 2. Creating a KeyboardEvent with modifier
+        testPart(() => new KeyboardEvent('keydown', { altKey: true }).getModifierState('Alt'));
+
+        // 3. Creating a KeyboardEvent with modifier
+        testPart(() => new KeyboardEvent('keydown', { modifierFnLock: true }).getModifierState('FnLock'));
+
+        // 4. Creating a KeyboardEvent with modifier
+        testPart(() => new KeyboardEvent('keydown', { modifierHyper: true }).getModifierState('Hyper'));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/custom-mouse-event.html
+++ b/Tests/LibWeb/Text/input/UIEvents/custom-mouse-event.html
@@ -1,0 +1,22 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let testCounter = 1;
+        function testPart(part) {
+            println(`${testCounter}. ${JSON.stringify(part())}`);
+            testCounter++;
+        }
+
+        // 1. Creating a MouseEvent
+        testPart(() => new MouseEvent('click', { clientX: 10 }).clientX);
+
+        // 2. Creating a MouseEvent with modifier
+        testPart(() => new MouseEvent('click', { ctrlKey: true }).getModifierState('Control'));
+
+        // 3. Creating a MouseEvent with modifier
+        testPart(() => new MouseEvent('click', { modifierAltGraph: true }).getModifierState('AltGraph'));
+
+        // 4. Creating a MouseEvent with modifier
+        testPart(() => new MouseEvent('click', { modifierSymbolLock: true }).getModifierState('SymbolLock'));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/UIEvents/EventModifier.h
+++ b/Userland/Libraries/LibWeb/UIEvents/EventModifier.h
@@ -16,6 +16,17 @@ struct EventModifierInit : public UIEventInit {
     bool shift_key { false };
     bool alt_key { false };
     bool meta_key { false };
+
+    bool modifier_alt_graph { false };
+    bool modifier_caps_lock { false };
+    bool modifier_fn { false };
+    bool modifier_fn_lock { false };
+    bool modifier_hyper { false };
+    bool modifier_num_lock { false };
+    bool modifier_scroll_lock { false };
+    bool modifier_super { false };
+    bool modifier_symbol { false };
+    bool modifier_symbol_lock { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/EventModifier.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/EventModifier.idl
@@ -6,5 +6,14 @@ dictionary EventModifierInit : UIEventInit {
     boolean altKey = false;
     boolean metaKey = false;
 
-    // FIXME: modifier* fields
+    boolean modifierAltGraph = false;
+    boolean modifierCapsLock = false;
+    boolean modifierFn = false;
+    boolean modifierFnLock = false;
+    boolean modifierHyper = false;
+    boolean modifierNumLock = false;
+    boolean modifierScrollLock = false;
+    boolean modifierSuper = false;
+    boolean modifierSymbol = false;
+    boolean modifierSymbolLock = false;
 };

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -653,16 +653,36 @@ JS::NonnullGCPtr<KeyboardEvent> KeyboardEvent::create_from_platform_event(JS::Re
     return event;
 }
 
-bool KeyboardEvent::get_modifier_state(String const& key_arg)
+bool KeyboardEvent::get_modifier_state(String const& key_arg) const
 {
-    if (key_arg == "Alt")
-        return m_alt_key;
     if (key_arg == "Control")
         return m_ctrl_key;
     if (key_arg == "Shift")
         return m_shift_key;
+    if (key_arg == "Alt")
+        return m_alt_key;
     if (key_arg == "Meta")
         return m_meta_key;
+    if (key_arg == "AltGraph")
+        return m_modifier_alt_graph;
+    if (key_arg == "CapsLock")
+        return m_modifier_caps_lock;
+    if (key_arg == "Fn")
+        return m_modifier_fn;
+    if (key_arg == "FnLock")
+        return m_modifier_fn_lock;
+    if (key_arg == "Hyper")
+        return m_modifier_hyper;
+    if (key_arg == "NumLock")
+        return m_modifier_num_lock;
+    if (key_arg == "ScrollLock")
+        return m_modifier_scroll_lock;
+    if (key_arg == "Super")
+        return m_modifier_super;
+    if (key_arg == "Symbol")
+        return m_modifier_symbol;
+    if (key_arg == "SymbolLock")
+        return m_modifier_symbol_lock;
     return false;
 }
 
@@ -685,6 +705,16 @@ KeyboardEvent::KeyboardEvent(JS::Realm& realm, FlyString const& event_name, Keyb
     , m_shift_key(event_init.shift_key)
     , m_alt_key(event_init.alt_key)
     , m_meta_key(event_init.meta_key)
+    , m_modifier_alt_graph(event_init.modifier_alt_graph)
+    , m_modifier_caps_lock(event_init.modifier_caps_lock)
+    , m_modifier_fn(event_init.modifier_fn)
+    , m_modifier_fn_lock(event_init.modifier_fn_lock)
+    , m_modifier_hyper(event_init.modifier_hyper)
+    , m_modifier_num_lock(event_init.modifier_num_lock)
+    , m_modifier_scroll_lock(event_init.modifier_scroll_lock)
+    , m_modifier_super(event_init.modifier_super)
+    , m_modifier_symbol(event_init.modifier_symbol)
+    , m_modifier_symbol_lock(event_init.modifier_symbol_lock)
     , m_repeat(event_init.repeat)
     , m_is_composing(event_init.is_composing)
     , m_key_code(event_init.key_code)

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -58,7 +58,7 @@ public:
     bool repeat() const { return m_repeat; }
     bool is_composing() const { return m_is_composing; }
 
-    bool get_modifier_state(String const& key_arg);
+    bool get_modifier_state(String const& key_arg) const;
 
     virtual u32 which() const override { return m_key_code; }
 
@@ -74,6 +74,16 @@ private:
     bool m_shift_key { false };
     bool m_alt_key { false };
     bool m_meta_key { false };
+    bool m_modifier_alt_graph { false };
+    bool m_modifier_caps_lock { false };
+    bool m_modifier_fn { false };
+    bool m_modifier_fn_lock { false };
+    bool m_modifier_hyper { false };
+    bool m_modifier_num_lock { false };
+    bool m_modifier_scroll_lock { false };
+    bool m_modifier_super { false };
+    bool m_modifier_symbol { false };
+    bool m_modifier_symbol_lock { false };
     bool m_repeat { false };
     bool m_is_composing { false };
     u32 m_key_code { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -113,6 +113,11 @@ JS::NonnullGCPtr<MouseEvent> MouseEvent::create(JS::Realm& realm, FlyString cons
     return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
 }
 
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
+{
+    return create(realm, event_name, event_init);
+}
+
 WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons, unsigned modifiers)
 {
     MouseEventInit event_init {};

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -29,7 +29,7 @@ class MouseEvent : public UIEvent {
     JS_DECLARE_ALLOCATOR(MouseEvent);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0, unsigned modifiers = 0);
+    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons, unsigned modifiers);
 
     virtual ~MouseEvent() override;
@@ -60,10 +60,12 @@ public:
     i16 button() const { return m_button; }
     u16 buttons() const { return m_buttons; }
 
+    bool get_modifier_state(String const& key_arg) const;
+
     virtual u32 which() const override { return m_button + 1; }
 
 protected:
-    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers);
+    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
 
     virtual void initialize(JS::Realm&) override;
 
@@ -82,6 +84,16 @@ private:
     bool m_shift_key { false };
     bool m_alt_key { false };
     bool m_meta_key { false };
+    bool m_modifier_alt_graph { false };
+    bool m_modifier_caps_lock { false };
+    bool m_modifier_fn { false };
+    bool m_modifier_fn_lock { false };
+    bool m_modifier_hyper { false };
+    bool m_modifier_num_lock { false };
+    bool m_modifier_scroll_lock { false };
+    bool m_modifier_super { false };
+    bool m_modifier_symbol { false };
+    bool m_modifier_symbol_lock { false };
     double m_movement_x { 0 };
     double m_movement_y { 0 };
     i16 m_button { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -31,6 +31,7 @@ class MouseEvent : public UIEvent {
 public:
     [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons, unsigned modifiers);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> construct_impl(JS::Realm&, FlyString const& event_name, MouseEventInit const&);
 
     virtual ~MouseEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -1,4 +1,4 @@
-#import <UIEvents/UIEvent.idl>
+#import <UIEvents/EventModifier.idl>
 
 // https://w3c.github.io/uievents/#mouseevent
 [Exposed=Window]
@@ -31,7 +31,7 @@ interface MouseEvent : UIEvent {
 
     // FIXME: readonly attribute EventTarget? relatedTarget;
 
-    // FIXME: boolean getModifierState(DOMString keyArg);
+    boolean getModifierState(DOMString keyArg);
 };
 
 // https://w3c.github.io/uievents/#idl-mouseeventinit

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -3,7 +3,7 @@
 // https://w3c.github.io/uievents/#mouseevent
 [Exposed=Window]
 interface MouseEvent : UIEvent {
-    // FIXME: constructor(DOMString type, optional MouseEventInit eventInitDict = {});
+    constructor(DOMString type, optional MouseEventInit eventInitDict = {});
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
     readonly attribute double screenX;

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/API/KeyCode.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
@@ -14,8 +15,8 @@ namespace Web::UIEvents {
 
 JS_DEFINE_ALLOCATOR(WheelEvent);
 
-WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers)
-    : MouseEvent(realm, event_name, event_init, page_x, page_y, offset_x, offset_y, modifiers)
+WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
+    : MouseEvent(realm, event_name, event_init, page_x, page_y, offset_x, offset_y)
     , m_delta_x(event_init.delta_x)
     , m_delta_y(event_init.delta_y)
     , m_delta_mode(event_init.delta_mode)
@@ -31,14 +32,18 @@ void WheelEvent::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::WheelEventPrototype>(realm, "WheelEvent"_fly_string));
 }
 
-JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers)
+JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
 {
-    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y, modifiers);
+    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons, unsigned modifiers)
 {
     WheelEventInit event_init {};
+    event_init.ctrl_key = modifiers & Mod_Ctrl;
+    event_init.shift_key = modifiers & Mod_Shift;
+    event_init.alt_key = modifiers & Mod_Alt;
+    event_init.meta_key = modifiers & Mod_Super;
     event_init.screen_x = screen.x().to_double();
     event_init.screen_y = screen.y().to_double();
     event_init.client_x = client.x().to_double();
@@ -48,7 +53,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platfo
     event_init.delta_x = delta_x;
     event_init.delta_y = delta_y;
     event_init.delta_mode = WheelDeltaMode::DOM_DELTA_PIXEL;
-    auto event = WheelEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double(), modifiers);
+    auto event = WheelEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double());
     event->set_is_trusted(true);
     return event;
 }

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -30,7 +30,7 @@ class WheelEvent final : public MouseEvent {
     JS_DECLARE_ALLOCATOR(WheelEvent);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0, unsigned modifiers = 0);
+    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons, unsigned modifiers);
 
     virtual ~WheelEvent() override;
@@ -41,7 +41,7 @@ public:
     unsigned long delta_mode() const { return to_underlying(m_delta_mode); }
 
 private:
-    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers);
+    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
 
     virtual void initialize(JS::Realm&) override;
 


### PR DESCRIPTION
This pr implements some missing LibWeb UIEvents features:

- Add missing EventModifierInit fields
- Add MouseEvent getModifierState
- Add MouseEvent constructor

Hope you like it :^)