### PR TITLE
ls: Show correct permissions in long mode for non-executable files

### DIFF
--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -365,10 +365,14 @@ static bool print_filesystem_object(ByteString const& path, ByteString const& na
     printf("%c%c%c%c%c%c%c%c",
         st.st_mode & S_IRUSR ? 'r' : '-',
         st.st_mode & S_IWUSR ? 'w' : '-',
-        st.st_mode & S_ISUID ? 's' : (st.st_mode & S_IXUSR ? 'x' : '-'),
+        st.st_mode & S_ISUID
+            ? (st.st_mode & S_IXUSR ? 's' : 'S')
+            : (st.st_mode & S_IXUSR ? 'x' : '-'),
         st.st_mode & S_IRGRP ? 'r' : '-',
         st.st_mode & S_IWGRP ? 'w' : '-',
-        st.st_mode & S_ISGID ? 's' : (st.st_mode & S_IXGRP ? 'x' : '-'),
+        st.st_mode & S_ISGID
+            ? (st.st_mode & S_IXGRP ? 's' : 'S')
+            : (st.st_mode & S_IXGRP ? 'x' : '-'),
         st.st_mode & S_IROTH ? 'r' : '-',
         st.st_mode & S_IWOTH ? 'w' : '-');
 

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -377,7 +377,7 @@ static bool print_filesystem_object(ByteString const& path, ByteString const& na
         st.st_mode & S_IWOTH ? 'w' : '-');
 
     if (st.st_mode & S_ISVTX)
-        printf("t");
+        printf("%c", st.st_mode & S_IXOTH ? 't' : 'T');
     else
         printf("%c", st.st_mode & S_IXOTH ? 'x' : '-');
 


### PR DESCRIPTION
This change modifies how permissions are displayed in long mode, so that:
* An 'S' is shown if the SUID/SGID bit is set for non-executable files.
* A 'T' is shown if the sticky bit is set for non-executable files.

This matches the behavior of `ls` on Linux.

Example usage:

![ls_non_executable_special_permissions](https://github.com/SerenityOS/serenity/assets/2817754/569a6b9d-8dd5-491a-962b-33b736b1515b)

