### PR TITLE
LibWeb: Use platform's OpenGL in WebGL when it is available

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Context.h
+++ b/Userland/Libraries/LibAccelGfx/Context.h
@@ -25,6 +25,12 @@ public:
     Context()
     {
     }
+
+    virtual ~Context()
+    {
+    }
+
+    virtual void activate() = 0;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -621,6 +621,7 @@ set(SOURCES
     WebDriver/Screenshot.cpp
     WebDriver/TimeoutsConfiguration.cpp
     WebGL/EventNames.cpp
+    WebGL/OpenGLContext.cpp
     WebGL/WebGLContextAttributes.cpp
     WebGL/WebGLContextEvent.cpp
     WebGL/WebGLRenderingContext.cpp
@@ -679,12 +680,18 @@ set(GENERATED_SOURCES
 serenity_lib(LibWeb web)
 
 # NOTE: We link with LibSoftGPU here instead of lazy loading it via dlopen() so that we do not have to unveil the library and pledge prot_exec.
-target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibMarkdown LibHTTP LibGemini LibGL LibGUI LibGfx LibIPC LibLocale LibRegex LibSoftGPU LibSyntax LibTextCodec LibUnicode LibAudio LibVideo LibWasm LibXML LibIDL)
+target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibMarkdown LibHTTP LibGemini LibGUI LibGfx LibIPC LibLocale LibRegex LibSoftGPU LibSyntax LibTextCodec LibUnicode LibAudio LibVideo LibWasm LibXML LibIDL)
 link_with_locale_data(LibWeb)
 
 if (HAS_ACCELERATED_GRAPHICS)
+    target_link_libraries(LibWeb PRIVATE ${ACCEL_GFX_LIBS})
     target_sources(LibWeb PRIVATE Painting/PaintingCommandExecutorGPU.cpp)
     target_link_libraries(LibWeb PRIVATE LibAccelGfx)
+    target_compile_definitions(LibWeb PRIVATE HAS_ACCELERATED_GRAPHICS)
+endif()
+
+if (SERENITYOS)
+    target_link_libraries(LibWeb PRIVATE LibGL)
 endif()
 
 generate_js_bindings(LibWeb)

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Vector2.h>
 #include <LibWeb/HTML/Canvas/CanvasPath.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -14,6 +14,7 @@ PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(AccelGfx::Context& contex
     : m_target_bitmap(bitmap)
     , m_context(context)
 {
+    m_context.activate();
     auto canvas = AccelGfx::Canvas::create(bitmap.size());
     auto painter = AccelGfx::Painter::create(m_context, canvas);
     m_stacking_contexts.append({ .canvas = canvas,
@@ -25,6 +26,7 @@ PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(AccelGfx::Context& contex
 
 PaintingCommandExecutorGPU::~PaintingCommandExecutorGPU()
 {
+    m_context.activate();
     VERIFY(m_stacking_contexts.size() == 1);
     painter().flush(m_target_bitmap);
 }
@@ -416,6 +418,11 @@ bool PaintingCommandExecutorGPU::would_be_fully_clipped_by_painter(Gfx::IntRect 
 void PaintingCommandExecutorGPU::prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs)
 {
     AccelGfx::GlyphAtlas::the().update(unique_glyphs);
+}
+
+void PaintingCommandExecutorGPU::prepare_to_execute()
+{
+    m_context.activate();
 }
 
 void PaintingCommandExecutorGPU::update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>& immutable_bitmaps)

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -52,6 +52,8 @@ public:
     virtual bool needs_prepare_glyphs_texture() const override { return true; }
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override;
 
+    virtual void prepare_to_execute() override;
+
     bool needs_update_immutable_bitmap_texture_cache() const override { return true; }
     void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override;
 

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -448,6 +448,8 @@ void RecordingPainter::apply_scroll_offsets(Vector<Gfx::IntPoint> const& offsets
 
 void RecordingPainter::execute(PaintingCommandExecutor& executor)
 {
+    executor.prepare_to_execute();
+
     if (executor.needs_prepare_glyphs_texture()) {
         HashMap<Gfx::Font const*, HashTable<u32>> unique_glyphs;
         for (auto& command_with_scroll_id : m_painting_commands) {

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -486,6 +486,8 @@ public:
     virtual bool needs_prepare_glyphs_texture() const { return false; }
     virtual void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs) = 0;
 
+    virtual void prepare_to_execute() { }
+
     virtual bool needs_update_immutable_bitmap_texture_cache() const = 0;
     virtual void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) = 0;
 };

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/OwnPtr.h>
+#include <LibGfx/Bitmap.h>
+#include <LibWeb/WebGL/OpenGLContext.h>
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+#    include <LibAccelGfx/Canvas.h>
+#    include <LibAccelGfx/Context.h>
+#elif defined(AK_OS_SERENITY)
+#    include <LibGL/GLContext.h>
+#endif
+
+namespace Web::WebGL {
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+class AccelGfxContext : public OpenGLContext {
+public:
+    virtual void activate() override
+    {
+        m_context->activate();
+    }
+
+    virtual void present(Gfx::Bitmap& bitmap) override
+    {
+        VERIFY(bitmap.format() == Gfx::BitmapFormat::BGRA8888);
+        glPixelStorei(GL_PACK_ALIGNMENT, 1);
+        glReadPixels(0, 0, bitmap.width(), bitmap.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap.scanline(0));
+    }
+
+    virtual GLenum gl_get_error() override
+    {
+        activate();
+        return glGetError();
+    }
+
+    virtual void gl_get_doublev(GLenum pname, GLdouble* params) override
+    {
+        activate();
+        glGetDoublev(pname, params);
+    }
+
+    virtual void gl_get_integerv(GLenum pname, GLint* params) override
+    {
+        activate();
+        glGetIntegerv(pname, params);
+    }
+
+    virtual void gl_clear(GLbitfield mask) override
+    {
+        activate();
+        glClear(mask);
+    }
+
+    virtual void gl_clear_color(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha) override
+    {
+        activate();
+        glClearColor(red, green, blue, alpha);
+    }
+
+    virtual void gl_clear_depth(GLdouble depth) override
+    {
+        activate();
+        glClearDepth(depth);
+    }
+
+    virtual void gl_clear_stencil(GLint s) override
+    {
+        activate();
+        glClearStencil(s);
+    }
+
+    virtual void gl_active_texture(GLenum texture) override
+    {
+        activate();
+        glActiveTexture(texture);
+    }
+
+    virtual void gl_viewport(GLint x, GLint y, GLsizei width, GLsizei height) override
+    {
+        activate();
+        glViewport(x, y, width, height);
+    }
+
+    virtual void gl_line_width(GLfloat width) override
+    {
+        activate();
+        glLineWidth(width);
+    }
+
+    virtual void gl_polygon_offset(GLfloat factor, GLfloat units) override
+    {
+        activate();
+        glPolygonOffset(factor, units);
+    }
+
+    virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) override
+    {
+        activate();
+        glScissor(x, y, width, height);
+    }
+
+    virtual void gl_depth_mask(GLboolean mask) override
+    {
+        activate();
+        glDepthMask(mask);
+    }
+
+    virtual void gl_depth_func(GLenum func) override
+    {
+        activate();
+        glDepthFunc(func);
+    }
+
+    virtual void gl_depth_range(GLdouble z_near, GLdouble z_far) override
+    {
+        activate();
+        glDepthRange(z_near, z_far);
+    }
+
+    virtual void gl_cull_face(GLenum mode) override
+    {
+        activate();
+        glCullFace(mode);
+    }
+
+    virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override
+    {
+        activate();
+        glColorMask(red, green, blue, alpha);
+    }
+
+    virtual void gl_front_face(GLenum mode) override
+    {
+        activate();
+        glFrontFace(mode);
+    }
+
+    virtual void gl_finish() override
+    {
+        activate();
+        glFinish();
+    }
+
+    virtual void gl_flush() override
+    {
+        activate();
+        glFlush();
+    }
+
+    virtual void gl_stencil_op_separate(GLenum, GLenum, GLenum, GLenum) override
+    {
+        TODO();
+    }
+
+    AccelGfxContext(OwnPtr<AccelGfx::Context> context, NonnullRefPtr<AccelGfx::Canvas> canvas)
+        : m_context(move(context))
+        , m_canvas(move(canvas))
+    {
+    }
+
+private:
+    OwnPtr<AccelGfx::Context> m_context;
+    NonnullRefPtr<AccelGfx::Canvas> m_canvas;
+};
+#endif
+
+#ifdef AK_OS_SERENITY
+class LibGLContext : public OpenGLContext {
+public:
+    virtual void activate() override
+    {
+        GL::make_context_current(m_context);
+    }
+
+    virtual void present(Gfx::Bitmap&) override
+    {
+        m_context->present();
+    }
+
+    virtual GLenum gl_get_error() override
+    {
+        return m_context->gl_get_error();
+    }
+
+    virtual void gl_get_doublev(GLenum pname, GLdouble* params) override
+    {
+        m_context->gl_get_doublev(pname, params);
+    }
+
+    virtual void gl_get_integerv(GLenum pname, GLint* params) override
+    {
+        m_context->gl_get_integerv(pname, params);
+    }
+
+    virtual void gl_clear(GLbitfield mask) override
+    {
+        m_context->gl_clear(mask);
+    }
+
+    virtual void gl_clear_color(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha) override
+    {
+        m_context->gl_clear_color(red, green, blue, alpha);
+    }
+
+    virtual void gl_clear_depth(GLdouble depth) override
+    {
+        m_context->gl_clear_depth(depth);
+    }
+
+    virtual void gl_clear_stencil(GLint s) override
+    {
+        m_context->gl_clear_stencil(s);
+    }
+
+    virtual void gl_active_texture(GLenum texture) override
+    {
+        m_context->gl_active_texture(texture);
+    }
+
+    virtual void gl_viewport(GLint x, GLint y, GLsizei width, GLsizei height) override
+    {
+        m_context->gl_viewport(x, y, width, height);
+    }
+
+    virtual void gl_line_width(GLfloat width) override
+    {
+        m_context->gl_line_width(width);
+    }
+
+    virtual void gl_polygon_offset(GLfloat factor, GLfloat units) override
+    {
+        m_context->gl_polygon_offset(factor, units);
+    }
+
+    virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) override
+    {
+        m_context->gl_scissor(x, y, width, height);
+    }
+
+    virtual void gl_depth_mask(GLboolean flag) override
+    {
+        m_context->gl_depth_mask(flag);
+    }
+
+    virtual void gl_depth_func(GLenum func) override
+    {
+        m_context->gl_depth_func(func);
+    }
+
+    virtual void gl_depth_range(GLdouble z_near, GLdouble z_far) override
+    {
+        m_context->gl_depth_range(z_near, z_far);
+    }
+
+    virtual void gl_cull_face(GLenum mode) override
+    {
+        m_context->gl_cull_face(mode);
+    }
+
+    virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override
+    {
+        m_context->gl_color_mask(red, green, blue, alpha);
+    }
+
+    virtual void gl_front_face(GLenum mode) override
+    {
+        m_context->gl_front_face(mode);
+    }
+
+    virtual void gl_finish() override
+    {
+        m_context->gl_finish();
+    }
+
+    virtual void gl_flush() override
+    {
+        m_context->gl_flush();
+    }
+
+    virtual void gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass) override
+    {
+        m_context->gl_stencil_op_separate(face, sfail, dpfail, dppass);
+    }
+
+    LibGLContext(OwnPtr<GL::GLContext> context)
+        : m_context(move(context))
+    {
+    }
+
+private:
+    OwnPtr<GL::GLContext> m_context;
+};
+#endif
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+static OwnPtr<AccelGfxContext> make_accelgfx_context(Gfx::Bitmap& bitmap)
+{
+    auto context = AccelGfx::Context::create();
+    auto canvas = AccelGfx::Canvas::create(bitmap.size());
+    canvas->bind();
+    return make<AccelGfxContext>(move(context), move(canvas));
+}
+#endif
+
+#ifdef AK_OS_SERENITY
+static OwnPtr<LibGLContext> make_libgl_context(Gfx::Bitmap& bitmap)
+{
+    auto context_or_error = GL::create_context(bitmap);
+    return make<LibGLContext>(move(context_or_error.value()));
+}
+#endif
+
+OwnPtr<OpenGLContext> OpenGLContext::create(Gfx::Bitmap& bitmap)
+{
+#ifdef HAS_ACCELERATED_GRAPHICS
+    return make_accelgfx_context(bitmap);
+#elif defined(AK_OS_SERENITY)
+    return make_libgl_context(bitmap);
+#endif
+
+    (void)bitmap;
+    return {};
+}
+
+void OpenGLContext::clear_buffer_to_default_values()
+{
+#if defined(HAS_ACCELERATED_GRAPHICS) || defined(AK_OS_SERENITY)
+    Array<GLdouble, 4> current_clear_color;
+    gl_get_doublev(GL_COLOR_CLEAR_VALUE, current_clear_color.data());
+
+    GLdouble current_clear_depth;
+    gl_get_doublev(GL_DEPTH_CLEAR_VALUE, &current_clear_depth);
+
+    GLint current_clear_stencil;
+    gl_get_integerv(GL_STENCIL_CLEAR_VALUE, &current_clear_stencil);
+
+    // The implicit clear value for the color buffer is (0, 0, 0, 0)
+    gl_clear_color(0, 0, 0, 0);
+
+    // The implicit clear value for the depth buffer is 1.0.
+    gl_clear_depth(1.0);
+
+    // The implicit clear value for the stencil buffer is 0.
+    gl_clear_stencil(0);
+
+    gl_clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+    // Restore the clear values.
+    gl_clear_color(current_clear_color[0], current_clear_color[1], current_clear_color[2], current_clear_color[3]);
+    gl_clear_depth(current_clear_depth);
+    gl_clear_stencil(current_clear_stencil);
+#endif
+}
+
+}

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Bitmap.h>
+#include <LibWeb/WebGL/Types.h>
+
+namespace Web::WebGL {
+
+class OpenGLContext {
+public:
+    static OwnPtr<OpenGLContext> create(Gfx::Bitmap&);
+
+    virtual void activate() = 0;
+    virtual void present(Gfx::Bitmap&) = 0;
+    void clear_buffer_to_default_values();
+
+    virtual GLenum gl_get_error() = 0;
+    virtual void gl_get_doublev(GLenum, GLdouble*) = 0;
+    virtual void gl_get_integerv(GLenum, GLint*) = 0;
+    virtual void gl_clear(GLbitfield) = 0;
+    virtual void gl_clear_color(GLfloat, GLfloat, GLfloat, GLfloat) = 0;
+    virtual void gl_clear_depth(GLdouble) = 0;
+    virtual void gl_clear_stencil(GLint) = 0;
+    virtual void gl_active_texture(GLenum) = 0;
+    virtual void gl_viewport(GLint, GLint, GLsizei, GLsizei) = 0;
+    virtual void gl_line_width(GLfloat) = 0;
+    virtual void gl_polygon_offset(GLfloat, GLfloat) = 0;
+    virtual void gl_scissor(GLint, GLint, GLsizei, GLsizei) = 0;
+    virtual void gl_depth_mask(GLboolean) = 0;
+    virtual void gl_depth_func(GLenum) = 0;
+    virtual void gl_depth_range(GLdouble, GLdouble) = 0;
+    virtual void gl_cull_face(GLenum) = 0;
+    virtual void gl_color_mask(GLboolean, GLboolean, GLboolean, GLboolean) = 0;
+    virtual void gl_front_face(GLenum) = 0;
+    virtual void gl_finish() = 0;
+    virtual void gl_flush() = 0;
+    virtual void gl_stencil_op_separate(GLenum, GLenum, GLenum, GLenum) = 0;
+
+    virtual ~OpenGLContext() { }
+};
+
+}

--- a/Userland/Libraries/LibWeb/WebGL/Types.h
+++ b/Userland/Libraries/LibWeb/WebGL/Types.h
@@ -6,4 +6,11 @@
 
 #pragma once
 
-// FIXME: This header is here just to satisfy the IDL code generator.
+typedef unsigned int GLenum;
+typedef unsigned char GLboolean;
+typedef int GLint;
+typedef int GLsizei;
+typedef float GLfloat;
+typedef double GLdouble;
+typedef GLfloat GLclampf;
+typedef unsigned int GLbitfield;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -44,15 +44,18 @@ JS::ThrowCompletionOr<JS::GCPtr<WebGLRenderingContext>> WebGLRenderingContext::c
         return JS::GCPtr<WebGLRenderingContext> { nullptr };
     }
 
-    auto context_or_error = GL::create_context(*canvas_element.bitmap());
-    if (context_or_error.is_error()) {
+    VERIFY(canvas_element.bitmap());
+    auto context = OpenGLContext::create(*canvas_element.bitmap());
+
+    if (!context) {
         fire_webgl_context_creation_error(canvas_element);
         return JS::GCPtr<WebGLRenderingContext> { nullptr };
     }
-    return realm.heap().allocate<WebGLRenderingContext>(realm, realm, canvas_element, context_or_error.release_value(), context_attributes, context_attributes);
+
+    return realm.heap().allocate<WebGLRenderingContext>(realm, realm, canvas_element, context.release_nonnull(), context_attributes, context_attributes);
 }
 
-WebGLRenderingContext::WebGLRenderingContext(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
+WebGLRenderingContext::WebGLRenderingContext(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<OpenGLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
     : WebGLRenderingContextBase(realm, canvas_element, move(context), move(context_creation_parameters), move(actual_context_parameters))
 {
 }

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
@@ -24,7 +26,7 @@ public:
 private:
     virtual void initialize(JS::Realm&) override;
 
-    WebGLRenderingContext(JS::Realm&, HTML::HTMLCanvasElement&, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
+    WebGLRenderingContext(JS::Realm&, HTML::HTMLCanvasElement&, NonnullOwnPtr<OpenGLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,13 +10,15 @@
 #include <AK/RefCountForwarder.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
-#include <LibGL/GLContext.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/WebGL/OpenGLContext.h>
 #include <LibWeb/WebGL/WebGLContextAttributes.h>
 
 namespace Web::WebGL {
+
+#define GL_NO_ERROR 0
 
 class WebGLRenderingContextBase : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(WebGLRenderingContextBase, Bindings::PlatformObject);
@@ -64,14 +67,14 @@ public:
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 
 protected:
-    WebGLRenderingContextBase(JS::Realm&, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
+    WebGLRenderingContextBase(JS::Realm&, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<OpenGLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters);
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::NonnullGCPtr<HTML::HTMLCanvasElement> m_canvas_element;
 
-    NonnullOwnPtr<GL::GLContext> m_context;
+    NonnullOwnPtr<OpenGLContext> m_context;
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-creation-parameters
     // Each WebGLRenderingContext has context creation parameters, set upon creation, in a WebGLContextAttributes object.


### PR DESCRIPTION
This change makes WebGL to use LibGL only in SerenityOS, and the
platform's OpenGL driver in Ladybird if it is available.

This is implemented by introducing wrapper class between WebGL and
OpenGL calls. This way it will also be possible to provide more
complete support in Ladybird even if we don't yet have all needed
calls implemented in LibGL.

For now, the wrapper class makes all GL calls virtual. However, we
can get rid of this and implement it at compile time in case of
performance problems.

Fixes https://github.com/SerenityOS/serenity/issues/22670
