### PR TITLE
AK+LibCore+LibHTTP: Ensure the ending \r\n is present before trying to read a line

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -752,7 +752,7 @@ ErrorOr<void> FormatBuilder::put_hexdump(ReadonlyBytes bytes, size_t width, char
 {
     auto put_char_view = [&](auto i) -> ErrorOr<void> {
         TRY(put_padding(fill, 4));
-        for (size_t j = i - width; j < i; ++j) {
+        for (size_t j = i - min(i, width); j < i; ++j) {
             auto ch = bytes[j];
             TRY(m_builder.try_append(ch >= 32 && ch <= 127 ? ch : '.')); // silly hack
         }
@@ -769,7 +769,7 @@ ErrorOr<void> FormatBuilder::put_hexdump(ReadonlyBytes bytes, size_t width, char
         TRY(put_u64(bytes[i], 16, false, false, true, false, Align::Right, 2));
     }
 
-    if (width > 0 && bytes.size() && bytes.size() % width == 0)
+    if (width > 0)
         TRY(put_char_view(bytes.size()));
 
     return {};

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -532,6 +532,8 @@ TEST_CASE(buffered_file_without_newlines)
 
     auto can_read_line = TRY_OR_FAIL(ro_file->can_read_line());
     EXPECT(can_read_line);
+    auto can_read_up_to_newline = TRY_OR_FAIL(ro_file->can_read_up_to_delimiter("\n"sv.bytes()));
+    EXPECT(!can_read_up_to_newline);
     Array<u8, new_newlines_message.length() + 1> buffer;
     EXPECT(ro_file->read_line(buffer).release_value() == new_newlines_message);
 }

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -369,6 +369,7 @@ public:
     virtual ErrorOr<StringView> read_line(Bytes buffer) = 0;
     virtual ErrorOr<Bytes> read_until(Bytes buffer, StringView candidate) = 0;
     virtual ErrorOr<bool> can_read_line() = 0;
+    virtual ErrorOr<bool> can_read_up_to_delimiter(ReadonlyBytes delimiter) = 0;
     virtual size_t buffer_size() const = 0;
 };
 
@@ -413,10 +414,14 @@ public:
     virtual void set_notifications_enabled(bool enabled) override { m_helper.stream().set_notifications_enabled(enabled); }
 
     virtual ErrorOr<StringView> read_line(Bytes buffer) override { return m_helper.read_line(move(buffer)); }
+    virtual ErrorOr<bool> can_read_line() override
+    {
+        return TRY(m_helper.can_read_up_to_delimiter("\n"sv.bytes())) || m_helper.is_eof_with_data_left_over();
+    }
     virtual ErrorOr<Bytes> read_until(Bytes buffer, StringView candidate) override { return m_helper.read_until(move(buffer), move(candidate)); }
     template<size_t N>
     ErrorOr<Bytes> read_until_any_of(Bytes buffer, Array<StringView, N> candidates) { return m_helper.read_until_any_of(move(buffer), move(candidates)); }
-    virtual ErrorOr<bool> can_read_line() override { return m_helper.can_read_line(); }
+    virtual ErrorOr<bool> can_read_up_to_delimiter(ReadonlyBytes delimiter) override { return m_helper.can_read_up_to_delimiter(delimiter); }
 
     virtual size_t buffer_size() const override { return m_helper.buffer_size(); }
 


### PR DESCRIPTION
Fixes #22838.