### PR TITLE
LibWeb: Stop assuming navigable's existance in FrameBox

### DIFF
--- a/Tests/LibWeb/Layout/expected/misc/create-iframes-using-innerhtml.txt
+++ b/Tests/LibWeb/Layout/expected/misc/create-iframes-using-innerhtml.txt
@@ -1,0 +1,41 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div#container> at (8,8) content-size 784x0 children: not-inline
+        BlockContainer <div> at (8,8) content-size 1x1 positioned [BFC] children: inline
+          frag 0 from FrameBox start: 0, length: 0, rect: [18,18 10x10] baseline: 30
+          frag 1 from FrameBox start: 0, length: 0, rect: [18,48 10x10] baseline: 30
+          frag 2 from FrameBox start: 0, length: 0, rect: [18,78 10x10] baseline: 30
+          frag 3 from FrameBox start: 0, length: 0, rect: [18,108 10x10] baseline: 30
+          frag 4 from FrameBox start: 0, length: 0, rect: [18,138 10x10] baseline: 30
+          frag 5 from FrameBox start: 0, length: 0, rect: [18,168 10x10] baseline: 30
+          frag 6 from FrameBox start: 0, length: 0, rect: [18,198 10x10] baseline: 30
+          frag 7 from FrameBox start: 0, length: 0, rect: [18,228 10x10] baseline: 30
+          frag 8 from FrameBox start: 0, length: 0, rect: [18,258 10x10] baseline: 30
+          frag 9 from FrameBox start: 0, length: 0, rect: [18,288 10x10] baseline: 30
+          FrameBox <iframe> at (18,18) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,48) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,78) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,108) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,138) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,168) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,198) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,228) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,258) content-size 10x10 children: not-inline (url: about:blank)
+          FrameBox <iframe> at (18,288) content-size 10x10 children: not-inline (url: about:blank)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 800x298]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 784x290]
+      PaintableWithLines (BlockContainer<DIV>#container) [8,8 784x0] overflow: [8,8 20x290]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 1x1] overflow: [8,8 20x290]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,13 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,43 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,73 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,103 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,133 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,163 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,193 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,223 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,253 20x20]
+          NestedBrowsingContextPaintable (FrameBox<IFRAME>) [13,283 20x20]

--- a/Tests/LibWeb/Layout/input/misc/create-iframes-using-innerhtml.html
+++ b/Tests/LibWeb/Layout/input/misc/create-iframes-using-innerhtml.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html><head><style>
+iframe {
+    border: 5px solid black;
+    margin: 5px;
+}
+</style></head><body><div id="container"></div><script>
+    const container = document.getElementById("container");
+    const manyIframes = "<iframe height=10 width=10></iframe>".repeat(10);
+    const topDiv = document.createElement("div");
+    topDiv.style.position = "absolute";
+    topDiv.style.height = "1px";
+    topDiv.style.width = "1px";
+    topDiv.innerHTML = manyIframes;
+    container.appendChild(topDiv);
+</script></body></html>

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/FrameBox.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/NestedBrowsingContextPaintable.h>
@@ -21,8 +20,6 @@ FrameBox::~FrameBox() = default;
 
 void FrameBox::prepare_for_replaced_layout()
 {
-    VERIFY(dom_node().nested_browsing_context());
-
     // FIXME: Do proper error checking, etc.
     set_natural_width(dom_node().get_attribute_value(HTML::AttributeNames::width).to_number<int>().value_or(300));
     set_natural_height(dom_node().get_attribute_value(HTML::AttributeNames::height).to_number<int>().value_or(150));
@@ -32,8 +29,8 @@ void FrameBox::did_set_content_size()
 {
     ReplacedBox::did_set_content_size();
 
-    VERIFY(dom_node().content_navigable());
-    dom_node().content_navigable()->set_size(paintable_box()->content_size());
+    if (dom_node().content_navigable())
+        dom_node().content_navigable()->set_size(paintable_box()->content_size());
 }
 
 JS::GCPtr<Painting::Paintable> FrameBox::create_paintable() const


### PR DESCRIPTION
If the loading of iframe's navigable has not finished by the time FrameBox layout occurs, we should not crash.

Fixes https://github.com/SerenityOS/serenity/issues/22874