### PR TITLE
LibC+LibELF: Pass information from linker via magic lookup

### DIFF
--- a/Userland/Libraries/LibC/dlfcn.cpp
+++ b/Userland/Libraries/LibC/dlfcn.cpp
@@ -11,10 +11,10 @@
 #include <string.h>
 
 // These are filled in by the dynamic loader.
-DlCloseFunction __dlclose;
-DlOpenFunction __dlopen;
-DlSymFunction __dlsym;
-DlAddrFunction __dladdr;
+[[gnu::weak]] DlCloseFunction __dlclose;
+[[gnu::weak]] DlOpenFunction __dlopen;
+[[gnu::weak]] DlSymFunction __dlsym;
+[[gnu::weak]] DlAddrFunction __dladdr;
 
 // FIXME: use thread_local and a String once TLS works
 #ifdef NO_TLS

--- a/Userland/Libraries/LibC/libcinit.cpp
+++ b/Userland/Libraries/LibC/libcinit.cpp
@@ -17,8 +17,8 @@ int errno_storage;
 #else
 __thread int errno_storage;
 #endif
-char** environ;
-bool __environ_is_malloced;
+[[gnu::weak]] char** environ;
+bool __environ_is_malloced = false;
 bool __stdio_is_initialized;
 void* __auxiliary_vector;
 

--- a/Userland/Libraries/LibC/link.cpp
+++ b/Userland/Libraries/LibC/link.cpp
@@ -12,7 +12,7 @@ extern "C" {
 using DlIteratePhdrCallbackFunction = int (*)(struct dl_phdr_info*, size_t, void*);
 using DlIteratePhdrFunction = int (*)(DlIteratePhdrCallbackFunction, void*);
 
-DlIteratePhdrFunction __dl_iterate_phdr;
+[[gnu::weak]] DlIteratePhdrFunction __dl_iterate_phdr;
 
 int dl_iterate_phdr(int (*callback)(struct dl_phdr_info* info, size_t size, void* data), void* data)
 {

--- a/Userland/Libraries/LibC/ssp.cpp
+++ b/Userland/Libraries/LibC/ssp.cpp
@@ -18,8 +18,8 @@
 extern "C" {
 
 extern uintptr_t __stack_chk_guard;
-// Initialized in `initialize_libc` (we leave a placeholder value here before initialization).
-__attribute__((used)) uintptr_t __stack_chk_guard = (uintptr_t)0xc6c7c8c9;
+// Populated by DynamicLinker in shared executables.
+[[gnu::weak]] uintptr_t __stack_chk_guard = (uintptr_t)0xc6c7c8c9;
 
 __attribute__((noreturn)) void __stack_chk_fail()
 {

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -345,7 +345,7 @@ static T c_str_to_floating_point(char const* str, char** endptr)
 
 extern "C" {
 
-void (*__call_fini_functions)();
+[[gnu::weak]] void (*__call_fini_functions)();
 
 void exit(int status)
 {


### PR DESCRIPTION
This works by defining a set of weak symbols in dynamic linker whose value would be provided by it. This has the same effect as preloading library that magically knows right addresses of functions shared between dynamic linker and LibC.

We were previously passing the same information by rewriting symbols based on hardcoded library name, so the new approach seems a little nicer to me.

------

This initially popped up in my excessively intrusive LibRuntime PR and thus didn't get merged but I reasoned it might a good change on its own.

Answering potential review question: no, I can't make `MagicWeakSymbol` not ref-counted, since it is impossible to store `OwnPtr`s in `HashMap`.