### PR TITLE
LibWeb: Don't lose track of inline margins when collapsing whitespace

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/leading-margin-on-inline-content-that-starts-with-collapsible-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/leading-margin-on-inline-content-that-starts-with-collapsible-whitespace.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      InlineNode <div>
+        frag 0 from TextNode start: 1, length: 9, rect: [28,8 82.125x17] baseline: 13.296875
+            "Download "
+        TextNode <#text>
+      InlineNode <div>
+        frag 0 from TextNode start: 1, length: 4, rect: [150,8 39.5625x17] baseline: 13.296875
+            "News"
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      InlinePaintable (InlineNode<DIV>)
+        TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<DIV>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/leading-margin-on-inline-content-that-starts-with-collapsible-whitespace.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/leading-margin-on-inline-content-that-starts-with-collapsible-whitespace.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black;
+    }
+    div {
+        display: inline;
+        margin-left: 20px;
+        margin-right: 20px;
+    }
+</style><body><div> Download </div><div> News </div>


### PR DESCRIPTION
When iterating inline level chunks for a piece of text like " hello ", we will get three separate items from InlineLevelIterator:

- Text " "
- Text "hello"
- Text " "

If the first item also had some leading margin (e.g margin-left: 10px) we would lose that information when deciding that the whitespace is collapsible.

This patch fixes the issue by accumulating the amount of leading margin present in any collapsed whitespace items, and then adding them to the next non-whitespace item in IFC.

It's a wee bit hackish, but so is the rest of the leading/trailing margin mechanism.

This makes the header menu on https://www.gimp.org/ look proper. :^)

Before:
![Screenshot at 2024-01-20 22-48-37](https://github.com/SerenityOS/serenity/assets/5954907/aca5977d-2d2b-4871-860e-7aed31d0d4d5)

After:
![Screenshot at 2024-01-20 22-49-19](https://github.com/SerenityOS/serenity/assets/5954907/84f1c270-3958-47ee-af53-8ecc3aa5b3da)
