### PR TITLE
LibWeb+ImageDecoder: Allow returning an empty list of frame !!WIP!!

### DIFF
--- a/Ladybird/ImageCodecPlugin.cpp
+++ b/Ladybird/ImageCodecPlugin.cpp
@@ -40,6 +40,7 @@ Optional<Web::Platform::DecodedImage> ImageCodecPlugin::decode_image(ReadonlyByt
     auto result = result_or_empty.release_value();
 
     Web::Platform::DecodedImage decoded_image;
+    decoded_image.size = result.size;
     decoded_image.is_animated = result.is_animated;
     decoded_image.loop_count = result.loop_count;
     for (auto const& frame : result.frames) {

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -46,13 +46,14 @@ Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional
         return {};
 
     DecodedImage image;
+    image.size = response.size();
     image.is_animated = response.is_animated();
     image.loop_count = response.loop_count();
     image.frames.ensure_capacity(response.bitmaps().size());
     auto bitmaps = response.take_bitmaps();
     for (size_t i = 0; i < bitmaps.size(); ++i) {
         if (!bitmaps[i].is_valid())
-            return {};
+            return image;
 
         image.frames.empend(*bitmaps[i].bitmap(), response.durations()[i]);
     }

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -19,6 +19,7 @@ struct Frame {
 };
 
 struct DecodedImage {
+    Gfx::IntSize size {};
     bool is_animated { false };
     u32 loop_count { 0 };
     Vector<Frame> frames;

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -13,13 +13,14 @@ namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(AnimatedBitmapDecodedImageData);
 
-ErrorOr<JS::NonnullGCPtr<AnimatedBitmapDecodedImageData>> AnimatedBitmapDecodedImageData::create(JS::Realm& realm, Vector<Frame>&& frames, size_t loop_count, bool animated)
+ErrorOr<JS::NonnullGCPtr<AnimatedBitmapDecodedImageData>> AnimatedBitmapDecodedImageData::create(JS::Realm& realm, Vector<Frame>&& frames, Gfx::IntSize size, size_t loop_count, bool animated)
 {
-    return realm.heap().allocate<AnimatedBitmapDecodedImageData>(realm, move(frames), loop_count, animated);
+    return realm.heap().allocate<AnimatedBitmapDecodedImageData>(realm, move(frames), size, loop_count, animated);
 }
 
-AnimatedBitmapDecodedImageData::AnimatedBitmapDecodedImageData(Vector<Frame>&& frames, size_t loop_count, bool animated)
-    : m_frames(move(frames))
+AnimatedBitmapDecodedImageData::AnimatedBitmapDecodedImageData(Vector<Frame>&& frames, Gfx::IntSize size, size_t loop_count, bool animated)
+    : m_intrinsic_size(size)
+    , m_frames(move(frames))
     , m_loop_count(loop_count)
     , m_animated(animated)
 {
@@ -43,17 +44,17 @@ int AnimatedBitmapDecodedImageData::frame_duration(size_t frame_index) const
 
 Optional<CSSPixels> AnimatedBitmapDecodedImageData::intrinsic_width() const
 {
-    return m_frames.first().bitmap->width();
+    return m_intrinsic_size.width();
 }
 
 Optional<CSSPixels> AnimatedBitmapDecodedImageData::intrinsic_height() const
 {
-    return m_frames.first().bitmap->height();
+    return m_intrinsic_size.height();
 }
 
 Optional<CSSPixelFraction> AnimatedBitmapDecodedImageData::intrinsic_aspect_ratio() const
 {
-    return CSSPixels(m_frames.first().bitmap->width()) / CSSPixels(m_frames.first().bitmap->height());
+    return CSSPixels(m_intrinsic_size.width()) / CSSPixels(m_intrinsic_size.height());
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -21,7 +21,7 @@ public:
         int duration { 0 };
     };
 
-    static ErrorOr<JS::NonnullGCPtr<AnimatedBitmapDecodedImageData>> create(JS::Realm&, Vector<Frame>&&, size_t loop_count, bool animated);
+    static ErrorOr<JS::NonnullGCPtr<AnimatedBitmapDecodedImageData>> create(JS::Realm&, Vector<Frame>&&, Gfx::IntSize size, size_t loop_count, bool animated);
     virtual ~AnimatedBitmapDecodedImageData() override;
 
     virtual RefPtr<Gfx::ImmutableBitmap> bitmap(size_t frame_index, Gfx::IntSize = {}) const override;
@@ -36,9 +36,10 @@ public:
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
 private:
-    AnimatedBitmapDecodedImageData(Vector<Frame>&&, size_t loop_count, bool animated);
+    AnimatedBitmapDecodedImageData(Vector<Frame>&&, Gfx::IntSize size, size_t loop_count, bool animated);
 
-    Vector<Frame> m_frames;
+    Gfx::IntSize m_intrinsic_size {};
+    Vector<Frame> m_frames {};
     size_t m_loop_count { 0 };
     bool m_animated { false };
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -182,8 +182,8 @@ unsigned HTMLImageElement::width() const
 
     // ...or else the density-corrected intrinsic width and height of the image, in CSS pixels,
     // if the image has intrinsic dimensions and is available but not being rendered.
-    if (auto bitmap = current_image_bitmap())
-        return bitmap->width();
+    if (auto width = intrinsic_width(); width.has_value())
+        return width->to_int();
 
     // ...or else 0, if the image is not available or does not have intrinsic dimensions.
     return 0;
@@ -211,8 +211,8 @@ unsigned HTMLImageElement::height() const
 
     // ...or else the density-corrected intrinsic height and height of the image, in CSS pixels,
     // if the image has intrinsic dimensions and is available but not being rendered.
-    if (auto bitmap = current_image_bitmap())
-        return bitmap->height();
+    if (auto height = intrinsic_height(); height.has_value())
+        return height->to_int();
 
     // ...or else 0, if the image is not available or does not have intrinsic dimensions.
     return 0;

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -158,18 +158,19 @@ void SharedImageRequest::handle_successful_fetch(AK::URL const& url_string, Stri
 
         image_data = result.release_value();
     } else {
-        auto result = Web::Platform::ImageCodecPlugin::the().decode_image(data.bytes());
-        if (!result.has_value())
+        auto maybe_result = Web::Platform::ImageCodecPlugin::the().decode_image(data.bytes());
+        if (!maybe_result.has_value())
             return handle_failed_decode();
+        auto& result = maybe_result.value();
 
         Vector<AnimatedBitmapDecodedImageData::Frame> frames;
-        for (auto& frame : result.value().frames) {
+        for (auto& frame : result.frames) {
             frames.append(AnimatedBitmapDecodedImageData::Frame {
                 .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap),
                 .duration = static_cast<int>(frame.duration),
             });
         }
-        image_data = AnimatedBitmapDecodedImageData::create(m_document->realm(), move(frames), result.value().loop_count, result.value().is_animated).release_value_but_fixme_should_propagate_errors();
+        image_data = AnimatedBitmapDecodedImageData::create(m_document->realm(), move(frames), result.size, result.loop_count, result.is_animated).release_value_but_fixme_should_propagate_errors();
     }
 
     m_image_data = image_data;

--- a/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.h
@@ -10,6 +10,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Size.h>
 
 namespace Web::Platform {
 
@@ -19,6 +20,7 @@ struct Frame {
 };
 
 struct DecodedImage {
+    Gfx::IntSize size {};
     bool is_animated { false };
     u32 loop_count { 0 };
     Vector<Frame> frames;

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -37,7 +37,7 @@ static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder
     }
 }
 
-static void decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> const& known_mime_type, bool& is_animated, u32& loop_count, Vector<Gfx::ShareableBitmap>& bitmaps, Vector<u32>& durations)
+static void decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> const& known_mime_type, Gfx::IntSize& size, bool& is_animated, u32& loop_count, Vector<Gfx::ShareableBitmap>& bitmaps, Vector<u32>& durations)
 {
     VERIFY(bitmaps.size() == 0);
     VERIFY(durations.size() == 0);
@@ -48,10 +48,7 @@ static void decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer,
         return;
     }
 
-    if (!decoder->frame_count()) {
-        dbgln_if(IMAGE_DECODER_DEBUG, "Could not decode image from encoded data");
-        return;
-    }
+    size = decoder->size();
     is_animated = decoder->is_animated();
     loop_count = decoder->loop_count();
     decode_image_to_bitmaps_and_durations_with_decoder(*decoder, ideal_size, bitmaps, durations);
@@ -64,12 +61,13 @@ Messages::ImageDecoderServer::DecodeImageResponse ConnectionFromClient::decode_i
         return nullptr;
     }
 
+    Gfx::IntSize size {};
     bool is_animated = false;
     u32 loop_count = 0;
     Vector<Gfx::ShareableBitmap> bitmaps;
     Vector<u32> durations;
-    decode_image_to_details(encoded_buffer, ideal_size, mime_type, is_animated, loop_count, bitmaps, durations);
-    return { is_animated, loop_count, bitmaps, durations };
+    decode_image_to_details(encoded_buffer, ideal_size, mime_type, size, is_animated, loop_count, bitmaps, durations);
+    return { size, is_animated, loop_count, bitmaps, durations };
 }
 
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -3,5 +3,5 @@
 
 endpoint ImageDecoderServer
 {
-    decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations)
+    decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (Gfx::IntSize size, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations)
 }


### PR DESCRIPTION
This is an attempt at fixing https://github.com/SerenityOS/serenity/issues/22869.

---

Basically the issue is that the HTML spec consider an image as valid as long as you can decode its size.
https://html.spec.whatwg.org/multipage/images.html#images-processing-model

But our current model (the multiple variant of `DecodedImage`) are constructed as a `Vector` of frame, with all different frame possibly having their own size. An image without a frame (as in the issue) would not carry its size information inside the `DecodedImage` struct.

This patch is decomposed in three parts:

1. Inside `ImageDecoder`, don't return an `OptionalNone{}` if no frame is available.
2. Plumbing through LibImageDecoderClient, IPC, ImageCodecPlugin and the `Web::Platform`
3. Making `AnimatedBitmapDecodedImageData` use its brand new `m_size` field instead of the size of the first frame. As it can now be non-existent.

This is a draft as I'm really not sure about what I did to `LibWeb` and it comes at the cost of breaking everything on SerenityOS :upside_down_face:. The latter is obviously fixable, but let's see if things looks ok on the `LibWeb` side before I dive into resolving that.