### PR TITLE
LibWeb/WebGL: Switch context in AccelGfxContext destructor

### DIFF
--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -163,6 +163,11 @@ public:
     {
     }
 
+    ~AccelGfxContext()
+    {
+        activate();
+    }
+
 private:
     OwnPtr<AccelGfx::Context> m_context;
     NonnullRefPtr<AccelGfx::Canvas> m_canvas;

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -20,7 +20,7 @@ namespace Web::WebGL {
 #ifdef HAS_ACCELERATED_GRAPHICS
 class AccelGfxContext : public OpenGLContext {
 public:
-    virtual void activate() override
+    void activate()
     {
         m_context->activate();
     }
@@ -172,11 +172,6 @@ private:
 #ifdef AK_OS_SERENITY
 class LibGLContext : public OpenGLContext {
 public:
-    virtual void activate() override
-    {
-        GL::make_context_current(m_context);
-    }
-
     virtual void present(Gfx::Bitmap&) override
     {
         m_context->present();

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
@@ -15,7 +15,6 @@ class OpenGLContext {
 public:
     static OwnPtr<OpenGLContext> create(Gfx::Bitmap&);
 
-    virtual void activate() = 0;
     virtual void present(Gfx::Bitmap&) = 0;
     void clear_buffer_to_default_values();
 


### PR DESCRIPTION
Destructor of AccelGfxContext needs to make sure that correct OpenGL
context is active so that destructors of its members could proceed
destroying they resources (for example framebuffer owned by
AccelGfx::Canvas).

Fixes https://github.com/SerenityOS/serenity/issues/22879