### PR TITLE
LibJS: Don't add uncaptured parameter bindings to environment

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -153,7 +153,11 @@ private:
 
     bool m_has_parameter_expressions { false };
     bool m_has_duplicates { false };
-    HashTable<DeprecatedFlyString> m_parameter_names;
+    enum class ParameterIsLocal {
+        No,
+        Yes,
+    };
+    HashMap<DeprecatedFlyString, ParameterIsLocal> m_parameter_names;
     Vector<FunctionDeclaration const&> m_functions_to_initialize;
     bool m_arguments_object_needed { false };
     bool m_is_module_wrapper { false };


### PR DESCRIPTION
For parameters that exist strictly as "locals", we can save time and space by not adding them to the function environment.

This is a speed-up across the board on basically every test. For example, ~11% on Octane/typescript.js :^)

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.032  0.810 ± 0.800 … 0.820     0.785 ± 0.780 … 0.790
Kraken      audio-beat-detection.js                  1.044  0.470 ± 0.460 … 0.480     0.450 ± 0.450 … 0.450
Kraken      audio-dft.js                             1      0.355 ± 0.350 … 0.360     0.355 ± 0.350 … 0.360
Kraken      audio-fft.js                             1.015  0.335 ± 0.330 … 0.340     0.330 ± 0.330 … 0.330
Kraken      audio-oscillator.js                      1.012  0.405 ± 0.400 … 0.410     0.400 ± 0.400 … 0.400
Kraken      imaging-darkroom.js                      1.026  2.955 ± 2.890 … 3.020     2.880 ± 2.830 … 2.930
Kraken      imaging-desaturate.js                    1.024  0.635 ± 0.630 … 0.640     0.620 ± 0.620 … 0.620
Kraken      imaging-gaussian-blur.js                 0.993  2.200 ± 2.180 … 2.220     2.215 ± 2.210 … 2.220
Kraken      json-parse-financial.js                  1      0.080 ± 0.080 … 0.080     0.080 ± 0.080 … 0.080
Kraken      json-stringify-tinderbox.js              1.056  0.190 ± 0.190 … 0.190     0.180 ± 0.180 … 0.180
Kraken      stanford-crypto-aes.js                   1.047  0.555 ± 0.550 … 0.560     0.530 ± 0.530 … 0.530
Kraken      stanford-crypto-ccm.js                   1.036  0.580 ± 0.580 … 0.580     0.560 ± 0.560 … 0.560
Kraken      stanford-crypto-pbkdf2.js                1.027  0.955 ± 0.950 … 0.960     0.930 ± 0.930 … 0.930
Kraken      stanford-crypto-sha256-iterative.js      1.049  0.425 ± 0.420 … 0.430     0.405 ± 0.400 … 0.410
Octane      box2d.js                                 1.058  2.470 ± 2.460 … 2.480     2.335 ± 2.330 … 2.340
Octane      code-load.js                             1      2.140 ± 2.140 … 2.140     2.140 ± 2.140 … 2.140
Octane      crypto.js                                1.002  5.045 ± 5.030 … 5.060     5.035 ± 5.030 … 5.040
Octane      deltablue.js                             1.003  3.075 ± 3.070 … 3.080     3.065 ± 3.030 … 3.100
Octane      earley-boyer.js                          1.049  21.910 ± 21.760 … 22.060  20.885 ± 20.700 … 21.070
Octane      gbemu.js                                 1.034  3.610 ± 3.610 … 3.610     3.490 ± 3.440 … 3.540
Octane      mandreel.js                              1.052  21.005 ± 20.760 … 21.250  19.970 ± 19.930 … 20.010
Octane      navier-stokes.js                         1.002  2.040 ± 2.040 … 2.040     2.035 ± 2.020 … 2.050
Octane      pdfjs.js                                 1.012  3.350 ± 3.330 … 3.370     3.310 ± 3.300 … 3.320
Octane      raytrace.js                              1.024  8.255 ± 8.220 … 8.290     8.065 ± 8.040 … 8.090
Octane      regexp.js                                0.997  25.970 ± 25.830 … 26.110  26.055 ± 25.830 … 26.280
Octane      richards.js                              1.002  2.020 ± 2.020 … 2.020     2.015 ± 2.010 … 2.020
Octane      splay.js                                 1.03   3.095 ± 3.090 … 3.100     3.005 ± 3.000 … 3.010
Octane      typescript.js                            1.111  49.550 ± 49.350 … 49.750  44.580 ± 44.430 … 44.730
Octane      zlib.js                                  1.001  80.005 ± 79.720 … 80.290  79.960 ± 78.690 … 81.230
Kraken      Total                                    1.021  10.950                    10.720
Octane      Total                                    1.034  233.540                   225.945
All Suites  Total                                    1.033  244.490                   236.665
```