### PR TITLE
LibWeb: Treat null as empty string in CSSStyleDeclaration::internal_set

### DIFF
--- a/Tests/LibWeb/Layout/expected/misc/set-display-null.txt
+++ b/Tests/LibWeb/Layout/expected/misc/set-display-null.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div#box> at (8,8) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>#box) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/misc/set-display-null.html
+++ b/Tests/LibWeb/Layout/input/misc/set-display-null.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: magenta;
+}
+</style><body><div id="box"></div></body><script>
+document.getElementById("box").style.display = "none";
+document.getElementById("box").style.display = null;</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -432,7 +432,7 @@ JS::ThrowCompletionOr<bool> CSSStyleDeclaration::internal_set(JS::PropertyKey co
     if (property_id == CSS::PropertyID::Invalid)
         return Base::internal_set(name, value, receiver, cacheable_metadata);
 
-    auto css_text = TRY(value.to_string(vm));
+    auto css_text = value.is_null() ? String {} : TRY(value.to_string(vm));
 
     TRY(Bindings::throw_dom_exception_if_needed(vm, [&] { return set_property(property_id, css_text); }));
     return true;


### PR DESCRIPTION
Spec defines `[LegacyNullToEmptyString]` on `value` argument of `setProperty` but since `internal_set` calls `setProperty` directly instead of using IDL generated binding, we need to make sure that null is treated as empty string.

Fixes items grid loading on https://d.rsms.me/stuff/