### PR TITLE
LibGfx/JPEG+TIFF: Expose Exif metadata from JPEGs

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -37,6 +37,9 @@ public:
     virtual IntSize size() override;
 
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
+
+    virtual Optional<Metadata const&> metadata() override;
+
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
     virtual NaturalFrameFormat natural_frame_format() const override;

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -620,4 +620,12 @@ ErrorOr<Optional<ReadonlyBytes>> TIFFImageDecoderPlugin::icc_data()
     return m_context->metadata().icc_profile().map([](auto const& buffer) -> ReadonlyBytes { return buffer.bytes(); });
 }
 
+ErrorOr<NonnullOwnPtr<ExifMetadata>> TIFFImageDecoderPlugin::read_exif_metadata(ReadonlyBytes data)
+{
+    auto stream = TRY(try_make<FixedMemoryStream>(data));
+    auto plugin = TRY(adopt_nonnull_own_or_enomem(new (nothrow) TIFFImageDecoderPlugin(move(stream))));
+    TRY(plugin->m_context->decode_image_header());
+    return try_make<ExifMetadata>(plugin->m_context->metadata());
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
@@ -7,9 +7,12 @@
 #pragma once
 
 #include <AK/MemoryStream.h>
+#include <AK/NonnullOwnPtr.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 
 namespace Gfx {
+
+class ExifMetadata;
 
 // This is a link to the main TIFF specification from 1992
 // https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
@@ -29,6 +32,7 @@ class TIFFImageDecoderPlugin : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ExifMetadata>> read_exif_metadata(ReadonlyBytes);
 
     virtual ~TIFFImageDecoderPlugin() override = default;
 


### PR DESCRIPTION
This is fairly simple as the main task was to get the two decoder to communicate.

![image](https://github.com/SerenityOS/serenity/assets/26030965/edab9453-2727-41be-bd2f-d6c521e3cf9f)