### PR TITLE
LibWeb: Find font that has whitespace glyph in first_available_font()

### DIFF
--- a/Tests/LibWeb/Ref/first-available-font-should-include-whitespace.html
+++ b/Tests/LibWeb/Ref/first-available-font-should-include-whitespace.html
@@ -1,0 +1,14 @@
+<!doctype html><link rel="match" href="reference/first-available-font-should-include-whitespace-ref.html" /><style>
+    * {
+        outline: 1px solid black;
+        font-family: HashFont, SerenitySans;
+    }
+    div {
+        width: min-content;
+    }
+    @font-face {
+        font-family: 'HashFont';
+        src: url('assets/HashSans.woff');
+        unicode-range: U+0;
+    }
+</style><div class="test">hello friends

--- a/Tests/LibWeb/Ref/reference/first-available-font-should-include-whitespace-ref.html
+++ b/Tests/LibWeb/Ref/reference/first-available-font-should-include-whitespace-ref.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black;
+        font-family: SerenitySans;
+    }
+    div {
+        width: min-content;
+    }
+</style><div class="test">hello friends

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -306,9 +306,8 @@ inline NodeWithStyle* Node::parent()
 inline Gfx::Font const& NodeWithStyle::first_available_font() const
 {
     // https://drafts.csswg.org/css-fonts/#first-available-font
-    // FIXME: Should be be the first font for which the character U+0020 (space) instead of
-    //        any first font in the list
-    return computed_values().font_list().first();
+    // First font for which the character U+0020 (space) is not excluded by a unicode-range
+    return computed_values().font_list().font_for_code_point(' ');
 }
 
 }


### PR DESCRIPTION
Fixes https://github.com/SerenityOS/serenity/issues/22853