### PR TITLE
Meta: Use BXSHARE instead of a hardcoded Bochs directory

### DIFF
--- a/Meta/bochsrc
+++ b/Meta/bochsrc
@@ -2,8 +2,8 @@
 config_interface: textconfig
 display_library: x
 memory: host=1024, guest=1024
-romimage: file="/usr/share/bochs/BIOS-bochs-latest", address=0x00000000, options=none
-vgaromimage: file="/usr/share/bochs/VGABIOS-lgpl-latest"
+romimage: file="$BXSHARE/BIOS-bochs-latest", address=0x00000000, options=none
+vgaromimage: file="$BXSHARE/VGABIOS-lgpl-latest"
 boot: disk
 #floppy_bootsig_check: disabled=0
 #floppya: type=1_44, 1_44=".floppy-image", status=inserted, write_protected=0


### PR DESCRIPTION
This allows using Bochs instances that are installed in non-standard directories.