### PR TITLE
AK: Store JsonValue's value in AK::Variant

### DIFF
--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -1,69 +1,77 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <AK/JsonParser.h>
 #include <AK/JsonValue.h>
 #include <AK/StringView.h>
 
-#ifndef KERNEL
-#    include <AK/JsonParser.h>
-#endif
-
 namespace AK {
 
-JsonValue::JsonValue(JsonValue const& other)
+namespace {
+using JsonValueStorage = Variant<
+    Empty,
+    bool,
+    i64,
+    u64,
+    double,
+    ByteString,
+    NonnullOwnPtr<JsonArray>,
+    NonnullOwnPtr<JsonObject>>;
+
+static ErrorOr<JsonValueStorage> clone(JsonValueStorage const& other)
 {
-    copy_from(other);
+    return other.visit(
+        [](NonnullOwnPtr<JsonArray> const& value) -> ErrorOr<JsonValueStorage> {
+            return TRY(try_make<JsonArray>(*value));
+        },
+        [](NonnullOwnPtr<JsonObject> const& value) -> ErrorOr<JsonValueStorage> {
+            return TRY(try_make<JsonObject>(*value));
+        },
+        [](auto const& value) -> ErrorOr<JsonValueStorage> { return JsonValueStorage(value); });
+}
+}
+
+JsonValue::JsonValue() = default;
+JsonValue::~JsonValue() = default;
+JsonValue::JsonValue(JsonValue&&) = default;
+JsonValue& JsonValue::operator=(JsonValue&&) = default;
+
+JsonValue::JsonValue(JsonValue const& other)
+    : m_value(MUST(clone(other.m_value)))
+{
 }
 
 JsonValue& JsonValue::operator=(JsonValue const& other)
 {
-    if (this != &other) {
-        clear();
-        copy_from(other);
-    }
+    if (this != &other)
+        m_value = MUST(clone(other.m_value));
     return *this;
 }
 
-void JsonValue::copy_from(JsonValue const& other)
+JsonValue& JsonValue::operator=(JsonArray const& other)
 {
-    m_type = other.m_type;
-    switch (m_type) {
-    case Type::String:
-        VERIFY(!m_value.as_string);
-        m_value.as_string = other.m_value.as_string;
-        m_value.as_string->ref();
-        break;
-    case Type::Object:
-        m_value.as_object = new JsonObject(*other.m_value.as_object);
-        break;
-    case Type::Array:
-        m_value.as_array = new JsonArray(*other.m_value.as_array);
-        break;
-    default:
-        m_value.as_u64 = other.m_value.as_u64;
-        break;
-    }
+    return *this = JsonValue(other);
 }
 
-JsonValue::JsonValue(JsonValue&& other)
+JsonValue& JsonValue::operator=(JsonArray&& other)
 {
-    m_type = exchange(other.m_type, Type::Null);
-    m_value.as_u64 = exchange(other.m_value.as_u64, 0);
+    return *this = JsonValue(other);
 }
 
-JsonValue& JsonValue::operator=(JsonValue&& other)
+JsonValue& JsonValue::operator=(JsonObject const& other)
 {
-    if (this != &other) {
-        clear();
-        m_type = exchange(other.m_type, Type::Null);
-        m_value.as_u64 = exchange(other.m_value.as_u64, 0);
-    }
-    return *this;
+    return *this = JsonValue(other);
+}
+
+JsonValue& JsonValue::operator=(JsonObject&& other)
+{
+    return *this = JsonValue(other);
 }
 
 bool JsonValue::equals(JsonValue const& other) const
@@ -127,122 +135,78 @@ bool JsonValue::equals(JsonValue const& other) const
 }
 
 JsonValue::JsonValue(int value)
-    : m_type(Type::Int32)
+    : m_value(i64 { value })
 {
-    m_value.as_i32 = value;
 }
 
 JsonValue::JsonValue(unsigned value)
-    : m_type(Type::UnsignedInt32)
+    : m_value(i64 { value })
 {
-    m_value.as_u32 = value;
 }
 
 JsonValue::JsonValue(long value)
-    : m_type(sizeof(long) == 8 ? Type::Int64 : Type::Int32)
+    : m_value(i64 { value })
 {
-    if constexpr (sizeof(long) == 8)
-        m_value.as_i64 = value;
-    else
-        m_value.as_i32 = value;
 }
 
 JsonValue::JsonValue(unsigned long value)
-    : m_type(sizeof(long) == 8 ? Type::UnsignedInt64 : Type::UnsignedInt32)
+    : m_value(u64 { value })
 {
-    if constexpr (sizeof(long) == 8)
-        m_value.as_u64 = value;
-    else
-        m_value.as_u32 = value;
 }
 
 JsonValue::JsonValue(long long value)
-    : m_type(Type::Int64)
+    : m_value(i64 { value })
 {
-    static_assert(sizeof(long long unsigned) == 8);
-    m_value.as_i64 = value;
 }
 
 JsonValue::JsonValue(long long unsigned value)
-    : m_type(Type::UnsignedInt64)
+    : m_value(u64 { value })
 {
-    static_assert(sizeof(long long unsigned) == 8);
-    m_value.as_u64 = value;
 }
 
 JsonValue::JsonValue(char const* cstring)
-    : JsonValue(ByteString(cstring))
+    : m_value(ByteString { cstring })
 {
 }
 
-#if !defined(KERNEL)
 JsonValue::JsonValue(double value)
-    : m_type(Type::Double)
+    : m_value(double { value })
 {
-    m_value.as_double = value;
 }
-#endif
 
 JsonValue::JsonValue(ByteString const& value)
+    : m_value(value)
 {
-    m_type = Type::String;
-    m_value.as_string = const_cast<StringImpl*>(value.impl());
-    m_value.as_string->ref();
 }
 
 JsonValue::JsonValue(StringView value)
-    : JsonValue(value.to_byte_string())
+    : m_value(ByteString { value })
 {
 }
 
 JsonValue::JsonValue(JsonObject const& value)
-    : m_type(Type::Object)
+    : m_value(make<JsonObject>(value))
 {
-    m_value.as_object = new JsonObject(value);
 }
 
 JsonValue::JsonValue(JsonArray const& value)
-    : m_type(Type::Array)
+    : m_value(make<JsonArray>(value))
 {
-    m_value.as_array = new JsonArray(value);
 }
 
 JsonValue::JsonValue(JsonObject&& value)
-    : m_type(Type::Object)
+    : m_value(make<JsonObject>(value))
 {
-    m_value.as_object = new JsonObject(move(value));
 }
 
 JsonValue::JsonValue(JsonArray&& value)
-    : m_type(Type::Array)
+    : m_value(make<JsonArray>(value))
 {
-    m_value.as_array = new JsonArray(move(value));
 }
 
-void JsonValue::clear()
-{
-    switch (m_type) {
-    case Type::String:
-        m_value.as_string->unref();
-        break;
-    case Type::Object:
-        delete m_value.as_object;
-        break;
-    case Type::Array:
-        delete m_value.as_array;
-        break;
-    default:
-        break;
-    }
-    m_type = Type::Null;
-    m_value.as_string = nullptr;
-}
-
-#ifndef KERNEL
 ErrorOr<JsonValue> JsonValue::from_string(StringView input)
 {
     return JsonParser(input).parse();
 }
-#endif
 
 }


### PR DESCRIPTION
As usual, more readable modern code, less unreadable C-style code, and less code in total!

The end goal of my AK refactoring PRs is to share memory layout of `ByteString` and `String` using now-merged (hooray!) `StringBase`. This patchset, in particular, removes the last remaining non-trivial user of `StringImpl` that complicated the process.