### PR TITLE
LibWeb: Remove invalid assertion in table fixup

### DIFF
--- a/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
@@ -1,0 +1,42 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x62 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x46 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 27.90625x46 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 27.90625x46 table-box [TFC] children: not-inline
+          Box <tbody> at (8,8) content-size 21.90625x38 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 21.90625x19 table-row children: not-inline
+              BlockContainer <td> at (11,11) content-size 9.09375x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
+                    "1"
+                TextNode <#text>
+              BlockContainer <td> at (24.09375,22.5) content-size 8.8125x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [24.09375,22.5 8.8125x17] baseline: 13.296875
+                    "2"
+                TextNode <#text>
+            Box <tr> at (10,31) content-size 21.90625x19 table-row children: not-inline
+              BlockContainer <td> at (11,32) content-size 9.09375x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,32 9.09375x17] baseline: 13.296875
+                    "3"
+                TextNode <#text>
+            Box <tr> at (10,52) content-size 21.90625x0 table-row children: not-inline
+              BlockContainer <(anonymous)> at (10,52) content-size 11.09375x0 table-cell [BFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,54) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x62]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x46]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 27.90625x46]
+        PaintableBox (Box<TABLE>) [8,8 27.90625x46]
+          PaintableBox (Box<TBODY>) [8,8 21.90625x38] overflow: [8,8 25.90625x44]
+            PaintableBox (Box<TR>) [10,10 21.90625x19] overflow: [10,10 23.90625x42]
+              PaintableWithLines (BlockContainer<TD>) [10,10 11.09375x19]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [23.09375,10 10.8125x42]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,31 21.90625x19]
+              PaintableWithLines (BlockContainer<TD>) [10,31 11.09375x19]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,52 21.90625x0]
+              PaintableWithLines (BlockContainer(anonymous)) [10,52 11.09375x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,54 784x0]

--- a/Tests/LibWeb/Layout/input/table-fixup-with-rowspan.html
+++ b/Tests/LibWeb/Layout/input/table-fixup-with-rowspan.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><table><tbody><tr><td>1</td><td rowspan="3">2</td></tr><tr><td>3</td></tr><tr></tr></tbody></table>

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -727,13 +727,10 @@ static void for_each_child_box_matching(Box& parent, Matcher matcher, Callback c
 
 static void fixup_row(Box& row_box, TableGrid const& table_grid, size_t row_index)
 {
-    bool missing_cells_run_has_started = false;
     for (size_t column_index = 0; column_index < table_grid.column_count(); ++column_index) {
-        if (table_grid.occupancy_grid().contains({ column_index, row_index })) {
-            VERIFY(!missing_cells_run_has_started);
+        if (table_grid.occupancy_grid().contains({ column_index, row_index }))
             continue;
-        }
-        missing_cells_run_has_started = true;
+
         auto row_computed_values = row_box.computed_values().clone_inherited_values();
         auto& cell_computed_values = static_cast<CSS::MutableComputedValues&>(row_computed_values);
         cell_computed_values.set_display(Web::CSS::Display { CSS::DisplayInternal::TableCell });


### PR DESCRIPTION
Previously, our code for the fixup of table rows assumed that missing cells in a table row must be sequential. This may not be true if the table contains cells have a rowspan greater than one.

Fixes #22815