### PR TITLE
LibJS: Avoid unnecessary MarkedVector in Bytecode::Op::Call::execute()

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1000,7 +1000,6 @@ static ThrowCompletionOr<Value> dispatch_builtin_call(Bytecode::Interpreter& int
 
 ThrowCompletionOr<void> Call::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    auto& vm = interpreter.vm();
     auto callee = interpreter.reg(m_callee);
 
     TRY(throw_if_needed_for_call(interpreter, callee, call_type(), expression_string()));
@@ -1010,12 +1009,7 @@ ThrowCompletionOr<void> Call::execute_impl(Bytecode::Interpreter& interpreter) c
         return {};
     }
 
-    MarkedVector<Value> argument_values(vm.heap());
-    argument_values.ensure_capacity(m_argument_count);
-    for (u32 i = 0; i < m_argument_count; ++i) {
-        argument_values.unchecked_append(interpreter.reg(Register { m_first_argument.index() + i }));
-    }
-    interpreter.accumulator() = TRY(perform_call(interpreter, interpreter.reg(m_this_value), call_type(), callee, move(argument_values)));
+    interpreter.accumulator() = TRY(perform_call(interpreter, interpreter.reg(m_this_value), call_type(), callee, interpreter.registers().slice(m_first_argument.index(), m_argument_count)));
     return {};
 }
 


### PR DESCRIPTION
perform_call() wants a ReadonlySpan<Value>, so just grab a slice of the current register window instead of making a MarkedVector.

10% speed-up on this function call microbenchmark:

    function callee(a, b, c) { }

    function caller(callee) {
        for (let i = 0; i < 10_000_000; ++i)
            callee(1, 2, 3)
    }

    caller(callee)