### PR TITLE
Userland: Use ByteString for file paths in a few places

### DIFF
--- a/Userland/Applications/3DFileViewer/MeshLoader.h
+++ b/Userland/Applications/3DFileViewer/MeshLoader.h
@@ -17,5 +17,5 @@ public:
     MeshLoader() = default;
     virtual ~MeshLoader() = default;
 
-    virtual ErrorOr<NonnullRefPtr<Mesh>> load(String const& filename, NonnullOwnPtr<Core::File> file) = 0;
+    virtual ErrorOr<NonnullRefPtr<Mesh>> load(ByteString const& filename, NonnullOwnPtr<Core::File> file) = 0;
 };

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -25,7 +25,7 @@ static ErrorOr<GLfloat> parse_float(StringView string)
     return maybe_float.release_value();
 }
 
-ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(String const& filename, NonnullOwnPtr<Core::File> file)
+ErrorOr<NonnullRefPtr<Mesh>> WavefrontOBJLoader::load(ByteString const& filename, NonnullOwnPtr<Core::File> file)
 {
     auto buffered_file = TRY(Core::InputBufferedFile::create(move(file)));
 

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.h
@@ -18,5 +18,5 @@ public:
     WavefrontOBJLoader() = default;
     ~WavefrontOBJLoader() override = default;
 
-    ErrorOr<NonnullRefPtr<Mesh>> load(String const& filename, NonnullOwnPtr<Core::File> file) override;
+    ErrorOr<NonnullRefPtr<Mesh>> load(ByteString const& filename, NonnullOwnPtr<Core::File> file) override;
 };

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -153,7 +153,7 @@ void GLContextWidget::drop_event(GUI::DropEvent& event)
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), url.serialize_path());
         if (response.is_error())
             return;
-        load_file(response.value().filename(), response.value().release_stream());
+        load_file(MUST(String::from_byte_string(response.value().filename())), response.value().release_stream());
     }
 }
 
@@ -389,7 +389,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
 
         auto file = response.release_value();
-        widget->load_file(file.filename(), file.release_stream());
+        widget->load_file(MUST(String::from_byte_string(file.filename())), file.release_stream());
     }));
     file_menu->add_separator();
     file_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) {
@@ -583,7 +583,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             GUI::MessageBox::show(window, ByteString::formatted("Opening \"{}\" failed: {}", filename, strerror(errno)), "Error"sv, GUI::MessageBox::Type::Error);
         return 1;
     }
-    widget->load_file(file.value().filename(), file.value().release_stream());
+    widget->load_file(TRY(String::from_byte_string(file.value().filename())), file.value().release_stream());
 
     return app->exec();
 }

--- a/Userland/Applications/Calendar/CalendarWidget.cpp
+++ b/Userland/Applications/Calendar/CalendarWidget.cpp
@@ -168,7 +168,7 @@ NonnullRefPtr<GUI::Action> CalendarWidget::create_save_action(GUI::Action& save_
             return;
         }
 
-        auto response = FileSystemAccessClient::Client::the().request_file(window(), current_filename().to_byte_string(), Core::File::OpenMode::Write);
+        auto response = FileSystemAccessClient::Client::the().request_file(window(), current_filename(), Core::File::OpenMode::Write);
         if (response.is_error())
             return;
 

--- a/Userland/Applications/Calendar/CalendarWidget.h
+++ b/Userland/Applications/Calendar/CalendarWidget.h
@@ -34,7 +34,7 @@ private:
 
     void create_on_tile_doubleclick();
 
-    String const& current_filename() const { return m_event_calendar->event_manager().current_filename(); }
+    ByteString const& current_filename() const { return m_event_calendar->event_manager().current_filename(); }
 
     void create_on_events_change();
     NonnullRefPtr<GUI::Action> create_save_as_action();

--- a/Userland/Applications/Calendar/EventManager.h
+++ b/Userland/Applications/Calendar/EventManager.h
@@ -30,8 +30,8 @@ class EventManager {
 public:
     static OwnPtr<EventManager> create();
 
-    String const& current_filename() const { return m_current_filename; }
-    void set_filename(String const& filename) { m_current_filename = filename; }
+    ByteString const& current_filename() const { return m_current_filename; }
+    void set_filename(ByteString filename) { m_current_filename = move(filename); }
 
     ErrorOr<void> save(FileSystemAccessClient::File& file);
     ErrorOr<void> load_file(FileSystemAccessClient::File& file);
@@ -53,7 +53,7 @@ private:
     Vector<Event> m_events;
 
     bool m_dirty { false };
-    String m_current_filename;
+    ByteString m_current_filename;
 };
 
 }

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -110,7 +110,7 @@ ErrorOr<void> BackgroundSettingsWidget::create_frame()
         if (response.is_error())
             return;
         m_wallpaper_view->selection().clear();
-        m_monitor_widget->set_wallpaper(response.release_value().filename());
+        m_monitor_widget->set_wallpaper(MUST(String::from_byte_string(response.release_value().filename())));
         m_background_settings_changed = true;
         set_modified(true);
     };

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -167,7 +167,7 @@ ErrorOr<void> MainWidget::create_actions()
         if (auto result = save_file(file.filename(), file.release_stream()); result.is_error())
             show_error(result.release_error(), "Saving"sv, file.filename());
         else
-            GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
+            GUI::Application::the()->set_most_recently_open_file(file.filename());
     });
 
     m_cut_action = GUI::CommonActions::make_cut_action([this](auto&) {

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -596,13 +596,12 @@ void HexEditorWidget::update_title()
     window()->set_title(builder.to_byte_string());
 }
 
-void HexEditorWidget::open_file(String const& filename, NonnullOwnPtr<Core::File> file)
+void HexEditorWidget::open_file(ByteString const& filename, NonnullOwnPtr<Core::File> file)
 {
     window()->set_modified(false);
     m_editor->open_file(move(file));
-    auto filename_byte_string = filename.to_byte_string();
-    set_path(filename_byte_string);
-    GUI::Application::the()->set_most_recently_open_file(filename_byte_string);
+    set_path(filename);
+    GUI::Application::the()->set_most_recently_open_file(filename);
 }
 
 bool HexEditorWidget::request_close()

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -24,7 +24,7 @@ class HexEditorWidget final : public GUI::Widget {
     C_OBJECT_ABSTRACT(HexEditorWidget)
 public:
     virtual ~HexEditorWidget() override = default;
-    void open_file(String const& filename, NonnullOwnPtr<Core::File>);
+    void open_file(ByteString const& filename, NonnullOwnPtr<Core::File>);
     ErrorOr<void> initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -169,7 +169,7 @@ void ViewWidget::navigate(Directions direction)
     m_current_index = index;
 
     auto value = result.release_value();
-    open_file(value.filename(), value.stream());
+    open_file(MUST(String::from_byte_string(value.filename())), value.stream());
 }
 
 void ViewWidget::doubleclick_event(GUI::MouseEvent&)

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -106,7 +106,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
 
         auto value = result.release_value();
-        widget.open_file(value.filename(), value.stream());
+        widget.open_file(MUST(String::from_byte_string(value.filename())), value.stream());
 
         for (size_t i = 1; i < urls.size(); ++i) {
             Desktop::Launcher::open(URL::create_with_file_scheme(urls[i].serialize_path().characters()), "/bin/ImageViewer");
@@ -130,7 +130,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 return;
 
             auto value = result.release_value();
-            widget.open_file(value.filename(), value.stream());
+            widget.open_file(MUST(String::from_byte_string(value.filename())), value.stream());
         });
 
     auto delete_action = GUI::CommonActions::make_delete_action(
@@ -318,7 +318,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
 
         auto value = result.release_value();
-        widget.open_file(value.filename(), value.stream());
+        widget.open_file(MUST(String::from_byte_string(value.filename())), value.stream());
     });
 
     file_menu->add_action(quit_action);
@@ -380,7 +380,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return 1;
 
         auto value = result.release_value();
-        widget.open_file(value.filename(), value.stream());
+        widget.open_file(MUST(String::from_byte_string(value.filename())), value.stream());
     } else {
         widget.clear();
     }

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -63,13 +63,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file_menu = window->add_menu("&File"_string);
     file_menu->add_action(GUI::CommonActions::make_save_as_action([&](auto&) {
-        AK::ByteString filename = "file for saving";
+        ByteString filename = "file for saving";
         auto do_save = [&]() -> ErrorOr<void> {
             auto response = FileSystemAccessClient::Client::the().save_file(window, "Capture", "png");
             if (response.is_error())
                 return {};
             auto file = response.value().release_stream();
-            auto path = AK::LexicalPath(response.value().filename().to_byte_string());
+            auto path = LexicalPath(response.value().filename());
             filename = path.basename();
             auto encoded = TRY(dump_bitmap(magnifier->current_bitmap(), path.extension()));
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -776,7 +776,7 @@ void ImageEditor::save_project_as()
         GUI::MessageBox::show_error(window(), MUST(String::formatted("Could not save {}: {}", file.filename(), result.release_error())));
         return;
     }
-    set_path(file.filename().to_byte_string());
+    set_path(file.filename());
     set_loaded_from_image(false);
     set_unmodified();
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1304,11 +1304,11 @@ void MainWidget::open_image(FileSystemAccessClient::File file)
     auto& image = *m_loader.release_image();
     auto& editor = create_new_editor(image);
     editor.set_loaded_from_image(m_loader.is_raw_image());
-    editor.set_path(file.filename().to_byte_string());
+    editor.set_path(file.filename());
     editor.set_unmodified();
     m_layer_list_widget->set_image(&image);
     m_toolbox->ensure_tool_selection();
-    GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
+    GUI::Application::the()->set_most_recently_open_file(file.filename());
 }
 
 ErrorOr<void> MainWidget::create_default_image()

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -177,7 +177,7 @@ void CSVImportDialogPage::update_preview()
     m_data_preview_table_view->update();
 }
 
-ErrorOr<Vector<NonnullRefPtr<Sheet>>, ByteString> ImportDialog::make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook& workbook)
+ErrorOr<Vector<NonnullRefPtr<Sheet>>, ByteString> ImportDialog::make_and_run_for(GUI::Window& parent, StringView mime, ByteString const& filename, Core::File& file, Workbook& workbook)
 {
     auto wizard = GUI::WizardDialog::create(&parent).release_value_but_fixme_should_propagate_errors();
     wizard->set_title("File Import Wizard");
@@ -247,7 +247,7 @@ ErrorOr<Vector<NonnullRefPtr<Sheet>>, ByteString> ImportDialog::make_and_run_for
     } else {
         auto page = GUI::WizardPage::create(
             "Import File Format"sv,
-            ByteString::formatted("Select the format you wish to import '{}' as", LexicalPath::basename(filename.to_byte_string())))
+            ByteString::formatted("Select the format you wish to import '{}' as", LexicalPath::basename(filename)))
                         .release_value_but_fixme_should_propagate_errors();
 
         page->on_next_page = [] { return nullptr; };

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -55,7 +55,7 @@ private:
 };
 
 struct ImportDialog {
-    static ErrorOr<Vector<NonnullRefPtr<Sheet>>, ByteString> make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook&);
+    static ErrorOr<Vector<NonnullRefPtr<Sheet>>, ByteString> make_and_run_for(GUI::Window& parent, StringView mime, ByteString const& filename, Core::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -136,7 +136,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto response = FileSystemAccessClient::Client::the().open_file(window(), options);
         if (response.is_error())
             return;
-        load_file(response.value().filename(), response.value().stream());
+        load_file(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
     });
 
     m_import_action = GUI::Action::create("Import Sheets...", [&](auto&) {
@@ -150,7 +150,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         if (response.is_error())
             return;
 
-        import_sheets(response.value().filename(), response.value().stream());
+        import_sheets(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {
@@ -162,7 +162,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto response = FileSystemAccessClient::Client::the().request_file(window(), current_filename(), Core::File::OpenMode::Write);
         if (response.is_error())
             return;
-        save(response.value().filename(), response.value().stream());
+        save(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
@@ -170,7 +170,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto response = FileSystemAccessClient::Client::the().save_file(window(), name, "sheets");
         if (response.is_error())
             return;
-        save(response.value().filename(), response.value().stream());
+        save(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
         update_window_title();
     });
 
@@ -733,7 +733,7 @@ ErrorOr<void> SpreadsheetWidget::initialize_menubar(GUI::Window& window)
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(&window, action.text());
         if (response.is_error())
             return;
-        load_file(response.value().filename(), response.value().stream());
+        load_file(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
     });
     file_menu->add_action(*m_quit_action);
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -136,7 +136,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto response = FileSystemAccessClient::Client::the().open_file(window(), options);
         if (response.is_error())
             return;
-        load_file(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
+        load_file(response.value().filename(), response.value().stream());
     });
 
     m_import_action = GUI::Action::create("Import Sheets...", [&](auto&) {
@@ -150,7 +150,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         if (response.is_error())
             return;
 
-        import_sheets(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
+        import_sheets(response.value().filename(), response.value().stream());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {
@@ -162,7 +162,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto response = FileSystemAccessClient::Client::the().request_file(window(), current_filename(), Core::File::OpenMode::Write);
         if (response.is_error())
             return;
-        save(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
+        save(response.value().filename(), response.value().stream());
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
@@ -170,7 +170,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto response = FileSystemAccessClient::Client::the().save_file(window(), name, "sheets");
         if (response.is_error())
             return;
-        save(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
+        save(response.value().filename(), response.value().stream());
         update_window_title();
     });
 
@@ -560,7 +560,7 @@ void SpreadsheetWidget::change_cell_static_color_format(Spreadsheet::FormatType 
         apply_color_to_selected_cells(dialog->color());
 }
 
-void SpreadsheetWidget::save(String const& filename, Core::File& file)
+void SpreadsheetWidget::save(ByteString const& filename, Core::File& file)
 {
     auto result = m_workbook->write_to_file(filename, file);
     if (result.is_error()) {
@@ -569,10 +569,10 @@ void SpreadsheetWidget::save(String const& filename, Core::File& file)
     }
     undo_stack().set_current_unmodified();
     window()->set_modified(false);
-    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
+    GUI::Application::the()->set_most_recently_open_file(filename);
 }
 
-void SpreadsheetWidget::load_file(String const& filename, Core::File& file)
+void SpreadsheetWidget::load_file(ByteString const& filename, Core::File& file)
 {
     auto result = m_workbook->open_file(filename, file);
     if (result.is_error()) {
@@ -592,10 +592,10 @@ void SpreadsheetWidget::load_file(String const& filename, Core::File& file)
 
     setup_tabs(m_workbook->sheets());
     update_window_title();
-    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
+    GUI::Application::the()->set_most_recently_open_file(filename);
 }
 
-void SpreadsheetWidget::import_sheets(String const& filename, Core::File& file)
+void SpreadsheetWidget::import_sheets(ByteString const& filename, Core::File& file)
 {
     auto result = m_workbook->import_file(filename, file);
     if (result.is_error()) {
@@ -733,7 +733,7 @@ ErrorOr<void> SpreadsheetWidget::initialize_menubar(GUI::Window& window)
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(&window, action.text());
         if (response.is_error())
             return;
-        load_file(MUST(String::from_byte_string(response.value().filename())), response.value().stream());
+        load_file(response.value().filename(), response.value().stream());
     });
     file_menu->add_action(*m_quit_action);
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -22,9 +22,9 @@ class SpreadsheetWidget final
 public:
     virtual ~SpreadsheetWidget() override = default;
 
-    void save(String const& filename, Core::File&);
-    void load_file(String const& filename, Core::File&);
-    void import_sheets(String const& filename, Core::File&);
+    void save(ByteString const& filename, Core::File&);
+    void load_file(ByteString const& filename, Core::File&);
+    void import_sheets(ByteString const& filename, Core::File&);
     bool request_close();
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -50,31 +50,31 @@ bool Workbook::set_filename(ByteString const& filename)
     return true;
 }
 
-ErrorOr<void, ByteString> Workbook::open_file(String const& filename, Core::File& file)
+ErrorOr<void, ByteString> Workbook::open_file(ByteString const& filename, Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
     // Make an import dialog, we might need to import it.
     m_sheets = TRY(ImportDialog::make_and_run_for(m_parent_window, mime, filename, file, *this));
 
-    set_filename(filename.to_byte_string());
+    set_filename(filename);
 
     return {};
 }
 
-ErrorOr<void> Workbook::write_to_file(String const& filename, Core::File& stream)
+ErrorOr<void> Workbook::write_to_file(ByteString const& filename, Core::File& stream)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
     // Make an export dialog, we might need to import it.
-    TRY(ExportDialog::make_and_run_for(mime, stream, filename.to_byte_string(), *this));
+    TRY(ExportDialog::make_and_run_for(mime, stream, filename, *this));
 
-    set_filename(filename.to_byte_string());
+    set_filename(filename);
     set_dirty(false);
     return {};
 }
 
-ErrorOr<bool, ByteString> Workbook::import_file(String const& filename, Core::File& file)
+ErrorOr<bool, ByteString> Workbook::import_file(ByteString const& filename, Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -15,10 +15,10 @@ class Workbook {
 public:
     Workbook(Vector<NonnullRefPtr<Sheet>>&& sheets, GUI::Window& parent_window);
 
-    ErrorOr<void, ByteString> open_file(String const& filename, Core::File&);
-    ErrorOr<void> write_to_file(String const& filename, Core::File&);
+    ErrorOr<void, ByteString> open_file(ByteString const& filename, Core::File&);
+    ErrorOr<void> write_to_file(ByteString const& filename, Core::File&);
 
-    ErrorOr<bool, ByteString> import_file(String const& filename, Core::File&);
+    ErrorOr<bool, ByteString> import_file(ByteString const& filename, Core::File&);
 
     ByteString const& current_filename() const { return m_current_filename; }
     bool set_filename(ByteString const& filename);

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (!filename.is_empty()) {
         auto file = TRY(FileSystemAccessClient::Client::the().request_file_read_only_approved(window, filename));
-        spreadsheet_widget->load_file(file.filename(), file.stream());
+        spreadsheet_widget->load_file(TRY(String::from_byte_string(file.filename())), file.stream());
     }
 
     return app->exec();

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (!filename.is_empty()) {
         auto file = TRY(FileSystemAccessClient::Client::the().request_file_read_only_approved(window, filename));
-        spreadsheet_widget->load_file(TRY(String::from_byte_string(file.filename())), file.stream());
+        spreadsheet_widget->load_file(file.filename(), file.stream());
     }
 
     return app->exec();

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -293,7 +293,7 @@ MainWidget::MainWidget()
         }
 
         set_path(file.filename());
-        GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
+        GUI::Application::the()->set_most_recently_open_file(file.filename());
         dbgln("Wrote document to {}", file.filename());
     });
 
@@ -799,11 +799,11 @@ void MainWidget::update_title()
     window()->set_title(builder.to_byte_string());
 }
 
-ErrorOr<void> MainWidget::read_file(String const& filename, Core::File& file)
+ErrorOr<void> MainWidget::read_file(ByteString const& filename, Core::File& file)
 {
     m_editor->set_text(TRY(file.read_until_eof()));
     set_path(filename);
-    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
+    GUI::Application::the()->set_most_recently_open_file(filename);
     m_editor->set_focus(true);
     return {};
 }

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -25,7 +25,7 @@ class MainWidget final : public GUI::Widget {
 
 public:
     virtual ~MainWidget() override = default;
-    ErrorOr<void> read_file(String const& filename, Core::File&);
+    ErrorOr<void> read_file(ByteString const& filename, Core::File&);
     void open_nonexistent_file(ByteString const& path);
     bool request_close();
 

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -349,9 +349,8 @@ void MainWidget::set_path(ByteString path)
     update_title();
 }
 
-void MainWidget::save_to_file(String const& filename_string, NonnullOwnPtr<Core::File> file)
+void MainWidget::save_to_file(ByteString const& filename, NonnullOwnPtr<Core::File> file)
 {
-    auto filename = filename_string.to_byte_string();
     auto theme = Core::ConfigFile::open(filename, move(file)).release_value_but_fixme_should_propagate_errors();
 
 #define __ENUMERATE_ALIGNMENT_ROLE(role) theme->write_entry("Alignments", to_string(Gfx::AlignmentRole::role), to_string(m_current_palette.alignment(Gfx::AlignmentRole::role)));
@@ -635,15 +634,15 @@ void MainWidget::show_path_picker_dialog(StringView property_display_name, GUI::
     path_input.set_text(*result);
 }
 
-ErrorOr<void> MainWidget::load_from_file(String const& filename, NonnullOwnPtr<Core::File> file)
+ErrorOr<void> MainWidget::load_from_file(ByteString const& filename, NonnullOwnPtr<Core::File> file)
 {
-    auto config_file = TRY(Core::ConfigFile::open(filename.to_byte_string(), move(file)));
+    auto config_file = TRY(Core::ConfigFile::open(filename, move(file)));
     auto theme = TRY(Gfx::load_system_theme(config_file));
     VERIFY(theme.is_valid());
 
     auto new_palette = Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(theme));
     set_palette(move(new_palette));
-    set_path(filename.to_byte_string());
+    set_path(filename);
 
 #define __ENUMERATE_ALIGNMENT_ROLE(role)                                                    \
     if (auto alignment_input = m_alignment_inputs[to_underlying(Gfx::AlignmentRole::role)]) \
@@ -677,7 +676,7 @@ ErrorOr<void> MainWidget::load_from_file(String const& filename, NonnullOwnPtr<C
 
     m_last_modified_time = MonotonicTime::now();
     window()->set_modified(false);
-    GUI::Application::the()->set_most_recently_open_file(filename.to_byte_string());
+    GUI::Application::the()->set_most_recently_open_file(filename);
     return {};
 }
 

--- a/Userland/Applications/ThemeEditor/MainWidget.h
+++ b/Userland/Applications/ThemeEditor/MainWidget.h
@@ -86,7 +86,7 @@ public:
     ErrorOr<void> initialize_menubar(GUI::Window&);
     GUI::Window::CloseRequestDecision request_close();
     void update_title();
-    ErrorOr<void> load_from_file(String const& filename, NonnullOwnPtr<Core::File> file);
+    ErrorOr<void> load_from_file(ByteString const& filename, NonnullOwnPtr<Core::File> file);
 
 private:
     explicit MainWidget(NonnullRefPtr<AlignmentModel>);
@@ -94,7 +94,7 @@ private:
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
-    void save_to_file(String const& filename, NonnullOwnPtr<Core::File> file);
+    void save_to_file(ByteString const& filename, NonnullOwnPtr<Core::File> file);
     ErrorOr<Core::AnonymousBuffer> encode();
     void set_path(ByteString);
 

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -134,7 +134,7 @@ void VideoPlayerWidget::open_file(FileSystemAccessClient::File file)
         return;
     }
 
-    m_path = file.filename();
+    m_path = MUST(String::from_byte_string(file.filename()));
     update_title();
     close_file();
 

--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -126,10 +126,10 @@ void MainWidget::load_file(FileSystemAccessClient::File file)
     m_editor->set_text(buffer_or_error.release_value());
     m_editor->set_focus(true);
 
-    m_file_path = file.filename().to_byte_string();
+    m_file_path = file.filename();
     update_title();
 
-    GUI::Application::the()->set_most_recently_open_file(file.filename().to_byte_string());
+    GUI::Application::the()->set_most_recently_open_file(file.filename());
 }
 
 ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
@@ -147,10 +147,10 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             GUI::MessageBox::show(&window, ByteString::formatted("Unable to save file: {}\n"sv, result.release_error()), "Error"sv, GUI::MessageBox::Type::Error);
             return;
         }
-        m_file_path = response.value().filename().to_byte_string();
+        m_file_path = response.value().filename();
         update_title();
 
-        GUI::Application::the()->set_most_recently_open_file(response.value().filename().to_byte_string());
+        GUI::Application::the()->set_most_recently_open_file(response.value().filename());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -145,8 +145,7 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
 
     auto file_or_error = [&]() -> ErrorOr<File> {
         auto stream = TRY(Core::File::adopt_fd(ipc_file->take_fd(), Core::File::OpenMode::ReadWrite));
-        auto filename = TRY(String::from_byte_string(*chosen_file));
-        return File({}, move(stream), filename);
+        return File({}, move(stream), *chosen_file);
     }();
     if (file_or_error.is_error()) {
         auto maybe_message = String::formatted("{} \"{}\" failed: {}", action, *chosen_file, file_or_error.error());

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -31,7 +31,7 @@ enum ErrorFlag : u32 {
 class Client;
 class File {
 public:
-    File(Badge<Client>, NonnullOwnPtr<Core::File> stream, String filename)
+    File(Badge<Client>, NonnullOwnPtr<Core::File> stream, ByteString filename)
         : m_stream(move(stream))
         , m_filename(filename)
     {
@@ -39,11 +39,11 @@ public:
 
     Core::File& stream() const { return *m_stream; }
     NonnullOwnPtr<Core::File> release_stream() { return move(m_stream); }
-    String filename() const { return m_filename; }
+    ByteString const& filename() const { return m_filename; }
 
 private:
     NonnullOwnPtr<Core::File> m_stream;
-    String m_filename;
+    ByteString m_filename;
 };
 
 using Result = ErrorOr<File>;

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -251,7 +251,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto file = file_or_error.release_value();
 
             auto statbuf = TRY(Core::System::lstat(path));
-            auto canonicalized_path = TRY(String::from_byte_string(LexicalPath::canonicalized_path(path)));
+            auto canonicalized_path = LexicalPath::canonicalized_path(path);
             // FIXME: We should stream instead of reading the entire file in one go, but TarOutputStream does not have any interface to do so.
             auto file_content = TRY(file->read_until_eof());
             TRY(tar_stream.add_file(canonicalized_path, statbuf.st_mode, file_content));
@@ -264,7 +264,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto add_link = [&](ByteString path) -> ErrorOr<void> {
             auto statbuf = TRY(Core::System::lstat(path));
 
-            auto canonicalized_path = TRY(String::from_byte_string(LexicalPath::canonicalized_path(path)));
+            auto canonicalized_path = LexicalPath::canonicalized_path(path);
             TRY(tar_stream.add_link(canonicalized_path, statbuf.st_mode, TRY(Core::System::readlink(path))));
             if (verbose)
                 outln("{}", canonicalized_path);
@@ -275,7 +275,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto add_directory = [&](ByteString path, auto handle_directory) -> ErrorOr<void> {
             auto statbuf = TRY(Core::System::lstat(path));
 
-            auto canonicalized_path = TRY(String::from_byte_string(LexicalPath::canonicalized_path(path)));
+            auto canonicalized_path = LexicalPath::canonicalized_path(path);
             TRY(tar_stream.add_directory(canonicalized_path, statbuf.st_mode));
             if (verbose)
                 outln("{}", canonicalized_path);


### PR DESCRIPTION
Specifically:
- Paths returned from `FileSystemAccessServer`.
- ~~The path provided to `Application::set_most_recently_open_file()`.~~ (Done in #22866)
- Spreadsheet
- 3DFileViewer
- tar