### PR TITLE
LibWeb: Resolve all layout-dependent properties in one loop

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -189,10 +189,7 @@ struct LayoutState {
 
 private:
     void resolve_relative_positions();
-    void resolve_border_radii();
-    void resolve_box_shadow_data();
-    void resolve_text_shadows(Vector<Painting::PaintableWithLines&> const& paintables_with_lines);
-    void resolve_css_transform();
+    void resolve_layout_dependent_properties();
 };
 
 }


### PR DESCRIPTION
Instead of using separate loops for each property, all the work can be completed in one loop.

Performance improvement on https://html.spec.whatwg.org/