### PR TITLE
KeyboardMapper: Convert Utf-8 char in String to Utf-32 code point

### DIFF
--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -69,7 +69,7 @@ void KeyboardMapperWidget::create_frame()
                 if (value.is_empty())
                     map[index] = '\0'; // Empty string
                 else
-                    map[index] = value.bytes().at(0);
+                    map[index] = *value.code_points().begin();
 
                 window()->set_modified(true);
             }


### PR DESCRIPTION
```
Ensure that the Utf-8 encoded "mapping character" in String (from
InputBox) gets converted to Utf-32 code point. Before, only the first
byte of Utf-8 char sequence was used as a Utf-32 code point.

That used to result in incorrect characters getting written in the
keymap file for all the "non-ascii" characters used as the mapping
character.
```

Had hard time coming up with a concise commit message even for (or
maybe because of? :thinking:) such a short diff.