### PR TITLE
LibWeb: Add missing visits in MessageEvent

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -28,8 +28,12 @@ MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, Messag
     , m_origin(event_init.origin)
     , m_last_event_id(event_init.last_event_id)
     , m_source(event_init.source)
-    , m_ports(event_init.ports)
 {
+    m_ports.ensure_capacity(event_init.ports.size());
+    for (auto& port : event_init.ports) {
+        VERIFY(port);
+        m_ports.unchecked_append(*port);
+    }
 }
 
 MessageEvent::~MessageEvent() = default;
@@ -44,6 +48,9 @@ void MessageEvent::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_data);
+    visitor.visit(m_ports_array);
+    for (auto& port : m_ports)
+        visitor.visit(port);
 }
 
 Variant<JS::Handle<WindowProxy>, JS::Handle<MessagePort>, Empty> MessageEvent::source() const

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -48,7 +48,7 @@ private:
     String m_origin;
     String m_last_event_id;
     Optional<MessageEventSource> m_source;
-    Vector<JS::Handle<JS::Object>> m_ports;
+    Vector<JS::NonnullGCPtr<JS::Object>> m_ports;
     mutable JS::GCPtr<JS::Array> m_ports_array;
 };
 


### PR DESCRIPTION
Also change a `Vector<Handle>` to a `Vector<NonnullGCPtr>` while we're here, since there's no need to use handles for members of a cell.

Fixes an ASAN error on the HTML/Window-postMessage.html test.