### PR TITLE
uptime: Add some nice options that Linux and the BSDs provide

### DIFF
--- a/AK/NumberFormat.cpp
+++ b/AK/NumberFormat.cpp
@@ -5,10 +5,8 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/ByteString.h>
 #include <AK/NumberFormat.h>
 #include <AK/NumericLimits.h>
-#include <AK/StringView.h>
 
 namespace AK {
 
@@ -75,7 +73,7 @@ ByteString human_readable_size_long(u64 size, UseThousandsSeparator use_thousand
     return ByteString::formatted("{} ({} bytes)", human_readable_size_string, size);
 }
 
-ByteString human_readable_time(i64 time_in_seconds)
+String human_readable_time(i64 time_in_seconds)
 {
     auto days = time_in_seconds / 86400;
     time_in_seconds = time_in_seconds % 86400;
@@ -99,10 +97,10 @@ ByteString human_readable_time(i64 time_in_seconds)
 
     builder.appendff("{} second{}", time_in_seconds, time_in_seconds == 1 ? "" : "s");
 
-    return builder.to_byte_string();
+    return MUST(builder.to_string());
 }
 
-ByteString human_readable_digital_time(i64 time_in_seconds)
+String human_readable_digital_time(i64 time_in_seconds)
 {
     auto hours = time_in_seconds / 3600;
     time_in_seconds = time_in_seconds % 3600;
@@ -117,7 +115,7 @@ ByteString human_readable_digital_time(i64 time_in_seconds)
     builder.appendff("{:02}:", minutes);
     builder.appendff("{:02}", time_in_seconds);
 
-    return builder.to_byte_string();
+    return MUST(builder.to_string());
 }
 
 }

--- a/AK/NumberFormat.cpp
+++ b/AK/NumberFormat.cpp
@@ -11,7 +11,7 @@
 namespace AK {
 
 // FIXME: Remove this hackery once printf() supports floats.
-static ByteString number_string_with_one_decimal(u64 number, u64 unit, StringView suffix, UseThousandsSeparator use_thousands_separator)
+static String number_string_with_one_decimal(u64 number, u64 unit, StringView suffix, UseThousandsSeparator use_thousands_separator)
 {
     constexpr auto max_unit_size = NumericLimits<u64>::max() / 10;
     VERIFY(unit < max_unit_size);
@@ -19,25 +19,25 @@ static ByteString number_string_with_one_decimal(u64 number, u64 unit, StringVie
     auto integer_part = number / unit;
     auto decimal_part = (number % unit) * 10 / unit;
     if (use_thousands_separator == UseThousandsSeparator::Yes)
-        return ByteString::formatted("{:'d}.{} {}", integer_part, decimal_part, suffix);
+        return MUST(String::formatted("{:'d}.{} {}", integer_part, decimal_part, suffix));
 
-    return ByteString::formatted("{}.{} {}", integer_part, decimal_part, suffix);
+    return MUST(String::formatted("{}.{} {}", integer_part, decimal_part, suffix));
 }
 
-ByteString human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on, StringView unit, UseThousandsSeparator use_thousands_separator)
+String human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on, StringView unit, UseThousandsSeparator use_thousands_separator)
 {
     u64 size_of_unit = based_on == HumanReadableBasedOn::Base2 ? 1024 : 1000;
     constexpr auto unit_prefixes = AK::Array { "", "K", "M", "G", "T", "P", "E" };
     auto full_unit_suffix = [&](int index) {
         auto binary_infix = (based_on == HumanReadableBasedOn::Base2 && index != 0) ? "i"sv : ""sv;
-        return ByteString::formatted("{}{}{}",
-            unit_prefixes[index], binary_infix, unit);
+        return MUST(String::formatted("{}{}{}",
+            unit_prefixes[index], binary_infix, unit));
     };
 
     auto size_of_current_unit = size_of_unit;
 
     if (quantity < size_of_unit)
-        return ByteString::formatted("{} {}", quantity, full_unit_suffix(0));
+        return MUST(String::formatted("{} {}", quantity, full_unit_suffix(0)));
 
     for (size_t i = 1; i < unit_prefixes.size() - 1; i++) {
         auto suffix = full_unit_suffix(i);
@@ -52,25 +52,25 @@ ByteString human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on, 
         size_of_current_unit, full_unit_suffix(unit_prefixes.size() - 1), use_thousands_separator);
 }
 
-ByteString human_readable_size(u64 size, HumanReadableBasedOn based_on, UseThousandsSeparator use_thousands_separator)
+String human_readable_size(u64 size, HumanReadableBasedOn based_on, UseThousandsSeparator use_thousands_separator)
 {
     return human_readable_quantity(size, based_on, "B"sv, use_thousands_separator);
 }
 
-ByteString human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator)
+String human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator)
 {
     if (size < 1 * KiB) {
         if (use_thousands_separator == UseThousandsSeparator::Yes)
-            return ByteString::formatted("{:'d} bytes", size);
+            return MUST(String::formatted("{:'d} bytes", size));
 
-        return ByteString::formatted("{} bytes", size);
+        return MUST(String::formatted("{} bytes", size));
     }
 
     auto human_readable_size_string = human_readable_size(size, HumanReadableBasedOn::Base2, use_thousands_separator);
     if (use_thousands_separator == UseThousandsSeparator::Yes)
-        return ByteString::formatted("{} ({:'d} bytes)", human_readable_size_string, size);
+        return MUST(String::formatted("{} ({:'d} bytes)", human_readable_size_string, size));
 
-    return ByteString::formatted("{} ({} bytes)", human_readable_size_string, size);
+    return MUST(String::formatted("{} ({} bytes)", human_readable_size_string, size));
 }
 
 String human_readable_time(i64 time_in_seconds)

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
+#include <AK/String.h>
 
 namespace AK {
 
@@ -24,8 +24,8 @@ ByteString human_readable_size(u64 size, HumanReadableBasedOn based_on = HumanRe
 ByteString human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, StringView unit = "B"sv, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
 
 ByteString human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
-ByteString human_readable_time(i64 time_in_seconds);
-ByteString human_readable_digital_time(i64 time_in_seconds);
+String human_readable_time(i64 time_in_seconds);
+String human_readable_digital_time(i64 time_in_seconds);
 
 }
 

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -20,10 +20,10 @@ enum class UseThousandsSeparator {
     No
 };
 
-ByteString human_readable_size(u64 size, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
-ByteString human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, StringView unit = "B"sv, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
+String human_readable_size(u64 size, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
+String human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, StringView unit = "B"sv, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
 
-ByteString human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
+String human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
 String human_readable_time(i64 time_in_seconds);
 String human_readable_digital_time(i64 time_in_seconds);
 

--- a/Base/usr/share/man/man1/uptime.md
+++ b/Base/usr/share/man/man1/uptime.md
@@ -8,9 +8,23 @@ uptime - Tell how long the system has been running
 $ uptime
 ```
 
+## Description
+
+`uptime` outputs information about the system, in a single line, to STDOUT.
+This information includes when the system came online and how long it has been up.
+
+## Options
+
+* `-p`, `--pretty`: Output only the uptime, in human-readable format.
+
 ## Examples
 
 ```sh
 $ uptime
+2024-01-24 06:23:27 up 4:20:00
+```
+
+```sh
+$ uptime -p
 Up 2 minutes, 20 seconds
 ```

--- a/Base/usr/share/man/man1/uptime.md
+++ b/Base/usr/share/man/man1/uptime.md
@@ -16,6 +16,7 @@ This information includes when the system came online and how long it has been u
 ## Options
 
 * `-p`, `--pretty`: Output only the uptime, in human-readable format.
+* `-s`, `--since`: Output only the datetime when the system came online.
 
 ## Examples
 
@@ -27,4 +28,9 @@ $ uptime
 ```sh
 $ uptime -p
 Up 2 minutes, 20 seconds
+```
+
+```sh
+$ uptime -s
+2024-01-24 06:23:27
 ```

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -186,7 +186,7 @@ ErrorOr<void> PropertiesWindow::create_general_tab(GUI::TabWidget& tab_widget, b
     m_size_label = general_tab.find_descendant_of_type_named<GUI::Label>("size");
     m_size_label->set_text(S_ISDIR(st.st_mode)
             ? "Calculating..."_string
-            : TRY(String::from_byte_string(human_readable_size_long(st.st_size, UseThousandsSeparator::Yes))));
+            : human_readable_size_long(st.st_size, UseThousandsSeparator::Yes));
 
     auto* owner = general_tab.find_descendant_of_type_named<GUI::Label>("owner");
     owner->set_text(String::formatted("{} ({})", owner_name, st.st_uid).release_value_but_fixme_should_propagate_errors());
@@ -266,7 +266,7 @@ ErrorOr<void> PropertiesWindow::create_archive_tab(GUI::TabWidget& tab_widget, N
     tab.find_descendant_of_type_named<GUI::Label>("archive_file_count")->set_text(TRY(String::number(statistics.file_count())));
     tab.find_descendant_of_type_named<GUI::Label>("archive_format")->set_text("ZIP"_string);
     tab.find_descendant_of_type_named<GUI::Label>("archive_directory_count")->set_text(TRY(String::number(statistics.directory_count())));
-    tab.find_descendant_of_type_named<GUI::Label>("archive_uncompressed_size")->set_text(TRY(String::from_byte_string(AK::human_readable_size(statistics.total_uncompressed_bytes()))));
+    tab.find_descendant_of_type_named<GUI::Label>("archive_uncompressed_size")->set_text(human_readable_size(statistics.total_uncompressed_bytes()));
 
     return {};
 }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -285,7 +285,7 @@ ErrorOr<void> PropertiesWindow::create_audio_tab(GUI::TabWidget& tab_widget, Non
 
     tab.find_descendant_of_type_named<GUI::Label>("audio_type")->set_text(TRY(String::from_byte_string(loader->format_name())));
     auto duration_seconds = loader->total_samples() / loader->sample_rate();
-    tab.find_descendant_of_type_named<GUI::Label>("audio_duration")->set_text(TRY(String::from_byte_string(human_readable_digital_time(duration_seconds))));
+    tab.find_descendant_of_type_named<GUI::Label>("audio_duration")->set_text(human_readable_digital_time(duration_seconds));
     tab.find_descendant_of_type_named<GUI::Label>("audio_sample_rate")->set_text(TRY(String::formatted("{} Hz", loader->sample_rate())));
     tab.find_descendant_of_type_named<GUI::Label>("audio_format")->set_text(TRY(String::formatted("{}-bit", loader->bits_per_sample())));
 

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -138,7 +138,7 @@ void Field::initialize()
     m_timer = Core::Timer::create_repeating(
         1000, [this] {
             ++m_time_elapsed;
-            m_time_label.set_text(String::from_byte_string(human_readable_digital_time(m_time_elapsed)).release_value_but_fixme_should_propagate_errors());
+            m_time_label.set_text(human_readable_digital_time(m_time_elapsed));
         },
         this)
                   .release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -60,7 +60,7 @@ ErrorOr<String> load_file_directory_page(AK::URL const& url)
             contents.append("<tr>"sv);
             contents.appendff("<td><span class=\"{}\"></span></td>", is_directory ? "folder" : "file");
             contents.appendff("<td><a href=\"file://{}\">{}</a></td><td>&nbsp;</td>"sv, path, name);
-            contents.appendff("<td>{:10}</td><td>&nbsp;</td>", is_directory ? "-" : human_readable_size(st.st_size));
+            contents.appendff("<td>{:10}</td><td>&nbsp;</td>", is_directory ? "-"_string : human_readable_size(st.st_size));
             contents.appendff("<td>{}</td>"sv, Core::DateTime::from_timestamp(st.st_mtime).to_byte_string());
             contents.append("</tr>\n"sv);
         }

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -324,7 +324,7 @@ ErrorOr<void> Client::handle_directory_listing(String const& requested_path, Str
         TRY(builder.try_append(escape_html_entities(name)));
         TRY(builder.try_append("</a></td><td>&nbsp;</td>"sv));
 
-        TRY(builder.try_appendff("<td>{:10}</td><td>&nbsp;</td>", is_directory ? "-" : human_readable_size(st.st_size)));
+        TRY(builder.try_appendff("<td>{:10}</td><td>&nbsp;</td>", is_directory ? "-"_string : human_readable_size(st.st_size)));
         TRY(builder.try_append("<td>"sv));
         TRY(builder.try_append(TRY(Core::DateTime::from_timestamp(st.st_mtime).to_string())));
         TRY(builder.try_append("</td>"sv));

--- a/Userland/Utilities/dd.cpp
+++ b/Userland/Utilities/dd.cpp
@@ -56,7 +56,7 @@ static void closing_statistics()
     warnln("{}+{} blocks out", statistics.total_blocks_out, statistics.partial_blocks_out);
     if (statistics.status != Noxfer) {
         auto elapsed_time = statistics.timer.elapsed_time();
-        ByteString copy_speed = "INF B/s";
+        String copy_speed = "INF B/s"_string;
         if (!elapsed_time.is_zero()) {
             auto speed = statistics.total_bytes_copied * 1000 / elapsed_time.to_milliseconds();
             copy_speed = human_readable_quantity(speed, AK::HumanReadableBasedOn::Base2, "B/s"sv);

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -405,9 +405,9 @@ static bool print_filesystem_object(ByteString const& path, ByteString const& na
         printf("  %4u,%4u ", major(st.st_rdev), minor(st.st_rdev));
     } else {
         if (flag_human_readable) {
-            printf(" %10s ", human_readable_size(st.st_size).characters());
+            printf(" %10s ", human_readable_size(st.st_size).to_byte_string().characters());
         } else if (flag_human_readable_si) {
-            printf(" %10s ", human_readable_size(st.st_size, AK::HumanReadableBasedOn::Base10).characters());
+            printf(" %10s ", human_readable_size(st.st_size, AK::HumanReadableBasedOn::Base10).to_byte_string().characters());
         } else {
             printf(" %10" PRIu64 " ", (uint64_t)st.st_size);
         }

--- a/Userland/Utilities/uptime.cpp
+++ b/Userland/Utilities/uptime.cpp
@@ -1,18 +1,27 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Karol Kosek <krkk@serenityos.org>
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/NumberFormat.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/DateTime.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
-ErrorOr<int> serenity_main(Main::Arguments)
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
+
+    bool pretty_output = false;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(pretty_output, "Output only the uptime, in human-readable format", "pretty", 'p');
+    args_parser.parse(arguments);
 
     auto file = TRY(Core::File::open("/sys/kernel/uptime"sv, Core::File::OpenMode::Read));
 
@@ -25,6 +34,14 @@ ErrorOr<int> serenity_main(Main::Arguments)
         return Error::from_string_literal("Couldn't convert to number");
     auto seconds = maybe_seconds.release_value();
 
-    outln("Up {}", human_readable_time(seconds));
+    if (pretty_output) {
+        outln("Up {}", human_readable_time(seconds));
+    } else {
+        auto current_time = TRY(Core::DateTime::now().to_string());
+        // FIXME: To match Linux and the BSDs, we should also include the number of current users,
+        //        and some load averages, but these don't seem to be available yet.
+        outln("{} up {}", current_time, human_readable_digital_time(seconds));
+    }
+
     return 0;
 }

--- a/Userland/Utilities/uptime.cpp
+++ b/Userland/Utilities/uptime.cpp
@@ -18,9 +18,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath"));
 
     bool pretty_output = false;
+    bool output_since = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(pretty_output, "Output only the uptime, in human-readable format", "pretty", 'p');
+    args_parser.add_option(output_since, "Show when the system is up since, in yyyy-mm-dd HH:MM:SS format", "since", 's');
     args_parser.parse(arguments);
 
     auto file = TRY(Core::File::open("/sys/kernel/uptime"sv, Core::File::OpenMode::Read));
@@ -34,7 +36,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return Error::from_string_literal("Couldn't convert to number");
     auto seconds = maybe_seconds.release_value();
 
-    if (pretty_output) {
+    if (output_since) {
+        auto since_timestamp = Core::DateTime::now().timestamp() - seconds;
+        auto since_time = TRY(Core::DateTime::from_timestamp(since_timestamp).to_string());
+        outln("{}", since_time);
+    } else if (pretty_output) {
         outln("Up {}", human_readable_time(seconds));
     } else {
         auto current_time = TRY(Core::DateTime::now().to_string());


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/3ac99e4b-3028-48a8-beac-157d47b435d3)

Adds `-p/--pretty` for the previous human-readable output, with the longer Linux/BSD-like output for when this isn't present. And then adds `-s/--since` to just output the datetime we came online. This also means `uptime` now gets the standard `--version` and `--help` options.

Before that, convert the `human_readable_foo()` functions to return `String` instead of `ByteString`. Since these are in AK, I'm a little conflicted about whether they should return `ErrorOr<String>` instead, BUT they're not used in the kernel, and are already not OOM-safe, so I don't worry about that for now.