### PR TITLE
LibAccelGfx+LibWeb+WebContent: Handle OpenGL Context init errors

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Context.h
+++ b/Userland/Libraries/LibAccelGfx/Context.h
@@ -20,7 +20,7 @@ namespace AccelGfx {
 
 class Context {
 public:
-    static OwnPtr<Context> create();
+    static ErrorOr<NonnullOwnPtr<Context>> create();
 
     Context()
     {

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -157,7 +157,7 @@ public:
         TODO();
     }
 
-    AccelGfxContext(OwnPtr<AccelGfx::Context> context, NonnullRefPtr<AccelGfx::Canvas> canvas)
+    AccelGfxContext(NonnullOwnPtr<AccelGfx::Context> context, NonnullRefPtr<AccelGfx::Canvas> canvas)
         : m_context(move(context))
         , m_canvas(move(canvas))
     {
@@ -169,7 +169,7 @@ public:
     }
 
 private:
-    OwnPtr<AccelGfx::Context> m_context;
+    NonnullOwnPtr<AccelGfx::Context> m_context;
     NonnullRefPtr<AccelGfx::Canvas> m_canvas;
 };
 #endif
@@ -301,9 +301,13 @@ private:
 static OwnPtr<AccelGfxContext> make_accelgfx_context(Gfx::Bitmap& bitmap)
 {
     auto context = AccelGfx::Context::create();
+    if (context.is_error()) {
+        dbgln("Failed to create AccelGfx context: {}", context.error().string_literal());
+        return {};
+    }
     auto canvas = AccelGfx::Canvas::create(bitmap.size());
     canvas->bind();
-    return make<AccelGfxContext>(move(context), move(canvas));
+    return make<AccelGfxContext>(context.release_value(), move(canvas));
 }
 #endif
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -72,7 +72,12 @@ PageClient::PageClient(PageHost& owner, u64 id)
 
 #ifdef HAS_ACCELERATED_GRAPHICS
     if (s_use_gpu_painter) {
-        m_accelerated_graphics_context = AccelGfx::Context::create();
+        auto context = AccelGfx::Context::create();
+        if (context.is_error()) {
+            dbgln("Failed to create AccelGfx context: {}", context.error());
+            VERIFY_NOT_REACHED();
+        }
+        m_accelerated_graphics_context = AccelGfx::Context::create().release_value();
     }
 #endif
 }


### PR DESCRIPTION
Now, if OpenGL context fails, an error will be returned and a message printed, instead of crashing.