### PR TITLE
LibGUI+GMLCompiler: Introduce property definitions for widgets

### DIFF
--- a/Base/usr/share/man/man5/GML.md
+++ b/Base/usr/share/man/man5/GML.md
@@ -25,6 +25,7 @@ Or right clicking on a folder in the TreeView and using
 
 -   [Using GML](help://man/5/GML/Usage)
 -   [GML syntax](help://man/5/GML/Syntax)
+-   [GML property definitions](help://man/5/GML/PropertyDefinitions)
 -   Extending GML
     -   [Define properties](help://man/5/GML/Define-property)
     -   [Define widgets](help://man/5/GML/Define-widget)

--- a/Base/usr/share/man/man5/GML/Define-property.md
+++ b/Base/usr/share/man/man5/GML/Define-property.md
@@ -1,6 +1,6 @@
 ## Name
 
-GML Property Definition
+Registering widget properties
 
 ## Description
 

--- a/Base/usr/share/man/man5/GML/PropertyDefinitions.md
+++ b/Base/usr/share/man/man5/GML/PropertyDefinitions.md
@@ -1,0 +1,49 @@
+## Name
+
+GML property definition format
+
+## Description
+
+GML properties and widgets are described abstractly in JSON files. These descriptions are then used by multiple tools:
+
+-   GMLCompiler uses the descriptions, besides error-checking, to determine which C++ headers to include, how to convert JSON property values to C++ values, etc.
+-   [GMLPlayground](help://man/1/Applications/GMLPlayground) uses the descriptions for auto-complete.
+-   (Property registration?)
+-   Widget manpages (for LibGUI) are auto-generated from the JSON files.
+
+## Format
+
+A property definition file consists of an array of widget descriptions. Multiple JSON files may be merged (as done by e.g. the GMLCompiler) by concatenating the elements of this top-level array.
+
+Each widget definition object can contain the following keys:
+
+-   `name`: required, string. Fully qualified C++ name of the widget, including namespaces. Must be unique; it is recommended to use per-application namespaces for widgets that appear in GML.
+-   `header`: required, string. C++ header which defines this widget. May use any absolute include format that is accepted in Serenity, most importantly:
+    -   `LibGUI/Widget.h` for library headers
+    -   `Applications/Help/MainWidget.h` for application headers
+-   `inherits`: optional, string. `name` of another widget that this widget inherits from. Should reflect the C++ inheritance. All properties defined on that widget as well as its parents are also going to be available on this widget.
+-   `description`: optional, string. Description of the widget, displayed in manpages and auto-complete. Shouldn't contain a trailing period.
+-   `properties`: required, array of objects. All properties this widget defines. Properties in this list may override properties defined in parents.
+
+Each property definition is an object with the following keys:
+
+-   `name`: required, string. Identifier of the property as used in GML.
+-   `getter`: optional, string. Identifier of the C++ getter for this property. If not provided (recommended!), the `name` is used as the getter instead.
+-   `setter`: optional, string. Identifier of the C++ setter for this property. If not provided (recommended!), `set_name` is used as the setter instead.
+-   `description`: optional, string. Description of the property, displayed in manpages and auto-complete. Shouldn't contain a trailing period.
+-   `type`: required, string. Type of the property, as a C++(-like) type name. Supported types are:
+    -   `String`: GML value is a JSON string, property value is an `AK::String`. The setter may receive `String` or `String const&`.
+    -   `ByteString`: GML value is a JSON string, property value is an `AK::ByteString`. This type should only be used for file system paths. The setter may receive `ByteString` or `ByteString const&`.
+    -   `i64`: GML value is a JSON number that fits in a 64-bit integer, property value is an `i64`.
+    -   `u64`: GML value is a JSON number that fits in an unsigned 64-bit integer, property value is a `u64`.
+    -   `double`: GML value is a JSON number, property value is a `double`.
+    -   `bool`: GML value is a boolean, property value is a `bool`.
+    -   `Gfx::Bitmap`: GML value is a string, property value is a `NonnullRefPtr<Gfx::Bitmap>` or a compatible type like `RefPtr<Gfx::Bitmap>`.
+    -   `GUI::UIDimension`: Property value is a `GUI::UIDimension`. The valid GML values are detailed in [GML/UI-Dimensions(5)](help://man/5/GML/UI-Dimensions).
+    -   `Gfx::Color`: Property value is a color. It may be anything accepted by the `Gfx::Color` CSS-like string parser, which includes hex colors and `rgb()`, `rgba()`, and CSS named colors.
+    -   `GUI::Margins`: GML value is an array of integers (1-4), property value is `GUI::Margins`.
+    -   `Array<T>`: GML value is an array of homogenous inner types, property value is any number of `AK::Array`-types (between `Array<T, min_values>` and `Array<T, max_values>`). The inner type `T` must be one of the other legal property types.
+    - `Variant<T, U, V, W, ...>`: GML value has one of a few types, property value is `AK::Variant` of these types. The inner types must be other legal property types.
+    -   Any other type name is assumed to be the fully qualified name of a C++ enum. The GML value is a string that must be one of the enum variants, and the property value is the C++ enum.
+-   `min_values`: optional, integer. For array-typed properties: Minimum number of values that must be provided. Set min_values = max_values to only allow one array size.
+-   `max_values`: optional, integer. For array-typed properties: Maximum number of values that can be provided.

--- a/Base/usr/share/man/man5/GML/Usage.md
+++ b/Base/usr/share/man/man5/GML/Usage.md
@@ -51,13 +51,13 @@ From there, you can use `find_descendant_of_type_named` to select widgets from y
 m_mem_add_button = *find_descendant_of_type_named<GUI::Button>("mem_add_button");
 ```
 
-### `initialize_fallibles` Pattern
+### `initialize` Pattern
 
 Initialization, like adding models, attaching callbacks, etc., should be done in a member function with the signature:
 
 ```cpp
 // MyApp::Widget
-ErrorOr<void> initialize_fallibles();
+ErrorOr<void> initialize();
 ```
 
 This initializer function, if it exists, will automatically be called after the structure of your widget was set up by the auto-generated GML code.

--- a/Base/usr/share/man/man5/GML/Usage.md
+++ b/Base/usr/share/man/man5/GML/Usage.md
@@ -50,3 +50,16 @@ From there, you can use `find_descendant_of_type_named` to select widgets from y
 // MyApp::Widget::foo_bar
 m_mem_add_button = *find_descendant_of_type_named<GUI::Button>("mem_add_button");
 ```
+
+### `initialize_fallibles` Pattern
+
+Initialization, like adding models, attaching callbacks, etc., should be done in a member function with the signature:
+
+```cpp
+// MyApp::Widget
+ErrorOr<void> initialize_fallibles();
+```
+
+This initializer function, if it exists, will automatically be called after the structure of your widget was set up by the auto-generated GML code.
+
+The only case where this function cannot be used is when your initialization requires additional parameters, like a GUI window. You may still consider moving as much initialization to the canonical function as possible.

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -30,10 +30,16 @@ function(stringify_gml source output string_name)
 endfunction()
 
 function(compile_gml source output)
+    cmake_parse_arguments(PARSE_ARGV 2 "COMPILE_GML" "" "" "PROPERTIES")
+    # LibGUI's properties, as well as the properties of the current directory, are always needed and are included by default.
+    list(APPEND COMPILE_GML_PROPERTIES "Userland/Libraries/LibGUI")
+    list(TRANSFORM COMPILE_GML_PROPERTIES PREPEND "--property-definition=${CMAKE_SOURCE_DIR}/")
+    list(APPEND COMPILE_GML_PROPERTIES "--property-definition=${CMAKE_CURRENT_SOURCE_DIR}")
+    list(TRANSFORM COMPILE_GML_PROPERTIES APPEND "/property-definitions.json")
     set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
     add_custom_command(
         OUTPUT ${output}
-        COMMAND $<TARGET_FILE:Lagom::GMLCompiler> ${source} > ${output}.tmp
+        COMMAND $<TARGET_FILE:Lagom::GMLCompiler> ${COMPILE_GML_PROPERTIES} ${source} > ${output}.tmp
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${output}.tmp ${output}
         COMMAND "${CMAKE_COMMAND}" -E remove ${output}.tmp
         VERBATIM

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
+    PropertyDefinition.cpp
     main.cpp
 )
 
-lagom_tool(GMLCompiler LIBS LibMain LibCore LibGUI_GML)
+lagom_tool(GMLCompiler LIBS LibMain LibCore LibGfx LibGUI_GML)

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/PropertyDefinition.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/PropertyDefinition.cpp
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2024, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PropertyDefinition.h"
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <LibGUI/UIDimensions.h>
+#include <LibGfx/Color.h>
+
+static ErrorOr<String> escape_string(JsonValue to_escape)
+{
+    auto string = TRY(String::from_byte_string(to_escape.as_string()));
+
+    // All C++ simple escape sequences; see https://en.cppreference.com/w/cpp/language/escape
+    // Other commonly-escaped characters are hard-to-type Unicode and therefore fine to include verbatim in UTF-8 coded strings.
+    static HashMap<StringView, StringView> escape_sequences = {
+        { "\\"sv, "\\\\"sv }, // This needs to be the first because otherwise the the backslashes of other items will be double escaped
+        { "\0"sv, "\\0"sv },
+        { "\'"sv, "\\'"sv },
+        { "\""sv, "\\\""sv },
+        { "\a"sv, "\\a"sv },
+        { "\b"sv, "\\b"sv },
+        { "\f"sv, "\\f"sv },
+        { "\n"sv, "\\n"sv },
+        { "\r"sv, "\\r"sv },
+        { "\t"sv, "\\t"sv },
+        { "\v"sv, "\\v"sv },
+    };
+
+    for (auto const& entries : escape_sequences)
+        string = TRY(string.replace(entries.key, entries.value, ReplaceMode::All));
+
+    return string;
+}
+
+ErrorOr<PropertyType, PropertyError> PropertyType::parse(String const& type_name, Optional<u64> min_values, Optional<u64> max_values)
+{
+    if (type_name == "String"sv) {
+        return PropertyType { SimpleType::String };
+    } else if (type_name == "ByteString"sv) {
+        return PropertyType { SimpleType::ByteString };
+    } else if (type_name == "i64"sv) {
+        return PropertyType { SimpleType::I64 };
+    } else if (type_name == "u64"sv) {
+        return PropertyType { SimpleType::U64 };
+    } else if (type_name == "double"sv) {
+        return PropertyType { SimpleType::Double };
+    } else if (type_name == "bool"sv) {
+        return PropertyType { SimpleType::Bool };
+    } else if (type_name == "Gfx::Bitmap"sv) {
+        return PropertyType { SimpleType::Bitmap };
+    } else if (type_name == "Gfx::Color"sv) {
+        return PropertyType { SimpleType::Color };
+    } else if (type_name == "GUI::UIDimension"sv) {
+        return PropertyType { SimpleType::UIDimension };
+    } else if (type_name == "GUI::Margins"sv) {
+        return PropertyType { SimpleType::Margins };
+    } else if (type_name.starts_with_bytes("Array"sv)) {
+        auto inner_type_part = TRY(type_name.split('<'));
+        if (inner_type_part.size() != 2)
+            return PropertyError::format("No inner type specified for '{}'", type_name);
+        auto maybe_inner_type_name = TRY(inner_type_part.take_last().split('>'));
+        if (maybe_inner_type_name.is_empty())
+            return PropertyError::format("No inner type specified for '{}'", type_name);
+        auto const inner_type_name = maybe_inner_type_name.take_first();
+        if (!max_values.has_value() || !min_values.has_value())
+            return PropertyError::format("Missing array element bounds for type '{}'", type_name);
+        return PropertyType { CustomArray {
+            min_values.release_value(),
+            max_values.release_value(),
+            make<PropertyType>(TRY(parse(inner_type_name, {}, {}))),
+        } };
+    } else if (type_name.starts_with_bytes("Variant"sv)) {
+        auto inner_type_parts = TRY(type_name.split('<'));
+        if (inner_type_parts.size() != 2)
+            return PropertyError::format("No inner variant types specified for '{}'", type_name);
+        auto maybe_inner_type_name = TRY(inner_type_parts.take_last().split('>'));
+        if (maybe_inner_type_name.is_empty())
+            return PropertyError::format("No inner variant types specified for '{}'", type_name);
+        auto const inner_type_names = TRY(maybe_inner_type_name.take_first().split(','));
+
+        CustomVariant type;
+        for (auto const& inner_type_name : inner_type_names) {
+            auto const trimmed_type_name = TRY(inner_type_name.trim_ascii_whitespace());
+            TRY(type.variant_types.try_append(make<PropertyType>(TRY(parse(trimmed_type_name, {}, {})))));
+        }
+        return PropertyType { move(type) };
+    } else {
+        return PropertyType { EnumType { type_name } };
+    }
+}
+
+String PropertyType::name(Optional<size_t> element_count) const
+{
+    return visit([=](SimpleType const& type) -> String {
+        switch (type) {
+        case SimpleType::Bool:
+            return "bool"_string;
+        case SimpleType::I64:
+            return "i64"_string;
+        case SimpleType::U64:
+            return "u64"_string;
+        case SimpleType::Double:
+            return "double"_string;
+        case SimpleType::String:
+            return "::AK::String"_string;
+        case SimpleType::ByteString:
+            return "::AK::ByteString"_string;
+        case SimpleType::Bitmap:
+            return "::Gfx::Bitmap"_string;
+        case SimpleType::Color:
+            return "::Gfx::Color"_string;
+        case SimpleType::UIDimension:
+            return "::GUI::UIDimension"_string;
+        case SimpleType::Margins:
+            return "::GUI::Margins"_string;
+        } },
+        [=](EnumType const& type) -> String {
+            return type.name;
+        },
+        [=](CustomVariant const& type) -> String {
+            StringBuilder builder;
+            builder.append("::AK::Variant<"sv);
+            Vector<String> strings;
+            for (auto const& subtype : type.variant_types)
+                strings.append(subtype->name());
+            builder.join(", "sv, strings);
+            builder.append('>');
+            return builder.to_string_without_validation();
+        },
+        [&](CustomArray const& type) -> String {
+            // Try to make use of C++ template argument deduction, if necessary.
+            if (!element_count.has_value())
+                return "Array"_string;
+            return MUST(String::formatted("Array<{}, {}>", type.element_type->name(), element_count.release_value()));
+        });
+}
+
+ErrorOr<String, PropertyError> PropertyType::generate_initializer_for(JsonValue const& property) const
+{
+    return visit([=](SimpleType const& type) -> ErrorOr<String, PropertyError> {
+        switch (type) {
+        case SimpleType::Bool:
+            if (!property.is_bool())
+                return PropertyError::format("Non-bool value {} supplied for boolean property", property);
+            return TRY(String::formatted("{}", property.as_bool()));
+        case SimpleType::I64:
+            if (!property.is_integer<i64>())
+                return PropertyError::format("Non-integer value {} supplied for i64 property", property);
+            return TRY(String::formatted("static_cast<i64>({})", property.as_integer<i64>()));
+        case SimpleType::U64:
+            if (!property.is_integer<u64>())
+                return PropertyError::format("Non-integer value {} supplied for u64 property", property);
+            return TRY(String::formatted("static_cast<u64>({})", property.as_integer<u64>()));
+        case SimpleType::Double:
+            if (!property.is_number())
+                return PropertyError::format("Non-number value {} supplied for double property", property);
+            return TRY(String::formatted("static_cast<double>({})", property.get_double_with_precision_loss().release_value()));
+        case SimpleType::String:
+            if (!property.is_string())
+                return PropertyError::format("Non-string value {} supplied for string property", property);
+            return TRY(String::formatted(R"~~~("{}"_string)~~~", TRY(escape_string(property))));
+        case SimpleType::ByteString:
+            if (!property.is_string())
+                return PropertyError::format("Non-string value {} supplied for byte string property", property);
+            return TRY(String::formatted(R"~~~("{}"sv)~~~", TRY(escape_string(property))));
+        case SimpleType::Bitmap:
+            if (!property.is_string())
+                return PropertyError::format("Non-string value {} supplied for bitmap property", property);
+            return TRY(String::formatted(R"~~~(TRY(Gfx::Bitmap::load_from_file("{}"sv)))~~~", TRY(escape_string(property))));
+        case SimpleType::Color: {
+            if (!property.is_string())
+                return PropertyError::format("Non-string value {} supplied for color property", property);
+            auto maybe_color = Gfx::Color::from_string(property.as_string());
+            if (!maybe_color.has_value())
+                return PropertyError::format("Invalid color {}", property);
+            auto const color = maybe_color.release_value();
+            return TRY(String::formatted("::Gfx::Color {{ {}, {}, {}, {} }}", color.red(), color.green(), color.blue(), color.alpha()));
+        }
+        case SimpleType::UIDimension: {
+            auto maybe_dimension =  GUI::UIDimension::construct_from_json_value(property);
+            if (!maybe_dimension.has_value())
+                return PropertyError::format("Invalid UI dimension {}", property);
+            return TRY(maybe_dimension->as_cpp_source());
+        }
+        case SimpleType::Margins: {
+            if (!property.is_array())
+                return PropertyError::format("Non-array value {} supplied for margins property", property);
+            auto const element_count = property.as_array().size();
+            if (element_count < 1 || element_count > 4)
+                return PropertyError::format("margins array must have between 1 and 4 elements, but {} were given", element_count);
+            StringBuilder builder;
+            TRY(builder.try_appendff("{} {{", name(element_count)));
+            for (auto const& child_value : property.as_array().values())
+                builder.appendff("{}, ", TRY(PropertyType { SimpleType::I64 }.generate_initializer_for(child_value)));
+            TRY(builder.try_append('}'));
+            return TRY(builder.to_string());
+        }
+        } },
+        [=](EnumType const& type) -> ErrorOr<String, PropertyError> {
+            if (!property.is_string())
+                return PropertyError::format("Non-string value {} supplied for enum property", property);
+            return TRY(String::formatted("{}::{}", type.name, property.as_string()));
+        },
+        [=](CustomVariant const& type) -> ErrorOr<String, PropertyError> {
+            // Find the first variant subtype that accepts the value.
+            for (auto const& subtype : type.variant_types) {
+                auto maybe_initializer = subtype->generate_initializer_for(property);
+                if (!maybe_initializer.is_error())
+                    return maybe_initializer.release_value();
+            }
+            return PropertyError::format("Invalid value {} for variant property {}", property, name());
+        },
+        [=](CustomArray const& type) -> ErrorOr<String, PropertyError> {
+            if (!property.is_array())
+                return PropertyError::format("Non-array value {} supplied for array property {}", property, name());
+            auto const element_count = property.as_array().size();
+            StringBuilder builder;
+            TRY(builder.try_appendff("{} {{", name(element_count)));
+            for (auto const& child_value : property.as_array().values())
+                builder.appendff("{}, ", TRY(type.element_type->generate_initializer_for(child_value)));
+            TRY(builder.try_append('}'));
+            return TRY(builder.to_string());
+        });
+}
+ErrorOr<HashMap<String, WidgetProperties>, PropertyError> WidgetProperties::parse_properties(JsonArray const& property_definitions)
+{
+    HashMap<String, WidgetProperties> widgets;
+
+    for (auto const& widget : property_definitions.values()) {
+        if (!widget.is_object())
+            return PropertyError::format("Widget definition {} is not an object", widget);
+
+        auto const& widget_object = widget.as_object();
+        auto maybe_name = widget_object.get_byte_string("name"sv);
+        auto maybe_header = widget_object.get_byte_string("header"sv);
+        auto maybe_inherits = widget_object.get_byte_string("inherits"sv);
+        auto maybe_description = widget_object.get_byte_string("description"sv);
+        auto maybe_properties = widget_object.get_array("properties"sv);
+        if (!maybe_name.has_value() || !maybe_header.has_value())
+            return PropertyError::format("in JSON object {}: Name or header of widget is missing", widget);
+
+        WidgetProperties widget_properties {
+            TRY(String::from_byte_string(maybe_name.release_value())),
+            TRY(String::from_byte_string(maybe_header.release_value())),
+            TRY(maybe_inherits.map([](auto inherits) { return String::from_byte_string(inherits); })),
+            TRY(String::from_byte_string(maybe_description.value_or(""))),
+        };
+
+        if (maybe_properties.has_value()) {
+            auto const& properties = maybe_properties.release_value();
+            for (auto const& property : properties.values()) {
+                if (!property.is_object())
+                    return PropertyError::in_widget(widget_properties.m_cpp_identifier, "Property {} is not an object", property);
+
+                auto const& property_object = property.as_object();
+                auto maybe_property_name = property_object.get_byte_string("name"sv);
+                auto maybe_property_getter = property_object.get_byte_string("getter"sv);
+                auto maybe_property_setter = property_object.get_byte_string("setter"sv);
+                auto maybe_property_description = property_object.get_byte_string("description"sv);
+                auto maybe_property_type_string = property_object.get_byte_string("type"sv);
+                auto maybe_property_min_values = property_object.get_u64("min_values"sv);
+                auto maybe_property_max_values = property_object.get_u64("max_values"sv);
+                if (!maybe_property_name.has_value() || !maybe_property_type_string.has_value())
+                    return PropertyError::in_widget(widget_properties.m_cpp_identifier, "Name or type of property is missing in JSON object {}", property);
+
+                auto property_name = TRY(String::from_byte_string(maybe_property_name.release_value()));
+                auto maybe_property_type = PropertyType::parse(TRY(String::from_byte_string(maybe_property_type_string.release_value())), maybe_property_min_values, maybe_property_max_values);
+                if (maybe_property_type.is_error())
+                    return maybe_property_type.release_error().add_widget_and_property(widget_properties.m_cpp_identifier, property_name);
+
+                widget_properties.m_properties.set(property_name,
+                    PropertyDefinition {
+                        .name = property_name,
+                        .getter = TRY(maybe_property_getter.map([](auto getter) {
+                            return String::from_byte_string(getter);
+                        })).value_or(property_name),
+                        .setter = TRY(TRY(maybe_property_setter.map([](auto setter) {
+                            return String::from_byte_string(setter);
+                        })).try_value_or_lazy_evaluated([&] {
+                            return String::formatted("set_{}", property_name);
+                        })),
+                        .description = TRY(String::from_byte_string(maybe_property_description.value_or({}))),
+                        .type = maybe_property_type.release_value(),
+                    });
+            }
+        }
+
+        TRY(widgets.try_set(widget_properties.m_cpp_identifier, move(widget_properties)));
+    }
+
+    return widgets;
+}
+
+static ErrorOr<void, PropertyError> expand_widget(String const& widget_name, HashMap<String, WidgetProperties>& widgets, HashTable<String>& expanded_widgets)
+{
+    // Prevent repeated work by keeping track of which widgets have been expanded already.
+    if (expanded_widgets.contains(widget_name))
+        return {};
+    expanded_widgets.set(widget_name);
+
+    auto properties = widgets.get(widget_name);
+
+    // No inheritance -> no work to do.
+    if (!properties.has_value() || !properties->inherits().has_value())
+        return {};
+
+    // Ensure that all direct and indirect parents are expanded.
+    TRY(expand_widget(properties->inherits().value(), widgets, expanded_widgets));
+
+    // Set all parent properties on this widget as well.
+    auto const maybe_parent = widgets.get(properties->inherits().value());
+    if (!maybe_parent.has_value())
+        return PropertyError::in_widget(widget_name, "Couldn't find parent widget {}", properties->inherits().value());
+
+    auto const& parent = maybe_parent.value();
+    for (auto const& parent_property : parent.properties()) {
+        properties->properties().ensure(parent_property.key, [&] { return parent_property.value; });
+    }
+    return {};
+}
+
+ErrorOr<void, PropertyError> WidgetProperties::expand_inherited_properties(HashMap<String, WidgetProperties>& widgets)
+{
+    HashTable<String> expanded_widgets;
+    for (auto& entry : widgets)
+        TRY(expand_widget(entry.key, widgets, expanded_widgets));
+
+    return {};
+}

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/PropertyDefinition.h
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/PropertyDefinition.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2024, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
+#include <AK/Variant.h>
+
+// Error type that owns its error text
+// and allows constructing homogenous error messages for the property definition system.
+struct PropertyError {
+    String text;
+
+    explicit PropertyError(String text)
+        : text(move(text))
+    {
+    }
+
+    // NOTE: Needs to be implicit so that TRY() can convert from AK::Error to PropertyError.
+    PropertyError(AK::Error error)
+        : text(MUST(String::from_utf8(error.string_literal())))
+    {
+    }
+
+    template<typename... Parameters>
+    static PropertyError format(AK::CheckedFormatString<Parameters...>&& format_string, Parameters const&... arguments)
+    {
+        return PropertyError { MUST(String::formatted(forward<AK::CheckedFormatString<Parameters...>>(format_string), forward<Parameters const&>(arguments)...)) };
+    }
+
+    template<typename... Parameters>
+    static PropertyError in_widget(String const& widget_name, AK::CheckedFormatString<Parameters...>&& format_string, Parameters const&... arguments)
+    {
+        return PropertyError { MUST(String::formatted("in widget {}: {}", widget_name, MUST(String::formatted(forward<AK::CheckedFormatString<Parameters...>>(format_string), forward<Parameters const&>(arguments)...)))) };
+    }
+    PropertyError add_widget_and_property(String const& widget_name, String const& property_name) const&&
+    {
+        return PropertyError { MUST(String::formatted("in widget {}: in property {}: {}", widget_name, property_name, this->text)) };
+    }
+};
+
+template<>
+struct AK::Formatter<PropertyError> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, PropertyError const& error)
+    {
+        return builder.put_string(error.text);
+    }
+};
+
+class PropertyType;
+
+struct CustomVariant final {
+    CustomVariant(Vector<NonnullOwnPtr<PropertyType>> variant_types)
+        : variant_types(move(variant_types))
+    {
+    }
+    CustomVariant(CustomVariant const& other)
+    {
+        for (auto const& type : other.variant_types)
+            variant_types.append(make<PropertyType>(*type));
+    }
+    CustomVariant() = default;
+    AK_MAKE_DEFAULT_MOVABLE(CustomVariant);
+
+    size_t element_count() const { return variant_types.size(); }
+
+    Vector<NonnullOwnPtr<PropertyType>> variant_types;
+};
+
+struct CustomArray final {
+    CustomArray(size_t min_values, size_t max_values, NonnullOwnPtr<PropertyType> element_type)
+        : min_values(min_values)
+        , max_values(max_values)
+        , element_type(move(element_type))
+    {
+    }
+    CustomArray(CustomArray const& other)
+        : min_values(other.min_values)
+        , max_values(other.max_values)
+        , element_type(make<PropertyType>(*other.element_type))
+    {
+    }
+    AK_MAKE_DEFAULT_MOVABLE(CustomArray);
+
+    size_t min_values;
+    size_t max_values;
+    NonnullOwnPtr<PropertyType> element_type;
+};
+
+// Any type that is handled with its own custom initializer.
+enum class SimpleType {
+    Bool,
+    I64,
+    U64,
+    Double,
+    String,
+    ByteString,
+    Bitmap,
+    Color,
+    UIDimension,
+    Margins,
+};
+
+struct EnumType {
+    String name;
+};
+
+class PropertyType final : public Variant<SimpleType, EnumType, CustomVariant, CustomArray> {
+public:
+    static ErrorOr<PropertyType, PropertyError> parse(String const& type_name, Optional<u64> min_values, Optional<u64> max_values);
+
+    ErrorOr<String, PropertyError> generate_initializer_for(JsonValue const& property_value) const;
+    String name(Optional<size_t> element_count = {}) const;
+};
+
+// A property that can be set on a widget via GML.
+struct PropertyDefinition {
+    String name;
+    String getter;
+    String setter;
+    String description;
+    PropertyType type;
+};
+
+// A collection of properties for a certain widget type.
+class WidgetProperties final {
+    AK_MAKE_DEFAULT_COPYABLE(WidgetProperties);
+    AK_MAKE_DEFAULT_MOVABLE(WidgetProperties);
+
+public:
+    static ErrorOr<HashMap<String, WidgetProperties>, PropertyError> parse_properties(JsonArray const&);
+    // Copy all properties of a widget's direct (or indirect) parents to that widget.
+    static ErrorOr<void, PropertyError> expand_inherited_properties(HashMap<String, WidgetProperties>& widgets);
+
+    StringView cpp_identifier() const { return m_cpp_identifier.bytes_as_string_view(); }
+    StringView header() const { return m_header.bytes_as_string_view(); }
+    Optional<String> const& inherits() const { return m_inherits; }
+    StringView description() const { return m_description.bytes_as_string_view(); }
+    HashMap<String, PropertyDefinition> const& properties() const { return m_properties; }
+    HashMap<String, PropertyDefinition>& properties() { return m_properties; }
+
+private:
+    WidgetProperties(String cpp_identifier, String header, Optional<String> inherits, String description)
+        : m_cpp_identifier(move(cpp_identifier))
+        , m_header(move(header))
+        , m_inherits(move(inherits))
+        , m_description(move(description))
+    {
+    }
+
+    String m_cpp_identifier;
+    String m_header;
+    Optional<String> m_inherits;
+    String m_description;
+
+    HashMap<String, PropertyDefinition> m_properties;
+};

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -334,6 +334,8 @@ static ErrorOr<void> generate_loader_for_object(GUI::GML::Object const& gml_obje
         return {};
     }));
 
+    TRY(append(generator, "TRY(::GUI::initialize(*@object_name@));"));
+
     generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)).bytes_as_string_view());
     generator.appendln("}");
 

--- a/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.h
@@ -27,13 +27,13 @@ class AutoplaySettingsWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(AutoplaySettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
-    static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> try_create();
     AutoplaySettingsWidget() = default;
 
     void set_allowlist_model(NonnullRefPtr<AutoplayAllowlistModel> model);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -95,16 +95,7 @@ private:
     Vector<WebView::SearchEngine> m_search_engines;
 };
 
-ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> BrowserSettingsWidget::create()
-{
-    auto widget = TRY(BrowserSettingsWidget::try_create());
-
-    TRY(widget->setup());
-
-    return widget;
-}
-
-ErrorOr<void> BrowserSettingsWidget::setup()
+ErrorOr<void> BrowserSettingsWidget::initialize()
 {
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
     m_homepage_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, Browser::default_homepage_url), GUI::AllowCallback::No);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
@@ -17,17 +17,15 @@ namespace BrowserSettings {
 class BrowserSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(BrowserSettingsWidget)
 public:
-    static ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> try_create();
     virtual ~BrowserSettingsWidget() override = default;
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
+    ErrorOr<void> initialize();
+
 private:
-    static ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> try_create();
-
-    ErrorOr<void> setup();
-
     RefPtr<GUI::TextBox> m_homepage_url_textbox;
     RefPtr<GUI::TextBox> m_new_tab_url_textbox;
     void set_color_scheme(StringView);

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
@@ -37,13 +37,13 @@ class ContentFilterSettingsWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(ContentFilterSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
-    static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> try_create();
     ContentFilterSettingsWidget() = default;
 
     void set_domain_list_model(NonnullRefPtr<DomainListModel>);

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -37,9 +37,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Browser Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    (void)TRY(window->add_tab(TRY(BrowserSettings::BrowserSettingsWidget::create()), "Browser"_string, "browser"sv));
-    (void)TRY(window->add_tab(TRY(BrowserSettings::ContentFilterSettingsWidget::create()), "Content Filtering"_string, "content-filtering"sv));
-    (void)TRY(window->add_tab(TRY(BrowserSettings::AutoplaySettingsWidget::create()), "Autoplay"_string, "autoplay"sv));
+    (void)TRY(window->add_tab<BrowserSettings::BrowserSettingsWidget>("Browser"_string, "browser"sv));
+    (void)TRY(window->add_tab<BrowserSettings::ContentFilterSettingsWidget>("Content Filtering"_string, "content-filtering"sv));
+    (void)TRY(window->add_tab<BrowserSettings::AutoplaySettingsWidget>("Autoplay"_string, "autoplay"sv));
     window->set_active_tab(selected_tab);
 
     window->show();

--- a/Userland/Applications/BrowserSettings/property-definitions.json
+++ b/Userland/Applications/BrowserSettings/property-definitions.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "BrowserSettings::BrowserSettingsWidget",
+        "header": "Applications/BrowserSettings/BrowserSettingsWidget.h",
+        "description": "BrowserSettings's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "BrowserSettings::AutoplaySettingsWidget",
+        "header": "Applications/BrowserSettings/AutoplaySettingsWidget.h",
+        "description": "Autoplay settings widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "BrowserSettings::ContentFilterSettingsWidget",
+        "header": "Applications/BrowserSettings/ContentFilterSettingsWidget.h",
+        "description": "Content filter settings widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -17,89 +17,87 @@
 
 namespace Calculator {
 
-ErrorOr<NonnullRefPtr<CalculatorWidget>> CalculatorWidget::create()
+ErrorOr<void> CalculatorWidget::initialize()
 {
-    auto widget = TRY(CalculatorWidget::try_create());
-
-    widget->m_entry = *widget->find_descendant_of_type_named<GUI::TextBox>("entry_textbox");
+    m_entry = *find_descendant_of_type_named<GUI::TextBox>("entry_textbox");
     // FIXME: Use GML for this.
-    widget->m_entry->set_relative_rect(5, 5, 244, 26);
-    widget->m_entry->set_text_alignment(Gfx::TextAlignment::CenterRight);
+    m_entry->set_relative_rect(5, 5, 244, 26);
+    m_entry->set_text_alignment(Gfx::TextAlignment::CenterRight);
 
     // FIXME: Use GML for this.
-    widget->m_label = *widget->find_descendant_of_type_named<GUI::Label>("label");
-    widget->m_label->set_frame_style(Gfx::FrameStyle::SunkenContainer);
+    m_label = *find_descendant_of_type_named<GUI::Label>("label");
+    m_label->set_frame_style(Gfx::FrameStyle::SunkenContainer);
 
     for (int i = 0; i < 10; i++) {
-        widget->m_digit_button[i] = *widget->find_descendant_of_type_named<GUI::Button>(TRY(String::formatted("{}_button", i)));
-        widget->add_digit_button(*widget->m_digit_button[i], i);
+        m_digit_button[i] = *find_descendant_of_type_named<GUI::Button>(TRY(String::formatted("{}_button", i)));
+        add_digit_button(*m_digit_button[i], i);
     }
 
-    widget->m_mem_add_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_add_button");
-    widget->add_operation_button(*widget->m_mem_add_button, Calculator::Operation::MemAdd);
+    m_mem_add_button = *find_descendant_of_type_named<GUI::Button>("mem_add_button");
+    add_operation_button(*m_mem_add_button, Calculator::Operation::MemAdd);
 
-    widget->m_mem_save_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_save_button");
-    widget->add_operation_button(*widget->m_mem_save_button, Calculator::Operation::MemSave);
+    m_mem_save_button = *find_descendant_of_type_named<GUI::Button>("mem_save_button");
+    add_operation_button(*m_mem_save_button, Calculator::Operation::MemSave);
 
-    widget->m_mem_recall_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_recall_button");
-    widget->add_operation_button(*widget->m_mem_recall_button, Calculator::Operation::MemRecall);
+    m_mem_recall_button = *find_descendant_of_type_named<GUI::Button>("mem_recall_button");
+    add_operation_button(*m_mem_recall_button, Calculator::Operation::MemRecall);
 
-    widget->m_mem_clear_button = *widget->find_descendant_of_type_named<GUI::Button>("mem_clear_button");
-    widget->add_operation_button(*widget->m_mem_clear_button, Calculator::Operation::MemClear);
+    m_mem_clear_button = *find_descendant_of_type_named<GUI::Button>("mem_clear_button");
+    add_operation_button(*m_mem_clear_button, Calculator::Operation::MemClear);
 
-    widget->m_clear_button = *widget->find_descendant_of_type_named<GUI::Button>("clear_button");
-    widget->m_clear_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.set_to_0();
-        self->m_calculator.clear_operation();
-        self->update_display();
+    m_clear_button = *find_descendant_of_type_named<GUI::Button>("clear_button");
+    m_clear_button->on_click = [this](auto) {
+        m_keypad.set_to_0();
+        m_calculator.clear_operation();
+        update_display();
     };
 
-    widget->m_clear_error_button = *widget->find_descendant_of_type_named<GUI::Button>("clear_error_button");
-    widget->m_clear_error_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.set_to_0();
-        self->update_display();
+    m_clear_error_button = *find_descendant_of_type_named<GUI::Button>("clear_error_button");
+    m_clear_error_button->on_click = [this](auto) {
+        m_keypad.set_to_0();
+        update_display();
     };
 
-    widget->m_backspace_button = *widget->find_descendant_of_type_named<GUI::Button>("backspace_button");
-    widget->m_backspace_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.type_backspace();
-        self->update_display();
+    m_backspace_button = *find_descendant_of_type_named<GUI::Button>("backspace_button");
+    m_backspace_button->on_click = [this](auto) {
+        m_keypad.type_backspace();
+        update_display();
     };
 
-    widget->m_decimal_point_button = *widget->find_descendant_of_type_named<GUI::Button>("decimal_button");
-    widget->m_decimal_point_button->on_click = [self = NonnullRefPtr<CalculatorWidget>(widget)](auto) {
-        self->m_keypad.type_decimal_point();
-        self->update_display();
+    m_decimal_point_button = *find_descendant_of_type_named<GUI::Button>("decimal_button");
+    m_decimal_point_button->on_click = [this](auto) {
+        m_keypad.type_decimal_point();
+        update_display();
     };
 
-    widget->m_sign_button = *widget->find_descendant_of_type_named<GUI::Button>("sign_button");
-    widget->add_operation_button(*widget->m_sign_button, Calculator::Operation::ToggleSign);
+    m_sign_button = *find_descendant_of_type_named<GUI::Button>("sign_button");
+    add_operation_button(*m_sign_button, Calculator::Operation::ToggleSign);
 
-    widget->m_add_button = *widget->find_descendant_of_type_named<GUI::Button>("add_button");
-    widget->add_operation_button(*widget->m_add_button, Calculator::Operation::Add);
+    m_add_button = *find_descendant_of_type_named<GUI::Button>("add_button");
+    add_operation_button(*m_add_button, Calculator::Operation::Add);
 
-    widget->m_subtract_button = *widget->find_descendant_of_type_named<GUI::Button>("subtract_button");
-    widget->add_operation_button(*widget->m_subtract_button, Calculator::Operation::Subtract);
+    m_subtract_button = *find_descendant_of_type_named<GUI::Button>("subtract_button");
+    add_operation_button(*m_subtract_button, Calculator::Operation::Subtract);
 
-    widget->m_multiply_button = *widget->find_descendant_of_type_named<GUI::Button>("multiply_button");
-    widget->add_operation_button(*widget->m_multiply_button, Calculator::Operation::Multiply);
+    m_multiply_button = *find_descendant_of_type_named<GUI::Button>("multiply_button");
+    add_operation_button(*m_multiply_button, Calculator::Operation::Multiply);
 
-    widget->m_divide_button = *widget->find_descendant_of_type_named<GUI::Button>("divide_button");
-    widget->add_operation_button(*widget->m_divide_button, Calculator::Operation::Divide);
+    m_divide_button = *find_descendant_of_type_named<GUI::Button>("divide_button");
+    add_operation_button(*m_divide_button, Calculator::Operation::Divide);
 
-    widget->m_sqrt_button = *widget->find_descendant_of_type_named<GUI::Button>("sqrt_button");
-    widget->add_operation_button(*widget->m_sqrt_button, Calculator::Operation::Sqrt);
+    m_sqrt_button = *find_descendant_of_type_named<GUI::Button>("sqrt_button");
+    add_operation_button(*m_sqrt_button, Calculator::Operation::Sqrt);
 
-    widget->m_inverse_button = *widget->find_descendant_of_type_named<GUI::Button>("inverse_button");
-    widget->add_operation_button(*widget->m_inverse_button, Calculator::Operation::Inverse);
+    m_inverse_button = *find_descendant_of_type_named<GUI::Button>("inverse_button");
+    add_operation_button(*m_inverse_button, Calculator::Operation::Inverse);
 
-    widget->m_percent_button = *widget->find_descendant_of_type_named<GUI::Button>("mod_button");
-    widget->add_operation_button(*widget->m_percent_button, Calculator::Operation::Percent);
+    m_percent_button = *find_descendant_of_type_named<GUI::Button>("mod_button");
+    add_operation_button(*m_percent_button, Calculator::Operation::Percent);
 
-    widget->m_equals_button = *widget->find_descendant_of_type_named<GUI::Button>("equal_button");
-    widget->add_operation_button(*widget->m_equals_button, Calculator::Operation::Equals);
+    m_equals_button = *find_descendant_of_type_named<GUI::Button>("equal_button");
+    add_operation_button(*m_equals_button, Calculator::Operation::Equals);
 
-    return widget;
+    return {};
 }
 
 void CalculatorWidget::perform_operation(Calculator::Operation operation)

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -20,7 +20,8 @@ namespace Calculator {
 class CalculatorWidget final : public GUI::Widget {
     C_OBJECT(CalculatorWidget)
 public:
-    static ErrorOr<NonnullRefPtr<CalculatorWidget>> create();
+    static ErrorOr<NonnullRefPtr<CalculatorWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual ~CalculatorWidget() override = default;
     String get_entry();
@@ -34,7 +35,6 @@ public:
     void set_rounding_custom(GUI::Action& action, StringView);
 
 private:
-    static ErrorOr<NonnullRefPtr<CalculatorWidget>> try_create();
     CalculatorWidget() = default;
 
     void add_operation_button(GUI::Button&, Calculator::Operation);

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
     window->resize(250, 215);
 
-    auto widget = TRY(Calculator::CalculatorWidget::create());
+    auto widget = TRY(Calculator::CalculatorWidget::try_create());
     window->set_main_widget(widget.ptr());
 
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Applications/Calculator/property-definitions.json
+++ b/Userland/Applications/Calculator/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "Calculator::CalculatorWidget",
+        "header": "Applications/Calculator/CalculatorWidget.h",
+        "description": "Calculator's main widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/Calendar/property-definitions.json
+++ b/Userland/Applications/Calendar/property-definitions.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Calendar::CalendarWidget",
+        "header": "Applications/Calendar/CalendarWidget.h",
+        "description": "Calendar's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Calendar::EventCalendar",
+        "header": "Applications/Calendar/EventCalendar.h",
+        "description": "Calendar that displays events",
+        "inherits": "GUI::Calendar"
+    },
+    {
+        "name": "Calendar::AddEventWidget",
+        "header": "Applications/Calendar/AddEventWidget.h",
+        "description": "Dialog widget for adding a new event",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
@@ -30,14 +30,7 @@ void CalendarSettingsWidget::reset_default_values()
     m_default_view_combobox->set_text("Month");
 }
 
-ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> CalendarSettingsWidget::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> CalendarSettingsWidget::setup()
+ErrorOr<void> CalendarSettingsWidget::initialize()
 {
     m_first_day_of_week_combobox = *find_descendant_of_type_named<GUI::ComboBox>("first_day_of_week");
     m_first_day_of_week_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "FirstDayOfWeek"sv, "Sunday"sv));

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.h
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.h
@@ -15,16 +15,15 @@ class CalendarSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CalendarSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     CalendarSettingsWidget() = default;
-    static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> try_create();
 
-    ErrorOr<void> setup();
     static constexpr Array<StringView, 2> const m_view_modes = { "Month"sv, "Year"sv };
 
     RefPtr<GUI::ComboBox> m_first_day_of_week_combobox;

--- a/Userland/Applications/CalendarSettings/main.cpp
+++ b/Userland/Applications/CalendarSettings/main.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-calendar"sv);
 
     auto window = TRY(GUI::SettingsWindow::create("Calendar Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab(TRY(CalendarSettings::CalendarSettingsWidget::create()), "Calendar"_string, "Calendar"sv));
+    (void)TRY(window->add_tab<CalendarSettings::CalendarSettingsWidget>("Calendar"_string, "Calendar"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_active_tab(selected_tab);
 

--- a/Userland/Applications/CalendarSettings/property-definitions.json
+++ b/Userland/Applications/CalendarSettings/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "CalendarSettings::CalendarSettingsWidget",
+        "header": "Applications/CalendarSettings/CalendarSettingsWidget.h",
+        "description": "CalendarSettings' main widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
@@ -151,13 +151,6 @@ ErrorOr<void> CertificateStoreWidget::export_pem()
     return {};
 }
 
-ErrorOr<NonnullRefPtr<CertificateStoreWidget>> CertificateStoreWidget::create()
-{
-    auto widget = TRY(CertificateStoreWidget::try_create());
-    TRY(widget->initialize());
-    return widget;
-}
-
 ErrorOr<void> CertificateStoreWidget::initialize()
 {
     m_root_ca_tableview = find_descendant_of_type_named<GUI::TableView>("root_ca_tableview");

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
@@ -58,14 +58,13 @@ class CertificateStoreWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CertStoreWidget)
 public:
     virtual ~CertificateStoreWidget() override = default;
-    static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> create();
+    static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> try_create();
+    ErrorOr<void> initialize();
     virtual void apply_settings() override {};
 
 private:
-    static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> try_create();
     CertificateStoreWidget() = default;
 
-    ErrorOr<void> initialize();
     ErrorOr<void> import_pem();
     ErrorOr<void> export_pem();
 

--- a/Userland/Applications/CertificateSettings/main.cpp
+++ b/Userland/Applications/CertificateSettings/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     auto app_icon = GUI::Icon::default_icon("certificate"sv);
     auto window = TRY(GUI::SettingsWindow::create("Certificate Settings", GUI::SettingsWindow::ShowDefaultsButton::No));
-    TRY(window->add_tab(TRY(CertificateSettings::CertificateStoreWidget::create()), "Certificate Store"_string, "certificate"sv));
+    (void)TRY(window->add_tab<CertificateSettings::CertificateStoreWidget>("Certificate Store"_string, "certificate"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/CertificateSettings/property-definitions.json
+++ b/Userland/Applications/CertificateSettings/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "CertificateSettings::CertificateStoreWidget",
+        "header": "Applications/CertificateSettings/CertificateStoreWidget.h",
+        "description": "Certificate store settings widget",
+        "inherits": "GUI::SettingsWindow::Tab"
+    }
+]

--- a/Userland/Applications/CrashReporter/property-definitions.json
+++ b/Userland/Applications/CrashReporter/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "CrashReporter::MainWidget",
+        "header": "Applications/CrashReporter/MainWidget.h",
+        "description": "CrashReporter's main widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/Escalator/property-definitions.json
+++ b/Userland/Applications/Escalator/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "Escalator::MainWidget",
+        "header": "Applications/Escalator/MainWidget.h",
+        "description": "Escalator's main widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.cpp
@@ -61,13 +61,6 @@ void CardGamePreview::paint_event(GUI::PaintEvent& event)
         stack->paint(painter, background_color);
 }
 
-ErrorOr<NonnullRefPtr<CardSettingsWidget>> CardSettingsWidget::create()
-{
-    auto card_settings_widget = TRY(try_create());
-    TRY(card_settings_widget->initialize());
-    return card_settings_widget;
-}
-
 ErrorOr<void> CardSettingsWidget::initialize()
 {
     auto background_color = Gfx::Color::from_string(Config::read_string("Games"sv, "Cards"sv, "BackgroundColor"sv)).value_or(Gfx::Color::from_rgb(0x008000));

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.gml
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.gml
@@ -19,7 +19,7 @@
 
         @GUI::ColorInput {
             name: "cards_background_color"
-            color_has_alpha_channel: false
+            has_alpha_channel: false
         }
     }
 

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.h
@@ -21,7 +21,7 @@ class CardSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CardSettingsWidget)
 public:
     static ErrorOr<NonnullRefPtr<CardSettingsWidget>> try_create();
-    static ErrorOr<NonnullRefPtr<CardSettingsWidget>> create();
+    ErrorOr<void> initialize();
     virtual ~CardSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -29,7 +29,6 @@ public:
 
 private:
     CardSettingsWidget() = default;
-    ErrorOr<void> initialize();
 
     bool set_card_back_image_path(StringView);
     String card_back_image_path() const;

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -231,13 +231,6 @@ void ChessGamePreview::paint_event(GUI::PaintEvent& event)
     }
 }
 
-ErrorOr<NonnullRefPtr<ChessSettingsWidget>> ChessSettingsWidget::create()
-{
-    auto chess_settings_widget = TRY(try_create());
-    TRY(chess_settings_widget->initialize());
-    return chess_settings_widget;
-}
-
 ErrorOr<void> ChessSettingsWidget::initialize()
 {
     auto piece_set_name = Config::read_string("Games"sv, "Chess"sv, "PieceSet"sv, "Classic"sv);

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.h
@@ -18,7 +18,7 @@ class ChessSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(ChessSettingsWidget)
 public:
     static ErrorOr<NonnullRefPtr<ChessSettingsWidget>> try_create();
-    static ErrorOr<NonnullRefPtr<ChessSettingsWidget>> create();
+    ErrorOr<void> initialize();
     virtual ~ChessSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -26,7 +26,6 @@ public:
 
 private:
     ChessSettingsWidget() = default;
-    ErrorOr<void> initialize();
 
     Vector<ByteString> m_piece_sets;
 

--- a/Userland/Applications/GamesSettings/main.cpp
+++ b/Userland/Applications/GamesSettings/main.cpp
@@ -35,10 +35,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Games Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto widget_cards = TRY(GamesSettings::CardSettingsWidget::create());
-    auto widget_chess = TRY(GamesSettings::ChessSettingsWidget::create());
-    (void)TRY(window->add_tab(widget_cards, "Cards"_string, "cards"sv));
-    (void)TRY(window->add_tab(widget_chess, "Chess"_string, "chess"sv));
+    (void)TRY(window->add_tab<GamesSettings::CardSettingsWidget>("Cards"_string, "cards"sv));
+    (void)TRY(window->add_tab<GamesSettings::ChessSettingsWidget>("Chess"_string, "chess"sv));
     window->set_active_tab(selected_tab);
 
     window->show();

--- a/Userland/Applications/GamesSettings/property-definitions.json
+++ b/Userland/Applications/GamesSettings/property-definitions.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "GamesSettings::CardSettingsWidget",
+        "header": "Applications/GamesSettings/CardSettingsWidget.h",
+        "description": "Card settings widget",
+        "inherits": "GUI::SettingsWindow::Tab"
+    },
+    {
+        "name": "GamesSettings::ChessSettingsWidget",
+        "header": "Applications/GamesSettings/ChessSettingsWidget.h",
+        "description": "Chess settings widget",
+        "inherits": "GUI::SettingsWindow::Tab"
+    },
+    {
+        "name": "GamesSettings::CardGamePreview",
+        "header": "Applications/GamesSettings/CardGamePreview.h",
+        "description": "Previews the style of card games",
+        "inherits": "GUI::Frame"
+    },
+    {
+        "name": "GamesSettings::ChessGamePreview",
+        "header": "Applications/GamesSettings/ChessGamePreview.h",
+        "description": "Previews the style of chess games",
+        "inherits": "GUI::Frame"
+    }
+]

--- a/Userland/Applications/Help/CMakeLists.txt
+++ b/Userland/Applications/Help/CMakeLists.txt
@@ -5,7 +5,7 @@ serenity_component(
     DEPENDS WebContent
 )
 
-compile_gml(HelpWindow.gml HelpWindowGML.cpp)
+compile_gml(HelpWindow.gml HelpWindowGML.cpp PROPERTIES Userland/Libraries/LibWebView)
 
 set(SOURCES
     History.cpp

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -61,7 +61,7 @@ ErrorOr<void> MainWidget::set_start_page(Vector<StringView, 2> query_parameters)
     return {};
 }
 
-ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
+ErrorOr<void> MainWidget::initialize(GUI::Window& window)
 {
     m_toolbar = find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("tab_widget");

--- a/Userland/Applications/Help/MainWidget.h
+++ b/Userland/Applications/Help/MainWidget.h
@@ -21,7 +21,7 @@ public:
 
     static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
 
-    ErrorOr<void> initialize_fallibles(GUI::Window&);
+    ErrorOr<void> initialize(GUI::Window&);
     ErrorOr<void> set_start_page(Vector<StringView, 2> query_parameters);
 
 private:

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -63,7 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto main_widget = TRY(MainWidget::try_create());
     window->set_main_widget(main_widget);
 
-    TRY(main_widget->initialize_fallibles(window));
+    TRY(main_widget->initialize(window));
     TRY(main_widget->set_start_page(query_parameters));
 
     window->show();

--- a/Userland/Applications/Help/property-definitions.json
+++ b/Userland/Applications/Help/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "Help::MainWidget",
+        "header": "Applications/Help/MainWidget.h",
+        "description": "Help's main widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/HexEditor/property-definitions.json
+++ b/Userland/Applications/HexEditor/property-definitions.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "HexEditor::HexEditorWidget",
+        "header": "Applications/HexEditor/HexEditorWidget.h",
+        "description": "HexEditor's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "HexEditor::HexEditor",
+        "header": "Applications/HexEditor/HexEditor.h",
+        "description": "Hex editor",
+        "inherits": "GUI::AbstractScrollableWidget"
+    },
+    {
+        "name": "HexEditor::GoToOffsetWidget",
+        "header": "Applications/HexEditor/GoToOffsetWidget.h",
+        "description": "Widget for the Go To Offset dialog",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "HexEditor::FindWidget",
+        "header": "Applications/HexEditor/FindWidget.h",
+        "description": "Widget for the Find dialog",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "HexEditor::EditAnnotationWidget",
+        "header": "Applications/HexEditor/EditAnnotationWidget.h",
+        "description": "Widget for the Edit Annotation dialog",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/KeyboardSettings/property-definitions.json
+++ b/Userland/Applications/KeyboardSettings/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "KeyboardSettings::KeyboardSettingsWidget",
+        "header": "Applications/KeyboardSettings/KeyboardSettingsWidget.h",
+        "description": "Keyboard settings widget",
+        "inherits": "GUI::SettingsWindow::Tab"
+    },
+    {
+        "name": "KeyboardSettings::KeymapDialog",
+        "header": "Applications/KeyboardSettings/KeymapDialog.h",
+        "description": "Dialog for selecting a key map",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/Maps/FavoritesPanel.cpp
+++ b/Userland/Applications/Maps/FavoritesPanel.cpp
@@ -15,14 +15,7 @@
 
 namespace Maps {
 
-ErrorOr<NonnullRefPtr<FavoritesPanel>> FavoritesPanel::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> FavoritesPanel::setup()
+ErrorOr<void> FavoritesPanel::initialize()
 {
     m_empty_container = *find_descendant_of_type_named<GUI::Frame>("empty_container");
     m_favorites_list = *find_descendant_of_type_named<GUI::ListView>("favorites_list");

--- a/Userland/Applications/Maps/FavoritesPanel.h
+++ b/Userland/Applications/Maps/FavoritesPanel.h
@@ -22,7 +22,8 @@ public:
         MapWidget::LatLng latlng;
         int zoom;
     };
-    static ErrorOr<NonnullRefPtr<FavoritesPanel>> create();
+    static ErrorOr<NonnullRefPtr<FavoritesPanel>> try_create();
+    ErrorOr<void> initialize();
 
     void load_favorites();
     void reset();
@@ -33,10 +34,6 @@ public:
 
 protected:
     FavoritesPanel() = default;
-
-    static ErrorOr<NonnullRefPtr<FavoritesPanel>> try_create();
-
-    ErrorOr<void> setup();
 
 private:
     ErrorOr<void> edit_favorite(int row);

--- a/Userland/Applications/Maps/SearchPanel.cpp
+++ b/Userland/Applications/Maps/SearchPanel.cpp
@@ -9,14 +9,7 @@
 
 namespace Maps {
 
-ErrorOr<NonnullRefPtr<SearchPanel>> SearchPanel::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> SearchPanel::setup()
+ErrorOr<void> SearchPanel::initialize()
 {
     m_request_client = TRY(Protocol::RequestClient::try_create());
 

--- a/Userland/Applications/Maps/SearchPanel.gml
+++ b/Userland/Applications/Maps/SearchPanel.gml
@@ -21,7 +21,7 @@
 
         @GUI::Button {
             name: "search_button"
-            icon_from_path: "/res/icons/16x16/find.png"
+            icon: "/res/icons/16x16/find.png"
             fixed_width: 24
         }
     }

--- a/Userland/Applications/Maps/SearchPanel.h
+++ b/Userland/Applications/Maps/SearchPanel.h
@@ -21,7 +21,8 @@ class SearchPanel final : public GUI::Widget {
     C_OBJECT(SearchPanel)
 
 public:
-    static ErrorOr<NonnullRefPtr<SearchPanel>> create();
+    static ErrorOr<NonnullRefPtr<SearchPanel>> try_create();
+    ErrorOr<void> initialize();
 
     void search(StringView query);
     void reset();
@@ -36,10 +37,6 @@ public:
 
 private:
     SearchPanel() = default;
-
-    static ErrorOr<NonnullRefPtr<SearchPanel>> try_create();
-
-    ErrorOr<void> setup();
 
     RefPtr<Protocol::RequestClient> m_request_client;
     RefPtr<Protocol::Request> m_request;

--- a/Userland/Applications/Maps/main.cpp
+++ b/Userland/Applications/Maps/main.cpp
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int panel_width = Config::read_i32("Maps"sv, "Panel"sv, "Width"sv, INT_MIN);
 
     // Search panel
-    auto search_panel = TRY(Maps::SearchPanel::create());
+    auto search_panel = TRY(Maps::SearchPanel::try_create());
     search_panel->on_places_change = [&map_widget](auto) { map_widget.remove_markers_with_name("search"sv); };
     search_panel->on_selected_place_change = [&map_widget](auto const& place) {
         // Remove old search marker
@@ -105,7 +105,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Favorites panel
     auto marker_red_image = TRY(Gfx::Bitmap::load_from_file("/res/graphics/maps/marker-red.png"sv));
-    auto favorites_panel = TRY(Maps::FavoritesPanel::create());
+    auto favorites_panel = TRY(Maps::FavoritesPanel::try_create());
     favorites_panel->on_favorites_change = [&map_widget, marker_red_image](auto const& favorites) {
         // Sync all favorites markers
         map_widget.remove_markers_with_name("favorites"sv);

--- a/Userland/Applications/Maps/property-definitions.json
+++ b/Userland/Applications/Maps/property-definitions.json
@@ -1,0 +1,33 @@
+[
+    {
+        "name": "Maps::MapWidget",
+        "header": "Applications/Maps/MapWidget.h",
+        "description": "Widget displaying a geographical map",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "zoom",
+                "description": "Zoom level of the map",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "Maps::SearchPanel",
+        "header": "Applications/Maps/SearchPanel.h",
+        "description": "Side panel to search for points of interest on a map",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Maps::FavoritesPanel",
+        "header": "Applications/Maps/FavoritesPanel.h",
+        "description": "Side panel listing user favorites",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Maps::FavoritesEditDialog",
+        "header": "Applications/Maps/FavoritesEditDialog.h",
+        "description": "Dialog widget for editing favorites",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/MapsSettings/MapsSettingsWidget.cpp
+++ b/Userland/Applications/MapsSettings/MapsSettingsWidget.cpp
@@ -14,13 +14,6 @@
 
 namespace MapsSettings {
 
-ErrorOr<NonnullRefPtr<MapsSettingsWidget>> MapsSettingsWidget::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
 void MapsSettingsWidget::apply_settings()
 {
     // Tile Provider
@@ -43,7 +36,7 @@ void MapsSettingsWidget::reset_default_values()
     set_tile_provider(Maps::default_tile_provider_url_format);
 }
 
-ErrorOr<void> MapsSettingsWidget::setup()
+ErrorOr<void> MapsSettingsWidget::initialize()
 {
     // Tile Provider
     Vector<GUI::JsonArrayModel::FieldSpec> tile_provider_fields;

--- a/Userland/Applications/MapsSettings/MapsSettingsWidget.h
+++ b/Userland/Applications/MapsSettings/MapsSettingsWidget.h
@@ -14,16 +14,15 @@ class MapsSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(MapsSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     MapsSettingsWidget() = default;
-    static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> try_create();
 
-    ErrorOr<void> setup();
     void set_tile_provider(StringView url);
 
     RefPtr<GUI::ComboBox> m_tile_provider_combobox;

--- a/Userland/Applications/MapsSettings/main.cpp
+++ b/Userland/Applications/MapsSettings/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Maps Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    (void)TRY(window->add_tab(TRY(MapsSettings::MapsSettingsWidget::create()), "Maps"_string, "maps"sv));
+    (void)TRY(window->add_tab<MapsSettings::MapsSettingsWidget>("Maps"_string, "maps"sv));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/MapsSettings/property-definitions.json
+++ b/Userland/Applications/MapsSettings/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "MapsSettings::MapsSettingsWidget",
+        "header": "Applications/MapsSettings/MapsSettingsWidget.h",
+        "description": "Maps settings widget",
+        "inherits": "GUI::SettingsWindow::Tab"
+    }
+]

--- a/Userland/Applications/MouseSettings/property-definitions.json
+++ b/Userland/Applications/MouseSettings/property-definitions.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "MouseSettings::HighlightWidget",
+        "header": "Applications/MouseSettings/HighlightWidget.h",
+        "description": "Mouse highlight settings tab",
+        "inherits": "GUI::SettingsWindow::Tab"
+    },
+    {
+        "name": "MouseSettings::ThemeWidget",
+        "header": "Applications/MouseSettings/ThemeWidget.h",
+        "description": "Mouse theme settings tab",
+        "inherits": "GUI::SettingsWindow::Tab"
+    },
+    {
+        "name": "MouseSettings::MouseWidget",
+        "header": "Applications/MouseSettings/MouseWidget.h",
+        "description": "Mouse main settings tab",
+        "inherits": "GUI::SettingsWindow::Tab"
+    }
+]

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -29,14 +29,7 @@ static int netmask_to_cidr(IPv4Address const& address)
     return 32 - count_trailing_zeroes_safe(address_in_host_representation);
 }
 
-ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> NetworkSettingsWidget::create()
-{
-    auto widget = TRY(try_create());
-    TRY(widget->setup());
-    return widget;
-}
-
-ErrorOr<void> NetworkSettingsWidget::setup()
+ErrorOr<void> NetworkSettingsWidget::initialize()
 {
     m_adapters_combobox = *find_descendant_of_type_named<GUI::ComboBox>("adapters_combobox");
     m_enabled_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("enabled_checkbox");

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
@@ -16,17 +16,14 @@ class NetworkSettingsWidget : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(NetworkSettingsWidget)
 
 public:
-    static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> create();
+    static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> try_create();
+    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     void switch_adapter(ByteString const& adapter);
 
-protected:
-    static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> try_create();
-
 private:
     NetworkSettingsWidget() = default;
-    ErrorOr<void> setup();
 
     struct NetworkAdapterData {
         bool enabled = false;

--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     auto app_icon = GUI::Icon::default_icon("network"sv);
     auto window = TRY(GUI::SettingsWindow::create("Network Settings", GUI::SettingsWindow::ShowDefaultsButton::No));
 
-    auto network_settings_widget = TRY(NetworkSettings::NetworkSettingsWidget::create());
+    auto network_settings_widget = TRY(NetworkSettings::NetworkSettingsWidget::try_create());
     TRY(window->add_tab(network_settings_widget, "Network"_string, "network"sv));
     if (!adapter.is_null()) {
         network_settings_widget->switch_adapter(adapter);

--- a/Userland/Applications/NetworkSettings/property-definitions.json
+++ b/Userland/Applications/NetworkSettings/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "NetworkSettings::NetworkSettingsWidget",
+        "header": "Applications/NetworkSettings/NetworkSettingsWidget.h",
+        "description": "Network settings widget",
+        "inherits": "GUI::SettingsWindow::Tab"
+    }
+]

--- a/Userland/Applications/Piano/ExportProgressWindow.cpp
+++ b/Userland/Applications/Piano/ExportProgressWindow.cpp
@@ -18,7 +18,7 @@ ExportProgressWindow::ExportProgressWindow(GUI::Window& parent_window, Atomic<in
 {
 }
 
-ErrorOr<void> ExportProgressWindow::initialize_fallibles()
+ErrorOr<void> ExportProgressWindow::initialize()
 {
     auto main_widget = set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(export_progress_widget));

--- a/Userland/Applications/Piano/ExportProgressWindow.h
+++ b/Userland/Applications/Piano/ExportProgressWindow.h
@@ -17,7 +17,7 @@ class ExportProgressWindow : public GUI::Dialog {
 public:
     virtual ~ExportProgressWindow() override = default;
 
-    ErrorOr<void> initialize_fallibles();
+    ErrorOr<void> initialize();
 
     virtual void timer_event(Core::TimerEvent&) override;
 

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto wav_progress_window = ExportProgressWindow::construct(*window, wav_percent_written);
-    TRY(wav_progress_window->initialize_fallibles());
+    TRY(wav_progress_window->initialize());
 
     auto main_widget_updater = TRY(Core::Timer::create_repeating(static_cast<int>((1 / 30.0) * 1000), [&] {
         if (window->is_active())

--- a/Userland/Applications/Run/property-definitions.json
+++ b/Userland/Applications/Run/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "Run::MainWidget",
+        "header": "Applications/Run/MainWidget.h",
+        "description": "Run's main widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Applications/SpaceAnalyzer/property-definitions.json
+++ b/Userland/Applications/SpaceAnalyzer/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "SpaceAnalyzer::MainWidget",
+        "header": "Applications/SpaceAnalyzer/MainWidget.h",
+        "description": "SpaceAnalyzer's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "SpaceAnalyzer::TreeMapWidget",
+        "header": "Applications/SpaceAnalyzer/TreeMapWidget.h",
+        "description": "Tree map widget",
+        "inherits": "GUI::Frame"
+    }
+]

--- a/Userland/Applications/TerminalSettings/property-definitions.json
+++ b/Userland/Applications/TerminalSettings/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "TerminalSettings::MainWidget",
+        "header": "Applications/TerminalSettings/MainWidget.h",
+        "description": "Terminal main settings tab",
+        "inherits": "GUI::SettingsWindow::Tab"
+    },
+    {
+        "name": "TerminalSettings::ViewWidget",
+        "header": "Applications/TerminalSettings/ViewWidget.h",
+        "description": "Terminal view settings tab",
+        "inherits": "GUI::SettingsWindow::Tab"
+    }
+]

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -24,16 +24,7 @@
 
 namespace VideoPlayer {
 
-ErrorOr<NonnullRefPtr<VideoPlayerWidget>> VideoPlayerWidget::create()
-{
-    auto main_widget = TRY(try_create());
-
-    TRY(main_widget->setup_interface());
-
-    return main_widget;
-}
-
-ErrorOr<void> VideoPlayerWidget::setup_interface()
+ErrorOr<void> VideoPlayerWidget::initialize()
 {
     m_video_display = find_descendant_of_type_named<VideoPlayer::VideoFrameWidget>("video_frame");
     m_video_display->on_click = [&]() { toggle_pause(); };

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.gml
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.gml
@@ -25,7 +25,7 @@
 
                 @GUI::Button {
                     name: "playback"
-                    icon_from_path: "/res/icons/16x16/play.png"
+                    icon: "/res/icons/16x16/play.png"
                     fixed_width: 24
                     button_style: "Coolbar"
                 }
@@ -41,7 +41,7 @@
 
                 @GUI::Button {
                     name: "sizing"
-                    icon_from_path: "/res/icons/16x16/fit-image-to-view.png"
+                    icon: "/res/icons/16x16/fit-image-to-view.png"
                     fixed_width: 24
                     button_style: "Coolbar"
                 }
@@ -59,7 +59,7 @@
 
                 @GUI::Button {
                     name: "fullscreen"
-                    icon_from_path: "/res/icons/16x16/fullscreen.png"
+                    icon: "/res/icons/16x16/fullscreen.png"
                     fixed_width: 24
                     button_style: "Coolbar"
                 }

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -25,7 +25,7 @@ class VideoPlayerWidget final : public GUI::Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<VideoPlayerWidget>> try_create();
-    static ErrorOr<NonnullRefPtr<VideoPlayerWidget>> create();
+    ErrorOr<void> initialize();
     virtual ~VideoPlayerWidget() override = default;
     void close_file();
     void open_file(FileSystemAccessClient::File filename);
@@ -43,7 +43,6 @@ public:
 
 private:
     VideoPlayerWidget() = default;
-    ErrorOr<void> setup_interface();
     void update_play_pause_icon();
     void update_seek_slider_max();
     void set_current_timestamp(Duration);

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto main_widget = TRY(VideoPlayer::VideoPlayerWidget::create());
+    auto main_widget = TRY(VideoPlayer::VideoPlayerWidget::try_create());
     window->set_main_widget(main_widget);
     main_widget->update_title();
     TRY(main_widget->initialize_menubar(window));

--- a/Userland/Applications/VideoPlayer/property-definitions.json
+++ b/Userland/Applications/VideoPlayer/property-definitions.json
@@ -1,0 +1,31 @@
+[
+    {
+        "name": "VideoPlayer::VideoPlayerWidget",
+        "header": "Applications/VideoPlayer/VideoPlayerWidget.h",
+        "description": "Video player widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "VideoPlayer::VideoFrameWidget",
+        "header": "Applications/VideoPlayer/VideoFrameWidget.h",
+        "description": "Video frames display widget",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "auto_resize",
+                "description": "Whether the video should be automatically resized to fit in the widget",
+                "type": "bool"
+            },
+            {
+                "name": "sizing_mode",
+                "description": "How the video should be resized inside the widget",
+                "type": "VideoPlayer::VideoSizingMode"
+            },
+            {
+                "name": "bitmap",
+                "description": "'Video frame to display",
+                "type": "Gfx::Bitmap"
+            }
+        ]
+    }
+]

--- a/Userland/Games/Flood/property-definitions.json
+++ b/Userland/Games/Flood/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Flood::MainWidget",
+        "header": "Games/Flood/MainWidget.h",
+        "description": "Flood's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Flood::SettingsWidget",
+        "header": "Games/Flood/SettingsWidget.h",
+        "description": "Flood settings dialog widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Games/GameOfLife/property-definitions.json
+++ b/Userland/Games/GameOfLife/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "GameOfLife::MainWidget",
+        "header": "Games/GameOfLife/MainWidget.h",
+        "description": "GameOfLife's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GameOfLife::BoardWidget",
+        "header": "Games/GameOfLife/BoardWidget.h",
+        "description": "GameOfLife board",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Games/Hearts/CMakeLists.txt
+++ b/Userland/Games/Hearts/CMakeLists.txt
@@ -5,7 +5,7 @@ serenity_component(
     TARGETS Hearts
 )
 
-compile_gml(Hearts.gml HeartsGML.cpp)
+compile_gml(Hearts.gml HeartsGML.cpp PROPERTIES Userland/Libraries/LibCards)
 
 set(SOURCES
     Game.cpp

--- a/Userland/Games/Hearts/property-definitions.json
+++ b/Userland/Games/Hearts/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Hearts::MainWidget",
+        "header": "Games/Hearts/MainWidget.h",
+        "description": "Hearts' main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Hearts::Game",
+        "header": "Games/Hearts/Game.h",
+        "description": "Hearts' game widget",
+        "inherits": "Cards::CardGame"
+    }
+]

--- a/Userland/Games/MasterWord/property-definitions.json
+++ b/Userland/Games/MasterWord/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "MasterWord::MainWidget",
+        "header": "Games/MasterWord/MainWidget.h",
+        "description": "MasterWord's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "MasterWord::WordGame",
+        "header": "Games/MasterWord/WordGame.h",
+        "description": "MasterWord' game widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Games/Minesweeper/property-definitions.json
+++ b/Userland/Games/Minesweeper/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Minesweeper::MainWidget",
+        "header": "Games/Minesweeper/MainWidget.h",
+        "description": "Minesweeper's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Minesweeper::CustomGameWidget",
+        "header": "Games/Minesweeper/CustomGameWidget.h",
+        "description": "Minesweeper custom game dialog widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Games/Snake/CMakeLists.txt
+++ b/Userland/Games/Snake/CMakeLists.txt
@@ -4,7 +4,7 @@ serenity_component(
     TARGETS Snake
 )
 
-compile_gml(Snake.gml SnakeGML.cpp)
+compile_gml(Snake.gml SnakeGML.cpp PROPERTIES Userland/Libraries/LibCards)
 
 set(SOURCES
     Game.cpp

--- a/Userland/Games/Snake/property-definitions.json
+++ b/Userland/Games/Snake/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Snake::MainWidget",
+        "header": "Games/Snake/MainWidget.h",
+        "description": "Snake's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Snake::Game",
+        "header": "Games/Snake/Game.h",
+        "description": "Snake' game widget",
+        "inherits": "Cards::CardGame"
+    }
+]

--- a/Userland/Games/Solitaire/CMakeLists.txt
+++ b/Userland/Games/Solitaire/CMakeLists.txt
@@ -4,7 +4,7 @@ serenity_component(
     TARGETS Solitaire
 )
 
-compile_gml(Solitaire.gml SolitaireGML.cpp solitaire_gml)
+compile_gml(Solitaire.gml SolitaireGML.cpp PROPERTIES Userland/Libraries/LibCards)
 
 set(SOURCES
     Game.cpp

--- a/Userland/Games/Solitaire/property-definitions.json
+++ b/Userland/Games/Solitaire/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Solitaire::MainWidget",
+        "header": "Games/Solitaire/MainWidget.h",
+        "description": "Solitaire's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Solitaire::Game",
+        "header": "Games/Solitaire/Game.h",
+        "description": "Solitaire' game widget",
+        "inherits": "Cards::CardGame"
+    }
+]

--- a/Userland/Games/Spider/CMakeLists.txt
+++ b/Userland/Games/Spider/CMakeLists.txt
@@ -4,7 +4,7 @@ serenity_component(
     TARGETS Spider
 )
 
-compile_gml(Spider.gml SpiderGML.cpp spider_gml)
+compile_gml(Spider.gml SpiderGML.cpp PROPERTIES Userland/Libraries/LibCards)
 
 set(SOURCES
     Game.cpp

--- a/Userland/Games/Spider/property-definitions.json
+++ b/Userland/Games/Spider/property-definitions.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Spider::MainWidget",
+        "header": "Games/Spider/MainWidget.h",
+        "description": "Spider's main widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "Spider::Game",
+        "header": "Games/Spider/Game.h",
+        "description": "Spider' game widget",
+        "inherits": "Cards::CardGame"
+    }
+]

--- a/Userland/Libraries/LibCards/property-definitions.json
+++ b/Userland/Libraries/LibCards/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "Cards::CardGame",
+        "header": "Libraries/LibCards/CardGame.h",
+        "description": "Base class of card game widgets",
+        "inherits": "GUI::Frame"
+    }
+]

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -42,7 +42,6 @@ Button::Button(String text)
         { Gfx::ButtonStyle::Normal, "Normal" },
         { Gfx::ButtonStyle::Coolbar, "Coolbar" });
 
-    REGISTER_WRITE_ONLY_STRING_PROPERTY("icon", set_icon_from_path);
     REGISTER_BOOL_PROPERTY("default", is_default, set_default);
 }
 
@@ -184,16 +183,6 @@ void Button::set_icon(RefPtr<Gfx::Bitmap const> icon)
         return;
     m_icon = move(icon);
     update();
-}
-
-void Button::set_icon_from_path(ByteString const& path)
-{
-    auto maybe_bitmap = Gfx::Bitmap::load_from_file(path);
-    if (maybe_bitmap.is_error()) {
-        dbgln("Unable to load bitmap `{}` for button icon", path);
-        return;
-    }
-    set_icon(maybe_bitmap.release_value());
 }
 
 bool Button::is_uncheckable() const

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -29,7 +29,6 @@ public:
     virtual ~Button() override;
 
     void set_icon(RefPtr<Gfx::Bitmap const>);
-    void set_icon_from_path(ByteString const&);
     Gfx::Bitmap const* icon() const { return m_icon.ptr(); }
 
     void set_text_alignment(Gfx::TextAlignment text_alignment) { m_text_alignment = text_alignment; }

--- a/Userland/Libraries/LibGUI/DynamicWidgetContainerControls.gml
+++ b/Userland/Libraries/LibGUI/DynamicWidgetContainerControls.gml
@@ -12,7 +12,7 @@
         button_style: "Coolbar"
         preferred_width: "shrink"
         preferred_height: "shrink"
-        icon_from_path: "/res/icons/16x16/detach.png"
+        icon: "/res/icons/16x16/detach.png"
     }
 
     @GUI::Button {
@@ -20,7 +20,7 @@
         button_style: "Coolbar"
         preferred_width: "shrink"
         preferred_height: "shrink"
-        icon_from_path: "/res/icons/16x16/upward-triangle.png"
+        icon: "/res/icons/16x16/upward-triangle.png"
     }
 
     @GUI::Button {
@@ -28,6 +28,6 @@
         button_style: "Coolbar"
         preferred_width: "shrink"
         preferred_height: "shrink"
-        icon_from_path: "/res/icons/16x16/downward-triangle.png"
+        icon: "/res/icons/16x16/downward-triangle.png"
     }
 }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -71,27 +71,12 @@ enum class AllowCallback {
     Yes
 };
 
-template<typename T>
-concept HasFalliblesInitializer = requires(T object) {
-    {
-        object.initialize_fallibles()
-    } -> SameAs<ErrorOr<void>>;
+auto initialize = [](auto& object) -> ErrorOr<void> {
+    if constexpr (requires { { object.initialize() } -> SameAs<ErrorOr<void>>; })
+        return object.initialize();
+    else
+        return {};
 };
-
-template<typename T>
-requires(HasFalliblesInitializer<T>)
-ErrorOr<void> initialize_fallibles(T& object)
-{
-    return object.initialize_fallibles();
-}
-
-template<typename T>
-requires(!HasFalliblesInitializer<T>)
-ErrorOr<void> initialize_fallibles(T& object)
-{
-    (void)object;
-    return {};
-}
 
 class Widget : public GUI::Object {
     C_OBJECT(Widget)

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -71,6 +71,28 @@ enum class AllowCallback {
     Yes
 };
 
+template<typename T>
+concept HasFalliblesInitializer = requires(T object) {
+    {
+        object.initialize_fallibles()
+    } -> SameAs<ErrorOr<void>>;
+};
+
+template<typename T>
+requires(HasFalliblesInitializer<T>)
+ErrorOr<void> initialize_fallibles(T& object)
+{
+    return object.initialize_fallibles();
+}
+
+template<typename T>
+requires(!HasFalliblesInitializer<T>)
+ErrorOr<void> initialize_fallibles(T& object)
+{
+    (void)object;
+    return {};
+}
+
 class Widget : public GUI::Object {
     C_OBJECT(Widget)
 public:

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -71,7 +71,7 @@ enum class AllowCallback {
     Yes
 };
 
-auto initialize = [](auto& object) -> ErrorOr<void> {
+inline auto initialize = [](auto& object) -> ErrorOr<void> {
     if constexpr (requires { { object.initialize() } -> SameAs<ErrorOr<void>>; })
         return object.initialize();
     else

--- a/Userland/Libraries/LibGUI/property-definitions.json
+++ b/Userland/Libraries/LibGUI/property-definitions.json
@@ -1,0 +1,1080 @@
+[
+    {
+        "name": "GUI::Object",
+        "header": "LibGUI/Object.h",
+        "description": "Base class for GUI objects",
+        "properties": [
+            {
+                "name": "name",
+                "description": "Unique name of the widget, used to quickly access the widget via code later",
+                "type": "ByteString"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Widget",
+        "header": "LibGUI/Widget.h",
+        "description": "Base of all UI elements",
+        "inherits": "GUI::Object",
+        "properties": [
+            {
+                "name": "x",
+                "description": "x offset relative to parent",
+                "type": "i64"
+            },
+            {
+                "name": "y",
+                "description": "y offset relative to parent",
+                "type": "i64"
+            },
+            {
+                "name": "visible",
+                "description": "Whether widget and children are drawn",
+                "type": "bool"
+            },
+            {
+                "name": "focused",
+                "description": "Whether widget should be tab-focused on start",
+                "type": "bool"
+            },
+            {
+                "name": "auto_focusable",
+                "description": "Whether widget can be tab-focused",
+                "type": "bool"
+            },
+            {
+                "name": "focus_policy",
+                "description": "How the widget can receive focus",
+                "type": "GUI::FocusPolicy"
+            },
+            {
+                "name": "enabled",
+                "description": "Whether this widget is enabled for interactive purposes, e.g. can be clicked",
+                "type": "bool"
+            },
+            {
+                "name": "updates_enabled",
+                "description": "Whether this widget updates when its content changes",
+                "type": "bool"
+            },
+            {
+                "name": "title",
+                "description": "Title of the widget, used in various containers like tabs and dynamic containers",
+                "type": "String"
+            },
+            {
+                "name": "tooltip",
+                "description": "Mouse tooltip to show when hovering over this widget",
+                "type": "String"
+            },
+            {
+                "name": "cursor",
+                "description": "Mouse tooltip to show when hovering over this widget",
+                "type": "Variant<Gfx::StandardCursor, Gfx::Bitmap>"
+            },
+            {
+                "name": "grabbable_margins",
+                "description": "Margins within the widget which are grabbable, if the widget can be resized by the user",
+                "type": "Array<GUI::UIDimension>",
+                "min_values": 1,
+                "max_values": 4
+            },
+            {
+                "name": "min_size",
+                "description": "Minimum size the widget wants to occupy",
+                "type": "Array<GUI::UIDimension>",
+                "min_values": 2,
+                "max_values": 2
+            },
+            {
+                "name": "max_size",
+                "description": "Maximum size the widget wants to occupy",
+                "type": "Array<GUI::UIDimension>",
+                "min_values": 2,
+                "max_values": 2
+            },
+            {
+                "name": "preferred_size",
+                "description": "Preferred size this widget wants to occupy, if not otherwise constrained (Shrink means min_size)",
+                "type": "Array<GUI::UIDimension>",
+                "min_values": 2,
+                "max_values": 2
+            },
+            {
+                "name": "width",
+                "description": "Width of the widget, independent of its layout size calculation",
+                "type": "i64"
+            },
+            {
+                "name": "height",
+                "description": "Height of the widget, independent of its layout size calculation",
+                "type": "i64"
+            },
+            {
+                "name": "min_width",
+                "description": "Minimum width this widget wants to occupy (Shrink is equivalent to 0)",
+                "type": "GUI::UIDimension"
+            },
+            {
+                "name": "min_height",
+                "description": "Minimum height this widget wants to occupy (Shrink is equivalent to 0)",
+                "type": "GUI::UIDimension"
+            },
+            {
+                "name": "max_width",
+                "description": "Maximum width this widget wants to occupy",
+                "type": "GUI::UIDimension"
+            },
+            {
+                "name": "max_height",
+                "description": "Maximum height this widget wants to occupy",
+                "type": "GUI::UIDimension"
+            },
+            {
+                "name": "preferred_width",
+                "description": "Preferred width this widget wants to occupy, if not otherwise constrained (Shrink means min_width)",
+                "type": "GUI::UIDimension"
+            },
+            {
+                "name": "preferred_height",
+                "description": "Preferred height this widget wants to occupy, if not otherwise constrained (Shrink means min_height)",
+                "type": "GUI::UIDimension"
+            },
+            {
+                "name": "fixed_width",
+                "description": "Both maximum and minimum width; widget is fixed-width",
+                "type": "i64"
+            },
+            {
+                "name": "fixed_height",
+                "description": "Both maximum and minimum height; widget is fixed-height",
+                "type": "i64"
+            },
+            {
+                "name": "fixed_size",
+                "description": "Both maximum and minimum size; widget is fixed-size",
+                "type": "Array<i64>",
+                "min_values": 2,
+                "max_values": 2
+            },
+            {
+                "name": "shrink_to_fit",
+                "description": "Whether the widget shrinks as much as possible while still respecting its children's minimum sizes",
+                "type": "bool"
+            },
+            {
+                "name": "font",
+                "description": "Font family",
+                "type": "String"
+            },
+            {
+                "name": "font_size",
+                "description": "Font size",
+                "type": "i64"
+            },
+            {
+                "name": "font_weight",
+                "description": "Font weight",
+                "type": "Gfx::FontWeight"
+            },
+            {
+                "name": "font_fixed_width",
+                "description": "Whether font is fixed width",
+                "type": "bool"
+            },
+            {
+                "name": "foreground_color",
+                "description": "Color of foreground elements such as text",
+                "type": "Gfx::Color"
+            },
+            {
+                "name": "foreground_role",
+                "description": "Palette color role (depends on system theme) for the foreground elements",
+                "type": "Gfx::ColorRole"
+            },
+            {
+                "name": "background_color",
+                "description": "Color of the widget background",
+                "type": "Gfx::Color"
+            },
+            {
+                "name": "background_role",
+                "description": "Palette color role (depends on system theme) for the widget background",
+                "type": "Gfx::ColorRole"
+            },
+            {
+                "name": "fill_with_background_color",
+                "description": "Whether to fill the widget's background with the background color",
+                "type": "bool"
+            },
+            {
+                "name": "relative_rect",
+                "description": "Rectangle for relatively positioning the widget to the parent",
+                "type": "Array<i64>",
+                "min_values": 4,
+                "max_values": 4
+            }
+        ]
+    },
+    {
+        "name": "GUI::Frame",
+        "header": "LibGUI/Frame.h",
+        "description": "Container widget with a framed border",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "frame_style",
+                "description": "Visual style of the frame's border",
+                "type": "Gfx::FrameStyle"
+            }
+        ]
+    },
+    {
+        "name": "GUI::GroupBox",
+        "header": "LibGUI/GroupBox.h",
+        "description": "Container widget with a titled border",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GUI::Breadcrumbbar",
+        "header": "LibGUI/Breadcrumbbar.h",
+        "description": "Bread crumb toolbar widget",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GUI::RadioButton",
+        "header": "LibGUI/RadioButton.h",
+        "description": "Radio button / check box",
+        "inherits": "GUI::AbstractButton"
+    },
+    {
+        "name": "GUI::Toolbar",
+        "header": "LibGUI/Toolbar.h",
+        "description": "Toolbar. When `collapsible` is set to `true`, the toolbar can be resized below the size of its items. Any items that do not fit the current size, will be placed in an overflow menu. To keep groups (i.e. Buttons/items separated by Separators) together, and move them to the overflow menu as one, set the `grouped` property.",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "collapsible",
+                "description": "If items that do not fit should be placed in an overflow menu",
+                "type": "bool"
+            },
+            {
+                "name": "grouped",
+                "description": "If items should be moved to the overflow menu in groups, separated by Separator items",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::ToolbarContainer",
+        "header": "LibGUI/ToolbarContainer.h",
+        "description": "Container for a tool bar",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GUI::AbstractScrollableWidget",
+        "header": "LibGUI/AbstractScrollableWidget.h",
+        "description": "Base class for scrollable widgets",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "scrollbars_enabled",
+                "getter": "is_scrollbars_enabled",
+                "description": "Whether scroll bars are visible",
+                "type": "bool"
+            },
+            {
+                "name": "should_hide_unnecessary_scrollbars",
+                "description": "Whether unnecessary scroll bars should be hidden, if the contained widget doesn't occupy more than the widget's area",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::AbstractView",
+        "header": "LibGUI/AbstractView.h",
+        "description": "Base class for widgets that use ModelViews to display some underlying dynamic content",
+        "inherits": "GUI::AbstractScrollableWidget",
+        "properties": [
+            {
+                "name": "activates_on_selection",
+                "description": "Whether the widget activates when an element is selected",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::AbstractTableView",
+        "header": "LibGUI/AbstractTableView.h",
+        "description": "Base class for table-like views",
+        "inherits": "GUI::AbstractView"
+    },
+    {
+        "name": "GUI::TableView",
+        "header": "LibGUI/TableView.h",
+        "description": "Display content in a table",
+        "inherits": "GUI::AbstractTableView",
+        "properties": [
+            {
+                "name": "grid_style",
+                "description": "Style of the table grid",
+                "type": "GUI::TableView::GridStyle"
+            },
+            {
+                "name": "highlight_key_column",
+                "getter": "is_key_column_highlighted",
+                "description": "Whether to highlight the current key column (the column the table is sorted by)",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::ListView",
+        "header": "LibGUI/ListView.h",
+        "description": "Display content in a list",
+        "inherits": "GUI::AbstractView",
+        "properties": [
+            {
+                "name": "alternating_row_colors",
+                "description": "Whether to use alternating row colors for the list",
+                "type": "bool"
+            },
+            {
+                "name": "hover_highlighting",
+                "description": "Whether to highlight elements on hover",
+                "type": "bool"
+            },
+            {
+                "name": "item_height",
+                "description": "Height of rows",
+                "type": "i64"
+            },
+            {
+                "name": "horizontal_padding",
+                "description": "Padding between columns",
+                "type": "i64"
+            },
+            {
+                "name": "vertical_padding",
+                "description": "Padding between rows",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::TreeView",
+        "header": "LibGUI/TreeView.h",
+        "description": "Container for displaying items in an interactive tree",
+        "inherits": "GUI::AbstractTableView"
+    },
+    {
+        "name": "GUI::IconView",
+        "header": "LibGUI/IconView.h",
+        "description": "Container for displaying items as icons in a grid",
+        "inherits": "GUI::AbstractView",
+        "properties": [
+            {
+                "name": "flow_direction",
+                "description": "Flow direction of the icons",
+                "type": "GUI::IconView::FlowDirection"
+            },
+            {
+                "name": "always_wrap_item_labels",
+                "description": "Whether to always wrap item labels instead of eliding them",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Statusbar",
+        "header": "LibGUI/Statusbar.h",
+        "description": "Status bar for displaying textual application status",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "text",
+                "description": "Status text",
+                "type": "String"
+            },
+            {
+                "name": "segment_count",
+                "description": "Number of segments within the status bar",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::TextEditor",
+        "header": "LibGUI/TextEditor.h",
+        "description": "Text input widget",
+        "inherits": "GUI::AbstractScrollableWidget",
+        "properties": [
+            {
+                "name": "placeholder",
+                "description": "Placeholder text that is displayed when the text editor is empty",
+                "type": "ByteString"
+            },
+            {
+                "name": "visualize_trailing_whitespace",
+                "description": "Whether to visualize trailing whitespace (usually) with red background",
+                "type": "bool"
+            },
+            {
+                "name": "visualize_leading_whitespace",
+                "description": "Whether to visualize leading whitespace",
+                "type": "bool"
+            },
+            {
+                "name": "automatic_indentation_enabled",
+                "description": "Whether to enable automatic indentation when the user inserts a new line",
+                "type": "bool"
+            },
+            {
+                "name": "soft_tab_width",
+                "description": "Soft tab width",
+                "type": "i64"
+            },
+            {
+                "name": "wrapping_mode",
+                "description": "What to do when the line length exceeds the visual area",
+                "type": "GUI::TextEditor::WrappingMode"
+            },
+            {
+                "name": "text_alignment",
+                "description": "Alignment of contained text",
+                "type": "Gfx::TextAlignment"
+            },
+            {
+                "name": "mode",
+                "description": "Whether text can be selected and/or edited",
+                "type": "GUI::TextEditor::Mode"
+            },
+            {
+                "name": "relative_line_number",
+                "description": "Whether to display line numbers relative to the current cursor position",
+                "type": "bool"
+            },
+            {
+                "name": "ruler_visible",
+                "description": "Whether to display the line number ruler",
+                "type": "bool"
+            },
+            {
+                "name": "icon",
+                "description": "Icon to display in front of the line of a single-line text editor",
+                "type": "Gfx::Bitmap"
+            },
+            {
+                "name": "text",
+                "description": "Content text",
+                "type": "ByteString"
+            }
+        ]
+    },
+    {
+        "name": "GUI::TextBox",
+        "header": "LibGUI/TextBox.h",
+        "description": "Single-line text input",
+        "inherits": "GUI::TextEditor",
+        "properties": [
+            {
+                "name": "history_enabled",
+                "description": "Whether the user can see a list of previous inputs into this text box",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::AbstractButton",
+        "header": "LibGUI/AbstractButton.h",
+        "description": "Base class of button-like (clickable) input widgets",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "text",
+                "description": "Label text of the widget",
+                "type": "String"
+            },
+            {
+                "name": "exclusive",
+                "getter": "is_exclusive",
+                "description": "Whether the button's check state is exclusive to its group; this only applies to checkable subclasses",
+                "type": "bool"
+            },
+            {
+                "name": "checkable",
+                "getter": "is_checkable",
+                "description": "Whether the button can be checked; this only applies to checkable subclasses",
+                "type": "bool"
+            },
+            {
+                "name": "checked",
+                "getter": "is_checked",
+                "description": "Whether the button is checked; this only applies to checkable subclasses",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::AbstractSlider",
+        "header": "LibGUI/AbstractSlider.h",
+        "description": "Base class of slider inputs",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "orientation",
+                "description": "Slider orientation",
+                "type": "Gfx::Orientation"
+            },
+            {
+                "name": "value",
+                "description": "Current value",
+                "type": "i64"
+            },
+            {
+                "name": "min",
+                "description": "Minimum value",
+                "type": "i64"
+            },
+            {
+                "name": "max",
+                "description": "Maximum value",
+                "type": "i64"
+            },
+            {
+                "name": "step",
+                "description": "Step size for scroll inputs",
+                "type": "i64"
+            },
+            {
+                "name": "page_step",
+                "description": "Step size when scrolling an entire page",
+                "type": "i64"
+            },
+            {
+                "name": "jump_to_cursor",
+                "description": "Whether to jump to the cursor when a click happens off the scroll knob",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Slider",
+        "header": "LibGUI/Slider.h",
+        "description": "Generic slider input",
+        "inherits": "GUI::AbstractSlider",
+        "properties": [
+            {
+                "name": "knob_size_mode",
+                "description": "Size mode of the knob",
+                "type": "GUI::Slider::KnobSizeMode"
+            }
+        ]
+    },
+    {
+        "name": "GUI::VerticalSlider",
+        "header": "LibGUI/Slider.h",
+        "description": "Vertical slider input",
+        "inherits": "GUI::Slider"
+    },
+    {
+        "name": "GUI::HorizontalSlider",
+        "header": "LibGUI/HorizontalSlider.h",
+        "description": "Horizontal slider input",
+        "inherits": "GUI::Slider"
+    },
+    {
+        "name": "GUI::OpacitySlider",
+        "header": "LibGUI/OpacitySlider.h",
+        "description": "Slider for changing an opacity",
+        "inherits": "GUI::AbstractSlider",
+        "properties": [
+            {
+                "name": "base_color",
+                "description": "Base (non-transparent) color of the slider",
+                "type": "Gfx::Color"
+            }
+        ]
+    },
+    {
+        "name": "GUI::VerticalOpacitySlider",
+        "header": "LibGUI/OpacitySlider.h",
+        "description": "Vertical opacity slider input",
+        "inherits": "GUI::OpacitySlider"
+    },
+    {
+        "name": "GUI::HorizontalOpacitySlider",
+        "header": "LibGUI/OpacitySlider.h",
+        "description": "Horizontal opacity slider input",
+        "inherits": "GUI::OpacitySlider"
+    },
+    {
+        "name": "GUI::Button",
+        "header": "LibGUI/Button.h",
+        "description": "Button",
+        "inherits": "GUI::AbstractButton",
+        "properties": [
+            {
+                "name": "button_style",
+                "description": "Style of the button",
+                "type": "Gfx::ButtonStyle"
+            },
+            {
+                "name": "icon",
+                "description": "Icon to display in front of the button text",
+                "type": "Gfx::Bitmap"
+            },
+            {
+                "name": "text_alignment",
+                "description": "Alignment of button text",
+                "type": "Gfx::TextAlignment"
+            },
+            {
+                "name": "default",
+                "getter": "is_default",
+                "description": "Whether this button is the default button to be activated when the user presses enter in a dialog",
+                "type": "bool"
+            },
+            {
+                "name": "icon_spacing",
+                "description": "Set the spacing between the icon and the text",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::DialogButton",
+        "header": "LibGUI/Button.h",
+        "description": "Button for use in dialog windows",
+        "inherits": "GUI::Button"
+    },
+    {
+        "name": "GUI::CheckBox",
+        "header": "LibGUI/CheckBox.h",
+        "description": "Checkbox",
+        "inherits": "GUI::AbstractButton",
+        "properties": [
+            {
+                "name": "autosize",
+                "getter": "is_autosize",
+                "description": "Whether the checkbox autosizes to fit the text",
+                "type": "bool"
+            },
+            {
+                "name": "checkbox_position",
+                "description": "Position of the checkbox relative to the text",
+                "type": "GUI::CheckBox::CheckBoxPosition"
+            }
+        ]
+    },
+    {
+        "name": "GUI::ImageWidget",
+        "header": "LibGUI/ImageWidget.h",
+        "description": "Displays an image",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "bitmap",
+                "description": "Image to display",
+                "type": "Gfx::Bitmap"
+            },
+            {
+                "name": "should_stretch",
+                "description": "Whether the image should be stretched to fill the widget",
+                "type": "bool"
+            },
+            {
+                "name": "auto_resize",
+                "description": "Whether the image should be automatically resized to fit in the widget",
+                "type": "bool"
+            },
+            {
+                "name": "opacity_percent",
+                "description": "Opacity of the image in percent",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Label",
+        "header": "LibGUI/Label.h",
+        "description": "Text label",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "text",
+                "description": "Label text",
+                "type": "String"
+            },
+            {
+                "name": "text_alignment",
+                "description": "Alignment of label text",
+                "type": "Gfx::TextAlignment"
+            },
+            {
+                "name": "text_wrapping",
+                "description": "Wrapping behavior of label text",
+                "type": "Gfx::TextWrapping"
+            },
+            {
+                "name": "autosize",
+                "getter": "is_autosize",
+                "description": "Whether label auto-sizes",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::LabelWithEventDispatcher",
+        "header": "LibGUI/LabelWithEventDispatcher.h",
+        "description": "Text label with callbacks for mouse events",
+        "inherits": "GUI::Label"
+    },
+    {
+        "name": "GUI::LinkLabel",
+        "header": "LibGUI/LinkLabel.h",
+        "description": "Label with a clickable hyperlink",
+        "inherits": "GUI::Label"
+    },
+    {
+        "name": "GUI::ComboBox",
+        "header": "LibGUI/ComboBox.h",
+        "description": "Text combo box with a dropdown and selection of possible inputs",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "text",
+                "description": "Combo box text",
+                "type": "ByteString"
+            },
+            {
+                "name": "editor_placeholder",
+                "description": "Placeholder in the combo box text editor when no text was input",
+                "type": "ByteString"
+            },
+            {
+                "name": "only_allow_values_from_model",
+                "description": "Whether only values from the model can be input into the combo box",
+                "type": "bool"
+            },
+            {
+                "name": "max_visible_items",
+                "description": "Maximum number of visible items in the combo box list",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::NumericInput",
+        "header": "LibGUI/NumericInput.h",
+        "description": "Number input field",
+        "inherits": "GUI::TextBox",
+        "properties": [
+            {
+                "name": "value",
+                "description": "Current value",
+                "type": "i64"
+            },
+            {
+                "name": "min",
+                "description": "Minimum value",
+                "type": "i64"
+            },
+            {
+                "name": "max",
+                "description": "Maximum value",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::SpinBox",
+        "header": "LibGUI/SpinBox.h",
+        "description": "Number input field with an up-down spinner",
+        "inherits": "GUI::NumericInput"
+    },
+    {
+        "name": "GUI::PasswordBox",
+        "header": "LibGUI/TextBox.h",
+        "description": "Text box for inputting passwords or other sensitive text",
+        "inherits": "GUI::TextBox",
+        "properties": [
+            {
+                "name": "show_reveal_button",
+                "getter": "is_showing_reveal_button",
+                "description": "Whether to show the reveal button that allows viewing the clear text",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Progressbar",
+        "header": "LibGUI/Progressbar.h",
+        "description": "Progress bar",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "text",
+                "description": "Label text",
+                "type": "ByteString"
+            },
+            {
+                "name": "orientation",
+                "description": "Orientation of the bar",
+                "type": "Gfx::Orientation"
+            },
+            {
+                "name": "format",
+                "description": "Display format of the bar",
+                "type": "GUI:Progressbar::Format"
+            },
+            {
+                "name": "value",
+                "description": "Current value",
+                "type": "i64"
+            },
+            {
+                "name": "min",
+                "description": "Minimum value",
+                "type": "i64"
+            },
+            {
+                "name": "max",
+                "description": "Maximum value",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::ColorInput",
+        "header": "LibGUI/ColorInput.h",
+        "description": "Widget for selecting a color",
+        "inherits": "GUI::TextEditor",
+        "properties": [
+            {
+                "name": "color",
+                "description": "Current color of the color picker",
+                "type": "Gfx::Color"
+            },
+            {
+                "name": "has_alpha_channel",
+                "setter": "set_color_has_alpha_channel",
+                "description": "Whether the color has a selectable alpha channel",
+                "type": "bool"
+            },
+            {
+                "name": "color_picker_title",
+                "description": "Title of the color picker",
+                "type": "ByteString"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Splitter",
+        "header": "LibGUI/Splitter.h",
+        "description": "Container widget whose contents will be split by a user-adjustable splitter bar",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "opportunistic_resizee",
+                "description": "Which of the two contained widgets will resize when the available space changes; the other one will keep its size if possible",
+                "type": "GUI::Splitter::OpportunisticResizee"
+            }
+        ]
+    },
+    {
+        "name": "GUI::HorizontalSplitter",
+        "header": "LibGUI/Splitter.h",
+        "description": "Horizontal splitter",
+        "inherits": "GUI::Splitter"
+    },
+    {
+        "name": "GUI::VerticalSplitter",
+        "header": "LibGUI/Splitter.h",
+        "description": "Vertical splitter",
+        "inherits": "GUI::Splitter"
+    },
+    {
+        "name": "GUI::SeparatorWidget",
+        "header": "LibGUI/SeparatorWidget.h",
+        "description": "Widget that inserts a visual separator line",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GUI::HorizontalSeparator",
+        "header": "LibGUI/SeparatorWidget.h",
+        "description": "Horizontal separator",
+        "inherits": "GUI::SeparatorWidget"
+    },
+    {
+        "name": "GUI::VerticalSeparator",
+        "header": "LibGUI/SeparatorWidget.h",
+        "description": "Vertical separator",
+        "inherits": "GUI::SeparatorWidget"
+    },
+    {
+        "name": "GUI::TabWidget",
+        "header": "LibGUI/TabWidget.h",
+        "description": "Widget with one tab per child, uses the child titles to label each tab",
+        "inherits": "GUI::Widget",
+        "properties": [
+            {
+                "name": "container_margins",
+                "description": "Margins for the tab content",
+                "type": "GUI::Margins"
+            },
+            {
+                "name": "reorder_allowed",
+                "description": "Allow changing the order of the tabs",
+                "type": "bool"
+            },
+            {
+                "name": "show_close_buttons",
+                "description": "Show a close button on each tab",
+                "getter": "close_button_enabled",
+                "setter": "set_close_button_enabled",
+                "type": "bool"
+            },
+            {
+                "name": "show_tab_bar",
+                "description": "Whether to display the tabs",
+                "getter": "is_bar_visible",
+                "setter": "set_bar_visible",
+                "type": "bool"
+            },
+            {
+                "name": "text_alignment",
+                "description": "Alignment of tab text",
+                "type": "Gfx::TextAlignment"
+            },
+            {
+                "name": "tab_position",
+                "description": "Give all tabs the same width",
+                "type": "Gfx::TabPosition"
+            },
+            {
+                "name": "uniform_tabs",
+                "description": "Give all tabs the same width",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::Calendar",
+        "header": "LibGUI/Calendar.h",
+        "description": "Displays a calendar",
+        "inherits": "GUI::AbstractScrollableWidget",
+        "properties": [
+            {
+                "name": "grid",
+                "getter": "has_grid",
+                "description": "Whether the calendar has a grid separating dates",
+                "type": "bool"
+            },
+            {
+                "name": "show_year",
+                "getter": "is_showing_year",
+                "description": "Whether the year is displayed",
+                "type": "bool"
+            },
+            {
+                "name": "show_month_and_year",
+                "getter": "is_showing_month_and_year",
+                "description": "Whether month and year are displayed",
+                "type": "bool"
+            },
+            {
+                "name": "show_days_of_the_week",
+                "getter": "is_showing_days_of_the_week",
+                "description": "Whether the days of the week are displayed",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::SettingsWindow::Tab",
+        "header": "LibGUI/SettingsWindow.h",
+        "description": "Tab of a settings window",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GUI::DynamicWidgetContainer",
+        "header": "LibGUI/DynamicWidgetContainer.h",
+        "description": "Defines a container widget that will group its child widgets together so that they can be collapsed, expanded or detached to a new window as one unit. If DynamicWidgetContainers are nested within one DynamicWidgetContainer it is possible to move the positions of the child containers dynamically",
+        "inherits": "GUI::Frame",
+        "properties": [
+            {
+                "name": "view_state",
+                "description": "Initial view state",
+                "type": "GUI::DynamicWidgetContainer::ViewState"
+            },
+            {
+                "name": "section_label",
+                "description": "The label that will be used for the section",
+                "type": "String"
+            },
+            {
+                "name": "config_domain",
+                "description": "Defines if the changes to the widget's view state should be persisted. It is required that the domain has been already pleged by the application",
+                "type": "String"
+            },
+            {
+                "name": "controls",
+                "description": "Defines if the buttons and label should be visible or not. This allows e.g. a parent container to hide its controls but provide rearrenage functionality",
+                "type": "bool"
+            },
+            {
+                "name": "with_individual_order",
+                "getter": "is_container_with_individual_order",
+                "description": "",
+                "type": "bool"
+            },
+            {
+                "name": "view_state",
+                "description": "",
+                "type": "bool"
+            }
+        ]
+    },
+    {
+        "name": "GUI::DynamicWidgetContainerControls",
+        "header": "LibGUI/DynamicWidgetContainerControls.h",
+        "description": "Controls of a dynamic widget container",
+        "inherits": "GUI::Widget"
+    },
+    {
+        "name": "GUI::Layout",
+        "header": "LibGUI/Layout.h",
+        "description": "Base class of layout objects, not to be used directly",
+        "inherits": "GUI::Object",
+        "properties": [
+            {
+                "name": "margins",
+                "description": "Margins inside the container widget to the children",
+                "type": "GUI::Margins"
+            },
+            {
+                "name": "spacing",
+                "description": "Spacing between each inner widget",
+                "type": "i64"
+            }
+        ]
+    },
+    {
+        "name": "GUI::HorizontalBoxLayout",
+        "header": "LibGUI/BoxLayout.h",
+        "description": "Lays out elements horizontally within a container widget",
+        "inherits": "GUI::Layout"
+    },
+    {
+        "name": "GUI::VerticalBoxLayout",
+        "header": "LibGUI/BoxLayout.h",
+        "description": "Lays out elements vertically within a container widget",
+        "inherits": "GUI::Layout"
+    },
+    {
+        "name": "GUI::Layout::Spacer",
+        "header": "LibGUI/Layout.h",
+        "description": "Pseudo-widget that inserts empty space into the layout"
+    }
+]

--- a/Userland/Libraries/LibWebView/property-definitions.json
+++ b/Userland/Libraries/LibWebView/property-definitions.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "WebView::OutOfProcessWebView",
+        "header": "LibWebView/OutOfProcessWebView.h",
+        "description": "Display a website within a widget, rendered out-of-process",
+        "inherits": "GUI::AbstractScrollableWidget",
+        "properties": [
+            {
+                "name": "content_scales_to_viewport",
+                "description": "Whether the content scales to the viewport",
+                "type": "bool"
+            },
+            {
+                "name": "system_visibility_state",
+                "type": "bool"
+            }
+        ]
+    }
+]

--- a/Userland/Services/LoginServer/property-definitions.json
+++ b/Userland/Services/LoginServer/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "LoginServer::Widget",
+        "header": "Services/LoginServer/Widget.h",
+        "description": "LoginServer's login widget",
+        "inherits": "GUI::Widget"
+    }
+]

--- a/Userland/Services/NotificationServer/property-definitions.json
+++ b/Userland/Services/NotificationServer/property-definitions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "NotificationServer::NotificationWidget",
+        "header": "Services/NotificationServer/NotificationWidget.h",
+        "description": "NotificationServer's login widget",
+        "inherits": "GUI::Widget"
+    }
+]


### PR DESCRIPTION
*Note to scared reviewers: Most of this PR (>1000 lines) is the LibGUI property definition JSON. You may glance over this; the GMLCompiler checks that it's valid and so you may rely on CI for this.*

Property definitions complement GML and widgets in that they define what properties are legal on widgets, what their types are etc. This is an MVP for using this format to check GML even more strongly in the GML compiler and remove all of its accumulated edge cases.

CC @AtkinsSJ

### GMLCompiler+LibGUI: Add new property definition format

This property definition format defines widgets and their properties in
simple JSON. Apart from the description, it currently contains the bare
minimum amount of information to allow the GMLCompiler to generate
correct code without special-casing many properties and widgets. In
particular:
- Widgets define their header file, so no more special cases for widgets
  that live in unexpected places.
- Properties define their type, removing all of the many special cases
  for non-primitive types. This also allows the GML compiler to check
  that the type is correct before even generating invalid C++ code.
- Properties may define non-standard getters and setters, removing these
  special cases. (While some getters and setters should use a standard
  name, others are fine staying the way they are.)
- Property definitions are per library or application, and may be reused
  freely. In combination with the widget inheritance system, this keeps
  necessary property definitions to a minimum.

The format is designed to support three further uses later on:
- Automatically generate widget manpages; this is why the description
  key exists and is already populated with existing documentation where
  available.
- Automatically generate `REGISTER_*_PROPERTY` and `REGISTER_WIDGET` for
  dynamic GML loading. This would also ensure that compiled and dynamic
  GML provide the exact same properties.
- Autocomplete properties and widgets in GMLPlayground and HackStudio,
  complete with descriptions.

Since these are involved features on their own, they are not added here.
This is a minimum viable product, and properties and widgets from the
core LibGUI may still be missing.

### LibGUI: Remove Button::set_icon_from_path workaround

This was a workaround for the dynamic GML loading system that only had
one remaining (relatively recent) user. The GML compiler knows to use
bitmap loading for the icon property, which results in no behavior
change (the icon is still only actually loaded at runtime).

Icon loading using the dynamic GML loading system is currently broken,
but it already was before this commit. This change merely prevents
anyone from using the API in the future; the icon loading capability
will be reintroduced into the dynamic GML loading system with the use of
the property description system.