### PR TITLE
LibC: Add test for mkdir() without cpath pledge

### DIFF
--- a/Tests/LibC/TestMkDir.cpp
+++ b/Tests/LibC/TestMkDir.cpp
@@ -63,14 +63,12 @@ TEST_CASE(parent_is_file)
 
 TEST_CASE(pledge)
 {
-    int res = pledge("stdio cpath", nullptr);
+    int res = pledge("stdio proc cpath", nullptr);
     EXPECT(res == 0);
 
     auto dirname = random_dirname();
     res = mkdir(dirname.characters(), 0755);
     EXPECT(res == 0);
-    // FIXME: Somehow also check that mkdir() stops working when removing the cpath promise. This is currently
-    //        not possible because this would prevent the unveil test case from properly working.
 }
 
 TEST_CASE(unveil)
@@ -102,4 +100,16 @@ TEST_CASE(unveil)
 
     res = unveil(nullptr, nullptr);
     EXPECT(res == 0);
+}
+
+TEST_CASE(pledge_without_cpath)
+{
+    int res = pledge("stdio proc", nullptr);
+    EXPECT(res == 0);
+
+    auto dirname = random_dirname();
+    EXPECT_CRASH("Calling mkdir() without cpath pledge", [dirname] {
+        mkdir(dirname.characters(), 0755);
+        return Test::Crash::Failure::DidNotCrash;
+    });
 }


### PR DESCRIPTION
This PR resolves a FIXME that requested to add a test where `mkdir()` is shown to fail if the `cpath` pledge is omitted

<img width="1136" alt="image" src="https://github.com/SerenityOS/serenity/assets/2068912/8e6bbb1c-dac9-4585-8256-a4b2a5e6aace">

## Notes

I needed to add the `proc` pledge, presumably because `EXPECT_CRASH` requires it (?)