### PR TITLE
Kernel/riscv64: Add QEMU virt machine memory map

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -217,6 +217,29 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     // FIXME: Read the /chosen/bootargs property.
     kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
 #elif ARCH(RISCV64)
+    // FIXME: Get the actual memory map from the device tree.
+    static multiboot_memory_map_t mmap[] = {
+        {
+            // We currently can't get the actual size of firmware-reserved memory, so mark the first 0x20'0000 bytes as reserved.
+            // This reserved memory region should be large enough for now.
+            sizeof(multiboot_mmap_entry) - sizeof(u32),
+            0x8000'0000,
+            0x20'0000,
+            MULTIBOOT_MEMORY_RESERVED,
+        },
+        {
+            sizeof(multiboot_mmap_entry) - sizeof(u32),
+            0x8020'0000,
+            1 * GiB - 0x20'0000,
+            MULTIBOOT_MEMORY_AVAILABLE,
+        },
+    };
+
+    multiboot_memory_map = mmap;
+    multiboot_memory_map_count = array_size(mmap);
+    multiboot_modules = nullptr;
+    multiboot_modules_count = 0;
+
     kernel_cmdline = "serial_debug"sv;
 #endif
 


### PR DESCRIPTION
This temporary memory map is a hack until we support device tree parsing.