### PR TITLE
LibWeb: Clamp justification space between flex items to 0

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/space-between-with-negative-remaining-space-on-line.txt
+++ b/Tests/LibWeb/Layout/expected/flex/space-between-with-negative-remaining-space-on-line.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 400x100 flex-container(row) [FFC] children: not-inline
+      Box <div.outer> at (8,8) content-size 200x100 flex-container(column) flex-item [FFC] children: not-inline
+        BlockContainer <div.upper> at (8,8) content-size 200x200 flex-item [BFC] children: not-inline
+          BlockContainer <div.spacer> at (8,8) content-size 200x200 children: not-inline
+        BlockContainer <div.lower> at (8,208) content-size 200x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,208 26.953125x17] baseline: 13.296875
+              "whf"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116] overflow: [0,0 800x225]
+    PaintableBox (Box<BODY>) [8,8 400x100] overflow: [8,8 400x217]
+      PaintableBox (Box<DIV>.outer) [8,8 200x100] overflow: [8,8 200x217]
+        PaintableWithLines (BlockContainer<DIV>.upper) [8,8 200x200]
+          PaintableWithLines (BlockContainer<DIV>.spacer) [8,8 200x200]
+        PaintableWithLines (BlockContainer<DIV>.lower) [8,208 200x17]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/flex/space-between-with-negative-remaining-space-on-line.html
+++ b/Tests/LibWeb/Layout/input/flex/space-between-with-negative-remaining-space-on-line.html
@@ -1,0 +1,29 @@
+<!doctype html><style type="text/css">
+    html { background: white; }
+    * {
+        outline: 1px solid black;
+    }
+    body {
+        background: pink;
+        display: flex;
+        width: 400px;
+        height: 100px;
+    }
+    .outer {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        background: magenta;
+    }
+    .upper {
+        background: orange;
+    }
+    .lower {
+        background: yellow;
+    }
+    .spacer {
+        width: 200px;
+        height: 200px;
+        background: green;
+    }
+</style><body><div class="outer"><div class="upper"><div class="spacer"></div></div><div class="lower">whf

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1230,11 +1230,11 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
                     initial_offset = 0;
                 }
                 if (flex_line.remaining_free_space.has_value() && number_of_items > 1)
-                    space_between_items = flex_line.remaining_free_space.value() / (number_of_items - 1);
+                    space_between_items = max(CSSPixels(0), flex_line.remaining_free_space.value() / (number_of_items - 1));
                 break;
             case CSS::JustifyContent::SpaceAround:
                 if (flex_line.remaining_free_space.has_value())
-                    space_between_items = flex_line.remaining_free_space.value() / number_of_items;
+                    space_between_items = max(CSSPixels(0), flex_line.remaining_free_space.value() / number_of_items);
                 if (is_direction_reverse()) {
                     initial_offset = inner_main_size(m_flex_container_state) - space_between_items / 2;
                 } else {
@@ -1243,7 +1243,7 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
                 break;
             case CSS::JustifyContent::SpaceEvenly:
                 if (flex_line.remaining_free_space.has_value())
-                    space_between_items = flex_line.remaining_free_space.value() / (number_of_items + 1);
+                    space_between_items = max(CSSPixels(0), flex_line.remaining_free_space.value() / (number_of_items + 1));
                 if (is_direction_reverse()) {
                     initial_offset = inner_main_size(m_flex_container_state) - space_between_items;
                 } else {


### PR DESCRIPTION
Before this change, it was possible for flex lines with negative remaining space (due to overflowing items) to put a negative amount of space between items for some values of `justify-content`.

This makes https://polar.sh/SerenityOS look much better :^)

Before:
![Screenshot at 2024-01-25 12-53-56](https://github.com/SerenityOS/serenity/assets/5954907/65d1d57f-20e8-4986-9e28-25b5b3ee5704)

After:
![Screenshot at 2024-01-25 12-53-42](https://github.com/SerenityOS/serenity/assets/5954907/be87e65f-b050-4802-9c57-1a3fbf12fe5b)

