### PR TITLE
Toolchain: Simplify booting RISC-V Serenity via U-Boot

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -10,6 +10,7 @@ A list of useful pages across the web can be found on [the link list](Links.md).
 * [Troubleshooting](Troubleshooting.md)
 * [Running in VirtualBox](VirtualBox.md)
 * [Running in VMware](VMware.md)
+* [Building and running the RISC-V port](RISC-V.md)
 * [Running Tests](RunningTests.md)
 * [Setting Up Self-Hosted Runners](SelfHostedRunners.md)
 * [Profiling the Build](BuildProfilingInstructions.md)

--- a/Documentation/RISC-V.md
+++ b/Documentation/RISC-V.md
@@ -1,0 +1,22 @@
+# Building and running SerenityOS on RISC-V
+
+## NOTE
+
+SerenityOS on [RISC-V](https://riscv.org) (RV64G / RV64IMAFDZicsr_Zifencei, named riscv64) is in very early development. Use this guide if you want to setup a development environment, and ask in the #risc-v channel if you need assistance.
+
+## Building
+
+SerenityOS has RV64 Clang and GCC toolchains. The GCC toolchain is required for building U-Boot, but both toolchains can be used for SerenityOS.
+
+Currently, booting in QEMU via U-Boot is recommended. For this you need to build U-Boot via the `Toolchain/BuildUBoot.sh` script. This currently requires the GCC toolchain due to missing upstream support for Clang on RISC-V; if you do not have a SerenityOS toolchain you can also install and use the Linux cross-compiler gcc-riscv64-linux-gnu.
+
+## Running in QEMU
+
+run.py does not support running riscv64 in QEMU via U-Boot. The following command line should be adopted instead:
+
+```sh
+# Assuming you built QEMU with BuildQEMU.sh
+Toolchain/Local/qemu/bin/qemu-system-riscv64 -M virt -kernel Toolchain/Local/u-boot-riscv64/u-boot -drive id=disk,file=Build/riscv64clang/_disk_image,format=raw,if=none -device nvme,drive=disk,serial=deadbeef -m 2G -device VGA -serial mon:stdio
+```
+
+Change the `_disk_image` path depending on which toolchain you're using, and adopt the RAM amount as needed.

--- a/Toolchain/BuildUBoot.sh
+++ b/Toolchain/BuildUBoot.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -e
+
+# This file will need to be run in bash, for now.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root 'Do not run BuildUBoot.sh as root, parts of your Toolchain directory will become root-owned'
+
+# Since we don't have a Serenity port of U-Boot for now, the version information lives here.
+UBOOT_VERSION='2023.10'
+UBOOT_ARCHIVE="v${UBOOT_VERSION}.tar.gz"
+UBOOT_DIR="u-boot-${UBOOT_VERSION}"
+UBOOT_ARCHIVE_URL="https://github.com/u-boot/u-boot/archive/refs/tags/${UBOOT_ARCHIVE}"
+UBOOT_ARCHIVE_SHA256SUM="b22664ee56640bba87068a7cdcd7cb50f956973a348e844788d2fb882fe0dc55"
+
+mkdir -p "${DIR}/Tarballs"
+
+# Download and extract U-Boot source.
+pushd "${DIR}/Tarballs"
+    if [ ! -e "${UBOOT_ARCHIVE}" ]; then
+        curl -LC - -O "${UBOOT_ARCHIVE_URL}"
+    else
+        echo "Skipped downloading ${UBOOT_ARCHIVE}"
+    fi
+
+    if ! sha256sum --status -c <(echo "${UBOOT_ARCHIVE_SHA256SUM}" "${UBOOT_ARCHIVE}"); then
+        echo "U-Boot sha256 sum mismatching, please run script again."
+        rm -f "${UBOOT_ARCHIVE}"
+        exit 1
+    fi
+
+    if [ -d "$UBOOT_DIR" ]; then
+        rm -rf "$UBOOT_DIR"
+    fi
+
+    echo "Extracting U-Boot..."
+    tar -xf "${UBOOT_ARCHIVE}"
+popd
+
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
+
+# RISC-V QEMU U-Boot build.
+# This can be generalized later to build different U-Boot bootloaders for other (emulated) machines.
+
+PREFIX="${DIR}/Local/u-boot-riscv64"
+echo PREFIX is "$PREFIX"
+rm -rf "$PREFIX"
+
+# Check that we have a cross compiler available for building U-Boot.
+# Clang cannot be used; it requires some patches to the U-Boot build system to compile and then crashes on boot.
+LINUX_CROSS_GCC=$(find_executable "riscv64-linux-gnu-gcc")
+if [ -x "${DIR}/Local/riscv64/bin/riscv64-pc-serenity-gcc" ]; then
+	CROSS_COMPILE="${DIR}/Local/riscv64/bin/riscv64-pc-serenity-"
+elif [ -x "$LINUX_CROSS_GCC" ]; then
+    CROSS_COMPILE="${LINUX_CROSS_GCC%gcc}"
+fi
+
+if [ "${CROSS_COMPILE:x}" == 'x' ]; then
+    die Required cross-compiler not found. Please build a RISC-V toolchain or install the riscv64-linux-gnu cross-compiler.
+fi
+
+export CROSS_COMPILE
+echo Found cross compiler prefix "$CROSS_COMPILE"
+
+MAKEARGS="${MAKEARGS} O=${PREFIX}"
+
+# Build.
+pushd "${DIR}/Tarballs/${UBOOT_DIR}"
+    # shellcheck disable=SC2086 # Word splitting is intentional here
+    make $MAKEARGS mrproper
+
+    # shellcheck disable=SC2086
+    make $MAKEARGS qemu-riscv64_smode_defconfig
+    # Merge in our own configuration fragments.
+    scripts/kconfig/merge_config.sh -m -O "$PREFIX" "${PREFIX}/.config" "${DIR}/u-boot-riscv64.config"
+
+    # shellcheck disable=SC2086
+    make $MAKEARGS -j "$MAKEJOBS" all || exit 1
+popd

--- a/Toolchain/u-boot-riscv64.config
+++ b/Toolchain/u-boot-riscv64.config
@@ -1,0 +1,10 @@
+# KConfig fragment for RISC-V QEMU U-Boot.
+# Don't manually use this as a .config file for U-Boot since it is not complete.
+
+# Setup default boot command necessary for booting Serenity.
+CONFIG_USE_BOOTCOMMAND=y
+CONFIG_BOOTCOMMAND="nvme scan; if load nvme 0 $kernel_addr_r /boot/Kernel.bin; then go $kernel_addr_r; fi"
+# Enable NVMe since our Kernel likely lives there.
+CONFIG_CMD_NVME=y
+CONFIG_NVME=y
+CONFIG_NVME_PCI=y


### PR DESCRIPTION
A BuildUBoot script supports building U-Boot as a bootloader in QEMU, which is the only current way of running Serenity riscv64 in a virtual machine.

CC @spholz

I haven't added my [Clang patches](https://lore.kernel.org/u-boot/20240120001405.29294-1-filmroellchen@serenityos.org/) to this PR since they're (1) pointless and (2) being upstreamed.