### PR TITLE
LibWeb: Test nested elements in InlinePaintable::hit_test()

### DIFF
--- a/Tests/LibWeb/Text/expected/hit_testing/nested-inline-paintables.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/nested-inline-paintables.txt
@@ -1,0 +1,2 @@
+   lang "en"    <SPAN id="name" >
+<SPAN id="value" >

--- a/Tests/LibWeb/Text/input/hit_testing/nested-inline-paintables.html
+++ b/Tests/LibWeb/Text/input/hit_testing/nested-inline-paintables.html
@@ -1,0 +1,15 @@
+<script src="../include.js"></script>
+<body>
+    <span id="outer">
+        <span id="inner">
+            <span id="name">lang</span>
+            <span id="value">"en"</span>
+        </span>
+    </span>
+    <script type="text/javascript">
+        test(() => {
+            printElement(internals.hitTest(10, 10).node.parentNode);
+            printElement(internals.hitTest(50, 10).node.parentNode);
+        });
+    </script>
+</body>

--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -17,6 +17,13 @@ function println(s) {
     __outputElement.appendChild(document.createTextNode(s + "\n"));
 }
 
+function printElement(e) {
+    let element_string = `<${e.nodeName} `;
+    if (e.id) element_string += `id="${e.id}" `;
+    element_string += ">";
+    println(element_string);
+}
+
 document.addEventListener("DOMContentLoaded", function () {
     __outputElement = document.createElement("pre");
     __outputElement.setAttribute("id", "out");

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -173,7 +173,19 @@ Optional<HitTestResult> InlinePaintable::hit_test(CSSPixelPoint position, HitTes
                 fragment.text_index_at(position.x()) };
         }
     }
-    return {};
+
+    Optional<HitTestResult> hit_test_result;
+    for_each_child([&](Paintable const& child) {
+        if (child.stacking_context())
+            return IterationDecision::Continue;
+        if (auto result = child.hit_test(position, type); result.has_value()) {
+            hit_test_result = result;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    return hit_test_result;
 }
 
 CSSPixelRect InlinePaintable::bounding_rect() const


### PR DESCRIPTION
Before this change we were ignoring nested paintables inside inline paintable during hit-testing, but now we recurse into subtree.

Fixes https://github.com/SerenityOS/serenity/issues/22927