### PR TITLE
HackStudio: Use a single, filtered model for Locator output

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     Debugger/DisassemblyWidget.cpp
     Debugger/RegistersModel.cpp
     Debugger/VariablesModel.cpp
+    DeclarationsModel.cpp
     Dialogs/Git/GitCommitDialog.cpp
     Dialogs/NewProjectDialog.cpp
     Dialogs/ProjectTemplatesModel.cpp

--- a/Userland/DevTools/HackStudio/DeclarationsModel.cpp
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.cpp
@@ -57,4 +57,35 @@ GUI::Variant DeclarationsModel::data(GUI::ModelIndex const& index, GUI::ModelRol
     return {};
 }
 
+GUI::Model::MatchResult DeclarationsModel::data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const
+{
+    if (index.row() < 0 || (size_t)index.row() >= m_declarations.size())
+        return { TriState::False };
+
+    auto needle = term.as_string();
+    if (needle.is_empty())
+        return { TriState::True };
+
+    auto& declaration = m_declarations[index.row()];
+    if (declaration.is_filename()) {
+        if (declaration.as_filename->contains(needle, CaseSensitivity::CaseInsensitive))
+            return { TriState::True };
+        return { TriState::False };
+    }
+    if (declaration.is_symbol_declaration()) {
+        if (declaration.as_symbol_declaration->name.contains(needle, CaseSensitivity::CaseInsensitive)
+            || declaration.as_symbol_declaration->scope.contains(needle, CaseSensitivity::CaseInsensitive))
+            return { TriState::True };
+        return { TriState::False };
+    }
+
+    return { TriState::False };
+}
+
+void DeclarationsModel::set_declarations(Vector<HackStudio::Declaration>&& declarations)
+{
+    m_declarations = move(declarations);
+    did_update();
+}
+
 }

--- a/Userland/DevTools/HackStudio/DeclarationsModel.cpp
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.cpp
@@ -11,22 +11,22 @@
 
 namespace HackStudio {
 
-DeclarationsModel::Suggestion DeclarationsModel::Suggestion::create_filename(ByteString const& filename)
+Declaration Declaration::create_filename(ByteString const& filename)
 {
-    DeclarationsModel::Suggestion s;
+    Declaration s;
     s.as_filename = filename;
     return s;
 }
-DeclarationsModel::Suggestion DeclarationsModel::Suggestion::create_symbol_declaration(CodeComprehension::Declaration const& decl)
+Declaration Declaration::create_symbol_declaration(CodeComprehension::Declaration const& decl)
 {
-    DeclarationsModel::Suggestion s;
+    Declaration s;
     s.as_symbol_declaration = decl;
     return s;
 }
 
 GUI::Variant DeclarationsModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
-    auto& suggestion = m_suggestions.at(index.row());
+    auto& suggestion = m_declarations.at(index.row());
     if (role != GUI::ModelRole::Display)
         return {};
 

--- a/Userland/DevTools/HackStudio/DeclarationsModel.cpp
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "DeclarationsModel.h"
+#include "ProjectDeclarations.h"
+
+namespace HackStudio {
+
+DeclarationsModel::Suggestion DeclarationsModel::Suggestion::create_filename(ByteString const& filename)
+{
+    DeclarationsModel::Suggestion s;
+    s.as_filename = filename;
+    return s;
+}
+DeclarationsModel::Suggestion DeclarationsModel::Suggestion::create_symbol_declaration(CodeComprehension::Declaration const& decl)
+{
+    DeclarationsModel::Suggestion s;
+    s.as_symbol_declaration = decl;
+    return s;
+}
+
+GUI::Variant DeclarationsModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
+{
+    auto& suggestion = m_suggestions.at(index.row());
+    if (role != GUI::ModelRole::Display)
+        return {};
+
+    if (suggestion.is_filename()) {
+        if (index.column() == Column::Name)
+            return suggestion.as_filename.value();
+        if (index.column() == Column::Filename)
+            return "";
+        if (index.column() == Column::Icon)
+            return GUI::FileIconProvider::icon_for_path(suggestion.as_filename.value());
+    }
+    if (suggestion.is_symbol_declaration()) {
+        if (index.column() == Column::Name) {
+            if (!suggestion.as_symbol_declaration.value().scope.is_empty())
+                return suggestion.as_symbol_declaration.value().name;
+            return ByteString::formatted("{}::{}", suggestion.as_symbol_declaration.value().scope, suggestion.as_symbol_declaration.value().name);
+        }
+        if (index.column() == Column::Filename)
+            return suggestion.as_symbol_declaration.value().position.file;
+        if (index.column() == Column::Icon) {
+            auto icon = ProjectDeclarations::get_icon_for(suggestion.as_symbol_declaration.value().type);
+            if (icon.has_value())
+                return icon.value();
+            return {};
+        }
+    }
+
+    return {};
+}
+
+}

--- a/Userland/DevTools/HackStudio/DeclarationsModel.h
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.h
@@ -48,8 +48,10 @@ public:
 
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Column_Count; }
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override;
+    virtual MatchResult data_matches(GUI::ModelIndex const&, GUI::Variant const&) const override;
 
     Vector<Declaration> const& declarations() const { return m_declarations; }
+    void set_declarations(Vector<Declaration>&&);
 
 private:
     Vector<Declaration> m_declarations;

--- a/Userland/DevTools/HackStudio/DeclarationsModel.h
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.h
@@ -14,21 +14,21 @@
 
 namespace HackStudio {
 
+struct Declaration {
+    static Declaration create_filename(ByteString const& filename);
+    static Declaration create_symbol_declaration(CodeComprehension::Declaration const&);
+
+    bool is_filename() const { return as_filename.has_value(); }
+    bool is_symbol_declaration() const { return as_symbol_declaration.has_value(); }
+
+    Optional<ByteString> as_filename;
+    Optional<CodeComprehension::Declaration> as_symbol_declaration;
+};
+
 class DeclarationsModel final : public GUI::Model {
 public:
-    struct Suggestion {
-        static Suggestion create_filename(ByteString const& filename);
-        static Suggestion create_symbol_declaration(CodeComprehension::Declaration const&);
-
-        bool is_filename() const { return as_filename.has_value(); }
-        bool is_symbol_declaration() const { return as_symbol_declaration.has_value(); }
-
-        Optional<ByteString> as_filename;
-        Optional<CodeComprehension::Declaration> as_symbol_declaration;
-    };
-
-    explicit DeclarationsModel(Vector<Suggestion>&& suggestions)
-        : m_suggestions(move(suggestions))
+    explicit DeclarationsModel(Vector<Declaration>&& declarations)
+        : m_declarations(move(declarations))
     {
     }
 
@@ -38,14 +38,14 @@ public:
         Filename,
         __Column_Count,
     };
-    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_suggestions.size(); }
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_declarations.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Column_Count; }
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override;
 
-    Vector<Suggestion> const& suggestions() const { return m_suggestions; }
+    Vector<Declaration> const& declarations() const { return m_declarations; }
 
 private:
-    Vector<Suggestion> m_suggestions;
+    Vector<Declaration> m_declarations;
 };
 
 }

--- a/Userland/DevTools/HackStudio/DeclarationsModel.h
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCodeComprehension/Types.h>
+#include <LibGUI/FileIconProvider.h>
+#include <LibGUI/Model.h>
+
+namespace HackStudio {
+
+class DeclarationsModel final : public GUI::Model {
+public:
+    struct Suggestion {
+        static Suggestion create_filename(ByteString const& filename);
+        static Suggestion create_symbol_declaration(CodeComprehension::Declaration const&);
+
+        bool is_filename() const { return as_filename.has_value(); }
+        bool is_symbol_declaration() const { return as_symbol_declaration.has_value(); }
+
+        Optional<ByteString> as_filename;
+        Optional<CodeComprehension::Declaration> as_symbol_declaration;
+    };
+
+    explicit DeclarationsModel(Vector<Suggestion>&& suggestions)
+        : m_suggestions(move(suggestions))
+    {
+    }
+
+    enum Column {
+        Icon,
+        Name,
+        Filename,
+        __Column_Count,
+    };
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_suggestions.size(); }
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Column_Count; }
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override;
+
+    Vector<Suggestion> const& suggestions() const { return m_suggestions; }
+
+private:
+    Vector<Suggestion> m_suggestions;
+};
+
+}

--- a/Userland/DevTools/HackStudio/DeclarationsModel.h
+++ b/Userland/DevTools/HackStudio/DeclarationsModel.h
@@ -38,7 +38,14 @@ public:
         Filename,
         __Column_Count,
     };
-    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_declarations.size(); }
+
+    virtual int row_count(GUI::ModelIndex const& index = GUI::ModelIndex()) const override
+    {
+        if (!index.is_valid())
+            return m_declarations.size();
+        return 0;
+    }
+
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Column_Count; }
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override;
 

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -78,7 +79,7 @@ Locator::Locator(Core::EventReceiver* parent)
         open_suggestion(index);
     };
 
-    m_model = GUI::FilteringProxyModel::create(ProjectDeclarations::the().declarations_model()).release_value_but_fixme_should_propagate_errors();
+    m_model = GUI::FilteringProxyModel::create(ProjectDeclarations::the().declarations_model(), GUI::FilteringProxyModel::FilteringOptions::SortByScore).release_value_but_fixme_should_propagate_errors();
     m_suggestion_view->set_model(m_model);
 }
 

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -201,17 +201,6 @@ void Locator::update_suggestions()
             suggestions.append((LocatorSuggestionModel::Suggestion::create_symbol_declaration(decl)));
     });
 
-    dbgln("I have {} suggestion(s):", suggestions.size());
-    // Limit the debug logging otherwise this can be very slow for large projects
-    if (suggestions.size() < 100) {
-        for (auto& s : suggestions) {
-            if (s.is_filename())
-                dbgln("    {}", s.as_filename.value());
-            if (s.is_symbol_declaration())
-                dbgln("    {} ({})", s.as_symbol_declaration.value().name, s.as_symbol_declaration.value().position.file);
-        }
-    }
-
     bool has_suggestions = !suggestions.is_empty();
 
     m_suggestion_view->set_model(adopt_ref(*new LocatorSuggestionModel(move(suggestions))));
@@ -222,7 +211,6 @@ void Locator::update_suggestions()
         m_suggestion_view->selection().set(m_suggestion_view->model()->index(0));
 
     m_popup_window->move_to(screen_relative_rect().top_left().translated(0, -m_popup_window->height()));
-    dbgln("Popup rect: {}", m_popup_window->rect());
     m_popup_window->show();
 }
 }

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -82,7 +82,7 @@ Locator::Locator(Core::EventReceiver* parent)
 void Locator::open_suggestion(const GUI::ModelIndex& index)
 {
     auto& model = reinterpret_cast<DeclarationsModel&>(*m_suggestion_view->model());
-    auto suggestion = model.suggestions()[index.row()];
+    auto suggestion = model.declarations()[index.row()];
     if (suggestion.is_filename()) {
         auto filename = suggestion.as_filename.value();
         open_file(filename);
@@ -112,15 +112,15 @@ void Locator::close()
 void Locator::update_suggestions()
 {
     auto typed_text = m_textbox->text();
-    Vector<DeclarationsModel::Suggestion> suggestions;
+    Vector<Declaration> suggestions;
     project().for_each_text_file([&](auto& file) {
         if (file.name().contains(typed_text, CaseSensitivity::CaseInsensitive))
-            suggestions.append(DeclarationsModel::Suggestion::create_filename(file.name()));
+            suggestions.append(Declaration::create_filename(file.name()));
     });
 
     ProjectDeclarations::the().for_each_declared_symbol([&suggestions, &typed_text](auto& decl) {
         if (decl.name.contains(typed_text, CaseSensitivity::CaseInsensitive) || decl.scope.contains(typed_text, CaseSensitivity::CaseInsensitive))
-            suggestions.append((DeclarationsModel::Suggestion::create_symbol_declaration(decl)));
+            suggestions.append((Declaration::create_symbol_declaration(decl)));
     });
 
     bool has_suggestions = !suggestions.is_empty();

--- a/Userland/DevTools/HackStudio/Locator.h
+++ b/Userland/DevTools/HackStudio/Locator.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <LibGUI/FilteringProxyModel.h>
 #include <LibGUI/Widget.h>
 
 namespace HackStudio {
@@ -29,6 +30,7 @@ private:
     RefPtr<GUI::TextBox> m_textbox;
     RefPtr<GUI::Window> m_popup_window;
     RefPtr<GUI::TableView> m_suggestion_view;
+    RefPtr<GUI::FilteringProxyModel> m_model;
 };
 
 }

--- a/Userland/DevTools/HackStudio/ProjectDeclarations.cpp
+++ b/Userland/DevTools/HackStudio/ProjectDeclarations.cpp
@@ -1,24 +1,35 @@
 /*
  * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "ProjectDeclarations.h"
+#include "HackStudio.h"
 
-HackStudio::ProjectDeclarations& HackStudio::ProjectDeclarations::the()
+namespace HackStudio {
+
+ProjectDeclarations::ProjectDeclarations()
+    : m_declarations_model(adopt_ref(*new DeclarationsModel({})))
+{
+}
+
+ProjectDeclarations& ProjectDeclarations::the()
 {
     static ProjectDeclarations s_instance;
     return s_instance;
 }
-void HackStudio::ProjectDeclarations::set_declared_symbols(ByteString const& filename, Vector<CodeComprehension::Declaration> const& declarations)
+void ProjectDeclarations::set_declared_symbols(ByteString const& filename, Vector<CodeComprehension::Declaration> const& declarations)
 {
     m_document_to_declarations.set(filename, declarations);
+    // FIXME: Partially invalidate the model instead of fully rebuilding it.
+    update_declarations_model();
     if (on_update)
         on_update();
 }
 
-Optional<GUI::Icon> HackStudio::ProjectDeclarations::get_icon_for(CodeComprehension::DeclarationType type)
+Optional<GUI::Icon> ProjectDeclarations::get_icon_for(CodeComprehension::DeclarationType type)
 {
     static GUI::Icon struct_icon(Gfx::Bitmap::load_from_file("/res/icons/hackstudio/Struct.png"sv).release_value_but_fixme_should_propagate_errors());
     static GUI::Icon class_icon(Gfx::Bitmap::load_from_file("/res/icons/hackstudio/Class.png"sv).release_value_but_fixme_should_propagate_errors());
@@ -45,4 +56,18 @@ Optional<GUI::Icon> HackStudio::ProjectDeclarations::get_icon_for(CodeComprehens
     default:
         return {};
     }
+}
+
+void ProjectDeclarations::update_declarations_model()
+{
+    Vector<Declaration> declarations;
+    project().for_each_text_file([&](auto& file) {
+        declarations.append(Declaration::create_filename(file.name()));
+    });
+    for_each_declared_symbol([&declarations](auto& decl) {
+        declarations.append((Declaration::create_symbol_declaration(decl)));
+    });
+    m_declarations_model->set_declarations(move(declarations));
+}
+
 }

--- a/Userland/DevTools/HackStudio/ProjectDeclarations.h
+++ b/Userland/DevTools/HackStudio/ProjectDeclarations.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include "DeclarationsModel.h"
 #include <AK/ByteString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
@@ -25,13 +27,18 @@ public:
 
     void set_declared_symbols(ByteString const& filename, Vector<CodeComprehension::Declaration> const&);
 
+    DeclarationsModel& declarations_model() { return m_declarations_model; }
+    void update_declarations_model();
+
     static Optional<GUI::Icon> get_icon_for(CodeComprehension::DeclarationType);
 
     Function<void()> on_update = nullptr;
 
 private:
-    ProjectDeclarations() = default;
+    ProjectDeclarations();
+
     HashMap<ByteString, Vector<CodeComprehension::Declaration>> m_document_to_declarations;
+    NonnullRefPtr<DeclarationsModel> m_declarations_model;
 };
 
 template<typename Func>


### PR DESCRIPTION
Previously, we threw away and rebuilt the Model used for Locator suggestions, each time the input changed. That felt excessive to me, so this PR instead keeps a single DeclarationsModel around for the project, which the Locator accesses via a FilteringProxyModel that fuzzy-matches the declarations.

At some point maybe the "Classes" view could use this same source model, but I haven't looked into that.

Fuzzy-matching isn't perfect currently but that's outside the scope of this PR. The sorting of results definitely isn't worse than the previous unsorted list. :^)

ProjectDeclarations also seems like it should be part of Project, but one step at a time. Combining them would help with a small issue introduced here: The Locator will not list files until the first ComprehensionEngine results come back, because the Project and ProjectDeclarations gets initialized at different times and neither can see the other in its constructor.