### PR TITLE
LibWeb: Resolve postMessage test promises if iframes already loaded

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,4 +1,3 @@
 [Skipped]
-Text/input/HTML/Window-postMessage.html
 Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html

--- a/Tests/LibWeb/Text/input/HTML/Window-postMessage.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-postMessage.html
@@ -127,11 +127,21 @@
         globalThis.doneCallback = done;
 
         const blobIframeLoadPromise = new Promise(resolve => {
-            blobIframe.onload = () => resolve();
+            if (blobIframe.contentDocument.readyState === "complete") {
+                resolve();
+            }
+            else {
+                blobIframe.onload = () => resolve();
+            }
         });
 
         const srcdocIframeLoadPromise = new Promise(resolve => {
-            iframe.onload = () => resolve();
+            if (iframe.contentDocument.readyState === "complete") {
+                resolve()
+            }
+            else {
+                iframe.onload = () => resolve();
+            }
         });
 
         Promise.all([blobIframeLoadPromise, srcdocIframeLoadPromise]).then(() => {


### PR DESCRIPTION
For some reason on macOS with ASAN enabled, the test promises in HTML/Window-postMessage do not resolve. These promises wait for both the in-document and the blob url iframes to load. It's not clear why this works fine in Linux nor why the onload handler doesn't fire when the iframe has already loaded.