### PR TITLE
LibWeb: Remove SetFont painting command

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -55,10 +55,9 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
         if (layout_box().renders_as_alt_text()) {
             auto& image_element = verify_cast<HTML::HTMLImageElement>(*dom_node());
             auto enclosing_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
-            context.recording_painter().set_font(Platform::FontPlugin::the().default_font());
             context.recording_painter().paint_frame(enclosing_rect, context.palette(), Gfx::FrameStyle::SunkenContainer);
             auto alt = image_element.get_attribute_value(HTML::AttributeNames::alt);
-            context.recording_painter().draw_text(enclosing_rect, alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
+            context.recording_painter().draw_text(enclosing_rect, alt, Platform::FontPlugin::the().default_font(), Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
         } else if (auto bitmap = layout_box().image_provider().current_image_bitmap(image_rect.size().to_type<int>())) {
             ScopedCornerRadiusClip corner_clip { context, image_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
             auto image_int_rect = image_rect.to_type<int>();

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
@@ -85,13 +85,6 @@ CommandResult PaintingCommandExecutorCPU::clear_clip_rect()
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorCPU::set_font(Gfx::Font const& font)
-{
-    auto& painter = this->painter();
-    painter.set_font(font);
-    return CommandResult::Continue;
-}
-
 CommandResult PaintingCommandExecutorCPU::push_stacking_context(
     float opacity, bool is_fixed_position, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation,
     CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask)

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
@@ -20,7 +20,6 @@ public:
     CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
     CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
     CommandResult clear_clip_rect() override;
-    CommandResult set_font(Gfx::Font const&) override;
     CommandResult push_stacking_context(float opacity, bool is_fixed_position, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask) override;
     CommandResult pop_stacking_context() override;
     CommandResult paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&) override;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -88,12 +88,6 @@ CommandResult PaintingCommandExecutorGPU::clear_clip_rect()
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::set_font(Gfx::Font const&)
-{
-    // FIXME
-    return CommandResult::Continue;
-}
-
 CommandResult PaintingCommandExecutorGPU::push_stacking_context(float opacity, bool is_fixed_position, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering, StackingContextTransform transform, Optional<StackingContextMask>)
 {
     if (source_paintable_rect.is_empty())

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -21,7 +21,6 @@ public:
     CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
     CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
     CommandResult clear_clip_rect() override;
-    CommandResult set_font(Gfx::Font const&) override;
     CommandResult push_stacking_context(float opacity, bool, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask) override;
     CommandResult pop_stacking_context() override;
     CommandResult paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&) override;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -207,18 +207,6 @@ void RecordingPainter::draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color col
     });
 }
 
-void RecordingPainter::draw_text(Gfx::IntRect const& rect, String raw_text, Gfx::TextAlignment alignment, Color color, Gfx::TextElision elision, Gfx::TextWrapping wrapping)
-{
-    push_command(DrawText {
-        .rect = state().translation.map(rect),
-        .raw_text = move(raw_text),
-        .alignment = alignment,
-        .color = color,
-        .elision = elision,
-        .wrapping = wrapping,
-    });
-}
-
 void RecordingPainter::draw_text(Gfx::IntRect const& rect, String raw_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Color color, Gfx::TextElision elision, Gfx::TextWrapping wrapping)
 {
     push_command(DrawText {
@@ -279,11 +267,6 @@ void RecordingPainter::translate(int dx, int dy)
 void RecordingPainter::translate(Gfx::IntPoint delta)
 {
     m_state_stack.last().translation.translate(delta.to_type<float>());
-}
-
-void RecordingPainter::set_font(Gfx::Font const& font)
-{
-    push_command(SetFont { .font = font });
 }
 
 void RecordingPainter::save()
@@ -513,9 +496,6 @@ void RecordingPainter::execute(PaintingCommandExecutor& executor)
             },
             [&](ClearClipRect const&) {
                 return executor.clear_clip_rect();
-            },
-            [&](SetFont const& command) {
-                return executor.set_font(command.font);
             },
             [&](PushStackingContext const& command) {
                 return executor.push_stacking_context(command.opacity, command.is_fixed_position, command.source_paintable_rect, command.post_transform_translation, command.image_rendering, command.transform, command.mask);

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -99,10 +99,6 @@ struct SetClipRect {
 
 struct ClearClipRect { };
 
-struct SetFont {
-    NonnullRefPtr<Gfx::Font> font;
-};
-
 struct StackingContextTransform {
     Gfx::FloatPoint origin;
     Gfx::FloatMatrix4x4 matrix;
@@ -418,7 +414,6 @@ using PaintingCommand = Variant<
     DrawScaledImmutableBitmap,
     SetClipRect,
     ClearClipRect,
-    SetFont,
     PushStackingContext,
     PopStackingContext,
     PaintLinearGradient,
@@ -455,7 +450,6 @@ public:
     virtual CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;
     virtual CommandResult set_clip_rect(Gfx::IntRect const& rect) = 0;
     virtual CommandResult clear_clip_rect() = 0;
-    virtual CommandResult set_font(Gfx::Font const& font) = 0;
     virtual CommandResult push_stacking_context(float opacity, bool is_fixed_position, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask) = 0;
     virtual CommandResult pop_stacking_context() = 0;
     virtual CommandResult paint_linear_gradient(Gfx::IntRect const&, LinearGradientData const&) = 0;
@@ -546,7 +540,6 @@ public:
     void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::Painter::LineStyle style = Gfx::Painter::LineStyle::Solid, Color alternate_color = Color::Transparent);
 
     void draw_text(Gfx::IntRect const&, String, Gfx::Font const&, Gfx::TextAlignment = Gfx::TextAlignment::TopLeft, Color = Color::Black, Gfx::TextElision = Gfx::TextElision::None, Gfx::TextWrapping = Gfx::TextWrapping::DontWrap);
-    void draw_text(Gfx::IntRect const& rect, String raw_text, Gfx::TextAlignment alignment = Gfx::TextAlignment::TopLeft, Color color = Color::Black, Gfx::TextElision elision = Gfx::TextElision::None, Gfx::TextWrapping wrapping = Gfx::TextWrapping::DontWrap);
 
     void draw_signed_distance_field(Gfx::IntRect const& dst_rect, Color color, Gfx::GrayscaleBitmap const& sdf, float smoothing);
 
@@ -557,8 +550,6 @@ public:
 
     void translate(int dx, int dy);
     void translate(Gfx::IntPoint delta);
-
-    void set_font(Gfx::Font const& font);
 
     void set_scroll_frame_id(i32 id)
     {


### PR DESCRIPTION
It was only used in ImagePaintable for alt text and now it is replaced by saving font inside DrawText command.