### PR TITLE
LibWeb: Add initial support for nesting SVG viewports

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
+++ b/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
+      SVGSVGBox <svg#a> at (8,8) content-size 200x200 [SVG] children: inline
+        TextNode <#text>
+        SVGSVGBox <svg#b> at (8,8) content-size 200x200 [SVG] children: inline
+          TextNode <#text>
+          SVGSVGBox <svg#c> at (8,8) content-size 266.671875x266.671875 [SVG] children: inline
+            TextNode <#text>
+            SVGGeometryBox <rect> at (34.671875,34.671875) content-size 266.671875x266.671875 children: not-inline
+            TextNode <#text>
+            SVGGeometryBox <rect> at (34.671875,34.671875) content-size 133.328125x133.328125 children: not-inline
+            TextNode <#text>
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      SVGSVGPaintable (SVGSVGBox<svg>#a) [8,8 200x200]
+        SVGSVGPaintable (SVGSVGBox<svg>#b) [8,8 200x200]
+          SVGSVGPaintable (SVGSVGBox<svg>#c) [8,8 266.671875x266.671875]
+            SVGPathPaintable (SVGGeometryBox<rect>) [34.671875,34.671875 266.671875x266.671875]
+            SVGPathPaintable (SVGGeometryBox<rect>) [34.671875,34.671875 133.328125x133.328125]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
           TextNode <#text>
-          Box <use> at (8,8) content-size 215.625x130.90625 children: inline
+          Box <use> at (8,8) content-size 300x150 children: inline
             Box <symbol#braces> at (92.375,26.75) content-size 131.25x112.15625 [BFC] children: inline
               TextNode <#text>
               SVGGeometryBox <path> at (92.375,26.75) content-size 131.25x112.15625 children: inline
@@ -24,6 +24,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x150]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
-          PaintableBox (Box<use>) [8,8 215.625x130.90625]
+          PaintableBox (Box<use>) [8,8 300x150]
             PaintableBox (Box<symbol>#braces) [92.375,26.75 131.25x112.15625]
               SVGPathPaintable (SVGGeometryBox<path>) [92.375,26.75 131.25x112.15625]

--- a/Tests/LibWeb/Layout/expected/svg/use-honor-outer-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/use-honor-outer-viewBox.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x102 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100] baseline: 102
+      SVGSVGBox <svg#outer> at (9,9) content-size 100x100 [SVG] children: inline
+        TextNode <#text>
+        Box <use> at (9,9) content-size 100x100 children: inline
+          SVGSVGBox <svg#whee> at (9,9) content-size 100x100 [SVG] children: inline
+            TextNode <#text>
+            SVGGeometryBox <rect> at (9,9) content-size 50x50 children: inline
+              TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      SVGSVGPaintable (SVGSVGBox<svg>#outer) [8,8 102x102]
+        PaintableBox (Box<use>) [9,9 100x100]
+          SVGSVGPaintable (SVGSVGBox<svg>#whee) [9,9 100x100]
+            SVGPathPaintable (SVGGeometryBox<rect>) [9,9 50x50]

--- a/Tests/LibWeb/Layout/input/svg/nested-viewports.html
+++ b/Tests/LibWeb/Layout/input/svg/nested-viewports.html
@@ -1,0 +1,8 @@
+<svg id="a" viewBox="0 0 10 10" width="200" height="200">
+  <svg id="b" viewBox="0 0 6 6">
+    <svg id="c" viewBox="-1 -1 10 10" width="8" height="8">
+      <rect x="0" y="0" width="10" height="10" fill="red"></rect>
+      <rect x="0" y="0" width="5" height="5" fill="blue"></rect>
+    </svg>
+  </svg>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/use-honor-outer-viewBox.html
+++ b/Tests/LibWeb/Layout/input/svg/use-honor-outer-viewBox.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><style>
+  #outer { width: 100px; }
+  svg { border: 1px solid black; }
+</style>
+<svg id="outer" viewBox="0 0 10 10">
+  <use href="#whee"></use>
+</svg>
+
+<div style="display: none">
+  <svg width="10" height="10" id="whee">
+    <rect x="0" y="0" width="5" height="5" fill="#0062FF">
+  </svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -13,12 +13,15 @@ namespace Web::Layout {
 
 class SVGFormattingContext : public FormattingContext {
 public:
-    explicit SVGFormattingContext(LayoutState&, Box const&, FormattingContext* parent);
+    explicit SVGFormattingContext(LayoutState&, Box const&, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform = {});
     ~SVGFormattingContext();
 
     virtual void run(Box const&, LayoutMode, AvailableSpace const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
+
+private:
+    Gfx::AffineTransform m_parent_viewbox_transform {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -68,7 +68,7 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
     RecordingPainterStateSaver save_painter { context.recording_painter() };
 
     auto offset = context.floored_device_point(svg_element_rect.location()).to_type<int>().to_type<float>();
-    auto maybe_view_box = geometry_element.view_box();
+    auto maybe_view_box = svg_element->view_box();
 
     auto paint_transform = computed_transforms().svg_to_device_pixels_transform(context);
     Gfx::Path path = computed_path()->copy_transformed(paint_transform);

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -232,19 +232,4 @@ Optional<float> SVGGraphicsElement::stroke_width() const
     return width.to_px(*layout_node(), scaled_viewport_size).to_double();
 }
 
-Optional<ViewBox> SVGGraphicsElement::view_box() const
-{
-    if (auto* svg_svg_element = shadow_including_first_ancestor_of_type<SVGSVGElement>()) {
-        if (svg_svg_element->view_box().has_value())
-            return svg_svg_element->view_box();
-    }
-
-    if (auto* svg_symbol_element = shadow_including_first_ancestor_of_type<SVGSymbolElement>()) {
-        if (svg_symbol_element->view_box().has_value())
-            return svg_symbol_element->view_box();
-    }
-
-    return {};
-}
-
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -47,8 +47,6 @@ public:
 
     JS::GCPtr<SVG::SVGMaskElement const> mask() const;
 
-    Optional<ViewBox> view_box() const;
-
 protected:
     SVGGraphicsElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -9,11 +9,13 @@
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
+#include <LibWeb/SVG/SVGViewport.h>
 #include <LibWeb/SVG/ViewBox.h>
 
 namespace Web::SVG {
 
-class SVGSVGElement final : public SVGGraphicsElement {
+class SVGSVGElement final : public SVGGraphicsElement
+    , public SVGViewport {
     WEB_PLATFORM_OBJECT(SVGSVGElement, SVGGraphicsElement);
     JS_DECLARE_ALLOCATOR(SVGSVGElement);
 
@@ -25,8 +27,8 @@ public:
     virtual bool requires_svg_container() const override { return false; }
     virtual bool is_svg_container() const override { return true; }
 
-    [[nodiscard]] Optional<ViewBox> view_box() const;
-    Optional<PreserveAspectRatio> const& preserve_aspect_ratio() const { return m_preserve_aspect_ratio; }
+    virtual Optional<ViewBox> view_box() const override;
+    virtual Optional<PreserveAspectRatio> preserve_aspect_ratio() const override { return m_preserve_aspect_ratio; }
 
     void set_fallback_view_box_for_svg_as_image(Optional<ViewBox>);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -7,10 +7,12 @@
 #pragma once
 
 #include <LibWeb/SVG/SVGGraphicsElement.h>
+#include <LibWeb/SVG/SVGViewport.h>
 
 namespace Web::SVG {
 
-class SVGSymbolElement final : public SVGGraphicsElement {
+class SVGSymbolElement final : public SVGGraphicsElement
+    , public SVGViewport {
     WEB_PLATFORM_OBJECT(SVGSymbolElement, SVGGraphicsElement);
     JS_DECLARE_ALLOCATOR(SVGSymbolElement);
 
@@ -19,7 +21,12 @@ public:
 
     void apply_presentational_hints(CSS::StyleProperties& style) const override;
 
-    Optional<ViewBox> view_box() const { return m_view_box; }
+    virtual Optional<ViewBox> view_box() const override { return m_view_box; }
+    virtual Optional<PreserveAspectRatio> preserve_aspect_ratio() const override
+    {
+        // FIXME: Support the `preserveAspectRatio` attribute on <symbol>.
+        return {};
+    }
 
 private:
     SVGSymbolElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/SVG/SVGViewport.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGViewport.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/SVG/AttributeParser.h>
+#include <LibWeb/SVG/ViewBox.h>
+
+namespace Web::SVG {
+
+class SVGViewport {
+public:
+    virtual Optional<ViewBox> view_box() const = 0;
+    virtual Optional<PreserveAspectRatio> preserve_aspect_ratio() const = 0;
+    virtual ~SVGViewport() = default;
+};
+
+}


### PR DESCRIPTION
Previously, we were handling viewBoxes/viewports in a slightly hacky way, asking graphics elements to figure out what viewBox to use during layout. This does not work in all cases, and can't allow for more complex SVGs where it is possible to have nested viewports.

This commit makes the SVGFormattingContext keep track of the viewport/boxes, and it now lays out each viewport recursively, where each nested `<svg>` or `<symbol>` can establish a new viewport.

This fixes some previous edge cases, and starts to allow nested viewports (there's still some issues to resolve there).

Fixes #22931