### PR TITLE
LibWeb: Port Stream algorithms from JS::SafeFunction to JS::HeapFunction

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -636,6 +636,42 @@ struct __InvokeResult<F, Args...> {
 template<typename F, typename... Args>
 using InvokeResult = typename __InvokeResult<F, Args...>::type;
 
+template<typename Callable>
+struct EquivalentFunctionTypeImpl;
+
+template<template<typename> class Function, typename T, typename... Args>
+struct EquivalentFunctionTypeImpl<Function<T(Args...)>> {
+    using Type = T(Args...);
+};
+
+template<typename T, typename... Args>
+struct EquivalentFunctionTypeImpl<T(Args...)> {
+    using Type = T(Args...);
+};
+
+template<typename T, typename... Args>
+struct EquivalentFunctionTypeImpl<T (*)(Args...)> {
+    using Type = T(Args...);
+};
+
+template<typename L>
+struct EquivalentFunctionTypeImpl {
+    using Type = typename EquivalentFunctionTypeImpl<decltype(&L::operator())>::Type;
+};
+
+template<typename T, typename C, typename... Args>
+struct EquivalentFunctionTypeImpl<T (C::*)(Args...)> {
+    using Type = T(Args...);
+};
+
+template<typename T, typename C, typename... Args>
+struct EquivalentFunctionTypeImpl<T (C::*)(Args...) const> {
+    using Type = T(Args...);
+};
+
+template<typename Callable>
+using EquivalentFunctionType = typename EquivalentFunctionTypeImpl<Callable>::Type;
+
 }
 
 #if !USING_AK_GLOBALLY
@@ -651,6 +687,7 @@ using AK::Detail::Conditional;
 using AK::Detail::CopyConst;
 using AK::Detail::declval;
 using AK::Detail::DependentFalse;
+using AK::Detail::EquivalentFunctionType;
 using AK::Detail::FalseType;
 using AK::Detail::IdentityType;
 using AK::Detail::IndexSequence;

--- a/Userland/Libraries/LibJS/Heap/HeapFunction.h
+++ b/Userland/Libraries/LibJS/Heap/HeapFunction.h
@@ -41,10 +41,10 @@ private:
     Function<T> m_function;
 };
 
-template<typename T>
-static NonnullGCPtr<HeapFunction<T>> create_heap_function(Heap& heap, Function<T> function)
+template<typename Callable, typename T = EquivalentFunctionType<Callable>>
+static NonnullGCPtr<HeapFunction<T>> create_heap_function(Heap& heap, Callable&& function)
 {
-    return HeapFunction<T>::create(heap, move(function));
+    return HeapFunction<T>::create(heap, Function<T> { forward<Callable>(function) });
 }
 
 }

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -1091,19 +1091,14 @@ JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_re
 // https://streams.spec.whatwg.org/#readable-stream-default-controller-clear-algorithms
 void readable_stream_default_controller_clear_algorithms(ReadableStreamDefaultController& controller)
 {
-    // FIXME: This AO can be invoked from within one of the algorithms below. If we clear them, it invokes SafeFunction's
-    //        destructor, which asserts we are not currently invoking the function (as it clears the storage). We need to
-    //        figure out how to delay this, as these algorithms may keep objects alive that can otherwise be GC'd.
-    (void)controller;
-
     // 1. Set controller.[[pullAlgorithm]] to undefined.
-    // controller.set_pull_algorithm({});
+    controller.set_pull_algorithm({});
 
     // 2. Set controller.[[cancelAlgorithm]] to undefined.
-    // controller.set_cancel_algorithm({});
+    controller.set_cancel_algorithm({});
 
     // 3. Set controller.[[strategySizeAlgorithm]] to undefined.
-    // controller.set_strategy_size_algorithm({});
+    controller.set_strategy_size_algorithm({});
 }
 
 // https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-readable-state
@@ -1493,16 +1488,11 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_call_pull_if_needed(Re
 // https://streams.spec.whatwg.org/#readable-byte-stream-controller-clear-algorithms
 void readable_byte_stream_controller_clear_algorithms(ReadableByteStreamController& controller)
 {
-    // FIXME: This AO can be invoked from within one of the algorithms below. If we clear them, it invokes SafeFunction's
-    //        destructor, which asserts we are not currently invoking the function (as it clears the storage). We need to
-    //        figure out how to delay this, as these algorithms may keep objects alive that can otherwise be GC'd.
-    (void)controller;
-
     // 1. Set controller.[[pullAlgorithm]] to undefined.
-    // controller.set_pull_algorithm({});
+    controller.set_pull_algorithm({});
 
     // 2. Set controller.[[cancelAlgorithm]] to undefined.
-    // controller.set_cancel_algorithm({});
+    controller.set_cancel_algorithm({});
 }
 
 // https://streams.spec.whatwg.org/#readable-byte-stream-controller-clear-pending-pull-intos
@@ -3247,22 +3237,17 @@ WebIDL::ExceptionOr<void> writable_stream_default_controller_advance_queue_if_ne
 // https://streams.spec.whatwg.org/#writable-stream-default-controller-clear-algorithms
 void writable_stream_default_controller_clear_algorithms(WritableStreamDefaultController& controller)
 {
-    // FIXME: This AO can be invoked from within one of the algorithms below. If we clear them, it invokes SafeFunction's
-    //        destructor, which asserts we are not currently invoking the function (as it clears the storage). We need to
-    //        figure out how to delay this, as these algorithms may keep objects alive that can otherwise be GC'd.
-    (void)controller;
-
     // 1. Set controller.[[writeAlgorithm]] to undefined.
-    // controller.set_write_algorithm({});
+    controller.set_write_algorithm({});
 
     // 2. Set controller.[[closeAlgorithm]] to undefined.
-    // controller.set_close_algorithm({});
+    controller.set_close_algorithm({});
 
     // 3. Set controller.[[abortAlgorithm]] to undefined.
-    // controller.set_abort_algorithm({});
+    controller.set_abort_algorithm({});
 
     // 4. Set controller.[[strategySizeAlgorithm]] to undefined.
-    // controller.set_strategy_size_algorithm({});
+    controller.set_strategy_size_algorithm({});
 }
 
 // https://streams.spec.whatwg.org/#writable-stream-default-controller-close

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
- * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
  * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -18,21 +18,21 @@
 
 namespace Web::Streams {
 
-using SizeAlgorithm = JS::SafeFunction<JS::Completion(JS::Value)>;
-using PullAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
-using CancelAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
-using StartAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::Value>()>;
-using AbortAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
-using CloseAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
-using WriteAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
-using FlushAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
-using TransformAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
+using SizeAlgorithm = JS::HeapFunction<JS::Completion(JS::Value)>;
+using PullAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
+using CancelAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
+using StartAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::Value>()>;
+using AbortAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
+using CloseAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
+using WriteAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
+using FlushAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
+using TransformAlgorithm = JS::HeapFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamDefaultReader>> acquire_readable_stream_default_reader(ReadableStream&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamBYOBReader>> acquire_readable_stream_byob_reader(ReadableStream&);
 bool is_readable_stream_locked(ReadableStream const&);
 
-SizeAlgorithm extract_size_algorithm(QueuingStrategy const&);
+JS::NonnullGCPtr<SizeAlgorithm> extract_size_algorithm(JS::VM&, QueuingStrategy const&);
 WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, double default_hwm);
 
 void readable_stream_close(ReadableStream&);
@@ -73,10 +73,10 @@ void readable_stream_default_controller_clear_algorithms(ReadableStreamDefaultCo
 void readable_stream_default_controller_error(ReadableStreamDefaultController&, JS::Value error);
 Optional<double> readable_stream_default_controller_get_desired_size(ReadableStreamDefaultController&);
 bool readable_stream_default_controller_can_close_or_enqueue(ReadableStreamDefaultController&);
-WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller(ReadableStream&, ReadableStreamDefaultController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, SizeAlgorithm&&);
-WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source_value, UnderlyingSource, double high_water_mark, SizeAlgorithm&&);
-WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_support(ReadableStream&, Optional<PullAlgorithm>&& = {}, Optional<CancelAlgorithm>&& = {}, double high_water_mark = 0);
-WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&, ReadableByteStreamController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, JS::Value auto_allocate_chunk_size);
+WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller(ReadableStream&, ReadableStreamDefaultController&, JS::NonnullGCPtr<StartAlgorithm>, JS::NonnullGCPtr<PullAlgorithm>, JS::NonnullGCPtr<CancelAlgorithm>, double high_water_mark, JS::NonnullGCPtr<SizeAlgorithm>);
+WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source_value, UnderlyingSource, double high_water_mark, JS::NonnullGCPtr<SizeAlgorithm>);
+WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_support(ReadableStream&, JS::GCPtr<PullAlgorithm> = {}, JS::GCPtr<CancelAlgorithm> = {}, double high_water_mark = 0);
+WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&, ReadableByteStreamController&, JS::NonnullGCPtr<StartAlgorithm>, JS::NonnullGCPtr<PullAlgorithm>, JS::NonnullGCPtr<CancelAlgorithm>, double high_water_mark, JS::Value auto_allocate_chunk_size);
 WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source, UnderlyingSource const& underlying_source_dict, double high_water_mark);
 JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_request(JS::NonnullGCPtr<ReadableByteStreamController>);
 
@@ -108,9 +108,9 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_handle_queue_drain(Rea
 void readable_byte_stream_controller_invalidate_byob_request(ReadableByteStreamController&);
 bool readable_byte_stream_controller_should_call_pull(ReadableByteStreamController const&);
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, PullAlgorithm&& pull_algorithm, CancelAlgorithm&& cancel_algorithm, Optional<double> high_water_mark = {}, Optional<SizeAlgorithm>&& size_algorithm = {});
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_byte_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, PullAlgorithm&& pull_algorithm, CancelAlgorithm&& cancel_algorithm);
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> create_writable_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, WriteAlgorithm&& write_algorithm, CloseAlgorithm&& close_algorithm, AbortAlgorithm&& abort_algorithm, double high_water_mark, SizeAlgorithm&& size_algorithm);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_stream(JS::Realm& realm, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<PullAlgorithm> pull_algorithm, JS::NonnullGCPtr<CancelAlgorithm> cancel_algorithm, Optional<double> high_water_mark = {}, JS::GCPtr<SizeAlgorithm> size_algorithm = {});
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_byte_stream(JS::Realm& realm, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<PullAlgorithm> pull_algorithm, JS::NonnullGCPtr<CancelAlgorithm> cancel_algorithm);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> create_writable_stream(JS::Realm& realm, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<WriteAlgorithm> write_algorithm, JS::NonnullGCPtr<CloseAlgorithm> close_algorithm, JS::NonnullGCPtr<AbortAlgorithm> abort_algorithm, double high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> size_algorithm);
 void initialize_readable_stream(ReadableStream&);
 void initialize_writable_stream(WritableStream&);
 
@@ -143,8 +143,8 @@ Optional<double> writable_stream_default_writer_get_desired_size(WritableStreamD
 WebIDL::ExceptionOr<void> writable_stream_default_writer_release(WritableStreamDefaultWriter&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> writable_stream_default_writer_write(WritableStreamDefaultWriter&, JS::Value chunk);
 
-WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller(WritableStream&, WritableStreamDefaultController&, StartAlgorithm&&, WriteAlgorithm&&, CloseAlgorithm&&, AbortAlgorithm&&, double high_water_mark, SizeAlgorithm&&);
-WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underlying_sink(WritableStream&, JS::Value underlying_sink_value, UnderlyingSink&, double high_water_mark, SizeAlgorithm&& size_algorithm);
+WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller(WritableStream&, WritableStreamDefaultController&, JS::NonnullGCPtr<StartAlgorithm>, JS::NonnullGCPtr<WriteAlgorithm>, JS::NonnullGCPtr<CloseAlgorithm>, JS::NonnullGCPtr<AbortAlgorithm>, double high_water_mark, JS::NonnullGCPtr<SizeAlgorithm>);
+WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underlying_sink(WritableStream&, JS::Value underlying_sink_value, UnderlyingSink&, double high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> size_algorithm);
 WebIDL::ExceptionOr<void> writable_stream_default_controller_advance_queue_if_needed(WritableStreamDefaultController&);
 void writable_stream_default_controller_clear_algorithms(WritableStreamDefaultController&);
 WebIDL::ExceptionOr<void> writable_stream_default_controller_close(WritableStreamDefaultController&);
@@ -157,8 +157,8 @@ WebIDL::ExceptionOr<void> writable_stream_default_controller_process_close(Writa
 WebIDL::ExceptionOr<void> writable_stream_default_controller_process_write(WritableStreamDefaultController&, JS::Value chunk);
 WebIDL::ExceptionOr<void> writable_stream_default_controller_write(WritableStreamDefaultController&, JS::Value chunk, JS::Value chunk_size);
 
-WebIDL::ExceptionOr<void> initialize_transform_stream(TransformStream&, JS::NonnullGCPtr<JS::PromiseCapability> start_promise, double writable_high_water_mark, SizeAlgorithm&& writable_size_algorithm, double readable_high_water_mark, SizeAlgorithm&& readable_size_algorithm);
-void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, TransformAlgorithm&&, FlushAlgorithm&&);
+WebIDL::ExceptionOr<void> initialize_transform_stream(TransformStream&, JS::NonnullGCPtr<JS::PromiseCapability> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm);
+void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, JS::NonnullGCPtr<TransformAlgorithm>, JS::NonnullGCPtr<FlushAlgorithm>);
 WebIDL::ExceptionOr<void> set_up_transform_stream_default_controller_from_transformer(TransformStream&, JS::Value transformer, Transformer&);
 void transform_stream_default_controller_clear_algorithms(TransformStreamDefaultController&);
 WebIDL::ExceptionOr<void> transform_stream_default_controller_enqueue(TransformStreamDefaultController&, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
- * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -98,7 +98,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> ReadableByteStreamControl
     reset_queue(*this);
 
     // 3. Let result be the result of performing this.[[cancelAlgorithm]], passing in reason.
-    auto result = (*m_cancel_algorithm)(reason);
+    auto result = m_cancel_algorithm->function()(reason);
 
     // 4. Perform ! ReadableByteStreamControllerClearAlgorithms(this).
     readable_byte_stream_controller_clear_algorithms(*this);
@@ -201,6 +201,8 @@ void ReadableByteStreamController::visit_edges(Cell::Visitor& visitor)
     for (auto const& item : m_queue)
         visitor.visit(item.buffer);
     visitor.visit(m_stream);
+    visitor.visit(m_cancel_algorithm);
+    visitor.visit(m_pull_algorithm);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -94,8 +94,8 @@ public:
     Optional<u64> const& auto_allocate_chunk_size() { return m_auto_allocate_chunk_size; }
     void set_auto_allocate_chunk_size(Optional<u64> value) { m_auto_allocate_chunk_size = value; }
 
-    auto& cancel_algorithm() { return m_cancel_algorithm; }
-    void set_cancel_algorithm(Optional<CancelAlgorithm> value) { m_cancel_algorithm = move(value); }
+    JS::GCPtr<CancelAlgorithm> cancel_algorithm() { return m_cancel_algorithm; }
+    void set_cancel_algorithm(JS::GCPtr<CancelAlgorithm> value) { m_cancel_algorithm = value; }
 
     bool close_requested() const { return m_close_requested; }
     void set_close_requested(bool value) { m_close_requested = value; }
@@ -103,8 +103,8 @@ public:
     bool pull_again() const { return m_pull_again; }
     void set_pull_again(bool value) { m_pull_again = value; }
 
-    auto& pull_algorithm() { return m_pull_algorithm; }
-    void set_pull_algorithm(Optional<PullAlgorithm> value) { m_pull_algorithm = move(value); }
+    JS::GCPtr<PullAlgorithm> pull_algorithm() { return m_pull_algorithm; }
+    void set_pull_algorithm(JS::GCPtr<PullAlgorithm> value) { m_pull_algorithm = value; }
 
     bool pulling() const { return m_pulling; }
     void set_pulling(bool value) { m_pulling = value; }
@@ -148,7 +148,7 @@ private:
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-cancelalgorithm
     // A promise-returning algorithm, taking one argument (the cancel reason), which communicates a requested cancelation to the underlying source
-    Optional<CancelAlgorithm> m_cancel_algorithm;
+    JS::GCPtr<CancelAlgorithm> m_cancel_algorithm;
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-closerequested
     // A boolean flag indicating whether the stream has been closed by its underlying source, but still has chunks in its internal queue that have not yet been read
@@ -160,7 +160,7 @@ private:
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pullalgorithm
     // A promise-returning algorithm that pulls data from the underlying source
-    Optional<PullAlgorithm> m_pull_algorithm;
+    JS::GCPtr<PullAlgorithm> m_pull_algorithm;
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pulling
     // A boolean flag set to true while the underlying source's pull algorithm is executing and the returned promise has not yet fulfilled, used to prevent reentrant calls

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,13 +53,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::construct_
         VERIFY(!underlying_source_dict.type.has_value());
 
         // 2. Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
-        auto size_algorithm = extract_size_algorithm(strategy);
+        auto size_algorithm = extract_size_algorithm(vm, strategy);
 
         // 3. Let highWaterMark be ? ExtractHighWaterMark(strategy, 1).
         auto high_water_mark = TRY(extract_high_water_mark(strategy, 1));
 
         // 4. Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource(this, underlyingSource, underlyingSourceDict, highWaterMark, sizeAlgorithm).
-        TRY(set_up_readable_stream_default_controller_from_underlying_source(*readable_stream, underlying_source, underlying_source_dict, high_water_mark, move(size_algorithm)));
+        TRY(set_up_readable_stream_default_controller_from_underlying_source(*readable_stream, underlying_source, underlying_source_dict, high_water_mark, size_algorithm));
     }
 
     return readable_stream;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultController.cpp
@@ -71,7 +71,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> ReadableStreamDefaultCont
     reset_queue(*this);
 
     // 2. Let result be the result of performing this.[[cancelAlgorithm]], passing reason.
-    auto result = (*cancel_algorithm())(reason);
+    auto result = cancel_algorithm()->function()(reason);
 
     // 3. Perform ! ReadableStreamDefaultControllerClearAlgorithms(this).
     readable_stream_default_controller_clear_algorithms(*this);
@@ -138,6 +138,9 @@ void ReadableStreamDefaultController::visit_edges(Cell::Visitor& visitor)
     for (auto const& item : m_queue)
         visitor.visit(item.value);
     visitor.visit(m_stream);
+    visitor.visit(m_cancel_algorithm);
+    visitor.visit(m_pull_algorithm);
+    visitor.visit(m_strategy_size_algorithm);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultController.h
@@ -32,8 +32,8 @@ public:
     WebIDL::ExceptionOr<void> enqueue(JS::Value chunk);
     void error(JS::Value error);
 
-    auto& cancel_algorithm() { return m_cancel_algorithm; }
-    void set_cancel_algorithm(Optional<CancelAlgorithm> value) { m_cancel_algorithm = move(value); }
+    JS::GCPtr<CancelAlgorithm> cancel_algorithm() { return m_cancel_algorithm; }
+    void set_cancel_algorithm(JS::GCPtr<CancelAlgorithm> value) { m_cancel_algorithm = value; }
 
     bool close_requested() const { return m_close_requested; }
     void set_close_requested(bool value) { m_close_requested = value; }
@@ -41,8 +41,8 @@ public:
     bool pull_again() const { return m_pull_again; }
     void set_pull_again(bool value) { m_pull_again = value; }
 
-    auto& pull_algorithm() { return m_pull_algorithm; }
-    void set_pull_algorithm(Optional<PullAlgorithm> value) { m_pull_algorithm = move(value); }
+    JS::GCPtr<PullAlgorithm> pull_algorithm() { return m_pull_algorithm; }
+    void set_pull_algorithm(JS::GCPtr<PullAlgorithm> value) { m_pull_algorithm = value; }
 
     bool pulling() const { return m_pulling; }
     void set_pulling(bool value) { m_pulling = value; }
@@ -58,8 +58,8 @@ public:
     double strategy_hwm() const { return m_strategy_hwm; }
     void set_strategy_hwm(double value) { m_strategy_hwm = value; }
 
-    auto& strategy_size_algorithm() { return m_strategy_size_algorithm; }
-    void set_strategy_size_algorithm(Optional<SizeAlgorithm> value) { m_strategy_size_algorithm = move(value); }
+    JS::GCPtr<SizeAlgorithm> strategy_size_algorithm() { return m_strategy_size_algorithm; }
+    void set_strategy_size_algorithm(JS::GCPtr<SizeAlgorithm> value) { m_strategy_size_algorithm = value; }
 
     JS::GCPtr<ReadableStream> stream() { return m_stream; }
     void set_stream(JS::GCPtr<ReadableStream> value) { m_stream = value; }
@@ -75,7 +75,7 @@ private:
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-cancelalgorithm
     // A promise-returning algorithm, taking one argument (the cancel reason), which communicates a requested cancelation to the underlying source
-    Optional<CancelAlgorithm> m_cancel_algorithm;
+    JS::GCPtr<CancelAlgorithm> m_cancel_algorithm;
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-closerequested
     // A boolean flag indicating whether the stream has been closed by its underlying source, but still has chunks in its internal queue that have not yet been read
@@ -87,7 +87,7 @@ private:
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pullalgorithm
     // A promise-returning algorithm that pulls data from the underlying source
-    Optional<PullAlgorithm> m_pull_algorithm;
+    JS::GCPtr<PullAlgorithm> m_pull_algorithm;
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-pulling
     // A boolean flag set to true while the underlying source's pull algorithm is executing and the returned promise has not yet fulfilled, used to prevent reentrant calls
@@ -111,7 +111,7 @@ private:
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-strategysizealgorithm
     // An algorithm to calculate the size of enqueued chunks, as part of the stream’s queuing strategy
-    Optional<SizeAlgorithm> m_strategy_size_algorithm;
+    JS::GCPtr<SizeAlgorithm> m_strategy_size_algorithm;
 
     // https://streams.spec.whatwg.org/#readablestreamdefaultcontroller-stream
     // The ReadableStream instance controlled

--- a/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
@@ -42,13 +42,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<TransformStream>> TransformStream::construc
     auto readable_high_water_mark = TRY(extract_high_water_mark(readable_strategy, 0));
 
     // 6. Let readableSizeAlgorithm be ! ExtractSizeAlgorithm(readableStrategy).
-    auto readable_size_algorithm = extract_size_algorithm(readable_strategy);
+    auto readable_size_algorithm = extract_size_algorithm(vm, readable_strategy);
 
     // 7. Let writableHighWaterMark be ? ExtractHighWaterMark(writableStrategy, 1).
     auto writable_high_water_mark = TRY(extract_high_water_mark(writable_strategy, 1));
 
     // 8. Let writableSizeAlgorithm be ! ExtractSizeAlgorithm(writableStrategy).
-    auto writable_size_algorithm = extract_size_algorithm(writable_strategy);
+    auto writable_size_algorithm = extract_size_algorithm(vm, writable_strategy);
 
     // 9. Let startPromise be a new promise.
     auto start_promise = WebIDL::create_promise(realm);

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
@@ -29,6 +29,8 @@ void TransformStreamDefaultController::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_stream);
+    visitor.visit(m_flush_algorithm);
+    visitor.visit(m_transform_algorithm);
 }
 
 // https://streams.spec.whatwg.org/#ts-default-controller-desired-size

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.h
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.h
@@ -24,11 +24,11 @@ public:
     WebIDL::ExceptionOr<void> error(Optional<JS::Value> reason = {});
     WebIDL::ExceptionOr<void> terminate();
 
-    auto& flush_algorithm() { return m_flush_algorithm; }
-    void set_flush_algorithm(Optional<FlushAlgorithm>&& value) { m_flush_algorithm = move(value); }
+    JS::GCPtr<FlushAlgorithm> flush_algorithm() { return m_flush_algorithm; }
+    void set_flush_algorithm(JS::GCPtr<FlushAlgorithm>&& value) { m_flush_algorithm = move(value); }
 
-    auto& transform_algorithm() { return m_transform_algorithm; }
-    void set_transform_algorithm(Optional<TransformAlgorithm>&& value) { m_transform_algorithm = move(value); }
+    JS::GCPtr<TransformAlgorithm> transform_algorithm() { return m_transform_algorithm; }
+    void set_transform_algorithm(JS::GCPtr<TransformAlgorithm>&& value) { m_transform_algorithm = move(value); }
 
     JS::GCPtr<TransformStream> stream() { return m_stream; }
     void set_stream(JS::GCPtr<TransformStream> stream) { m_stream = stream; }
@@ -39,10 +39,10 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-flushalgorithm
-    Optional<FlushAlgorithm> m_flush_algorithm;
+    JS::GCPtr<FlushAlgorithm> m_flush_algorithm;
 
     // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-transformalgorithm
-    Optional<TransformAlgorithm> m_transform_algorithm;
+    JS::GCPtr<TransformAlgorithm> m_transform_algorithm;
 
     // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-stream
     JS::GCPtr<TransformStream> m_stream;

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -39,7 +39,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_
     // Note: This AO configures slot values which are already specified in the class's field initializers.
 
     // 5. Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
-    auto size_algorithm = extract_size_algorithm(strategy);
+    auto size_algorithm = extract_size_algorithm(vm, strategy);
 
     // 6. Let highWaterMark be ? ExtractHighWaterMark(strategy, 1).
     auto high_water_mark = TRY(extract_high_water_mark(strategy, 1));

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
@@ -19,6 +19,10 @@ void WritableStreamDefaultController::visit_edges(Visitor& visitor)
     for (auto& value : m_queue)
         visitor.visit(value.value);
     visitor.visit(m_stream);
+    visitor.visit(m_abort_algorithm);
+    visitor.visit(m_close_algorithm);
+    visitor.visit(m_strategy_size_algorithm);
+    visitor.visit(m_write_algorithm);
 }
 
 // https://streams.spec.whatwg.org/#ws-default-controller-error
@@ -39,7 +43,7 @@ WebIDL::ExceptionOr<void> WritableStreamDefaultController::error(JS::Value error
 WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> WritableStreamDefaultController::abort_steps(JS::Value reason)
 {
     // 1. Let result be the result of performing this.[[abortAlgorithm]], passing reason.
-    auto result = TRY((*m_abort_algorithm)(reason));
+    auto result = TRY(m_abort_algorithm->function()(reason));
 
     // 2. Perform ! WritableStreamDefaultControllerClearAlgorithms(this).
     writable_stream_default_controller_clear_algorithms(*this);

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.h
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.h
@@ -24,11 +24,11 @@ public:
     JS::NonnullGCPtr<DOM::AbortSignal> signal() { return *m_signal; }
     void set_signal(JS::NonnullGCPtr<DOM::AbortSignal> value) { m_signal = value; }
 
-    auto& abort_algorithm() { return m_abort_algorithm; }
-    void set_abort_algorithm(Optional<AbortAlgorithm>&& value) { m_abort_algorithm = move(value); }
+    JS::GCPtr<AbortAlgorithm> abort_algorithm() { return m_abort_algorithm; }
+    void set_abort_algorithm(JS::GCPtr<AbortAlgorithm> value) { m_abort_algorithm = value; }
 
-    auto& close_algorithm() { return m_close_algorithm; }
-    void set_close_algorithm(Optional<CloseAlgorithm>&& value) { m_close_algorithm = move(value); }
+    JS::GCPtr<CloseAlgorithm> close_algorithm() { return m_close_algorithm; }
+    void set_close_algorithm(JS::GCPtr<CloseAlgorithm> value) { m_close_algorithm = value; }
 
     SinglyLinkedList<ValueWithSize>& queue() { return m_queue; }
 
@@ -41,14 +41,14 @@ public:
     size_t strategy_hwm() const { return m_strategy_hwm; }
     void set_strategy_hwm(size_t value) { m_strategy_hwm = value; }
 
-    auto& strategy_size_algorithm() { return m_strategy_size_algorithm; }
-    void set_strategy_size_algorithm(Optional<SizeAlgorithm>&& value) { m_strategy_size_algorithm = move(value); }
+    JS::GCPtr<SizeAlgorithm> strategy_size_algorithm() { return m_strategy_size_algorithm; }
+    void set_strategy_size_algorithm(JS::GCPtr<SizeAlgorithm> value) { m_strategy_size_algorithm = value; }
 
     JS::NonnullGCPtr<WritableStream> stream() { return *m_stream; }
     void set_stream(JS::NonnullGCPtr<WritableStream> value) { m_stream = value; }
 
-    auto& write_algorithm() { return m_write_algorithm; }
-    void set_write_algorithm(Optional<WriteAlgorithm>&& value) { m_write_algorithm = move(value); }
+    JS::GCPtr<WriteAlgorithm> write_algorithm() { return m_write_algorithm; }
+    void set_write_algorithm(JS::GCPtr<WriteAlgorithm> value) { m_write_algorithm = value; }
 
     WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> abort_steps(JS::Value reason);
     void error_steps();
@@ -60,11 +60,11 @@ private:
 
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-abortalgorithm
     // A promise-returning algorithm, taking one argument (the abort reason), which communicates a requested abort to the underlying sink
-    Optional<AbortAlgorithm> m_abort_algorithm;
+    JS::GCPtr<AbortAlgorithm> m_abort_algorithm;
 
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-closealgorithm
     // A promise-returning algorithm which communicates a requested close to the underlying sink
-    Optional<CloseAlgorithm> m_close_algorithm;
+    JS::GCPtr<CloseAlgorithm> m_close_algorithm;
 
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-queue
     // A list representing the stream’s internal queue of chunks
@@ -88,7 +88,7 @@ private:
 
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-strategysizealgorithm
     // An algorithm to calculate the size of enqueued chunks, as part of the stream’s queuing strategy
-    Optional<SizeAlgorithm> m_strategy_size_algorithm;
+    JS::GCPtr<SizeAlgorithm> m_strategy_size_algorithm;
 
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-stream
     // The WritableStream instance controlled
@@ -96,7 +96,7 @@ private:
 
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-writealgorithm
     // A promise-returning algorithm, taking one argument (the chunk to write), which writes data to the underlying sink
-    Optional<WriteAlgorithm> m_write_algorithm;
+    JS::GCPtr<WriteAlgorithm> m_write_algorithm;
 };
 
 }


### PR DESCRIPTION
This allow us to actually clear stream controller algorithms when needed as
now these functions are GC-allocated like everything else.