### PR TITLE
LibGfx/PNM: Remove unnecessary line

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PAMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PAMLoader.cpp
@@ -57,7 +57,6 @@ ErrorOr<void> read_image_data(PAMLoadingContext& context)
         }
     }
 
-    context.state = PAMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PBMLoader.cpp
@@ -49,7 +49,6 @@ ErrorOr<void> read_image_data(PBMLoadingContext& context)
         }
     }
 
-    context.state = PBMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PGMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PGMLoader.cpp
@@ -36,7 +36,6 @@ ErrorOr<void> read_image_data(PGMLoadingContext& context)
         }
     }
 
-    context.state = PGMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PPMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PPMLoader.cpp
@@ -45,7 +45,6 @@ ErrorOr<void> read_image_data(PPMLoadingContext& context)
         }
     }
 
-    context.state = PPMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }


### PR DESCRIPTION
This is already done at the caller decode() in
PortableImageLoaderCommon.h, as pointed out by @LucasChollet at https://github.com/SerenityOS/serenity/pull/22935#discussion_r1467158789

No behavior change.