### PR TITLE
Ladybird/Qt: Properly listen for DPI changes on Wayland

### DIFF
--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -96,6 +96,7 @@ protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
+    virtual bool event(QEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
     virtual void moveEvent(QMoveEvent*) override;
     virtual void wheelEvent(QWheelEvent*) override;

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -35,6 +35,7 @@ public slots:
     void device_pixel_ratio_changed(qreal dpi);
 
 private:
+    bool event(QEvent*) override;
     void closeEvent(QCloseEvent*) override;
 
     QPoint to_widget_position(Gfx::IntPoint) const;

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -61,7 +61,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_layout->setSpacing(0);
     m_layout->setContentsMargins(0, 0, 0, 0);
 
-    m_view = new WebContentView(web_content_options, webdriver_content_ipc_path, parent_client, page_index);
+    m_view = new WebContentView(this, web_content_options, webdriver_content_ipc_path, parent_client, page_index);
     m_toolbar = new QToolBar(this);
     m_location_edit = new LocationEdit(this);
 

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -54,8 +54,9 @@ namespace Ladybird {
 
 bool is_using_dark_system_theme(QWidget&);
 
-WebContentView::WebContentView(WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
-    : m_web_content_options(web_content_options)
+WebContentView::WebContentView(QWidget* window, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
+    : QAbstractScrollArea(window)
+    , m_web_content_options(web_content_options)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
 {
     m_client_state.client = parent_client;

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -42,7 +42,7 @@ class WebContentView final
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
-    WebContentView(WebContentOptions const&, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
+    WebContentView(QWidget* window, WebContentOptions const&, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
     virtual ~WebContentView() override;
 
     Function<String(const AK::URL&, Web::HTML::ActivateTab)> on_tab_open_request;


### PR DESCRIPTION
Some Wayland compositors have support of fractional-scale-v1 protocol. The protocol allows compositor to announce a preferred fractional scale on a per-wl_surface basis. Qt forwards these Wayland events to an application using a usual DevicePixelRatioChange event. However, in contrast to the other platforms, this DevicePixelRatioChange event is issued directly on widgets and not screens. Additionally, the exact fractional scale is stored in QWindow object and not the current screen.

Note that in theory it is possible to obtain per-screen fractional scaling on Wayland by interpolating data provided by wl_output and xdg_output events but qtwayland does not do that.

If fractional-scale-v1 is not available, qtwayland will still fire per-Widget DevicePixelRatioChange events, but, obviously, with the per-screen possibly larger ceiled scaling.

This whole thing makes handling DPI changes on Wayland really simple. All we need to do is to intercept DevicePixelRatioChange events firing on QWindow objects and call the old device_pixel_ratio_changed handler with the window's devicePixelRatio(). The only caveat here is to not forget to always set QWidget's parent before calling devicePixelRatio() on it.

------

Unfortunately, this requires Qt >= 6.6, so I had to add some amount of preprocessor directives.