### PR TITLE
AK: Use IsSame<FlatPtr, T> instead of __LP64__ to guess FlatPtr's type

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -104,11 +104,17 @@ public:
 
     Optional<FlatPtr> get_addr() const
     {
-#ifdef __LP64__
-        return get_u64();
-#else
-        return get_u32();
-#endif
+        // Note: This makes the lambda dependent on the template parameter, which is necessary
+        //       for the `if constexpr` to not evaluate both branches.
+        auto fn = [&]<typename T>() -> Optional<T> {
+            if constexpr (IsSame<T, u64>) {
+                return get_u64();
+            } else {
+                return get_u32();
+            }
+        };
+
+        return fn.operator()<FlatPtr>();
     }
 
     Optional<bool> get_bool() const


### PR DESCRIPTION
Just because pointers don't use 64 bits doesn't mean the type FlatPtr will resolve to is the same as u32; instead of playing the guessing game, simply use whatever type FlatPtr is.

Of course it's because windows, what else <https://github.com/SerenityOS/jakt/actions/runs/7677815317/job/20926995435>.