### PR TITLE
LibWeb: Implement a slightly better ad-hoc `Body::clone` method

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/init-from-cloned-fetch-response.txt
+++ b/Tests/LibWeb/Text/expected/Streams/init-from-cloned-fetch-response.txt
@@ -1,0 +1,1 @@
+Was able to create a reader from a cloned Fetch response!

--- a/Tests/LibWeb/Text/input/Streams/init-from-cloned-fetch-response.html
+++ b/Tests/LibWeb/Text/input/Streams/init-from-cloned-fetch-response.html
@@ -1,0 +1,17 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        fetch("./../basic.html", { mode: "no-cors" })
+            .then(response => {
+                const clonedResponse = response.clone();
+                return clonedResponse.body;
+            })
+            .then(body => {
+                const reader = body.getReader();
+                reader.read();
+
+                println("Was able to create a reader from a cloned Fetch response!");
+                done();
+            });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -1741,6 +1741,25 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_stream(JS:
     return stream;
 }
 
+// https://streams.spec.whatwg.org/#abstract-opdef-createreadablebytestream
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_byte_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, PullAlgorithm&& pull_algorithm, CancelAlgorithm&& cancel_algorithm)
+{
+    // 1. Let stream be a new ReadableStream.
+    auto stream = realm.heap().allocate<ReadableStream>(realm, realm);
+
+    // 2. Perform ! InitializeReadableStream(stream).
+    initialize_readable_stream(*stream);
+
+    // 3. Let controller be a new ReadableByteStreamController.
+    auto controller = realm.heap().allocate<ReadableByteStreamController>(realm, realm);
+
+    // 4. Perform ? SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, 0, undefined).
+    TRY(set_up_readable_byte_stream_controller(stream, controller, move(start_algorithm), move(pull_algorithm), move(cancel_algorithm), 0, JS::js_undefined()));
+
+    // 5. Return stream.
+    return stream;
+}
+
 // https://streams.spec.whatwg.org/#create-writable-stream
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> create_writable_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, WriteAlgorithm&& write_algorithm, CloseAlgorithm&& close_algorithm, AbortAlgorithm&& abort_algorithm, double high_water_mark, SizeAlgorithm&& size_algorithm)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -109,6 +109,7 @@ void readable_byte_stream_controller_invalidate_byob_request(ReadableByteStreamC
 bool readable_byte_stream_controller_should_call_pull(ReadableByteStreamController const&);
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, PullAlgorithm&& pull_algorithm, CancelAlgorithm&& cancel_algorithm, Optional<double> high_water_mark = {}, Optional<SizeAlgorithm>&& size_algorithm = {});
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_byte_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, PullAlgorithm&& pull_algorithm, CancelAlgorithm&& cancel_algorithm);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> create_writable_stream(JS::Realm& realm, StartAlgorithm&& start_algorithm, WriteAlgorithm&& write_algorithm, CloseAlgorithm&& close_algorithm, AbortAlgorithm&& abort_algorithm, double high_water_mark, SizeAlgorithm&& size_algorithm);
 void initialize_readable_stream(ReadableStream&);
 void initialize_writable_stream(WritableStream&);


### PR DESCRIPTION
Fixes #22960

We still crash on chat.openai.com, but in CSS this time:
```
VERIFICATION FAILED: i < m_size at Meta/Lagom/../../AK/Vector.h:139
Build/lagom/lib/liblagom-ak.so.0(ak_verification_failed+0xc1) [0x7ff19c306da1]
Build/lagom/lib/liblagom-web.so.0 Web::CSS::SumCalculationNode::equals(Web::CSS::CalculationNode const&) const 0x9c) [0x7ff19b574cbc]
Build/lagom/lib/liblagom-web.so.0 Web::CSS::TransformationStyleValue::Properties::operator==(Web::CSS::TransformationStyleValue::Properties const&) const 0xba) [0x7ff19b59aa6a]
Build/lagom/lib/liblagom-web.so.0 Web::CSS::StyleValueList::Properties::operator==(Web::CSS::StyleValueList::Properties const&) const 0xba) [0x7ff19b59a66a]
Build/lagom/lib/liblagom-web.so.0 Web::DOM::Element::recompute_style() 0x13f) [0x7ff19b5dd91f]
```
