### PR TITLE
LibWeb: Fix vector OOB access when comparing some calc() values

### DIFF
--- a/Tests/LibWeb/Text/expected/css/replace-calc-function-with-same-kind-but-fewer-arguments.txt
+++ b/Tests/LibWeb/Text/expected/css/replace-calc-function-with-same-kind-but-fewer-arguments.txt
@@ -1,0 +1,1 @@
+PASS! (didn't crash) 

--- a/Tests/LibWeb/Text/input/css/replace-calc-function-with-same-kind-but-fewer-arguments.html
+++ b/Tests/LibWeb/Text/input/css/replace-calc-function-with-same-kind-but-fewer-arguments.html
@@ -1,0 +1,13 @@
+<!doctype html><script src="../include.js"></script><body><script>
+    test(() => {
+        let body = document.body;
+        body.style.width = 'max(10px, 20px, 30px)';
+        body.style.width = 'max(10px, 20px)';
+        body.style.width = 'min(10px, 20px, 30px)';
+        body.style.width = 'min(10px, 20px)';
+        body.style.width = 'calc(10px + 20px + 30px)';
+        body.style.width = 'calc(10px + 20px)';
+        body.style.width = 'calc(10px * 20px * 30px)';
+        body.style.width = 'calc(10px * 20px)';
+    });
+</script>PASS! (didn't crash)

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -372,6 +372,8 @@ bool SumCalculationNode::equals(CalculationNode const& other) const
         return true;
     if (type() != other.type())
         return false;
+    if (m_values.size() != static_cast<SumCalculationNode const&>(other).m_values.size())
+        return false;
     for (size_t i = 0; i < m_values.size(); ++i) {
         if (!m_values[i]->equals(*static_cast<SumCalculationNode const&>(other).m_values[i]))
             return false;
@@ -507,6 +509,8 @@ bool ProductCalculationNode::equals(CalculationNode const& other) const
     if (this == &other)
         return true;
     if (type() != other.type())
+        return false;
+    if (m_values.size() != static_cast<ProductCalculationNode const&>(other).m_values.size())
         return false;
     for (size_t i = 0; i < m_values.size(); ++i) {
         if (!m_values[i]->equals(*static_cast<ProductCalculationNode const&>(other).m_values[i]))
@@ -736,6 +740,8 @@ bool MinCalculationNode::equals(CalculationNode const& other) const
         return true;
     if (type() != other.type())
         return false;
+    if (m_values.size() != static_cast<MinCalculationNode const&>(other).m_values.size())
+        return false;
     for (size_t i = 0; i < m_values.size(); ++i) {
         if (!m_values[i]->equals(*static_cast<MinCalculationNode const&>(other).m_values[i]))
             return false;
@@ -830,6 +836,8 @@ bool MaxCalculationNode::equals(CalculationNode const& other) const
     if (this == &other)
         return true;
     if (type() != other.type())
+        return false;
+    if (m_values.size() != static_cast<MaxCalculationNode const&>(other).m_values.size())
         return false;
     for (size_t i = 0; i < m_values.size(); ++i) {
         if (!m_values[i]->equals(*static_cast<MaxCalculationNode const&>(other).m_values[i]))


### PR DESCRIPTION
Before comparing the elements of two vectors, we have to check that they have the same length. :^)

Fixes a crash seen on https://chat.openai.com/