### PR TITLE
LibWeb: Add missing ARIA roles to `RoleType::build_role_object()`

### DIFF
--- a/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
@@ -175,6 +175,8 @@ ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool foc
         return adopt_nonnull_own_or_enomem(new (nothrow) Complementary(data));
     case Role::composite:
         return adopt_nonnull_own_or_enomem(new (nothrow) ContentInfo(data));
+    case Role::contentinfo:
+        return adopt_nonnull_own_or_enomem(new (nothrow) ContentInfo(data));
     case Role::definition:
         return adopt_nonnull_own_or_enomem(new (nothrow) Definition(data));
     case Role::deletion:
@@ -241,6 +243,8 @@ ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool foc
         return adopt_nonnull_own_or_enomem(new (nothrow) MenuItemRadio(data));
     case Role::navigation:
         return adopt_nonnull_own_or_enomem(new (nothrow) Navigation(data));
+    case Role::none:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Presentation(data));
     case Role::note:
         return adopt_nonnull_own_or_enomem(new (nothrow) Note(data));
     case Role::option:
@@ -282,6 +286,10 @@ ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool foc
         return adopt_nonnull_own_or_enomem(new (nothrow) Status(data));
     case Role::strong:
         return adopt_nonnull_own_or_enomem(new (nothrow) Strong(data));
+    case Role::subscript:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Subscript(data));
+    case Role::superscript:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Superscript(data));
     case Role::switch_:
         return adopt_nonnull_own_or_enomem(new (nothrow) Switch(data));
     case Role::tab:

--- a/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
@@ -174,7 +174,7 @@ ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool foc
     case Role::complementary:
         return adopt_nonnull_own_or_enomem(new (nothrow) Complementary(data));
     case Role::composite:
-        return adopt_nonnull_own_or_enomem(new (nothrow) ContentInfo(data));
+        return adopt_nonnull_own_or_enomem(new (nothrow) Composite(data));
     case Role::contentinfo:
         return adopt_nonnull_own_or_enomem(new (nothrow) ContentInfo(data));
     case Role::definition:


### PR DESCRIPTION
This change allows `contentinfo`, `none`, `subscript` and `superscript` RoleTypes to be built. These were the only non-abstract role types missing from this function.

This fixes an issue where clicking on an element with one of these role types in Inspector would cause a crash.

Tested manually by clicking each of the elements on the following page in Inspector:
```html
<!DOCTYPE html>
<body>
<!-- These caused Inspector to crash previously !-->
<sub>sub</sub>
<sup>sup</sup>
<div role="contentinfo">contentinfo</div>
<div role="none">none</div>
```