### PR TITLE
LibWeb: Set select element text when an option is initially selected

### DIFF
--- a/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
+++ b/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 89.109375x17] baseline: 16.5
+      BlockContainer <select> at (13,10) content-size 89.109375x17 inline-block [BFC] children: not-inline
+        Box <div> at (13,10) content-size 89.109375x17 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (13,10) content-size 69.109375x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 8, rect: [13,10 69.109375x17] baseline: 13.296875
+                "Option 2"
+            TextNode <#text>
+          BlockContainer <div> at (86.109375,10.5) content-size 16x16 flex-item [BFC] children: inline
+            frag 0 from SVGSVGBox start: 0, length: 0, rect: [86.109375,10.5 16x16] baseline: 16
+            SVGSVGBox <svg> at (86.109375,10.5) content-size 16x16 [SVG] children: not-inline
+              SVGGeometryBox <path> at (90.109375,16.21875) content-size 8x4.953125 children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x37]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<SELECT>) [8,8 99.109375x21]
+        PaintableBox (Box<DIV>) [13,10 89.109375x17]
+          PaintableWithLines (BlockContainer<DIV>) [13,10 69.109375x17]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [86.109375,10.5 16x16]
+            SVGSVGPaintable (SVGSVGBox<svg>) [86.109375,10.5 16x16]
+              SVGPathPaintable (SVGGeometryBox<path>) [90.109375,16.21875 8x4.953125]

--- a/Tests/LibWeb/Layout/input/select-with-option-selected.html
+++ b/Tests/LibWeb/Layout/input/select-with-option-selected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<select>
+    <option>Option 1</option>
+    <option selected="selected">Option 2</option>
+</select>

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -323,9 +323,9 @@ void HTMLSelectElement::form_associated_element_was_inserted()
             auto options = list_of_options();
             if (options.size() > 0) {
                 options.at(0)->set_selected(true);
-                update_inner_text_element();
             }
         }
+        update_inner_text_element();
     });
 }
 


### PR DESCRIPTION
Previously, a select element's text would initially be empty if the `selected` property was set on one of its options.

This was affecting the search controls on the [Ladybird AUR page](https://aur.archlinux.org/packages/ladybird)

Before:
![ladybird_aur_before](https://github.com/SerenityOS/serenity/assets/2817754/948929ac-983e-4e3c-9d05-3b824bc833a3)

After:
![ladybird_aur_after](https://github.com/SerenityOS/serenity/assets/2817754/cce300e0-2b29-44ed-9ddc-7ba5af036dbe)

Note: This change doesn't affect the layout of the search controls. I've opened a separate issue (#22992) for that.