### PR TITLE
LibLine+LibVT: Internal functions to erase spaces and to search character. Also ASCII control characters.

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -156,6 +156,8 @@ void Editor::set_default_keybinds()
     register_key_input_callback(ctrl('K'), EDITOR_INTERNAL_FUNCTION(erase_to_end));
     register_key_input_callback(ctrl('L'), EDITOR_INTERNAL_FUNCTION(clear_screen));
     register_key_input_callback(ctrl('R'), EDITOR_INTERNAL_FUNCTION(enter_search));
+    register_key_input_callback(ctrl(']'), EDITOR_INTERNAL_FUNCTION(search_character_forwards));
+    register_key_input_callback(Key { ctrl(']'), Key::Alt }, EDITOR_INTERNAL_FUNCTION(search_character_backwards));
     register_key_input_callback(ctrl('T'), EDITOR_INTERNAL_FUNCTION(transpose_characters));
     register_key_input_callback('\n', EDITOR_INTERNAL_FUNCTION(finish));
 

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -172,6 +172,7 @@ void Editor::set_default_keybinds()
     // ^[^H: alt-backspace: backward delete word
     register_key_input_callback(Key { '\b', Key::Alt }, EDITOR_INTERNAL_FUNCTION(erase_alnum_word_backwards));
     register_key_input_callback(Key { 'd', Key::Alt }, EDITOR_INTERNAL_FUNCTION(erase_alnum_word_forwards));
+    register_key_input_callback(Key { '\\', Key::Alt }, EDITOR_INTERNAL_FUNCTION(erase_spaces));
     register_key_input_callback(Key { 'c', Key::Alt }, EDITOR_INTERNAL_FUNCTION(capitalize_word));
     register_key_input_callback(Key { 'l', Key::Alt }, EDITOR_INTERNAL_FUNCTION(lowercase_word));
     register_key_input_callback(Key { 'u', Key::Alt }, EDITOR_INTERNAL_FUNCTION(uppercase_word));

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -110,6 +110,8 @@ struct Configuration {
     M(cursor_right_word)                       \
     M(cursor_right_nonspace_word)              \
     M(enter_search)                            \
+    M(search_character_backwards)              \
+    M(search_character_forwards)               \
     M(erase_character_backwards)               \
     M(erase_character_forwards)                \
     M(erase_to_beginning)                      \

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -127,6 +127,7 @@ struct Configuration {
     M(insert_last_erased)                      \
     M(erase_alnum_word_backwards)              \
     M(erase_alnum_word_forwards)               \
+    M(erase_spaces)                            \
     M(capitalize_word)                         \
     M(lowercase_word)                          \
     M(uppercase_word)                          \

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -579,6 +579,23 @@ void Editor::erase_alnum_word_forwards()
     }
 }
 
+void Editor::erase_spaces()
+{
+    while (m_cursor < m_buffer.size()) {
+        if (is_ascii_space(m_buffer[m_cursor]))
+            erase_character_forwards();
+        else
+            break;
+    }
+
+    while (m_cursor > 0) {
+        if (is_ascii_space(m_buffer[m_cursor - 1]))
+            erase_character_backwards();
+        else
+            break;
+    }
+}
+
 void Editor::case_change_word(Editor::CaseChangeOp change_op)
 {
     // A word here is contiguous alnums. `foo=bar baz` is three words.

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -1533,11 +1533,25 @@ void Terminal::handle_key_press(KeyCode key, u32 code_point, u8 flags)
     // Key event was not one of the above special cases,
     // attempt to treat it as a character...
     if (ctrl) {
-        if (code_point >= 'a' && code_point <= 'z') {
-            code_point = code_point - 'a' + 1;
-        } else if (code_point == '\\') {
-            code_point = 0x1c;
-        }
+        constexpr auto ESC = '\033';
+        constexpr auto NUL = 0;
+        constexpr auto DEL = 0x7f;
+
+        if (code_point >= '@' && code_point < DEL)
+            code_point &= 0x1f;
+        // Legacy aliases
+        else if (code_point == '2' || code_point == ' ')
+            // Ctrl+{2, Space, @, `} -> ^@ (NUL)
+            code_point = NUL;
+        else if (code_point >= '3' && code_point <= '7')
+            // Ctrl+3 -> ^[ (ESC), Ctrl+4 -> ^\, Ctrl+5 -> ^], Ctrl+6 -> ^^, Ctrl+7 -> ^_
+            code_point = ESC + (code_point - '3');
+        else if (code_point == '8')
+            // Ctrl+8 -> ^? (DEL)
+            code_point = DEL;
+        else if (code_point == '/')
+            // Ctrl+/ -> ^_
+            code_point = '_' & 0x1f;
     }
 
     // Alt modifier sends escape prefix.


### PR DESCRIPTION
These are two the low-hanging (as i once thought; they turned out to be
not-so-low-hanging) internal functions that were yet to be implemented in LibLine.

---

#### LibLine: Add internal function to erase consecutive spaces under cursor

#### LibVT: Ability to generate each of the 32 ASCII control characters

*Edit: This is an old commit that has now been updated with new changes and commit message.*

```
    The 128 (7 bits) ASCII codes are divided into 4 groups (with 2 upper
    most significant bits) of 32 codes (5 least significant bits) each.

    The first group (bit pattern: 00x'xxxx) consist of the "non-printable"
    characters which are also the "control" characters. These control
    characters don't have a dedicated key in keyboards; they are supposed to
    be invoked with the "control" key.

    Pressing the control key in combination with another character (which is
    in one of the other three groups) sets the 2 upper most significant bits
    of that character code to zero (by AND-ing with 0x1f), thus generating a
    control character.

    This also means that there are three ways (corresponding to the three
    groups of printable characters) to produce a control character.

    For example, (for the US-English keyboard layout,) these three key
    combinations will produce the ASCII code for ESCAPE:

        Ctrl+[  Ctrl+Shift+[  and  Ctrl+;

    Before, the code allowed to generate only 27 control characters from ^A
    to ^Z and ^\. Now, it is possible to generate the remaining 5 and that
    too with three key combinations. :^)
```

So, this is the controversial one.

On my Linux box `Ctrl+2` generates `^@`; but with this commit, on serenity you
will have to do `Ctrl+Shift+2` to generate `^@`. (because `Ctrl+2` will generate
`^R` instead). Same with `Ctrl+/` -> `^_` and many others.

I don't know what is exactly going on there. That behaviour looks to be dependent
on the keymap, else how would you know that `Shift+2` is `@`?

So is it alright to have three ways to generate a control character? and to maybe
deviate from linux? Is there a standard for this?

#### LibLine: Add internal functions to search character forwards & backwards

Can use `Utf8View::decode_leading_byte()` and `Utf8View::decode_continuation_byte()`
for early abort but they are private members. But i don't even know how would you
input corrupt-illegal (for UTF-8 encoding) bytes via the keyboard such that the
function fails.
