### PR TITLE
LibVT: Write emoji to the pseudo-terminal master fd on emoji input

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -87,7 +87,7 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy)
     set_pty_master_fd(ptm_fd);
 
     on_emoji_input = [this](auto emoji) {
-        inject_string(emoji);
+        emit(emoji.bytes().data(), emoji.length());
     };
 
     m_cursor_blink_timer = add<Core::Timer>();


### PR DESCRIPTION
```
    ... instead of inserting it into the current output character stream
    that the terminal widget is going to render.

    This ensures that the emoji gets sent to the foreground process of the
    terminal.
```