### PR TITLE
HexEditor: Add comments to annotations, and show them in the GUI

### DIFF
--- a/Userland/Applications/HexEditor/AnnotationsModel.cpp
+++ b/Userland/Applications/HexEditor/AnnotationsModel.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "AnnotationsModel.h"
+
+GUI::Variant AnnotationsModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
+{
+    if (index.row() < 0 || index.row() >= row_count())
+        return {};
+
+    if (role == GUI::ModelRole::TextAlignment)
+        return Gfx::TextAlignment::CenterLeft;
+
+    auto& annotation = m_annotations.at(index.row());
+    if (role == GUI::ModelRole::Display) {
+        switch (index.column()) {
+        case Column::Start:
+            return MUST(String::formatted("{:#08X}", annotation.start_offset));
+        case Column::End:
+            return MUST(String::formatted("{:#08X}", annotation.end_offset));
+        case Column::Comments:
+            return annotation.comments;
+        }
+    }
+    switch (to_underlying(role)) {
+    case to_underlying(CustomRole::StartOffset):
+        return annotation.start_offset;
+    case to_underlying(CustomRole::EndOffset):
+        return annotation.end_offset;
+    case to_underlying(CustomRole::Comments):
+        return annotation.comments;
+    }
+
+    return {};
+}
+
+void AnnotationsModel::add_annotation(Annotation annotation)
+{
+    m_annotations.append(move(annotation));
+    invalidate();
+}
+
+void AnnotationsModel::delete_annotation(Annotation const& annotation)
+{
+    m_annotations.remove_first_matching([&](auto& other) {
+        return other == annotation;
+    });
+    invalidate();
+}
+
+Optional<Annotation&> AnnotationsModel::closest_annotation_at(size_t position)
+{
+    // FIXME: If we end up with a lot of annotations, we'll need to store them and query them in a smarter way.
+    Optional<Annotation&> result;
+    for (auto& annotation : m_annotations) {
+        if (annotation.start_offset <= position && position <= annotation.end_offset) {
+            // If multiple annotations cover this position, use whichever starts latest. This would be the innermost one
+            // if they overlap fully rather than partially.
+            if (!result.has_value() || result->start_offset < annotation.start_offset)
+                result = annotation;
+        }
+    }
+
+    return result;
+}

--- a/Userland/Applications/HexEditor/AnnotationsModel.h
+++ b/Userland/Applications/HexEditor/AnnotationsModel.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibGUI/Model.h>
+
+struct Annotation {
+    size_t start_offset { 0 };
+    size_t end_offset { 0 };
+    Gfx::Color background_color { Color::from_argb(0xfffce94f) };
+    String comments {};
+
+    bool operator==(Annotation const& other) const = default;
+};
+
+class AnnotationsModel final : public GUI::Model {
+public:
+    enum Column {
+        Start,
+        End,
+        Comments,
+    };
+
+    enum class CustomRole {
+        StartOffset = to_underlying(GUI::ModelRole::Custom) + 1,
+        EndOffset,
+        Comments,
+    };
+
+    virtual int row_count(GUI::ModelIndex const& index = GUI::ModelIndex()) const override
+    {
+        if (!index.is_valid())
+            return m_annotations.size();
+        return 0;
+    }
+
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override
+    {
+        return 3;
+    }
+
+    virtual ErrorOr<String> column_name(int column) const override
+    {
+        switch (column) {
+        case Column::Start:
+            return "Start"_string;
+        case Column::End:
+            return "End"_string;
+        case Column::Comments:
+            return "Comments"_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
+
+    void add_annotation(Annotation);
+    void delete_annotation(Annotation const&);
+    Optional<Annotation&> closest_annotation_at(size_t position);
+
+private:
+    Vector<Annotation> m_annotations;
+};

--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -10,6 +10,7 @@ compile_gml(GoToOffsetWidget.gml GoToOffsetWidgetGML.cpp)
 compile_gml(HexEditorWidget.gml HexEditorWidgetGML.cpp)
 
 set(SOURCES
+    AnnotationsModel.cpp
     EditAnnotationDialog.cpp
     EditAnnotationWidgetGML.cpp
     FindDialog.cpp

--- a/Userland/Applications/HexEditor/EditAnnotationDialog.cpp
+++ b/Userland/Applications/HexEditor/EditAnnotationDialog.cpp
@@ -104,9 +104,11 @@ EditAnnotationDialog::EditAnnotationDialog(GUI::Window* parent_window, NonnullRe
         };
         if (m_annotation.has_value()) {
             *m_annotation = move(result);
+            if (m_document)
+                m_document->annotations().invalidate();
         } else {
             if (m_document)
-                m_document->add_annotation(result);
+                m_document->annotations().add_annotation(result);
         }
         s_most_recent_color = m_background_color->color();
         done(ExecResult::OK);

--- a/Userland/Applications/HexEditor/EditAnnotationDialog.cpp
+++ b/Userland/Applications/HexEditor/EditAnnotationDialog.cpp
@@ -50,11 +50,16 @@ EditAnnotationDialog::EditAnnotationDialog(GUI::Window* parent_window, NonnullRe
     m_start_offset = find_descendant_of_type_named<GUI::NumericInput>("start_offset");
     m_end_offset = find_descendant_of_type_named<GUI::NumericInput>("end_offset");
     m_background_color = find_descendant_of_type_named<GUI::ColorInput>("background_color");
+    m_comments = find_descendant_of_type_named<GUI::TextEditor>("comments");
     m_save_button = find_descendant_of_type_named<GUI::DialogButton>("save_button");
     m_cancel_button = find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
 
     // FIXME: This could be specified in GML, but the GML doesn't like property setters that aren't `set_FOO()`.
     m_background_color->set_color_has_alpha_channel(false);
+    // FIXME: Move this to GML too.
+    m_comments->set_wrapping_mode(GUI::TextEditor::WrapAtWords);
+    // FIXME: `font_type: "Normal"` in GML once the compiler supports that.
+    m_comments->set_font(widget->font());
 
     // NOTE: The NumericInput stores an i64, so not all size_t values can fit. But I don't think we'll be
     //       hex-editing files larger than 9000 petabytes for the foreseeable future!
@@ -74,6 +79,7 @@ EditAnnotationDialog::EditAnnotationDialog(GUI::Window* parent_window, NonnullRe
             m_start_offset->set_value(m_annotation->start_offset);
             m_end_offset->set_value(m_annotation->end_offset);
             m_background_color->set_color(m_annotation->background_color);
+            m_comments->set_text(m_annotation->comments);
         },
         [this](Selection& selection) {
             set_title("Add Annotation"sv);
@@ -84,6 +90,7 @@ EditAnnotationDialog::EditAnnotationDialog(GUI::Window* parent_window, NonnullRe
             m_end_offset->set_value(selection.is_empty() ? selection.end : selection.end - 1);
             // Default to the most recently used annotation color.
             m_background_color->set_color(s_most_recent_color);
+            m_comments->clear();
         });
 
     m_save_button->on_click = [this](auto) {
@@ -93,6 +100,7 @@ EditAnnotationDialog::EditAnnotationDialog(GUI::Window* parent_window, NonnullRe
             .start_offset = min(start_offset, end_offset),
             .end_offset = max(start_offset, end_offset),
             .background_color = m_background_color->color(),
+            .comments = MUST(String::from_byte_string(m_comments->text())),
         };
         if (m_annotation.has_value()) {
             *m_annotation = move(result);

--- a/Userland/Applications/HexEditor/EditAnnotationDialog.h
+++ b/Userland/Applications/HexEditor/EditAnnotationDialog.h
@@ -13,6 +13,7 @@
 #include <LibGUI/ColorInput.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/NumericInput.h>
+#include <LibGUI/TextEditor.h>
 
 class EditAnnotationDialog : public GUI::Dialog {
     C_OBJECT_ABSTRACT(EditAnnotationDialog)
@@ -32,6 +33,7 @@ private:
     RefPtr<GUI::NumericInput> m_start_offset;
     RefPtr<GUI::NumericInput> m_end_offset;
     RefPtr<GUI::ColorInput> m_background_color;
+    RefPtr<GUI::TextEditor> m_comments;
     RefPtr<GUI::Button> m_save_button;
     RefPtr<GUI::Button> m_cancel_button;
 };

--- a/Userland/Applications/HexEditor/EditAnnotationWidget.gml
+++ b/Userland/Applications/HexEditor/EditAnnotationWidget.gml
@@ -55,6 +55,22 @@
     }
 
     @GUI::Widget {
+        layout: @GUI::VerticalBoxLayout {
+            margins: [4]
+        }
+        preferred_height: "fit"
+
+        @GUI::Label {
+            text: "Comments:"
+            text_alignment: "CenterLeft"
+        }
+
+        @GUI::TextEditor {
+            name: "comments"
+        }
+    }
+
+    @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {
             margins: [4]
         }

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -9,6 +9,11 @@
 #include <AK/TypeCasts.h>
 #include <LibCore/File.h>
 
+HexDocument::HexDocument()
+    : m_annotations(make_ref_counted<AnnotationsModel>())
+{
+}
+
 void HexDocument::set(size_t position, u8 value)
 {
     auto unchanged_value = get_unchanged(position);
@@ -23,34 +28,6 @@ void HexDocument::set(size_t position, u8 value)
 bool HexDocument::is_dirty() const
 {
     return m_changes.size() > 0;
-}
-
-void HexDocument::add_annotation(Annotation annotation)
-{
-    m_annotations.append(move(annotation));
-}
-
-void HexDocument::delete_annotation(Annotation const& annotation)
-{
-    m_annotations.remove_first_matching([&](auto& other) {
-        return other == annotation;
-    });
-}
-
-Optional<Annotation&> HexDocument::closest_annotation_at(size_t position)
-{
-    // FIXME: If we end up with a lot of annotations, we'll need to store them and query them in a smarter way.
-    Optional<Annotation&> result;
-    for (auto& annotation : m_annotations) {
-        if (annotation.start_offset <= position && position <= annotation.end_offset) {
-            // If multiple annotations cover this position, use whichever starts latest. This would be the innermost one
-            // if they overlap fully rather than partially.
-            if (!result.has_value() || result->start_offset < annotation.start_offset)
-                result = annotation;
-        }
-    }
-
-    return result;
 }
 
 HexDocumentMemory::HexDocumentMemory(ByteBuffer&& buffer)

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "AnnotationsModel.h"
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/String.h>
@@ -19,15 +20,6 @@
 #include <LibGfx/Color.h>
 
 constexpr Duration COMMAND_COMMIT_TIME = Duration::from_milliseconds(400);
-
-struct Annotation {
-    size_t start_offset { 0 };
-    size_t end_offset { 0 };
-    Gfx::Color background_color { Color::from_argb(0xfffce94f) };
-    String comments {};
-
-    bool operator==(Annotation const& other) const = default;
-};
 
 class HexDocument : public Weakable<HexDocument> {
 public:
@@ -50,14 +42,13 @@ public:
     virtual bool is_dirty() const;
     virtual void clear_changes() = 0;
 
-    ReadonlySpan<Annotation> annotations() const { return m_annotations; }
-    void add_annotation(Annotation);
-    void delete_annotation(Annotation const&);
-    Optional<Annotation&> closest_annotation_at(size_t position);
+    AnnotationsModel& annotations() { return *m_annotations; }
 
 protected:
+    HexDocument();
+
     HashMap<size_t, u8> m_changes;
-    Vector<Annotation> m_annotations;
+    NonnullRefPtr<AnnotationsModel> m_annotations;
 };
 
 class HexDocumentMemory final : public HexDocument {

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -9,6 +9,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
@@ -23,6 +24,7 @@ struct Annotation {
     size_t start_offset { 0 };
     size_t end_offset { 0 };
     Gfx::Color background_color { Color::from_argb(0xfffce94f) };
+    String comments {};
 
     bool operator==(Annotation const& other) const = default;
 };

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -347,7 +347,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
 
     if (maybe_offset_data.has_value()) {
         set_override_cursor(Gfx::StandardCursor::IBeam);
-        m_hovered_annotation = m_document->closest_annotation_at(maybe_offset_data->offset);
+        m_hovered_annotation = m_document->annotations().closest_annotation_at(maybe_offset_data->offset);
     } else {
         set_override_cursor(Gfx::StandardCursor::None);
         m_hovered_annotation.clear();
@@ -631,7 +631,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
                 return;
 
             auto const cell = m_document->get(byte_position);
-            auto const annotation = m_document->closest_annotation_at(byte_position);
+            auto const annotation = m_document->annotations().closest_annotation_at(byte_position);
 
             Gfx::IntRect hex_display_rect_high_nibble {
                 frame_thickness() + offset_margin_width() + j * cell_width() + 2 * m_padding,
@@ -933,7 +933,7 @@ void HexEditor::show_delete_annotation_dialog(Annotation& annotation)
 {
     auto result = GUI::MessageBox::show(window(), "Delete this annotation?"sv, "Delete annotation?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
     if (result == GUI::Dialog::ExecResult::Yes) {
-        m_document->delete_annotation(annotation);
+        m_document->annotations().delete_annotation(annotation);
         update();
     }
 }

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -363,7 +363,11 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
 
         update();
         update_status();
+        set_tooltip(""_string);
+    } else {
+        set_tooltip(m_hovered_annotation.has_value() ? m_hovered_annotation->comments : ""_string);
     }
+    show_or_hide_tooltip();
 }
 
 void HexEditor::mouseup_event(GUI::MouseEvent& event)

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -72,6 +72,8 @@ public:
     void show_edit_annotation_dialog(Annotation&);
     void show_delete_annotation_dialog(Annotation&);
 
+    HexDocument& document() { return *m_document; }
+
 protected:
     HexEditor();
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.gml
+++ b/Userland/Applications/HexEditor/HexEditorWidget.gml
@@ -44,6 +44,16 @@
                     activates_on_selection: true
                 }
             }
+
+            @GUI::Widget {
+                name: "annotations_container"
+                visible: false
+                layout: @GUI::VerticalBoxLayout {}
+
+                @GUI::TableView {
+                    name: "annotations"
+                }
+            }
         }
     }
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -38,6 +39,9 @@ private:
     HexEditorWidget() = default;
     void set_path(StringView);
     void update_title();
+    void update_side_panel_visibility();
+    void set_annotations_visible(bool visible);
+    void initialize_annotations_model();
     void set_search_results_visible(bool visible);
     void set_value_inspector_visible(bool visible);
     void update_inspector_values(size_t position);
@@ -67,6 +71,7 @@ private:
     RefPtr<GUI::Action> m_find_action;
     RefPtr<GUI::Action> m_goto_offset_action;
     RefPtr<GUI::Action> m_layout_toolbar_action;
+    RefPtr<GUI::Action> m_layout_annotations_action;
     RefPtr<GUI::Action> m_layout_search_results_action;
     RefPtr<GUI::Action> m_layout_value_inspector_action;
 
@@ -86,6 +91,8 @@ private:
     RefPtr<GUI::Widget> m_side_panel_container;
     RefPtr<GUI::Widget> m_value_inspector_container;
     RefPtr<GUI::TableView> m_value_inspector;
+    RefPtr<GUI::Widget> m_annotations_container;
+    RefPtr<GUI::TableView> m_annotations;
 
     bool m_value_inspector_little_endian { true };
     bool m_selecting_from_inspector { false };


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/73fe2a9c-d189-4f21-a523-7ac735535a79)

Make the annotations a bit more useful. Clicking on one in the table will jump to its first byte, similar to how the search results panel works.

Hovering over an annotation will show its comment text as a tooltip.