### PR TITLE
HexEditor: Save and load annotations to/from JSON files

### DIFF
--- a/Base/usr/share/man/man1/Applications/HexEditor.md
+++ b/Base/usr/share/man/man1/Applications/HexEditor.md
@@ -7,8 +7,7 @@
 ## Synopsis
 
 ```**sh
-$ HexEditor 
-$ HexEditor file
+$ HexEditor [--annotations <path>] [file]
 ```
 
 ## Description
@@ -35,3 +34,11 @@ An option to copy as hex value, as text, or as C-code is available and can extra
 ![](HexEditor_Copy_Hex_Text_C_Code.png)
 
 Hex Editor's simple and straight-forward interface offers search, export, byte pattern insertions and statistics. 
+
+## Options
+
+* `-a`, `--annotations`: Path to an annotations file to load on startup
+
+## Arguments
+
+* `file`: File to open on startup 

--- a/Userland/Applications/HexEditor/AnnotationsModel.h
+++ b/Userland/Applications/HexEditor/AnnotationsModel.h
@@ -65,6 +65,9 @@ public:
     void delete_annotation(Annotation const&);
     Optional<Annotation&> closest_annotation_at(size_t position);
 
+    ErrorOr<void> save_to_file(Core::File&) const;
+    ErrorOr<void> load_from_file(Core::File&);
+
 private:
     Vector<Annotation> m_annotations;
 };

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -676,6 +676,20 @@ void HexEditorWidget::open_file(ByteString const& filename, NonnullOwnPtr<Core::
     GUI::Application::the()->set_most_recently_open_file(filename);
 }
 
+void HexEditorWidget::open_annotations_file(StringView filename)
+{
+    auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), filename);
+    if (response.is_error())
+        return;
+
+    auto result = m_editor->document().annotations().load_from_file(response.value().stream());
+    if (result.is_error()) {
+        GUI::MessageBox::show(window(), ByteString::formatted("Unable to load annotations: {}\n"sv, result.error()), "Error"sv, GUI::MessageBox::Type::Error);
+        return;
+    }
+    m_annotations_path = filename;
+}
+
 bool HexEditorWidget::request_close()
 {
     if (!window()->is_modified())

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -53,6 +53,7 @@ private:
     ByteString m_path;
     ByteString m_name;
     ByteString m_extension;
+    ByteString m_annotations_path;
 
     int m_goto_history { 0 };
     String m_search_text;
@@ -64,6 +65,9 @@ private:
     RefPtr<GUI::Action> m_open_action;
     RefPtr<GUI::Action> m_save_action;
     RefPtr<GUI::Action> m_save_as_action;
+    RefPtr<GUI::Action> m_open_annotations_action;
+    RefPtr<GUI::Action> m_save_annotations_action;
+    RefPtr<GUI::Action> m_save_annotations_as_action;
 
     RefPtr<GUI::Action> m_undo_action;
     RefPtr<GUI::Action> m_redo_action;

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -26,6 +26,7 @@ class HexEditorWidget final : public GUI::Widget {
 public:
     virtual ~HexEditorWidget() override = default;
     void open_file(ByteString const& filename, NonnullOwnPtr<Core::File>);
+    void open_annotations_file(StringView filename);
     ErrorOr<void> initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -27,8 +27,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::create(arguments));
 
     StringView filename;
+    StringView annotations_filename;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(annotations_filename, "Annotations file to load", "annotations", 'a', "path");
     args_parser.add_positional_argument(filename, "File to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -68,6 +70,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (!response.is_error())
             hex_editor_widget->open_file(response.value().filename(), response.value().release_stream());
     }
+
+    if (!annotations_filename.is_empty())
+        hex_editor_widget->open_annotations_file(annotations_filename);
 
     return app->exec();
 }


### PR DESCRIPTION
~Builds on #23001. Draft until that's merged.~

----

Because if you've spent time annotating a file or general format, you don't want to lose that work. :^)
