### PR TITLE
LibWeb: Follow the spec more precisely in Element::getClientRects()

### DIFF
--- a/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-css-transform.txt
+++ b/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-css-transform.txt
@@ -1,0 +1,1 @@
+       {"x":68,"y":118,"width":100,"height":100,"top":118,"right":168,"bottom":218,"left":68}

--- a/Tests/LibWeb/Text/expected/element-get-client-rects.txt
+++ b/Tests/LibWeb/Text/expected/element-get-client-rects.txt
@@ -1,0 +1,2 @@
+ inline   {"0":{"x":8,"y":500,"width":784,"height":150,"top":500,"right":792,"bottom":650,"left":8}}
+{"0":{"x":8,"y":650,"width":41.296875,"height":17,"top":650,"right":49.296875,"bottom":667,"left":8}}

--- a/Tests/LibWeb/Text/input/element-get-bounding-client-rect-css-transform.html
+++ b/Tests/LibWeb/Text/input/element-get-bounding-client-rect-css-transform.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style type="text/css">
+    .transform-1 {
+        transform: translate(100px, 100px);
+    }
+
+    .transform-2 {
+        transform: translate(-50px, 0px);
+    }
+
+    #box {
+        background-color: magenta;
+        width: 100px;
+        height: 100px;
+        opacity: 0.1;
+        transform: translate(10px, 10px);
+    }
+</style>
+<div class="transform-1">
+    <div class="transform-2">
+        <div id="box"></div>
+    </div>
+</div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const transformed_box_rect = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(transformed_box_rect));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/element-get-client-rects.html
+++ b/Tests/LibWeb/Text/input/element-get-client-rects.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style type="text/css">
+    #box {
+        margin-top: 500px;
+        padding-top: 100px;
+        background-color: navy;
+        width: 100%;
+        height: 50px;
+    }
+</style>
+<div id="box"></div>
+<a id="inline">inline</a>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const box_rect = document.getElementById("box").getClientRects();
+        println(JSON.stringify(box_rect));
+
+        const inline_rect = document.getElementById("inline").getClientRects();
+        println(JSON.stringify(inline_rect));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -217,30 +217,18 @@ Optional<HitTestResult> InlinePaintable::hit_test(CSSPixelPoint position, HitTes
 
 CSSPixelRect InlinePaintable::bounding_rect() const
 {
-    auto top = CSSPixels::max();
-    auto left = CSSPixels::max();
-    auto right = CSSPixels::min();
-    auto bottom = CSSPixels::min();
-    auto has_fragments = false;
+    CSSPixelRect bounding_rect;
     for_each_fragment([&](auto const& fragment, bool, bool) {
-        has_fragments = true;
         auto fragment_absolute_rect = fragment.absolute_rect();
-        if (fragment_absolute_rect.top() < top)
-            top = fragment_absolute_rect.top();
-        if (fragment_absolute_rect.left() < left)
-            left = fragment_absolute_rect.left();
-        if (fragment_absolute_rect.right() > right)
-            right = fragment_absolute_rect.right();
-        if (fragment_absolute_rect.bottom() > bottom)
-            bottom = fragment_absolute_rect.bottom();
+        bounding_rect = bounding_rect.united(fragment_absolute_rect);
     });
 
-    if (!has_fragments) {
+    if (bounding_rect.is_empty()) {
         // FIXME: This is adhoc, and we should return rect of empty fragment instead.
         auto containing_block_position_in_absolute_coordinates = containing_block()->paintable_box()->absolute_position();
         return { containing_block_position_in_absolute_coordinates, { 0, 0 } };
     }
-    return { left, top, right - left, bottom - top };
+    return bounding_rect;
 }
 
 }


### PR DESCRIPTION
Align getClientRects() and getBoundingClientRect() implementations with the spec more precisely and make them account for CSS transform.