### PR TITLE
Meta: Create Build/lagom/Root/res with resources for lagom binaries

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -418,6 +418,28 @@ if (BUILD_LAGOM_TOOLS)
 endif()
 
 if (BUILD_LAGOM)
+
+    # Create lagom equivalent of Serenity's Build/foo/Root/res (which for Serenity becomes /res in the disk image).
+    # FIXME: Add more files as needed.
+    set(LAGOM_RES "${Lagom_BINARY_DIR}/Root/res")
+    file(MAKE_DIRECTORY "${LAGOM_RES}/fonts")
+    foreach(font
+        LiberationMono-Bold.ttf
+        LiberationMono-BoldItalic.ttf
+        LiberationMono-Italic.ttf
+        LiberationMono-Regular.ttf
+        LiberationSans-Bold.ttf
+        LiberationSans-BoldItalic.ttf
+        LiberationSans-Italic.ttf
+        LiberationSans-Regular.ttf
+        LiberationSerif-Bold.ttf
+        LiberationSerif-BoldItalic.ttf
+        LiberationSerif-Italic.ttf
+        LiberationSerif-Regular.ttf
+        )
+        configure_file("${SERENITY_PROJECT_ROOT}/Base/res/fonts/${font}" "${LAGOM_RES}/fonts/${font}" COPYONLY)
+    endforeach()
+
     # Lagom Libraries
     set(lagom_standard_libraries
         AccelGfx

--- a/Meta/Lagom/Contrib/MacPDF/AppDelegate.mm
+++ b/Meta/Lagom/Contrib/MacPDF/AppDelegate.mm
@@ -18,12 +18,12 @@
 {
     // FIXME: Copy the fonts to the bundle or something
 
-    // Get from `Build/lagom/bin/MacPDF.app/Contents/MacOS/MacPDF` to `.`.
+    // Get from `Build/lagom/bin/MacPDF.app/Contents/MacOS/MacPDF` to `Build/lagom/Root/res`.
     NSString* source_root = [[NSBundle mainBundle] executablePath];
-    for (int i = 0; i < 7; ++i)
+    for (int i = 0; i < 5; ++i)
         source_root = [source_root stringByDeletingLastPathComponent];
     auto source_root_string = ByteString([source_root UTF8String]);
-    Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(MUST(String::formatted("{}/Base/res", source_root_string))));
+    Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(MUST(String::formatted("{}/Root/res", source_root_string))));
 }
 
 - (void)applicationWillTerminate:(NSNotification*)aNotification

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -223,9 +223,9 @@ static PDF::PDFErrorOr<int> pdf_main(Main::Arguments arguments)
 
 #if !defined(AK_OS_SERENITY)
     if (debugging_stats || !render_path.is_empty()) {
-        // Get from Build/lagom/bin/pdf to Base/res/fonts.
-        auto source_root = LexicalPath(MUST(Core::System::current_executable_path())).parent().parent().parent().parent().string();
-        Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(TRY(String::formatted("{}/Base/res", source_root))));
+        // Get from Build/lagom/bin/pdf to Build/lagom/Root/res.
+        auto source_root = LexicalPath(MUST(Core::System::current_executable_path())).parent().parent().string();
+        Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(TRY(String::formatted("{}/Root/res", source_root))));
     }
 #endif
 


### PR DESCRIPTION
This way, build files can install things into
`${CMAKE_BINARY_DIR}/Root/res/` and it'll work in both serenity and
lagom builds.

It allows using a single `Core::ResourceImplementation::install()`
call to install both checked-in and generated files (as long as both
get copied into this new build-time staging dir).

No behavior change.

---

As discussed on Discord: I'd like to make LibPDF read a generated file. `Core::ResourceImplementation::install()` allows only  a single dir, so the thing we settled on was to make a new dir that has both pre-existing files and generated files and use that as ResourceImplementation dir.

This PR here copies the static files over. Other binaries can adopt this over time if they want.

I'll put the change to add a generated file in this new directory into a separate PR (preview: https://github.com/nico/serenity/pull/new/icc-cmyk-nicer).