### PR TITLE
LibWeb: Set document's URL when loading markdown file as inline content

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -78,7 +78,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_markdown_docume
                 return;
 
             auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(extra_head_contents), "utf-8");
-            parser->run(document.url());
+            parser->run(url);
         };
 
         auto process_body_error = [](auto) {


### PR DESCRIPTION
```
A markdown file gets loaded as an inline content document by
`create_document_for_inline_content()`, for which the default document
URL is "about:error". That breaks the fragment links.

Overriding "about:error" URL with the URL of the just loaded markdown
file ensures that the URL of the document is as expected.
```

#### Before:
![image](https://github.com/SerenityOS/serenity/assets/70647861/e6e9a89e-3500-49fb-bd52-bb653c5e3c09)

#### After:
![image](https://github.com/SerenityOS/serenity/assets/70647861/ba23fd80-e346-4f4c-8955-cf0cd508b8dc)

I don't know if this is the right fix or not.