### PR TITLE
Run: Fix bug where it would crash because uninitialized main widget

### DIFF
--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -26,6 +26,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+namespace Run {
+
 RunWindow::RunWindow()
     : m_path_history()
     , m_path_history_model(GUI::ItemListModel<ByteString>::create(m_path_history))
@@ -41,7 +43,8 @@ RunWindow::RunWindow()
     set_resizable(false);
     set_minimizable(false);
 
-    auto main_widget = set_main_widget<Run::MainWidget>();
+    auto main_widget = MUST(Run::MainWidget::try_create());
+    set_main_widget(main_widget);
 
     m_icon_image_widget = *main_widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     m_icon_image_widget->set_bitmap(app_icon.bitmap_for_size(32));
@@ -62,7 +65,7 @@ RunWindow::RunWindow()
         close();
     };
 
-    m_browse_button = *find_descendant_of_type_named<GUI::DialogButton>("browse_button");
+    m_browse_button = *main_widget->find_descendant_of_type_named<GUI::DialogButton>("browse_button");
     m_browse_button->on_click = [this](auto) {
         Optional<ByteString> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::Center);
         if (path.has_value())
@@ -188,4 +191,6 @@ ErrorOr<void> RunWindow::save_history()
         TRY(file->write_until_depleted(ByteString::formatted("{}\n", m_path_history[i]).bytes()));
 
     return {};
+}
+
 }

--- a/Userland/Applications/Run/RunWindow.h
+++ b/Userland/Applications/Run/RunWindow.h
@@ -13,6 +13,8 @@
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/Window.h>
 
+namespace Run {
+
 class RunWindow final : public GUI::Window {
     C_OBJECT(RunWindow)
 public:
@@ -40,3 +42,5 @@ private:
     RefPtr<GUI::Button> m_browse_button;
     RefPtr<GUI::ComboBox> m_path_combo_box;
 };
+
+}

--- a/Userland/Applications/Run/main.cpp
+++ b/Userland/Applications/Run/main.cpp
@@ -15,7 +15,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd thread cpath rpath wpath unix proc exec"));
 
     auto app = TRY(GUI::Application::create(arguments));
-    auto window = TRY(RunWindow::try_create());
+    auto window = TRY(Run::RunWindow::try_create());
 
     constexpr int margin = 16;
     window->move_to(margin, GUI::Desktop::the().rect().bottom() - 1 - GUI::Desktop::the().taskbar_height() - margin - window->height());


### PR DESCRIPTION
Currently the Run application is broken on the main branch for me, this pr fixes it.

**Explanation**: The set_main_widget<T>() function only calls the construct and not `try_create()` that the GMLCompiler generates so all calls to `find_descendant_of_type_named()` would result in null pointers that would resolve in a crash.