### PR TITLE
Taskbar: Fix bug where dropping item in quick launch widget would crash

### DIFF
--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -182,7 +182,8 @@ void QuickLaunchWidget::drop_event(GUI::DropEvent& event)
             auto path = url.serialize_path();
             auto entry = QuickLaunchEntry::create_from_path(path);
             if (entry) {
-                auto result = update_entry(entry->name(), entry.release_nonnull());
+                auto entry_name = entry->name();
+                auto result = update_entry(entry_name, entry.release_nonnull());
                 if (result.is_error())
                     GUI::MessageBox::show_error(window(), ByteString::formatted("Failed to add quick launch entry: {}", result.release_error()));
             }


### PR DESCRIPTION
This pr fixes a crash for me where dropping an item (`.af`, `bin` or symlink to a `bin`) in the Taskbar quick launch widget. An `OwnPtr::operator ->` and `OwnPtr::release_nonnull()` on the same line gives memory conflicts I think, putting the get name on a separated line fixes the issue.