### PR TITLE
LibWeb: Don't update input text if Ctrl or Alt are pressed

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -688,10 +688,12 @@ bool EventHandler::focus_previous_element()
     return element;
 }
 
-constexpr bool should_ignore_keydown_event(u32 code_point)
+constexpr bool should_ignore_keydown_event(u32 code_point, u32 modifiers)
 {
+    if (modifiers & (KeyModifier::Mod_Ctrl | KeyModifier::Mod_Alt))
+        return true;
+
     // FIXME: There are probably also keys with non-zero code points that should be filtered out.
-    // FIXME: We should take the modifier keys into consideration somehow. This treats "Ctrl+C" as just "c".
     return code_point == 0 || code_point == 27;
 }
 
@@ -754,7 +756,8 @@ bool EventHandler::handle_keydown(KeyCode key, u32 modifiers, u32 code_point)
                 m_edit_event_handler->handle_delete(*range);
                 return true;
             }
-            if (!should_ignore_keydown_event(code_point)) {
+            // FIXME: Text editing shortcut keys (copy/paste etc.) should be handled here.
+            if (!should_ignore_keydown_event(code_point, modifiers)) {
                 m_edit_event_handler->handle_delete(*range);
                 m_edit_event_handler->handle_insert(JS::NonnullGCPtr { *m_browsing_context->cursor_position() }, code_point);
                 m_browsing_context->increment_cursor_position_offset();
@@ -817,7 +820,8 @@ bool EventHandler::handle_keydown(KeyCode key, u32 modifiers, u32 code_point)
             input_element.commit_pending_changes();
             return true;
         }
-        if (!should_ignore_keydown_event(code_point)) {
+        // FIXME: Text editing shortcut keys (copy/paste etc.) should be handled here.
+        if (!should_ignore_keydown_event(code_point, modifiers)) {
             m_edit_event_handler->handle_insert(JS::NonnullGCPtr { *m_browsing_context->cursor_position() }, code_point);
             m_browsing_context->increment_cursor_position_offset();
             return true;


### PR DESCRIPTION
Previously, it was possible to enter various control characters into input elements by holding Ctrl and/or Alt. With this change, input elements ignore keypresses while Ctrl or Alt are pressed.

Note: This change doesn't affect the firing of `keydown` events, which are still fired if the keypress is ignored by the input. This matches the behavior of Chrome and Firefox.