### PR TITLE
LibPDF+Meta: Use a CMYK ICC profile to convert CMYK to RGB

### DIFF
--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -13,6 +13,7 @@ serenity_option(UNDEFINED_BEHAVIOR_IS_FATAL OFF CACHE BOOL "Make undefined behav
 
 serenity_option(ENABLE_ALL_THE_DEBUG_MACROS OFF CACHE BOOL "Enable all debug macros to validate they still compile")
 serenity_option(ENABLE_ALL_DEBUG_FACILITIES OFF CACHE BOOL "Enable all noisy debug symbols and options. Not recommended for normal developer use")
+serenity_option(ENABLE_ADOBE_ICC_PROFILES_DOWNLOAD ON CACHE BOOL "Enable download of Adobe's ICC profiles")
 serenity_option(ENABLE_COMPILETIME_HEADER_CHECK OFF CACHE BOOL "Enable compiletime check that each library header compiles stand-alone")
 
 serenity_option(ENABLE_TIME_ZONE_DATABASE_DOWNLOAD ON CACHE BOOL "Enable download of the IANA Time Zone Database at build time")

--- a/Meta/CMake/download_icc_profiles.cmake
+++ b/Meta/CMake/download_icc_profiles.cmake
@@ -1,0 +1,25 @@
+include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
+
+if (ENABLE_ADOBE_ICC_PROFILES_DOWNLOAD)
+    set(ADOBE_ICC_PROFILES_PATH "${SERENITY_CACHE_DIR}/AdobeICCProfiles" CACHE PATH "Download location for Adobe ICC profiles")
+    set(ADOBE_ICC_PROFILES_DATA_URL "https://download.adobe.com/pub/adobe/iccprofiles/win/AdobeICCProfilesCS4Win_end-user.zip")
+    set(ADOBE_ICC_PROFILES_ZIP_PATH "${ADOBE_ICC_PROFILES_PATH}/adobe-icc-profiles.zip")
+    if (ENABLE_NETWORK_DOWNLOADS)
+        download_file("${ADOBE_ICC_PROFILES_DATA_URL}" "${ADOBE_ICC_PROFILES_ZIP_PATH}")
+    else()
+        message(STATUS "Skipping download of ${ADOBE_ICC_PROFILES_DATA_URL}, expecting the archive to have been donwloaded to ${ADOBE_ICC_PROFILES_ZIP_PATH}")
+    endif()
+
+    function(extract_adobe_icc_profiles source path)
+        if(EXISTS "${ADOBE_ICC_PROFILES_ZIP_PATH}" AND NOT EXISTS "${path}")
+            file(ARCHIVE_EXTRACT INPUT "${ADOBE_ICC_PROFILES_ZIP_PATH}" DESTINATION "${ADOBE_ICC_PROFILES_PATH}" PATTERNS "${source}")
+        endif()
+    endfunction()
+
+    set(ADOBE_ICC_CMYK_SWOP "CMYK/USWebCoatedSWOP.icc")
+    set(ADOBE_ICC_CMYK_SWOP_PATH "${ADOBE_ICC_PROFILES_PATH}/Adobe ICC Profiles (end-user)/${ADOBE_ICC_CMYK_SWOP}")
+    extract_adobe_icc_profiles("Adobe ICC Profiles (end-user)/${ADOBE_ICC_CMYK_SWOP}" "${ADOBE_ICC_CMYK_SWOP_PATH}")
+
+    set(ADOBE_ICC_CMYK_SWOP_INSTALL_PATH "${CMAKE_BINARY_DIR}/Root/res/icc/Adobe/${ADOBE_ICC_CMYK_SWOP}")
+    configure_file("${ADOBE_ICC_CMYK_SWOP_PATH}" "${ADOBE_ICC_CMYK_SWOP_INSTALL_PATH}" COPYONLY)
+endif()

--- a/Meta/Lagom/Contrib/MacPDF/AppDelegate.mm
+++ b/Meta/Lagom/Contrib/MacPDF/AppDelegate.mm
@@ -16,7 +16,7 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification*)aNotification
 {
-    // FIXME: Copy the fonts to the bundle or something
+    // FIXME: Copy fonts and icc file to the bundle or something
 
     // Get from `Build/lagom/bin/MacPDF.app/Contents/MacOS/MacPDF` to `Build/lagom/Root/res`.
     NSString* source_root = [[NSBundle mainBundle] executablePath];

--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -6,7 +6,10 @@
 
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
+#include <AK/LexicalPath.h>
 #include <LibCore/MappedFile.h>
+#include <LibCore/ResourceImplementationFile.h>
+#include <LibCore/System.h>
 #include <LibGfx/Bitmap.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
@@ -293,6 +296,12 @@ TEST_CASE(postscript)
 
 TEST_CASE(render)
 {
+#if !defined(AK_OS_SERENITY)
+    // Get from Build/lagom/bin/TestPDF to Build/lagom/Root/res.
+    auto source_root = LexicalPath(MUST(Core::System::current_executable_path())).parent().parent().string();
+    Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(MUST(String::formatted("{}/Root/res", source_root))));
+#endif
+
     auto file = MUST(Core::MappedFile::map("colorspaces.pdf"sv));
     auto document = MUST(PDF::Document::create(file->bytes()));
     MUST(document->initialize());

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -74,15 +74,6 @@ public:
     static constexpr Color from_rgb(unsigned rgb) { return Color(rgb | 0xff000000); }
     static constexpr Color from_argb(unsigned argb) { return Color(argb); }
 
-    static constexpr Color from_cmyk(float c, float m, float y, float k)
-    {
-        auto r = static_cast<u8>(255.0f * (1.0f - c) * (1.0f - k));
-        auto g = static_cast<u8>(255.0f * (1.0f - m) * (1.0f - k));
-        auto b = static_cast<u8>(255.0f * (1.0f - y) * (1.0f - k));
-
-        return Color(r, g, b);
-    }
-
     static constexpr Color from_yuv(YUV const& yuv) { return from_yuv(yuv.y, yuv.u, yuv.v); }
     static constexpr Color from_yuv(float y, float u, float v)
     {

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -26,4 +26,6 @@ set(SOURCES
     )
 
 serenity_lib(LibPDF pdf)
-target_link_libraries(LibPDF PRIVATE LibCompress LibIPC LibGfx LibTextCodec LibCrypto)
+target_link_libraries(LibPDF PRIVATE LibCompress LibCore LibIPC LibGfx LibTextCodec LibCrypto)
+
+include(${SerenityOS_SOURCE_DIR}/Meta/CMake/download_icc_profiles.cmake)

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -53,7 +53,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(DeprecatedFlyString con
     if (name == CommonNames::DeviceRGB)
         return DeviceRGBColorSpace::the();
     if (name == CommonNames::DeviceCMYK)
-        return DeviceCMYKColorSpace::the();
+        return TRY(DeviceCMYKColorSpace::the());
     if (name == CommonNames::Pattern)
         return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
     VERIFY_NOT_REACHED();
@@ -134,7 +134,7 @@ Vector<float> DeviceRGBColorSpace::default_decode() const
     return { 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f };
 }
 
-NonnullRefPtr<DeviceCMYKColorSpace> DeviceCMYKColorSpace::the()
+ErrorOr<NonnullRefPtr<DeviceCMYKColorSpace>> DeviceCMYKColorSpace::the()
 {
     static auto instance = adopt_ref(*new DeviceCMYKColorSpace());
     return instance;

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -112,7 +112,7 @@ private:
 
 class DeviceCMYKColorSpace final : public ColorSpace {
 public:
-    static NonnullRefPtr<DeviceCMYKColorSpace> the();
+    static ErrorOr<NonnullRefPtr<DeviceCMYKColorSpace>> the();
 
     ~DeviceCMYKColorSpace() override = default;
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -695,14 +695,14 @@ RENDERER_HANDLER(set_painting_color_and_space_to_rgb)
 
 RENDERER_HANDLER(set_stroking_color_and_space_to_cmyk)
 {
-    state().stroke_color_space = DeviceCMYKColorSpace::the();
+    state().stroke_color_space = TRY(DeviceCMYKColorSpace::the());
     state().stroke_style = TRY(state().stroke_color_space->style(args));
     return {};
 }
 
 RENDERER_HANDLER(set_painting_color_and_space_to_cmyk)
 {
-    state().paint_color_space = DeviceCMYKColorSpace::the();
+    state().paint_color_space = TRY(DeviceCMYKColorSpace::the());
     state().paint_style = TRY(state().paint_color_space->style(args));
     return {};
 }


### PR DESCRIPTION
CMYK data describes which inks a printer should use to print a color.
If a screen should display a color that's supposed to look similar
to what the printer produces, it results in a color very different
to what Color::from_cmyk() produces. (It's also printer-dependent.)

There are many ICC profiles describing printing processes. It doesn't
matter too much which one we use -- most of them look somewhat
similar, and they all look dramatically better than Color::from_cmyk().

This patch adds a function to download a zip file that Adobe offers
on their web site. They even have a page for redistribution:
https://www.adobe.com/support/downloads/iccprofiles/icc_eula_win_dist.html

(That one leads to a broken download though, so this downloads the
end-user version.)

In case we have to move off this download at some point, there are also
a whole bunch of profiles at https://www.color.org/registry/index.xalter
that "may be used, embedded, exchanged, and shared without restriction".

The adobe zip contains a whole bunch of other useful and fun profiles,
so I went with it.

For now, this only unzips the USWebCoatedSWOP.icc file though, and
installs it in ${CMAKE_BINARY_DIR}/Root/res/icc/Adobe/CMYK/. In
Serenity builds, this will make it to /res/icc/Adobe/CMYK in the
disk image. And in lagom build, after https://github.com/SerenityOS/serenity/pull/23016 this is the
lagom res staging directory that tools can install via
Core::ResourceImplementation. `pdf` and `MacPDF` already do that,
`TestPDF` now does it too.

The final piece is that LibPDF then loads the profile from there
and uses it for DeviceCMYK color conversions.

(Doing file access from the bowels of a library is a bit weird,
especially in a system that has sandboxing built in. But LibGfx does
that in FontDatabase too already, and LibPDF uses that, so it's not a
new problem.)

---

The patch is probably smaller than that writeup :)