### PR TITLE
LibWeb: Remove contained_by_inline_node flag in PaintableFragment

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -626,15 +626,11 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     // FIXME: Find a smarter way to do this?
     if (phase == PaintPhase::Foreground) {
         for (auto& fragment : fragments()) {
-            if (fragment.contained_by_inline_node())
-                continue;
             paint_text_shadow(context, fragment, fragment.shadows());
         }
     }
 
     for (auto const& fragment : m_fragments) {
-        if (fragment.contained_by_inline_node())
-            continue;
         auto fragment_absolute_rect = fragment.absolute_rect();
         auto fragment_absolute_device_rect = context.enclosing_device_rect(fragment_absolute_rect);
         if (context.should_show_line_box_borders()) {

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -42,9 +42,6 @@ public:
 
     CSSPixelRect selection_rect(Gfx::Font const&) const;
 
-    bool contained_by_inline_node() const { return m_contained_by_inline_node; }
-    void set_contained_by_inline_node() { m_contained_by_inline_node = true; }
-
     CSSPixels width() const { return m_size.width(); }
     CSSPixels height() const { return m_size.height(); }
 


### PR DESCRIPTION
No longer used after we made inline paintables own their fragments.