### PR TITLE
LibJS: Don't crash when attempting to load from an invalid reference

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -268,7 +268,10 @@ CodeGenerationErrorOr<Optional<Generator::ReferenceRegisters>> Generator::emit_l
         }
         return Optional<ReferenceRegisters> {};
     }
-    VERIFY_NOT_REACHED();
+    return CodeGenerationError {
+        &node,
+        "Unimplemented/invalid node used a reference"sv
+    };
 }
 
 CodeGenerationErrorOr<void> Generator::emit_store_to_reference(JS::ASTNode const& node)

--- a/Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -5,6 +5,13 @@ test.xfail("assignment to function call", () => {
     }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
 });
 
+test.xfail("Postfix operator after function call", () => {
+    expect(() => {
+        function foo() {}
+        foo()++;
+    }).toThrow(ReferenceError);
+});
+
 test("assignment to function call in strict mode", () => {
     expect("'use strict'; foo() = 'foo'").toEval();
 });


### PR DESCRIPTION
Previously, attempting to load a value from an invalid reference would cause a crash. We now return a CodeGenerationError rather than hitting an assertion. This is not a complete solution, as ideally we would want to return a ReferenceError, but this now matches the behavior we see when we attempt to store something to an invalid reference.

I've written the test for this in a way that mirrors tests for other invalid assignments. I've left the message out, as the message displayed is not consistent across other browsers.

Fixes oss-fuzz issue [62067](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62067)

