### PR TITLE
LibGfx+image: Allow saving CMYK jpegs

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -392,7 +392,7 @@ ErrorOr<void> add_icc_data(Stream& stream, ReadonlyBytes icc_data)
     return {};
 }
 
-ErrorOr<void> add_frame_header(Stream& stream, JPEGEncodingContext const& context, Bitmap const& bitmap)
+ErrorOr<void> add_frame_header(Stream& stream, JPEGEncodingContext const& context, IntSize size)
 {
     // B.2.2 - Frame header syntax
     TRY(stream.write_value<BigEndian<Marker>>(JPEG_SOF0));
@@ -406,10 +406,10 @@ ErrorOr<void> add_frame_header(Stream& stream, JPEGEncodingContext const& contex
     TRY(stream.write_value<u8>(8));
 
     // Y
-    TRY(stream.write_value<BigEndian<u16>>(bitmap.height()));
+    TRY(stream.write_value<BigEndian<u16>>(size.height()));
 
     // X
-    TRY(stream.write_value<BigEndian<u16>>(bitmap.width()));
+    TRY(stream.write_value<BigEndian<u16>>(size.width()));
 
     // Nf
     TRY(stream.write_value<u8>(Nf));
@@ -537,7 +537,7 @@ ErrorOr<void> JPEGWriter::encode(Stream& stream, Bitmap const& bitmap, Options c
     if (options.icc_data.has_value())
         TRY(add_icc_data(stream, options.icc_data.value()));
 
-    TRY(add_frame_header(stream, context, bitmap));
+    TRY(add_frame_header(stream, context, bitmap.size()));
 
     TRY(add_quantization_table(stream, context.luminance_quantization_table()));
     TRY(add_quantization_table(stream, context.chrominance_quantization_table()));

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -397,8 +397,10 @@ ErrorOr<void> add_frame_header(Stream& stream, JPEGEncodingContext const& contex
     // B.2.2 - Frame header syntax
     TRY(stream.write_value<BigEndian<Marker>>(JPEG_SOF0));
 
-    // Lf = 8 + 3 × Nf, we only support a single image per frame so Nf = 3
-    TRY(stream.write_value<BigEndian<u16>>(17));
+    u16 const Nf = 3;
+
+    // Lf = 8 + 3 × Nf
+    TRY(stream.write_value<BigEndian<u16>>(8 + 3 * Nf));
 
     // P
     TRY(stream.write_value<u8>(8));
@@ -409,11 +411,11 @@ ErrorOr<void> add_frame_header(Stream& stream, JPEGEncodingContext const& contex
     // X
     TRY(stream.write_value<BigEndian<u16>>(bitmap.width()));
 
-    // Nf, as mentioned earlier, we only support Nf = 3
-    TRY(stream.write_value<u8>(3));
+    // Nf
+    TRY(stream.write_value<u8>(Nf));
 
-    // Encode 3 components
-    for (u8 i {}; i < 3; ++i) {
+    // Encode Nf components
+    for (u8 i {}; i < Nf; ++i) {
         // Ci
         TRY(stream.write_value<u8>(i + 1));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -547,19 +547,22 @@ ErrorOr<void> add_headers(Stream& stream, JPEGEncodingContext& context, JPEGWrit
     return {};
 }
 
+ErrorOr<void> add_image(Stream& stream, JPEGEncodingContext& context)
+{
+    context.fdct_and_quantization();
+    TRY(context.write_huffman_stream());
+    TRY(add_end_of_image(stream));
+    return {};
+}
+
 }
 
 ErrorOr<void> JPEGWriter::encode(Stream& stream, Bitmap const& bitmap, Options const& options)
 {
     JPEGEncodingContext context { JPEGBigEndianOutputBitStream { stream } };
     TRY(add_headers(stream, context, options, bitmap.size()));
-
     TRY(context.initialize_mcu(bitmap));
-    context.fdct_and_quantization();
-
-    TRY(context.write_huffman_stream());
-
-    TRY(add_end_of_image(stream));
+    TRY(add_image(stream, context));
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -101,8 +101,8 @@ public:
 
     ErrorOr<void> initialize_mcu(Bitmap const& bitmap)
     {
-        u64 const horizontal_macroblocks = bitmap.width() / 8 + (bitmap.width() % 8 == 0 ? 0 : 1);
-        m_vertical_macroblocks = bitmap.height() / 8 + (bitmap.height() % 8 == 0 ? 0 : 1);
+        u64 const horizontal_macroblocks = ceil_div(bitmap.width(), 8);
+        m_vertical_macroblocks = ceil_div(bitmap.height(), 8);
 
         TRY(m_macroblocks.try_resize(horizontal_macroblocks * m_vertical_macroblocks));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -486,14 +486,16 @@ ErrorOr<void> add_scan_header(Stream& stream)
     // B.2.3 - Scan header syntax
     TRY(stream.write_value<BigEndian<Marker>>(JPEG_SOS));
 
+    u16 const Ns = 3;
+
     // Ls - 6 + 2 × Ns
-    TRY(stream.write_value<BigEndian<u16>>(6 + 2 * 3));
+    TRY(stream.write_value<BigEndian<u16>>(6 + 2 * Ns));
 
     // Ns
-    TRY(stream.write_value<u8>(3));
+    TRY(stream.write_value<u8>(Ns));
 
-    // Encode 3 components
-    for (u8 i {}; i < 3; ++i) {
+    // Encode Ns components
+    for (u8 i {}; i < Ns; ++i) {
         // Csj
         TRY(stream.write_value<u8>(i + 1));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -102,9 +102,8 @@ public:
     ErrorOr<void> initialize_mcu(Bitmap const& bitmap)
     {
         u64 const horizontal_macroblocks = ceil_div(bitmap.width(), 8);
-        m_vertical_macroblocks = ceil_div(bitmap.height(), 8);
-
-        TRY(m_macroblocks.try_resize(horizontal_macroblocks * m_vertical_macroblocks));
+        u64 const vertical_macroblocks = ceil_div(bitmap.height(), 8);
+        TRY(m_macroblocks.try_resize(horizontal_macroblocks * vertical_macroblocks));
 
         for (u16 y {}; y < bitmap.height(); ++y) {
             u16 const vertical_macroblock_index = y / 8;
@@ -338,8 +337,6 @@ private:
 
     Vector<Macroblock> m_macroblocks {};
     Array<i16, 3> m_last_dc_values {};
-
-    u64 m_vertical_macroblocks {};
 
     JPEGBigEndianOutputBitStream m_bit_stream;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.h
@@ -21,6 +21,7 @@ public:
     using Options = JPEGEncoderOptions;
 
     static ErrorOr<void> encode(Stream&, Bitmap const&, Options const& = {});
+    static ErrorOr<void> encode(Stream&, CMYKBitmap const&, Options const& = {});
 
 private:
     JPEGWriter() = delete;


### PR DESCRIPTION
`image` can't transform from RGB to CMYK yet, so the only way to
do this is by having a CMYK input.

For example, this works now (and it does a full decode and re-encode):

    Build/lagom/bin/image -o out.jpg \
        Tests/LibGfx/test-inputs/jpg/buggie-cmyk.jpg

Using this to convert `.pam` files written by `mutool extract`
to jpegs is a somewhat convenient method of looking at these
.pam files.

---

Most of the commits are mechanical and tiny.