### PR TITLE
LibPDF: Tweak vertical position of truetype fonts again

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -52,8 +52,8 @@ PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
 {
     auto style = renderer.state().paint_style;
 
-    // Account for the reversed font baseline
-    auto position = point.translated(0, -m_font->pixel_metrics().descent - m_font->baseline());
+    // Undo shift in Glyf::Glyph::append_simple_path() via OpenType::Font::rasterize_glyph().
+    auto position = point.translated(0, -m_font->pixel_metrics().ascent);
 
     if (style.has<Color>()) {
         painter.draw_glyph(position, char_code, *m_font, style.get<Color>());

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -70,8 +70,8 @@ PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint po
     auto style = renderer.state().paint_style;
 
     if (!m_font_program) {
-        // Account for the reversed font baseline
-        auto position = point.translated(0, -m_font->pixel_metrics().descent - m_font->baseline());
+        // Undo shift in Glyf::Glyph::append_simple_path() via OpenType::Font::rasterize_glyph().
+        auto position = point.translated(0, -m_font->pixel_metrics().ascent);
         // FIXME: Bounding box and sample point look to be pretty wrong
         if (style.has<Color>()) {
             painter.draw_glyph(position, char_code, *m_font, style.get<Color>());


### PR DESCRIPTION
See #22821 for a previous attempt. This attempt should settle things once and for all.

The opentype render path adjusts by `-font_ascender * -y_scale` in Glyf::Glyph::append_simple_path(), so that's what we need to undo to draw at the font's baseline.

(OpenType::Font::metrics() returns ascender scaled by y_scale already, so no need to have the scale here where we undo the shift.)

Previously, we called `baseline()` which just returns the font's font size, which is pretty meaningless:

https://tonsky.me/blog/font-size/
https://simoncozens.github.io/fonts-and-layout/opentype.html#vertical-metrics-hhea-and-os2

Also, conceptually it makes sense to translate up by the ascender to get from the upper edge of the glyph to the baseline.