### PR TITLE
SystemServer: Treat services terminated by signals as not successful

### DIFF
--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -260,7 +260,7 @@ ErrorOr<void> Service::did_exit(int status)
         return {};
 
     auto run_time = m_run_timer.elapsed_time();
-    bool exited_successfully = WIFEXITED(status) == 0;
+    bool exited_successfully = WIFEXITED(status) && WEXITSTATUS(status) == 0;
 
     if (!exited_successfully && run_time < 1_sec) {
         switch (m_restart_attempts) {


### PR DESCRIPTION
This causes us to use the "3 tries then give up" logic for services that crash, instead of infinitely attempting to respawn them.

---

Discovered this when going from [my branch changing the ClipboardHistory.json format](https://github.com/SerenityOS/serenity/pull/23030) to master. ClipboardHistory then sees the wrong JSON format, crashes, and... SystemServer would infinitely try to respawn it, giving me an overwhelming number of CrashReporter popups. :sweat_smile:

I'm still a Unix noobie so there may be other signals we should treat as "this program executed successfully", or maybe SIGPIPE shouldn't be there. I don't know! I just know this fixes the issue for me.