### PR TITLE
Kernel: don't panic when LocalSocket is already bound

### DIFF
--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -162,7 +162,8 @@ ErrorOr<void> LocalSocket::bind(Credentials const& credentials, Userspace<sockad
 
 ErrorOr<void> LocalSocket::connect(Credentials const& credentials, OpenFileDescription& description, Userspace<sockaddr const*> user_address, socklen_t address_size)
 {
-    VERIFY(!m_bound);
+    if (m_bound)
+        return set_so_error(EISCONN);
 
     if (address_size > sizeof(sockaddr_un))
         return set_so_error(EINVAL);

--- a/Tests/Kernel/TestTCPSocket.cpp
+++ b/Tests/Kernel/TestTCPSocket.cpp
@@ -140,3 +140,33 @@ TEST_CASE(tcp_bind_connect)
         sched_yield();
     }
 }
+
+TEST_CASE(socket_connect_after_bind)
+{
+    unlink("/tmp/tmp-client.test");
+    unlink("/tmp/tmp.test");
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    EXPECT(fd >= 0);
+
+    struct sockaddr_un addr {
+        .sun_family = AF_UNIX,
+        .sun_path = "/tmp/tmp-client.test",
+    };
+
+    int bound = bind(fd, (struct sockaddr*)&addr, sizeof(addr));
+    EXPECT_NE(bound, -1);
+
+    struct sockaddr_un server_sockaddr {
+        .sun_family = AF_UNIX,
+        .sun_path = "/tmp/tmp.test",
+    };
+    int connected = connect(fd, (struct sockaddr*)&server_sockaddr, sizeof(server_sockaddr));
+    EXPECT_EQ(connected, -1);
+
+    int closed = close(fd);
+    EXPECT_EQ(closed, 0);
+
+    unlink("/tmp/tmp-client.test");
+    unlink("/tmp/tmp.test");
+}


### PR DESCRIPTION
Fixes #22701