### PR TITLE
LibWeb: Apply sniffing rules for text or binary resources in HTMLObjectElement

### DIFF
--- a/Tests/LibWeb/TestMimeSniff.cpp
+++ b/Tests/LibWeb/TestMimeSniff.cpp
@@ -320,3 +320,13 @@ TEST_CASE(determine_computed_mime_type_in_a_font_context)
 
     EXPECT_EQ(mime_type, computed_mime_type.essence());
 }
+
+TEST_CASE(determine_computed_mime_type_given_text_or_binary_context)
+{
+    auto supplied_type = MUST(Web::MimeSniff::MimeType::create("text"_string, "plain"_string));
+    auto computed_mime_type = MUST(Web::MimeSniff::Resource::sniff("\x00"sv.bytes(), Web::MimeSniff::SniffingConfiguration {
+                                                                                         .sniffing_context = Web::MimeSniff::SniffingContext::TextOrBinary,
+                                                                                         .supplied_type = supplied_type,
+                                                                                     }));
+    EXPECT_EQ("application/octet-stream"sv, MUST(computed_mime_type.serialized()));
+}

--- a/Userland/Libraries/LibWeb/MimeSniff/Resource.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/Resource.cpp
@@ -680,6 +680,8 @@ ErrorOr<void> Resource::context_specific_sniffing_algorithm(SniffingContext snif
         return rules_for_sniffing_audio_or_video_specifically();
     if (sniffing_context == SniffingContext::Font)
         return rules_for_sniffing_fonts_specifically();
+    if (sniffing_context == SniffingContext::TextOrBinary)
+        return rules_for_distinguishing_if_a_resource_is_text_or_binary();
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/MimeSniff/Resource.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/Resource.h
@@ -16,6 +16,10 @@ enum class SniffingContext {
     Image,
     AudioOrVideo,
     Font,
+
+    // Non-standard but used in cases where the spec expects us to only run
+    // https://mimesniff.spec.whatwg.org/#sniffing-a-mislabeled-binary-resource
+    TextOrBinary,
 };
 
 struct SniffingConfiguration {


### PR DESCRIPTION
This resolves a FIXME in HTMLObjectElement.cpp that has us sniff a resource using the [rules for distinguishing if a resource is text or binary](https://mimesniff.spec.whatwg.org/#rules-for-text-or-binary) if its HTTP Content-Type header is "text/plain".

I manually tested this change by using the following object element and a good old `dbgln()`:
```html
<object type="text/plain" data="binary_file.txt" width="600" height="140">
</object>
```

... where "binary_file.txt" is a file that contains the binary characters \x00 \x01. I just checked if the `binary` variable was set when I navigate to this HTML page and from looking at the runtime this appears to be the case.