### PR TITLE
LibGfx/PNM: Remove two fixmes

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -116,12 +116,12 @@ static ErrorOr<void> read_whitespace(TContext& context)
         auto const byte = byte_or_error.value();
 
         if (byte == '#') {
-            stream.seek(-1, SeekMode::FromCurrentPosition).release_value_but_fixme_should_propagate_errors();
+            TRY(stream.seek(-1, SeekMode::FromCurrentPosition));
             TRY(read_comment(context));
             continue;
         }
         if (byte != ' ' && byte != '\t' && byte != '\n' && byte != '\r') {
-            stream.seek(-1, SeekMode::FromCurrentPosition).release_value_but_fixme_should_propagate_errors();
+            TRY(stream.seek(-1, SeekMode::FromCurrentPosition));
             if (is_first_char)
                 return Error::from_string_literal("Can't read whitespace from stream");
             break;


### PR DESCRIPTION
bab2113ec1f made read_whitespace() return ErrorOr, which makes this easy to do.

(7cafd7d177f, which added the fixmes, landed slightly after bab2113ec1f, so not quite sure why it wasn't like this immediately. Maybe commit order got changed during review; both commits were in #17831.)

No behavior change.