### PR TITLE
LibCore: Replace select(2) with poll(2) in the UNIX event loop impl

### DIFF
--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -106,7 +106,7 @@ static void socket_notifier(CFSocketRef socket, CFSocketCallBackType notificatio
     // before dispatching the event, which allows it to be triggered again.
     CFSocketEnableCallBacks(socket, notification_type);
 
-    Core::NotifierActivationEvent event(notifier.fd());
+    Core::NotifierActivationEvent event(notifier.fd(), notifier.type());
     notifier.dispatch_event(event);
 
     // This manual process of enabling the callbacks also seems to require waking the event loop,

--- a/Ladybird/Qt/EventLoopImplementationQt.cpp
+++ b/Ladybird/Qt/EventLoopImplementationQt.cpp
@@ -118,7 +118,7 @@ bool EventLoopManagerQt::unregister_timer(int timer_id)
 
 static void qt_notifier_activated(Core::Notifier& notifier)
 {
-    Core::NotifierActivationEvent event(notifier.fd());
+    Core::NotifierActivationEvent event(notifier.fd(), notifier.type());
     notifier.dispatch_event(event);
 }
 

--- a/Userland/Libraries/LibCore/Event.h
+++ b/Userland/Libraries/LibCore/Event.h
@@ -83,6 +83,8 @@ enum class NotificationType {
     None = 0,
     Read = 1,
     Write = 2,
+    HangUp = 4,
+    Error = 8,
 };
 
 AK_ENUM_BITWISE_OPERATORS(NotificationType);

--- a/Userland/Libraries/LibCore/Event.h
+++ b/Userland/Libraries/LibCore/Event.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/Function.h>
 #include <AK/Types.h>
 #include <AK/WeakPtr.h>
@@ -78,19 +79,30 @@ private:
     int m_timer_id;
 };
 
+enum class NotificationType {
+    None = 0,
+    Read = 1,
+    Write = 2,
+};
+
+AK_ENUM_BITWISE_OPERATORS(NotificationType);
+
 class NotifierActivationEvent final : public Event {
 public:
-    explicit NotifierActivationEvent(int fd)
+    explicit NotifierActivationEvent(int fd, NotificationType type)
         : Event(Event::NotifierActivation)
         , m_fd(fd)
+        , m_type(type)
     {
     }
     ~NotifierActivationEvent() = default;
 
     int fd() const { return m_fd; }
+    NotificationType type() const { return m_type; }
 
 private:
     int m_fd;
+    NotificationType m_type;
 };
 
 class ChildEvent final : public Event {

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -267,6 +267,10 @@ try_select_again:
             type |= NotificationType::Read;
         if (has_flag(revents, POLLOUT))
             type |= NotificationType::Write;
+        if (has_flag(revents, POLLHUP))
+            type |= NotificationType::HangUp;
+        if (has_flag(revents, POLLERR))
+            type |= NotificationType::Error;
         type &= notifier.type();
         if (type != NotificationType::None)
             ThreadEventQueue::current().post_event(notifier, make<NotifierActivationEvent>(notifier.fd(), type));

--- a/Userland/Libraries/LibCore/Notifier.cpp
+++ b/Userland/Libraries/LibCore/Notifier.cpp
@@ -27,6 +27,9 @@ void Notifier::set_enabled(bool enabled)
 {
     if (m_fd < 0)
         return;
+    if (enabled == m_is_enabled)
+        return;
+    m_is_enabled = enabled;
     if (enabled)
         Core::EventLoop::register_notifier({}, *this);
     else
@@ -39,6 +42,18 @@ void Notifier::close()
         return;
     set_enabled(false);
     m_fd = -1;
+}
+
+void Notifier::set_type(Type type)
+{
+    if (m_is_enabled) {
+        // FIXME: Directly communicate intent to the EventLoop.
+        set_enabled(false);
+        m_type = type;
+        set_enabled(true);
+    } else {
+        m_type = type;
+    }
 }
 
 void Notifier::event(Core::Event& event)

--- a/Userland/Libraries/LibCore/Notifier.h
+++ b/Userland/Libraries/LibCore/Notifier.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <LibCore/Event.h>
 #include <LibCore/EventReceiver.h>
 
 namespace Core {
@@ -15,12 +16,7 @@ class Notifier final : public EventReceiver {
     C_OBJECT(Notifier);
 
 public:
-    enum class Type {
-        None,
-        Read,
-        Write,
-        Exceptional,
-    };
+    using Type = NotificationType;
 
     virtual ~Notifier() override;
 
@@ -32,7 +28,7 @@ public:
 
     int fd() const { return m_fd; }
     Type type() const { return m_type; }
-    void set_type(Type type) { m_type = type; }
+    void set_type(Type type);
 
     void event(Core::Event&) override;
 
@@ -40,6 +36,7 @@ private:
     Notifier(int fd, Type type, EventReceiver* parent = nullptr);
 
     int m_fd { -1 };
+    bool m_is_enabled { false };
     Type m_type { Type::None };
 };
 


### PR DESCRIPTION
As per Andrew's and Andreas' suggestion in #development. Also includes some trivial collateral damage to Notifier which will be useful later.