### PR TITLE
LibWeb: Support scrolling of iframes

### DIFF
--- a/Tests/LibWeb/Ref/reference/scroll-iframe-ref.html
+++ b/Tests/LibWeb/Ref/reference/scroll-iframe-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<body style="border: 1px solid black; width: fit-content">
+<div style="width: 200px; height: 200px; background-color: blue"></div>    
+</body>

--- a/Tests/LibWeb/Ref/scroll-iframe.html
+++ b/Tests/LibWeb/Ref/scroll-iframe.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/scroll-iframe-ref.html" />
+<style>
+    iframe {
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+</style>
+<body></body>
+<script>
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = `
+        <style>body { margin: 0 }</style>
+        <div style="width: 200px; height: 200px; background-color: darkblue"></div>
+        <div style="width: 200px; height: 200px; background-color: blue"></div>
+        <div style="width: 200px; height: 200px; background-color: magenta"></div>
+    `;
+    iframe.onload = function () {
+        iframe.contentWindow.scroll(0, 200);
+    };
+    document.body.appendChild(iframe);
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1879,8 +1879,8 @@ void Document::scroll_to_the_fragment()
 void Document::scroll_to_the_beginning_of_the_document()
 {
     // FIXME: Actually implement this algorithm
-    if (auto browsing_context = this->browsing_context())
-        browsing_context->scroll_to({ 0, 0 });
+    if (auto navigable = this->navigable())
+        navigable->perform_scroll_of_viewport({ 0, 0 });
 }
 
 StringView Document::ready_state() const

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1711,11 +1711,10 @@ static ErrorOr<void> scroll_an_element_into_view(DOM::Element& target, Bindings:
             (void)behavior;
 
             // AD-HOC:
-            auto& page = document.navigable()->traversable_navigable()->page();
             // NOTE: Since calculated position is relative to the viewport, we need to add the viewport's position to it
-            //       before passing to page_did_request_scroll_to() that expects a position relative to the page.
+            //       before passing to perform_scroll_of_viewport() that expects a position relative to the page.
             position.set_y(position.y() + scrolling_box.y());
-            page.client().page_did_request_scroll_to(position);
+            document.navigable()->perform_scroll_of_viewport(position);
         }
         // If scrolling box is associated with an element
         else {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -352,8 +352,8 @@ void BrowsingContext::scroll_to(CSSPixelPoint position)
             active_document()->update_layout();
     }
 
-    if (this == &m_page->top_level_browsing_context())
-        m_page->client().page_did_request_scroll_to(position);
+    if (auto navigable = active_document()->navigable())
+        navigable->perform_scroll_of_viewport(position);
 }
 
 JS::GCPtr<BrowsingContext> BrowsingContext::top_level_browsing_context() const

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -343,19 +343,6 @@ bool BrowsingContext::is_focused_context() const
     return &m_page->focused_context() == this;
 }
 
-void BrowsingContext::scroll_to(CSSPixelPoint position)
-{
-    // NOTE: Scrolling to a position requires up-to-date layout *unless* we're scrolling to (0, 0)
-    //       as (0, 0) is always guaranteed to be a valid scroll position.
-    if (!position.is_zero()) {
-        if (active_document())
-            active_document()->update_layout();
-    }
-
-    if (auto navigable = active_document()->navigable())
-        navigable->perform_scroll_of_viewport(position);
-}
-
 JS::GCPtr<BrowsingContext> BrowsingContext::top_level_browsing_context() const
 {
     auto const* start = this;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -121,8 +121,6 @@ public:
     Web::EventHandler& event_handler() { return m_event_handler; }
     Web::EventHandler const& event_handler() const { return m_event_handler; }
 
-    void scroll_to(CSSPixelPoint);
-
     JS::GCPtr<BrowsingContext> top_level_browsing_context() const;
 
     enum class WindowType {

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1983,6 +1983,17 @@ void Navigable::set_viewport_rect(CSSPixelRect const& rect)
     HTML::main_thread_event_loop().schedule();
 }
 
+void Navigable::perform_scroll_of_viewport(CSSPixelPoint position)
+{
+    auto viewport_rect = this->viewport_rect();
+    viewport_rect.set_location(position);
+    set_viewport_rect(viewport_rect);
+    set_needs_display();
+
+    if (is_traversable() && active_browsing_context())
+        active_browsing_context()->page().client().page_did_request_scroll_to(position);
+}
+
 void Navigable::set_size(CSSPixelSize size)
 {
     if (m_size == size)

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -161,6 +161,7 @@ public:
     CSSPixelPoint viewport_scroll_offset() const { return m_viewport_scroll_offset; }
     CSSPixelRect viewport_rect() const { return { m_viewport_scroll_offset, m_size }; }
     void set_viewport_rect(CSSPixelRect const&);
+    void perform_scroll_of_viewport(CSSPixelPoint position);
 
     void set_needs_display();
     void set_needs_display(CSSPixelRect const&);

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1217,7 +1217,9 @@ double Window::scroll_x() const
 {
     // The scrollX attribute must return the x-coordinate, relative to the initial containing block origin,
     // of the left of the viewport, or zero if there is no viewport.
-    return page().top_level_traversable()->viewport_scroll_offset().x().to_double();
+    if (auto const navigable = associated_document().navigable())
+        return navigable->viewport_rect().x().to_double();
+    return 0;
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view/#dom-window-scrolly
@@ -1225,7 +1227,9 @@ double Window::scroll_y() const
 {
     // The scrollY attribute must return the y-coordinate, relative to the initial containing block origin,
     // of the top of the viewport, or zero if there is no viewport.
-    return page().top_level_traversable()->viewport_scroll_offset().y().to_double();
+    if (auto const navigable = associated_document().navigable())
+        return navigable->viewport_rect().y().to_double();
+    return 0;
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view/#perform-a-scroll


### PR DESCRIPTION
With these changes `window.scroll()` works in iframe and iframes could be scrolled by mouse/trackpad.