### PR TITLE
Kernel/HID: Move code_point assignment before its use in key assignment

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -43,6 +43,9 @@ void KeyboardDevice::handle_input_event(KeyEvent queued_event)
         }
     }
 
+    if (queued_event.map_entry_index != 0xFF)
+        queued_event.code_point = HIDManagement::the().get_char_from_character_map(queued_event, queued_event.map_entry_index);
+
     // If using a non-QWERTY layout, queued_event.key needs to be updated to be the same as event.code_point
     KeyCode mapped_key = code_point_to_key_code(queued_event.code_point);
     if (mapped_key != KeyCode::Key_Invalid)
@@ -57,9 +60,6 @@ void KeyboardDevice::handle_input_event(KeyEvent queued_event)
         m_caps_lock_to_ctrl_pressed = queued_event.is_press();
         update_modifier(Mod_Ctrl, m_caps_lock_to_ctrl_pressed);
     }
-
-    if (queued_event.map_entry_index != 0xFF)
-        queued_event.code_point = HIDManagement::the().get_char_from_character_map(queued_event, queued_event.map_entry_index);
 
     {
         SpinlockLocker locker(HIDManagement::the().m_client_lock);


### PR DESCRIPTION
We need to handle the character map to set the code point before we can reassign the correct key to the queued_event.key. This fixes keyboard shortcuts using the incorrect keys based on the keyboard layout.

Before this fix all shortcut keys would be using the default qwerty keyboard layout even when the keyboard
map was changed to dvorak