### PR TITLE
AK: Fix OptionParser argument shifting

### DIFF
--- a/AK/OptionParser.cpp
+++ b/AK/OptionParser.cpp
@@ -239,7 +239,7 @@ void OptionParser::shift_argv()
 {
     // We've just parsed an option (which perhaps has a value).
     // Put the option (along with its value, if any) in front of other arguments.
-    if (m_consumed_args == 0 || m_skipped_arguments == 0) {
+    if (m_consumed_args == 0 && m_skipped_arguments == 0) {
         // Nothing to do!
         return;
     }
@@ -253,6 +253,12 @@ void OptionParser::shift_argv()
     m_args.slice(m_arg_index, m_consumed_args).copy_to(buffer_bytes);
     m_args.slice(m_arg_index - m_skipped_arguments, m_skipped_arguments).copy_to(m_args.slice(m_arg_index + m_consumed_args - m_skipped_arguments));
     buffer_bytes.slice(0, m_consumed_args).copy_to(m_args.slice(m_arg_index - m_skipped_arguments, m_consumed_args));
+
+    // m_arg_index took into account m_skipped_arguments (both are inc in find_next_option)
+    // so now we have to make m_arg_index point to the beginning of skipped arguments
+    m_arg_index -= m_skipped_arguments;
+    // and let's forget about skipped arguments
+    m_skipped_arguments = 0;
 }
 
 bool OptionParser::find_next_option()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -688,6 +688,8 @@ if (BUILD_LAGOM)
         endif()
 
         # LibCore
+        lagom_test(../../Tests/LibCore/TestLibCoreArgsParser.cpp)
+
         if ((LINUX OR APPLE) AND NOT EMSCRIPTEN)
             lagom_test(../../Tests/LibCore/TestLibCoreFileWatcher.cpp)
             lagom_test(../../Tests/LibCore/TestLibCorePromise.cpp LIBS LibThreading)

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -56,6 +56,7 @@ set(AK_TEST_SOURCES
     TestNonnullRefPtr.cpp
     TestNumberFormat.cpp
     TestOptional.cpp
+    TestOptionParser.cpp
     TestOwnPtr.cpp
     TestPrint.cpp
     TestQueue.cpp

--- a/Tests/AK/TestOptionParser.cpp
+++ b/Tests/AK/TestOptionParser.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Array.h>
+#include <AK/OptionParser.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+TEST_CASE(string_option)
+{
+    ByteString short_options = "";
+    int index_of_found_long_option = -1;
+    Vector<OptionParser::Option> long_options;
+    long_options.append(
+        { "string_opt"sv,
+            OptionParser::ArgumentRequirement::HasRequiredArgument,
+            &index_of_found_long_option,
+            0 });
+
+    Array<StringView, 3> argument_array({ "app"sv, "--string_opt"sv, "string_opt_value"sv });
+    Span<StringView> arguments(argument_array);
+    size_t next_argument_index = 1;
+
+    OptionParser parser;
+    auto result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+
+    // found a long option
+    EXPECT_EQ(result.result, 0);
+    // found long option at index 0
+    EXPECT_EQ(index_of_found_long_option, 0);
+    // 2 args consumed: option name and value
+    EXPECT_EQ(result.consumed_args, static_cast<size_t>(2));
+    // option has a value
+    EXPECT_EQ(result.optarg_value, "string_opt_value");
+
+    next_argument_index += result.consumed_args;
+    // we are past the end
+    EXPECT_EQ(next_argument_index, static_cast<size_t>(3));
+}
+
+TEST_CASE(string_option_then_positional)
+{
+    ByteString short_options = "";
+    int index_of_found_long_option = -1;
+    Vector<OptionParser::Option> long_options;
+    long_options.append(
+        { "string_opt"sv,
+            OptionParser::ArgumentRequirement::HasRequiredArgument,
+            &index_of_found_long_option,
+            0 });
+
+    Array<StringView, 4> argument_array({ "app"sv, "--string_opt"sv, "string_opt_value"sv, "positional"sv });
+    Span<StringView> arguments(argument_array);
+    size_t next_argument_index = 1;
+
+    OptionParser parser;
+    auto result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+
+    // found a long option
+    EXPECT_EQ(result.result, 0);
+    // found long option at index 0
+    EXPECT_EQ(index_of_found_long_option, 0);
+    // 2 args consumed: option name and value
+    EXPECT_EQ(result.consumed_args, static_cast<size_t>(2));
+    // option has a value
+    EXPECT_EQ(result.optarg_value, "string_opt_value");
+
+    next_argument_index += result.consumed_args;
+    // we are at "positional" index of arguments vector
+    EXPECT_EQ(next_argument_index, static_cast<size_t>(3));
+    EXPECT_EQ(arguments[next_argument_index], "positional");
+
+    result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+    // there's no more options
+    EXPECT_EQ(result.result, -1);
+}
+
+TEST_CASE(positional_then_string_option)
+{
+    ByteString short_options = "";
+    int index_of_found_long_option = -1;
+    Vector<OptionParser::Option> long_options;
+    long_options.append(
+        { "string_opt"sv,
+            OptionParser::ArgumentRequirement::HasRequiredArgument,
+            &index_of_found_long_option,
+            0 });
+
+    Array<StringView, 4> argument_array({ "app"sv, "positional"sv, "--string_opt"sv, "string_opt_value"sv });
+    Span<StringView> arguments(argument_array);
+    size_t next_argument_index = 1;
+
+    OptionParser parser;
+    auto result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+
+    // found a long option
+    EXPECT_EQ(result.result, 0);
+    // found long option at index 0
+    EXPECT_EQ(index_of_found_long_option, 0);
+    // 2 args consumed: option name and value
+    EXPECT_EQ(result.consumed_args, static_cast<size_t>(2));
+    // option has a value
+    EXPECT_EQ(result.optarg_value, "string_opt_value");
+
+    next_argument_index += result.consumed_args;
+    // we are at "positional" index of arguments vector
+    EXPECT_EQ(next_argument_index, static_cast<size_t>(3));
+    EXPECT_EQ(arguments[next_argument_index], "positional");
+
+    result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+    // there's no more options
+    EXPECT_EQ(result.result, -1);
+}
+
+TEST_CASE(positional_then_string_option_then_bool_option)
+{
+    // #22759: Positional arguments were sometimes incorrectly not shifted, leading to an incorrect parse.
+
+    ByteString short_options = "";
+    int index_of_found_long_option = -1;
+    Vector<OptionParser::Option> long_options;
+    long_options.append(
+        { "string_opt"sv,
+            OptionParser::ArgumentRequirement::HasRequiredArgument,
+            &index_of_found_long_option,
+            0 });
+    long_options.append(
+        { "bool_opt"sv,
+            OptionParser::ArgumentRequirement::NoArgument,
+            &index_of_found_long_option,
+            1 });
+
+    Array<StringView, 5> argument_array({ "app"sv, "positional"sv, "--string_opt"sv, "string_opt_value"sv, "--bool_opt"sv });
+    Span<StringView> arguments(argument_array);
+    size_t next_argument_index = 1;
+
+    OptionParser parser;
+    auto result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+    // found a long option
+    EXPECT_EQ(result.result, 0);
+    // found long option at index 0
+    EXPECT_EQ(index_of_found_long_option, 0);
+    // 2 args consumed: option name and value
+    EXPECT_EQ(result.consumed_args, static_cast<size_t>(2));
+    // option has a value
+    EXPECT_EQ(result.optarg_value, "string_opt_value");
+
+    next_argument_index += result.consumed_args;
+    EXPECT_EQ(next_argument_index, static_cast<size_t>(3));
+    // positional argument has been shifted here
+    EXPECT_EQ(arguments[next_argument_index], "positional");
+
+    result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+    // found another long option
+    EXPECT_EQ(result.result, 0);
+    // found long option at index 1
+    EXPECT_EQ(index_of_found_long_option, 1);
+    // 1 arg consumed: option name
+    EXPECT_EQ(result.consumed_args, static_cast<size_t>(1));
+
+    next_argument_index += result.consumed_args;
+    // "positional" argument has been shifted here
+    EXPECT_EQ(next_argument_index, static_cast<size_t>(4));
+    EXPECT_EQ(arguments[next_argument_index], "positional");
+
+    result = parser.getopt(arguments.slice(1), short_options, long_options, {});
+    // there's no more options
+    EXPECT_EQ(result.result, -1);
+}


### PR DESCRIPTION
Changes made to fix https://github.com/SerenityOS/serenity/issues/22759
Basically, there was an issue in OptionParser class where the positional argument was not shifted to the right, ending in reading an optional argument as the positional one.
Unit tests added to the existing ones for ArgsParser class using OptionParser class as an underlying parser.
Added ArgsParser unit tests to the unit test suite
New unit tests for OptionParser class