### PR TITLE
LibGfx/JPEG+TIFF: Allow the TIFF decoder to read JPEG tables

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGHuffmanTable.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGHuffmanTable.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Vector.h>
+
+namespace Gfx::JPEG {
+
+struct HuffmanTable {
+    u8 type { 0 };
+    u8 destination_id { 0 };
+    u8 code_counts[16] = { 0 };
+    Vector<u8> symbols;
+    Vector<u16> codes;
+
+    // Note: The value 8 is chosen quite arbitrarily, the only current constraint
+    //       is that both the symbol and the size fit in an u16. I've tested more
+    //       values but none stand out, and 8 is the value used by libjpeg-turbo.
+    static constexpr u8 bits_per_cached_code = 8;
+    static constexpr u8 maximum_bits_per_code = 16;
+    u8 first_non_cached_code_index {};
+
+    ErrorOr<void> generate_codes()
+    {
+        unsigned code = 0;
+        for (auto number_of_codes : code_counts) {
+            for (int i = 0; i < number_of_codes; i++)
+                codes.append(code++);
+            code <<= 1;
+        }
+
+        TRY(generate_lookup_table());
+        return {};
+    }
+
+    struct SymbolAndSize {
+        u8 symbol {};
+        u8 size {};
+    };
+
+    ErrorOr<SymbolAndSize> symbol_from_code(u16 code) const
+    {
+        static constexpr u8 shift_for_cache = maximum_bits_per_code - bits_per_cached_code;
+
+        if (lookup_table[code >> shift_for_cache] != invalid_entry) {
+            u8 const code_length = lookup_table[code >> shift_for_cache] >> bits_per_cached_code;
+            return SymbolAndSize { static_cast<u8>(lookup_table[code >> shift_for_cache]), code_length };
+        }
+
+        u64 code_cursor = first_non_cached_code_index;
+
+        for (u8 i = HuffmanTable::bits_per_cached_code; i < 16; i++) {
+            auto const result = code >> (maximum_bits_per_code - 1 - i);
+            for (u32 j = 0; j < code_counts[i]; j++) {
+                if (result == codes[code_cursor])
+                    return SymbolAndSize { symbols[code_cursor], static_cast<u8>(i + 1) };
+
+                code_cursor++;
+            }
+        }
+
+        return Error::from_string_literal("This kind of JPEG is not yet supported by the decoder");
+    }
+
+private:
+    static constexpr u16 invalid_entry = 0xFF;
+
+    ErrorOr<void> generate_lookup_table()
+    {
+        lookup_table.fill(invalid_entry);
+
+        u32 code_offset = 0;
+        for (u8 code_length = 1; code_length <= bits_per_cached_code; code_length++) {
+            for (u32 i = 0; i < code_counts[code_length - 1]; i++, code_offset++) {
+                u32 code_key = codes[code_offset] << (bits_per_cached_code - code_length);
+                u8 duplicate_count = 1 << (bits_per_cached_code - code_length);
+                if (code_key + duplicate_count >= lookup_table.size())
+                    return Error::from_string_literal("Malformed Huffman table");
+
+                for (; duplicate_count > 0; duplicate_count--) {
+                    lookup_table[code_key] = (code_length << bits_per_cached_code) | symbols[code_offset];
+                    code_key++;
+                }
+            }
+        }
+        return {};
+    }
+
+    Array<u16, 1 << bits_per_cached_code> lookup_table {};
+};
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -16,6 +16,7 @@
 #include <AK/String.h>
 #include <AK/Try.h>
 #include <AK/Vector.h>
+#include <LibGfx/ImageFormats/JPEGHuffmanTable.h>
 #include <LibGfx/ImageFormats/JPEGLoader.h>
 #include <LibGfx/ImageFormats/JPEGShared.h>
 #include <LibGfx/ImageFormats/TIFFLoader.h>
@@ -88,89 +89,6 @@ struct StartOfFrame {
     u8 precision { 0 };
     u16 height { 0 };
     u16 width { 0 };
-};
-
-struct HuffmanTable {
-    u8 type { 0 };
-    u8 destination_id { 0 };
-    u8 code_counts[16] = { 0 };
-    Vector<u8> symbols;
-    Vector<u16> codes;
-
-    // Note: The value 8 is chosen quite arbitrarily, the only current constraint
-    //       is that both the symbol and the size fit in an u16. I've tested more
-    //       values but none stand out, and 8 is the value used by libjpeg-turbo.
-    static constexpr u8 bits_per_cached_code = 8;
-    static constexpr u8 maximum_bits_per_code = 16;
-    u8 first_non_cached_code_index {};
-
-    ErrorOr<void> generate_codes()
-    {
-        unsigned code = 0;
-        for (auto number_of_codes : code_counts) {
-            for (int i = 0; i < number_of_codes; i++)
-                codes.append(code++);
-            code <<= 1;
-        }
-
-        TRY(generate_lookup_table());
-        return {};
-    }
-
-    struct SymbolAndSize {
-        u8 symbol {};
-        u8 size {};
-    };
-
-    ErrorOr<SymbolAndSize> symbol_from_code(u16 code) const
-    {
-        static constexpr u8 shift_for_cache = maximum_bits_per_code - bits_per_cached_code;
-
-        if (lookup_table[code >> shift_for_cache] != invalid_entry) {
-            u8 const code_length = lookup_table[code >> shift_for_cache] >> bits_per_cached_code;
-            return SymbolAndSize { static_cast<u8>(lookup_table[code >> shift_for_cache]), code_length };
-        }
-
-        u64 code_cursor = first_non_cached_code_index;
-
-        for (u8 i = HuffmanTable::bits_per_cached_code; i < 16; i++) {
-            auto const result = code >> (maximum_bits_per_code - 1 - i);
-            for (u32 j = 0; j < code_counts[i]; j++) {
-                if (result == codes[code_cursor])
-                    return SymbolAndSize { symbols[code_cursor], static_cast<u8>(i + 1) };
-
-                code_cursor++;
-            }
-        }
-
-        return Error::from_string_literal("This kind of JPEG is not yet supported by the decoder");
-    }
-
-private:
-    static constexpr u16 invalid_entry = 0xFF;
-
-    ErrorOr<void> generate_lookup_table()
-    {
-        lookup_table.fill(invalid_entry);
-
-        u32 code_offset = 0;
-        for (u8 code_length = 1; code_length <= bits_per_cached_code; code_length++) {
-            for (u32 i = 0; i < code_counts[code_length - 1]; i++, code_offset++) {
-                u32 code_key = codes[code_offset] << (bits_per_cached_code - code_length);
-                u8 duplicate_count = 1 << (bits_per_cached_code - code_length);
-                if (code_key + duplicate_count >= lookup_table.size())
-                    return Error::from_string_literal("Malformed Huffman table");
-
-                for (; duplicate_count > 0; duplicate_count--) {
-                    lookup_table[code_key] = (code_length << bits_per_cached_code) | symbols[code_offset];
-                    code_key++;
-                }
-            }
-        }
-        return {};
-    }
-
-    Array<u16, 1 << bits_per_cached_code> lookup_table {};
 };
 
 class HuffmanStream;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -12,7 +12,9 @@
 
 namespace Gfx {
 
-struct JPEGLoadingContext;
+namespace JPEG {
+struct LoadingContext;
+}
 
 // For the specification, see: https://www.w3.org/Graphics/JPEG/itu-t81.pdf
 
@@ -46,9 +48,9 @@ public:
     virtual ErrorOr<NonnullRefPtr<CMYKBitmap>> cmyk_frame() override;
 
 private:
-    JPEGImageDecoderPlugin(NonnullOwnPtr<JPEGLoadingContext>);
+    JPEGImageDecoderPlugin(NonnullOwnPtr<JPEG::LoadingContext>);
 
-    NonnullOwnPtr<JPEGLoadingContext> m_context;
+    NonnullOwnPtr<JPEG::LoadingContext> m_context;
 };
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -7,13 +7,26 @@
 
 #pragma once
 
+#include <AK/Array.h>
+#include <AK/HashMap.h>
 #include <AK/MemoryStream.h>
+#include <AK/Optional.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
+#include <LibGfx/ImageFormats/JPEGHuffmanTable.h>
 
 namespace Gfx {
 
 namespace JPEG {
 struct LoadingContext;
+
+using QuantizationTables = Array<Optional<Array<u16, 64>>, 4>;
+
+struct Tables {
+    QuantizationTables quantization_tables {};
+    HashMap<u8, HuffmanTable> dc_tables {};
+    HashMap<u8, HuffmanTable> ac_tables {};
+};
+
 }
 
 // For the specification, see: https://www.w3.org/Graphics/JPEG/itu-t81.pdf
@@ -27,6 +40,13 @@ struct JPEGDecoderOptions {
         PDF,
     };
     CMYK cmyk { CMYK::Normal };
+
+    enum class TIFFSpecialHandling {
+        None,
+        TablesOnly,
+    };
+
+    TIFFSpecialHandling tiff_special_handling { TIFFSpecialHandling::None };
 };
 
 class JPEGImageDecoderPlugin : public ImageDecoderPlugin {
@@ -34,6 +54,9 @@ public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create_with_options(ReadonlyBytes, JPEGDecoderOptions = {});
+
+    // This is intended to be used by the TIFF decoder
+    static ErrorOr<JPEG::Tables> read_tables(ReadonlyBytes);
 
     virtual ~JPEGImageDecoderPlugin() override;
     virtual IntSize size() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -15,6 +15,7 @@
 #include <LibGfx/CMYKBitmap.h>
 #include <LibGfx/ImageFormats/CCITTDecoder.h>
 #include <LibGfx/ImageFormats/ExifOrientedBitmap.h>
+#include <LibGfx/ImageFormats/JPEGLoader.h>
 #include <LibGfx/ImageFormats/TIFFMetadata.h>
 
 namespace Gfx {
@@ -399,6 +400,13 @@ private:
 
             TRY(loop_over_pixels(move(decode_lzw_strip)));
             break;
+        }
+        case Compression::JPEG: {
+            Optional<JPEG::Tables> tables;
+            if (m_metadata.jpeg_tables().has_value())
+                tables = TRY(JPEGImageDecoderPlugin::read_tables(*metadata().jpeg_tables()));
+
+            return Error::from_string_literal("TIFFImageDecoderPlugin: JPEG compression is not supported yet :^(");
         }
         case Compression::AdobeDeflate:
         case Compression::PixarDeflate: {

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -144,6 +144,7 @@ known_tags: List[Tag] = [
     Tag('320', [TIFFType.UnsignedShort], [], None, "ColorMap"),
     Tag('338', [TIFFType.UnsignedShort], [], None, "ExtraSamples", ExtraSample),
     Tag('339', [TIFFType.UnsignedShort], [], SampleFormat.Unsigned, "SampleFormat", SampleFormat),
+    Tag('347', [TIFFType.Undefined], [], None, "JPEGTables"),
     Tag('34665', [TIFFType.UnsignedLong, TIFFType.IFD], [1], None, "ExifIFD"),
     Tag('34675', [TIFFType.Undefined], [], None, "ICCProfile"),
 ]


### PR DESCRIPTION
The TIFF container has support for embedded JPEG. Each strip or tile is encoded as a standalone JPEG except for the decompression tables (quantization and huffman). These are encoded in a previous JPEG bitstream containing only these tables. 

This PR adds support for reading these partial streams in the JPEG decoder and some code to call that from the TIFF decoder.