### PR TITLE
Calendar: Add ability to view events

### DIFF
--- a/Userland/Applications/Calendar/CMakeLists.txt
+++ b/Userland/Applications/Calendar/CMakeLists.txt
@@ -5,6 +5,7 @@ serenity_component(
 
 compile_gml(CalendarWidget.gml CalendarWidgetGML.cpp)
 compile_gml(AddEventDialog.gml AddEventDialogGML.cpp)
+compile_gml(ViewEventDialog.gml ViewEventDialogGML.cpp)
 
 set(SOURCES
     AddEventDialog.cpp
@@ -15,6 +16,9 @@ set(SOURCES
     EventCalendar.cpp
     EventManager.cpp
     main.cpp
+    ViewEventDialog.cpp
+    ViewEventDialogGML.cpp
+    ViewEventWidget.cpp
 )
 
 serenity_app(Calendar ICON app-calendar)

--- a/Userland/Applications/Calendar/CalendarWidget.cpp
+++ b/Userland/Applications/Calendar/CalendarWidget.cpp
@@ -7,6 +7,7 @@
 
 #include "CalendarWidget.h"
 #include "AddEventDialog.h"
+#include "ViewEventDialog.h"
 #include <AK/JsonParser.h>
 #include <AK/LexicalPath.h>
 #include <LibConfig/Client.h>
@@ -298,8 +299,17 @@ ErrorOr<NonnullRefPtr<GUI::Action>> CalendarWidget::create_open_settings_action(
 void CalendarWidget::create_on_tile_doubleclick()
 {
     m_event_calendar->on_tile_doubleclick = [&] {
+        for (const auto& event : m_event_calendar->event_manager().events()) {
+            auto start = event.start;
+            auto selected_date = m_event_calendar->selected_date();
+
+            if (start.year() == selected_date.year() && start.month() == selected_date.month() && start.day() == selected_date.day()) {
+                ViewEventDialog::show(selected_date, m_event_calendar->event_manager(), window());
+                return;
+            }
+        }
+
         AddEventDialog::show(m_event_calendar->selected_date(), m_event_calendar->event_manager(), window());
     };
 }
-
 }

--- a/Userland/Applications/Calendar/ViewEventDialog.cpp
+++ b/Userland/Applications/Calendar/ViewEventDialog.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ViewEventDialog.h"
+#include "AddEventDialog.h"
+#include "ViewEventWidget.h"
+#include <LibGUI/Label.h>
+
+namespace Calendar {
+
+ViewEventDialog::ViewEventDialog(Core::DateTime date_time, EventManager& event_manager, GUI::Window* parent_window)
+    : GUI::Dialog(parent_window)
+    , m_event_manager(event_manager)
+    , m_date_time(date_time)
+{
+    set_title("Events");
+    set_resizable(true);
+    set_icon(parent_window->icon());
+
+    update_events();
+
+    auto main_widget = MUST(ViewEventWidget::create(this, m_events));
+    set_main_widget(main_widget);
+}
+
+void ViewEventDialog::update_events()
+{
+    for (auto const& event : m_event_manager.events()) {
+        auto start_date = event.start;
+        if (start_date.year() == m_date_time.year() && start_date.month() == m_date_time.month() && start_date.day() == m_date_time.day()) {
+            m_events.append(event);
+        }
+    }
+}
+
+void ViewEventDialog::close_and_open_add_event_dialog()
+{
+    close();
+    AddEventDialog::show(m_date_time, m_event_manager, find_parent_window());
+}
+
+}

--- a/Userland/Applications/Calendar/ViewEventDialog.gml
+++ b/Userland/Applications/Calendar/ViewEventDialog.gml
@@ -1,0 +1,18 @@
+@Calendar::ViewEventWidget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [4]
+    }
+
+    @GUI::Widget {
+        fill_with_background_color: true
+        layout: @GUI::VerticalBoxLayout {}
+        name: "events_list"
+        min_width: 100
+    }
+
+    @GUI::Button {
+        name: "add_event_button"
+        text: "Add Event"
+    }
+}

--- a/Userland/Applications/Calendar/ViewEventDialog.h
+++ b/Userland/Applications/Calendar/ViewEventDialog.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "EventManager.h"
+#include <LibGUI/Calendar.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/Window.h>
+
+namespace Calendar {
+
+class ViewEventDialog final : public GUI::Dialog {
+    C_OBJECT(ViewEventDialog)
+public:
+    virtual ~ViewEventDialog() override = default;
+
+    static void show(Core::DateTime date, EventManager& event_manager, Window* parent_window = nullptr)
+    {
+        auto dialog = ViewEventDialog::construct(date, event_manager, parent_window);
+        dialog->exec();
+    }
+    void close_and_open_add_event_dialog();
+
+private:
+    ViewEventDialog(Core::DateTime, EventManager&, Window*);
+    void update_events();
+
+    EventManager& m_event_manager;
+    Core::DateTime m_date_time;
+
+    Vector<Event> m_events;
+};
+
+}

--- a/Userland/Applications/Calendar/ViewEventWidget.cpp
+++ b/Userland/Applications/Calendar/ViewEventWidget.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ViewEventWidget.h"
+#include <LibGUI/Button.h>
+#include <LibGUI/Label.h>
+
+namespace Calendar {
+ErrorOr<NonnullRefPtr<ViewEventWidget>> ViewEventWidget::create(ViewEventDialog* parent_window, Vector<Event>& events)
+{
+    auto widget = TRY(try_create());
+
+    auto* events_list = widget->find_descendant_of_type_named<GUI::Widget>("events_list");
+    for (auto const& event : events) {
+        String text = MUST(String::formatted("{} {}", event.start.to_byte_string("%H:%M"sv), event.summary));
+        auto label = GUI::Label::construct(text);
+        label->set_fill_with_background_color(true);
+        label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
+        events_list->add_child(label);
+    }
+
+    auto* add_new_event_button = widget->find_descendant_of_type_named<GUI::Button>("add_event_button");
+    add_new_event_button->on_click = [window = parent_window](auto) {
+        window->close_and_open_add_event_dialog();
+    };
+
+    return widget;
+}
+
+}

--- a/Userland/Applications/Calendar/ViewEventWidget.h
+++ b/Userland/Applications/Calendar/ViewEventWidget.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ViewEventDialog.h"
+#include <LibGUI/Calendar.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/Model.h>
+#include <LibGUI/Window.h>
+
+namespace Calendar {
+
+class ViewEventWidget final : public GUI::Widget {
+    C_OBJECT(ViewEventWidget);
+
+public:
+    static ErrorOr<NonnullRefPtr<ViewEventWidget>> create(ViewEventDialog*, Vector<Event>& events);
+    virtual ~ViewEventWidget() override = default;
+
+private:
+    ViewEventWidget() = default;
+    static ErrorOr<NonnullRefPtr<ViewEventWidget>> try_create();
+};
+
+}


### PR DESCRIPTION
This addresses part of #22622. Created events can now be viewed by double clicking on a tile which has some events in it.

![image](https://github.com/SerenityOS/serenity/assets/44319106/3e007129-9d5d-49aa-bb5d-a41e678a1299)

Events are currently arranged in the order they are added.
![image](https://github.com/SerenityOS/serenity/assets/44319106/798c9ac1-c35e-48d9-bcac-31d9e41dcdb7)
