### PR TITLE
LibWeb: Resolve effective overflow-x and overflow-y according to spec

### DIFF
--- a/Tests/LibWeb/Ref/overflow-hidden-7.html
+++ b/Tests/LibWeb/Ref/overflow-hidden-7.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/overflow-hidden-7-ref.html" />
+<style>
+    .box {
+        overflow-y: hidden;
+        overflow-x: visible;
+        width: 200px;
+        height: 200px;
+    }
+
+    .inner {
+        width: 300px;
+        height: 300px;
+        background-color: darkblue;
+    }
+</style>
+<div class="box">
+    <div class="inner"></div>
+</div>

--- a/Tests/LibWeb/Ref/reference/overflow-hidden-7-ref.html
+++ b/Tests/LibWeb/Ref/reference/overflow-hidden-7-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    .box {
+        width: 200px;
+        height: 200px;
+        background-color: darkblue;
+    }
+</style>
+<div class="box"></div>

--- a/Tests/LibWeb/Text/expected/resolve-css-overflow-effective-value.txt
+++ b/Tests/LibWeb/Text/expected/resolve-css-overflow-effective-value.txt
@@ -1,0 +1,2 @@
+   overflow-x: auto
+overflow-y: hidden

--- a/Tests/LibWeb/Text/input/resolve-css-overflow-effective-value.html
+++ b/Tests/LibWeb/Text/input/resolve-css-overflow-effective-value.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    .box {
+        overflow-y: hidden;
+        overflow-x: visible;
+        width: 200px;
+        height: 200px;
+        background-color: darkblue;
+    }
+</style>
+<body><div class="box"></div></body>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const box = window.getComputedStyle(document.querySelector(".box"));
+        println(`overflow-x: ${box.getPropertyValue("overflow-x")}`);
+        println(`overflow-y: ${box.getPropertyValue("overflow-y")}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -129,6 +129,7 @@ private:
     void compute_math_depth(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void compute_defaulted_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void absolutize_values(StyleProperties&) const;
+    void resolve_effective_overflow_values(StyleProperties&) const;
     void transform_box_type_if_needed(StyleProperties&, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type>) const;
 
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement::Type>) const;


### PR DESCRIPTION
Implements following rule from CSS Overflow Module Level 3: "The visible/clip values of overflow compute to auto/hidden (respectively) if one of overflow-x or overflow-y is neither visible nor clip."