### PR TITLE
Ports: Update URL for qt6-qt5compat

### DIFF
--- a/Ports/qt6-qt5compat/package.sh
+++ b/Ports/qt6-qt5compat/package.sh
@@ -4,7 +4,7 @@ version='6.4.0'
 workdir="qt5compat-everywhere-src-${version}"
 useconfigure='true'
 files=(
-    "https://download.qt.io/official_releases/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qt5compat-everywhere-src-${version}.tar.xz#73475d0837f78246d509199f211a35c71fc36cccf64b3de258ebc6387194a4c0"
+    "https://download.qt.io/archive/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qt5compat-everywhere-src-${version}.tar.xz#73475d0837f78246d509199f211a35c71fc36cccf64b3de258ebc6387194a4c0"
 )
 depends=(
     'qt6-qtbase'


### PR DESCRIPTION
They moved the file from `official_releases` to `archive` :^)