### PR TITLE
Kernel/riscv64: Don't touch reserved fields of the sstatus CSR in boot.S

### DIFF
--- a/Kernel/Arch/riscv64/boot.S
+++ b/Kernel/Arch/riscv64/boot.S
@@ -16,8 +16,8 @@ start:
   // Don't touch a0/a1 as we expect those registers to contain the hart ID
   // and a pointer to the Flattened Fevice Tree.
 
-  // Set sstatus to a known state (which includes disabling supervisor interrupts).
-  csrw sstatus, zero
+  // Clear sstatus.SIE, which disables all interrupts in supervisor mode.
+  csrci sstatus, 1 << 1
 
   // Also, disable all interrupts sources and mark them as non-pending.
   csrw sie, zero


### PR DESCRIPTION
Multiple fields in sstatus are defined as WPRI "Reserved Writes Preserve Values, Reads Ignore Values", which means we have to preserve their values when writing to other fields in the same CSR.

We don't really need to touch any fields except SIE. Interrupts are probably already disabled, but just to be safe, disable them explicitly.