### PR TITLE
LibGfx: Two micro-optimizations for lerp_nd()

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -48,15 +48,15 @@ inline FloatVector3 lerp_nd(Function<unsigned(size_t)> size, Function<FloatVecto
 
     FloatVector3 sample_output {};
     // The i'th bit of mask indicates if the i'th coordinate is rounded up or down.
-    Vector<unsigned> coordinates;
-    coordinates.resize(x.size());
+    unsigned coordinates[x.size()];
+    ReadonlySpan<unsigned> coordinates_span { coordinates, x.size() };
     for (size_t mask = 0; mask < (1u << x.size()); ++mask) {
         float sample_weight = 1.0f;
         for (size_t i = 0; i < x.size(); ++i) {
             coordinates[i] = left_index[i] + ((mask >> i) & 1u);
             sample_weight *= ((mask >> i) & 1u) ? factor[i] : 1.0f - factor[i];
         }
-        sample_output += sample(coordinates) * sample_weight;
+        sample_output += sample(coordinates_span) * sample_weight;
     }
 
     return sample_output;

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -37,13 +37,13 @@ float lerp_1d(ReadonlySpan<T> values, float x)
 // `sample()` gets a vector where 0 <= i'th coordinate < size(i) and should return the value of the look-up table at that position.
 inline FloatVector3 lerp_nd(Function<unsigned(size_t)> size, Function<FloatVector3(Vector<unsigned> const&)> sample, Vector<float> const& x)
 {
-    Vector<unsigned, 4> left_index;
-    Vector<float, 4> factor;
+    unsigned left_index[x.size()];
+    float factor[x.size()];
     for (size_t i = 0; i < x.size(); ++i) {
         unsigned n = size(i) - 1;
         float ec = x[i] * n;
-        left_index.append(min(static_cast<unsigned>(ec), n - 1));
-        factor.append(ec - left_index[i]);
+        left_index[i] = min(static_cast<unsigned>(ec), n - 1);
+        factor[i] = ec - left_index[i];
     }
 
     FloatVector3 sample_output {};

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -35,7 +35,7 @@ float lerp_1d(ReadonlySpan<T> values, float x)
 // Does multi-dimensional linear interpolation over a lookup table.
 // `size(i)` should returns the number of samples in the i'th dimension.
 // `sample()` gets a vector where 0 <= i'th coordinate < size(i) and should return the value of the look-up table at that position.
-inline FloatVector3 lerp_nd(Function<unsigned(size_t)> size, Function<FloatVector3(Vector<unsigned> const&)> sample, Vector<float> const& x)
+inline FloatVector3 lerp_nd(Function<unsigned(size_t)> size, Function<FloatVector3(ReadonlySpan<unsigned> const&)> sample, Vector<float> const& x)
 {
     unsigned left_index[x.size()];
     float factor[x.size()];
@@ -1077,7 +1077,7 @@ inline ErrorOr<FloatVector3> Lut16TagData::evaluate(ColorSpace input_space, Colo
     //  The first sequential byte of the entry contains the function value for the first output function,
     //  the second sequential byte of the entry contains the function value for the second output function,
     //  and so on until all the output functions have been supplied."
-    auto sample = [this](Vector<unsigned> const& coordinates) {
+    auto sample = [this](ReadonlySpan<unsigned> const& coordinates) {
         size_t stride = 3;
         size_t offset = 0;
         for (int i = coordinates.size() - 1; i >= 0; --i) {
@@ -1165,7 +1165,7 @@ inline ErrorOr<FloatVector3> Lut8TagData::evaluate(ColorSpace input_space, Color
     //  The first sequential byte of the entry contains the function value for the first output function,
     //  the second sequential byte of the entry contains the function value for the second output function,
     //  and so on until all the output functions have been supplied."
-    auto sample = [this](Vector<unsigned> const& coordinates) {
+    auto sample = [this](ReadonlySpan<unsigned> const& coordinates) {
         size_t stride = 3;
         size_t offset = 0;
         for (int i = coordinates.size() - 1; i >= 0; --i) {
@@ -1238,7 +1238,7 @@ inline ErrorOr<FloatVector3> LutAToBTagData::evaluate(ColorSpace connection_spac
             in_color.append(evaluate_curve(a_curves[c], color_u8[c] / 255.0f));
 
         auto const& clut = m_clut.value();
-        auto sample1 = [&clut]<typename T>(Vector<T> const& data, Vector<unsigned> const& coordinates) {
+        auto sample1 = [&clut]<typename T>(Vector<T> const& data, ReadonlySpan<unsigned> const& coordinates) {
             size_t stride = 3;
             size_t offset = 0;
             for (int i = coordinates.size() - 1; i >= 0; --i) {
@@ -1247,7 +1247,7 @@ inline ErrorOr<FloatVector3> LutAToBTagData::evaluate(ColorSpace connection_spac
             }
             return FloatVector3 { (float)data[offset], (float)data[offset + 1], (float)data[offset + 2] };
         };
-        auto sample = [&clut, &sample1](Vector<unsigned> const& coordinates) {
+        auto sample = [&clut, &sample1](ReadonlySpan<unsigned> const& coordinates) {
             return clut.values.visit(
                 [&](Vector<u8> const& v) { return sample1(v, coordinates) / 255.0f; },
                 [&](Vector<u16> const& v) { return sample1(v, coordinates) / 65535.0f; });

--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -28,7 +28,7 @@ public:
 private:
     SampledFunction(NonnullRefPtr<StreamObject>);
 
-    float sample(Vector<int> const& coordinates, size_t r) const
+    float sample(ReadonlySpan<int> const& coordinates, size_t r) const
     {
         // "For a function with multidimensional input (more than one input variable),
         //  the sample values in the first dimension vary fastest,


### PR DESCRIPTION
Combined, take

    Build/lagom/bin/image --no-output \
        --assign-color-profile \
            Build/lagom/Root/res/icc/Adobe/CMYK/USWebCoatedSWOP.icc \
        --convert-to-color-profile serenity-sRGB.icc \
        cmyk.jpg

from 2.81s to 2.66s on my machine, about 5.3% faster.