### PR TITLE
Assistant: Check for access before showing file results

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -224,6 +224,9 @@ void FileProvider::build_filesystem_cache()
                         return IterationDecision::Continue;
 
                     auto full_path = LexicalPath::join(directory.path().string(), entry.name).string();
+                    if (access(full_path.characters(), R_OK) != 0)
+                        return IterationDecision::Continue;
+
                     m_full_path_cache.append(full_path);
 
                     if (S_ISDIR(st.st_mode)) {


### PR DESCRIPTION
Fixing up from #22597. Apologies for the slip then!

This change checks whether a file is readable to the user before adding files to the cache.

This can be tested by doing the following setup (I find I have to do each on each boot as the build process makes the files world readable again):
```console
$ touch assistant-test-anon.txt
$ su
# touch assistant-test-root.txt
# touch assistant-test-secret.txt
# chmod o-rwx assistant-test-secret.txt
```

With this setup, before this change is applied the `assistant-test-secret.txt` entry will show up. After this change is applied, that entry is not present. The `assistant-test-root.txt` will show up as it is still readable to the user, but they will get errors when trying to write.

Everything else seems to work the same. It shows files, binaries, directories, AppFiles, browser auto. 

The following change was also done in the original PR, but does not apply here. This would only be the case if the AppFile pointed to an executable that was not readable. In the default setup this does not apply. https://github.com/SerenityOS/serenity/pull/22597/files#diff-c9e586702df74fd7b42b802d49a642ce17204b0b3a6b62a21319754beeaa2202L69