### PR TITLE
LibWeb/CSS: Resolve value of "height" in special way according to spec

### DIFF
--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -81,7 +81,7 @@ grid-row-start: auto
 grid-template-areas: 
 grid-template-columns: 
 grid-template-rows: 
-height: auto
+height: 1411px
 image-rendering: auto
 inset-block-end: auto
 inset-block-start: auto


### PR DESCRIPTION
Per spec value of height should be resolved to used value if "display" property is not "none" or "contents".