### PR TITLE
Meta: Disable misc-include-cleaner in clang-tidy and clangd

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@
 # performance-noexcept-move-constructor: The project does not use exceptions, so there are no such optimizations available
 # performance-no-int-to-ptr: This rule flags every pointer to integer cast, which gets quite noisy. Should only be enabled on a case-by-case basis
 # readability-braces-around-statements: Redundant braces around single-line conditions is against project style
+# readability-function-cognitive-complexity: Most regular contributors seem to turn this one off anyway. Violations are hard to fix as well
 # readability-magic-numbers: This check is very noisy in the codebase, especially in AK.
 # readability-named-parameter: We frequently omit parameter names to work around -Wunused-parameter
 # FIXME: readability-uppercase-literal-suffix: Enable this check, the rationale is solid but the findings are numerous
@@ -38,6 +39,7 @@ Checks: >
   -performance-noexcept-move-constructor,
   -performance-no-int-to-ptr,
   -readability-braces-around-statements,
+  -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-named-parameter,
@@ -53,5 +55,3 @@ CheckOptions:
     value: true
   - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: true
-  - key: readability-function-cognitive-complexity.Threshold
-    value: 100 # FIXME: Lower this (30? 50?), and refactor complex functions

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@
 #   cert-dcl51-cpp: Alias for bugprone-reserved-identifier
 # cert-dcl21-cpp: No reference to this rule exists on Carnegie Mellon's SEI CERT C++ Confluence. And the suggestion is unusual
 # misc-no-recursion: The project uses recursive algorithms in several places.
+# misc-include-cleaner: This check is nice for cleanliness, but is very very noisy
 # FIXME: misc-non-private-member-variables-in-classes: Audit uses of protected member variables to see if they really need to be protected
 # performance-noexcept-move-constructor: The project does not use exceptions, so there are no such optimizations available
 # performance-no-int-to-ptr: This rule flags every pointer to integer cast, which gets quite noisy. Should only be enabled on a case-by-case basis
@@ -30,6 +31,7 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp,
   -cert-dcl21-cpp,
+  -misc-include-cleaner,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-use-anonymous-namespace,

--- a/Documentation/EmacsConfiguration.md
+++ b/Documentation/EmacsConfiguration.md
@@ -15,6 +15,10 @@ CompileFlags:
     - "-UNO_TLS"
     - "-I/path/to/serenity/Toolchain/Local/x86_64/x86_64-pc-serenity/include/c++/13.1.0"
     - "-I/path/to/serenity/Toolchain/Local/x86_64/x86_64-pc-serenity/include/c++/13.1.0/x86_64-pc-serenity"
+
+Diagnostics:
+  UnusedIncludes: None
+  MissingIncludes: None
 ```
 
 You will need to change `/path/to/serenity` and change `13.1.0` to

--- a/Documentation/HelixConfiguration.md
+++ b/Documentation/HelixConfiguration.md
@@ -6,6 +6,10 @@ The following `.clangd` should be placed in the project root:
 CompileFlags:
   CompilationDatabase: Build/x86_64 # Or whatever architecture you're targeting, e.g. aarch64
   Add: [-D__serenity__]
+
+Diagnostics:
+  UnusedIncludes: None
+  MissingIncludes: None
 ```
 
 You also need to configure the clangd server to detect headers properly from the Serenity toolchain. To do this, create a `.helix/languages.toml` file in the project root:

--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -25,7 +25,14 @@ Depending on which configuration you use most, set the CompilationDatabase confi
 CompileFlags:
   Add: [-D__serenity__]
   CompilationDatabase: Build/x86_64
+  
+Diagnostics:
+  UnusedIncludes: None
+  MissingIncludes: None
 ```
+
+The UnusedIncludes and MissingIncludes flags are used to disable the [Include Cleaner](https://clangd.llvm.org/design/include-cleaner) feature of newer clangd releases.
+It can be re-enabled if you don't mind the noisy inlay hints and problems in the problem view.
 
 Run ``./Meta/serenity.sh run`` at least once to generate the ``compile_commands.json`` file.
 


### PR DESCRIPTION
IncludeCleaner is a new feature of clang-tidy/clangd that adds upstream
support for the include-what-you-use (IWYU) tool's checks.

However, this tool is very noisy on our codebase. It can be enabled by
individual contributors at their leisure.

Also disable the cognitive complexity check, as folks have said on discord that it doesn't really help code quality.

fwiw, CC @BenWiederhake . There's now a native IWYU tool in clangd/clang-tidy :)