### PR TITLE
ntpquery: Use AK::convert_between_host_and_network_endian

### DIFF
--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -10,30 +10,6 @@
 #include <AK/Forward.h>
 #include <AK/Platform.h>
 
-#if defined(AK_OS_MACOS)
-#    include <libkern/OSByteOrder.h>
-#    include <machine/endian.h>
-
-#    define htobe16(x) OSSwapHostToBigInt16(x)
-#    define htole16(x) OSSwapHostToLittleInt16(x)
-#    define be16toh(x) OSSwapBigToHostInt16(x)
-#    define le16toh(x) OSSwapLittleToHostInt16(x)
-
-#    define htobe32(x) OSSwapHostToBigInt32(x)
-#    define htole32(x) OSSwapHostToLittleInt32(x)
-#    define be32toh(x) OSSwapBigToHostInt32(x)
-#    define le32toh(x) OSSwapLittleToHostInt32(x)
-
-#    define htobe64(x) OSSwapHostToBigInt64(x)
-#    define htole64(x) OSSwapHostToLittleInt64(x)
-#    define be64toh(x) OSSwapBigToHostInt64(x)
-#    define le64toh(x) OSSwapLittleToHostInt64(x)
-
-#    define __BIG_ENDIAN BIG_ENDIAN
-#    define __LITTLE_ENDIAN LITTLE_ENDIAN
-#    define __BYTE_ORDER BYTE_ORDER
-#endif
-
 namespace AK {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 inline constexpr static bool HostIsLittleEndian = true;


### PR DESCRIPTION
Instead of polluting global namespace with definitions from libkern/OSByteOrder.h and machine/endian.h on MacOS, just use AK functions for conversions.

---

Again, this is from https://github.com/SerenityOS/serenity/pull/21995