### PR TITLE
LibWeb: Make WebDriver check if the BC's navigable has been destroyed

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -614,4 +614,10 @@ SandboxingFlagSet determine_the_creation_sandboxing_flags(BrowsingContext const&
     return {};
 }
 
+bool BrowsingContext::has_navigable_been_destroyed() const
+{
+    auto navigable = active_document()->navigable();
+    return navigable && navigable->has_been_destroyed();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -144,7 +144,7 @@ public:
     // https://html.spec.whatwg.org/multipage/origin.html#one-permitted-sandboxed-navigator
     BrowsingContext const* the_one_permitted_sandboxed_navigator() const;
 
-    bool has_been_discarded() const { return m_has_been_discarded; }
+    bool has_navigable_been_destroyed() const;
 
     JS::GCPtr<BrowsingContext> opener_browsing_context() const { return m_opener_browsing_context; }
     void set_opener_browsing_context(JS::GCPtr<BrowsingContext> browsing_context) { m_opener_browsing_context = browsing_context; }
@@ -197,8 +197,6 @@ private:
     JS::GCPtr<BrowsingContext> m_last_child;
     JS::GCPtr<BrowsingContext> m_next_sibling;
     JS::GCPtr<BrowsingContext> m_previous_sibling;
-
-    bool m_has_been_discarded { false };
 };
 
 HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin);

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -115,9 +115,9 @@ static ErrorOr<JsonValue, ExecuteScriptResultType> internal_json_clone_algorithm
     if (is<HTML::WindowProxy>(value.as_object())) {
         auto const& window_proxy = static_cast<HTML::WindowProxy&>(value.as_object());
 
-        // If the associated browsing context of the WindowProxy object in value has been discarded, return error with
+        // If the associated browsing context of the WindowProxy object in value has been destroyed, return error with
         // error code stale element reference.
-        if (window_proxy.associated_browsing_context()->has_been_discarded())
+        if (window_proxy.associated_browsing_context()->has_navigable_been_destroyed())
             return ExecuteScriptResultType::BrowsingContextDiscarded;
 
         // Otherwise return success with data set to WindowProxy reference object for value.

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1833,8 +1833,8 @@ Messages::WebDriverClient::PrintPageResponse WebDriverConnection::print_page()
 // https://w3c.github.io/webdriver/#dfn-no-longer-open
 Messages::WebDriverClient::EnsureTopLevelBrowsingContextIsOpenResponse WebDriverConnection::ensure_top_level_browsing_context_is_open()
 {
-    // A browsing context is said to be no longer open if it has been discarded.
-    if (m_page_client.page().top_level_browsing_context().has_been_discarded())
+    // A browsing context is said to be no longer open if its navigable has been destroyed.
+    if (m_page_client.page().top_level_browsing_context().has_navigable_been_destroyed())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found"sv);
     return JsonValue {};
 }
@@ -1901,7 +1901,7 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::wait_for_navigation_to
         return {};
 
     // 2. If the current browsing context is no longer open, return success with data null.
-    if (m_page_client.page().top_level_browsing_context().has_been_discarded())
+    if (m_page_client.page().top_level_browsing_context().has_navigable_been_destroyed())
         return {};
 
     // FIXME: 3. Start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout in milliseconds, return an error with error code timeout.


### PR DESCRIPTION
The spec steps to check if a browsing context is open have been updated for navigables.

Follow-up to #23063

(There have apparently been a good number of other WebDriver updates we should catch up on, :yakstack:++)