### PR TITLE
HexEditor: Deduplicate repeated coordinate calculations, and fix some bugs in the process

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -288,9 +288,6 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
 
     // Hexadecimal display
     if (absolute_x >= hex_start_x && absolute_x <= hex_end_x && absolute_y >= hex_start_y && absolute_y <= hex_end_y) {
-        if (absolute_x < hex_start_x || absolute_y < hex_start_y)
-            return {};
-
         auto hex_text_start_x = hex_start_x + m_padding;
         auto hex_text_end_x = hex_end_x - m_padding;
         absolute_x = clamp(absolute_x, hex_text_start_x, hex_text_end_x);
@@ -307,9 +304,6 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
 
     // Text display
     if (absolute_x >= text_start_x && absolute_x <= text_end_x && absolute_y >= text_start_y && absolute_y <= text_end_y) {
-        if (absolute_x < hex_start_x || absolute_y < hex_start_y)
-            return {};
-
         auto text_text_start_x = text_start_x + m_padding;
         auto text_text_end_x = text_end_x - m_padding;
         absolute_x = clamp(absolute_x, text_text_start_x, text_text_end_x);

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -636,7 +636,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             Gfx::IntRect hex_display_rect_high_nibble {
                 frame_thickness() + offset_margin_width() + column * cell_width() + 2 * m_padding,
                 frame_thickness() + m_padding + row * line_height(),
-                cell_width() / 2,
+                character_width(),
                 line_height() - m_line_spacing
             };
 

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -567,6 +567,12 @@ void HexEditor::context_menu_event(GUI::ContextMenuEvent& event)
     m_context_menu->popup(event.screen_position());
 }
 
+void HexEditor::theme_change_event(GUI::ThemeChangeEvent&)
+{
+    set_font(Gfx::FontDatabase::default_fixed_width_font());
+    update_content_size();
+}
+
 void HexEditor::update_status()
 {
     if (on_status_change)

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -607,10 +607,13 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     size_t max_row = min(total_rows(), min_row + ceil_div(view_height, line_height())); // if above calculated rows, use calculated rows
 
     for (size_t row = min_row; row < max_row; row++) {
+        int row_text_y = frame_thickness() + m_padding + row * line_height();
+        int row_background_y = row_text_y - m_line_spacing / 2;
+
         // Paint offsets
         Gfx::IntRect side_offset_rect {
             frame_thickness() + m_padding,
-            static_cast<int>(frame_thickness() + m_padding + row * line_height()),
+            row_text_y,
             width() - width_occupied_by_vertical_scrollbar(),
             height() - height_occupied_by_horizontal_scrollbar()
         };
@@ -634,10 +637,10 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             auto const annotation = m_document->annotations().closest_annotation_at(byte_position);
 
             Gfx::IntRect hex_display_rect_high_nibble {
-                frame_thickness() + offset_margin_width() + column * cell_width() + 2 * m_padding,
-                frame_thickness() + m_padding + row * line_height(),
-                character_width(),
-                line_height() - m_line_spacing
+                static_cast<int>(frame_thickness() + offset_margin_width() + column * cell_width() + 2 * m_padding),
+                row_text_y,
+                static_cast<int>(character_width()),
+                static_cast<int>(line_height() - m_line_spacing),
             };
 
             Gfx::IntRect hex_display_rect_low_nibble {
@@ -648,10 +651,10 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             };
 
             Gfx::IntRect background_rect {
-                frame_thickness() + offset_margin_width() + column * cell_width() + 1 * m_padding,
-                frame_thickness() + m_line_spacing / 2 + row * line_height(),
-                cell_width(),
-                line_height()
+                static_cast<int>(frame_thickness() + offset_margin_width() + column * cell_width() + 1 * m_padding),
+                row_background_y,
+                static_cast<int>(cell_width()),
+                static_cast<int>(line_height()),
             };
 
             auto line = String::formatted("{:02X}", cell.value).release_value_but_fixme_should_propagate_errors();
@@ -698,17 +701,17 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             painter.fill_rect(background_rect, background_color_hex);
 
             Gfx::IntRect text_display_rect {
-                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding,
-                frame_thickness() + m_padding + row * line_height(),
-                character_width(),
-                line_height() - m_line_spacing
+                static_cast<int>(frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding),
+                row_text_y,
+                static_cast<int>(character_width()),
+                static_cast<int>(line_height() - m_line_spacing),
             };
 
             auto draw_cursor_rect = [&]() {
                 if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
                         (m_edit_mode == EditMode::Hex) ? static_cast<int>(hex_display_rect_high_nibble.left() + m_cursor_at_low_nibble * character_width()) : text_display_rect.left(),
-                        static_cast<int>(frame_thickness() + m_line_spacing / 2 + row * line_height()),
+                        row_background_y,
                         static_cast<int>(character_width()),
                         static_cast<int>(line_height())
                     };
@@ -728,10 +731,10 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             }
 
             Gfx::IntRect text_background_rect {
-                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding,
-                frame_thickness() + m_line_spacing / 2 + row * line_height(),
-                character_width(),
-                line_height()
+                static_cast<int>(frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding),
+                row_background_y,
+                static_cast<int>(character_width()),
+                static_cast<int>(line_height()),
             };
 
             painter.fill_rect(text_background_rect, background_color_text);

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -232,13 +232,20 @@ bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
     return true;
 }
 
-void HexEditor::set_bytes_per_row(size_t bytes_per_row)
+void HexEditor::update_content_size()
 {
-    m_bytes_per_row = bytes_per_row;
     auto new_width = offset_area_width() + hex_area_width() + text_area_width();
     auto new_height = total_rows() * line_height() + 2 * m_padding;
     set_content_size({ static_cast<int>(new_width), static_cast<int>(new_height) });
     update();
+}
+
+void HexEditor::set_bytes_per_row(size_t bytes_per_row)
+{
+    if (bytes_per_row == m_bytes_per_row)
+        return;
+    m_bytes_per_row = bytes_per_row;
+    update_content_size();
 }
 
 void HexEditor::set_content_length(size_t length)
@@ -246,9 +253,7 @@ void HexEditor::set_content_length(size_t length)
     if (length == m_content_length)
         return;
     m_content_length = length;
-    auto new_width = offset_area_width() + hex_area_width() + text_area_width();
-    auto new_height = total_rows() * line_height() + 2 * m_padding;
-    set_content_size({ static_cast<int>(new_width), static_cast<int>(new_height) });
+    update_content_size();
 }
 
 Optional<u8> HexEditor::get_byte(size_t position)

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -605,8 +605,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     size_t min_row = max(0, vertical_scrollbar().value() / line_height());              // if below 0 then use 0
     size_t max_row = min(total_rows(), min_row + ceil_div(view_height, line_height())); // if above calculated rows, use calculated rows
 
-    // paint offsets
     for (size_t row = min_row; row < max_row; row++) {
+        // Paint offsets
         Gfx::IntRect side_offset_rect {
             frame_thickness() + m_padding,
             static_cast<int>(frame_thickness() + m_padding + row * line_height()),
@@ -615,16 +615,15 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
         };
 
         bool is_current_line = (m_position / bytes_per_row()) == row;
-        auto line = String::formatted("{:#08X}", row * bytes_per_row()).release_value_but_fixme_should_propagate_errors();
+        auto offset_text = String::formatted("{:#08X}", row * bytes_per_row()).release_value_but_fixme_should_propagate_errors();
         painter.draw_text(
             side_offset_rect,
-            line,
+            offset_text,
             is_current_line ? font().bold_variant() : font(),
             Gfx::TextAlignment::TopLeft,
             is_current_line ? palette().ruler_active_text() : palette().ruler_inactive_text());
-    }
 
-    for (size_t row = min_row; row < max_row; row++) {
+        // Paint bytes
         for (size_t column = 0; column < bytes_per_row(); column++) {
             auto byte_position = (row * bytes_per_row()) + column;
             if (byte_position >= m_document->size())

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -235,9 +235,9 @@ bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
 void HexEditor::set_bytes_per_row(size_t bytes_per_row)
 {
     m_bytes_per_row = bytes_per_row;
-    auto newWidth = offset_margin_width() + (m_bytes_per_row * cell_width()) + 2 * m_padding + (m_bytes_per_row * character_width()) + 4 * m_padding;
-    auto newHeight = total_rows() * line_height() + 2 * m_padding;
-    set_content_size({ static_cast<int>(newWidth), static_cast<int>(newHeight) });
+    auto new_width = offset_area_width() + hex_area_width() + text_area_width();
+    auto new_height = total_rows() * line_height() + 2 * m_padding;
+    set_content_size({ static_cast<int>(new_width), static_cast<int>(new_height) });
     update();
 }
 
@@ -246,9 +246,9 @@ void HexEditor::set_content_length(size_t length)
     if (length == m_content_length)
         return;
     m_content_length = length;
-    auto newWidth = offset_margin_width() + (m_bytes_per_row * cell_width()) + 2 * m_padding + (m_bytes_per_row * character_width()) + 4 * m_padding;
-    auto newHeight = total_rows() * line_height() + 2 * m_padding;
-    set_content_size({ static_cast<int>(newWidth), static_cast<int>(newHeight) });
+    auto new_width = offset_area_width() + hex_area_width() + text_area_width();
+    auto new_height = total_rows() * line_height() + 2 * m_padding;
+    set_content_size({ static_cast<int>(new_width), static_cast<int>(new_height) });
 }
 
 Optional<u8> HexEditor::get_byte(size_t position)
@@ -276,14 +276,14 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
     auto absolute_x = horizontal_scrollbar().value() + position.x();
     auto absolute_y = vertical_scrollbar().value() + position.y();
 
-    auto hex_start_x = frame_thickness() + m_address_bar_width;
+    auto hex_start_x = frame_thickness() + offset_area_width();
     auto hex_start_y = frame_thickness() + m_padding;
-    auto hex_end_x = static_cast<int>(hex_start_x + bytes_per_row() * cell_width());
+    auto hex_end_x = hex_start_x + hex_area_width();
     auto hex_end_y = static_cast<int>(hex_start_y + m_padding + total_rows() * line_height());
 
-    auto text_start_x = static_cast<int>(frame_thickness() + m_address_bar_width + 2 * m_padding + bytes_per_row() * cell_width());
+    auto text_start_x = hex_start_x + hex_area_width();
     auto text_start_y = frame_thickness() + m_padding;
-    auto text_end_x = static_cast<int>(text_start_x + bytes_per_row() * character_width());
+    auto text_end_x = text_start_x + text_area_width();
     auto text_end_y = static_cast<int>(text_start_y + m_padding + total_rows() * line_height());
 
     // Hexadecimal display
@@ -390,7 +390,7 @@ void HexEditor::scroll_position_into_view(size_t position)
     size_t y = position / bytes_per_row();
     size_t x = position % bytes_per_row();
     Gfx::IntRect rect {
-        static_cast<int>(frame_thickness() + offset_margin_width() + x * cell_width() + 2 * m_padding),
+        static_cast<int>(frame_thickness() + offset_area_width() + m_padding + x * cell_width()),
         static_cast<int>(frame_thickness() + m_padding + y * line_height()),
         static_cast<int>(cell_width()),
         static_cast<int>(line_height() - m_line_spacing)
@@ -590,15 +590,14 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     Gfx::IntRect offset_clip_rect {
         0,
         vertical_scrollbar().value(),
-        m_address_bar_width - m_padding,
+        offset_area_width(),
         height() - height_occupied_by_horizontal_scrollbar() //(total_rows() * line_height()) + 5
     };
     painter.fill_rect(offset_clip_rect, palette().ruler());
     painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right(), palette().ruler_border());
 
-    auto margin_and_hex_width = static_cast<int>(offset_margin_width() + m_bytes_per_row * cell_width() + 3 * m_padding);
-    painter.draw_line({ margin_and_hex_width, 0 },
-        { margin_and_hex_width, vertical_scrollbar().value() + (height() - height_occupied_by_horizontal_scrollbar()) },
+    painter.draw_line({ offset_area_width() + hex_area_width(), 0 },
+        { offset_area_width() + hex_area_width(), vertical_scrollbar().value() + (height() - height_occupied_by_horizontal_scrollbar()) },
         palette().ruler_border());
 
     size_t view_height = (height() - height_occupied_by_horizontal_scrollbar());

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -606,16 +606,16 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     size_t max_row = min(total_rows(), min_row + ceil_div(view_height, line_height())); // if above calculated rows, use calculated rows
 
     // paint offsets
-    for (size_t i = min_row; i < max_row; i++) {
+    for (size_t row = min_row; row < max_row; row++) {
         Gfx::IntRect side_offset_rect {
             frame_thickness() + m_padding,
-            static_cast<int>(frame_thickness() + m_padding + i * line_height()),
+            static_cast<int>(frame_thickness() + m_padding + row * line_height()),
             width() - width_occupied_by_vertical_scrollbar(),
             height() - height_occupied_by_horizontal_scrollbar()
         };
 
-        bool is_current_line = (m_position / bytes_per_row()) == i;
-        auto line = String::formatted("{:#08X}", i * bytes_per_row()).release_value_but_fixme_should_propagate_errors();
+        bool is_current_line = (m_position / bytes_per_row()) == row;
+        auto line = String::formatted("{:#08X}", row * bytes_per_row()).release_value_but_fixme_should_propagate_errors();
         painter.draw_text(
             side_offset_rect,
             line,
@@ -624,9 +624,9 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             is_current_line ? palette().ruler_active_text() : palette().ruler_inactive_text());
     }
 
-    for (size_t i = min_row; i < max_row; i++) {
-        for (size_t j = 0; j < bytes_per_row(); j++) {
-            auto byte_position = (i * bytes_per_row()) + j;
+    for (size_t row = min_row; row < max_row; row++) {
+        for (size_t column = 0; column < bytes_per_row(); column++) {
+            auto byte_position = (row * bytes_per_row()) + column;
             if (byte_position >= m_document->size())
                 return;
 
@@ -634,8 +634,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             auto const annotation = m_document->annotations().closest_annotation_at(byte_position);
 
             Gfx::IntRect hex_display_rect_high_nibble {
-                frame_thickness() + offset_margin_width() + j * cell_width() + 2 * m_padding,
-                frame_thickness() + m_padding + i * line_height(),
+                frame_thickness() + offset_margin_width() + column * cell_width() + 2 * m_padding,
+                frame_thickness() + m_padding + row * line_height(),
                 cell_width() / 2,
                 line_height() - m_line_spacing
             };
@@ -648,8 +648,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             };
 
             Gfx::IntRect background_rect {
-                frame_thickness() + offset_margin_width() + j * cell_width() + 1 * m_padding,
-                frame_thickness() + m_line_spacing / 2 + i * line_height(),
+                frame_thickness() + offset_margin_width() + column * cell_width() + 1 * m_padding,
+                frame_thickness() + m_line_spacing / 2 + row * line_height(),
                 cell_width(),
                 line_height()
             };
@@ -698,8 +698,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             painter.fill_rect(background_rect, background_color_hex);
 
             Gfx::IntRect text_display_rect {
-                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + j * character_width() + 4 * m_padding,
-                frame_thickness() + m_padding + i * line_height(),
+                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding,
+                frame_thickness() + m_padding + row * line_height(),
                 character_width(),
                 line_height() - m_line_spacing
             };
@@ -708,7 +708,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
                 if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
                         (m_edit_mode == EditMode::Hex) ? static_cast<int>(hex_display_rect_high_nibble.left() + m_cursor_at_low_nibble * character_width()) : text_display_rect.left(),
-                        static_cast<int>(frame_thickness() + m_line_spacing / 2 + i * line_height()),
+                        static_cast<int>(frame_thickness() + m_line_spacing / 2 + row * line_height()),
                         static_cast<int>(character_width()),
                         static_cast<int>(line_height())
                     };
@@ -728,8 +728,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             }
 
             Gfx::IntRect text_background_rect {
-                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + j * character_width() + 4 * m_padding,
-                frame_thickness() + m_line_spacing / 2 + i * line_height(),
+                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding,
+                frame_thickness() + m_line_spacing / 2 + row * line_height(),
                 character_width(),
                 line_height()
             };

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -291,7 +291,11 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
         if (absolute_x < hex_start_x || absolute_y < hex_start_y)
             return {};
 
-        auto byte_x = (absolute_x - hex_start_x) / cell_width();
+        auto hex_text_start_x = hex_start_x + m_padding;
+        auto hex_text_end_x = hex_end_x - m_padding;
+        absolute_x = clamp(absolute_x, hex_text_start_x, hex_text_end_x);
+
+        auto byte_x = (absolute_x - hex_text_start_x) / cell_width();
         auto byte_y = (absolute_y - hex_start_y) / line_height();
         auto offset = (byte_y * m_bytes_per_row) + byte_x;
 
@@ -306,7 +310,11 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
         if (absolute_x < hex_start_x || absolute_y < hex_start_y)
             return {};
 
-        auto byte_x = (absolute_x - text_start_x) / character_width();
+        auto text_text_start_x = text_start_x + m_padding;
+        auto text_text_end_x = text_end_x - m_padding;
+        absolute_x = clamp(absolute_x, text_text_start_x, text_text_end_x);
+
+        auto byte_x = (absolute_x - text_text_start_x) / character_width();
         auto byte_y = (absolute_y - text_start_y) / line_height();
         auto offset = (byte_y * m_bytes_per_row) + byte_x;
 

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -594,7 +594,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
         height() - height_occupied_by_horizontal_scrollbar() //(total_rows() * line_height()) + 5
     };
     painter.fill_rect(offset_clip_rect, palette().ruler());
-    painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right().translated(-1), palette().ruler_border());
+    painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right(), palette().ruler_border());
 
     auto margin_and_hex_width = static_cast<int>(offset_margin_width() + m_bytes_per_row * cell_width() + 3 * m_padding);
     painter.draw_line({ margin_and_hex_width, 0 },

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -589,6 +589,13 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     painter.translate(frame_thickness(), frame_thickness());
     painter.translate(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
 
+    int offset_area_start_x = frame_thickness();
+    int offset_area_text_start_x = offset_area_start_x + m_padding;
+    int hex_area_start_x = offset_area_start_x + offset_area_width();
+    int hex_area_text_start_x = hex_area_start_x + m_padding;
+    int text_area_start_x = hex_area_start_x + hex_area_width();
+    int text_area_text_start_x = text_area_start_x + m_padding;
+
     Gfx::IntRect offset_clip_rect {
         0,
         vertical_scrollbar().value(),
@@ -598,8 +605,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     painter.fill_rect(offset_clip_rect, palette().ruler());
     painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right(), palette().ruler_border());
 
-    painter.draw_line({ offset_area_width() + hex_area_width(), 0 },
-        { offset_area_width() + hex_area_width(), vertical_scrollbar().value() + (height() - height_occupied_by_horizontal_scrollbar()) },
+    painter.draw_line({ text_area_start_x, 0 },
+        { text_area_start_x, vertical_scrollbar().value() + (height() - height_occupied_by_horizontal_scrollbar()) },
         palette().ruler_border());
 
     size_t view_height = (height() - height_occupied_by_horizontal_scrollbar());
@@ -612,7 +619,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
 
         // Paint offsets
         Gfx::IntRect side_offset_rect {
-            frame_thickness() + m_padding,
+            offset_area_text_start_x,
             row_text_y,
             width() - width_occupied_by_vertical_scrollbar(),
             height() - height_occupied_by_horizontal_scrollbar()
@@ -637,7 +644,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             auto const annotation = m_document->annotations().closest_annotation_at(byte_position);
 
             Gfx::IntRect hex_display_rect_high_nibble {
-                static_cast<int>(frame_thickness() + offset_margin_width() + column * cell_width() + 2 * m_padding),
+                static_cast<int>(hex_area_text_start_x + column * cell_width()),
                 row_text_y,
                 static_cast<int>(character_width()),
                 static_cast<int>(line_height() - m_line_spacing),
@@ -651,7 +658,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             };
 
             Gfx::IntRect background_rect {
-                static_cast<int>(frame_thickness() + offset_margin_width() + column * cell_width() + 1 * m_padding),
+                static_cast<int>(hex_display_rect_high_nibble.x() - character_width() / 2),
                 row_background_y,
                 static_cast<int>(cell_width()),
                 static_cast<int>(line_height()),
@@ -701,7 +708,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             painter.fill_rect(background_rect, background_color_hex);
 
             Gfx::IntRect text_display_rect {
-                static_cast<int>(frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding),
+                static_cast<int>(text_area_text_start_x + column * character_width()),
                 row_text_y,
                 static_cast<int>(character_width()),
                 static_cast<int>(line_height() - m_line_spacing),
@@ -731,7 +738,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             }
 
             Gfx::IntRect text_background_rect {
-                static_cast<int>(frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + column * character_width() + 4 * m_padding),
+                static_cast<int>(text_area_text_start_x + column * character_width()),
                 row_background_y,
                 static_cast<int>(character_width()),
                 static_cast<int>(line_height()),

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -108,7 +108,7 @@ private:
 
     size_t total_rows() const { return ceil_div(m_content_length, m_bytes_per_row); }
     size_t line_height() const { return font().pixel_size_rounded_up() + m_line_spacing; }
-    size_t character_width() const { return font().glyph_width('W'); }
+    size_t character_width() const { return font().glyph_fixed_width(); }
     size_t cell_width() const { return character_width() * 3; }
     size_t offset_margin_width() const { return 80; }
 

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -110,9 +110,8 @@ private:
     size_t line_height() const { return font().pixel_size_rounded_up() + m_line_spacing; }
     size_t character_width() const { return font().glyph_fixed_width(); }
     size_t cell_width() const { return character_width() * 3; }
-    size_t offset_margin_width() const { return 80; }
 
-    int offset_area_width() const { return offset_margin_width() + m_padding; }
+    int offset_area_width() const { return m_padding + font().width_rounded_up("0X12345678"sv) + m_padding; }
     int hex_area_width() const { return m_padding + m_bytes_per_row * cell_width() + m_padding; }
     int text_area_width() const { return m_padding + m_bytes_per_row * character_width() + m_padding; }
 

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -83,6 +83,7 @@ protected:
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
+    virtual void theme_change_event(GUI::ThemeChangeEvent&) override;
 
 private:
     size_t m_line_spacing { 4 };

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -125,7 +125,8 @@ private:
     ErrorOr<void> hex_mode_keydown_event(GUI::KeyEvent&);
     ErrorOr<void> text_mode_keydown_event(GUI::KeyEvent&);
 
-    void set_content_length(size_t); // I might make this public if I add fetching data on demand.
+    void set_content_length(size_t);
+    void update_content_size();
     void update_status();
     void did_change();
     ErrorOr<void> did_complete_action(size_t position, u8 old_value, u8 new_value);

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -102,7 +102,6 @@ private:
     RefPtr<GUI::Action> m_edit_annotation_action;
     RefPtr<GUI::Action> m_delete_annotation_action;
 
-    static constexpr int m_address_bar_width = 90;
     static constexpr int m_padding = 5;
 
     void scroll_position_into_view(size_t position);
@@ -112,6 +111,10 @@ private:
     size_t character_width() const { return font().glyph_width('W'); }
     size_t cell_width() const { return character_width() * 3; }
     size_t offset_margin_width() const { return 80; }
+
+    int offset_area_width() const { return offset_margin_width() + m_padding; }
+    int hex_area_width() const { return m_padding + m_bytes_per_row * cell_width() + m_padding; }
+    int text_area_width() const { return m_padding + m_bytes_per_row * character_width() + m_padding; }
 
     struct OffsetData {
         size_t offset;


### PR DESCRIPTION
This is progress toward a destination I didn't get to yet. :sweat_smile: Some highlights:
- Calculate positions less often when painting. Many of them don't change for a row, and others don't change at all.
- Size the offsets column based on the size of the offset text, instead of using 2 hard-coded numbers, neither of which was the actual width of the column. :upside_down_face:
- Respond to the default monospace font changing.
- Get rid of a little kink in one of the column lines.

![image](https://github.com/SerenityOS/serenity/assets/222642/2c6809a5-b6af-4115-87ca-c9f855b4bed3)
