### PR TITLE
Ladybird/Qt: Map Enter keypresses to the code point '\n'

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -451,10 +451,16 @@ void WebContentView::keyPressEvent(QKeyEvent* event)
         return;
     }
 
+    auto modifiers = get_modifiers_from_qt_keyboard_event(*event);
+    if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
+        // This ensures consistent behavior between systems that treat Enter as '\n' and '\r\n'
+        client().async_key_down(m_client_state.page_index, KeyCode::Key_Return, modifiers, '\n');
+        return;
+    }
+
     auto text = event->text();
     auto point = text.isEmpty() ? 0u : event->text()[0].unicode();
     auto keycode = get_keycode_from_qt_keyboard_event(*event);
-    auto modifiers = get_modifiers_from_qt_keyboard_event(*event);
     client().async_key_down(m_client_state.page_index, keycode, modifiers, point);
 }
 


### PR DESCRIPTION
Previously, on systems where pressing Enter would generate "\r\n", only the '\r' character was being sent to the event handler. This change ensures consistent behavior across platforms regardless of their native line ending character.s

Before
![ladybird_textarea_newline_before](https://github.com/SerenityOS/serenity/assets/2817754/3b4e58c7-62e7-4ca2-8773-077a9c199af6)

After
![ladybird_textarea_newline_after](https://github.com/SerenityOS/serenity/assets/2817754/f79488c8-f683-4101-b90a-8655a23b98a1)



