### PR TITLE
LibPDF: Always treat `/Subtype /Image` as binary data when dumping

### DIFF
--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Hex.h>
+#include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
 #include <LibPDF/ObjectDerivatives.h>
 
@@ -135,6 +136,9 @@ ByteString StreamObject::to_byte_string(int indent) const
     if (bytes().size())
         percentage_ascii = ascii_count * 100 / bytes().size();
     bool is_mostly_text = percentage_ascii > 95;
+
+    if (dict()->contains(CommonNames::Subtype) && dict()->get_name(CommonNames::Subtype)->name() == "Image")
+        is_mostly_text = false;
 
     if (is_mostly_text) {
         for (size_t i = 0; i < bytes().size(); ++i) {


### PR DESCRIPTION
Sometimes, the "is mostly text" heuristic fails for images.

Before:

    Build/lagom/bin/pdf --render out.png ~/Downloads/0000/0000521.pdf \
        --page 10 --dump-contents 2>&1 | wc -l
       25709

After:

    Build/lagom/bin/pdf --render out.png ~/Downloads/0000/0000521.pdf \
         --page 10 --dump-contents 2>&1 | wc -l
       11376

(…and scrolling through, all these 11k lines look useful.)