### PR TITLE
LibWeb: Use unsigned long long for ProgressEventInit

### DIFF
--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
@@ -8,16 +8,14 @@
 
 #include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::XHR {
 
-// FIXME: All the "u32"s should be "u64"s, however LibJS doesn't currently support constructing values with u64,
-//        and the IDL parser doesn't properly parse "unsigned long long".
-
 struct ProgressEventInit : public DOM::EventInit {
     bool length_computable { false };
-    u32 loaded { 0 };
-    u32 total { 0 };
+    WebIDL::UnsignedLongLong loaded { 0 };
+    WebIDL::UnsignedLongLong total { 0 };
 };
 
 class ProgressEvent final : public DOM::Event {

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
@@ -29,8 +29,8 @@ public:
     virtual ~ProgressEvent() override;
 
     bool length_computable() const { return m_length_computable; }
-    u64 loaded() const { return m_loaded; }
-    u64 total() const { return m_total; }
+    WebIDL::UnsignedLongLong loaded() const { return m_loaded; }
+    WebIDL::UnsignedLongLong total() const { return m_total; }
 
 private:
     ProgressEvent(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
@@ -38,8 +38,8 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     bool m_length_computable { false };
-    u64 m_loaded { 0 };
-    u64 m_total { 0 };
+    WebIDL::UnsignedLongLong m_loaded { 0 };
+    WebIDL::UnsignedLongLong m_total { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.idl
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.idl
@@ -12,6 +12,6 @@ interface ProgressEvent : Event {
 
 dictionary ProgressEventInit : EventInit {
     boolean lengthComputable = false;
-    unsigned long loaded = 0;
-    unsigned long total = 0;
+    unsigned long long loaded = 0;
+    unsigned long long total = 0;
 };


### PR DESCRIPTION
Noticed this low hanging fruit FIXME while investigating some other changes - trivial to fix now that the IDL generator supports this :^)