### PR TITLE
LibWeb: Implement `document.elementFromPoint()`

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Element-from-point.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-from-point.txt
@@ -1,0 +1,5 @@
+  Negative coordinates return null: true
+Coordinates outside the viewport return null: true
+<HTML id="root-element" >
+<DIV id="large-box" >
+<DIV id="small-box" >

--- a/Tests/LibWeb/Text/input/DOM/Element-from-point.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-from-point.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html id="root-element">
+<style>
+    #large-box {
+        position: absolute;
+        top: 10px;
+        left: 500px;
+        width: 100px;
+        height: 100px;
+        background-color: magenta;
+    }
+
+    #small-box {
+        position: absolute;
+        top: 35px;
+        left: 525px;
+        width: 50px;
+        height: 50px;
+        background-color: yellow;
+    }
+</style>
+<script src="../include.js"></script>
+<div id="large-box"></div><div id="small-box"></div>
+<script>    
+    test(() => {
+        println(`Negative coordinates return null: ${document.elementFromPoint(-1, -1) === null}`);
+        println(`Coordinates outside the viewport return null: ${document.elementFromPoint(99999, 99999) === null}`);
+        printElement(document.elementFromPoint(0, 0));
+        printElement(document.elementFromPoint(500, 10));
+        printElement(document.elementFromPoint(550, 60));        
+    });
+</script>
+</html>

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -560,6 +560,8 @@ public:
     void add_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
     void remove_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
 
+    Element const* element_from_point(double x, double y);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -116,6 +116,9 @@ interface Document : Node {
 
     // https://www.w3.org/TR/web-animations-1/#extensions-to-the-document-interface
     readonly attribute DocumentTimeline timeline;
+
+    // https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface
+    Element? elementFromPoint(double x, double y);
 };
 
 dictionary ElementCreationOptions {


### PR DESCRIPTION
This function uses our existing hit testing code to determine the topmost element at the given coordinates relative to the viewport.

https://regexr.com/ was complaining because we didn't have this.