### PR TITLE
RequestServer+LibTLS: Allow applications to specify multiple root certs

### DIFF
--- a/Ladybird/Android/src/main/cpp/RequestServerService.cpp
+++ b/Ladybird/Android/src/main/cpp/RequestServerService.cpp
@@ -21,13 +21,13 @@
 #include <RequestServer/HttpsProtocol.h>
 
 // FIXME: Share b/w RequestServer and WebSocket
-ErrorOr<String> find_certificates(StringView serenity_resource_root)
+ErrorOr<ByteString> find_certificates(StringView serenity_resource_root)
 {
-    auto cert_path = TRY(String::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root));
+    auto cert_path = ByteString::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root);
     if (!FileSystem::exists(cert_path)) {
         auto app_dir = LexicalPath::dirname(TRY(Core::System::current_executable_path()));
 
-        cert_path = TRY(String::formatted("{}/cacert.pem", LexicalPath(app_dir).parent()));
+        cert_path = ByteString::formatted("{}/cacert.pem", LexicalPath(app_dir).parent());
         if (!FileSystem::exists(cert_path))
             return Error::from_string_view("Don't know how to load certs!"sv);
     }
@@ -37,7 +37,7 @@ ErrorOr<String> find_certificates(StringView serenity_resource_root)
 ErrorOr<int> service_main(int ipc_socket, int fd_passing_socket)
 {
     // Ensure the certificates are read out here.
-    DefaultRootCACertificates::set_default_certificate_path(TRY(find_certificates(s_serenity_resource_root)));
+    DefaultRootCACertificates::set_default_certificate_paths(Vector { TRY(find_certificates(s_serenity_resource_root)) });
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;

--- a/Ladybird/Android/src/main/cpp/WebSocketService.cpp
+++ b/Ladybird/Android/src/main/cpp/WebSocketService.cpp
@@ -17,13 +17,13 @@
 #include <WebSocket/ConnectionFromClient.h>
 
 // FIXME: Share b/w RequestServer and WebSocket
-ErrorOr<String> find_certificates(StringView serenity_resource_root)
+ErrorOr<ByteString> find_certificates(StringView serenity_resource_root)
 {
-    auto cert_path = TRY(String::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root));
+    auto cert_path = ByteString::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root);
     if (!FileSystem::exists(cert_path)) {
         auto app_dir = LexicalPath::dirname(TRY(Core::System::current_executable_path()));
 
-        cert_path = TRY(String::formatted("{}/cacert.pem", LexicalPath(app_dir).parent()));
+        cert_path = ByteString::formatted("{}/cacert.pem", LexicalPath(app_dir).parent());
         if (!FileSystem::exists(cert_path))
             return Error::from_string_view("Don't know how to load certs!"sv);
     }
@@ -33,7 +33,7 @@ ErrorOr<String> find_certificates(StringView serenity_resource_root)
 ErrorOr<int> service_main(int ipc_socket, int fd_passing_socket)
 {
     // Ensure the certificates are read out here.
-    DefaultRootCACertificates::set_default_certificate_path(TRY(find_certificates(s_serenity_resource_root)));
+    DefaultRootCACertificates::set_default_certificate_paths(Vector { TRY(find_certificates(s_serenity_resource_root)) });
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -52,8 +52,8 @@ WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float de
             on_scroll(to_widget_position(position));
     };
 
-    on_request_worker_agent = []() {
-        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv))));
+    on_request_worker_agent = [this]() {
+        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), m_web_content_options.certificates));
         return worker_client->dup_sockets();
     };
 }

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -41,6 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Gfx::FontDatabase::set_fixed_width_font_query("Csilla 10 400 0");
 
     Vector<StringView> raw_urls;
+    Vector<ByteString> certificates;
     StringView webdriver_content_ipc_path;
     bool use_gpu_painting = false;
     bool debug_web_content = false;
@@ -51,6 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
     args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting", 0);
     args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content", 0);
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.parse(arguments);
 
     auto sql_server_paths = TRY(get_paths_for_helper_process("SQLServer"sv));
@@ -73,6 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Ladybird::WebContentOptions web_content_options {
         .command_line = MUST(command_line_builder.to_string()),
         .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
+        .certificates = move(certificates),
         .enable_gpu_painting = use_gpu_painting ? Ladybird::EnableGPUPainting::Yes : Ladybird::EnableGPUPainting::No,
         .use_lagom_networking = Ladybird::UseLagomNetworking::Yes,
         .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -23,6 +23,6 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     Ladybird::WebContentOptions const&);
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<String> candidate_image_decoder_paths);
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<String> candidate_web_worker_paths);
-ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<String> candidate_request_server_paths, StringView serenity_resource_root);
-ErrorOr<NonnullRefPtr<Protocol::WebSocketClient>> launch_web_socket_process(ReadonlySpan<String> candidate_web_socket_paths, StringView serenity_resource_root);
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<String> candidate_web_worker_paths, Vector<ByteString> const& certificates);
+ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<String> candidate_request_server_paths, StringView serenity_resource_root, Vector<ByteString> const& certificates);
+ErrorOr<NonnullRefPtr<Protocol::WebSocketClient>> launch_web_socket_process(ReadonlySpan<String> candidate_web_socket_paths, StringView serenity_resource_root, Vector<ByteString> const& certificates);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -118,8 +118,8 @@ WebContentView::WebContentView(WebContentOptions const& web_content_options, Str
         QToolTip::hideText();
     };
 
-    on_request_worker_agent = []() {
-        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv))));
+    on_request_worker_agent = [this]() {
+        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), m_web_content_options.certificates));
         return worker_client->dup_sockets();
     };
 }

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -105,6 +105,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Vector<StringView> raw_urls;
     StringView webdriver_content_ipc_path;
+    Vector<ByteString> certificates;
     bool enable_callgrind_profiling = false;
     bool disable_sql_database = false;
     bool enable_qt_networking = false;
@@ -120,6 +121,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(enable_qt_networking, "Enable Qt as the backend networking service", "enable-qt-networking", 0);
     args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting", 0);
     args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content", 0);
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.parse(arguments);
 
     RefPtr<WebView::Database> database;
@@ -148,6 +150,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Ladybird::WebContentOptions web_content_options {
         .command_line = MUST(command_line_builder.to_string()),
         .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
+        .certificates = move(certificates),
         .enable_callgrind_profiling = enable_callgrind_profiling ? Ladybird::EnableCallgrindProfiling::Yes : Ladybird::EnableCallgrindProfiling::No,
         .enable_gpu_painting = use_gpu_painting ? Ladybird::EnableGPUPainting::Yes : Ladybird::EnableGPUPainting::No,
         .use_lagom_networking = enable_qt_networking ? Ladybird::UseLagomNetworking::No : Ladybird::UseLagomNetworking::Yes,

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -21,13 +21,13 @@
 #include <RequestServer/HttpsProtocol.h>
 
 // FIXME: Share b/w RequestServer and WebSocket
-ErrorOr<String> find_certificates(StringView serenity_resource_root)
+ErrorOr<ByteString> find_certificates(StringView serenity_resource_root)
 {
-    auto cert_path = TRY(String::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root));
+    auto cert_path = ByteString::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root);
     if (!FileSystem::exists(cert_path)) {
         auto app_dir = LexicalPath::dirname(TRY(Core::System::current_executable_path()));
 
-        cert_path = TRY(String::formatted("{}/cacert.pem", LexicalPath(app_dir).parent()));
+        cert_path = ByteString::formatted("{}/cacert.pem", LexicalPath(app_dir).parent());
         if (!FileSystem::exists(cert_path))
             return Error::from_string_view("Don't know how to load certs!"sv);
     }
@@ -40,14 +40,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     int fd_passing_socket { -1 };
     StringView serenity_resource_root;
+    Vector<ByteString> certificates;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(fd_passing_socket, "File descriptor of the fd passing socket", "fd-passing-socket", 'c', "fd-passing-socket");
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
     args_parser.parse(arguments);
 
     // Ensure the certificates are read out here.
-    DefaultRootCACertificates::set_default_certificate_path(TRY(find_certificates(serenity_resource_root)));
+    if (certificates.is_empty())
+        certificates.append(TRY(find_certificates(serenity_resource_root)));
+    DefaultRootCACertificates::set_default_certificate_paths(certificates.span());
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;

--- a/Ladybird/Types.h
+++ b/Ladybird/Types.h
@@ -38,6 +38,7 @@ enum class WaitForDebugger {
 struct WebContentOptions {
     String command_line;
     String executable_path;
+    Vector<ByteString> certificates;
     EnableCallgrindProfiling enable_callgrind_profiling { EnableCallgrindProfiling::No };
     EnableGPUPainting enable_gpu_painting { EnableGPUPainting::No };
     IsLayoutTestMode is_layout_test_mode { IsLayoutTestMode::No };

--- a/Ladybird/WebSocket/main.cpp
+++ b/Ladybird/WebSocket/main.cpp
@@ -17,13 +17,13 @@
 #include <WebSocket/ConnectionFromClient.h>
 
 // FIXME: Share b/w RequestServer and WebSocket
-ErrorOr<String> find_certificates(StringView serenity_resource_root)
+ErrorOr<ByteString> find_certificates(StringView serenity_resource_root)
 {
-    auto cert_path = TRY(String::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root));
+    auto cert_path = ByteString::formatted("{}/res/ladybird/cacert.pem", serenity_resource_root);
     if (!FileSystem::exists(cert_path)) {
         auto app_dir = LexicalPath::dirname(TRY(Core::System::current_executable_path()));
 
-        cert_path = TRY(String::formatted("{}/cacert.pem", LexicalPath(app_dir).parent()));
+        cert_path = ByteString::formatted("{}/cacert.pem", LexicalPath(app_dir).parent());
         if (!FileSystem::exists(cert_path))
             return Error::from_string_view("Don't know how to load certs!"sv);
     }
@@ -36,14 +36,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     int fd_passing_socket { -1 };
     StringView serenity_resource_root;
+    Vector<ByteString> certificates;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(fd_passing_socket, "File descriptor of the fd passing socket", "fd-passing-socket", 'c', "fd-passing-socket");
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
     args_parser.parse(arguments);
 
     // Ensure the certificates are read out here.
-    DefaultRootCACertificates::set_default_certificate_path(TRY(find_certificates(serenity_resource_root)));
+    if (certificates.is_empty())
+        certificates.append(TRY(find_certificates(serenity_resource_root)));
+    DefaultRootCACertificates::set_default_certificate_paths(certificates.span());
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -292,11 +292,11 @@ public:
     Vector<Certificate> const& certificates() const { return m_ca_certificates; }
 
     static ErrorOr<Vector<Certificate>> parse_pem_root_certificate_authorities(ByteBuffer&);
-    static ErrorOr<Vector<Certificate>> load_certificates(StringView custom_cert_path = {});
+    static ErrorOr<Vector<Certificate>> load_certificates(Span<ByteString> custom_cert_paths = {});
 
     static DefaultRootCACertificates& the();
 
-    static void set_default_certificate_path(String);
+    static void set_default_certificate_paths(Span<ByteString> paths);
 
 private:
     Vector<Certificate> m_ca_certificates;

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -34,6 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd"));
 
     // Ensure the certificates are read out here.
+    // FIXME: Allow specifying extra certificates on the command line, or in other configuration.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;

--- a/Userland/Services/WebSocket/main.cpp
+++ b/Userland/Services/WebSocket/main.cpp
@@ -17,6 +17,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio inet unix rpath sendfd recvfd"));
 
     // Ensure the certificates are read out here.
+    // FIXME: Allow specifying extra certificates on the command line, or in other configuration.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;


### PR DESCRIPTION
And extend this to Ladybird in Lagom. It's a bit awkward to figure out how to do this for Serenity's RequestServer, so let's pretend the problem doesn't exist :) 

This means you can run Ladybird like so:

```console
./Build/lagom/bin/Ladybird --certificate=$PWD/Tests/LibWeb/WPT/wpt/tools/certs/cacert.pem
```

To run with *only* the WPT custom Root CA cert. If you want to keep loading the default path, you'll need to pass it explicitly as another --certificate argument:

```console
./Build/lagom/bin/Ladybird --certificate=$PWD/Tests/LibWeb/WPT/wpt/tools/certs/cacert.pem --certificate=$PWD/Build/lagom/cacert.pem
```

This also means that packagers/distro people who want to force us to use a distro-wide cert can do so by adding the --certificate option to the default launch args.

Partially addresses #22465