### PR TITLE
HexEditor: Make the panels :sparkles: fancy :sparkles: 

### DIFF
--- a/Userland/Applications/HexEditor/AnnotationsModel.cpp
+++ b/Userland/Applications/HexEditor/AnnotationsModel.cpp
@@ -69,6 +69,13 @@ Optional<Annotation&> AnnotationsModel::closest_annotation_at(size_t position)
     return result;
 }
 
+Optional<Annotation&> AnnotationsModel::get_annotation(GUI::ModelIndex const& index)
+{
+    if (index.row() < 0 || index.row() >= row_count())
+        return {};
+    return m_annotations.at(index.row());
+}
+
 ErrorOr<void> AnnotationsModel::save_to_file(Core::File& file) const
 {
     JsonArray array {};

--- a/Userland/Applications/HexEditor/AnnotationsModel.h
+++ b/Userland/Applications/HexEditor/AnnotationsModel.h
@@ -64,6 +64,7 @@ public:
     void add_annotation(Annotation);
     void delete_annotation(Annotation const&);
     Optional<Annotation&> closest_annotation_at(size_t position);
+    Optional<Annotation&> get_annotation(GUI::ModelIndex const& index);
 
     ErrorOr<void> save_to_file(Core::File&) const;
     ErrorOr<void> load_from_file(Core::File&);

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -931,7 +931,18 @@ void HexEditor::show_edit_annotation_dialog(Annotation& annotation)
 
 void HexEditor::show_delete_annotation_dialog(Annotation& annotation)
 {
-    auto result = GUI::MessageBox::show(window(), "Delete this annotation?"sv, "Delete annotation?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
+    StringBuilder builder;
+    builder.append("Delete '"sv);
+    Utf8View comments_first_line { annotation.comments.bytes_as_string_view().find_first_split_view('\n') };
+    auto const max_annotation_text_length = 40;
+    if (comments_first_line.length() <= max_annotation_text_length) {
+        builder.append(comments_first_line.as_string());
+    } else {
+        builder.appendff("{}...", comments_first_line.unicode_substring_view(0, max_annotation_text_length));
+    }
+    builder.append("'?"sv);
+
+    auto result = GUI::MessageBox::show(window(), builder.string_view(), "Delete annotation?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
     if (result == GUI::Dialog::ExecResult::Yes) {
         m_document->annotations().delete_annotation(annotation);
         update();

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -56,9 +56,12 @@ ErrorOr<void> HexEditorWidget::setup()
     m_annotations_container = *find_descendant_of_type_named<GUI::Widget>("annotations_container");
     m_search_results = *find_descendant_of_type_named<GUI::TableView>("search_results");
     m_search_results_container = *find_descendant_of_type_named<GUI::Widget>("search_results_container");
-    m_side_panel_container = *find_descendant_of_type_named<GUI::Widget>("side_panel_container");
+    m_side_panel_container = *find_descendant_of_type_named<GUI::DynamicWidgetContainer>("side_panel_container");
     m_value_inspector_container = *find_descendant_of_type_named<GUI::Widget>("value_inspector_container");
     m_value_inspector = *find_descendant_of_type_named<GUI::TableView>("value_inspector");
+
+    // FIXME: Set this in GML once the compiler supports it.
+    m_side_panel_container->set_container_with_individual_order(true);
 
     m_value_inspector->on_activation = [this](GUI::ModelIndex const& index) {
         if (!index.is_valid())

--- a/Userland/Applications/HexEditor/HexEditorWidget.gml
+++ b/Userland/Applications/HexEditor/HexEditorWidget.gml
@@ -20,24 +20,32 @@
             name: "editor"
         }
 
-        @GUI::VerticalSplitter {
+        @GUI::DynamicWidgetContainer {
             name: "side_panel_container"
             visible: false
+            section_label: "Panels"
+            config_domain: "HexEditor"
+            preferred_height: "grow"
+            show_controls: false
 
-            @GUI::Widget {
+            @GUI::DynamicWidgetContainer {
                 name: "search_results_container"
+                section_label: "Search Results"
+                config_domain: "HexEditor"
+                preferred_height: "grow"
                 visible: false
-                layout: @GUI::VerticalBoxLayout {}
 
                 @GUI::TableView {
                     name: "search_results"
                 }
             }
 
-            @GUI::Widget {
+            @GUI::DynamicWidgetContainer {
                 name: "value_inspector_container"
+                section_label: "Value Inspector"
+                config_domain: "HexEditor"
+                preferred_height: "grow"
                 visible: false
-                layout: @GUI::VerticalBoxLayout {}
 
                 @GUI::TableView {
                     name: "value_inspector"
@@ -45,10 +53,12 @@
                 }
             }
 
-            @GUI::Widget {
+            @GUI::DynamicWidgetContainer {
                 name: "annotations_container"
+                section_label: "Annotations"
+                config_domain: "HexEditor"
+                preferred_height: "grow"
                 visible: false
-                layout: @GUI::VerticalBoxLayout {}
 
                 @GUI::TableView {
                     name: "annotations"

--- a/Userland/Applications/HexEditor/HexEditorWidget.gml
+++ b/Userland/Applications/HexEditor/HexEditorWidget.gml
@@ -60,6 +60,14 @@
                 preferred_height: "grow"
                 visible: false
 
+                @GUI::ToolbarContainer {
+                    name: "annotations_toolbar_container"
+
+                    @GUI::Toolbar {
+                        name: "annotations_toolbar"
+                    }
+                }
+
                 @GUI::TableView {
                     name: "annotations"
                 }

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -16,6 +16,7 @@
 #include <AK/LexicalPath.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/DynamicWidgetContainer.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -93,7 +94,7 @@ private:
     RefPtr<GUI::ToolbarContainer> m_toolbar_container;
     RefPtr<GUI::TableView> m_search_results;
     RefPtr<GUI::Widget> m_search_results_container;
-    RefPtr<GUI::Widget> m_side_panel_container;
+    RefPtr<GUI::DynamicWidgetContainer> m_side_panel_container;
     RefPtr<GUI::Widget> m_value_inspector_container;
     RefPtr<GUI::TableView> m_value_inspector;
     RefPtr<GUI::Widget> m_annotations_container;

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -17,6 +17,7 @@
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/DynamicWidgetContainer.h>
+#include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -97,8 +98,13 @@ private:
     RefPtr<GUI::DynamicWidgetContainer> m_side_panel_container;
     RefPtr<GUI::Widget> m_value_inspector_container;
     RefPtr<GUI::TableView> m_value_inspector;
+
     RefPtr<GUI::Widget> m_annotations_container;
     RefPtr<GUI::TableView> m_annotations;
+    RefPtr<GUI::SortingProxyModel> m_annotations_sorting_model;
+    RefPtr<GUI::Menu> m_annotations_context_menu;
+    RefPtr<GUI::Action> m_edit_annotation_action;
+    RefPtr<GUI::Action> m_delete_annotation_action;
 
     bool m_value_inspector_little_endian { true };
     bool m_selecting_from_inspector { false };


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/57acee35-252a-4597-9b5b-dbde95077b02)

Make the panels use DynamicWidgetContainers because those are cool and fancy, and then add a toolbar and context menu to the annotations panel. Also snuck in a tweak to the delete-annotation confirmation dialog so it tells you what you're about to delete.