### PR TITLE
LibGfx/OpenType: Support cmaps with format Unicode

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -34,6 +34,16 @@ public:
             ManyToOneRange = 13,
             UnicodeVariationSequences = 14,
         };
+        enum class UnicodeEncoding {
+            DeprecatedUnicode1_0 = 0,
+            DeprecatedUnicode1_1 = 1,
+            DeprecatedISO10646 = 2,
+            Unicode2_0_BMP_Only = 3,
+            Unicode2_0_FullRepertoire = 4,
+            UnicodeVariationSequences = 5, // "for use with subtable format 14"
+            UnicodeFullRepertoire = 6,     // "for use with subtable format 13"
+        };
+
         enum class WindowsEncoding {
             UnicodeBMP = 1,
             UnicodeFullRepertoire = 10,

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -236,7 +236,18 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
         /* NOTE: The encoding records are sorted first by platform ID, then by encoding ID.
            This means that the Windows platform will take precedence over Macintosh, which is
            usually what we want here. */
-        if (platform.value() == Cmap::Subtable::Platform::Windows) {
+        if (platform.value() == Cmap::Subtable::Platform::Unicode) {
+            if (subtable.encoding_id() == (u16)Cmap::Subtable::UnicodeEncoding::Unicode2_0_FullRepertoire) {
+                // "Encoding ID 3 should be used in conjunction with 'cmap' subtable formats 4 or 6."
+                cmap.set_active_index(i);
+                break;
+            }
+            if (subtable.encoding_id() == (u16)Cmap::Subtable::UnicodeEncoding::Unicode2_0_BMP_Only) {
+                // "Encoding ID 4 should be used in conjunction with subtable formats 10 or 12."
+                cmap.set_active_index(i);
+                break;
+            }
+        } else if (platform.value() == Cmap::Subtable::Platform::Windows) {
             if (subtable.encoding_id() == (u16)Cmap::Subtable::WindowsEncoding::UnicodeFullRepertoire) {
                 cmap.set_active_index(i);
                 break;


### PR DESCRIPTION
Some fonts only contain unicode tables. This makes them work.