### PR TITLE
Terminal+TerminalSettings: Don't crash when opening TerminalSettings

### DIFF
--- a/Base/home/anon/.config/Terminal.ini
+++ b/Base/home/anon/.config/Terminal.ini
@@ -3,6 +3,7 @@ Command=
 [Terminal]
 ShowScrollBar=true
 MaxHistorySize=1024
+AutoMark=MarkInteractiveShellPrompt
 [Window]
 Opacity=255
 Bell=Visible

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -77,6 +77,9 @@ public:
         } else if (group == "Cursor" && key == "Shape") {
             auto cursor_shape = VT::TerminalWidget::parse_cursor_shape(value).value_or(VT::CursorShape::Block);
             m_parent_terminal.set_cursor_shape(cursor_shape);
+        } else if (group == "Terminal" && key == "AutoMark") {
+            auto automark_mode = VT::TerminalWidget::parse_automark_mode(value).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
+            m_parent_terminal.set_auto_mark_mode(automark_mode);
         }
     }
 

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -65,13 +65,7 @@ public:
         VERIFY(domain == "Terminal");
 
         if (group == "Window" && key == "Bell") {
-            auto bell_mode = VT::TerminalWidget::BellMode::Visible;
-            if (value == "AudibleBeep")
-                bell_mode = VT::TerminalWidget::BellMode::AudibleBeep;
-            if (value == "Visible")
-                bell_mode = VT::TerminalWidget::BellMode::Visible;
-            if (value == "Disabled")
-                bell_mode = VT::TerminalWidget::BellMode::Disabled;
+            auto bell_mode = VT::TerminalWidget::parse_bell(value).value_or(VT::TerminalWidget::BellMode::Visible);
             m_parent_terminal.set_bell_mode(bell_mode);
         } else if (group == "Text" && key == "Font") {
             auto font = Gfx::FontDatabase::the().get_by_name(value);

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -40,7 +40,7 @@ ErrorOr<void> MainWidget::setup()
     auto& beep_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("beep_bell_radio");
     auto& visual_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("visual_bell_radio");
     auto& no_bell_radio = *find_descendant_of_type_named<GUI::RadioButton>("no_bell_radio");
-    auto& automark_off_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_of");
+    auto& automark_off_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_off");
     auto& automark_on_interactive_prompt_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_on_interactive_prompt");
 
     m_bell_mode = parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv));

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -119,6 +119,7 @@ void MainWidget::write_back_settings() const
 {
     Config::write_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, m_orignal_confirm_close);
     Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_original_bell_mode));
+    Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
 }
 
 void MainWidget::cancel_settings()

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -43,10 +43,10 @@ ErrorOr<void> MainWidget::setup()
     auto& automark_off_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_off");
     auto& automark_on_interactive_prompt_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_on_interactive_prompt");
 
-    m_bell_mode = parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv)).value_or(VT::TerminalWidget::BellMode::Visible);
+    m_bell_mode = VT::TerminalWidget::parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv)).value_or(VT::TerminalWidget::BellMode::Visible);
     m_original_bell_mode = m_bell_mode;
 
-    m_automark_mode = parse_automark_mode(Config::read_string("Terminal"sv, "Terminal"sv, "AutoMark"sv)).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
+    m_automark_mode = VT::TerminalWidget::parse_automark_mode(Config::read_string("Terminal"sv, "Terminal"sv, "AutoMark"sv)).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
     m_original_automark_mode = m_automark_mode;
 
     switch (m_bell_mode) {
@@ -63,17 +63,17 @@ ErrorOr<void> MainWidget::setup()
 
     beep_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::AudibleBeep;
-        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, stringify_bell(m_bell_mode));
+        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_bell_mode));
         set_modified(true);
     };
     visual_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::Visible;
-        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, stringify_bell(m_bell_mode));
+        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_bell_mode));
         set_modified(true);
     };
     no_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::Disabled;
-        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, stringify_bell(m_bell_mode));
+        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_bell_mode));
         set_modified(true);
     };
 
@@ -88,12 +88,12 @@ ErrorOr<void> MainWidget::setup()
 
     automark_off_radio.on_checked = [this](bool) {
         m_automark_mode = VT::TerminalWidget::AutoMarkMode::MarkNothing;
-        Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, stringify_automark_mode(m_automark_mode));
+        Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
         set_modified(true);
     };
     automark_on_interactive_prompt_radio.on_checked = [this](bool) {
         m_automark_mode = VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt;
-        Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, stringify_automark_mode(m_automark_mode));
+        Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
         set_modified(true);
     };
 
@@ -109,46 +109,6 @@ ErrorOr<void> MainWidget::setup()
     return {};
 }
 
-Optional<VT::TerminalWidget::BellMode> MainWidget::parse_bell(StringView bell_string)
-{
-    if (bell_string == "AudibleBeep")
-        return VT::TerminalWidget::BellMode::AudibleBeep;
-    if (bell_string == "Visible")
-        return VT::TerminalWidget::BellMode::Visible;
-    if (bell_string == "Disabled")
-        return VT::TerminalWidget::BellMode::Disabled;
-    return {};
-}
-
-ByteString MainWidget::stringify_bell(VT::TerminalWidget::BellMode bell_mode)
-{
-    if (bell_mode == VT::TerminalWidget::BellMode::AudibleBeep)
-        return "AudibleBeep";
-    if (bell_mode == VT::TerminalWidget::BellMode::Disabled)
-        return "Disabled";
-    if (bell_mode == VT::TerminalWidget::BellMode::Visible)
-        return "Visible";
-    VERIFY_NOT_REACHED();
-}
-
-Optional<VT::TerminalWidget::AutoMarkMode> MainWidget::parse_automark_mode(StringView automark_mode)
-{
-    if (automark_mode == "MarkNothing")
-        return VT::TerminalWidget::AutoMarkMode::MarkNothing;
-    if (automark_mode == "MarkInteractiveShellPrompt")
-        return VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt;
-    return {};
-}
-
-ByteString MainWidget::stringify_automark_mode(VT::TerminalWidget::AutoMarkMode automark_mode)
-{
-    if (automark_mode == VT::TerminalWidget::AutoMarkMode::MarkNothing)
-        return "MarkNothing";
-    if (automark_mode == VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt)
-        return "MarkInteractiveShellPrompt";
-    VERIFY_NOT_REACHED();
-}
-
 void MainWidget::apply_settings()
 {
     m_original_bell_mode = m_bell_mode;
@@ -158,7 +118,7 @@ void MainWidget::apply_settings()
 void MainWidget::write_back_settings() const
 {
     Config::write_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, m_orignal_confirm_close);
-    Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, stringify_bell(m_original_bell_mode));
+    Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_original_bell_mode));
 }
 
 void MainWidget::cancel_settings()

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -43,10 +43,10 @@ ErrorOr<void> MainWidget::setup()
     auto& automark_off_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_off");
     auto& automark_on_interactive_prompt_radio = *find_descendant_of_type_named<GUI::RadioButton>("automark_on_interactive_prompt");
 
-    m_bell_mode = parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv));
+    m_bell_mode = parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv)).value_or(VT::TerminalWidget::BellMode::Visible);
     m_original_bell_mode = m_bell_mode;
 
-    m_automark_mode = parse_automark_mode(Config::read_string("Terminal"sv, "Terminal"sv, "AutoMark"sv));
+    m_automark_mode = parse_automark_mode(Config::read_string("Terminal"sv, "Terminal"sv, "AutoMark"sv)).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
     m_original_automark_mode = m_automark_mode;
 
     switch (m_bell_mode) {
@@ -109,7 +109,7 @@ ErrorOr<void> MainWidget::setup()
     return {};
 }
 
-VT::TerminalWidget::BellMode MainWidget::parse_bell(StringView bell_string)
+Optional<VT::TerminalWidget::BellMode> MainWidget::parse_bell(StringView bell_string)
 {
     if (bell_string == "AudibleBeep")
         return VT::TerminalWidget::BellMode::AudibleBeep;
@@ -117,7 +117,7 @@ VT::TerminalWidget::BellMode MainWidget::parse_bell(StringView bell_string)
         return VT::TerminalWidget::BellMode::Visible;
     if (bell_string == "Disabled")
         return VT::TerminalWidget::BellMode::Disabled;
-    VERIFY_NOT_REACHED();
+    return {};
 }
 
 ByteString MainWidget::stringify_bell(VT::TerminalWidget::BellMode bell_mode)
@@ -131,13 +131,13 @@ ByteString MainWidget::stringify_bell(VT::TerminalWidget::BellMode bell_mode)
     VERIFY_NOT_REACHED();
 }
 
-VT::TerminalWidget::AutoMarkMode MainWidget::parse_automark_mode(StringView automark_mode)
+Optional<VT::TerminalWidget::AutoMarkMode> MainWidget::parse_automark_mode(StringView automark_mode)
 {
     if (automark_mode == "MarkNothing")
         return VT::TerminalWidget::AutoMarkMode::MarkNothing;
     if (automark_mode == "MarkInteractiveShellPrompt")
         return VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt;
-    VERIFY_NOT_REACHED();
+    return {};
 }
 
 ByteString MainWidget::stringify_automark_mode(VT::TerminalWidget::AutoMarkMode automark_mode)

--- a/Userland/Applications/TerminalSettings/MainWidget.h
+++ b/Userland/Applications/TerminalSettings/MainWidget.h
@@ -28,8 +28,8 @@ private:
     ErrorOr<void> setup();
     void write_back_settings() const;
 
-    static VT::TerminalWidget::BellMode parse_bell(StringView bell_string);
-    static VT::TerminalWidget::AutoMarkMode parse_automark_mode(StringView automark_mode);
+    static Optional<VT::TerminalWidget::BellMode> parse_bell(StringView bell_string);
+    static Optional<VT::TerminalWidget::AutoMarkMode> parse_automark_mode(StringView automark_mode);
     static ByteString stringify_bell(VT::TerminalWidget::BellMode bell_mode);
     static ByteString stringify_automark_mode(VT::TerminalWidget::AutoMarkMode automark_mode);
 

--- a/Userland/Applications/TerminalSettings/MainWidget.h
+++ b/Userland/Applications/TerminalSettings/MainWidget.h
@@ -28,11 +28,6 @@ private:
     ErrorOr<void> setup();
     void write_back_settings() const;
 
-    static Optional<VT::TerminalWidget::BellMode> parse_bell(StringView bell_string);
-    static Optional<VT::TerminalWidget::AutoMarkMode> parse_automark_mode(StringView automark_mode);
-    static ByteString stringify_bell(VT::TerminalWidget::BellMode bell_mode);
-    static ByteString stringify_automark_mode(VT::TerminalWidget::AutoMarkMode automark_mode);
-
     VT::TerminalWidget::BellMode m_bell_mode { VT::TerminalWidget::BellMode::Disabled };
     VT::TerminalWidget::AutoMarkMode m_automark_mode { VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt };
     bool m_confirm_close { true };

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1415,6 +1415,46 @@ ByteString TerminalWidget::stringify_cursor_shape(VT::CursorShape cursor_shape)
     VERIFY_NOT_REACHED();
 }
 
+Optional<TerminalWidget::BellMode> TerminalWidget::parse_bell(StringView bell_string)
+{
+    if (bell_string == "AudibleBeep")
+        return BellMode::AudibleBeep;
+    if (bell_string == "Visible")
+        return BellMode::Visible;
+    if (bell_string == "Disabled")
+        return BellMode::Disabled;
+    return {};
+}
+
+ByteString TerminalWidget::stringify_bell(TerminalWidget::BellMode bell_mode)
+{
+    if (bell_mode == BellMode::AudibleBeep)
+        return "AudibleBeep";
+    if (bell_mode == BellMode::Disabled)
+        return "Disabled";
+    if (bell_mode == BellMode::Visible)
+        return "Visible";
+    VERIFY_NOT_REACHED();
+}
+
+Optional<TerminalWidget::AutoMarkMode> TerminalWidget::parse_automark_mode(StringView automark_mode)
+{
+    if (automark_mode == "MarkNothing")
+        return AutoMarkMode::MarkNothing;
+    if (automark_mode == "MarkInteractiveShellPrompt")
+        return AutoMarkMode::MarkInteractiveShellPrompt;
+    return {};
+}
+
+ByteString TerminalWidget::stringify_automark_mode(AutoMarkMode automark_mode)
+{
+    if (automark_mode == AutoMarkMode::MarkNothing)
+        return "MarkNothing";
+    if (automark_mode == AutoMarkMode::MarkInteractiveShellPrompt)
+        return "MarkInteractiveShellPrompt";
+    VERIFY_NOT_REACHED();
+}
+
 void TerminalWidget::handle_pty_owner_change(pid_t new_owner)
 {
     if (m_auto_mark_mode == AutoMarkMode::MarkInteractiveShellPrompt && new_owner == m_startup_process_id) {

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -115,7 +115,11 @@ public:
     virtual void set_cursor_shape(CursorShape) override;
 
     static Optional<VT::CursorShape> parse_cursor_shape(StringView);
+    static Optional<BellMode> parse_bell(StringView);
+    static Optional<AutoMarkMode> parse_automark_mode(StringView);
     static ByteString stringify_cursor_shape(VT::CursorShape);
+    static ByteString stringify_bell(BellMode);
+    static ByteString stringify_automark_mode(AutoMarkMode);
 
 private:
     TerminalWidget(int ptm_fd, bool automatic_size_policy);


### PR DESCRIPTION
This PR includes a few fixes for the new AutoMark setting TerminalSettings and Terminal to ensure we don't crash when opening the Terminal Settings window. 

The AutoMark setting is now propagated to the terminal when it is changed and is reverted when cancel is pressed.

CC: @alimpfard 