### PR TITLE
LibWeb+WebContent: Run painting commands executing in a separate thread

### DIFF
--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -4,6 +4,7 @@ set(WEBCONTENT_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/WebContent/)
 set(WEBCONTENT_SOURCES
     ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.cpp
     ${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalEnvironmentExtensions.cpp
+    ${WEBCONTENT_SOURCE_DIR}/RenderLoopExecutor.cpp
     ${WEBCONTENT_SOURCE_DIR}/PageClient.cpp
     ${WEBCONTENT_SOURCE_DIR}/PageHost.cpp
     ${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.cpp
@@ -80,7 +81,7 @@ endif()
 
 target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
 target_include_directories(WebContent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(WebContent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView)
+target_link_libraries(WebContent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView LibThreading)
 
 if (HAVE_PULSEAUDIO)
     target_compile_definitions(WebContent PRIVATE HAVE_PULSEAUDIO=1)

--- a/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
@@ -54,6 +54,7 @@ executable("WebContent") {
     "//Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp",
     "//Userland/Services/WebContent/PageClient.cpp",
     "//Userland/Services/WebContent/PageHost.cpp",
+    "//Userland/Services/WebContent/RenderLoopExecutor.cpp",
     "//Userland/Services/WebContent/WebContentConsoleClient.cpp",
     "//Userland/Services/WebContent/WebDriverConnection.cpp",
     "main.cpp",

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/Bitmap.h>
 #include <AK/ByteReader.h>
 #include <AK/RefCounted.h>
@@ -143,7 +144,7 @@ enum FontWidth {
     UltraExpanded = 9
 };
 
-class Font : public RefCounted<Font> {
+class Font : public AtomicRefCounted<Font> {
 public:
     enum class AllowInexactSizeMatch {
         No,

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -228,7 +228,7 @@ public:
     virtual DevicePixelRect screen_rect() const = 0;
     virtual double device_pixels_per_css_pixel() const = 0;
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
-    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, PaintOptions = {}) = 0;
+    virtual NonnullOwnPtr<Web::Painting::RecordingPainter> paint(DevicePixelRect const&, PaintOptions = {}) = 0;
     virtual void page_did_change_title(ByteString const&) { }
     virtual void page_did_request_navigate_back() { }
     virtual void page_did_request_navigate_forward() { }

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -179,7 +179,8 @@ void RecordingPainter::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bit
 {
     push_command(DrawScaledBitmap {
         .dst_rect = state().translation.map(dst_rect),
-        .bitmap = bitmap,
+        // NOTE: Bitmap has to be cloned to prevent concurrent access from main and rendering threads.
+        .bitmap = MUST(bitmap.clone()),
         .src_rect = src_rect,
         .scaling_mode = scaling_mode,
     });

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -487,6 +487,8 @@ public:
 };
 
 class RecordingPainter {
+    AK_MAKE_NONCOPYABLE(RecordingPainter);
+
 public:
     void fill_rect(Gfx::IntRect const& rect, Color color);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -47,7 +47,7 @@ public:
     virtual double device_pixels_per_css_pixel() const override { return 1.0; }
     virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page.client().preferred_color_scheme(); }
     virtual void request_file(FileRequest) override { }
-    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override { }
+    virtual NonnullOwnPtr<Web::Painting::RecordingPainter> paint(DevicePixelRect const&, Web::PaintOptions = {}) override { VERIFY_NOT_REACHED(); }
 
 private:
     explicit SVGPageClient(Page& host_page)

--- a/Userland/Services/WebContent/CMakeLists.txt
+++ b/Userland/Services/WebContent/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     ConnectionFromClient.cpp
     ConsoleGlobalEnvironmentExtensions.cpp
     ImageCodecPluginSerenity.cpp
+    RenderLoopExecutor.cpp
     PageClient.cpp
     PageHost.cpp
     WebContentConsoleClient.cpp
@@ -31,7 +32,7 @@ set(GENERATED_SOURCES
 )
 
 serenity_bin(WebContent)
-target_link_libraries(WebContent PRIVATE LibCore LibFileSystem LibIPC LibGfx LibAudio LibImageDecoderClient LibJS LibWebView LibWeb LibLocale LibMain)
+target_link_libraries(WebContent PRIVATE LibCore LibFileSystem LibIPC LibGfx LibAudio LibImageDecoderClient LibJS LibWebView LibWeb LibLocale LibMain LibThreading)
 link_with_locale_data(WebContent)
 
 if (HAS_ACCELERATED_GRAPHICS)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -12,11 +12,7 @@
 #include <LibGfx/Rect.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
-#include <WebContent/Forward.h>
-
-#ifdef HAS_ACCELERATED_GRAPHICS
-#    include <LibAccelGfx/Context.h>
-#endif
+#include <WebContent/RenderLoopExecutor.h>
 
 namespace WebContent {
 
@@ -35,7 +31,7 @@ public:
 
     ErrorOr<void> connect_to_webdriver(ByteString const& webdriver_ipc_path);
 
-    virtual void paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap&, Web::PaintOptions = {}) override;
+    virtual NonnullOwnPtr<Web::Painting::RecordingPainter> paint(Web::DevicePixelRect const& content_rect, Web::PaintOptions = {}) override;
 
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport_rect(Web::DevicePixelRect const&);
@@ -175,22 +171,12 @@ private:
 
     RefPtr<WebDriverConnection> m_webdriver;
 
-#ifdef HAS_ACCELERATED_GRAPHICS
-    OwnPtr<AccelGfx::Context> m_accelerated_graphics_context;
-#endif
-
-    struct BackingStores {
-        i32 front_bitmap_id { -1 };
-        i32 back_bitmap_id { -1 };
-        RefPtr<Gfx::Bitmap> front_bitmap;
-        RefPtr<Gfx::Bitmap> back_bitmap;
-    };
-    BackingStores m_backing_stores;
-
     HashMap<Web::DOM::Document*, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
     WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
 
     JS::Handle<JS::GlobalObject> m_console_global_object;
+
+    RenderLoopExecutor m_render_loop_executor;
 };
 
 }

--- a/Userland/Services/WebContent/RenderLoopExecutor.cpp
+++ b/Userland/Services/WebContent/RenderLoopExecutor.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibWeb/Painting/PaintingCommandExecutorCPU.h>
+#include <WebContent/RenderLoopExecutor.h>
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+#    include <LibWeb/Painting/PaintingCommandExecutorGPU.h>
+#endif
+
+namespace WebContent {
+
+RenderLoopExecutor::RenderLoopExecutor(bool use_gpu_painter)
+    : m_main_thread_event_loop(Core::EventLoop::current())
+    , m_use_gpu_painter(use_gpu_painter)
+{
+}
+
+RenderLoopExecutor::~RenderLoopExecutor()
+{
+    m_exit = true;
+    m_paint_task_ready_wake_condition.signal();
+}
+
+void RenderLoopExecutor::paint(NonnullOwnPtr<Web::Painting::RecordingPainter> recording_painter, Function<void(i32)> on_completion)
+{
+    if (!m_backing_stores.back_bitmap)
+        return;
+
+    enqueue_paint_task([this, recording_painter = move(recording_painter), on_completion = move(on_completion)]() mutable {
+        i32 front_bitmap_id;
+        {
+            Threading::MutexLocker locker { m_backing_stores_mutex };
+            auto& bitmap = *m_backing_stores.back_bitmap;
+
+            if (m_use_gpu_painter) {
+#ifdef HAS_ACCELERATED_GRAPHICS
+                Web::Painting::PaintingCommandExecutorGPU painting_command_executor(*m_accelerated_graphics_context,
+                    bitmap);
+                recording_painter->execute(painting_command_executor);
+#else
+                static bool has_warned_about_configuration = false;
+
+                if (!has_warned_about_configuration) {
+                    warnln("\033[31;1mConfigured to use GPU painter, but current platform does not have accelerated graphics\033[0m");
+                    has_warned_about_configuration = true;
+                }
+#endif
+            } else {
+                Web::Painting::PaintingCommandExecutorCPU painting_command_executor(bitmap);
+                recording_painter->execute(painting_command_executor);
+            }
+
+            swap(m_backing_stores.front_bitmap, m_backing_stores.back_bitmap);
+            swap(m_backing_stores.front_bitmap_id, m_backing_stores.back_bitmap_id);
+            front_bitmap_id = m_backing_stores.front_bitmap_id;
+        }
+
+        m_main_thread_event_loop.deferred_invoke([on_completion = move(on_completion), front_bitmap_id]() {
+            on_completion(front_bitmap_id);
+        });
+
+        {
+            Threading::MutexLocker locker { m_ready_to_paint_mutex };
+            m_ready_to_paint_wake_condition.wait();
+        }
+    });
+}
+
+void RenderLoopExecutor::ready_to_paint()
+{
+    Threading::MutexLocker locker { m_ready_to_paint_mutex };
+    m_ready_to_paint_wake_condition.signal();
+}
+
+void RenderLoopExecutor::start()
+{
+    m_thread = Threading::Thread::construct([this]() mutable -> intptr_t {
+#ifdef HAS_ACCELERATED_GRAPHICS
+        if (m_use_gpu_painter) {
+            auto context = AccelGfx::Context::create();
+            if (context.is_error()) {
+                dbgln("Failed to create AccelGfx context: {}", context.error());
+                VERIFY_NOT_REACHED();
+            }
+            m_accelerated_graphics_context = context.release_value();
+        }
+#endif
+        repaint_loop();
+        return (intptr_t)0;
+    },
+        "RenderLoopExecutor"sv);
+    m_thread->start();
+}
+
+void RenderLoopExecutor::add_backing_store(i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap)
+{
+    Threading::MutexLocker locker { m_backing_stores_mutex };
+    m_backing_stores.front_bitmap_id = front_bitmap_id;
+    m_backing_stores.back_bitmap_id = back_bitmap_id;
+    m_backing_stores.front_bitmap = *const_cast<Gfx::ShareableBitmap&>(front_bitmap).bitmap();
+    m_backing_stores.back_bitmap = *const_cast<Gfx::ShareableBitmap&>(back_bitmap).bitmap();
+}
+
+void RenderLoopExecutor::enqueue_paint_task(Function<void()>&& task)
+{
+    Threading::MutexLocker locker { m_paint_task_mutex };
+    m_paint_task.emplace(forward<Function<void()>>(task));
+    m_paint_task_ready_wake_condition.signal();
+}
+
+void RenderLoopExecutor::repaint_loop()
+{
+    while (true) {
+        auto task = [this]() -> Function<void()> {
+            Threading::MutexLocker locker { m_paint_task_mutex };
+            while (!m_paint_task.has_value() && !m_exit) {
+                m_paint_task_ready_wake_condition.wait();
+            }
+            if (m_exit)
+                return nullptr;
+            return m_paint_task.release_value();
+        }();
+
+        if (!task) {
+            VERIFY(m_exit);
+            break;
+        }
+        task();
+    }
+}
+
+}

--- a/Userland/Services/WebContent/RenderLoopExecutor.h
+++ b/Userland/Services/WebContent/RenderLoopExecutor.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Forward.h>
+#include <LibThreading/ConditionVariable.h>
+#include <LibThreading/MutexProtected.h>
+#include <LibThreading/Thread.h>
+#include <LibWeb/Painting/RecordingPainter.h>
+#include <WebContent/Forward.h>
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+#    include <LibAccelGfx/Context.h>
+#endif
+
+namespace WebContent {
+
+class RenderLoopExecutor {
+    AK_MAKE_NONCOPYABLE(RenderLoopExecutor);
+    AK_MAKE_NONMOVABLE(RenderLoopExecutor);
+
+public:
+    struct BackingStores {
+        i32 front_bitmap_id { -1 };
+        i32 back_bitmap_id { -1 };
+        RefPtr<Gfx::Bitmap> front_bitmap;
+        RefPtr<Gfx::Bitmap> back_bitmap;
+    };
+
+    void paint(NonnullOwnPtr<Web::Painting::RecordingPainter> recording_painter, Function<void(i32)> on_completion);
+    void start();
+    void add_backing_store(i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap);
+    void ready_to_paint();
+
+    RenderLoopExecutor(bool use_gpu_painter);
+    ~RenderLoopExecutor();
+
+private:
+    void enqueue_paint_task(Function<void()>&& task);
+    void repaint_loop();
+
+    RefPtr<Threading::Thread> m_thread;
+    Atomic<bool> m_exit { false };
+
+    Optional<Function<void()>> m_paint_task;
+    Threading::Mutex m_paint_task_mutex;
+    Threading::ConditionVariable m_paint_task_ready_wake_condition { m_paint_task_mutex };
+
+    Threading::Mutex m_ready_to_paint_mutex;
+    Threading::ConditionVariable m_ready_to_paint_wake_condition { m_ready_to_paint_mutex };
+
+    Core::EventLoop& m_main_thread_event_loop;
+
+    BackingStores m_backing_stores;
+    Threading::Mutex m_backing_stores_mutex;
+
+    bool m_use_gpu_painter { false };
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+    OwnPtr<AccelGfx::Context> m_accelerated_graphics_context;
+#endif
+};
+
+}

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -37,6 +37,8 @@
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/PaintingCommandExecutorCPU.h>
+#include <LibWeb/Painting/RecordingPainter.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 #include <LibWeb/UIEvents/EventNames.h>
@@ -1781,7 +1783,11 @@ Messages::WebDriverClient::TakeScreenshotResponse WebDriverConnection::take_scre
     auto root_rect = calculate_absolute_rect_of_element(m_page_client.page(), *document->document_element());
 
     auto encoded_string = TRY(Web::WebDriver::capture_element_screenshot(
-        [&](auto const& rect, auto& bitmap) { m_page_client.paint(rect.template to_type<Web::DevicePixels>(), bitmap); },
+        [&](auto const& rect, auto& bitmap) {
+            auto recording_painter = m_page_client.paint(rect.template to_type<Web::DevicePixels>());
+            Web::Painting::PaintingCommandExecutorCPU painting_command_executor(bitmap);
+            recording_painter->execute(painting_command_executor);
+        },
         m_page_client.page(),
         *document->document_element(),
         root_rect));
@@ -1814,7 +1820,11 @@ Messages::WebDriverClient::TakeElementScreenshotResponse WebDriverConnection::ta
     auto element_rect = calculate_absolute_rect_of_element(m_page_client.page(), *element);
 
     auto encoded_string = TRY(Web::WebDriver::capture_element_screenshot(
-        [&](auto const& rect, auto& bitmap) { m_page_client.paint(rect.template to_type<Web::DevicePixels>(), bitmap); },
+        [&](auto const& rect, auto& bitmap) {
+            auto recording_painter = m_page_client.paint(rect.template to_type<Web::DevicePixels>());
+            Web::Painting::PaintingCommandExecutorCPU painting_command_executor(bitmap);
+            recording_painter->execute(painting_command_executor);
+        },
         m_page_client.page(),
         *element,
         element_rect));

--- a/Userland/Services/WebWorker/PageHost.cpp
+++ b/Userland/Services/WebWorker/PageHost.cpp
@@ -65,8 +65,9 @@ Web::CSS::PreferredColorScheme PageHost::preferred_color_scheme() const
     return Web::CSS::PreferredColorScheme::Auto;
 }
 
-void PageHost::paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions)
+NonnullOwnPtr<Web::Painting::RecordingPainter> PageHost::paint(Web::DevicePixelRect const&, Web::PaintOptions)
 {
+    VERIFY_NOT_REACHED();
 }
 
 void PageHost::request_file(Web::FileRequest request)

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -28,7 +28,7 @@ public:
     virtual Web::DevicePixelRect screen_rect() const override;
     virtual double device_pixels_per_css_pixel() const override;
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
-    virtual void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override;
+    virtual NonnullOwnPtr<Web::Painting::RecordingPainter> paint(Web::DevicePixelRect const&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;
 
 private:


### PR DESCRIPTION
With this change, we take advantage of having a serialized list of painting commands that does not have any pointers to DOM/Layout/Paintable tree nodes. Now, when the recorded list of commands is ready, instead of executing it on the main thread, we schedule a task on the rendering thread and let the main thread proceed to work on the next frame.

The following objects had to be modified to fix concurrent access:

- The Gfx::Font object is now AtomicRefCounted because it is stored in painting commands and shared with the main thread.
- The mutable Gfx::Bitmap (used in HTMLCanvasElement) is now cloned into the painting command to avoid concurrent access.

On my computer with CPU painter on https://benchmarks.slaylines.io/dom.html we have 16 fps before and 38 fps after this change.