### PR TITLE
LibWeb: Invalidate paint-only property after relayout

### DIFF
--- a/Tests/LibWeb/Ref/reference/resolve-paint-only-properties-after-layout-ref.html
+++ b/Tests/LibWeb/Ref/reference/resolve-paint-only-properties-after-layout-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/resolve-paint-only-properties-after-layout-ref.html" />
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        border-radius: 50px;
+    }
+</style>
+<div id="box">hello</div>

--- a/Tests/LibWeb/Ref/resolve-paint-only-properties-after-layout.html
+++ b/Tests/LibWeb/Ref/resolve-paint-only-properties-after-layout.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/resolve-paint-only-properties-after-layout-ref.html" />
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        border-radius: 50px;
+    }
+</style>
+<div id="box"></div>
+<script>
+    window.onload = function () {
+        const box = document.getElementById("box");
+        box.innerHTML = 'hello';        
+    };
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1060,8 +1060,10 @@ void Document::update_layout()
     // Broadcast the current viewport rect to any new paintables, so they know whether they're visible or not.
     inform_all_viewport_clients_about_the_current_viewport_rect();
 
-    if (navigable())
+    if (navigable()) {
+        navigable()->set_needs_to_resolve_paint_only_properties();
         navigable()->set_needs_display();
+    }
 
     if (navigable()->is_traversable()) {
         page().client().page_did_layout();


### PR DESCRIPTION
Before this change, `set_needs_to_resolve_paint_only_properties()` was only called after style invalidation. However, since relayout can be triggered independently from style invalidation, we need to ensure that paint-only properties are updated in that case too.