### PR TITLE
Meta: Prevent "serenity.sh gdb" to close other tmux sessions

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -286,9 +286,9 @@ delete_toolchain() {
 }
 
 kill_tmux_session() {
-    local TMUX_SESSION
-    TMUX_SESSION="$(tmux display-message -p '#S')"
-    [ -z "$TMUX_SESSION" ] || tmux kill-session -t "$TMUX_SESSION"
+    if [ -n "$TMUX_SESSION" ]; then
+        tmux has-session -t "$TMUX_SESSION" >/dev/null 2>&1 && tmux kill-session -t "$TMUX_SESSION"
+    fi
 }
 
 set_tmux_title() {
@@ -415,7 +415,9 @@ if [[ "$CMD" =~ ^(build|install|image|copy-src|run|gdb|test|rebuild|recreate|kad
                 build_target
                 build_target install
                 build_image
-                tmux new-session "$ARG0" __tmux_cmd "$TARGET" "$TOOLCHAIN_TYPE" run "${CMD_ARGS[@]}" \; set-option -t 0 mouse on \; split-window "$ARG0" __tmux_cmd "$TARGET" "$TOOLCHAIN_TYPE" gdb "${CMD_ARGS[@]}" \;
+
+                TMUX_SESSION="tmux-serenity-gdb-$(date +%s)"
+                tmux new-session -e "TMUX_SESSION=$TMUX_SESSION" -s "$TMUX_SESSION" "$ARG0" __tmux_cmd "$TARGET" "$TOOLCHAIN_TYPE" run "${CMD_ARGS[@]}" \; set-option -t 0 mouse on \; split-window -e "TMUX_SESSION=$TMUX_SESSION" "$ARG0" __tmux_cmd "$TARGET" "$TOOLCHAIN_TYPE" gdb "${CMD_ARGS[@]}" \;
             fi
             ;;
         test)


### PR DESCRIPTION
`Meta/serenity.sh gdb` will open `tmux` with 2 windows for GDB and emulator's logs. Once debugging is finished it will use `tmux kill-session` command for the current session.

The problem is that if there already is a tmux session it will be closed once `serenity.sh gdb` finishes. This happens due to `trap kill_tmux_session EXIT` is setup twice (for both windows/shells), but `trap` invokes the handler after the shell is exited, so it will kill current tmux session after GDB's shell or emulator's is exited and then, since another shell is also exited `trap` will invoke the handler again, but now for previously opened tmux session.

This PR tries to prevent such a behavior in the following way: `trap` handlers are still setup twice, but the only one of them is able to kill current tmux session, i.e. another one just does some clean up and exits.