### PR TITLE
Everywhere: Prefer `_string` when constructing strings from literals

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -1331,7 +1331,7 @@ URL URLParser::basic_parse(StringView raw_input, Optional<URL> const& base_url, 
         // -> file state, https://url.spec.whatwg.org/#file-state
         case State::File:
             // 1. Set url’s scheme to "file".
-            url->m_scheme = String::from_utf8("file"sv).release_value_but_fixme_should_propagate_errors();
+            url->m_scheme = "file"_string;
 
             // 2. Set url’s host to the empty string.
             url->m_host = String {};

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -299,7 +299,7 @@ static ErrorOr<void> generate_loader_for_object(GUI::GML::Object const& gml_obje
     // Layout
     if (gml_object.layout_object() != nullptr) {
         TRY(append(generator, "RefPtr<GUI::Layout> layout;"));
-        TRY(generate_loader_for_object(*gml_object.layout_object(), generator.fork(), TRY(String::from_utf8("layout"sv)), indentation + 1, UseObjectConstructor::Yes));
+        TRY(generate_loader_for_object(*gml_object.layout_object(), generator.fork(), "layout"_string, indentation + 1, UseObjectConstructor::Yes));
         TRY(append(generator, "@object_name@->set_layout(layout.release_nonnull());"));
         generator.appendln("");
     }
@@ -352,16 +352,16 @@ static ErrorOr<String> generate_cpp(NonnullRefPtr<GUI::GML::GMLFile> gml, Lexica
     auto& main_class = gml->main_class();
     auto necessary_includes = TRY(extract_necessary_includes(main_class, gml_file_name));
     static String const always_necessary_includes[] = {
-        TRY(String::from_utf8("<AK/Error.h>"sv)),
-        TRY(String::from_utf8("<AK/JsonValue.h>"sv)),
-        TRY(String::from_utf8("<AK/NonnullRefPtr.h>"sv)),
-        TRY(String::from_utf8("<AK/RefPtr.h>"sv)),
-        TRY(String::from_utf8("<LibGfx/Font/FontWeight.h>"sv)),
+        "<AK/Error.h>"_string,
+        "<AK/JsonValue.h>"_string,
+        "<AK/NonnullRefPtr.h>"_string,
+        "<AK/RefPtr.h>"_string,
+        "<LibGfx/Font/FontWeight.h>"_string,
         // For Gfx::ColorRole
-        TRY(String::from_utf8("<LibGfx/SystemTheme.h>"sv)),
-        TRY(String::from_utf8("<LibGUI/Widget.h>"sv)),
+        "<LibGfx/SystemTheme.h>"_string,
+        "<LibGUI/Widget.h>"_string,
         // For Gfx::FontWeight
-        TRY(String::from_utf8("<LibGfx/Font/FontDatabase.h>"sv)),
+        "<LibGfx/Font/FontDatabase.h>"_string,
     };
     TRY(necessary_includes.try_set_from(always_necessary_includes));
     for (auto const& include : necessary_includes)

--- a/Tests/LibCrypto/TestChacha20Poly1305.cpp
+++ b/Tests/LibCrypto/TestChacha20Poly1305.cpp
@@ -92,7 +92,7 @@ TEST_CASE(test_keygen_vector_4)
 // https://datatracker.ietf.org/doc/html/rfc8439#section-2.8.2
 TEST_CASE(test_aead_encrypt_1)
 {
-    auto plaintext = MUST(String::from_utf8("Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."sv));
+    auto plaintext = "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."_string;
     u8 aad[12] = { 0x50, 0x51, 0x52, 0x53, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7 };
     u8 key[32] = {
         0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
@@ -192,7 +192,7 @@ TEST_CASE(test_aead_decrypt_1)
 
 TEST_CASE(test_aead_encrypt_and_decrypt)
 {
-    auto plaintext = MUST(String::from_utf8("Well, hello friends :)"sv));
+    auto plaintext = "Well, hello friends :)"_string;
     u8 aad[12] = { 0x50, 0x51, 0x52, 0x53, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7 };
     u8 key[32] = {
         0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,

--- a/Userland/Libraries/LibCore/Version.cpp
+++ b/Userland/Libraries/LibCore/Version.cpp
@@ -20,7 +20,7 @@ ErrorOr<String> read_long_version_string()
 
     return String::formatted("Version {} revision {}", version, git_hash);
 #else
-    return String::from_utf8("Version 1.0"sv);
+    return "Version 1.0"_string;
 #endif
 }
 


### PR DESCRIPTION
Apparently I missed some places this change could have been made in #21078