### PR TITLE
Kernel/riscv64: Implement RISC-V context switching

### DIFF
--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -92,6 +92,11 @@ struct [[gnu::packed]] alignas(u64) SATP {
     {
         return bit_cast<SATP>(CSR::read(CSR::Address::SATP));
     }
+
+    bool operator==(SATP const& other) const
+    {
+        return bit_cast<u64>(*this) == bit_cast<u64>(other);
+    }
 };
 static_assert(AssertSize<SATP, 8>());
 

--- a/Kernel/Arch/riscv64/FPUState.h
+++ b/Kernel/Arch/riscv64/FPUState.h
@@ -16,6 +16,7 @@ namespace Kernel {
 // This struct will get pushed on the stack by the signal handling code.
 // Therefore, it has to be aligned to a 16-byte boundary.
 struct [[gnu::aligned(16)]] FPUState {
+    // FIXME: Add support for the Q extension.
     u64 f[32];
     u64 fcsr;
 };

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -295,7 +295,7 @@ StringView ProcessorBase<T>::platform_string()
 template<typename T>
 void ProcessorBase<T>::set_thread_specific_data(VirtualAddress)
 {
-    TODO_RISCV64();
+    // FIXME: Add support for thread-local storage on RISC-V
 }
 
 template<typename T>

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -17,6 +17,88 @@ namespace Kernel {
 
 Processor* g_current_processor;
 
+static void store_fpu_state(FPUState* fpu_state)
+{
+    asm volatile(
+        "fsd f0, 0*8(%0) \n"
+        "fsd f1, 1*8(%0) \n"
+        "fsd f2, 2*8(%0) \n"
+        "fsd f3, 3*8(%0) \n"
+        "fsd f4, 4*8(%0) \n"
+        "fsd f5, 5*8(%0) \n"
+        "fsd f6, 6*8(%0) \n"
+        "fsd f7, 7*8(%0) \n"
+        "fsd f8, 8*8(%0) \n"
+        "fsd f9, 9*8(%0) \n"
+        "fsd f10, 10*8(%0) \n"
+        "fsd f11, 11*8(%0) \n"
+        "fsd f12, 12*8(%0) \n"
+        "fsd f13, 13*8(%0) \n"
+        "fsd f14, 14*8(%0) \n"
+        "fsd f15, 15*8(%0) \n"
+        "fsd f16, 16*8(%0) \n"
+        "fsd f17, 17*8(%0) \n"
+        "fsd f18, 18*8(%0) \n"
+        "fsd f19, 19*8(%0) \n"
+        "fsd f20, 20*8(%0) \n"
+        "fsd f21, 21*8(%0) \n"
+        "fsd f22, 22*8(%0) \n"
+        "fsd f23, 23*8(%0) \n"
+        "fsd f24, 24*8(%0) \n"
+        "fsd f25, 25*8(%0) \n"
+        "fsd f26, 26*8(%0) \n"
+        "fsd f27, 27*8(%0) \n"
+        "fsd f28, 28*8(%0) \n"
+        "fsd f29, 29*8(%0) \n"
+        "fsd f30, 30*8(%0) \n"
+        "fsd f31, 31*8(%0) \n"
+
+        "csrr t0, fcsr \n"
+        "sd t0, 32*8(%0) \n" ::"r"(fpu_state)
+        : "t0", "memory");
+}
+
+[[maybe_unused]] static void load_fpu_state(FPUState* fpu_state)
+{
+    asm volatile(
+        "fld f0, 0*8(%0) \n"
+        "fld f1, 1*8(%0) \n"
+        "fld f2, 2*8(%0) \n"
+        "fld f3, 3*8(%0) \n"
+        "fld f4, 4*8(%0) \n"
+        "fld f5, 5*8(%0) \n"
+        "fld f6, 6*8(%0) \n"
+        "fld f7, 7*8(%0) \n"
+        "fld f8, 8*8(%0) \n"
+        "fld f9, 9*8(%0) \n"
+        "fld f10, 10*8(%0) \n"
+        "fld f11, 11*8(%0) \n"
+        "fld f12, 12*8(%0) \n"
+        "fld f13, 13*8(%0) \n"
+        "fld f14, 14*8(%0) \n"
+        "fld f15, 15*8(%0) \n"
+        "fld f16, 16*8(%0) \n"
+        "fld f17, 17*8(%0) \n"
+        "fld f18, 18*8(%0) \n"
+        "fld f19, 19*8(%0) \n"
+        "fld f20, 20*8(%0) \n"
+        "fld f21, 21*8(%0) \n"
+        "fld f22, 22*8(%0) \n"
+        "fld f23, 23*8(%0) \n"
+        "fld f24, 24*8(%0) \n"
+        "fld f25, 25*8(%0) \n"
+        "fld f26, 26*8(%0) \n"
+        "fld f27, 27*8(%0) \n"
+        "fld f28, 28*8(%0) \n"
+        "fld f29, 29*8(%0) \n"
+        "fld f30, 30*8(%0) \n"
+        "fld f31, 31*8(%0) \n"
+
+        "ld t0, 32*8(%0) \n"
+        "csrw fcsr, t0 \n" ::"r"(fpu_state)
+        : "t0", "memory");
+}
+
 template<typename T>
 void ProcessorBase<T>::early_initialize(u32 cpu)
 {
@@ -35,6 +117,8 @@ void ProcessorBase<T>::initialize(u32)
     auto sstatus = RISCV64::CSR::SSTATUS::read();
     sstatus.FS = RISCV64::CSR::SSTATUS::FloatingPointStatus::Initial;
     RISCV64::CSR::SSTATUS::write(sstatus);
+
+    store_fpu_state(&s_clean_fpu_state);
 
     initialize_interrupts();
 }

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -330,15 +330,29 @@ void ProcessorBase<T>::switch_context(Thread*& from_thread, Thread*& to_thread)
     dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 }
 
-extern "C" FlatPtr do_init_context(Thread*, u32)
+extern "C" FlatPtr do_init_context(Thread* thread, u32 new_interrupts_state)
 {
-    TODO_RISCV64();
+    VERIFY_INTERRUPTS_DISABLED();
+
+    thread->regs().sstatus.SPIE = (new_interrupts_state == to_underlying(InterruptsState::Enabled));
+
+    return Processor::current().init_context(*thread, true);
 }
 
 template<typename T>
-void ProcessorBase<T>::assume_context(Thread&, InterruptsState)
+void ProcessorBase<T>::assume_context(Thread& thread, InterruptsState new_interrupts_state)
 {
-    TODO_RISCV64();
+    dbgln_if(CONTEXT_SWITCH_DEBUG, "Assume context for thread {} {}", VirtualAddress(&thread), thread);
+
+    VERIFY_INTERRUPTS_DISABLED();
+    Scheduler::prepare_after_exec();
+    // in_critical() should be 2 here. The critical section in Process::exec
+    // and then the scheduler lock
+    VERIFY(Processor::in_critical() == 2);
+
+    do_assume_context(&thread, to_underlying(new_interrupts_state));
+
+    VERIFY_NOT_REACHED();
 }
 
 template<typename T>
@@ -505,7 +519,22 @@ NAKED void thread_context_first_enter()
 
 NAKED void do_assume_context(Thread*, u32)
 {
-    asm("unimp");
+    // clang-format off
+    asm(
+        "mv s1, a0 \n" // save thread ptr
+        // We're going to call Processor::init_context, so just make sure
+        // we have enough stack space so we don't stomp over it
+        "addi sp, sp, -" __STRINGIFY(8 + REGISTER_STATE_SIZE + TRAP_FRAME_SIZE + 8) " \n"
+        "call do_init_context \n"
+        "mv sp, a0 \n"  // move stack pointer to what Processor::init_context set up for us
+        "mv a0, s1 \n" // to_thread
+        "mv a1, s1 \n" // from_thread
+        "addi sp, sp, -32 \n"
+        "sd s1, 0(sp) \n"
+        "sd s1, 8(sp) \n"
+        "la ra, thread_context_first_enter \n" // should be same as regs.sepc
+        "tail enter_thread_context \n");
+    // clang-format on
 }
 
 template<typename T>

--- a/Kernel/Arch/riscv64/trap_handler.S
+++ b/Kernel/Arch/riscv64/trap_handler.S
@@ -90,6 +90,9 @@ asm_trap_handler:
 
     call trap_handler
 
+.global restore_context_and_sret
+restore_context_and_sret:
+
     // Remove TrapFrame from the stack
     addi sp, sp, 16
 
@@ -130,8 +133,6 @@ asm_trap_handler:
     ld x29, 28*8(sp)
     ld x30, 29*8(sp)
     ld x31, 30*8(sp)
-
-    ld x2, 1*8(sp)
 
     addi sp, sp, REGISTER_STATE_SIZE
     sret


### PR DESCRIPTION
I originally wanted to refactor TLS before submitting this PR.
We need to refactor TLS, as we currently expect that every architecture has a thread pointer register for each privilege mode.
I'm going to delay RISC-V TLS until I have the energy to finish refactoring our TLS handling (the only major missing thing is freeing TLS memory after a thread exits).

A lot of this code is quite similar to aarch64.

This PR only adds support for context switching of kernel threads. I will submit my userspace context switching and trap handling support in a future PR.