### PR TITLE
Everywhere: Propagate errors using `TRY()` where possible

### DIFF
--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -92,7 +92,7 @@ ErrorOr<void> Device::setup_queues(u16 requested_queue_count)
     VERIFY(!m_did_setup_queues);
     m_did_setup_queues = true;
 
-    auto* common_cfg = m_transport_entity->get_config(ConfigurationType::Common).release_value_but_fixme_should_propagate_errors();
+    auto* common_cfg = TRY(m_transport_entity->get_config(ConfigurationType::Common));
     if (common_cfg) {
         auto maximum_queue_count = m_transport_entity->config_read16(*common_cfg, COMMON_CFG_NUM_QUEUES);
         if (requested_queue_count == 0) {

--- a/Kernel/Devices/Storage/ATA/AHCI/Controller.cpp
+++ b/Kernel/Devices/Storage/ATA/AHCI/Controller.cpp
@@ -64,7 +64,7 @@ ErrorOr<void> AHCIController::reset()
 
     auto implemented_ports = AHCI::MaskedBitField((u32 volatile&)(hba().control_regs.pi));
     for (auto index : implemented_ports.to_vector()) {
-        auto port = AHCIPort::create(*this, m_hba_capabilities, static_cast<volatile AHCI::PortRegisters&>(hba().port_regs[index]), index).release_value_but_fixme_should_propagate_errors();
+        auto port = TRY(AHCIPort::create(*this, m_hba_capabilities, static_cast<volatile AHCI::PortRegisters&>(hba().port_regs[index]), index));
         m_ports[index] = port;
         port->reset();
     }
@@ -174,7 +174,7 @@ UNMAP_AFTER_INIT ErrorOr<void> AHCIController::initialize_hba(PCI::DeviceIdentif
     enable_global_interrupts();
 
     auto implemented_ports = AHCI::MaskedBitField((u32 volatile&)(hba().control_regs.pi));
-    m_irq_handler = AHCIInterruptHandler::create(*this, irq, implemented_ports).release_value_but_fixme_should_propagate_errors();
+    m_irq_handler = TRY(AHCIInterruptHandler::create(*this, irq, implemented_ports));
     TRY(reset());
 
     dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Version = {:#08x}", device_identifier().address(), version);

--- a/Tests/LibGfx/BenchmarkGfxPainter.cpp
+++ b/Tests/LibGfx/BenchmarkGfxPainter.cpp
@@ -16,7 +16,7 @@ BENCHMARK_CASE(diagonal_lines)
     int const run_count = 50;
     int const bitmap_size = 2000;
 
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { bitmap_size, bitmap_size }).release_value_but_fixme_should_propagate_errors();
+    auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { bitmap_size, bitmap_size }));
     Gfx::Painter painter(bitmap);
 
     for (int run = 0; run < run_count; run++) {
@@ -32,7 +32,7 @@ BENCHMARK_CASE(fill)
     int const run_count = 1000;
     int const bitmap_size = 2000;
 
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { bitmap_size, bitmap_size }).release_value_but_fixme_should_propagate_errors();
+    auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { bitmap_size, bitmap_size }));
     Gfx::Painter painter(bitmap);
 
     for (int run = 0; run < run_count; run++) {
@@ -45,7 +45,7 @@ BENCHMARK_CASE(fill_with_gradient)
     int const run_count = 50;
     int const bitmap_size = 2000;
 
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { bitmap_size, bitmap_size }).release_value_but_fixme_should_propagate_errors();
+    auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { bitmap_size, bitmap_size }));
     Gfx::Painter painter(bitmap);
 
     for (int run = 0; run < run_count; run++) {

--- a/Userland/Applications/Calendar/AddEventWidget.cpp
+++ b/Userland/Applications/Calendar/AddEventWidget.cpp
@@ -26,7 +26,7 @@ ErrorOr<NonnullRefPtr<AddEventWidget>> AddEventWidget::create(AddEventDialog* wi
 
     widget->m_start_date_box = *widget->find_descendant_of_type_named<GUI::TextBox>("start_date");
 
-    auto calendar_date_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/calendar-date.png"sv).release_value_but_fixme_should_propagate_errors();
+    auto calendar_date_icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/calendar-date.png"sv));
 
     auto& pick_start_date_button = *widget->find_descendant_of_type_named<GUI::Button>("pick_start_date");
     pick_start_date_button.set_icon(calendar_date_icon);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -104,7 +104,7 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
         m_directory_statistics_calculator->on_update = [this, origin_event_loop = &Core::EventLoop::current()](off_t total_size_in_bytes, size_t file_count, size_t directory_count) {
             origin_event_loop->deferred_invoke([=, weak_this = make_weak_ptr<PropertiesWindow>()] {
                 if (auto strong_this = weak_this.strong_ref())
-                    strong_this->m_size_label->set_text(String::formatted("{}\n{} files, {} subdirectories", human_readable_size_long(total_size_in_bytes, UseThousandsSeparator::Yes), file_count, directory_count).release_value_but_fixme_should_propagate_errors());
+                    strong_this->m_size_label->set_text(MUST(String::formatted("{}\n{} files, {} subdirectories", human_readable_size_long(total_size_in_bytes, UseThousandsSeparator::Yes), file_count, directory_count)));
             });
         };
         m_directory_statistics_calculator->start();
@@ -195,10 +195,10 @@ ErrorOr<void> PropertiesWindow::create_general_tab(GUI::TabWidget& tab_widget, b
     group->set_text(String::formatted("{} ({})", group_name, st.st_gid).release_value_but_fixme_should_propagate_errors());
 
     auto* created_at = general_tab.find_descendant_of_type_named<GUI::Label>("created_at");
-    created_at->set_text(String::from_byte_string(GUI::FileSystemModel::timestamp_string(st.st_ctime)).release_value_but_fixme_should_propagate_errors());
+    created_at->set_text(MUST(String::from_byte_string(GUI::FileSystemModel::timestamp_string(st.st_ctime))));
 
     auto* last_modified = general_tab.find_descendant_of_type_named<GUI::Label>("last_modified");
-    last_modified->set_text(String::from_byte_string(GUI::FileSystemModel::timestamp_string(st.st_mtime)).release_value_but_fixme_should_propagate_errors());
+    last_modified->set_text(MUST(String::from_byte_string(GUI::FileSystemModel::timestamp_string(st.st_mtime))));
 
     auto* owner_read = general_tab.find_descendant_of_type_named<GUI::CheckBox>("owner_read");
     auto* owner_write = general_tab.find_descendant_of_type_named<GUI::CheckBox>("owner_write");

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -116,7 +116,7 @@ ErrorOr<void> HexEditorWidget::setup()
         m_editor->update();
     };
 
-    m_new_action = GUI::Action::create("New...", { Mod_Ctrl, Key_N }, Gfx::Bitmap::load_from_file("/res/icons/16x16/new.png"sv).release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    m_new_action = GUI::Action::create("New...", { Mod_Ctrl, Key_N }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/new.png"sv)), [this](const GUI::Action&) {
         String value;
         if (request_close() && GUI::InputBox::show(window(), value, "Enter a size:"sv, "New File"sv, GUI::InputType::NonemptyText) == GUI::InputBox::ExecResult::OK) {
             auto file_size = AK::StringUtils::convert_to_uint(value);
@@ -175,7 +175,7 @@ ErrorOr<void> HexEditorWidget::setup()
         dbgln("Wrote document to {}", file.filename());
     });
 
-    m_open_annotations_action = GUI::Action::create("Load Annotations...", Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+    m_open_annotations_action = GUI::Action::create("Load Annotations...", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"sv)), [this](auto&) {
         auto response = FileSystemAccessClient::Client::the().open_file(window(),
             { .window_title = "Load annotations file"sv,
                 .requested_access = Core::File::OpenMode::Read,
@@ -192,7 +192,7 @@ ErrorOr<void> HexEditorWidget::setup()
     });
     m_open_annotations_action->set_status_tip("Load annotations from a file"_string);
 
-    m_save_annotations_action = GUI::Action::create("Save Annotations", Gfx::Bitmap::load_from_file("/res/icons/16x16/save.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+    m_save_annotations_action = GUI::Action::create("Save Annotations", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/save.png"sv)), [&](auto&) {
         if (m_annotations_path.is_empty())
             return m_save_annotations_as_action->activate();
 
@@ -206,7 +206,7 @@ ErrorOr<void> HexEditorWidget::setup()
     });
     m_save_annotations_action->set_status_tip("Save annotations to a file"_string);
 
-    m_save_annotations_as_action = GUI::Action::create("Save Annotations As...", Gfx::Bitmap::load_from_file("/res/icons/16x16/save-as.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+    m_save_annotations_as_action = GUI::Action::create("Save Annotations As...", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/save-as.png"sv)), [&](auto&) {
         auto response = FileSystemAccessClient::Client::the().save_file(window(), m_name, "annotations"sv, Core::File::OpenMode::Write | Core::File::OpenMode::Truncate);
         if (response.is_error())
             return;
@@ -227,7 +227,7 @@ ErrorOr<void> HexEditorWidget::setup()
     });
     m_redo_action->set_enabled(false);
 
-    m_find_action = GUI::Action::create("&Find...", { Mod_Ctrl, Key_F }, Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+    m_find_action = GUI::Action::create("&Find...", { Mod_Ctrl, Key_F }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)), [&](const GUI::Action&) {
         auto old_buffer = m_search_buffer;
         bool find_all = false;
         if (FindDialog::show(window(), m_search_text, m_search_buffer, find_all) == GUI::InputBox::ExecResult::OK) {
@@ -264,7 +264,7 @@ ErrorOr<void> HexEditorWidget::setup()
         }
     });
 
-    m_goto_offset_action = GUI::Action::create("&Go to Offset...", { Mod_Ctrl, Key_G }, Gfx::Bitmap::load_from_file("/res/icons/16x16/go-to.png"sv).release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    m_goto_offset_action = GUI::Action::create("&Go to Offset...", { Mod_Ctrl, Key_G }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/go-to.png"sv)), [this](const GUI::Action&) {
         int new_offset;
         auto result = GoToOffsetDialog::show(
             window(),
@@ -293,17 +293,17 @@ ErrorOr<void> HexEditorWidget::setup()
         Config::write_bool("HexEditor"sv, "Layout"sv, "ShowSearchResults"sv, action.is_checked());
     });
 
-    m_copy_hex_action = GUI::Action::create("Copy &Hex", { Mod_Ctrl, Key_C }, Gfx::Bitmap::load_from_file("/res/icons/16x16/hex.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+    m_copy_hex_action = GUI::Action::create("Copy &Hex", { Mod_Ctrl, Key_C }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/hex.png"sv)), [&](const GUI::Action&) {
         m_editor->copy_selected_hex_to_clipboard();
     });
     m_copy_hex_action->set_enabled(false);
 
-    m_copy_text_action = GUI::Action::create("Copy &Text", { Mod_Ctrl | Mod_Shift, Key_C }, Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+    m_copy_text_action = GUI::Action::create("Copy &Text", { Mod_Ctrl | Mod_Shift, Key_C }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"sv)), [&](const GUI::Action&) {
         m_editor->copy_selected_text_to_clipboard();
     });
     m_copy_text_action->set_enabled(false);
 
-    m_copy_as_c_code_action = GUI::Action::create("Copy as &C Code", { Mod_Alt | Mod_Shift, Key_C }, Gfx::Bitmap::load_from_file("/res/icons/16x16/c.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+    m_copy_as_c_code_action = GUI::Action::create("Copy as &C Code", { Mod_Alt | Mod_Shift, Key_C }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/c.png"sv)), [&](const GUI::Action&) {
         m_editor->copy_selected_hex_to_clipboard_as_c_code();
     });
     m_copy_as_c_code_action->set_enabled(false);
@@ -519,7 +519,7 @@ ErrorOr<void> HexEditorWidget::initialize_menubar(GUI::Window& window)
     edit_menu->add_separator();
     edit_menu->add_action(GUI::Action::create(
         "Add Annotation",
-        Gfx::Bitmap::load_from_file("/res/icons/16x16/annotation-add.png"sv).release_value_but_fixme_should_propagate_errors(),
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/annotation-add.png"sv)),
         [this](GUI::Action&) { m_editor->show_create_annotation_dialog(); },
         this));
     edit_menu->add_separator();

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -160,7 +160,7 @@ ErrorOr<bool> MailWidget::connect_and_login()
 
     auto& list_items = response.data().list_items();
 
-    m_statusbar->set_text(String::formatted("Loaded {} mailboxes", list_items.size()).release_value_but_fixme_should_propagate_errors());
+    m_statusbar->set_text(MUST(String::formatted("Loaded {} mailboxes", list_items.size())));
 
     m_account_holder = AccountHolder::create();
     m_account_holder->add_account_with_name_and_mailboxes(username, move(list_items));

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -30,7 +30,7 @@
 namespace TerminalSettings {
 ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::create()
 {
-    auto widget = MainWidget::try_create().release_value_but_fixme_should_propagate_errors();
+    auto widget = TRY(MainWidget::try_create());
     TRY(widget->setup());
     return widget;
 }

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -46,8 +46,8 @@ ErrorOr<void> GalleryWidget::load_basic_model_tab()
     m_add_new_item = *tab.find_descendant_of_type_named<GUI::Button>("add_new_item");
     m_remove_selected_item = *tab.find_descendant_of_type_named<GUI::Button>("remove_selected_item");
 
-    m_add_new_item->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/plus.png"sv).release_value_but_fixme_should_propagate_errors());
-    m_remove_selected_item->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/minus.png"sv).release_value_but_fixme_should_propagate_errors());
+    m_add_new_item->set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/plus.png"sv)));
+    m_remove_selected_item->set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/minus.png"sv)));
 
     m_new_item_name->on_return_pressed = [&] { add_textbox_contents_to_basic_model(); };
     m_add_new_item->on_click = [&](auto) { add_textbox_contents_to_basic_model(); };

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -172,12 +172,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         update_source_model();
     };
 
-    auto disassembly_action = GUI::Action::create_checkable("Show &Disassembly", { Mod_Ctrl, Key_D }, Gfx::Bitmap::load_from_file("/res/icons/16x16/x86.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto& action) {
+    auto disassembly_action = GUI::Action::create_checkable("Show &Disassembly", { Mod_Ctrl, Key_D }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/x86.png"sv)), [&](auto& action) {
         disassembly_view.set_visible(action.is_checked());
         update_disassembly_model();
     });
 
-    auto source_action = GUI::Action::create_checkable("Show &Source", { Mod_Ctrl, Key_S }, Gfx::Bitmap::load_from_file("/res/icons/16x16/x86.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto& action) {
+    auto source_action = GUI::Action::create_checkable("Show &Source", { Mod_Ctrl, Key_S }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/x86.png"sv)), [&](auto& action) {
         source_view.set_visible(action.is_checked());
         update_source_model();
     });

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -37,14 +37,14 @@ struct Proxy {
     ErrorOr<NonnullOwnPtr<StorageType>> tunnel(URL const& url, Args&&... args)
     {
         if (data.type == Core::ProxyData::Direct) {
-            return TRY(SocketType::connect(url.serialized_host().release_value_but_fixme_should_propagate_errors().to_byte_string(), url.port_or_default(), forward<Args>(args)...));
+            return TRY(SocketType::connect(TRY(url.serialized_host()).to_byte_string(), url.port_or_default(), forward<Args>(args)...));
         }
         if (data.type == Core::ProxyData::SOCKS5) {
             if constexpr (requires { SocketType::connect(declval<ByteString>(), *proxy_client_storage, forward<Args>(args)...); }) {
-                proxy_client_storage = TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, url.serialized_host().release_value_but_fixme_should_propagate_errors().to_byte_string(), url.port_or_default()));
-                return TRY(SocketType::connect(url.serialized_host().release_value_but_fixme_should_propagate_errors().to_byte_string(), *proxy_client_storage, forward<Args>(args)...));
+                proxy_client_storage = TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, TRY(url.serialized_host()).to_byte_string(), url.port_or_default()));
+                return TRY(SocketType::connect(TRY(url.serialized_host()).to_byte_string(), *proxy_client_storage, forward<Args>(args)...));
             } else if constexpr (IsSame<SocketType, Core::TCPSocket>) {
-                return TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, url.serialized_host().release_value_but_fixme_should_propagate_errors().to_byte_string(), url.port_or_default()));
+                return TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, TRY(url.serialized_host()).to_byte_string(), url.port_or_default()));
             } else {
                 return Error::from_string_literal("SOCKS5 not supported for this socket type");
             }


### PR DESCRIPTION
This PR replaces calls to `release_value_but_fixme_should_propagate_errors()` with `TRY()` where it is trivial to do so. 

