### PR TITLE
Meta: Fix script_path calculation when CDPATH is set

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 . "${script_path}/shell_include.sh"
 

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 . "${script_path}/shell_include.sh"
 

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 . "${script_path}/shell_include.sh"
 

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -173,7 +173,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 "$script_path/build-root-filesystem.sh"
 
 if [ $use_genext2fs = 1 ]; then

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -3,7 +3,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 
 export LC_ALL=C  # Make the directory order reproducible

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 . "${script_path}/shell_include.sh"
 

--- a/Meta/check-ak-test-files.sh
+++ b/Meta/check-ak-test-files.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 
 MISSING_FILES=n

--- a/Meta/check-debug-flags.sh
+++ b/Meta/check-debug-flags.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 
 MISSING_FLAGS=n

--- a/Meta/check-markdown.sh
+++ b/Meta/check-markdown.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 
 if [ -z "${MARKDOWN_CHECK_BINARY:-}" ] ; then

--- a/Meta/check-png-sizes.sh
+++ b/Meta/check-png-sizes.sh
@@ -5,7 +5,8 @@ set -eo pipefail
 # How many bytes optipng has to be able to strip out of the file for the optimization to be worth it. The default is 1 KiB.
 : "${MINIMUM_OPTIMIZATION_BYTES:=1024}"
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 
 if ! command -v optipng >/dev/null ; then

--- a/Meta/check-symbols.sh
+++ b/Meta/check-symbols.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "$script_path/.." || exit 1
 
 # The __cxa_guard_* calls are generated for (non trivial) initialization of local static objects.

--- a/Meta/export-argsparser-manpages.sh
+++ b/Meta/export-argsparser-manpages.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 
 if ! command -v tar >/dev/null 2>&1 ; then

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.." || exit 1
 
 ports=true

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "1" ]; then

--- a/Meta/lint-executable-resources.sh
+++ b/Meta/lint-executable-resources.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "$script_path/.."
 
 if [ "$(uname -s)" = "Darwin" ]; then

--- a/Meta/lint-gml-format.sh
+++ b/Meta/lint-gml-format.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.." || exit 1
 
 if [ -z "${GML_FORMAT:-}" ] ; then

--- a/Meta/lint-gn.sh
+++ b/Meta/lint-gn.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then

--- a/Meta/lint-python.sh
+++ b/Meta/lint-python.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+unset CDPATH
+script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "$script_path/.."
 
 if [ "$#" -eq "0" ]; then

--- a/Meta/new-project.sh
+++ b/Meta/new-project.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+unset CDPATH
 script_path="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 cd "${script_path}/.."
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -77,6 +77,7 @@ if [ "$CMD" = "help" ]; then
     exit 0
 fi
 
+unset CDPATH
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
The script_path variable is using a combination of `cd` and `pwd` to get the directory the script invoked lives in. This fails if the user has set the `CDPATH`.

The `CDPATH` allows users to configure a suite of paths to search for targets if there is no match in the current working directory. When the `CDPATH` variable is set, the shell will print the directory changed to. This is getting incorrectly concatenated with the output of the `pwd` leading to an unexpected value for the `script_path` variable.