### PR TITLE
HexEditor: Prefer ErrorOr to Result in FindDialog

### DIFF
--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -24,8 +24,8 @@ struct Option {
 
 static constexpr Array<Option, 2> options = {
     {
-        { "ASCII String"sv, OPTION_ASCII_STRING, true, true },
-        { "Hex value"sv, OPTION_HEX_VALUE, true, false },
+        { "ASCII String"sv, OptionId::AsciiString, true, true },
+        { "Hex value"sv, OptionId::HexValue, true, false },
     }
 };
 
@@ -77,9 +77,9 @@ ErrorOr<ByteBuffer> FindDialog::process_input(StringView text_value, OptionId op
     VERIFY(!text_value.is_empty());
 
     switch (opt) {
-    case OPTION_ASCII_STRING:
+    case OptionId::AsciiString:
         return ByteBuffer::copy(text_value.bytes());
-    case OPTION_HEX_VALUE: {
+    case OptionId::HexValue: {
         auto text_no_spaces = text_value.replace(" "sv, ""sv, ReplaceMode::All);
         return decode_hex(text_no_spaces);
     }

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -21,7 +21,7 @@ class FindDialog : public GUI::Dialog {
     C_OBJECT_ABSTRACT(FindDialog);
 
 public:
-    static ExecResult show(GUI::Window* parent_window, String& out_tex, ByteBuffer& out_buffer, bool& find_all);
+    static ExecResult show(GUI::Window* parent_window, String& out_text, ByteBuffer& out_buffer, bool& find_all);
     static ErrorOr<NonnullRefPtr<FindDialog>> try_create();
 
 private:

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -11,10 +11,10 @@
 #include <AK/String.h>
 #include <LibGUI/Dialog.h>
 
-enum OptionId {
-    OPTION_INVALID = -1,
-    OPTION_ASCII_STRING,
-    OPTION_HEX_VALUE
+enum class OptionId {
+    Invalid = -1,
+    AsciiString,
+    HexValue
 };
 
 class FindDialog : public GUI::Dialog {
@@ -41,5 +41,5 @@ private:
 
     bool m_find_all { false };
     String m_text_value;
-    OptionId m_selected_option { OPTION_INVALID };
+    OptionId m_selected_option { OptionId::Invalid };
 };

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -25,7 +25,7 @@ public:
     static ErrorOr<NonnullRefPtr<FindDialog>> try_create();
 
 private:
-    Result<ByteBuffer, String> process_input(String text_value, OptionId opt);
+    static ErrorOr<ByteBuffer> process_input(StringView text_value, OptionId opt);
 
     String text_value() const { return m_text_value; }
     OptionId selected_option() const { return m_selected_option; }


### PR DESCRIPTION
This PR ensures that errors are propagated from the HexEditor find dialog.

I also included a commit to change the `OptionId` enum to match our current code style.