### PR TITLE
LibGfx/OpenType: Reject fonts we can't render glyphs from earlier

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -55,6 +55,9 @@ public:
             , m_encoding_id(encoding_id)
         {
         }
+
+        ErrorOr<void> validate_format_can_be_read() const;
+
         // Returns 0 if glyph not found. This corresponds to the "missing glyph"
         u32 glyph_id_for_code_point(u32 code_point) const;
         Optional<Platform> platform_id() const;
@@ -107,6 +110,7 @@ public:
     u32 num_subtables() const;
     Optional<Subtable> subtable(u32 index) const;
     void set_active_index(u32 index) { m_active_index = index; }
+    ErrorOr<void> validate_active_cmap_format() const;
     // Returns 0 if glyph not found. This corresponds to the "missing glyph"
     u32 glyph_id_for_code_point(u32 code_point) const;
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -264,6 +264,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
     }
     if (!active_cmap_index.has_value())
         return Error::from_string_literal("No suitable cmap subtable found");
+    TRY(cmap.subtable(active_cmap_index.value()).value().validate_format_can_be_read());
     cmap.set_active_index(active_cmap_index.value());
 
     return adopt_ref(*new Font(


### PR DESCRIPTION
Make them emit an error instead of silently drawing missing glyph boxes.