### PR TITLE
LibWeb: Properly round CSSPixels values in device_to_css_rect

### DIFF
--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -120,10 +120,10 @@ CSSPixelRect Page::device_to_css_rect(DevicePixelRect rect) const
 {
     auto scale = client().device_pixels_per_css_pixel();
     return {
-        rect.x().value() / scale,
-        rect.y().value() / scale,
-        rect.width().value() / scale,
-        rect.height().value() / scale
+        CSSPixels::nearest_value_for(rect.x().value() / scale),
+        CSSPixels::nearest_value_for(rect.y().value() / scale),
+        CSSPixels::floored_value_for(rect.width().value() / scale),
+        CSSPixels::floored_value_for(rect.height().value() / scale),
     };
 }
 

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -98,6 +98,15 @@ public:
         return from_raw(raw_value);
     }
 
+    template<FloatingPoint F>
+    static CSSPixels floored_value_for(F value)
+    {
+        i32 raw_value = 0;
+        if (!isnan(value))
+            raw_value = AK::clamp_to<int>(floor(value * fixed_point_denominator));
+        return from_raw(raw_value);
+    }
+
     template<Unsigned U>
     constexpr CSSPixels(U value)
     {


### PR DESCRIPTION
Ceiling width or height of a chrome viewport (this function is only used when a chrome notifies LibWeb about a new viewport size) is never correct. If we do that, PageClient::page_did_layout will set content size to be 1 larger than an actual physical width or height respectively (it always ceils) and thus a spurious scrollbar will appear.

This prevents occasional scrollbar flickering in Ladybird/Qt on Wayland with fractional scaling enabled on compositors supporting wp-fractional-scale-v1.

This in a way "fixes up" #22957.