### PR TITLE
LibPDF: Fix small bug from #21452

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -763,7 +763,7 @@ PDFErrorOr<Vector<DeprecatedFlyString>> CFF::parse_charset(Reader&& reader, size
         while (names.size() < glyph_count - 1) {
             // CFF spec, "Table 21 Range2 Format"
             auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
-            int left = TRY(reader.try_read<Card16>());
+            int left = TRY(reader.try_read<BigEndian<Card16>>());
             for (SID sid = first_sid; left >= 0 && names.size() < glyph_count - 1; left--, sid++)
                 TRY(names.try_append(resolve_sid(sid, strings)));
         }


### PR DESCRIPTION
I implemented CFF charset format 2 in 6f783929dd0 with the note "I haven't seen this being used in the wild". Now that I have seen it (0000658.pdf), I can say that this has never worked, despite me claiming "it's easy to implement".

But now it works!

---

Making fonts show up in 0000658.pdf needs a bunch of other changes too. I have those locally, but they aren't upstream yet. But this can land independently :)