### PR TITLE
LibWeb: Update the cursor position when an editable element is clicked

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -405,12 +405,14 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen
                     }
                 }
 
-                // If we didn't focus anything, place the document text cursor at the mouse position.
-                // FIXME: This is all rather strange. Find a better solution.
                 if (!did_focus_something) {
                     if (auto* focused_element = document->focused_element())
                         HTML::run_unfocusing_steps(focused_element);
+                }
 
+                // If we didn't focus anything, place the document text cursor at the mouse position.
+                // FIXME: This is all rather strange. Find a better solution.
+                if (!did_focus_something || paintable->dom_node()->is_editable()) {
                     auto& realm = document->realm();
                     m_browsing_context->set_cursor_position(DOM::Position::create(realm, *paintable->dom_node(), result->index_in_node));
                     if (auto selection = document->get_selection()) {


### PR DESCRIPTION
With this change, clicking on an editable element, such as an `input` or `textarea` causes the cursor position to be updated to the current mouse position.

The behavior of the cursor still isn't perfect. It has a tendency to jump around unexpectedly if you drag at all when clicking. Dragging to create a selection also isn't currently working as expected.

Before:

https://github.com/SerenityOS/serenity/assets/2817754/9d60baff-0157-4778-a50a-ce8d37a4e7e5


After:

https://github.com/SerenityOS/serenity/assets/2817754/eb691e49-b690-4316-af89-ada3d5d36e11

