### PR TITLE
Revert "LibPDF: Don't over-read in charset formats 1 and 2"

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -756,7 +756,7 @@ PDFErrorOr<Vector<CFF::SID>> CFF::parse_charset(Reader&& reader, size_t glyph_co
             // CFF spec, "Table 19 Range1 Format (Charset)"
             auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
             int left = TRY(reader.try_read<Card8>());
-            for (SID sid = first_sid; left >= 0 && names.size() < glyph_count - 1; left--, sid++)
+            for (SID sid = first_sid; left >= 0; left--, sid++)
                 TRY(names.try_append(sid));
         }
     } else if (format == 2) {
@@ -767,7 +767,7 @@ PDFErrorOr<Vector<CFF::SID>> CFF::parse_charset(Reader&& reader, size_t glyph_co
             // CFF spec, "Table 21 Range2 Format"
             auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
             int left = TRY(reader.try_read<BigEndian<Card16>>());
-            for (SID sid = first_sid; left >= 0 && names.size() < glyph_count - 1; left--, sid++)
+            for (SID sid = first_sid; left >= 0; left--, sid++)
                 TRY(names.try_append(sid));
         }
     } else {


### PR DESCRIPTION
This reverts commit 52afa936c48f62df8a9b7fec0e78fa75d55407ec.

No longer necessary after #23122 -- turns out things work better when you do them right.

No behavior change.