### PR TITLE
LibPDF: Make CFF::parse_charset() return SIDs 

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -249,26 +249,26 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
     }
 
     // CFF spec, "Table 22 Charset ID"
-    Vector<DeprecatedFlyString> charset;
+    Vector<DeprecatedFlyString> charset_names;
     switch (charset_offset) {
     case 0:
         dbgln_if(CFF_DEBUG, "CFF predefined charset ISOAdobe");
         // CFF spec, "Appendix C Predefined Charsets, ISOAdobe"
         for (SID sid = 1; sid <= 228; sid++)
-            TRY(charset.try_append(resolve_sid(sid, strings)));
+            TRY(charset_names.try_append(resolve_sid(sid, strings)));
         break;
     case 1:
         dbgln_if(CFF_DEBUG, "CFF predefined charset Expert");
         for (SID sid : s_predefined_charset_expert)
-            TRY(charset.try_append(resolve_sid(sid, strings)));
+            TRY(charset_names.try_append(resolve_sid(sid, strings)));
         break;
     case 2:
         dbgln_if(CFF_DEBUG, "CFF predefined charset Expert Subset");
         for (SID sid : s_predefined_charset_expert_subset)
-            TRY(charset.try_append(resolve_sid(sid, strings)));
+            TRY(charset_names.try_append(resolve_sid(sid, strings)));
         break;
     default:
-        charset = TRY(parse_charset(Reader { cff_bytes.slice(charset_offset) }, glyphs.size(), strings));
+        charset_names = TRY(parse_charset(Reader { cff_bytes.slice(charset_offset) }, glyphs.size(), strings));
         break;
     }
 
@@ -285,7 +285,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
             TRY(cff->add_glyph(0, move(glyphs[0])));
             continue;
         }
-        auto const& name = charset[i - 1];
+        auto const& name = charset_names[i - 1];
         TRY(cff->add_glyph(name, move(glyphs[i])));
     }
     cff->consolidate_glyphs();
@@ -302,10 +302,10 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                 encoding->set(0, ".notdef");
                 continue;
             }
-            if (i >= encoding_codes.size() || i >= charset.size())
+            if (i >= encoding_codes.size() || i >= charset_names.size())
                 break;
             auto code = encoding_codes[i - 1];
-            auto char_name = charset[i - 1];
+            auto char_name = charset_names[i - 1];
             encoding->set(code, char_name);
         }
         for (auto const& entry : encoding_supplemental)

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -97,7 +97,7 @@ public:
     static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
 
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
-    static PDFErrorOr<Vector<DeprecatedFlyString>> parse_charset(Reader&&, size_t, Vector<StringView> const&);
+    static PDFErrorOr<Vector<SID>> parse_charset(Reader&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_encoding(Reader&&, HashMap<Card8, SID>& supplemental);
 };
 


### PR DESCRIPTION
...and do string expansion at the call site.

CID-keyed fonts treat the charset as CIDs instead of as SIDs,
so having access to the SIDs in numberic form will be useful
when we implement support for CID-keyed CFF fonts.

No behavior change.