### PR TITLE
AK: Add to_array()

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -162,9 +162,24 @@ constexpr auto iota_array(T const offset = {})
     return Detail::integer_sequence_generate_array<T>(offset, MakeIntegerSequence<T, N>());
 }
 
+namespace Detail {
+template<typename T, size_t N, size_t... Is>
+constexpr auto to_array_impl(T (&&a)[N], IndexSequence<Is...>) -> Array<T, sizeof...(Is)>
+{
+    return { { a[Is]... } };
+}
+}
+
+template<typename T, size_t N>
+constexpr auto to_array(T (&&a)[N])
+{
+    return Detail::to_array_impl(move(a), MakeIndexSequence<N>());
+}
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::Array;
 using AK::iota_array;
+using AK::to_array;
 #endif

--- a/AK/Array.h
+++ b/AK/Array.h
@@ -156,7 +156,7 @@ constexpr auto integer_sequence_generate_array([[maybe_unused]] T const offset, 
 }
 
 template<typename T, T N>
-constexpr static auto iota_array(T const offset = {})
+constexpr auto iota_array(T const offset = {})
 {
     static_assert(N >= T {}, "Negative sizes not allowed in iota_array()");
     return Detail::integer_sequence_generate_array<T>(offset, MakeIntegerSequence<T, N>());

--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/BitCast.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -8,6 +8,7 @@
 
 #include <AK/DefaultDelete.h>
 #include <AK/SinglyLinkedListSizePolicy.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/Platform.h>
+#include <AK/Types.h>
 
 namespace AK::Detail {
 
@@ -175,19 +176,6 @@ inline constexpr bool IsSame = false;
 template<typename T>
 inline constexpr bool IsSame<T, T> = true;
 
-template<bool condition, class TrueType, class FalseType>
-struct __Conditional {
-    using Type = TrueType;
-};
-
-template<class TrueType, class FalseType>
-struct __Conditional<false, TrueType, FalseType> {
-    using Type = FalseType;
-};
-
-template<bool condition, class TrueType, class FalseType>
-using Conditional = typename __Conditional<condition, TrueType, FalseType>::Type;
-
 template<typename T>
 inline constexpr bool IsNullPointer = IsSame<decltype(nullptr), RemoveCV<T>>;
 
@@ -283,64 +271,6 @@ struct __MakeUnsigned<wchar_t> {
 
 template<typename T>
 using MakeUnsigned = typename __MakeUnsigned<T>::Type;
-
-template<typename T>
-struct __MakeSigned {
-    using Type = void;
-};
-template<>
-struct __MakeSigned<signed char> {
-    using Type = signed char;
-};
-template<>
-struct __MakeSigned<short> {
-    using Type = short;
-};
-template<>
-struct __MakeSigned<int> {
-    using Type = int;
-};
-template<>
-struct __MakeSigned<long> {
-    using Type = long;
-};
-template<>
-struct __MakeSigned<long long> {
-    using Type = long long;
-};
-template<>
-struct __MakeSigned<unsigned char> {
-    using Type = char;
-};
-template<>
-struct __MakeSigned<unsigned short> {
-    using Type = short;
-};
-template<>
-struct __MakeSigned<unsigned int> {
-    using Type = int;
-};
-template<>
-struct __MakeSigned<unsigned long> {
-    using Type = long;
-};
-template<>
-struct __MakeSigned<unsigned long long> {
-    using Type = long long;
-};
-template<>
-struct __MakeSigned<char> {
-    using Type = char;
-};
-#if ARCH(AARCH64)
-template<>
-struct __MakeSigned<wchar_t> {
-    using Type = void;
-};
-#endif
-
-template<typename T>
-using MakeSigned = typename __MakeSigned<T>::Type;
 
 template<typename T>
 auto declval() -> T;
@@ -451,8 +381,8 @@ struct IntegerSequence {
     static constexpr unsigned size() noexcept { return sizeof...(Ts); }
 };
 
-template<unsigned... Indices>
-using IndexSequence = IntegerSequence<unsigned, Indices...>;
+template<size_t... Indices>
+using IndexSequence = IntegerSequence<size_t, Indices...>;
 
 #if __has_builtin(__make_integer_seq)
 template<typename T, T N>
@@ -474,8 +404,8 @@ template<typename T, T N>
 using MakeIntegerSequence = decltype(make_integer_sequence_impl<T, N>());
 #endif
 
-template<unsigned N>
-using MakeIndexSequence = MakeIntegerSequence<unsigned, N>;
+template<size_t N>
+using MakeIndexSequence = MakeIntegerSequence<size_t, N>;
 
 template<typename T>
 struct __IdentityType {

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -41,14 +41,14 @@ struct Tuple<T> {
         return const_cast<Tuple<T>&>(*this).get<U>();
     }
 
-    template<typename U, unsigned index>
+    template<typename U, size_t index>
     U& get_with_index()
     {
         static_assert(IsSame<T, U> && index == 0, "Invalid tuple access");
         return value;
     }
 
-    template<typename U, unsigned index>
+    template<typename U, size_t index>
     U const& get_with_index() const
     {
         return const_cast<Tuple<T>&>(*this).get_with_index<U, index>();
@@ -89,7 +89,7 @@ struct Tuple<T, TRest...> : Tuple<TRest...> {
         return const_cast<Tuple<T, TRest...>&>(*this).get<U>();
     }
 
-    template<typename U, unsigned index>
+    template<typename U, size_t index>
     U& get_with_index()
     {
         if constexpr (IsSame<T, U> && index == 0)
@@ -98,7 +98,7 @@ struct Tuple<T, TRest...> : Tuple<TRest...> {
             return Tuple<TRest...>::template get_with_index<U, index - 1>();
     }
 
-    template<typename U, unsigned index>
+    template<typename U, size_t index>
     U const& get_with_index() const
     {
         return const_cast<Tuple<T, TRest...>&>(*this).get_with_index<U, index>();
@@ -146,7 +146,7 @@ struct Tuple : Detail::Tuple<Ts...> {
         return Detail::Tuple<Ts...>::template get<T>();
     }
 
-    template<unsigned index>
+    template<size_t index>
     auto& get()
     {
         return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
@@ -158,7 +158,7 @@ struct Tuple : Detail::Tuple<Ts...> {
         return Detail::Tuple<Ts...>::template get<T>();
     }
 
-    template<unsigned index>
+    template<size_t index>
     auto& get() const
     {
         return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
@@ -179,37 +179,37 @@ struct Tuple : Detail::Tuple<Ts...> {
     static constexpr auto size() { return sizeof...(Ts); }
 
 private:
-    template<unsigned... Is>
+    template<size_t... Is>
     Tuple(Tuple&& other, IndexSequence<Is...>)
         : Detail::Tuple<Ts...>(move(other.get<Is>())...)
     {
     }
 
-    template<unsigned... Is>
+    template<size_t... Is>
     Tuple(Tuple const& other, IndexSequence<Is...>)
         : Detail::Tuple<Ts...>(other.get<Is>()...)
     {
     }
 
-    template<unsigned... Is>
+    template<size_t... Is>
     void set(Tuple&& other, IndexSequence<Is...>)
     {
         ((get<Is>() = move(other.get<Is>())), ...);
     }
 
-    template<unsigned... Is>
+    template<size_t... Is>
     void set(Tuple const& other, IndexSequence<Is...>)
     {
         ((get<Is>() = other.get<Is>()), ...);
     }
 
-    template<typename F, unsigned... Is>
+    template<typename F, size_t... Is>
     auto apply_as_args(F&& f, IndexSequence<Is...>)
     {
         return forward<F>(f)(get<Is>()...);
     }
 
-    template<typename F, unsigned... Is>
+    template<typename F, size_t... Is>
     auto apply_as_args(F&& f, IndexSequence<Is...>) const
     {
         return forward<F>(f)(get<Is>()...);

--- a/AK/TypeList.h
+++ b/AK/TypeList.h
@@ -46,7 +46,7 @@ struct TypeWrapper {
     using Type = T;
 };
 
-template<typename List, typename F, unsigned... Indices>
+template<typename List, typename F, size_t... Indices>
 constexpr void for_each_type_impl(F&& f, IndexSequence<Indices...>)
 {
     (forward<F>(f)(TypeWrapper<typename List::template Type<Indices>> {}), ...);
@@ -58,7 +58,7 @@ constexpr void for_each_type(F&& f)
     for_each_type_impl<List>(forward<F>(f), MakeIndexSequence<List::size> {});
 }
 
-template<typename ListA, typename ListB, typename F, unsigned... Indices>
+template<typename ListA, typename ListB, typename F, size_t... Indices>
 constexpr void for_each_type_zipped_impl(F&& f, IndexSequence<Indices...>)
 {
     (forward<F>(f)(TypeWrapper<typename ListA::template Type<Indices>> {}, TypeWrapper<typename ListB::template Type<Indices>> {}), ...);

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Platform.h>
-#include <AK/StdLibExtras.h>
 
 using u64 = __UINT64_TYPE__;
 using u32 = __UINT32_TYPE__;
@@ -33,6 +32,85 @@ using f80 = long double;
 using f128 = long double;
 #    endif
 #endif
+
+namespace AK::Detail {
+
+// MakeSigned<> is here instead of in StdLibExtras.h because it's used in the definition of size_t and ssize_t
+// and Types.h must not include StdLibExtras.h to avoid circular dependencies.
+template<typename T>
+struct __MakeSigned {
+    using Type = void;
+};
+template<>
+struct __MakeSigned<signed char> {
+    using Type = signed char;
+};
+template<>
+struct __MakeSigned<short> {
+    using Type = short;
+};
+template<>
+struct __MakeSigned<int> {
+    using Type = int;
+};
+template<>
+struct __MakeSigned<long> {
+    using Type = long;
+};
+template<>
+struct __MakeSigned<long long> {
+    using Type = long long;
+};
+template<>
+struct __MakeSigned<unsigned char> {
+    using Type = char;
+};
+template<>
+struct __MakeSigned<unsigned short> {
+    using Type = short;
+};
+template<>
+struct __MakeSigned<unsigned int> {
+    using Type = int;
+};
+template<>
+struct __MakeSigned<unsigned long> {
+    using Type = long;
+};
+template<>
+struct __MakeSigned<unsigned long long> {
+    using Type = long long;
+};
+template<>
+struct __MakeSigned<char> {
+    using Type = char;
+};
+#if ARCH(AARCH64)
+template<>
+struct __MakeSigned<wchar_t> {
+    using Type = void;
+};
+#endif
+
+template<typename T>
+using MakeSigned = typename __MakeSigned<T>::Type;
+
+// Conditional<> is here instead of in StdLibExtras.h because it's used in the definition of FlatPtr
+// and Types.h must not include StdLibExtras.h to avoid circular dependencies.
+template<bool condition, class TrueType, class FalseType>
+struct __Conditional {
+    using Type = TrueType;
+};
+
+template<class TrueType, class FalseType>
+struct __Conditional<false, TrueType, FalseType> {
+    using Type = FalseType;
+};
+
+template<bool condition, class TrueType, class FalseType>
+using Conditional = typename __Conditional<condition, TrueType, FalseType>::Type;
+
+}
 
 #ifdef AK_OS_SERENITY
 

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -182,14 +182,14 @@ inline constexpr bool IsTypeInPack<T, ParameterPack<Ts...>> = (IsSame<T, Ts> || 
 template<typename T, typename... Qs>
 using BlankIfDuplicate = Conditional<(IsTypeInPack<T, Qs> || ...), Blank<T>, T>;
 
-template<unsigned I, typename...>
+template<size_t I, typename...>
 struct InheritFromUniqueEntries;
 
 // InheritFromUniqueEntries will inherit from both Qs and Ts, but only scan entries going *forwards*
 // that is to say, if it's scanning from index I in Qs, it won't scan for duplicates for entries before I
 // as that has already been checked before.
 // This makes sure that the search is linear in time (like the 'merge' step of merge sort).
-template<unsigned I, typename... Ts, unsigned... Js, typename... Qs>
+template<size_t I, typename... Ts, size_t... Js, typename... Qs>
 struct InheritFromUniqueEntries<I, ParameterPack<Ts...>, IndexSequence<Js...>, Qs...>
     : public BlankIfDuplicate<Ts, Conditional<Js <= I, ParameterPack<>, Qs>...>... {
 
@@ -201,7 +201,7 @@ struct InheritFromPacks;
 
 // InheritFromPacks will attempt to 'merge' the pack 'Ps' with *itself*, but skip the duplicate entries
 // (via InheritFromUniqueEntries).
-template<unsigned... Is, typename... Ps>
+template<size_t... Is, typename... Ps>
 struct InheritFromPacks<IndexSequence<Is...>, Ps...>
     : public InheritFromUniqueEntries<Is, Ps, IndexSequence<Is...>, Ps...>... {
 

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <AK/Userspace.h>
 #include <Kernel/API/POSIX/sched.h>

--- a/Kernel/Arch/aarch64/PageDirectory.h
+++ b/Kernel/Arch/aarch64/PageDirectory.h
@@ -12,6 +12,7 @@
 #include <AK/HashMap.h>
 #include <AK/IntrusiveRedBlackTree.h>
 #include <AK/RefPtr.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/Spinlock.h>

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -11,6 +11,8 @@
 #include <Kernel/Security/ExecutionMode.h>
 
 #include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
+
 VALIDATE_IS_AARCH64()
 
 namespace Kernel {

--- a/Kernel/Arch/aarch64/TrapFrame.h
+++ b/Kernel/Arch/aarch64/TrapFrame.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/RegisterState.h>
 

--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -8,6 +8,7 @@
 
 #include <AK/BitCast.h>
 #include <AK/Format.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 #include <AK/Platform.h>

--- a/Kernel/Arch/riscv64/RegisterState.h
+++ b/Kernel/Arch/riscv64/RegisterState.h
@@ -12,6 +12,8 @@
 #include <Kernel/Security/ExecutionMode.h>
 
 #include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
+
 VALIDATE_IS_RISCV64()
 
 namespace Kernel {

--- a/Kernel/Arch/riscv64/SBI.h
+++ b/Kernel/Arch/riscv64/SBI.h
@@ -8,6 +8,7 @@
 
 #include <AK/Error.h>
 #include <AK/Format.h>
+#include <AK/StdLibExtras.h>
 
 // Documentation about the SBI:
 // RISC-V Supervisor Binary Interface Specification (https://github.com/riscv-non-isa/riscv-sbi-doc)

--- a/Kernel/Arch/riscv64/TrapFrame.h
+++ b/Kernel/Arch/riscv64/TrapFrame.h
@@ -9,6 +9,8 @@
 #include <Kernel/Arch/RegisterState.h>
 
 #include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
+
 VALIDATE_IS_RISCV64()
 
 namespace Kernel {

--- a/Kernel/Devices/Storage/SD/Commands.h
+++ b/Kernel/Devices/Storage/SD/Commands.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace Kernel::SD {

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -46,3 +46,12 @@ TEST_CASE(first_index_of)
     EXPECT(array.first_index_of(7) == 7u);
     EXPECT(!array.first_index_of(42).has_value());
 }
+
+TEST_CASE(to_array)
+{
+    constexpr auto array = to_array<u8>({ 0, 2, 1 });
+    static_assert(array.size() == 3);
+    static_assert(array[0] == 0);
+    static_assert(array[1] == 2);
+    static_assert(array[2] == 1);
+}

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -19,7 +19,7 @@ static constexpr int constexpr_sum(ReadonlySpan<int> const span)
 
 TEST_CASE(compile_time_constructible)
 {
-    constexpr Array<int, 4> array = { 0, 1, 2, 3 };
+    constexpr Array array = { 0, 1, 2, 3 };
     static_assert(array.size() == 4);
 }
 

--- a/Tests/AK/TestIndexSequence.cpp
+++ b/Tests/AK/TestIndexSequence.cpp
@@ -37,7 +37,7 @@ TEST_CASE(TestIndexSequence)
     constexpr auto index_seq2 = MakeIndexSequence<3> {};
     static_assert(IsSame<decltype(index_seq1), decltype(index_seq2)>, "");
 
-    verify_sequence(MakeIndexSequence<10> {}, std::initializer_list<unsigned> { 0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U });
+    verify_sequence(MakeIndexSequence<10> {}, std::initializer_list<size_t> { 0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U });
     verify_sequence(MakeIntegerSequence<long, 16> {}, std::initializer_list<long> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
 }
 

--- a/Userland/Libraries/LibC/arch/aarch64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/aarch64/fenv.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <AK/Types.h>
 #include <fenv.h>
 

--- a/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <AK/Types.h>
 #include <fenv.h>
 

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -54,10 +54,10 @@ ErrorOr<NonnullRefPtr<VM>> VM::create(OwnPtr<CustomData> custom_data)
     return vm;
 }
 
-template<u32... code_points>
+template<size_t... code_points>
 static constexpr auto make_single_ascii_character_strings(IndexSequence<code_points...>)
 {
-    return AK::Array { (String::from_code_point(code_points))... };
+    return AK::Array { (String::from_code_point(static_cast<u32>(code_points)))... };
 }
 
 static constexpr auto single_ascii_character_strings = make_single_ascii_character_strings(MakeIndexSequence<128>());


### PR DESCRIPTION
This is useful if you want an array with an explicit type but still
want its size to be inferred.

---

…and random minor stuff along the way, such as making IndexSequence<> use size_t as it should, which requires not including StdLibExtras.h from Types.h. Went with a hack for that one for now; imho Types.h shouldn't use AK::Details metaprogramming at all. FlatPtr doesn't necessarily have to use Conditional<> and ssize_t could maybe be in its own header or something. But since it's tangential to this PR, not doing this here.

I have a use for this locally (in LibPDF, surprise), but let's keep this PR about AK.