### PR TITLE
LibGUI/Application:  Resize recent files list to max open file size

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -387,6 +387,7 @@ void Application::set_most_recently_open_file(ByteString new_path)
     });
 
     new_recent_files_list.prepend(new_path);
+    new_recent_files_list.resize(max_recently_open_files());
 
     for (size_t i = 0; i < max_recently_open_files(); ++i) {
         auto& path = new_recent_files_list[i];


### PR DESCRIPTION
Since it's possible to have less recently opened files than max_recently_open_files(), which causes us to crash when we try to access new_recent_files_list where index >= size.

Found while looking for a fix to #23130.