### PR TITLE
PixelPaint: Don't crash when cancel is pressed when saving a file

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -763,6 +763,8 @@ void ImageEditor::save_project()
         return;
     }
     set_unmodified();
+    if (on_file_saved)
+        on_file_saved(path());
 }
 
 void ImageEditor::save_project_as()
@@ -779,6 +781,8 @@ void ImageEditor::save_project_as()
     set_path(file.filename());
     set_loaded_from_image(false);
     set_unmodified();
+    if (on_file_saved)
+        on_file_saved(path());
 }
 
 ErrorOr<void> ImageEditor::save_project_to_file(NonnullOwnPtr<Core::File> file) const

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -90,6 +90,8 @@ public:
     Function<void(void)> on_leave;
     Function<void(bool modified)> on_modified_change;
 
+    Function<void(ByteString const& filename)> on_file_saved;
+
     bool request_close();
 
     void save_project_as();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -208,14 +208,12 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         auto* editor = current_image_editor();
         VERIFY(editor);
         editor->save_project_as();
-        GUI::Application::the()->set_most_recently_open_file(editor->path());
     });
 
     m_save_image_action = GUI::CommonActions::make_save_action([&](auto&) {
         auto* editor = current_image_editor();
         VERIFY(editor);
         editor->save_project();
-        GUI::Application::the()->set_most_recently_open_file(editor->path());
     });
 
     file_menu->add_action(*m_new_image_action);
@@ -1440,6 +1438,9 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         m_palette_widget->set_secondary_color(color);
         if (image_editor.active_tool())
             image_editor.active_tool()->on_secondary_color_change(color);
+    };
+    image_editor.on_file_saved = [](ByteString const& filename) {
+        GUI::Application::the()->set_most_recently_open_file(filename);
     };
 
     if (image->layer_count())

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -373,6 +373,7 @@ void Application::update_recent_file_actions()
 
 void Application::set_most_recently_open_file(ByteString new_path)
 {
+    VERIFY(!new_path.is_empty());
     Vector<ByteString> new_recent_files_list;
 
     for (size_t i = 0; i < max_recently_open_files(); ++i) {


### PR DESCRIPTION
Previously, we were attempting to add an empty string to the most recently open files list when no file was saved.

`Application::set_most_recently_open_file()` now asserts that the path you are trying to set isn't empty. Doing this doesn't make sense and trying to set an empty path causes a crash that isn't immediately obvious. Better to fail early in this case.

NB: #23131 stops the above-mentioned crash from happening.

Fixes #23130