### PR TITLE
LibWeb: Optimize scroll offset and clip state recalculation

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1064,6 +1064,11 @@ void Document::update_layout()
     set_needs_to_resolve_paint_only_properties();
 
     if (navigable()->is_traversable()) {
+        // NOTE: The assignment of scroll frames only needs to occur for traversables because they take care of all
+        //       nested navigable documents.
+        paintable()->assign_scroll_frames();
+        paintable()->assign_clip_frames();
+
         page().client().page_did_layout();
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1060,10 +1060,8 @@ void Document::update_layout()
     // Broadcast the current viewport rect to any new paintables, so they know whether they're visible or not.
     inform_all_viewport_clients_about_the_current_viewport_rect();
 
-    if (navigable()) {
-        navigable()->set_needs_to_resolve_paint_only_properties();
-        navigable()->set_needs_display();
-    }
+    navigable()->set_needs_display();
+    set_needs_to_resolve_paint_only_properties();
 
     if (navigable()->is_traversable()) {
         page().client().page_did_layout();
@@ -1143,6 +1141,15 @@ void Document::update_style()
     }
     m_needs_full_style_update = false;
     m_style_update_timer->stop();
+}
+
+void Document::update_paint_and_hit_testing_properties_if_needed()
+{
+    if (!m_needs_to_resolve_paint_only_properties)
+        return;
+    m_needs_to_resolve_paint_only_properties = false;
+    if (auto* paintable = this->paintable())
+        paintable->resolve_paint_only_properties();
 }
 
 void Document::set_link_color(Color color)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -202,6 +202,7 @@ public:
 
     void update_style();
     void update_layout();
+    void update_paint_and_hit_testing_properties_if_needed();
 
     void set_needs_layout();
 
@@ -562,6 +563,8 @@ public:
 
     Element const* element_from_point(double x, double y);
 
+    void set_needs_to_resolve_paint_only_properties() { m_needs_to_resolve_paint_only_properties = true; }
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -785,6 +788,8 @@ private:
     bool m_ready_to_run_scripts { false };
 
     Vector<HTML::FormAssociatedElement*> m_form_associated_elements_with_form_attribute;
+
+    bool m_needs_to_resolve_paint_only_properties { true };
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -593,8 +593,8 @@ Element::RequiredInvalidationAfterStyleChange Element::recompute_style()
     m_computed_css_values = move(new_computed_css_values);
     computed_css_values_changed();
 
-    if (invalidation.repaint && document().navigable())
-        document().navigable()->set_needs_to_resolve_paint_only_properties();
+    if (invalidation.repaint)
+        document().set_needs_to_resolve_paint_only_properties();
 
     if (!invalidation.rebuild_layout_tree && layout_node()) {
         // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2106,10 +2106,7 @@ void Navigable::paint(Painting::RecordingPainter& recording_painter, PaintConfig
     context.set_should_paint_overlay(config.paint_overlay);
     context.set_has_focus(config.has_focus);
 
-    if (m_needs_to_resolve_paint_only_properties) {
-        document->paintable()->resolve_paint_only_properties();
-        m_needs_to_resolve_paint_only_properties = false;
-    }
+    document->update_paint_and_hit_testing_properties_if_needed();
 
     HashMap<Painting::PaintableBox const*, Painting::ViewportPaintable::ScrollFrame> scroll_frames;
     if (is_traversable()) {

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2108,21 +2108,24 @@ void Navigable::paint(Painting::RecordingPainter& recording_painter, PaintConfig
 
     document->update_paint_and_hit_testing_properties_if_needed();
 
-    HashMap<Painting::PaintableBox const*, Painting::ViewportPaintable::ScrollFrame> scroll_frames;
+    auto& viewport_paintable = *document->paintable();
+
+    // NOTE: We only need to refresh the scroll state for traversables because they are responsible
+    //       for tracking the state of all nested navigables.
     if (is_traversable()) {
-        document->paintable()->assign_scroll_frame_ids(scroll_frames);
-        document->paintable()->assign_clip_rectangles();
+        viewport_paintable.refresh_scroll_state();
+        viewport_paintable.refresh_clip_state();
     }
 
-    document->paintable()->paint_all_phases(context);
+    viewport_paintable.paint_all_phases(context);
 
     // FIXME: Support scrollable frames inside iframes.
     if (is_traversable()) {
         Vector<Gfx::IntPoint> scroll_offsets_by_frame_id;
-        scroll_offsets_by_frame_id.resize(scroll_frames.size());
-        for (auto [_, scrollable_frame] : scroll_frames) {
-            auto scroll_offset = context.rounded_device_point(scrollable_frame.offset).to_type<int>();
-            scroll_offsets_by_frame_id[scrollable_frame.id] = scroll_offset;
+        scroll_offsets_by_frame_id.resize(viewport_paintable.scroll_state.size());
+        for (auto [_, scrollable_frame] : viewport_paintable.scroll_state) {
+            auto scroll_offset = context.rounded_device_point(scrollable_frame->offset).to_type<int>();
+            scroll_offsets_by_frame_id[scrollable_frame->id] = scroll_offset;
         }
         recording_painter.apply_scroll_offsets(scroll_offsets_by_frame_id);
     }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -180,8 +180,6 @@ public:
     };
     void paint(Painting::RecordingPainter&, PaintConfig);
 
-    void set_needs_to_resolve_paint_only_properties() { m_needs_to_resolve_paint_only_properties = true; }
-
 protected:
     Navigable();
 
@@ -223,8 +221,6 @@ private:
 
     CSSPixelSize m_size;
     CSSPixelPoint m_viewport_scroll_offset;
-
-    bool m_needs_to_resolve_paint_only_properties { true };
 };
 
 HashTable<Navigable*>& all_navigables();

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -37,9 +37,12 @@ public:
     void set_box_shadow_data(Vector<ShadowData>&& box_shadow_data) { m_box_shadow_data = move(box_shadow_data); }
     Vector<ShadowData> const& box_shadow_data() const { return m_box_shadow_data; }
 
-    void set_scroll_frame_id(int id) { m_scroll_frame_id = id; }
-    void set_enclosing_scroll_frame_offset(CSSPixelPoint offset) { m_enclosing_scroll_frame_offset = offset; }
-    void set_clip_rect(Optional<CSSPixelRect> rect) { m_clip_rect = rect; }
+    void set_enclosing_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_enclosing_scroll_frame = scroll_frame; }
+    void set_enclosing_clip_frame(RefPtr<ClipFrame> clip_frame) { m_enclosing_clip_frame = clip_frame; }
+
+    Optional<int> scroll_frame_id() const;
+    Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const;
+    Optional<CSSPixelRect> clip_rect() const;
 
 private:
     InlinePaintable(Layout::InlineNode const&);
@@ -47,9 +50,9 @@ private:
     template<typename Callback>
     void for_each_fragment(Callback) const;
 
-    Optional<int> m_scroll_frame_id;
-    Optional<CSSPixelPoint> m_enclosing_scroll_frame_offset;
     Optional<CSSPixelRect> m_clip_rect;
+    RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
+    RefPtr<ClipFrame const> m_enclosing_clip_frame;
 
     Vector<ShadowData> m_box_shadow_data;
     Vector<PaintableFragment> m_fragments;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -14,6 +14,16 @@
 
 namespace Web::Painting {
 
+struct ScrollFrame : public RefCounted<ScrollFrame> {
+    i32 id { -1 };
+    CSSPixelPoint offset;
+};
+
+struct ClipFrame : public RefCounted<ClipFrame> {
+    CSSPixelRect rect;
+    Optional<BorderRadiiData> corner_clip_radii;
+};
+
 class PaintableBox : public Paintable {
     JS_CELL(PaintableBox, Paintable);
 
@@ -193,14 +203,13 @@ public:
 
     Optional<CSSPixelRect> get_clip_rect() const;
 
-    void set_clip_rect(Optional<CSSPixelRect> rect) { m_clip_rect = rect; }
-    void set_scroll_frame_id(int id) { m_scroll_frame_id = id; }
-    void set_enclosing_scroll_frame_offset(CSSPixelPoint offset) { m_enclosing_scroll_frame_offset = offset; }
-    void set_corner_clip_radii(BorderRadiiData const& corner_radii) { m_corner_clip_radii = corner_radii; }
+    void set_enclosing_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_enclosing_scroll_frame = scroll_frame; }
+    void set_enclosing_clip_frame(RefPtr<ClipFrame> clip_frame) { m_enclosing_clip_frame = clip_frame; }
 
-    Optional<int> scroll_frame_id() const { return m_scroll_frame_id; }
-    Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const { return m_enclosing_scroll_frame_offset; }
-    Optional<CSSPixelRect> clip_rect() const { return m_clip_rect; }
+    Optional<int> scroll_frame_id() const;
+    Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const;
+    Optional<CSSPixelRect> clip_rect() const;
+    Optional<BorderRadiiData> corner_clip_radii() const;
 
 protected:
     explicit PaintableBox(Layout::Box const&);
@@ -227,10 +236,8 @@ private:
     mutable bool m_clipping_overflow { false };
     mutable Optional<u32> m_corner_clipper_id;
 
-    Optional<CSSPixelRect> m_clip_rect;
-    Optional<int> m_scroll_frame_id;
-    Optional<CSSPixelPoint> m_enclosing_scroll_frame_offset;
-    Optional<BorderRadiiData> m_corner_clip_radii;
+    RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
+    RefPtr<ClipFrame const> m_enclosing_clip_frame;
 
     Optional<BordersDataWithElementKind> m_override_borders_data;
     Optional<TableCellCoordinates> m_table_cell_coordinates;

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -58,37 +58,28 @@ void ViewportPaintable::paint_all_phases(PaintContext& context)
     stacking_context()->paint(context);
 }
 
-void ViewportPaintable::assign_scroll_frame_ids(HashMap<Painting::PaintableBox const*, ScrollFrame>& scroll_frames) const
+void ViewportPaintable::assign_scroll_frames()
 {
-    i32 next_id = 0;
-    // Collect scroll frames with their offsets (accumulated offset for nested scroll frames).
+    int next_id = 0;
     for_each_in_subtree_of_type<PaintableBox>([&](auto const& paintable_box) {
         if (paintable_box.has_scrollable_overflow()) {
-            auto offset = paintable_box.scroll_offset();
-            auto ancestor = paintable_box.containing_block();
-            while (ancestor) {
-                if (ancestor->paintable()->is_paintable_box() && static_cast<PaintableBox const*>(ancestor->paintable())->has_scrollable_overflow())
-                    offset.translate_by(static_cast<PaintableBox const*>(ancestor->paintable())->scroll_offset());
-                ancestor = ancestor->containing_block();
-            }
-            scroll_frames.set(&paintable_box, { .id = next_id++, .offset = -offset });
+            auto scroll_frame = adopt_ref(*new ScrollFrame());
+            scroll_frame->id = next_id++;
+            scroll_state.set(&paintable_box, move(scroll_frame));
         }
         return TraversalDecision::Continue;
     });
 
-    // Assign scroll frame id to all paintables contained in a scroll frame.
     for_each_in_subtree([&](auto const& paintable) {
         for (auto block = paintable.containing_block(); block; block = block->containing_block()) {
             auto const& block_paintable_box = *block->paintable_box();
-            if (auto scroll_frame_id = scroll_frames.get(&block_paintable_box); scroll_frame_id.has_value()) {
+            if (auto scroll_frame = scroll_state.get(&block_paintable_box); scroll_frame.has_value()) {
                 if (paintable.is_paintable_box()) {
                     auto const& paintable_box = static_cast<PaintableBox const&>(paintable);
-                    const_cast<PaintableBox&>(paintable_box).set_scroll_frame_id(scroll_frame_id->id);
-                    const_cast<PaintableBox&>(paintable_box).set_enclosing_scroll_frame_offset(scroll_frame_id->offset);
+                    const_cast<PaintableBox&>(paintable_box).set_enclosing_scroll_frame(scroll_frame.value());
                 } else if (paintable.is_inline_paintable()) {
                     auto const& inline_paintable = static_cast<InlinePaintable const&>(paintable);
-                    const_cast<InlinePaintable&>(inline_paintable).set_scroll_frame_id(scroll_frame_id->id);
-                    const_cast<InlinePaintable&>(inline_paintable).set_enclosing_scroll_frame_offset(scroll_frame_id->offset);
+                    const_cast<InlinePaintable&>(inline_paintable).set_enclosing_scroll_frame(scroll_frame.value());
                 }
                 break;
             }
@@ -97,19 +88,64 @@ void ViewportPaintable::assign_scroll_frame_ids(HashMap<Painting::PaintableBox c
     });
 }
 
-void ViewportPaintable::assign_clip_rectangles()
+void ViewportPaintable::assign_clip_frames()
 {
-    HashMap<Paintable const*, CSSPixelRect> clip_rects;
-    // Calculate clip rects for all boxes that either have hidden overflow or a CSS clip property.
     for_each_in_subtree_of_type<PaintableBox>([&](auto const& paintable_box) {
+        auto overflow_x = paintable_box.computed_values().overflow_x();
+        auto overflow_y = paintable_box.computed_values().overflow_y();
+        auto has_hidden_overflow = overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible;
+        if (has_hidden_overflow || paintable_box.get_clip_rect().has_value()) {
+            auto clip_frame = adopt_ref(*new ClipFrame());
+            clip_state.set(&paintable_box, move(clip_frame));
+        }
+        return TraversalDecision::Continue;
+    });
+
+    for_each_in_subtree([&](auto const& paintable) {
+        for (auto block = paintable.containing_block(); block; block = block->containing_block()) {
+            auto const& block_paintable_box = *block->paintable_box();
+            if (auto clip_frame = clip_state.get(&block_paintable_box); clip_frame.has_value()) {
+                if (paintable.is_paintable_box()) {
+                    auto const& paintable_box = static_cast<PaintableBox const&>(paintable);
+                    const_cast<PaintableBox&>(paintable_box).set_enclosing_clip_frame(clip_frame.value());
+                } else if (paintable.is_inline_paintable()) {
+                    auto const& inline_paintable = static_cast<InlinePaintable const&>(paintable);
+                    const_cast<InlinePaintable&>(inline_paintable).set_enclosing_clip_frame(clip_frame.value());
+                }
+                break;
+            }
+        }
+        return TraversalDecision::Continue;
+    });
+}
+
+void ViewportPaintable::refresh_scroll_state()
+{
+    for (auto& it : scroll_state) {
+        auto const& paintable_box = *it.key;
+        auto& scroll_frame = *it.value;
+        CSSPixelPoint offset;
+        for (auto const* block = &paintable_box.layout_box(); block; block = block->containing_block()) {
+            auto const& block_paintable_box = *block->paintable_box();
+            offset.translate_by(block_paintable_box.scroll_offset());
+        }
+        scroll_frame.offset = -offset;
+    }
+}
+
+void ViewportPaintable::refresh_clip_state()
+{
+    for (auto& it : clip_state) {
+        auto const& paintable_box = *it.key;
+        auto& clip_frame = *it.value;
         auto overflow_x = paintable_box.computed_values().overflow_x();
         auto overflow_y = paintable_box.computed_values().overflow_y();
         // Start from CSS clip property if it exists.
         Optional<CSSPixelRect> clip_rect = paintable_box.get_clip_rect();
-        // FIXME: Support overflow clip in one direction only.
+
         if (overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible) {
             auto overflow_clip_rect = paintable_box.compute_absolute_padding_rect_with_css_transform_applied();
-            for (auto block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
+            for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
                 auto const& block_paintable_box = *block->paintable_box();
                 auto block_overflow_x = block_paintable_box.computed_values().overflow_x();
                 auto block_overflow_y = block_paintable_box.computed_values().overflow_y();
@@ -120,39 +156,15 @@ void ViewportPaintable::assign_clip_rectangles()
             }
             clip_rect = overflow_clip_rect;
         }
-        if (clip_rect.has_value())
-            clip_rects.set(&paintable_box, *clip_rect);
-        return TraversalDecision::Continue;
-    });
 
-    // Assign clip rects to all paintable boxes contained by a box with a hidden overflow or a CSS clip property.
-    for_each_in_subtree_of_type<PaintableBox>([&](auto const& paintable_box) {
-        Optional<CSSPixelRect> clip_rect = paintable_box.get_clip_rect();
-        for (auto block = paintable_box.containing_block(); block; block = block->containing_block()) {
-            if (auto containing_block_clip_rect = clip_rects.get(block->paintable()); containing_block_clip_rect.has_value()) {
-                auto border_radii_data = block->paintable_box()->normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
-                if (border_radii_data.has_any_radius()) {
-                    // FIXME: Border radii of all boxes in containing block chain should be taken into account instead of just the closest one.
-                    const_cast<PaintableBox&>(paintable_box).set_corner_clip_radii(border_radii_data);
-                }
-                clip_rect = *containing_block_clip_rect;
-                break;
-            }
+        auto border_radii_data = paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
+        if (border_radii_data.has_any_radius()) {
+            // FIXME: Border radii of all boxes in containing block chain should be taken into account.
+            clip_frame.corner_clip_radii = border_radii_data;
         }
-        const_cast<PaintableBox&>(paintable_box).set_clip_rect(clip_rect);
-        return TraversalDecision::Continue;
-    });
 
-    // Assign clip rects to all inline paintables contained by a box with hidden overflow or a CSS clip property.
-    for_each_in_subtree_of_type<InlinePaintable>([&](auto const& paintable_box) {
-        for (auto block = paintable_box.containing_block(); block; block = block->containing_block()) {
-            if (auto clip_rect = clip_rects.get(block->paintable()); clip_rect.has_value()) {
-                const_cast<InlinePaintable&>(paintable_box).set_clip_rect(clip_rect);
-                break;
-            }
-        }
-        return TraversalDecision::Continue;
-    });
+        clip_frame.rect = *clip_rect;
+    }
 }
 
 static Painting::BorderRadiiData normalize_border_radii_data(Layout::Node const& node, CSSPixelRect const& rect, CSS::BorderRadiusData top_left_radius, CSS::BorderRadiusData top_right_radius, CSS::BorderRadiusData bottom_right_radius, CSS::BorderRadiusData bottom_left_radius)

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -20,12 +20,14 @@ public:
     void paint_all_phases(PaintContext&);
     void build_stacking_context_tree_if_needed();
 
-    struct ScrollFrame {
-        i32 id { -1 };
-        CSSPixelPoint offset;
-    };
-    void assign_scroll_frame_ids(HashMap<Painting::PaintableBox const*, ScrollFrame>&) const;
-    void assign_clip_rectangles();
+    HashMap<PaintableBox const*, RefPtr<ScrollFrame>> scroll_state;
+    void assign_scroll_frames();
+    void refresh_scroll_state();
+
+    HashMap<PaintableBox const*, RefPtr<ClipFrame>> clip_state;
+    void assign_clip_frames();
+    void refresh_clip_state();
+
     void resolve_paint_only_properties();
 
 private:


### PR DESCRIPTION
In this commit we have optimized the handling of scroll offsets and
clip rectangles to improve performance. Previously, the process
involved multiple full traversals of the paintable tree before each
repaint, which was highly inefficient, especially on pages with a
large number of paintables. The steps were:

1. Traverse the paintable tree to identify all boxes with scrollable or
   clipped overflow.
2. Gather the accumulated scroll offset or clip rectangle for each box.
3. Perform another traversal to apply the corresponding scroll offset
   and clip rectangle to each paintable.

To address this, we've adopted a new strategy that separates the
assignment of the scroll/clip frame from the refresh of accumulated
scroll offsets and clip rectangles, thus reducing the workload:

1. Post-relayout: Identify all boxes with overflow and link each
   paintable to the state of its containing scroll/clip frame.
2. Pre-repaint: Update the clip rectangle and scroll offset only in the
   previously identified boxes.

This adjustment ensures that the costly tree traversals are only
necessary after a relayout, substantially decreasing the amount of work
required before each repaint.

Performance improvement is very noticeable on https://news.ycombinator.com/item?id=39271449 for example :)