### PR TITLE
LibPDF/CFF: Add enum values for remaining PrivDictOperators

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -184,6 +184,25 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                 Reader priv_dict_reader { cff_bytes.slice(private_dict_offset, private_dict_size) };
                 TRY(parse_dict<PrivDictOperator>(priv_dict_reader, [&](PrivDictOperator op, Vector<DictOperand> const& operands) -> PDFErrorOr<void> {
                     switch (op) {
+                    case PrivDictOperator::BlueValues:
+                    case PrivDictOperator::OtherBlues:
+                    case PrivDictOperator::FamilyBlues:
+                    case PrivDictOperator::FamilyOtherBlues:
+                    case PrivDictOperator::BlueScale:
+                    case PrivDictOperator::BlueShift:
+                    case PrivDictOperator::BlueFuzz:
+                    case PrivDictOperator::StemSnapH:
+                    case PrivDictOperator::StemSnapV:
+                    case PrivDictOperator::ForceBold:
+                    case PrivDictOperator::LanguageGroup:
+                    case PrivDictOperator::ExpansionFactor:
+                    case PrivDictOperator::InitialRandomSeed:
+                        // Ignore hinting-related operators for now.
+                        break;
+                    case PrivDictOperator::StdHW:
+                    case PrivDictOperator::StdVW:
+                        // FIXME: What do these do?
+                        break;
                     case PrivDictOperator::Subrs: {
                         // CFF spec, "16 Local/Global Subrs INDEXes"
                         // "Local subrs are stored in an INDEX structure which is located via the offset operand of the Subrs operator in the Private DICT."
@@ -203,6 +222,8 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                         if (!operands.is_empty())
                             nominalWidthX = to_number(operands[0]);
                         break;
+                    default:
+                        dbgln("CFF: Unhandled private dict entry {}", static_cast<int>(op));
                     }
                     return {};
                 }));

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -51,6 +51,21 @@ private:
 
     // CFF spec, "Table 23 Private DICT Operators"
     enum class PrivDictOperator {
+        BlueValues = 6,
+        OtherBlues,
+        FamilyBlues,
+        FamilyOtherBlues,
+        BlueScale = (12 << 8 | 9),
+        BlueShift,
+        BlueFuzz,
+        StdHW = 10,
+        StdVW,
+        StemSnapH = (12 << 8 | 12),
+        StemSnapV,
+        ForceBold,
+        LanguageGroup = (12 << 8 | 17),
+        ExpansionFactor,
+        InitialRandomSeed,
         Subrs = 19,
         DefaultWidthX,
         NominalWidthX,


### PR DESCRIPTION
No behavior change, except that we now dbgln() if we see a PrivDictOperator we don't know about. (I haven't seen this in practice, but I found this useful while debugging things.)