### PR TITLE
BrickGame: Make action shortcuts work when the game is paused

### DIFF
--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -509,8 +509,10 @@ void BrickGame::keydown_event(GUI::KeyEvent& event)
         break;
     }
 
-    if (m_brick_game->state() == Bricks::GameState::Paused)
+    if (m_brick_game->state() == Bricks::GameState::Paused) {
+        event.ignore();
         return;
+    }
 
     Bricks::RenderRequest render_request { Bricks::RenderRequest::SkipRender };
     switch (event.key()) {


### PR DESCRIPTION
We previously never called event.ignore(), so the keydown event for F2 or F11 etc would be consumed by the BrickGame widget instead of bubbling up. Now you can start a new game, or escape fullscreen mode, even if you've paused the game. :^)