### PR TITLE
LibWeb: Add internals.wheel() to simulate mouse wheel events

### DIFF
--- a/Tests/LibWeb/Ref/reference/scroll-using-mousewheel-event-ref.html
+++ b/Tests/LibWeb/Ref/reference/scroll-using-mousewheel-event-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+.item {
+    width: 100px;
+    height: 100px;
+    box-sizing: border-box;
+    border: 1px solid black;
+}
+</style>
+<div class="item">2</div>
+<div class="item">3</div>
+<div class="item">4</div>

--- a/Tests/LibWeb/Ref/scroll-using-mousewheel-event.html
+++ b/Tests/LibWeb/Ref/scroll-using-mousewheel-event.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/scroll-using-mousewheel-event-ref.html" />
+<style>
+.scrollable {
+    overflow-y: scroll;
+    width: 100px;
+    height: 300px;
+}
+
+.item {
+    width: 100px;
+    height: 100px;
+    box-sizing: border-box;
+    border: 1px solid black;
+}
+</style>
+<div class="scrollable">
+    <div class="item">1</div>
+    <div class="item">2</div>
+    <div class="item">3</div>
+    <div class="item">4</div>
+    <div class="item">5</div>
+    <div class="item">6</div>
+    <div class="item">7</div>
+</div>
+<script>
+    internals.wheel(10, 10, 0, 100);
+</script>

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -83,6 +83,12 @@ void Internals::click(double x, double y)
     page.handle_mouseup({ x, y }, { x, y }, 1, 0, 0);
 }
 
+void Internals::wheel(double x, double y, double delta_x, double delta_y)
+{
+    auto& page = global_object().browsing_context()->page();
+    page.handle_mousewheel({ x, y }, { x, y }, 0, 0, 0, delta_x, delta_y);
+}
+
 WebIDL::ExceptionOr<bool> Internals::dispatch_user_activated_event(DOM::EventTarget& target, DOM::Event& event)
 {
     event.set_is_trusted(true);

--- a/Userland/Libraries/LibWeb/Internals/Internals.h
+++ b/Userland/Libraries/LibWeb/Internals/Internals.h
@@ -26,6 +26,7 @@ public:
     void commit_text();
 
     void click(double x, double y);
+    void wheel(double x, double y, double delta_x, double delta_y);
 
     WebIDL::ExceptionOr<bool> dispatch_user_activated_event(DOM::EventTarget&, DOM::Event& event);
 

--- a/Userland/Libraries/LibWeb/Internals/Internals.idl
+++ b/Userland/Libraries/LibWeb/Internals/Internals.idl
@@ -11,6 +11,7 @@
     undefined commitText();
 
     undefined click(double x, double y);
+    undefined wheel(double x, double y, double deltaX, double deltaY);
 
     boolean dispatchUserActivatedEvent(EventTarget target, Event event);
 


### PR DESCRIPTION
This function allows us to write tests for scrolling scenarios where the events are processed by the EventHandler.