### PR TITLE
LibWeb: Implement `document.designMode`

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Document-set-designMode.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-set-designMode.txt
@@ -1,0 +1,6 @@
+document.designMode initial value: off
+document.designMode after setting to "invalid": off
+document.designMode after setting to "on": on
+document.designMode after setting to "off": off
+document.designMode after setting to "ON": on
+document.designMode after setting to "OFF": off

--- a/Tests/LibWeb/Text/input/DOM/Document-set-designMode.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-set-designMode.html
@@ -1,0 +1,17 @@
+<script src="../include.js"></script>
+<script>    
+    function setDesignMode(value) {
+        document.designMode = value;
+        println(`document.designMode after setting to "${value}": ${document.designMode}`);
+    }
+    
+    test(() => {
+        println(`document.designMode initial value: ${document.designMode}`);
+        
+        setDesignMode("invalid");
+        setDesignMode("on");
+        setDesignMode("off");
+        setDesignMode("ON");
+        setDesignMode("OFF");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -561,6 +561,11 @@ public:
     void add_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
     void remove_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
 
+    bool design_mode_enabled_state() const { return m_design_mode_enabled; }
+    void set_design_mode_enabled_state(bool);
+    String design_mode() const;
+    WebIDL::ExceptionOr<void> set_design_mode(String const&);
+
     Element const* element_from_point(double x, double y);
 
     void set_needs_to_resolve_paint_only_properties() { m_needs_to_resolve_paint_only_properties = true; }
@@ -788,6 +793,8 @@ private:
     bool m_ready_to_run_scripts { false };
 
     Vector<HTML::FormAssociatedElement*> m_form_associated_elements_with_form_attribute;
+
+    bool m_design_mode_enabled { false };
 
     bool m_needs_to_resolve_paint_only_properties { true };
 };

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -114,6 +114,8 @@ interface Document : Node {
 
     Selection? getSelection();
 
+    [CEReactions] attribute DOMString designMode;
+
     // https://www.w3.org/TR/web-animations-1/#extensions-to-the-document-interface
     readonly attribute DocumentTimeline timeline;
 


### PR DESCRIPTION
Setting this attribute to "on" makes the entire document editable.

Demo:

https://github.com/SerenityOS/serenity/assets/2817754/43a11cd5-9730-4527-b40d-68fe4fa88332

Note: Trying to edit more complex websites doesn't work too well at the moment. Simpler websites like serenityos.org work as expected.

