### PR TITLE
LibELF+readelf: Add support for RISC-V dynamic relocations

### DIFF
--- a/Userland/Libraries/LibELF/Arch/GenericDynamicRelocationType.h
+++ b/Userland/Libraries/LibELF/Arch/GenericDynamicRelocationType.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if ARCH(AARCH64)
+#    include <Userland/Libraries/LibELF/Arch/aarch64/GenericDynamicRelocationType.h>
+#elif ARCH(X86_64)
+#    include <Userland/Libraries/LibELF/Arch/x86_64/GenericDynamicRelocationType.h>
+#else
+#    error Unknown architecture
+#endif

--- a/Userland/Libraries/LibELF/Arch/GenericDynamicRelocationType.h
+++ b/Userland/Libraries/LibELF/Arch/GenericDynamicRelocationType.h
@@ -10,6 +10,8 @@
 
 #if ARCH(AARCH64)
 #    include <Userland/Libraries/LibELF/Arch/aarch64/GenericDynamicRelocationType.h>
+#elif ARCH(RISCV64)
+#    include <Userland/Libraries/LibELF/Arch/riscv64/GenericDynamicRelocationType.h>
 #elif ARCH(X86_64)
 #    include <Userland/Libraries/LibELF/Arch/x86_64/GenericDynamicRelocationType.h>
 #else

--- a/Userland/Libraries/LibELF/Arch/aarch64/GenericDynamicRelocationType.h
+++ b/Userland/Libraries/LibELF/Arch/aarch64/GenericDynamicRelocationType.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Userland/Libraries/LibELF/ELFABI.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_AARCH64()
+
+namespace ELF {
+
+enum class GenericDynamicRelocationType : unsigned {
+    NONE = R_AARCH64_NONE,
+    ABSOLUTE = R_AARCH64_ABS64,
+    COPY = R_AARCH64_COPY,
+    GLOB_DAT = R_AARCH64_GLOB_DAT,
+    JUMP_SLOT = R_AARCH64_JUMP_SLOT,
+    RELATIVE = R_AARCH64_RELATIVE,
+    TLS_DTPMOD = R_AARCH64_TLS_DTPMOD,
+    TLS_DTPREL = R_AARCH64_TLS_DTPREL,
+    TLS_TPREL = R_AARCH64_TLS_TPREL,
+    TLSDESC = R_AARCH64_TLSDESC,
+    IRELATIVE = R_AARCH64_IRELATIVE,
+};
+
+}

--- a/Userland/Libraries/LibELF/Arch/riscv64/GenericDynamicRelocationType.h
+++ b/Userland/Libraries/LibELF/Arch/riscv64/GenericDynamicRelocationType.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Userland/Libraries/LibELF/ELFABI.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace ELF {
+
+enum class GenericDynamicRelocationType : unsigned {
+    NONE = R_RISCV_NONE,
+    ABSOLUTE = R_RISCV_64,
+    COPY = R_RISCV_COPY,
+    // there is no R_RISCV_GLOB_DAT
+    JUMP_SLOT = R_RISCV_JUMP_SLOT,
+    RELATIVE = R_RISCV_RELATIVE,
+    TLS_DTPMOD = R_RISCV_TLS_DTPMOD64,
+    TLS_DTPREL = R_RISCV_TLS_DTPREL64,
+    TLS_TPREL = R_RISCV_TLS_TPREL64,
+    TLSDESC = R_RISCV_TLSDESC,
+    IRELATIVE = R_RISCV_IRELATIVE,
+};
+
+}

--- a/Userland/Libraries/LibELF/Arch/x86_64/GenericDynamicRelocationType.h
+++ b/Userland/Libraries/LibELF/Arch/x86_64/GenericDynamicRelocationType.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Userland/Libraries/LibELF/ELFABI.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_X86()
+
+namespace ELF {
+
+enum class GenericDynamicRelocationType : unsigned {
+    NONE = R_X86_64_NONE,
+    ABSOLUTE = R_X86_64_64,
+    COPY = R_X86_64_COPY,
+    GLOB_DAT = R_X86_64_GLOB_DAT,
+    JUMP_SLOT = R_X86_64_JUMP_SLOT,
+    RELATIVE = R_X86_64_RELATIVE,
+    TLS_DTPMOD = R_X86_64_DTPMOD64,
+    TLS_DTPREL = R_X86_64_DTPOFF64,
+    TLS_TPREL = R_X86_64_TPOFF64,
+    TLSDESC = R_X86_64_TLSDESC,
+    IRELATIVE = R_X86_64_IRELATIVE,
+};
+
+}

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -536,7 +536,7 @@ void DynamicLoader::load_program_headers()
 
 DynamicLoader::RelocationResult DynamicLoader::do_direct_relocation(DynamicObject::Relocation const& relocation,
     Optional<DynamicLoader::CachedLookupResult>& cached_result,
-    ShouldInitializeWeak should_initialize_weak,
+    [[maybe_unused]] ShouldInitializeWeak should_initialize_weak,
     ShouldCallIfuncResolver should_call_ifunc_resolver)
 {
     FlatPtr* patch_ptr = nullptr;
@@ -603,6 +603,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_direct_relocation(DynamicObjec
             *patch_ptr = call_ifunc_resolver(VirtualAddress { *patch_ptr }).get();
         break;
     }
+#if !ARCH(RISCV64)
     case GLOB_DAT: {
         auto symbol = relocation.symbol();
         auto res = lookup_symbol(symbol);
@@ -633,6 +634,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_direct_relocation(DynamicObjec
         *patch_ptr = symbol_location.get();
         break;
     }
+#endif
     case RELATIVE: {
         if (!image().is_dynamic())
             break;

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -13,6 +13,7 @@
 #include <AK/Concepts.h>
 #include <AK/RefCounted.h>
 #include <Kernel/Memory/VirtualAddress.h>
+#include <LibELF/Arch/GenericDynamicRelocationType.h>
 #include <LibELF/ELFABI.h>
 #include <link.h>
 
@@ -402,7 +403,7 @@ inline void DynamicObject::RelocationSection::for_each_relocation(F func) const
 {
     for (unsigned i = 0; i < relocation_count(); ++i) {
         auto const reloc = relocation(i);
-        if (reloc.type() == 0)
+        if (static_cast<GenericDynamicRelocationType>(reloc.type()) == GenericDynamicRelocationType::NONE)
             continue;
         if (func(reloc) == IterationDecision::Break)
             break;

--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -882,3 +882,27 @@ struct elf_args {
     R(R_AARCH64_TLS_TPREL)                    \
     R(R_AARCH64_TLSDESC)                      \
     R(R_AARCH64_IRELATIVE)
+
+/* https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/v1.0/riscv-elf.adoc#relocations */
+#define R_RISCV_NONE 0
+#define R_RISCV_64 2
+#define R_RISCV_RELATIVE 3
+#define R_RISCV_COPY 4
+#define R_RISCV_JUMP_SLOT 5
+#define R_RISCV_TLS_DTPMOD64 7
+#define R_RISCV_TLS_DTPREL64 9
+#define R_RISCV_TLS_TPREL64 11
+#define R_RISCV_TLSDESC 12
+#define R_RISCV_IRELATIVE 58
+
+#define __ENUMERATE_RISCV_DYNAMIC_RELOCS(R) \
+    R(R_RISCV_NONE)                         \
+    R(R_RISCV_64)                           \
+    R(R_RISCV_RELATIVE)                     \
+    R(R_RISCV_COPY)                         \
+    R(R_RISCV_JUMP_SLOT)                    \
+    R(R_RISCV_TLS_DTPMOD64)                 \
+    R(R_RISCV_TLS_DTPREL64)                 \
+    R(R_RISCV_TLS_TPREL64)                  \
+    R(R_RISCV_TLSDESC)                      \
+    R(R_RISCV_IRELATIVE)

--- a/Userland/Libraries/LibELF/Relocation.cpp
+++ b/Userland/Libraries/LibELF/Relocation.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibELF/Arch/GenericDynamicRelocationType.h>
 #include <LibELF/ELFABI.h>
 #include <LibELF/Relocation.h>
 
@@ -59,7 +60,7 @@ bool perform_relative_relocations(FlatPtr base_address)
     for (unsigned i = 0; i < relocation_count; ++i) {
         size_t offset_in_section = i * relocation_entry_size;
         auto* relocation = (Elf_Rela*)(relocation_section_addr + offset_in_section);
-        VERIFY(ELF64_R_TYPE(relocation->r_info) == R_X86_64_RELATIVE || ELF64_R_TYPE(relocation->r_info) == R_AARCH64_RELATIVE);
+        VERIFY(static_cast<GenericDynamicRelocationType>(ELF64_R_TYPE(relocation->r_info)) == GenericDynamicRelocationType::RELATIVE);
         auto* patch_address = (FlatPtr*)(base_address + relocation->r_offset);
         FlatPtr relocated_address;
         if (use_addend) {

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -197,6 +197,10 @@ static char const* object_relocation_type_to_string(Elf_Half machine, Elf_Word t
         switch (type) {
             __ENUMERATE_AARCH64_DYNAMIC_RELOCS(ENUMERATE_RELOCATION)
         }
+    } else if (machine == EM_RISCV) {
+        switch (type) {
+            __ENUMERATE_RISCV_DYNAMIC_RELOCS(ENUMERATE_RELOCATION)
+        }
     }
 #undef ENUMERATE_RELOCATION
     return "(?)";


### PR DESCRIPTION
This PR refactors how we handle dynamic relocations so we can support RISC-V relocations.

`GenericDyanmicRelocationType` is quite a long name, but should hopefully make its purpose of abstracting arch-specific enum values clearer.