### PR TITLE
LibCore: Some random work on ELIUnix

### DIFF
--- a/Ladybird/AppKit/Application/EventLoopImplementation.h
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.h
@@ -16,8 +16,8 @@ class CFEventLoopManager final : public Core::EventLoopManager {
 public:
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
-    virtual int register_timer(Core::EventReceiver&, int interval_milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
-    virtual void unregister_timer(int timer_id) override;
+    virtual intptr_t register_timer(Core::EventReceiver&, int interval_milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
+    virtual void unregister_timer(intptr_t timer_id) override;
 
     virtual void register_notifier(Core::Notifier&) override;
     virtual void unregister_notifier(Core::Notifier&) override;

--- a/Ladybird/AppKit/Application/EventLoopImplementation.h
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.h
@@ -17,7 +17,7 @@ public:
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
     virtual int register_timer(Core::EventReceiver&, int interval_milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
-    virtual bool unregister_timer(int timer_id) override;
+    virtual void unregister_timer(int timer_id) override;
 
     virtual void register_notifier(Core::Notifier&) override;
     virtual void unregister_notifier(Core::Notifier&) override;

--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -72,7 +72,7 @@ int CFEventLoopManager::register_timer(Core::EventReceiver& receiver, int interv
                 }
             }
 
-            Core::TimerEvent event(timer_id);
+            Core::TimerEvent event;
             receiver->dispatch_event(event);
         });
 

--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -82,18 +82,15 @@ int CFEventLoopManager::register_timer(Core::EventReceiver& receiver, int interv
     return timer_id;
 }
 
-bool CFEventLoopManager::unregister_timer(int timer_id)
+void CFEventLoopManager::unregister_timer(int timer_id)
 {
     auto& thread_data = ThreadData::the();
     thread_data.timer_id_allocator.deallocate(timer_id);
 
-    if (auto timer = thread_data.timers.take(timer_id); timer.has_value()) {
-        CFRunLoopTimerInvalidate(*timer);
-        CFRelease(*timer);
-        return true;
-    }
-
-    return false;
+    auto timer = thread_data.timers.take(timer_id);
+    VERIFY(timer.has_value());
+    CFRunLoopTimerInvalidate(*timer);
+    CFRelease(*timer);
 }
 
 static void socket_notifier(CFSocketRef socket, CFSocketCallBackType notification_type, CFDataRef, void const*, void* info)

--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -48,7 +48,7 @@ NonnullOwnPtr<Core::EventLoopImplementation> CFEventLoopManager::make_implementa
     return CFEventLoopImplementation::create();
 }
 
-int CFEventLoopManager::register_timer(Core::EventReceiver& receiver, int interval_milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible)
+intptr_t CFEventLoopManager::register_timer(Core::EventReceiver& receiver, int interval_milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible)
 {
     auto& thread_data = ThreadData::the();
 
@@ -82,12 +82,12 @@ int CFEventLoopManager::register_timer(Core::EventReceiver& receiver, int interv
     return timer_id;
 }
 
-void CFEventLoopManager::unregister_timer(int timer_id)
+void CFEventLoopManager::unregister_timer(intptr_t timer_id)
 {
     auto& thread_data = ThreadData::the();
-    thread_data.timer_id_allocator.deallocate(timer_id);
+    thread_data.timer_id_allocator.deallocate(static_cast<int>(timer_id));
 
-    auto timer = thread_data.timers.take(timer_id);
+    auto timer = thread_data.timers.take(static_cast<int>(timer_id));
     VERIFY(timer.has_value());
     CFRunLoopTimerInvalidate(*timer);
     CFRelease(*timer);

--- a/Ladybird/Qt/EventLoopImplementationQt.cpp
+++ b/Ladybird/Qt/EventLoopImplementationQt.cpp
@@ -109,11 +109,11 @@ int EventLoopManagerQt::register_timer(Core::EventReceiver& object, int millisec
     return timer_id;
 }
 
-bool EventLoopManagerQt::unregister_timer(int timer_id)
+void EventLoopManagerQt::unregister_timer(int timer_id)
 {
     auto& thread_data = ThreadData::the();
     thread_data.timer_id_allocator.deallocate(timer_id);
-    return thread_data.timers.remove(timer_id);
+    VERIFY(thread_data.timers.remove(timer_id));
 }
 
 static void qt_notifier_activated(Core::Notifier& notifier)

--- a/Ladybird/Qt/EventLoopImplementationQt.h
+++ b/Ladybird/Qt/EventLoopImplementationQt.h
@@ -27,7 +27,7 @@ public:
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
     virtual int register_timer(Core::EventReceiver&, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
-    virtual bool unregister_timer(int timer_id) override;
+    virtual void unregister_timer(int timer_id) override;
 
     virtual void register_notifier(Core::Notifier&) override;
     virtual void unregister_notifier(Core::Notifier&) override;

--- a/Ladybird/Qt/EventLoopImplementationQt.h
+++ b/Ladybird/Qt/EventLoopImplementationQt.h
@@ -26,8 +26,8 @@ public:
     virtual ~EventLoopManagerQt() override;
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
-    virtual int register_timer(Core::EventReceiver&, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
-    virtual void unregister_timer(int timer_id) override;
+    virtual intptr_t register_timer(Core::EventReceiver&, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
+    virtual void unregister_timer(intptr_t timer_id) override;
 
     virtual void register_notifier(Core::Notifier&) override;
     virtual void unregister_notifier(Core::Notifier&) override;

--- a/Userland/Libraries/LibCore/Event.h
+++ b/Userland/Libraries/LibCore/Event.h
@@ -66,17 +66,12 @@ private:
 
 class TimerEvent final : public Event {
 public:
-    explicit TimerEvent(int timer_id)
+    explicit TimerEvent()
         : Event(Event::Timer)
-        , m_timer_id(timer_id)
     {
     }
+
     ~TimerEvent() = default;
-
-    int timer_id() const { return m_timer_id; }
-
-private:
-    int m_timer_id;
 };
 
 enum class NotificationType {

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -130,9 +130,9 @@ int EventLoop::register_timer(EventReceiver& object, int milliseconds, bool shou
     return EventLoopManager::the().register_timer(object, milliseconds, should_reload, fire_when_not_visible);
 }
 
-bool EventLoop::unregister_timer(int timer_id)
+void EventLoop::unregister_timer(int timer_id)
 {
-    return EventLoopManager::the().unregister_timer(timer_id);
+    EventLoopManager::the().unregister_timer(timer_id);
 }
 
 void EventLoop::register_notifier(Badge<Notifier>, Notifier& notifier)

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -125,12 +125,12 @@ void EventLoop::notify_forked(ForkEvent)
     current().m_impl->notify_forked_and_in_child();
 }
 
-int EventLoop::register_timer(EventReceiver& object, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible fire_when_not_visible)
+intptr_t EventLoop::register_timer(EventReceiver& object, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible fire_when_not_visible)
 {
     return EventLoopManager::the().register_timer(object, milliseconds, should_reload, fire_when_not_visible);
 }
 
-void EventLoop::unregister_timer(int timer_id)
+void EventLoop::unregister_timer(intptr_t timer_id)
 {
     EventLoopManager::the().unregister_timer(timer_id);
 }

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -77,7 +77,7 @@ public:
 
     // The registration functions act upon the current loop of the current thread.
     static int register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible);
-    static bool unregister_timer(int timer_id);
+    static void unregister_timer(int timer_id);
 
     static void register_notifier(Badge<Notifier>, Notifier&);
     static void unregister_notifier(Badge<Notifier>, Notifier&);

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -76,8 +76,8 @@ public:
     bool was_exit_requested() const;
 
     // The registration functions act upon the current loop of the current thread.
-    static int register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible);
-    static void unregister_timer(int timer_id);
+    static intptr_t register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible);
+    static void unregister_timer(intptr_t timer_id);
 
     static void register_notifier(Badge<Notifier>, Notifier&);
     static void unregister_notifier(Badge<Notifier>, Notifier&);

--- a/Userland/Libraries/LibCore/EventLoopImplementation.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementation.h
@@ -23,8 +23,8 @@ public:
 
     virtual NonnullOwnPtr<EventLoopImplementation> make_implementation() = 0;
 
-    virtual int register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) = 0;
-    virtual void unregister_timer(int timer_id) = 0;
+    virtual intptr_t register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) = 0;
+    virtual void unregister_timer(intptr_t timer_id) = 0;
 
     virtual void register_notifier(Notifier&) = 0;
     virtual void unregister_notifier(Notifier&) = 0;

--- a/Userland/Libraries/LibCore/EventLoopImplementation.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementation.h
@@ -24,7 +24,7 @@ public:
     virtual NonnullOwnPtr<EventLoopImplementation> make_implementation() = 0;
 
     virtual int register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) = 0;
-    virtual bool unregister_timer(int timer_id) = 0;
+    virtual void unregister_timer(int timer_id) = 0;
 
     virtual void register_notifier(Notifier&) = 0;
     virtual void unregister_notifier(Notifier&) = 0;

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -509,11 +509,11 @@ int EventLoopManagerUnix::register_timer(EventReceiver& object, int milliseconds
     return timer_id;
 }
 
-bool EventLoopManagerUnix::unregister_timer(int timer_id)
+void EventLoopManagerUnix::unregister_timer(int timer_id)
 {
     auto& thread_data = ThreadData::the();
     thread_data.id_allocator.deallocate(timer_id);
-    return thread_data.timers.remove(timer_id);
+    VERIFY(thread_data.timers.remove(timer_id));
 }
 
 void EventLoopManagerUnix::register_notifier(Notifier& notifier)

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -244,7 +244,7 @@ try_select_again:
             }
 
             if (owner)
-                ThreadEventQueue::current().post_event(*owner, make<TimerEvent>(timer.timer_id));
+                ThreadEventQueue::current().post_event(*owner, make<TimerEvent>());
             if (timer.should_reload) {
                 timer.reload(now);
             } else {

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -17,8 +17,8 @@ public:
 
     virtual NonnullOwnPtr<EventLoopImplementation> make_implementation() override;
 
-    virtual int register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) override;
-    virtual void unregister_timer(int timer_id) override;
+    virtual intptr_t register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) override;
+    virtual void unregister_timer(intptr_t timer_id) override;
 
     virtual void register_notifier(Notifier&) override;
     virtual void unregister_notifier(Notifier&) override;

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -18,7 +18,7 @@ public:
     virtual NonnullOwnPtr<EventLoopImplementation> make_implementation() override;
 
     virtual int register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) override;
-    virtual bool unregister_timer(int timer_id) override;
+    virtual void unregister_timer(int timer_id) override;
 
     virtual void register_notifier(Notifier&) override;
     virtual void unregister_notifier(Notifier&) override;

--- a/Userland/Libraries/LibCore/EventReceiver.cpp
+++ b/Userland/Libraries/LibCore/EventReceiver.cpp
@@ -129,10 +129,7 @@ void EventReceiver::stop_timer()
 {
     if (!m_timer_id)
         return;
-    bool success = Core::EventLoop::unregister_timer(m_timer_id);
-    if (!success) {
-        dbgln("{:p} could not unregister timer {}", this, m_timer_id);
-    }
+    Core::EventLoop::unregister_timer(m_timer_id);
     m_timer_id = 0;
 }
 

--- a/Userland/Libraries/LibCore/EventReceiver.h
+++ b/Userland/Libraries/LibCore/EventReceiver.h
@@ -169,7 +169,7 @@ protected:
 private:
     EventReceiver* m_parent { nullptr };
     ByteString m_name;
-    int m_timer_id { 0 };
+    intptr_t m_timer_id { 0 };
     Vector<NonnullRefPtr<EventReceiver>> m_children;
     Function<bool(Core::Event&)> m_event_filter;
 };


### PR DESCRIPTION
This PR contains a trivial cleanup of generic Core::Timer infrastructure and an overhaul of timer handling code in ELIUnix that makes it more extensible and faster in the case of large amounts of timers.