### PR TITLE
LibGUI: fix resize event trigger in calendar widget

### DIFF
--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -80,7 +80,8 @@ void Calendar::toggle_mode()
     set_show_year(!m_show_year);
     set_show_month_and_year(!m_show_month_year);
     update_tiles(this->view_year(), this->view_month());
-    this->resize(this->height(), this->width());
+    ResizeEvent resize_evt(relative_rect().size());
+    event(resize_evt);
     invalidate_layout();
 }
 

--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -64,6 +64,10 @@ Calendar::Calendar(Core::DateTime date_time, Mode mode)
     }
 
     update_tiles(m_selected_date.year(), m_selected_date.month());
+
+    REGISTER_ENUM_PROPERTY("mode", this->mode, this->set_mode, Calendar::Mode,
+        { Calendar::Mode::Month, "Month" },
+        { Calendar::Mode::Year, "Year" });
 }
 
 void Calendar::set_grid(bool show)
@@ -83,6 +87,13 @@ void Calendar::toggle_mode()
     ResizeEvent resize_evt(relative_rect().size());
     event(resize_evt);
     invalidate_layout();
+}
+
+void Calendar::set_mode(Mode mode)
+{
+    if (mode != m_mode) {
+        toggle_mode();
+    }
 }
 
 void Calendar::show_previous_date()

--- a/Userland/Libraries/LibGUI/Calendar.h
+++ b/Userland/Libraries/LibGUI/Calendar.h
@@ -66,6 +66,7 @@ public:
     ErrorOr<String> formatted_date(Format format = LongMonthYear);
 
     Mode mode() const { return m_mode; }
+    void set_mode(Mode);
     void toggle_mode();
 
     void update_tiles(unsigned year, unsigned month);

--- a/Userland/Libraries/LibGUI/DatePicker.cpp
+++ b/Userland/Libraries/LibGUI/DatePicker.cpp
@@ -8,8 +8,6 @@
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/DatePicker.h>
 #include <LibGUI/DatePickerDialogGML.h>
-#include <LibGUI/ImageWidget.h>
-#include <LibGUI/Label.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
 
@@ -48,7 +46,6 @@ DatePicker::DatePicker(Window* parent_window, String const& title, Core::DateTim
         m_selected_date.set_time(static_cast<int>(m_selected_date.year()), index.row() + 1);
         calendar.set_selected_date(m_selected_date);
         calendar.update_tiles(m_selected_date.year(), m_selected_date.month());
-        calendar.update();
     };
 
     m_year_box = widget->find_descendant_of_type_named<GUI::SpinBox>("year_box");
@@ -57,7 +54,6 @@ DatePicker::DatePicker(Window* parent_window, String const& title, Core::DateTim
         m_selected_date.set_time(year, static_cast<int>(m_selected_date.month()));
         calendar.set_selected_date(m_selected_date);
         calendar.update_tiles(m_selected_date.year(), m_selected_date.month());
-        calendar.update();
     };
 
     auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");

--- a/Userland/Libraries/LibGUI/DatePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/DatePickerDialog.gml
@@ -30,6 +30,7 @@
 
         @GUI::Calendar {
             name: "calendar_view"
+            mode: "Month"
         }
     }
 


### PR DESCRIPTION
Calendar::toogle_mode function performed a call to Widget::resize with swapped width and height parameters as a quick way to trigger a resize_event (resize event is generated only when the new rect size is different from the old one, hence the swapped parameters).

This method does not work when width and height are equal, such as in the DatePicker widget where width and height are fixed to 200x200. In such case, calls to Calendar::toggle_mode would not generate a resize event, leaving tiles uninitialized, therefore the widget was not able to properly paint the Month view.

This commit replaces Widget::resize call with a manual triggering of the event.