### PR TITLE
LibWeb: ignore repeat(auto-fit/auto-fill, auto) as it is not allowed

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/repeat-auto-fit-fill-cannot-have-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat-auto-fit-fill-cannot-have-auto.txt
@@ -1,0 +1,62 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x50 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x34 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+          TextNode <#text>
+        Box <div.four> at (8,8) content-size 784x34 [GFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+          BlockContainer <div> at (8,8) content-size 196x17 [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
+                "A"
+            TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+          BlockContainer <div> at (204,8) content-size 196x17 [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [204,8 9.34375x17] baseline: 13.296875
+                "B"
+            TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+          BlockContainer <div> at (400,8) content-size 196x17 [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [400,8 10.3125x17] baseline: 13.296875
+                "C"
+            TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+          BlockContainer <div> at (596,8) content-size 196x17 [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [596,8 11.140625x17] baseline: 13.296875
+                "D"
+            TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+          BlockContainer <div> at (8,25) content-size 196x17 [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [8,25 11.859375x17] baseline: 13.296875
+                "E"
+            TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x34]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableBox (Box<DIV>.four) [8,8 784x34]
+          PaintableWithLines (BlockContainer<DIV>) [8,8 196x17]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [204,8 196x17]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [400,8 196x17]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [596,8 196x17]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [8,25 196x17]
+            TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]

--- a/Tests/LibWeb/Layout/input/grid/repeat-auto-fit-fill-cannot-have-auto.html
+++ b/Tests/LibWeb/Layout/input/grid/repeat-auto-fit-fill-cannot-have-auto.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+	.four {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		grid-template-rows: repeat(auto-fit, auto); /* 'auto' not allowed here, line should be ignored */
+	}
+</style>
+<div>
+<div class="four">
+	<div>A</div>
+	<div>B</div>
+	<div>C</div>
+	<div>D</div>
+	<div>E</div>
+</div>
+</div>


### PR DESCRIPTION
Fixes #23154 