### PR TITLE
LibPDF: Add some CIDFontType0C scaffolding

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -32,6 +32,7 @@
     X(CF)                         \
     X(CFM)                        \
     X(CIDFontType0)               \
+    X(CIDFontType0C)              \
     X(CIDFontType2)               \
     X(CIDSystemInfo)              \
     X(CIDToGIDMap)                \


### PR DESCRIPTION
No real behavior change. We don't actually load the CFF data yet (blocked on #23136 and some more), and we don't have drawing code yet, and Type0Font::draw_string() doesn't do any drawing yet.

But it's a step in the right direction.