### PR TITLE
Kernel: Make `ftruncate` change `st_ctime` as per spec

### DIFF
--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -96,7 +96,8 @@ ErrorOr<NonnullOwnPtr<KString>> InodeFile::pseudo_path(OpenFileDescription const
 ErrorOr<void> InodeFile::truncate(u64 size)
 {
     TRY(m_inode->truncate(size));
-    TRY(m_inode->update_timestamps({}, {}, kgettimeofday()));
+    auto truncated_at = kgettimeofday();
+    TRY(m_inode->update_timestamps({}, truncated_at, truncated_at));
     return {};
 }
 


### PR DESCRIPTION
While investigating #23097 I found an unrelated issue in our `ftruncate` implementation.