### PR TITLE
LibPDF: Scale default glyph width by font size and x scale

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -69,7 +69,7 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::
         else if (auto width = get_glyph_width(char_code); width.has_value())
             glyph_width = width.value();
         else
-            glyph_width = m_missing_width; // FIXME: times m_font_matrix.x_scale() probably?
+            glyph_width = font_size * m_missing_width * m_font_matrix.x_scale();
 
         Gfx::FloatPoint glyph_render_position = text_rendering_matrix.map(glyph_position);
         TRY(draw_glyph(painter, glyph_render_position, glyph_width, char_code, renderer));


### PR DESCRIPTION
This fixes rendering of commas in 0000941.pdf page 1. The commas use the default width, and without this they show up very large, covering the page.

Also, it's nice that the code now looks like the regular case 4 lines further up.