### PR TITLE
LibWeb: Fix hit-testing for button element

### DIFF
--- a/Tests/LibWeb/Text/expected/hit_testing/button.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/button.txt
@@ -1,0 +1,1 @@
+Button  Clicked!

--- a/Tests/LibWeb/Text/input/hit_testing/button.html
+++ b/Tests/LibWeb/Text/input/hit_testing/button.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    #btn {
+        background-color: gold;
+        font-size: 100px;
+        width: 500px;
+        border: none;
+    }
+</style>
+<script src="../include.js"></script>
+<button type="submit" id="btn">Button</button>
+<script>
+    asyncTest(done => {
+        const brn = document.getElementById("btn");
+        btn.onclick = () => {
+            println("Clicked!");
+            done();
+        };
+        internals.click(50, 50);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -34,8 +34,12 @@ static JS::GCPtr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable& pai
         return node;
     if (auto node = paintable.dom_node())
         return node;
-    if (auto* layout_parent = paintable.layout_node().parent())
-        return layout_parent->dom_node();
+    auto* layout_parent = paintable.layout_node().parent();
+    while (layout_parent) {
+        if (auto* node = layout_parent->dom_node())
+            return node;
+        layout_parent = layout_parent->parent();
+    }
     return nullptr;
 }
 


### PR DESCRIPTION
Change 'dom_node_for_event_dispatch' to locate the closest layout node with a DOM node instead of only checking the direct ancestor.

This fixes hit-testing for buttons because they are wrapped into multiple anonymous layout nodes (internally we use flex formatting for them).