### PR TITLE
LibGfx/TIFF+CCITT: Couple of fixes for CCITT3 1D

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -269,7 +269,9 @@ ErrorOr<void> decode_single_ccitt3_1d_line(BigEndianInputBitStream& input_bit_st
     auto const ccitt_white = Color::NamedColor::White;
     auto const ccitt_black = Color::NamedColor::Black;
 
-    Color current_color { ccitt_white };
+    // We always flip the color when entering the loop, so let's initialize the
+    // color with black to make the first marker actually be white.
+    Color current_color { ccitt_black };
     u32 run_length = 0;
     u32 column = 0;
 
@@ -283,10 +285,6 @@ ErrorOr<void> decode_single_ccitt3_1d_line(BigEndianInputBitStream& input_bit_st
         }
 
         current_color = current_color == ccitt_white ? ccitt_black : ccitt_white;
-
-        if (column == 0) {
-            current_color = ccitt_white;
-        }
 
         u8 size {};
         u16 potential_code {};

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -273,7 +273,7 @@ ErrorOr<void> decode_single_ccitt3_1d_line(BigEndianInputBitStream& input_bit_st
     u32 run_length = 0;
     u32 column = 0;
 
-    while (column < image_width) {
+    while (column < image_width - 1) {
         if (run_length > 0) {
             run_length--;
             TRY(decoded_bits.write_bits(current_color == ccitt_white ? 0u : 1u, 1));

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -73,6 +73,11 @@ class PhotometricInterpretation(EnumWithExportName):
     CIELab = 8
 
 
+class FillOrder(EnumWithExportName):
+    LeftToRight = 1
+    RightToLeft = 2
+
+
 class Orientation(EnumWithExportName):
     Default = 1
     FlipHorizontally = 2
@@ -124,6 +129,7 @@ known_tags: List[Tag] = [
     Tag('259', [TIFFType.UnsignedShort], [1], None, "Compression", Compression, is_required=True),
     Tag('262', [TIFFType.UnsignedShort], [1], None, "PhotometricInterpretation",
         PhotometricInterpretation, is_required=True),
+    Tag('266', [TIFFType.UnsignedShort], [1], FillOrder.LeftToRight, "FillOrder", FillOrder),
     Tag('271', [TIFFType.ASCII], [], None, "Make"),
     Tag('272', [TIFFType.ASCII], [], None, "Model"),
     Tag('273', [TIFFType.UnsignedShort, TIFFType.UnsignedLong], [], None, "StripOffsets", is_required=True),


### PR DESCRIPTION
These three patches make us successfully decode all (non-corrupted) CCITT images from libtiff's test suite.

![Screenshot from 2024-02-12 10-52-41](https://github.com/SerenityOS/serenity/assets/26030965/027a21e9-82c0-49f9-ab68-33aeb6c011da)

Yes, you've read that correctly: fax2d.tiff is encoded using CCITT3 1D :upside_down_face:
