### PR TITLE
LibConfig+ConfigServer: Add permissive mode, fixing a GMLPlayground crash

### DIFF
--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,7 +23,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath unix"));
     auto app = TRY(GUI::Application::create(arguments));
 
-    Config::pledge_domains({ "GMLPlayground", "Calendar" });
+    Config::enable_permissive_mode();
+    Config::pledge_domain("GMLPlayground");
     app->set_config_domain("GMLPlayground"_string);
 
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -43,6 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::create(arguments));
     app->set_config_domain("HackStudio"_string);
+    Config::enable_permissive_mode();
     Config::pledge_domains({ "HackStudio", "Terminal", "FileManager" });
 
     auto window = GUI::Window::construct();

--- a/Userland/Libraries/LibConfig/Client.cpp
+++ b/Userland/Libraries/LibConfig/Client.cpp
@@ -19,6 +19,11 @@ Client& Client::the()
     return *s_the;
 }
 
+void Client::enable_permissive_mode()
+{
+    async_enable_permissive_mode();
+}
+
 void Client::pledge_domains(Vector<ByteString> const& domains)
 {
     async_pledge_domains(domains);

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -20,6 +20,8 @@ class Client final
     IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/config"sv)
 
 public:
+    /// Permissive mode makes reads and writes to non-pledged domains into no-ops instead of client misbehavior errors.
+    void enable_permissive_mode();
     void pledge_domains(Vector<ByteString> const&);
     void monitor_domain(ByteString const&);
 
@@ -119,6 +121,11 @@ inline void remove_group(StringView domain, StringView group)
 inline void add_group(StringView domain, StringView group)
 {
     Client::the().add_group(domain, group);
+}
+
+inline void enable_permissive_mode()
+{
+    Client::the().enable_permissive_mode();
 }
 
 inline void pledge_domains(Vector<ByteString> const& domains)

--- a/Userland/Services/ConfigServer/ConfigServer.ipc
+++ b/Userland/Services/ConfigServer/ConfigServer.ipc
@@ -1,5 +1,6 @@
 endpoint ConfigServer
 {
+    enable_permissive_mode() =|
     pledge_domains(Vector<ByteString> domains) =|
 
     monitor_domain(ByteString domain) =|

--- a/Userland/Services/ConfigServer/ConnectionFromClient.h
+++ b/Userland/Services/ConfigServer/ConnectionFromClient.h
@@ -26,6 +26,7 @@ private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>, int client_id);
 
     virtual void pledge_domains(Vector<ByteString> const&) override;
+    virtual void enable_permissive_mode() override;
     virtual void monitor_domain(ByteString const&) override;
     virtual Messages::ConfigServer::ListConfigGroupsResponse list_config_groups([[maybe_unused]] ByteString const& domain) override;
     virtual Messages::ConfigServer::ListConfigKeysResponse list_config_keys([[maybe_unused]] ByteString const& domain, [[maybe_unused]] ByteString const& group) override;
@@ -46,6 +47,7 @@ private:
     void start_or_restart_sync_timer();
 
     bool m_has_pledged { false };
+    bool m_permissive_mode { false };
     HashTable<ByteString> m_pledged_domains;
 
     HashTable<ByteString> m_monitored_domains;


### PR DESCRIPTION
When in permissive mode, the ConfigServer will not treat reads and
writes to non-pledged domains as errors, but instead turns them into
no-ops: Reads will act as if the key was not found, and writes will do
nothing. Permissive mode must be enabled before pledging any domains.

This is needed to make GUI Widgets nicer to work with in GML Playground:
a few Widgets include reads and writes to LibConfig in order to load
system settings (eg, GUI::Calendar) or to save and restore state
(eg, GUI::DynamicWidgetContainer). Without this change, editing a
layout that includes one of these Widgets will cause GML Playground to
crash when they try to access config domains that are not pledged.

The solution used previously is to make Playground pledge more domains,
but not only does this mean Playground has to know about these cases,
but also that working on a layout file can alter the user's settings in
other arbitrary apps, which is not something we want.

By simply ignoring these config accesses, we avoid those downsides, and
Widgets will simply use the fallback values they already have to provide
to Config::read_foo_value().