### PR TITLE
LibWeb: Invert return value from EventHandler key event handling methods

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -847,12 +847,12 @@ bool EventHandler::handle_keydown(KeyCode key, u32 modifiers, u32 code_point)
     }
 
     // FIXME: Work out and implement the difference between this and keydown.
-    return fire_keyboard_event(UIEvents::EventNames::keypress, m_browsing_context, key, modifiers, code_point);
+    return !fire_keyboard_event(UIEvents::EventNames::keypress, m_browsing_context, key, modifiers, code_point);
 }
 
 bool EventHandler::handle_keyup(KeyCode key, u32 modifiers, u32 code_point)
 {
-    return fire_keyboard_event(UIEvents::EventNames::keyup, m_browsing_context, key, modifiers, code_point);
+    return !fire_keyboard_event(UIEvents::EventNames::keyup, m_browsing_context, key, modifiers, code_point);
 }
 
 void EventHandler::set_mouse_event_tracking_paintable(Painting::Paintable* paintable)


### PR DESCRIPTION
`EventHandler::handle_keyup()` and `EventHandler::handle_keydown()` return true if the event has been handled and false otherwise. This is the opposite behavior to `EventHandler::fire_keyboard_event()`. This change inverts the return value from `fire_keyboard_event` in these methods, allowing shortcut keys to be propagated to the Serenity Browser UI as expected.

Fixes #23159