### PR TITLE
LibWeb: Display an IBeam cursor by default when mousing over a text node

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -489,7 +489,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
             if (hovered_link_element)
                 is_hovering_link = true;
 
-            if (node->is_text()) {
+            if (paintable->layout_node().is_text_node()) {
                 if (cursor == CSS::Cursor::Auto)
                     hovered_node_cursor = Gfx::StandardCursor::IBeam;
                 else


### PR DESCRIPTION
We now check the type of the layout node at the current mouse position when determining which cursor to display during a mouse move event.

Before:

https://github.com/SerenityOS/serenity/assets/2817754/3eaa886f-cb7b-409c-aa9f-52cb7b606ecf

After:

https://github.com/SerenityOS/serenity/assets/2817754/09a32b65-816f-48f5-bc29-755524be3ec0




