### PR TITLE
Fuzzers: Add PAM fuzzer

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzPAMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPAMLoader.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ImageFormats/PAMLoader.h>
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
+{
+    AK::set_debug_enabled(false);
+    auto decoder_or_error = Gfx::PAMImageDecoderPlugin::create({ data, size });
+    if (decoder_or_error.is_error())
+        return 0;
+    auto decoder = decoder_or_error.release_value();
+    (void)decoder->frame(0);
+    return 0;
+}

--- a/Meta/Lagom/Fuzzers/FuzzPAMLoader.dict
+++ b/Meta/Lagom/Fuzzers/FuzzPAMLoader.dict
@@ -1,0 +1,14 @@
+magic_bytes="P7"
+
+header_token_endhdr="ENDHDR"
+header_token_width="WIDTH"
+header_token_height="HEIGHT"
+header_token_depth="DEPTH"
+header_token_maxval="MAXVAL"
+header_token_tupltype="TUPLTYPE"
+
+tupltype_value_blackandwhite="BLACKANDWHITE"
+tupltype_value_grayscale="GRAYSCALE"
+tupltype_value_rgb="RGB"
+tupltype_value_cmyk="CMYK"
+tupltype_value_alpha_suffix="_ALPHA"

--- a/Meta/Lagom/Fuzzers/fuzzers.cmake
+++ b/Meta/Lagom/Fuzzers/fuzzers.cmake
@@ -28,6 +28,7 @@ set(FUZZER_TARGETS
     MatroskaReader
     MD5
     MP3Loader
+    PAMLoader
     PBMLoader
     PDF
     PEM
@@ -99,6 +100,7 @@ set(FUZZER_DEPENDENCIES_Markdown LibMarkdown)
 set(FUZZER_DEPENDENCIES_MatroskaReader LibVideo)
 set(FUZZER_DEPENDENCIES_MD5 LibCrypto)
 set(FUZZER_DEPENDENCIES_MP3Loader LibAudio)
+set(FUZZER_DEPENDENCIES_PAMLoader LibGfx)
 set(FUZZER_DEPENDENCIES_PBMLoader LibGfx)
 set(FUZZER_DEPENDENCIES_PDF LibPDF)
 set(FUZZER_DEPENDENCIES_PEM LibCrypto)

--- a/Userland/Utilities/test-fuzz.cpp
+++ b/Userland/Utilities/test-fuzz.cpp
@@ -42,6 +42,7 @@
     T(MatroskaReader)        \
     T(MD5)                   \
     T(MP3Loader)             \
+    T(PAMLoader)             \
     T(PBMLoader)             \
     T(PDF)                   \
     T(PEM)                   \


### PR DESCRIPTION
I've included a dictionary of constants taken from [the PAM format specification](https://netpbm.sourceforge.net/doc/pam.html) to improve coverage.

NB: The above link doesn't mention the CMYK TUPLTYPE. I included it in the dictionary because it's used in one of our test files.