### PR TITLE
Kernel/TTY: Support non-blocking reads with termios VMIN == 0

### DIFF
--- a/Kernel/Devices/TTY/TTY.h
+++ b/Kernel/Devices/TTY/TTY.h
@@ -37,7 +37,6 @@ public:
         return 0;
     }
 
-    ErrorOr<void> set_termios(termios const&);
     bool should_generate_signals() const { return (m_termios.c_lflag & ISIG) == ISIG; }
     bool should_flush_on_signal() const { return (m_termios.c_lflag & NOFLSH) != NOFLSH; }
     bool should_echo_input() const { return (m_termios.c_lflag & ECHO) == ECHO; }
@@ -78,6 +77,7 @@ private:
     virtual bool is_tty() const final override { return true; }
 
     virtual void echo(u8) = 0;
+    ErrorOr<void> set_termios(OpenFileDescription&, termios const&);
 
     template<typename Functor>
     void process_output(u8, Functor put_char);


### PR DESCRIPTION
In a TTY's non-canonical mode, data availability can be configured by setting VMIN and VTIME to determine the minimum amount of bytes to read and the timeout between bytes, respectively. Some ports (such as SRB2) set VMIN to 0 which effectively makes reading a TTY such as stdin a non-blocking read. We didn't support this, causing ports to hang as soon as they try to read stdin without any data available.

Add a very duct-tapey implementation for the case where VMIN == 0 by overwriting the TTY's description's blocking status; 3 FIXMEs are included to make sure we clean this up some day.

You can test this behavior by installing the SRB2 port, and running `/usr/local/games/SRB2/srb2` from a Terminal window. The game should hang without this patch, only proceeding with new frames on (keyboard) input in the TTY.