### PR TITLE
LibPDF: Add some plumbing for the CCITTFax decode filter

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -22,6 +22,7 @@
     X(BaseFont)                   \
     X(BitsPerComponent)           \
     X(BitsPerSample)              \
+    X(BlackIs1)                   \
     X(BlackPoint)                 \
     X(Bounds)                     \
     X(C)                          \
@@ -51,6 +52,7 @@
     X(D)                          \
     X(DCTDecode)                  \
     X(DW)                         \
+    X(DamagedRowsBeforeError)     \
     X(Decode)                     \
     X(DecodeParms)                \
     X(DescendantFonts)            \
@@ -65,9 +67,12 @@
     X(E)                          \
     X(EarlyChange)                \
     X(Encode)                     \
+    X(EncodedByteAlign)           \
     X(Encoding)                   \
     X(Encrypt)                    \
     X(EncryptMetadata)            \
+    X(EndOfBlock)                 \
+    X(EndOfLine)                  \
     X(ExtGState)                  \
     X(F)                          \
     X(FL)                         \
@@ -106,6 +111,7 @@
     X(Intent)                     \
     X(JBIG2Decode)                \
     X(JPXDecode)                  \
+    X(K)                          \
     X(Keywords)                   \
     X(Kids)                       \
     X(L)                          \
@@ -152,6 +158,7 @@
     X(Registry)                   \
     X(Resources)                  \
     X(Root)                       \
+    X(Rows)                       \
     X(Rotate)                     \
     X(RunLengthDecode)            \
     X(S)                          \

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -30,7 +30,7 @@ PDFErrorOr<ByteBuffer> Filter::decode(ReadonlyBytes bytes, DeprecatedFlyString c
     if (encoding_type == CommonNames::RunLengthDecode)
         return decode_run_length(bytes);
     if (encoding_type == CommonNames::CCITTFaxDecode)
-        return decode_ccitt(bytes);
+        return decode_ccitt(bytes, decode_parms);
     if (encoding_type == CommonNames::JBIG2Decode)
         return decode_jbig2(bytes);
     if (encoding_type == CommonNames::DCTDecode)
@@ -275,8 +275,46 @@ PDFErrorOr<ByteBuffer> Filter::decode_run_length(ReadonlyBytes bytes)
     return TRY(Compress::PackBits::decode_all(bytes, OptionalNone {}, Compress::PackBits::CompatibilityMode::PDF));
 }
 
-PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes)
+PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes, RefPtr<DictObject> decode_parms)
 {
+    // Table 3.9 Optional parameters for the CCITTFaxDecode filter
+    int k = 0;
+    bool require_end_of_line = false;
+    bool encoded_byte_align = false;
+    int columns = 1728;
+    int rows = 0;
+    bool end_of_block = true;
+    bool black_is_1 = false;
+    int damaged_rows_before_error = 0;
+    if (decode_parms) {
+        if (decode_parms->contains(CommonNames::K))
+            k = decode_parms->get_value(CommonNames::K).get<int>();
+        if (decode_parms->contains(CommonNames::EndOfLine))
+            require_end_of_line = decode_parms->get_value(CommonNames::EndOfLine).get<bool>();
+        if (decode_parms->contains(CommonNames::EncodedByteAlign))
+            encoded_byte_align = decode_parms->get_value(CommonNames::EncodedByteAlign).get<bool>();
+        if (decode_parms->contains(CommonNames::Columns))
+            columns = decode_parms->get_value(CommonNames::Columns).get<int>();
+        if (decode_parms->contains(CommonNames::Rows))
+            rows = decode_parms->get_value(CommonNames::Rows).get<int>();
+        if (decode_parms->contains(CommonNames::EndOfBlock))
+            end_of_block = decode_parms->get_value(CommonNames::EndOfBlock).get<bool>();
+        if (decode_parms->contains(CommonNames::BlackIs1))
+            black_is_1 = decode_parms->get_value(CommonNames::BlackIs1).get<bool>();
+        if (decode_parms->contains(CommonNames::DamagedRowsBeforeError))
+            damaged_rows_before_error = decode_parms->get_value(CommonNames::DamagedRowsBeforeError).get<int>();
+    }
+
+    // FIXME: Do something with these.
+    (void)k;
+    (void)require_end_of_line;
+    (void)encoded_byte_align;
+    (void)columns;
+    (void)rows;
+    (void)end_of_block;
+    (void)black_is_1;
+    (void)damaged_rows_before_error;
+
     return Error::rendering_unsupported_error("CCITTFaxDecode Filter is unsupported");
 }
 

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -306,7 +306,6 @@ PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes, RefPtr<DictObject> de
     }
 
     // FIXME: Do something with these.
-    (void)k;
     (void)require_end_of_line;
     (void)encoded_byte_align;
     (void)columns;
@@ -315,7 +314,11 @@ PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes, RefPtr<DictObject> de
     (void)black_is_1;
     (void)damaged_rows_before_error;
 
-    return Error::rendering_unsupported_error("CCITTFaxDecode Filter is unsupported");
+    if (k < 0)
+        return Error::rendering_unsupported_error("CCITTFaxDecode Filter Group 4 is unsupported");
+    if (k == 0)
+        return Error::rendering_unsupported_error("CCITTFaxDecode Filter Group 3, 1-D is unsupported");
+    return Error::rendering_unsupported_error("CCITTFaxDecode Filter Group 3, 2-D is unsupported");
 }
 
 PDFErrorOr<ByteBuffer> Filter::decode_jbig2(ReadonlyBytes)

--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -25,7 +25,7 @@ private:
     static PDFErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes, RefPtr<DictObject> decode_parms);
     static PDFErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, RefPtr<DictObject> decode_parms);
     static PDFErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);
-    static PDFErrorOr<ByteBuffer> decode_ccitt(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_ccitt(ReadonlyBytes bytes, RefPtr<DictObject> decode_parms);
     static PDFErrorOr<ByteBuffer> decode_jbig2(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_dct(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_jpx(ReadonlyBytes bytes);

--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -22,8 +22,8 @@ private:
     static PDFErrorOr<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, size_t bytes_per_row, size_t bytes_per_pixel);
     static PDFErrorOr<ByteBuffer> decode_tiff_prediction(Bytes bytes, int columns, int colors, int bits_per_component);
-    static PDFErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component, int early_change);
-    static PDFErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component);
+    static PDFErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes, RefPtr<DictObject> decode_parms);
+    static PDFErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, RefPtr<DictObject> decode_parms);
     static PDFErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_ccitt(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_jbig2(ReadonlyBytes bytes);
@@ -31,7 +31,7 @@ private:
     static PDFErrorOr<ByteBuffer> decode_jpx(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_crypt(ReadonlyBytes bytes);
 
-    static PDFErrorOr<ByteBuffer> handle_lzw_and_flate_parameters(ByteBuffer buffer, int predictor, int columns, int colors, int bits_per_component);
+    static PDFErrorOr<ByteBuffer> handle_lzw_and_flate_parameters(ByteBuffer buffer, RefPtr<DictObject> decode_parms);
 };
 
 }


### PR DESCRIPTION
No behavior change (except for more granular errors – but in practice everything seems to be group 4).