### PR TITLE
LibGL: Add some API stubs

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -304,6 +304,7 @@ Vector<FunctionDefinition> create_function_definitions(ByteString function_name,
     // Create functions for each name and/or variant
     Vector<FunctionDefinition> functions;
 
+    function_name = function_definition.get_byte_string("name"sv).value_or(function_name);
     auto return_type = function_definition.get_byte_string("return_type"sv).value_or("void");
     auto function_implementation = function_definition.get_byte_string("implementation"sv).value_or(function_name.to_snakecase());
     auto function_unimplemented = function_definition.get_bool("unimplemented"sv).value_or(false);

--- a/Userland/Libraries/LibGL/GLAPI.json
+++ b/Userland/Libraries/LibGL/GLAPI.json
@@ -48,6 +48,12 @@
             {"type": "GLubyte const*", "name": "bitmap"}
         ]
     },
+    "BlendEquation": {
+        "arguments": [
+            {"type": "GLenum", "name": "mode"}
+        ],
+        "unimplemented": true
+    },
     "BlendFunc": {
         "arguments": [
             {"type": "GLenum", "name": ["sfactor", "dfactor"]}
@@ -468,6 +474,15 @@
         ],
         "implementation": "get_program"
     },
+    "GetShaderInfoLog": {
+        "arguments": [
+            {"type": "GLuint", "name": "shader"},
+            {"type": "GLsizei", "name": "maxLength"},
+            {"type": "GLsizei*", "name": "length"},
+            {"type": "GLchar*", "name": "infoLog"}
+        ],
+        "unimplemented": true
+    },
     "GetShaderiv": {
         "arguments": [
             {"type": "GLuint", "name": "shader"},
@@ -505,6 +520,13 @@
                 "iv!": {"implementation": "get_tex_parameter_integerv"}
             }
         }
+    },
+    "GetUniformLocation": {
+        "arguments": [
+            {"type": "GLuint", "name": "program"},
+            {"type": "GLchar const*", "name": "name"}
+        ],
+        "unimplemented": true
     },
     "Hint": {
         "arguments": [
@@ -1134,6 +1156,40 @@
             "types": {
                 "d": {},
                 "f": {}
+            }
+        }
+    },
+    "Uniform": {
+        "arguments": [
+            {"type": "GLint", "name": "location"},
+            {"name": ["v0", "v1", "v2", "v3"]}
+        ],
+        "unimplemented": true,
+        "variants": {
+            "argument_counts": [1, 2, 3, 4],
+            "argument_defaults": ["0.", "0.", "0.", "0."],
+            "types": {
+                "f": {},
+                "i": {},
+                "ui": {}
+            }
+        }
+    },
+    "Uniform_v": {
+        "arguments": [
+            {"type": "GLint", "name": "location"},
+            {"type": "GLsizei", "name": "count"},
+            {"name": "value"}
+        ],
+        "name": "Uniform",
+        "unimplemented": true,
+        "variants": {
+            "argument_counts": [1, 2, 3, 4],
+            "pointer_argument": "value",
+            "types": {
+                "fv": {},
+                "iv": {},
+                "uiv": {}
             }
         }
     },

--- a/Userland/Libraries/LibGL/GLAPI.json
+++ b/Userland/Libraries/LibGL/GLAPI.json
@@ -554,9 +554,25 @@
         "arguments": [
             {"type": "GLenum", "name": "pname"},
             {"name": "param"},
+            {"name": ["y", "z", "w"]}
+        ],
+        "variants": {
+            "argument_counts": [1],
+            "argument_defaults": ["0.f", "0.f", "0.f", "0.f"],
+            "types": {
+                "f": {},
+                "i": {}
+            }
+        }
+    },
+    "LightModel_v": {
+        "arguments": [
+            {"type": "GLenum", "name": "pname"},
+            {"name": "param"},
             {"type": "GLenum", "expression": "@variant_gl_type@"}
         ],
         "implementation": "light_modelv",
+        "name": "LightModel",
         "variants": {
             "argument_counts": [1],
             "pointer_argument": "params",
@@ -565,22 +581,6 @@
                 "iv": {}
             }
         }
-    },
-    "LightModelf": {
-        "arguments": [
-            {"type": "GLenum", "name": "pname"},
-            {"type": "GLfloat", "name": "x"},
-            {"name": ["y", "z", "w"], "expression": "0.f"}
-        ],
-        "implementation": "light_model"
-    },
-    "LightModeli": {
-        "arguments": [
-            {"type": "GLenum", "name": "pname"},
-            {"type": "GLint", "name": "x", "cast_to": "GLfloat"},
-            {"name": ["y", "z", "w"], "expression": "0.f"}
-        ],
-        "implementation": "light_model"
     },
     "LineWidth": {
         "arguments": [


### PR DESCRIPTION
Adding these stubs gives us full API coverage for the SRB2 port (although it currently still crashes in OpenGL mode).