### PR TITLE
LibWeb: Add support for opening and closing non-modal dialog elements

### DIFF
--- a/Tests/LibWeb/Text/expected/close-non-modal-dialog.txt
+++ b/Tests/LibWeb/Text/expected/close-non-modal-dialog.txt
@@ -1,0 +1,3 @@
+  dialog.open state before close(): true
+dialog.open state after close(): false
+dialog.returnValue state after close(): after-close

--- a/Tests/LibWeb/Text/expected/form-method-dialog.txt
+++ b/Tests/LibWeb/Text/expected/form-method-dialog.txt
@@ -1,0 +1,2 @@
+  dialog.open before form submit: true
+dialog.open after form submit: false

--- a/Tests/LibWeb/Text/expected/show-non-modal-dialog.txt
+++ b/Tests/LibWeb/Text/expected/show-non-modal-dialog.txt
@@ -1,0 +1,2 @@
+  dialog.open state before show(): false
+dialog.open state after show(): true

--- a/Tests/LibWeb/Text/input/close-non-modal-dialog.html
+++ b/Tests/LibWeb/Text/input/close-non-modal-dialog.html
@@ -1,0 +1,14 @@
+<script src="./include.js"></script>
+<dialog id="test-dialog" open></dialog>
+<script>
+    asyncTest((done) => {
+        const dialog = document.getElementById("test-dialog");
+        println(`dialog.open state before close(): ${dialog.open}`);
+        dialog.addEventListener("close", (event) => {
+            println(`dialog.open state after close(): ${dialog.open}`);
+            println(`dialog.returnValue state after close(): ${dialog.returnValue}`);
+            done();
+        });
+        dialog.close("after-close");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/form-method-dialog.html
+++ b/Tests/LibWeb/Text/input/form-method-dialog.html
@@ -1,0 +1,22 @@
+<style>
+    #test-dialog {
+    }
+</style>
+<script src="./include.js"></script>
+<dialog id="test-dialog" open>
+    <form method="dialog">
+        <button id="submit-button">Submit</button>
+    </form>
+</dialog>
+<script>
+    test(() => {
+        const dialog = document.getElementById("test-dialog");
+        const submitter = document.getElementById("submit-button");
+        const submitterRect = submitter.getBoundingClientRect();
+        const form = document.forms[0];        
+        println(`dialog.open before form submit: ${dialog.open}`);
+        form.submit();
+        println(`dialog.open after form submit: ${dialog.open}`);
+
+    });
+</script>

--- a/Tests/LibWeb/Text/input/show-non-modal-dialog.html
+++ b/Tests/LibWeb/Text/input/show-non-modal-dialog.html
@@ -1,0 +1,10 @@
+<script src="./include.js"></script>
+<dialog id="test-dialog"></dialog>
+<script>
+    test(() => {
+        const dialog = document.getElementById("test-dialog");
+        println(`dialog.open state before show(): ${dialog.open}`)
+        dialog.show();
+        println(`dialog.open state after show(): ${dialog.open}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Event.h>
+#include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/HTMLDialogElement.h>
 
 namespace Web::HTML {
@@ -26,9 +27,25 @@ void HTMLDialogElement::initialize(JS::Realm& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show
-void HTMLDialogElement::show()
+WebIDL::ExceptionOr<void> HTMLDialogElement::show()
 {
-    dbgln("(STUBBED) HTMLDialogElement::show()");
+    // 1. If this has an open attribute and the is modal flag of this is false, then return.
+    // FIXME: Add modal flag check here when modal dialog support is added
+    if (has_attribute(AttributeNames::open))
+        return {};
+
+    // FIXME: 2. If this has an open attribute, then throw an "InvalidStateError" DOMException.
+
+    // 3. Add an open attribute to this, whose value is the empty string.
+    TRY(set_attribute(AttributeNames::open, {}));
+
+    // FIXME 4. Set this's previously focused element to the focused element.
+    // FIXME 5. Run hide all popovers given this's node document.
+
+    // 6. Run the dialog focusing steps given this.
+    run_dialog_focusing_steps();
+
+    return {};
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal
@@ -90,6 +107,23 @@ void HTMLDialogElement::close_the_dialog(Optional<String> result)
     // FIXME: 9. If subject's close watcher is not null, then:
     //           1. Destroy subject's close watcher.
     //           2. Set subject's close watcher to null.
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps
+void HTMLDialogElement::run_dialog_focusing_steps()
+{
+    // 1. Let control be null
+    JS::GCPtr<Element> control = nullptr;
+
+    // FIXME 2. If subject has the autofocus attribute, then set control to subject.
+    // FIXME 3. If control is null, then set control to the focus delegate of subject.
+
+    // 4. If control is null, then set control to subject.
+    if (!control)
+        control = this;
+
+    // 5. Run the focusing steps for control.
+    run_focusing_steps(control);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/HTMLDialogElement.h>
 
 namespace Web::HTML {
@@ -37,9 +38,11 @@ void HTMLDialogElement::show_modal()
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-close
-void HTMLDialogElement::close(Optional<String>)
+void HTMLDialogElement::close(Optional<String> return_value)
 {
-    dbgln("(STUBBED) HTMLDialogElement::close()");
+    // 1. If returnValue is not given, then set it to null.
+    // 2. Close the dialog this with returnValue.
+    close_the_dialog(move(return_value));
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-returnvalue
@@ -52,6 +55,41 @@ String HTMLDialogElement::return_value() const
 void HTMLDialogElement::set_return_value(String return_value)
 {
     m_return_value = move(return_value);
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#close-the-dialog
+void HTMLDialogElement::close_the_dialog(Optional<String> result)
+{
+    // 1. If subject does not have an open attribute, then return.
+    if (!has_attribute(AttributeNames::open))
+        return;
+
+    // 2. Remove subject's open attribute.
+    remove_attribute(AttributeNames::open);
+
+    // FIXME: 3. If the is modal flag of subject is true, then request an element to be removed from the top layer given subject.
+    // FIXME: 4. Let wasModal be the value of subject's is modal flag.
+    // FIXME: 5. Set the is modal flag of subject to false.
+
+    // 6. If result is not null, then set the returnValue attribute to result.
+    if (result.has_value())
+        set_return_value(result.release_value());
+
+    // FIXME: 7. If subject's previously focused element is not null, then:
+    //           1. Let element be subject's previously focused element.
+    //           2. Set subject's previously focused element to null.
+    //           3. If subject's node document's focused area of the document's DOM anchor is a shadow-including inclusive descendant of element,
+    //              or wasModal is true, then run the focusing steps for element; the viewport should not be scrolled by doing this step.
+
+    // 8. Queue an element task on the user interaction task source given the subject element to fire an event named close at subject.
+    queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
+        auto close_event = DOM::Event::create(realm(), HTML::EventNames::close);
+        dispatch_event(close_event);
+    });
+
+    // FIXME: 9. If subject's close watcher is not null, then:
+    //           1. Destroy subject's close watcher.
+    //           2. Set subject's close watcher to null.
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -21,7 +21,7 @@ public:
     String return_value() const;
     void set_return_value(String);
 
-    void show();
+    WebIDL::ExceptionOr<void> show();
     void show_modal();
     void close(Optional<String> return_value);
 
@@ -34,6 +34,8 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     void close_the_dialog(Optional<String> result);
+
+    void run_dialog_focusing_steps();
 
     String m_return_value;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -33,6 +33,8 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
+    void close_the_dialog(Optional<String> result);
+
     String m_return_value;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/FormControlInfrastructure.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
+#include <LibWeb/HTML/HTMLDialogElement.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
@@ -179,17 +180,26 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
 
     // 11. If method is dialog, then:
     if (method == MethodAttributeState::Dialog) {
-        // FIXME: 1. If form does not have an ancestor dialog element, then return.
-        // FIXME: 2. Let subject be form's nearest ancestor dialog element.
-        // FIXME: 3. Let result be null.
+        // 1. If form does not have an ancestor dialog element, then return.
+        // 2. Let subject be form's nearest ancestor dialog element.
+        auto* subject = first_ancestor_of_type<HTMLDialogElement>();
+        if (!subject)
+            return {};
+
+        // 3. Let result be null.
+        Optional<String> result;
+
         // FIXME: 4. If submitter is an input element whose type attribute is in the Image Button state, then:
         //           1. Let (x, y) be the selected coordinate.
         //           2. Set result to the concatenation of x, ",", and y.
-        // FIXME: 5. Otherwise, if submitter has a value, then set result to that value.
-        // FIXME: 6. Close the dialog subject with result.
-        // FIXME: 7. Return.
 
-        dbgln("FIXME: Implement form submission with `dialog` action. Returning from form submission.");
+        // 5. Otherwise, if submitter has a value, then set result to that value.
+        result = submitter->get_attribute_value(AttributeNames::value);
+
+        // 6. Close the dialog subject with result.
+        subject->close(move(result));
+
+        // 7. Return.
         return {};
     }
 


### PR DESCRIPTION
This PR fleshes out `HTMLDialogElement::show()` and  `HTMLDialogElement::close()`, which were previously stubbed out. Support for submission of forms with the "dialog" method has also been added.

Note: The parts of these methods I have left unimplemented deal with non-modal dialogs, which we don't yet support.

Demo with this test page:
```html
<!DOCTYPE html>
<body>
    <dialog id="test-dialog" open>
        <form method="dialog">
            <button>Close</button>
        </form>
    </dialog>
    <button id="show-button" onClick="show()" hidden>Show</button>
</body>
<script>
    const dialogElement = document.getElementById("test-dialog");
    const showButton = document.getElementById("show-button");
    dialogElement.addEventListener("close", (event) => {
        showButton.hidden = false;
    });
    function show() {
        dialogElement.show();
        showButton.hidden = true;
    }
</script>
```

https://github.com/SerenityOS/serenity/assets/2817754/68b20d95-56aa-42fb-8400-943180594f77




