### PR TITLE
LibPDF/CFF: Yet more CID-keyed fonts scaffolding

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -127,6 +127,7 @@ public:
         float defaultWidthX = 0;
         float nominalWidthX = 0;
         int fdselect_offset = 0;
+        int fdarray_offset = 0;
     };
     static PDFErrorOr<Vector<TopDict>> parse_top_dicts(Reader&, ReadonlyBytes const& cff_bytes);
 

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -128,7 +128,7 @@ public:
         float nominalWidthX = 0;
         int fdselect_offset = 0;
     };
-    static PDFErrorOr<TopDict> parse_top_dict(Reader&, ReadonlyBytes const& cff_bytes);
+    static PDFErrorOr<Vector<TopDict>> parse_top_dicts(Reader&, ReadonlyBytes const& cff_bytes);
 
     static PDFErrorOr<Vector<StringView>> parse_strings(Reader&);
 

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -126,6 +126,7 @@ public:
         Vector<ByteBuffer> local_subroutines;
         float defaultWidthX = 0;
         float nominalWidthX = 0;
+        bool is_cid_keyed = false;
         int fdselect_offset = 0;
         int fdarray_offset = 0;
     };

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -118,6 +118,18 @@ public:
     template<typename OperatorT>
     static PDFErrorOr<OperatorT> parse_dict_operator(u8, Reader&);
 
+    // CFF spec, "8 Top DICT INDEX"
+    struct TopDict {
+        int charset_offset = 0;
+        int encoding_offset = 0;
+        int charstrings_offset = 0;
+        Vector<ByteBuffer> local_subroutines;
+        float defaultWidthX = 0;
+        float nominalWidthX = 0;
+        int fdselect_offset = 0;
+    };
+    static PDFErrorOr<TopDict> parse_top_dict(Reader&, ReadonlyBytes const& cff_bytes);
+
     static PDFErrorOr<Vector<StringView>> parse_strings(Reader&);
 
     static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -44,6 +44,10 @@ PDFErrorOr<void> Type1Font::initialize(Document* document, NonnullRefPtr<DictObj
             m_font_program = TRY(PS1FontProgram::create(font_file_stream->bytes(), encoding(), length1, length2));
         }
     }
+
+    if (m_font_program && m_font_program->kind() == Type1FontProgram::Kind::CIDKeyed)
+        return Error::parse_error("Type1 fonts must not be CID-keyed"sv);
+
     if (!m_font_program) {
         m_font = TRY(replacement_for(base_font_name().to_lowercase(), font_size));
     }

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -20,9 +20,16 @@ class Encoding;
 class Type1FontProgram : public RefCounted<Type1FontProgram> {
 
 public:
+    enum Kind {
+        NameKeyed,
+        CIDKeyed,
+    };
+
     RefPtr<Gfx::Bitmap> rasterize_glyph(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
     Gfx::FloatPoint glyph_translation(DeprecatedFlyString const& char_name, float width) const;
     RefPtr<Encoding> encoding() const { return m_encoding; }
+
+    Kind kind() const { return m_kind; }
 
 protected:
     struct AccentedCharacter {
@@ -111,10 +118,13 @@ protected:
 
     void consolidate_glyphs();
 
+    void set_kind(Kind kind) { m_kind = kind; }
+
 private:
     HashMap<DeprecatedFlyString, Glyph> m_glyph_map;
     Gfx::AffineTransform m_font_matrix;
     RefPtr<Encoding> m_encoding;
+    Kind m_kind { NameKeyed };
 
     Gfx::Path build_char(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
     Gfx::AffineTransform glyph_transform_to_device_space(Glyph const& glyph, float width) const;


### PR DESCRIPTION
Almost there! But no behavior change yet, since we don't pass CID-keyed CFF data into the CFF parser yet.

The diff isn't as big as it looks: The first commit moves some code around, and that looks like a lot of movement, but it's just extracting existing code unchanged to a new function. The rest is small.