### PR TITLE
Kernel/riscv64: Add missing include in Delay.cpp

### DIFF
--- a/Kernel/Arch/riscv64/Delay.cpp
+++ b/Kernel/Arch/riscv64/Delay.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <Kernel/Arch/Delay.h>
 
 namespace Kernel {


### PR DESCRIPTION
This include was missed in 4409b33145.
RISC-V should build again now.