### PR TITLE
LibPDF: Initial support for drawing CFF-based Type0 fonts

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -843,6 +843,8 @@ DeprecatedFlyString CFF::resolve_sid(SID sid, Vector<StringView> const& strings)
 PDFErrorOr<Vector<CFF::SID>> CFF::parse_charset(Reader&& reader, size_t glyph_count)
 {
     // CFF spec, "13 Charsets"
+
+    // Maps `GID - 1` to a SID (or CID, for CID-keyed fonts). The name of GID 0 is implicitly ".notdef".
     Vector<SID> names;
     auto format = TRY(reader.try_read<Card8>());
     if (format == 0) {

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -124,8 +124,8 @@ public:
         int encoding_offset = 0;
         int charstrings_offset = 0;
         Vector<ByteBuffer> local_subroutines;
-        float defaultWidthX = 0;
-        float nominalWidthX = 0;
+        Optional<float> defaultWidthX;
+        Optional<float> nominalWidthX;
         bool is_cid_keyed = false;
         int fdselect_offset = 0;
         int fdarray_offset = 0;


### PR DESCRIPTION
Together with the already-merged https://github.com/SerenityOS/serenity/pull/23122, https://github.com/SerenityOS/serenity/pull/23128, https://github.com/SerenityOS/serenity/pull/23135, https://github.com/SerenityOS/serenity/pull/23136, https://github.com/SerenityOS/serenity/pull/23162,
and https://github.com/SerenityOS/serenity/pull/23167, https://github.com/SerenityOS/serenity/pull/23179, https://github.com/SerenityOS/serenity/pull/23190, https://github.com/SerenityOS/serenity/pull/23194 this adds initial support for
rendering some CFF-based Type0 fonts :^)

There's a long list of things that still need improving after this:

* A small number of CFF programs contain the charstring command 0,
  which is invalid. Currently, this makes us reject the whole font.

* Type1FontProgram::rasterize_glyph() is name-based. For CID-based
  fonts, we want a version that takes CIDs (character IDs) instead.
  For now, I'm printing the CID to a string and using that, yuck.
  (I looked into doing this nicely. I do want to do that, but I
  need to read up on how the `seac` type1 charstring command uses
  character names to identify parts of an accented character.
  Also, it looks like `seac`'s accented character handling moved
  over to `endchar` in type2 charstring commands (i.e. in CFF data),
  and it looks like we don't implement that at all. So I need to do
  more reading first, and I didn't want to block this on that.)

* The name for the first string in name-based CFF fonts looks wrong;
  added a FIXME for that for now.

* This supports the named Identity-H cmap only for now. Identity-H
  maps UTF16-BE values to glyph IDs with the idenity function, and
  assumes it's horizontal text. Other named cmaps in my test files are
  UniJIS-UCS2-H, UniCNS-UCS2-H, Identity-V, UniGB-UCS2-H, UniKS-UCS2-H.
  (There are also 2 files using the stream-based cmaps instead of the
  name-based ones.)

  * In particular, we can't draw vertical text (`-V`) yet

* Passing in the encoding to CFF::create() is awkward (it's nullptr
  for CID-keyed fonts), and it's also not necessary since
  `Type1Font::draw_glyph()` already does the "take encoding from PDF,
  and only from font if the PDF doesn't store one" dance.

* This doesn't cache glyphs but re-rasterizes them each time. Easy
  to add, but maybe I want to look at rotation first. And things
  don't feel glacial as-is.

* Type0Font::draw_glyph() is pretty similar to second half of
  Type1Font::draw_glyph()