### PR TITLE
LibMarkdown: Setext headings, paragraph interruption, and other CommonMark stuff

### DIFF
--- a/Meta/CMake/commonmark_spec.cmake
+++ b/Meta/CMake/commonmark_spec.cmake
@@ -1,7 +1,7 @@
 option(ENABLE_COMMONMARK_SPEC_DOWNLOAD "Enable download of commonmark test suite at build time" ON)
 
 set(MARKDOWN_TEST_PATH ${SERENITY_CACHE_DIR}/commonmark.spec.json)
-set(MARKDOWN_TEST_URL https://spec.commonmark.org/0.30/spec.json)
+set(MARKDOWN_TEST_URL https://spec.commonmark.org/0.31.2/spec.json)
 
 if(ENABLE_COMMONMARK_SPEC_DOWNLOAD)
     download_file(${MARKDOWN_TEST_URL} ${MARKDOWN_TEST_PATH})

--- a/Tests/LibMarkdown/TestImageSizeExtension.cpp
+++ b/Tests/LibMarkdown/TestImageSizeExtension.cpp
@@ -15,17 +15,17 @@ struct TestCase {
 
 static constexpr Array image_size_tests {
     // No image size:
-    TestCase { .markdown = "![](foo.png)"sv, .expected_html = R"(<p><img src="foo.png" alt="" ></p>)"sv },
+    TestCase { .markdown = "![](foo.png)"sv, .expected_html = R"(<p><img src="foo.png" alt="" /></p>)"sv },
     // Only width given:
-    TestCase { .markdown = "![](foo.png =100x)"sv, .expected_html = R"(<p><img src="foo.png" style="width: 100px;" alt="" ></p>)"sv },
+    TestCase { .markdown = "![](foo.png =100x)"sv, .expected_html = R"(<p><img src="foo.png" style="width: 100px;" alt="" /></p>)"sv },
     // Only height given:
-    TestCase { .markdown = "![](foo.png =x200)"sv, .expected_html = R"(<p><img src="foo.png" style="height: 200px;" alt="" ></p>)"sv },
+    TestCase { .markdown = "![](foo.png =x200)"sv, .expected_html = R"(<p><img src="foo.png" style="height: 200px;" alt="" /></p>)"sv },
     // Both width and height given
-    TestCase { .markdown = "![](foo.png =50x25)"sv, .expected_html = R"(<p><img src="foo.png" style="width: 50px;height: 25px;" alt="" ></p>)"sv },
+    TestCase { .markdown = "![](foo.png =50x25)"sv, .expected_html = R"(<p><img src="foo.png" style="width: 50px;height: 25px;" alt="" /></p>)"sv },
     // Size contains invalid width
-    TestCase { .markdown = "![](foo.png =1oox50)"sv, .expected_html = R"(<p><img src="foo.png =1oox50" alt="" ></p>)"sv },
+    TestCase { .markdown = "![](foo.png =1oox50)"sv, .expected_html = R"(<p><img src="foo.png =1oox50" alt="" /></p>)"sv },
     // Size contains invalid height
-    TestCase { .markdown = "![](foo.png =900xfour)"sv, .expected_html = R"(<p><img src="foo.png =900xfour" alt="" ></p>)"sv },
+    TestCase { .markdown = "![](foo.png =900xfour)"sv, .expected_html = R"(<p><img src="foo.png =900xfour" alt="" /></p>)"sv },
 };
 
 TEST_CASE(test_image_size_markdown_extension)

--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -153,6 +153,10 @@ OwnPtr<CodeBlock> CodeBlock::parse_backticks(LineIterator& lines, Heading* curre
     auto style = matches[2].view.string_view();
     auto language = matches[3].view.string_view();
 
+    size_t fence_indent = 0;
+    while (fence_indent < line.length() && line[fence_indent] == ' ')
+        ++fence_indent;
+
     ++lines;
 
     StringBuilder builder;
@@ -169,7 +173,14 @@ OwnPtr<CodeBlock> CodeBlock::parse_backticks(LineIterator& lines, Heading* curre
             if (close_fence[0] == fence[0] && close_fence.length() >= fence.length())
                 break;
         }
-        builder.append(line);
+
+        // If the opening fence is indented, content lines will have equivalent
+        // opening indentation removed, if present. (example 131, 132 and 133)
+        size_t offset = 0;
+        while (offset < line.length() && offset < fence_indent && line[offset] == ' ')
+            ++offset;
+
+        builder.append(line.substring_view(offset));
         builder.append('\n');
     }
 

--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -117,7 +117,7 @@ static Optional<size_t> line_block_prefix(StringView const& line)
     return {};
 }
 
-OwnPtr<CodeBlock> CodeBlock::parse(LineIterator& lines, Heading* current_section)
+OwnPtr<CodeBlock> CodeBlock::parse(LineIterator& lines, Heading* current_section, bool is_interrupting_paragraph)
 {
     if (lines.is_end())
         return {};
@@ -125,6 +125,10 @@ OwnPtr<CodeBlock> CodeBlock::parse(LineIterator& lines, Heading* current_section
     StringView line = *lines;
     if (open_fence_re.match(line).success)
         return parse_backticks(lines, current_section);
+
+    // An indented code block cannot interrupt a paragraph (example 113)
+    if (is_interrupting_paragraph)
+        return {};
 
     if (line_block_prefix(line).has_value())
         return parse_indent(lines);

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -12,6 +12,7 @@
 #include <LibMarkdown/Heading.h>
 #include <LibMarkdown/LineIterator.h>
 #include <LibMarkdown/Text.h>
+#include <LibRegex/Regex.h>
 
 namespace Markdown {
 
@@ -37,7 +38,7 @@ private:
     ByteString m_style;
     Heading* m_current_section;
 
-    static OwnPtr<CodeBlock> parse_backticks(LineIterator& lines, Heading* current_section);
+    static OwnPtr<CodeBlock> parse_backticks(LineIterator& lines, Heading* current_section, RegexResult match_result);
     static OwnPtr<CodeBlock> parse_indent(LineIterator& lines);
 };
 

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -29,7 +29,7 @@ public:
     virtual ByteString render_to_html(bool tight = false) const override;
     virtual Vector<ByteString> render_lines_for_terminal(size_t view_width = 0) const override;
     virtual RecursionDecision walk(Visitor&) const override;
-    static OwnPtr<CodeBlock> parse(LineIterator& lines, Heading* current_section);
+    static OwnPtr<CodeBlock> parse(LineIterator& lines, Heading* current_section, bool is_interrupting_paragraph);
 
 private:
     ByteString m_code;

--- a/Userland/Libraries/LibMarkdown/LineIterator.cpp
+++ b/Userland/Libraries/LibMarkdown/LineIterator.cpp
@@ -39,6 +39,9 @@ Optional<StringView> LineIterator::match_context(StringView line) const
             if (offset >= line.length() || line[offset] != '>') {
                 return {};
             }
+            // The block quote marker '>' can be followed by an optional space (example 252)
+            if (offset + 1 < line.length() && line[offset + 1] == ' ')
+                ++offset;
             ++offset;
             break;
         }

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -152,8 +152,18 @@ OwnPtr<List> List::parse(LineIterator& lines, bool is_interrupting_paragraph)
             break;
         }
 
+        VERIFY(line[offset] == ' ');
+
+        size_t fallback_context_indent = offset + 1;
+
         while (offset < line.length() && line[offset] == ' ')
             offset++;
+
+        size_t context_indent = offset;
+
+        // Item starting with indented code (example 273)
+        if (1 + offset - fallback_context_indent > 4)
+            context_indent = fallback_context_indent;
 
         if (first) {
             is_ordered = appears_ordered;
@@ -163,7 +173,7 @@ OwnPtr<List> List::parse(LineIterator& lines, bool is_interrupting_paragraph)
 
         is_tight = is_tight && !has_trailing_blank_lines;
 
-        lines.push_context(LineIterator::Context::list_item(offset));
+        lines.push_context(LineIterator::Context::list_item(context_indent));
 
         auto list_item = ContainerBlock::parse(lines);
         is_tight = is_tight && !list_item->has_blank_lines();

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -85,7 +85,7 @@ RecursionDecision List::walk(Visitor& visitor) const
     return RecursionDecision::Continue;
 }
 
-OwnPtr<List> List::parse(LineIterator& lines)
+OwnPtr<List> List::parse(LineIterator& lines, bool is_interrupting_paragraph)
 {
     Vector<OwnPtr<ContainerBlock>> items;
 
@@ -124,8 +124,12 @@ OwnPtr<List> List::parse(LineIterator& lines)
                     auto maybe_start_number = line.substring_view(offset, i - offset).to_number<size_t>();
                     if (!maybe_start_number.has_value())
                         break;
-                    if (first)
+                    if (first) {
                         start_number = maybe_start_number.value();
+                        // Only ordered lists starting with 1 can iterrupt a paragraph (example 304)
+                        if (is_interrupting_paragraph && start_number != 1)
+                            return {};
+                    }
                     appears_ordered = true;
                     offset = i + 1;
                 }

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -107,6 +107,14 @@ OwnPtr<List> List::parse(LineIterator& lines, bool is_interrupting_paragraph)
         while (offset < line.length() && line[offset] == ' ')
             ++offset;
 
+        // Optional initial indentation of maximum three spaces (example 289)
+        if (offset > 3) {
+            if (first)
+                return {};
+
+            break;
+        }
+
         if (offset + 2 <= line.length()) {
             if (line[offset + 1] == ' ' && (line[offset] == '*' || line[offset] == '-' || line[offset] == '+')) {
                 appears_unordered = true;

--- a/Userland/Libraries/LibMarkdown/List.h
+++ b/Userland/Libraries/LibMarkdown/List.h
@@ -29,7 +29,7 @@ public:
     virtual Vector<ByteString> render_lines_for_terminal(size_t view_width = 0) const override;
     virtual RecursionDecision walk(Visitor&) const override;
 
-    static OwnPtr<List> parse(LineIterator& lines);
+    static OwnPtr<List> parse(LineIterator& lines, bool is_interrupting_paragraph);
 
 private:
     Vector<OwnPtr<ContainerBlock>> m_items;

--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -167,7 +167,7 @@ void Text::LinkNode::render_to_html(StringBuilder& builder) const
         }
         builder.append("\" alt=\""sv);
         text->render_to_html(builder);
-        builder.append("\" >"sv);
+        builder.append("\" />"sv);
     } else {
         builder.append("<a href=\""sv);
         builder.append(escape_html_entities(href));


### PR DESCRIPTION
Contributes towards #22049.

The "Fragment / Shortcut links in heading" feature and "prepend `file://` if absolute path" feature needs to be disabled to test against CommonMark test suite.

I tried implementing Render Extensions infrastructure (in ~https://github.com/ronak69/serenity/commit/78a19a64ecae49c1ef40d7f3534d93b7a70849c3~ ~https://github.com/ronak69/serenity/commit/dcd58794e762c4acf09cd9bc0c9c24ae3a12cc47~ https://github.com/ronak69/serenity/commit/f57338ee8cc9461456afb98ea17b0acade0040a1) but maybe it is not the right way to implement extension support. (any other ideas?)

Use that branch or simply apply these patches to disable those two features to
actually see which examples this PR fixes.

<details>

<summary>The Patch</summary>

```diff
diff --git a/Tests/LibMarkdown/CMakeLists.txt b/Tests/LibMarkdown/CMakeLists.txt
index adf499594..97bff35e4 100644
--- a/Tests/LibMarkdown/CMakeLists.txt
+++ b/Tests/LibMarkdown/CMakeLists.txt
@@ -8,7 +8,3 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibMarkdown LIBS LibMarkdown)
 endforeach()
-
-if (BUILD_LAGOM)
-    set_tests_properties(TestCommonmark PROPERTIES DISABLED YES)
-endif()
diff --git a/Userland/Libraries/LibMarkdown/Heading.cpp b/Userland/Libraries/LibMarkdown/Heading.cpp
index be0991c14..92e2608d7 100644
--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -14,9 +14,7 @@ namespace Markdown {
 
 ByteString Heading::render_to_html(bool) const
 {
-    auto input = Unicode::normalize(m_text.render_for_raw_print(), Unicode::NormalizationForm::NFD);
-    auto slugified = MUST(AK::slugify(input));
-    return ByteString::formatted("<h{} id='{}'><a href='#{}'>#</a> {}</h{}>\n", m_level, slugified, slugified, m_text.render_to_html(), m_level);
+    return ByteString::formatted("<h{}>{}</h{}>\n", m_level, m_text.render_to_html(), m_level);
 }
 
 Vector<ByteString> Heading::render_lines_for_terminal(size_t) const
diff --git a/Userland/Libraries/LibMarkdown/Text.cpp b/Userland/Libraries/LibMarkdown/Text.cpp
index f321bf9e6..a17316ef3 100644
--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -673,10 +673,6 @@ NonnullOwnPtr<Text::Node> Text::parse_link(Vector<Token>::ConstIterator& tokens)
 
             ByteString href = address.to_byte_string().trim_whitespace();
 
-            // Add file:// if the link is an absolute path otherwise it will be assumed relative.
-            if (AK::StringUtils::starts_with(href, "/"sv, CaseSensitivity::CaseSensitive))
-                href = ByteString::formatted("file://{}", href);
-
             return make<LinkNode>(is_image, move(link_text), move(href), image_width, image_height);
         }

```
</details>

|         | passed | failed |
|---------|--------|--------|
| master  |  299   |  353   |
| this PR |  327   |  325   |

with extensions disabled:

|         | passed | failed |
|---------|--------|--------|
| master  |  325   |  327   |
| this PR |  377   |  275   |

