### PR TITLE
LibWeb: Implement `HTMLFormElement.requestSubmit()`

### DIFF
--- a/Tests/LibWeb/Text/expected/form-method-dialog.txt
+++ b/Tests/LibWeb/Text/expected/form-method-dialog.txt
@@ -1,2 +1,4 @@
   dialog.open before form submit: true
+dialog.returnValue before form submit should be empty: true
 dialog.open after form submit: false
+dialog.returnValue after form submit: PASS

--- a/Tests/LibWeb/Text/expected/form-requestSubmit.txt
+++ b/Tests/LibWeb/Text/expected/form-requestSubmit.txt
@@ -1,0 +1,4 @@
+       Submitter is null
+<INPUT id="form-associated-button" >
+Exception: NotFoundError
+Exception: TypeError

--- a/Tests/LibWeb/Text/input/form-method-dialog.html
+++ b/Tests/LibWeb/Text/input/form-method-dialog.html
@@ -1,7 +1,7 @@
 <script src="./include.js"></script>
 <dialog id="test-dialog" open>
     <form method="dialog">
-        <button id="submit-button">Submit</button>
+        <button id="submit-button" value="PASS">Submit</button>
     </form>
 </dialog>
 <script>
@@ -10,8 +10,9 @@
         const submitter = document.getElementById("submit-button");
         const form = document.forms[0];
         println(`dialog.open before form submit: ${dialog.open}`);
-        form.submit();
+        println(`dialog.returnValue before form submit should be empty: ${dialog.returnValue === ""}`);
+        form.requestSubmit(submitter);
         println(`dialog.open after form submit: ${dialog.open}`);
-
+        println(`dialog.returnValue after form submit: ${dialog.returnValue}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/form-method-dialog.html
+++ b/Tests/LibWeb/Text/input/form-method-dialog.html
@@ -1,7 +1,3 @@
-<style>
-    #test-dialog {
-    }
-</style>
 <script src="./include.js"></script>
 <dialog id="test-dialog" open>
     <form method="dialog">
@@ -12,8 +8,7 @@
     test(() => {
         const dialog = document.getElementById("test-dialog");
         const submitter = document.getElementById("submit-button");
-        const submitterRect = submitter.getBoundingClientRect();
-        const form = document.forms[0];        
+        const form = document.forms[0];
         println(`dialog.open before form submit: ${dialog.open}`);
         form.submit();
         println(`dialog.open after form submit: ${dialog.open}`);

--- a/Tests/LibWeb/Text/input/form-requestSubmit.html
+++ b/Tests/LibWeb/Text/input/form-requestSubmit.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<span id="not-a-submit-button"></span>
+<form>
+    <input type="Submit" id="form-associated-button"  />
+</form>
+<input type="Submit" id="other-button" />
+<script src="./include.js"></script>
+<script>
+    test(() => {
+        const form = document.forms[0];
+        form.addEventListener("submit", event => {
+            event.preventDefault();
+            if (event.submitter) {
+                printElement(event.submitter);
+            } else {
+                println("Submitter is null");
+            }
+        });
+        
+        form.requestSubmit();
+        
+        const formAssociatedButton = document.getElementById("form-associated-button");
+        form.requestSubmit(formAssociatedButton);
+
+        const otherButton = document.getElementById("other-button");
+        try {
+            form.requestSubmit(otherButton);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception: ${e.name}`);
+        }
+
+        const notASubmitButton = document.getElementById("not-a-submit-button");
+        try {
+            form.requestSubmit(notASubmitButton);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception: ${e.name}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -66,6 +66,9 @@ public:
     WebIDL::ExceptionOr<void> submit();
 
     // NOTE: This is for the JS bindings. Use submit_form instead.
+    WebIDL::ExceptionOr<void> request_submit(JS::GCPtr<Element> submitter);
+
+    // NOTE: This is for the JS bindings. Use submit_form instead.
     void reset();
 
     void add_associated_element(Badge<FormAssociatedElement>, HTMLElement&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -25,7 +25,7 @@ interface HTMLFormElement : HTMLElement {
     getter (RadioNodeList or Element) (DOMString name);
 
     undefined submit();
-    // FIXME: undefined requestSubmit(optional HTMLElement? submitter = null);
+    undefined requestSubmit(optional HTMLElement? submitter = null);
     [CEReactions] undefined reset();
     boolean checkValidity();
     boolean reportValidity();


### PR DESCRIPTION
This PR implements the `HTMLFormElement.requestSubmit()` method, which can be used to programatically submit a form using a specific submit button.

My motivation for adding this is that I wanted to use it in a test I had previously written; I've taken the opportunity to update that test as part of this PR.

This method also appears to be used by [some WPT tests](https://github.com/search?q=repo%3Aweb-platform-tests%2Fwpt%20requestSubmit&type=code).