### PR TITLE
Kernel/riscv64: Don't use the memory before .text as the initial stack

### DIFF
--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -150,20 +150,12 @@ static UNMAP_AFTER_INIT void build_mappings(PageBumpAllocator& allocator, u64* r
     auto start_of_kernel_range = VirtualAddress { bit_cast<FlatPtr>(+start_of_kernel_image) };
     auto end_of_kernel_range = VirtualAddress { bit_cast<FlatPtr>(+end_of_kernel_image) };
 
-    // FIXME: don't use the memory before `start` as the stack
-    auto start_of_stack_range = VirtualAddress { bit_cast<FlatPtr>(+start_of_kernel_image) }.offset(-64 * KiB);
-    auto end_of_stack_range = VirtualAddress { bit_cast<FlatPtr>(+start_of_kernel_image) };
-
     auto start_of_physical_kernel_range = PhysicalAddress { start_of_kernel_range.get() }.offset(-calculate_physical_to_link_time_address_offset());
-    auto start_of_physical_stack_range = PhysicalAddress { start_of_stack_range.get() }.offset(-calculate_physical_to_link_time_address_offset());
 
     // FIXME: dont map everything RWX
 
     // Map kernel into high virtual memory
     insert_entries_for_memory_range(allocator, root_table, start_of_kernel_range, end_of_kernel_range, start_of_physical_kernel_range, PageTableEntryBits::Readable | PageTableEntryBits::Writeable | PageTableEntryBits::Executable);
-
-    // Map the stack
-    insert_entries_for_memory_range(allocator, root_table, start_of_stack_range, end_of_stack_range, start_of_physical_stack_range, PageTableEntryBits::Readable | PageTableEntryBits::Writeable);
 }
 
 static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)

--- a/Kernel/Arch/riscv64/boot.S
+++ b/Kernel/Arch/riscv64/boot.S
@@ -35,8 +35,8 @@ Lclear_bss_loop:
   bltu t0, t1, Lclear_bss_loop
 Lclear_bss_done:
 
-  // Let the stack start before .text for now.
-  lla sp, start
+  // Set the stack pointer register to the location defined in the linker script.
+  lla sp, end_of_initial_stack
 
   // Zero all registers except sp, a0 and a1.
   li ra, 0

--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -98,6 +98,12 @@ SECTIONS
         *(.heap)
     } :bss
 
+    . = ALIGN(4K);
+    start_of_initial_stack = .;
+
+    . += 32K;
+    end_of_initial_stack = .;
+
     /*
         FIXME: 8MB is enough space for all of the tables required to identity map
                physical memory. 8M is wasteful, so this should be properly calculated.


### PR DESCRIPTION
This PR also makes kernel backtraces appear before `init_stage2`, as we check if the frame pointer is below `kernel_mapping_base` in `dump_backtrace_impl`.