### PR TITLE
LibWeb: Implement Document named properties with light caching

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Document-named-properties.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-named-properties.txt
@@ -1,0 +1,16 @@
+ Submit        <FORM >
+document.bob === document.forms[0]: true
+<BUTTON id="fred" >
+img element with name 'foo' and id 'bar':
+<IMG id="bar" >
+img element with id 'baz', but no name:
+baz === undefined: true
+Multiple elements with name 'foo':
+foos.length = 2
+<IMG id="bar" >
+<FORM >
+obj element with name 'greg' and id 'banana':
+<OBJECT id="banana" >
+<OBJECT id="banana" >
+goodbye greg/banana
+no more greg or banana: true, true

--- a/Tests/LibWeb/Text/input/DOM/Document-named-properties.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-named-properties.html
@@ -1,0 +1,45 @@
+<form name="bob">
+    <button type="submit" id="fred" name="george" value="submit">Submit</button>
+</form>
+<img name="foo" id="bar" src="http://www.example.com" alt="Example" />
+<img id="baz" src="http://www.example.com" alt="Example" />
+<form name="foo">
+</form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        printElement(document.bob);
+        println(`document.bob === document.forms[0]: ${document.bob === document.forms[0]}`);
+        printElement(document.bob.fred);
+
+        println("img element with name 'foo' and id 'bar':");
+        printElement(document.bar);
+
+        println("img element with id 'baz', but no name:");
+        let baz = document.baz;
+        println(`baz === undefined: ${baz === undefined}`);
+
+        println("Multiple elements with name 'foo':");
+        let foos = document.foo;
+
+        println(`foos.length = ${foos.length}`);
+        for (let i = 0; i < foos.length; i++) {
+            printElement(foos[i]);
+        }
+
+        let obj = document.createElement("object");
+        obj.name = "greg";
+        obj.id = "banana";
+
+        document.body.insertBefore(obj, document.foo[0]);
+
+        println("obj element with name 'greg' and id 'banana':");
+        printElement(document.greg);
+        printElement(document.banana);
+
+        println("goodbye greg/banana");
+        document.body.removeChild(document.greg);
+
+        println(`no more greg or banana: ${document.greg === undefined}, ${document.banana === undefined}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -555,8 +555,12 @@ public:
     JS::GCPtr<HTML::SessionHistoryEntry> latest_entry() const { return m_latest_entry; }
     void set_latest_entry(JS::GCPtr<HTML::SessionHistoryEntry> e) { m_latest_entry = e; }
 
-    void element_id_changed(Badge<DOM::Element>);
-    void element_with_id_was_added_or_removed(Badge<DOM::Element>);
+    void element_id_changed(Badge<DOM::Element>, JS::NonnullGCPtr<DOM::Element> element);
+    void element_with_id_was_added(Badge<DOM::Element>, JS::NonnullGCPtr<DOM::Element> element);
+    void element_with_id_was_removed(Badge<DOM::Element>, JS::NonnullGCPtr<DOM::Element> element);
+    void element_name_changed(Badge<DOM::Element>, JS::NonnullGCPtr<DOM::Element> element);
+    void element_with_name_was_added(Badge<DOM::Element>, JS::NonnullGCPtr<DOM::Element> element);
+    void element_with_name_was_removed(Badge<DOM::Element>, JS::NonnullGCPtr<DOM::Element> element);
 
     void add_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
     void remove_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
@@ -571,6 +575,10 @@ public:
     JS::GCPtr<Element const> scrolling_element() const;
 
     void set_needs_to_resolve_paint_only_properties() { m_needs_to_resolve_paint_only_properties = true; }
+
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
+    virtual Vector<FlyString> supported_property_names() const override;
+    Vector<JS::NonnullGCPtr<DOM::Element>> const& potentially_named_elements() const { return m_potentially_named_elements; }
 
 protected:
     virtual void initialize(JS::Realm&) override;
@@ -795,6 +803,8 @@ private:
     bool m_ready_to_run_scripts { false };
 
     Vector<HTML::FormAssociatedElement*> m_form_associated_elements_with_form_attribute;
+
+    Vector<JS::NonnullGCPtr<DOM::Element>> m_potentially_named_elements;
 
     bool m_design_mode_enabled { false };
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -24,7 +24,8 @@
 #import <Selection/Selection.idl>
 
 // https://dom.spec.whatwg.org/#document
-[Exposed=Window]
+// https://html.spec.whatwg.org/multipage/dom.html#the-document-object
+[Exposed=Window, LegacyOverrideBuiltins]
 interface Document : Node {
     constructor();
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -466,12 +466,14 @@ void Element::attribute_changed(FlyString const& name, Optional<String> const& v
         else
             m_id = value_or_empty;
 
-        document().element_id_changed({});
+        document().element_id_changed({}, *this);
     } else if (name == HTML::AttributeNames::name) {
         if (!value.has_value())
             m_name = {};
         else
             m_name = value_or_empty;
+
+        document().element_name_changed({}, *this);
     } else if (name == HTML::AttributeNames::class_) {
         auto new_classes = value_or_empty.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
         m_classes.clear();
@@ -1033,7 +1035,10 @@ void Element::inserted()
     Base::inserted();
 
     if (m_id.has_value())
-        document().element_with_id_was_added_or_removed({});
+        document().element_with_id_was_added({}, *this);
+
+    if (m_name.has_value())
+        document().element_with_name_was_added({}, *this);
 }
 
 void Element::removed_from(Node* node)
@@ -1041,7 +1046,10 @@ void Element::removed_from(Node* node)
     Base::removed_from(node);
 
     if (m_id.has_value())
-        document().element_with_id_was_added_or_removed({});
+        document().element_with_id_was_removed({}, *this);
+
+    if (m_name.has_value())
+        document().element_with_name_was_removed({}, *this);
 }
 
 void Element::children_changed()


### PR DESCRIPTION
We now cache potentially named elements on the Document when elements are inserted and removed. This allows us to do lookup of what names are supported much faster than if we had to iterate the tree every time.

This first cut doesn't implement the rules for 'exposed' object and embed elements.

Fixes #22232