### PR TITLE
LibWeb: Implement `document.scrollingElement`

### DIFF
--- a/Tests/LibWeb/Text/expected/document-scrollingElement-quirks-mode.txt
+++ b/Tests/LibWeb/Text/expected/document-scrollingElement-quirks-mode.txt
@@ -1,0 +1,2 @@
+document.compatMode: BackCompat
+document.scrollingElement is body element: true

--- a/Tests/LibWeb/Text/expected/document-scrollingElement.txt
+++ b/Tests/LibWeb/Text/expected/document-scrollingElement.txt
@@ -1,0 +1,2 @@
+document.compatMode: CSS1Compat
+document.scrollingElement is document root element: true

--- a/Tests/LibWeb/Text/input/document-scrollingElement-quirks-mode.html
+++ b/Tests/LibWeb/Text/input/document-scrollingElement-quirks-mode.html
@@ -1,0 +1,8 @@
+<!-- quirks mode -->
+<script src="include.js"></script>
+<script type="">
+    test(() => {        
+        println(`document.compatMode: ${document.compatMode}`);
+        println(`document.scrollingElement is body element: ${document.scrollingElement === document.body}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/document-scrollingElement.html
+++ b/Tests/LibWeb/Text/input/document-scrollingElement.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println(`document.compatMode: ${document.compatMode}`);
+        println(`document.scrollingElement is document root element: ${document.scrollingElement === document.documentElement}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3854,4 +3854,26 @@ Vector<JS::NonnullGCPtr<Element>> Document::elements_from_point(double x, double
     return sequence;
 }
 
+// https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement
+JS::GCPtr<Element const> Document::scrolling_element() const
+{
+    // 1. If the Document is in quirks mode, follow these substeps:
+    if (in_quirks_mode()) {
+        // 1. If the body element exists, and it is not potentially scrollable, return the body element and abort these steps.
+        //    For this purpose, a value of overflow:clip on the the body element’s parent element must be treated as overflow:hidden.
+        if (auto const* body_element = body(); body_element && !body_element->is_potentially_scrollable())
+            return body_element;
+
+        // 2. Return null and abort these steps.
+        return nullptr;
+    }
+
+    // 2. If there is a root element, return the root element and abort these steps.
+    if (auto const* root_element = document_element(); root_element)
+        return root_element;
+
+    // 3. Return null.
+    return nullptr;
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -568,6 +568,7 @@ public:
 
     Element const* element_from_point(double x, double y);
     Vector<JS::NonnullGCPtr<Element>> elements_from_point(double x, double y);
+    JS::GCPtr<Element const> scrolling_element() const;
 
     void set_needs_to_resolve_paint_only_properties() { m_needs_to_resolve_paint_only_properties = true; }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -122,6 +122,7 @@ interface Document : Node {
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface
     Element? elementFromPoint(double x, double y);
     sequence<Element> elementsFromPoint(double x, double y);
+    readonly attribute Element? scrollingElement;
 };
 
 dictionary ElementCreationOptions {


### PR DESCRIPTION
This returns a reference to the element that scrolls the document. In standards mode it is equivalent to `document.documentElement`.

This property is used by [a number of WPT tests](https://github.com/search?q=repo%3Aweb-platform-tests%2Fwpt+document.scrollingElement&type=code), so this should help us to run more of those tests.