### PR TITLE
LibWeb: Stub out all the functions from the execCommand spec

### DIFF
--- a/Tests/LibWeb/Text/expected/Editing/execCommand-is-a-noop.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-is-a-noop.txt
@@ -1,0 +1,7 @@
+Hello, world!I'm totally bold rn  execCommand("bold") returned false
+Hello, world!<b>I'm totally bold rn</b>
+queryCommandEnabled("bold") returned false
+queryCommandIndeterm("bold") returned false
+queryCommandState("bold") returned false
+queryCommandSupported("bold") returned false
+queryCommandValue("bold") returned ""

--- a/Tests/LibWeb/Text/input/Editing/execCommand-is-a-noop.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-is-a-noop.html
@@ -1,0 +1,32 @@
+<script src="../include.js"></script>
+<div id="text" contenteditable="true"></div>
+<script>
+    test(() => {
+        let text = document.getElementById("text");
+        text.focus();
+
+        let hello = text.appendChild(document.createTextNode("Hello, world!"));
+
+        let boldText = document.createTextNode("I'm totally bold rn");
+        let boldTag = text.appendChild(document.createElement("b"));
+        boldTag.appendChild(boldText);
+
+        // select the text
+        let range = document.createRange();
+        range.selectNodeContents(hello);
+        let selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        let e = document.execCommand("bold", false, "on");
+        println(`execCommand("bold") returned ${e}`);
+        let allTheText = text.innerHTML;
+        println(allTheText);
+
+        println(`queryCommandEnabled("bold") returned ${document.queryCommandEnabled("bold")}`);
+        println(`queryCommandIndeterm("bold") returned ${document.queryCommandIndeterm("bold")}`);
+        println(`queryCommandState("bold") returned ${document.queryCommandState("bold")}`);
+        println(`queryCommandSupported("bold") returned ${document.queryCommandSupported("bold")}`);
+        println(`queryCommandValue("bold") returned "${document.queryCommandValue("bold")}"`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2987,13 +2987,6 @@ void Document::did_stop_being_active_document_in_navigable()
     }
 }
 
-// https://w3c.github.io/editing/docs/execCommand/#querycommandsupported()
-bool Document::query_command_supported(String const& command) const
-{
-    dbgln("(STUBBED) Document::query_command_supported(command='{}')", command);
-    return false;
-}
-
 void Document::increment_throw_on_dynamic_markup_insertion_counter(Badge<HTML::HTMLParser>)
 {
     ++m_throw_on_dynamic_markup_insertion_counter;
@@ -4074,6 +4067,42 @@ WebIDL::ExceptionOr<JS::Value> Document::named_item_value(FlyString const& name)
         return (element.name() == name);
     });
     return collection;
+}
+
+// https://w3c.github.io/editing/docs/execCommand/#execcommand()
+bool Document::exec_command(String, bool, String)
+{
+    return false;
+}
+
+// https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()
+bool Document::query_command_enabled(String)
+{
+    return false;
+}
+
+// https://w3c.github.io/editing/docs/execCommand/#querycommandindeterm()
+bool Document::query_command_indeterm(String)
+{
+    return false;
+}
+
+// https://w3c.github.io/editing/docs/execCommand/#querycommandstate()
+bool Document::query_command_state(String)
+{
+    return false;
+}
+
+// https://w3c.github.io/editing/docs/execCommand/#querycommandsupported()
+bool Document::query_command_supported(String)
+{
+    return false;
+}
+
+// https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()
+String Document::query_command_value(String)
+{
+    return String {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -500,11 +500,17 @@ public:
     DocumentUnloadTimingInfo const& previous_document_unload_timing() const { return m_previous_document_unload_timing; }
     void set_previous_document_unload_timing(DocumentUnloadTimingInfo const& previous_document_unload_timing) { m_previous_document_unload_timing = previous_document_unload_timing; }
 
+    // https://w3c.github.io/editing/docs/execCommand/
+    bool exec_command(String command_id, bool show_ui, String value);
+    bool query_command_enabled(String command_id);
+    bool query_command_indeterm(String command_id);
+    bool query_command_state(String command_id);
+    bool query_command_supported(String command_id);
+    String query_command_value(String command_id);
+
     bool is_allowed_to_use_feature(PolicyControlledFeature) const;
 
     void did_stop_being_active_document_in_navigable();
-
-    bool query_command_supported(String const&) const;
 
     String dump_accessibility_tree_as_json();
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -106,7 +106,6 @@ interface Document : Node {
 
     [CEReactions] attribute DOMString title;
 
-    boolean queryCommandSupported(DOMString commandId);
     readonly attribute boolean hidden;
     readonly attribute DOMString visibilityState;
 
@@ -124,6 +123,14 @@ interface Document : Node {
     Element? elementFromPoint(double x, double y);
     sequence<Element> elementsFromPoint(double x, double y);
     readonly attribute Element? scrollingElement;
+
+    // https://w3c.github.io/editing/docs/execCommand/
+    [CEReactions] boolean execCommand(DOMString commandId, optional boolean showUI = false, optional DOMString value = "");
+    boolean queryCommandEnabled(DOMString commandId);
+    boolean queryCommandIndeterm(DOMString commandId);
+    boolean queryCommandState(DOMString commandId);
+    boolean queryCommandSupported(DOMString commandId);
+    DOMString queryCommandValue(DOMString commandId);
 };
 
 dictionary ElementCreationOptions {


### PR DESCRIPTION
Per the specification, it's ok if we say that nothing is supported.

It's not ok if we say something is supported but do nothing, apparently.

First step towards #23176