### PR TITLE
LibWeb: Return overflow rect width(height) from Element::scroll_width(height)

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/element-scroll-height.txt
+++ b/Tests/LibWeb/Text/expected/DOM/element-scroll-height.txt
@@ -1,0 +1,1 @@
+Item 1Item 2Item 3Item 4Item 5Item 6Item 7Item 8Item 9Item 10Item 11Item 12  1200

--- a/Tests/LibWeb/Text/expected/DOM/element-scroll-width.txt
+++ b/Tests/LibWeb/Text/expected/DOM/element-scroll-width.txt
@@ -1,0 +1,1 @@
+Item 1Item 2Item 3Item 4Item 5Item 6Item 7Item 8Item 9Item 10Item 11Item 12  1200

--- a/Tests/LibWeb/Text/input/DOM/element-scroll-height.html
+++ b/Tests/LibWeb/Text/input/DOM/element-scroll-height.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    * {
+        outline: 1px solid black;
+    }
+
+    .scrollable {
+        height: 300px;
+        overflow-y: auto;
+    }
+
+    span {
+        width: 100px;
+        height: 100px;
+        display: block
+    }
+</style>
+<div class="scrollable"><span>Item 1</span><span>Item 2</span><span>Item 3</span><span>Item 4</span><span>Item 5</span><span>Item 6</span><span>Item 7</span><span>Item 8</span><span>Item 9</span><span>Item 10</span><span>Item 11</span><span>Item 12</span></div>
+<script>
+    test(() => {
+        const scrollable = document.querySelector(".scrollable");
+        println(scrollable.scrollHeight);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/element-scroll-width.html
+++ b/Tests/LibWeb/Text/input/DOM/element-scroll-width.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    * {
+        outline: 1px solid black;
+    }
+
+    .scrollable {
+        width: 300px;
+        overflow-x: auto;
+        white-space: nowrap;
+    }
+
+    span {
+        width: 100px;
+        height: 100px;
+        display: inline-block;
+    }
+</style>
+<div class="scrollable"><span>Item 1</span><span>Item 2</span><span>Item 3</span><span>Item 4</span><span>Item 5</span><span>Item 6</span><span>Item 7</span><span>Item 8</span><span>Item 9</span><span>Item 10</span><span>Item 11</span><span>Item 12</span></div>
+<script>
+    test(() => {
+        const scrollable = document.querySelector(".scrollable");
+        println(scrollable.scrollWidth);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1430,7 +1430,7 @@ int Element::scroll_height() const
         return 0;
 
     // 7. Return the height of the element’s scrolling area.
-    return paintable_box()->border_box_height().to_int();
+    return paintable_box()->scrollable_overflow_rect()->height().to_int();
 }
 
 // https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1371,6 +1371,9 @@ int Element::scroll_width() const
     if (!document.is_active())
         return 0;
 
+    // NOTE: Ensure that layout is up-to-date before looking at metrics.
+    const_cast<Document&>(document).update_layout();
+
     // 3. Let viewport width be the width of the viewport excluding the width of the scroll bar, if any,
     //    or zero if there is no viewport.
     auto viewport_width = document.viewport_rect().width().to_int();

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1407,6 +1407,9 @@ int Element::scroll_height() const
     if (!document.is_active())
         return 0;
 
+    // NOTE: Ensure that layout is up-to-date before looking at metrics.
+    const_cast<Document&>(document).update_layout();
+
     // 3. Let viewport height be the height of the viewport excluding the height of the scroll bar, if any,
     //    or zero if there is no viewport.
     auto viewport_height = document.viewport_rect().height().to_int();

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1394,7 +1394,7 @@ int Element::scroll_width() const
         return 0;
 
     // 7. Return the width of the element’s scrolling area.
-    return paintable_box()->border_box_width().to_int();
+    return paintable_box()->scrollable_overflow_rect()->width().to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollheight


### PR DESCRIPTION
Spec says that this function has to return "width/height of the element
scrolling area" which is width/height of "scrolling overflow rect" in our model.