### PR TITLE
LibGfx/OpenType: Replace a magic number with a calculation

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -358,8 +358,8 @@ Gfx::ScaledGlyphMetrics Font::glyph_metrics(u32 glyph_id, float x_scale, float y
             //        the pixels-per-em values and the font point size. It appears that bitmaps are not in the same
             //        coordinate space as the head table's "units per em" value.
             //        There's definitely some cleaner way to do this.
-            float x_scale = (point_width * 1.3333333f) / static_cast<float>(data.bitmap_size.ppem_x);
-            float y_scale = (point_height * 1.3333333f) / static_cast<float>(data.bitmap_size.ppem_y);
+            float x_scale = (point_width * DEFAULT_DPI) / (POINTS_PER_INCH * data.bitmap_size.ppem_x);
+            float y_scale = (point_height * DEFAULT_DPI) / (POINTS_PER_INCH * data.bitmap_size.ppem_y);
 
             return Gfx::ScaledGlyphMetrics {
                 .ascender = static_cast<float>(data.bitmap_size.hori.ascender) * y_scale,

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -12,9 +12,6 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/VectorFont.h>
 
-#define POINTS_PER_INCH 72.0f
-#define DEFAULT_DPI 96
-
 namespace Gfx {
 
 struct GlyphIndexWithSubpixelOffset {

--- a/Userland/Libraries/LibGfx/Font/VectorFont.h
+++ b/Userland/Libraries/LibGfx/Font/VectorFont.h
@@ -12,6 +12,9 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Path.h>
 
+#define POINTS_PER_INCH 72.0f
+#define DEFAULT_DPI 96
+
 namespace Gfx {
 
 class ScaledFont;


### PR DESCRIPTION
Makes this code look like the corresponding code in the ScaledFont ctor.

Similar to the last commit on https://github.com/SerenityOS/serenity/pull/20084.

No behavior change.