### PR TITLE
LibIDL: Emit an error when two decls of the same function are present

### DIFF
--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -234,6 +234,34 @@ private:
 #endif
 };
 
+class LineTrackingLexer : public GenericLexer {
+public:
+    using GenericLexer::GenericLexer;
+
+    struct Position {
+        size_t offset { 0 };
+        size_t line { 0 };
+        size_t column { 0 };
+    };
+
+    LineTrackingLexer(StringView input, Position start_position)
+        : GenericLexer(input)
+        , m_cached_position {
+            .line = start_position.line,
+            .column = start_position.column,
+        }
+    {
+    }
+
+    Position cached_position() const { return m_cached_position; }
+    void restore_cached_offset(Position cached_position) { m_cached_position = cached_position; }
+    Position position_for(size_t) const;
+    Position current_position() const { return position_for(m_index); }
+
+protected:
+    mutable Position m_cached_position;
+};
+
 constexpr auto is_any_of(StringView values)
 {
     return [values](auto c) { return values.contains(c); };
@@ -254,4 +282,5 @@ using AK::GenericLexer;
 using AK::is_any_of;
 using AK::is_path_separator;
 using AK::is_quote;
+using AK::LineTrackingLexer;
 #endif

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/Lexer.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/Lexer.cpp
@@ -14,7 +14,7 @@
 namespace JSSpecCompiler {
 
 namespace {
-Optional<Token> consume_number(XML::LineTrackingLexer& lexer, Location& location)
+Optional<Token> consume_number(LineTrackingLexer& lexer, Location& location)
 {
     u64 start = lexer.tell();
 
@@ -73,14 +73,14 @@ void tokenize_string(SpecificationParsingContext& ctx, XML::Node const* node, St
         { "+"sv, TokenType::Plus },
     };
 
-    XML::LineTrackingLexer lexer(view, node->offset);
+    LineTrackingLexer lexer(view, node->offset);
 
     while (!lexer.is_eof()) {
         lexer.ignore_while(is_ascii_space);
 
         // FIXME: This is incorrect since we count text offset after XML reference resolution. To do
         //        this properly, we need support from XML::Parser.
-        Location token_location = ctx.location_from_xml_offset(lexer.offset_for(lexer.tell()));
+        Location token_location = ctx.location_from_xml_offset(lexer.position_for(lexer.tell()));
 
         if (auto result = consume_number(lexer, token_location); result.has_value()) {
             tokens.append(result.release_value());

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/SpecParser.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/SpecParser.cpp
@@ -50,12 +50,12 @@ Location SpecificationParsingContext::file_scope() const
     return { .filename = m_translation_unit->filename() };
 }
 
-Location SpecificationParsingContext::location_from_xml_offset(XML::Offset offset) const
+Location SpecificationParsingContext::location_from_xml_offset(LineTrackingLexer::Position position) const
 {
     return {
         .filename = m_translation_unit->filename(),
-        .line = offset.line,
-        .column = offset.column,
+        .line = position.line,
+        .column = position.column,
         .logical_location = m_current_logical_scope,
     };
 }

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/SpecParser.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/SpecParser.h
@@ -37,7 +37,7 @@ public:
     int step_list_nesting_level() const;
 
     Location file_scope() const;
-    Location location_from_xml_offset(XML::Offset offset) const;
+    Location location_from_xml_offset(LineTrackingLexer::Position position) const;
 
 private:
     TranslationUnitRef m_translation_unit;

--- a/Userland/Libraries/LibIDL/IDLParser.h
+++ b/Userland/Libraries/LibIDL/IDLParser.h
@@ -61,7 +61,7 @@ private:
     ByteString import_base_path;
     ByteString filename;
     StringView input;
-    GenericLexer lexer;
+    LineTrackingLexer lexer;
 
     HashTable<NonnullOwnPtr<Interface>>& top_level_interfaces();
     HashTable<NonnullOwnPtr<Interface>> interfaces;

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -158,6 +158,7 @@ struct Function {
     ByteString name;
     Vector<Parameter> parameters;
     HashMap<ByteString, ByteString> extended_attributes;
+    LineTrackingLexer::Position source_position;
     size_t overload_index { 0 };
     bool is_overloaded { false };
 

--- a/Userland/Libraries/LibXML/DOM/Node.h
+++ b/Userland/Libraries/LibXML/DOM/Node.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/GenericLexer.h>
 #include <AK/HashMap.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
@@ -17,12 +18,6 @@ namespace XML {
 struct Attribute {
     Name name;
     ByteString value;
-};
-
-struct Offset {
-    size_t offset { 0 };
-    size_t line { 0 };
-    size_t column { 0 };
 };
 
 struct Node {
@@ -40,7 +35,7 @@ struct Node {
 
     bool operator==(Node const&) const;
 
-    Offset offset;
+    LineTrackingLexer::Position offset;
     Variant<Text, Comment, Element> content;
     Node* parent { nullptr };
 


### PR DESCRIPTION
Duplicates can show up when copy-pasting IDL snippets into existing IDL
files, and the resulting error is extremely useless and misleading.
This commit makes it so the parser catches these cases, and emits a more
helpful error like "Overload set 'instantiate' contains multiple
identical declarations".