### PR TITLE
LibGfx/TIFF: Reduce execution time by 50% to 70%

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -116,6 +116,7 @@ public:
             m_image_width = m_metadata.image_width().value();
         if (m_metadata.predictor().has_value())
             m_predictor = m_metadata.predictor().value();
+        m_alpha_channel_index = alpha_channel_index();
     }
 
     ErrorOr<void> decode_frame()
@@ -213,12 +214,11 @@ private:
         // them, conserve the alpha value (if any) and discard everything else.
 
         auto const number_base_channels = samples_for_photometric_interpretation();
-        auto const alpha_index = alpha_channel_index();
 
         Optional<u8> alpha {};
 
         for (u8 i = number_base_channels; i < m_bits_per_sample.size(); ++i) {
-            if (alpha_index == i)
+            if (m_alpha_channel_index == i)
                 alpha = TRY(read_component(stream, m_bits_per_sample[i]));
             else
                 TRY(read_component(stream, m_bits_per_sample[i]));
@@ -344,7 +344,7 @@ private:
                             color.set_red(last_color->red() + color.red());
                             color.set_green(last_color->green() + color.green());
                             color.set_blue(last_color->blue() + color.blue());
-                            if (alpha_channel_index().has_value())
+                            if (m_alpha_channel_index.has_value())
                                 color.set_alpha(last_color->alpha() + color.alpha());
                         }
 
@@ -686,6 +686,8 @@ private:
     Vector<u32, 4> m_bits_per_sample {};
     u32 m_image_width {};
     Predictor m_predictor {};
+
+    Optional<u8> m_alpha_channel_index {};
 };
 
 }


### PR DESCRIPTION
Before:
```
Benchmark 1: ./Meta/Lagom/BuildLagom/bin/image TIFF/ccitt.tiff --no-output
  Time (mean ± σ):      58.6 ms ±  13.4 ms    [User: 55.9 ms, System: 2.9 ms]
  Range (min … max):    43.2 ms …  78.2 ms    40 runs

Benchmark 1: ./Meta/Lagom/BuildLagom/bin/image TIFF/deflate.tiff --no-output
  Time (mean ± σ):      51.0 ms ±  14.4 ms    [User: 46.4 ms, System: 4.5 ms]
  Range (min … max):    37.8 ms …  75.7 ms    50 runs

Benchmark 1: ../../Meta/Lagom/BuildLagom/bin/TestImageDecoder
  Time (mean ± σ):      1.163 s ±  0.039 s    [User: 1.101 s, System: 0.062 s]
  Range (min … max):    1.127 s …  1.259 s    10 runs
```

After:
```
Benchmark 1: ./Meta/Lagom/BuildLagom/bin/image TIFF/ccitt.tiff --no-output
  Time (mean ± σ):       9.1 ms ±   3.6 ms    [User: 6.2 ms, System: 2.8 ms]
  Range (min … max):     5.5 ms …  17.4 ms    441 runs

Benchmark 1: ./Meta/Lagom/BuildLagom/bin/image TIFF/deflate.tiff --no-output
  Time (mean ± σ):      21.0 ms ±   6.6 ms    [User: 15.6 ms, System: 5.2 ms]
  Range (min … max):     9.3 ms …  35.6 ms    249 runs

Benchmark 1: ../../Meta/Lagom/BuildLagom/bin/TestImageDecoder
  Time (mean ± σ):     625.1 ms ±  18.7 ms    [User: 562.2 ms, System: 62.7 ms]
  Range (min … max):   594.5 ms … 652.3 ms    10 runs
```