### PR TITLE
LibWeb: Implement Element::animate; Generate keyframes for Web Animations

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -5,7 +5,7 @@
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
  * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
  * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
- * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023-2024, Matthew Olsson <mattco@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,6 +28,7 @@ static bool is_platform_object(Type const& type)
     // might simply need to add another type here.
     static constexpr Array types = {
         "AbortSignal"sv,
+        "Animation"sv,
         "AnimationEffect"sv,
         "AnimationTimeline"sv,
         "Attr"sv,

--- a/Userland/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.cpp
@@ -5,17 +5,52 @@
  */
 
 #include <LibWeb/Animations/Animatable.h>
-#include <LibWeb/WebIDL/ExceptionOr.h>
+#include <LibWeb/Animations/Animation.h>
+#include <LibWeb/Animations/DocumentTimeline.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 
 namespace Web::Animations {
 
 // https://www.w3.org/TR/web-animations-1/#dom-animatable-animate
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> Animatable::animate(Optional<JS::Handle<JS::Object>> keyframes, Variant<Empty, double, KeyframeAnimationOptions> options)
 {
-    // FIXME: Implement this
-    (void)keyframes;
-    (void)options;
-    return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Element.animate is not implemented"sv };
+    // 1. Let target be the object on which this method was called.
+    JS::NonnullGCPtr target { *static_cast<DOM::Element*>(this) };
+    auto& realm = target->realm();
+
+    // 2. Construct a new KeyframeEffect object, effect, in the relevant Realm of target by using the same procedure as
+    //    the KeyframeEffect(target, keyframes, options) constructor, passing target as the target argument, and the
+    //    keyframes and options arguments as supplied.
+    //
+    //    If the above procedure causes an exception to be thrown, propagate the exception and abort this procedure.
+    auto effect = TRY(options.visit(
+        [&](Empty) { return KeyframeEffect::construct_impl(realm, target, keyframes); },
+        [&](auto const& value) { return KeyframeEffect::construct_impl(realm, target, keyframes, value); }));
+
+    // 3. If options is a KeyframeAnimationOptions object, let timeline be the timeline member of options or, if
+    //    timeline member of options is missing, be the default document timeline of the node document of the element
+    //    on which this method was called.
+    JS::GCPtr<AnimationTimeline> timeline;
+    if (options.has<KeyframeAnimationOptions>())
+        timeline = options.get<KeyframeAnimationOptions>().timeline;
+    if (!timeline)
+        timeline = target->document().timeline();
+
+    // 4. Construct a new Animation object, animation, in the relevant Realm of target by using the same procedure as
+    //    the Animation() constructor, passing effect and timeline as arguments of the same name.
+    auto animation = TRY(Animation::construct_impl(realm, effect, timeline));
+
+    // 5. If options is a KeyframeAnimationOptions object, assign the value of the id member of options to animation’s
+    //    id attribute.
+    if (options.has<KeyframeAnimationOptions>())
+        animation->set_id(options.get<KeyframeAnimationOptions>().id);
+
+    //  6. Run the procedure to play an animation for animation with the auto-rewind flag set to true.
+    TRY(animation->play_an_animation(Animation::AutoRewind::Yes));
+
+    // 7. Return animation.
+    return animation;
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-animatable-getanimations

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -7,12 +7,12 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <AK/RedBlackTree.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Bindings/KeyframeEffectPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleValue.h>
-#include <LibWeb/DOM/Element.h>
 
 namespace Web::Animations {
 
@@ -58,6 +58,14 @@ class KeyframeEffect : public AnimationEffect {
     JS_DECLARE_ALLOCATOR(KeyframeEffect);
 
 public:
+    struct KeyFrameSet : public RefCounted<KeyFrameSet> {
+        struct UseInitial { };
+        struct ResolvedKeyFrame {
+            HashMap<CSS::PropertyID, Variant<UseInitial, NonnullRefPtr<CSS::StyleValue const>>> resolved_properties {};
+        };
+        RedBlackTree<u64, ResolvedKeyFrame> keyframes_by_key;
+    };
+
     static JS::NonnullGCPtr<KeyframeEffect> create(JS::Realm&);
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyframeEffect>> construct_impl(
@@ -80,6 +88,9 @@ public:
     WebIDL::ExceptionOr<Vector<JS::Object*>> get_keyframes();
     WebIDL::ExceptionOr<void> set_keyframes(Optional<JS::Handle<JS::Object>> const&);
 
+    KeyFrameSet const* key_frame_set() { return m_key_frame_set; }
+    void set_key_frame_set(RefPtr<KeyFrameSet const> key_frame_set) { m_key_frame_set = key_frame_set; }
+
 private:
     KeyframeEffect(JS::Realm&);
 
@@ -100,6 +111,8 @@ private:
 
     // A cached version of m_keyframes suitable for returning from get_keyframes()
     Vector<JS::Object*> m_keyframe_objects {};
+
+    RefPtr<KeyFrameSet const> m_key_frame_set {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -58,6 +58,8 @@ class KeyframeEffect : public AnimationEffect {
     JS_DECLARE_ALLOCATOR(KeyframeEffect);
 
 public:
+    constexpr static double AnimationKeyFrameKeyScaleFactor = 1000.0; // 0..100000
+
     struct KeyFrameSet : public RefCounted<KeyFrameSet> {
         struct UseInitial { };
         struct ResolvedKeyFrame {
@@ -65,6 +67,7 @@ public:
         };
         RedBlackTree<u64, ResolvedKeyFrame> keyframes_by_key;
     };
+    static void generate_initial_and_final_frames(RefPtr<KeyFrameSet>, HashTable<CSS::PropertyID> const& animated_properties);
 
     static JS::NonnullGCPtr<KeyframeEffect> create(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/ARIA/ARIAMixin.h>
+#include <LibWeb/Animations/Animatable.h>
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
@@ -67,7 +68,8 @@ class Element
     , public ChildNode<Element>
     , public NonDocumentTypeChildNode<Element>
     , public SlottableMixin
-    , public ARIA::ARIAMixin {
+    , public ARIA::ARIAMixin
+    , public Animations::Animatable {
     WEB_PLATFORM_OBJECT(Element, ParentNode);
 
 public:

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -1,3 +1,4 @@
+#import <Animations/Animatable.idl>
 #import <ARIA/ARIAMixin.idl>
 #import <DOM/Attr.idl>
 #import <DOM/ChildNode.idl>
@@ -105,3 +106,5 @@ Element includes InnerHTML;
 // https://www.w3.org/TR/wai-aria-1.2/#idl_element
 Element includes ARIAMixin;
 Element includes Slottable;
+// https://www.w3.org/TR/web-animations-1/#extensions-to-the-element-interface
+Element includes Animatable;


### PR DESCRIPTION
There may be a bit of code duplication between `StyleComputer` and the Web Animations stuff for a bit, but that'll get resolved eventually.

Independent of #23184, but there may be merge conflicts (please merge that one first!).

Word towards #21570. Note that this PR doesn't close that issue yet because while you can now call `.animate()` on an element and get back an animation object, it will not affect how the element is rendered at all.

Also advances (closes?) #22014