### PR TITLE
LibPDF+LibGfx: Add initial support for truetype-based type0 fonts

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -20,12 +20,18 @@
 
 namespace OpenType {
 
+class CharCodeToGlyphIndex {
+public:
+    virtual ~CharCodeToGlyphIndex() = default;
+    virtual u32 glyph_id_for_code_point(u32) const = 0;
+};
+
 class Font : public Gfx::VectorFont {
     AK_MAKE_NONCOPYABLE(Font);
 
 public:
     static ErrorOr<NonnullRefPtr<Font>> try_load_from_resource(Core::Resource const&, unsigned index = 0);
-    static ErrorOr<NonnullRefPtr<Font>> try_load_from_externally_owned_memory(ReadonlyBytes bytes, unsigned index = 0);
+    static ErrorOr<NonnullRefPtr<Font>> try_load_from_externally_owned_memory(ReadonlyBytes bytes, unsigned index = 0, OwnPtr<CharCodeToGlyphIndex> external_cmap = {});
 
     virtual Gfx::ScaledFontMetrics metrics(float x_scale, float y_scale) const override;
     virtual Gfx::ScaledGlyphMetrics glyph_metrics(u32 glyph_id, float x_scale, float y_scale, float point_width, float point_height) const override;
@@ -68,7 +74,7 @@ private:
 
     EmbeddedBitmapData embedded_bitmap_data_for_glyph(u32 glyph_id) const;
 
-    static ErrorOr<NonnullRefPtr<Font>> try_load_from_offset(ReadonlyBytes, unsigned index = 0);
+    static ErrorOr<NonnullRefPtr<Font>> try_load_from_offset(ReadonlyBytes, unsigned index, OwnPtr<CharCodeToGlyphIndex> external_cmap);
 
     Font(
         Head&& head,
@@ -76,7 +82,7 @@ private:
         Hhea&& hhea,
         Maxp&& maxp,
         Hmtx&& hmtx,
-        Cmap&& cmap,
+        NonnullOwnPtr<CharCodeToGlyphIndex> cmap,
         Optional<Loca>&& loca,
         Optional<Glyf>&& glyf,
         Optional<OS2> os2,
@@ -114,7 +120,7 @@ private:
     Hmtx m_hmtx;
     Optional<Loca> m_loca;
     Optional<Glyf> m_glyf;
-    Cmap m_cmap;
+    NonnullOwnPtr<CharCodeToGlyphIndex> m_cmap;
     Optional<OS2> m_os2;
     Optional<Kern> m_kern;
     Optional<Fpgm> m_fpgm;


### PR DESCRIPTION
From a LibPDF point of view, this is a _huge_ progression: Before this, 303 of my 1000 test files rendered without any diagnostics (which doesn't mean that they look 100% correct, but they probably look kinda decent). After this, 652 of my 1000 test files render without any diagnostics.

Disclaimers, similar to what's on #23202 (and most of the
prerequisites mentioned there are needed for this too):

* Only supports the `Identity-H` type0 cmap at the moment
* Doesn't support vertical text yet
* Only supports the `Identity` CIDToGIDMap at the moment
  (this one is a truetype-only thing)

In other words, with this it's (barely, but still) more likely than not that a random PDF of the web will show up fine.

From a LibGfx point of view, this adds a way to provide an external opentype cmap, since PDF needs this. PDFs generally need very little from a font file, since they're already laid out, they're already shaped (ligature replacement has happened etc), characters have dimensions assigned at the PDF level, etc. So a) many tables in an opentype file aren't necessary b) for that reason, many tables that are technically required by opentype aren't included in PDF files: For example, the cmap, but also in some files 'hmtx' (after this patch here, in 25 of my 1000 files – before this patch in 24 of them, so this seems to happen more for type2 fonts than for type0 truetype) or 'name' (after this patch, in 41 of 1000 – before in 10). All PDFs really need are the glyphs. So maybe a better approach might be to split OpenType/Font.cpp into the binary reading parts and the font parts and only use the low-level parts in LibPDF. But for now, this keeps the current architecture and just adds a layer of indirection to make it possible to inject the external CIDToGIDMap. (Doing this requires way less code than this paragraph has words.)