### PR TITLE
Toolchain: Don't skip extracting tarballs if `--dev` passed to Build*.sh

### DIFF
--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -214,7 +214,7 @@ pushd "$DIR/Tarballs"
 
     patch_md5="$($MD5SUM "$DIR"/Patches/llvm/*.patch)"
 
-    if [ ! -d "$LLVM_NAME" ] || [ "$(cat $LLVM_NAME/.patch.applied)" != "$patch_md5" ]; then
+    if [ ! -d "$LLVM_NAME" ] || [ "$(cat $LLVM_NAME/.patch.applied)" != "$patch_md5" ] || [ "$dev" = "1" ]; then
         if [ -d "$LLVM_NAME" ]; then
             # Drop the previously patched extracted dir
             rm -rf "${LLVM_NAME}"

--- a/Toolchain/BuildGNU.sh
+++ b/Toolchain/BuildGNU.sh
@@ -158,7 +158,7 @@ pushd "$DIR/Tarballs"
 
     patch_md5="$(${MD5SUM} "${DIR}"/Patches/binutils/*.patch)"
 
-    if [ ! -d "${BINUTILS_NAME}" ] || [ "$(cat ${BINUTILS_NAME}/.patch.applied)" != "${patch_md5}" ]; then
+    if [ ! -d "${BINUTILS_NAME}" ] || [ "$(cat ${BINUTILS_NAME}/.patch.applied)" != "${patch_md5}" ] || [ "${git_patch}" = "1" ]; then
         if [ -d ${BINUTILS_NAME} ]; then
             rm -rf "${BINUTILS_NAME}"
             rm -rf "${DIR}/Build/${ARCH}/${BINUTILS_NAME}"
@@ -186,7 +186,7 @@ pushd "$DIR/Tarballs"
 
     patch_md5="$(${MD5SUM} "${DIR}"/Patches/gcc/*.patch)"
 
-    if [ ! -d "${GCC_NAME}" ] || [ "$(cat ${GCC_NAME}/.patch.applied)" != "${patch_md5}" ]; then
+    if [ ! -d "${GCC_NAME}" ] || [ "$(cat ${GCC_NAME}/.patch.applied)" != "${patch_md5}" ] || [ "${git_patch}" = "1" ]; then
         if [ -d ${GCC_NAME} ]; then
             rm -rf "${GCC_NAME}"
             rm -rf "${DIR}/Build/${ARCH}/${GCC_NAME}"


### PR DESCRIPTION
`--dev` will otherwise not work if the toolchains are already extracted.