### PR TITLE
LibWeb: Fully implement the HTMLInputElement `value` setter and getter

### DIFF
--- a/Tests/LibWeb/Text/expected/input-value.txt
+++ b/Tests/LibWeb/Text/expected/input-value.txt
@@ -1,0 +1,5 @@
+pass       text: "pass"
+hidden: "pass"
+button: "pass"
+checkbox: "pass"
+file: "" (threw exception)

--- a/Tests/LibWeb/Text/input/input-value.html
+++ b/Tests/LibWeb/Text/input/input-value.html
@@ -1,0 +1,26 @@
+<input id="text" type="text" />
+<input id="hidden" type="hidden" />
+<input id="button" type="button" />
+<input id="checkbox" type="checkbox" />
+<input id="file" type="file" />
+<script src="include.js"></script>
+<script>
+    const testInput = (id) => {
+        let input = document.getElementById(id);
+
+        try {
+            input.value = "pass";
+            println(`${id}: "${input.value}"`);
+        } catch (e) {
+            println(`${id}: "${input.value}" (threw exception)`);
+        }
+    };
+
+    test(() => {
+        testInput("text");
+        testInput("hidden");
+        testInput("button");
+        testInput("checkbox");
+        testInput("file");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -216,6 +216,14 @@ private:
     // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm
     String value_sanitization_algorithm(String const&) const;
 
+    enum class ValueAttributeMode {
+        Value,
+        Default,
+        DefaultOn,
+        Filename,
+    };
+    ValueAttributeMode value_attribute_mode() const;
+
     void update_placeholder_visibility();
     JS::GCPtr<DOM::Element> m_placeholder_element;
     JS::GCPtr<DOM::Text> m_placeholder_text_node;


### PR DESCRIPTION
The setter was missing an implementation for the default and default/on value attribute modes. This patch adds a method to get the current value attribute mode, and implements the value setter and getter based on that mode according to the spec.

Fixes #23234