### PR TITLE
LibJS: More updates to Temporal, working towards Duration.round fixes

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -237,6 +237,7 @@ set(SOURCES
     Runtime/Temporal/Temporal.cpp
     Runtime/Temporal/TimeZone.cpp
     Runtime/Temporal/TimeZoneConstructor.cpp
+    Runtime/Temporal/TimeZoneMethods.cpp
     Runtime/Temporal/TimeZonePrototype.cpp
     Runtime/Temporal/ZonedDateTime.cpp
     Runtime/Temporal/ZonedDateTimeConstructor.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -292,6 +292,7 @@ struct CalendarMethods;
 struct DurationRecord;
 struct DateDurationRecord;
 struct TimeDurationRecord;
+struct TimeZoneMethods;
 struct PartialDurationRecord;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -14,6 +14,7 @@
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/ISO8601.h>
+#include <LibJS/Runtime/Temporal/TimeZoneMethods.h>
 #include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS::Temporal {
@@ -148,7 +149,16 @@ ThrowCompletionOr<u64> to_temporal_rounding_increment(VM&, Object const& normali
 ThrowCompletionOr<u64> to_temporal_date_time_rounding_increment(VM&, Object const& normalized_options, StringView smallest_unit);
 ThrowCompletionOr<SecondsStringPrecision> to_seconds_string_precision(VM&, Object const& normalized_options);
 ThrowCompletionOr<Optional<String>> get_temporal_unit(VM&, Object const& normalized_options, PropertyKey const&, UnitGroup, TemporalUnitDefault const& default_, Vector<StringView> const& extra_values = {});
-ThrowCompletionOr<Value> to_relative_temporal_object(VM&, Object const& options);
+
+struct RelativeTo {
+    GCPtr<PlainDate> plain_relative_to;         // [[PlainRelativeTo]]
+    GCPtr<ZonedDateTime> zoned_relative_to;     // [[ZonedRelativeTo]]
+    Optional<TimeZoneMethods> time_zone_record; // [[TimeZoneRec]]
+};
+ThrowCompletionOr<RelativeTo> to_relative_temporal_object(VM&, Object const& options);
+
+Value relative_to_converted_to_value(RelativeTo const&);
+
 StringView larger_of_two_temporal_units(StringView, StringView);
 ThrowCompletionOr<Object*> merge_largest_unit_option(VM&, Object const& options, String largest_unit);
 Optional<u16> maximum_temporal_duration_rounding_increment(StringView unit);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -2039,11 +2039,11 @@ ThrowCompletionOr<NonnullGCPtr<Duration>> add_duration_to_or_subtract_duration_f
     // 3. Set options to ? GetOptionsObject(options).
     auto const* options = TRY(get_options_object(vm, options_value));
 
-    // 4. Let relativeTo be ? ToRelativeTemporalObject(options).
-    auto relative_to = TRY(to_relative_temporal_object(vm, *options));
+    // 4. Let relativeToRecord be ? ToRelativeTemporalObject(options).
+    auto relative_to_record = TRY(to_relative_temporal_object(vm, *options));
 
     // 5. Let result be ? AddDuration(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], sign × other.[[Years]], sign × other.[[Months]], sign × other.[[Weeks]], sign × other.[[Days]], sign × other.[[Hours]], sign × other.[[Minutes]], sign × other.[[Seconds]], sign × other.[[Milliseconds]], sign × other.[[Microseconds]], sign × other.[[Nanoseconds]], relativeTo).
-    auto result = TRY(add_duration(vm, duration.years(), duration.months(), duration.weeks(), duration.days(), duration.hours(), duration.minutes(), duration.seconds(), duration.milliseconds(), duration.microseconds(), duration.nanoseconds(), sign * other.years, sign * other.months, sign * other.weeks, sign * other.days, sign * other.hours, sign * other.minutes, sign * other.seconds, sign * other.milliseconds, sign * other.microseconds, sign * other.nanoseconds, relative_to));
+    auto result = TRY(add_duration(vm, duration.years(), duration.months(), duration.weeks(), duration.days(), duration.hours(), duration.minutes(), duration.seconds(), duration.milliseconds(), duration.microseconds(), duration.nanoseconds(), sign * other.years, sign * other.months, sign * other.weeks, sign * other.days, sign * other.hours, sign * other.minutes, sign * other.seconds, sign * other.milliseconds, sign * other.microseconds, sign * other.nanoseconds, relative_to_converted_to_value(relative_to_record)));
 
     // 6. Return ! CreateTemporalDuration(result.[[Years]], result.[[Months]], result.[[Weeks]], result.[[Days]], result.[[Hours]], result.[[Minutes]], result.[[Seconds]], result.[[Milliseconds]], result.[[Microseconds]], result.[[Nanoseconds]]).
     return MUST(create_temporal_duration(vm, result.years, result.months, result.weeks, result.days, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.cpp
@@ -117,7 +117,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationConstructor::compare)
     auto const* options = TRY(get_options_object(vm, vm.argument(2)));
 
     // 4. Let relativeTo be ? ToRelativeTemporalObject(options).
-    auto relative_to = TRY(to_relative_temporal_object(vm, *options));
+    auto relative_to = relative_to_converted_to_value(TRY(to_relative_temporal_object(vm, *options)));
 
     // 5. Let shift1 be ? CalculateOffsetShift(relativeTo, one.[[Years]], one.[[Months]], one.[[Weeks]], one.[[Days]]).
     auto shift1 = TRY(calculate_offset_shift(vm, relative_to, one->years(), one->months(), one->weeks(), one->days()));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -389,12 +389,12 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
         largest_unit_present = false;
 
         // b. Set largestUnit to defaultLargestUnit.
-        largest_unit = TRY_OR_THROW_OOM(vm, String::from_utf8(default_largest_unit));
+        largest_unit = MUST(String::from_utf8(default_largest_unit));
     }
     // 14. Else if largestUnit is "auto", then
     else if (*largest_unit == "auto"sv) {
         // a. Set largestUnit to defaultLargestUnit.
-        largest_unit = TRY_OR_THROW_OOM(vm, String::from_utf8(default_largest_unit));
+        largest_unit = MUST(String::from_utf8(default_largest_unit));
     }
 
     // 15. If smallestUnitPresent is false and largestUnitPresent is false, then
@@ -533,7 +533,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::to_string)
     auto result = TRY(round_duration(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), precision.increment, precision.unit, rounding_mode)).duration_record;
 
     // 8. Return ! TemporalDurationToString(result.[[Years]], result.[[Months]], result.[[Weeks]], result.[[Days]], result.[[Hours]], result.[[Minutes]], result.[[Seconds]], result.[[Milliseconds]], result.[[Microseconds]], result.[[Nanoseconds]], precision.[[Precision]]).
-    return PrimitiveString::create(vm, MUST_OR_THROW_OOM(temporal_duration_to_string(vm, result.years, result.months, result.weeks, result.days, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds, precision.precision)));
+    return PrimitiveString::create(vm, MUST(temporal_duration_to_string(vm, result.years, result.months, result.weeks, result.days, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds, precision.precision)));
 }
 
 // 7.3.23 Temporal.Duration.prototype.toJSON ( ), https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson
@@ -544,7 +544,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::to_json)
     auto duration = TRY(typed_this_object(vm));
 
     // 3. Return ! TemporalDurationToString(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], "auto").
-    return PrimitiveString::create(vm, MUST_OR_THROW_OOM(temporal_duration_to_string(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), "auto"sv)));
+    return PrimitiveString::create(vm, MUST(temporal_duration_to_string(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), "auto"sv)));
 }
 
 // 7.3.24 Temporal.Duration.prototype.toLocaleString ( [ locales [ , options ] ] ), https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring
@@ -556,7 +556,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::to_locale_string)
     auto duration = TRY(typed_this_object(vm));
 
     // 3. Return ! TemporalDurationToString(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], "auto").
-    return PrimitiveString::create(vm, MUST_OR_THROW_OOM(temporal_duration_to_string(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), "auto"sv)));
+    return PrimitiveString::create(vm, MUST(temporal_duration_to_string(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), "auto"sv)));
 }
 
 // 7.3.25 Temporal.Duration.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -326,12 +326,14 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
 {
     auto& realm = *vm.current_realm();
 
+    auto round_to_value = vm.argument(0);
+
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto duration = TRY(typed_this_object(vm));
 
     // 3. If roundTo is undefined, then
-    if (vm.argument(0).is_undefined()) {
+    if (round_to_value.is_undefined()) {
         // a. Throw a TypeError exception.
         return vm.throw_completion<TypeError>(ErrorType::TemporalMissingOptionsObject);
     }
@@ -339,7 +341,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
     Object* round_to;
 
     // 4. If Type(roundTo) is String, then
-    if (vm.argument(0).is_string()) {
+    if (round_to_value.is_string()) {
         // a. Let paramString be roundTo.
 
         // b. Set roundTo to OrdinaryObjectCreate(null).
@@ -351,7 +353,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
     // 5. Else,
     else {
         // a. Set roundTo to ? GetOptionsObject(roundTo).
-        round_to = TRY(get_options_object(vm, vm.argument(0)));
+        round_to = TRY(get_options_object(vm, round_to_value));
     }
 
     // 6. Let smallestUnitPresent be true.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -418,43 +418,29 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
 
     // 20. Let relativeTo be ? ToRelativeTemporalObject(roundTo).
     auto relative_to = TRY(to_relative_temporal_object(vm, *round_to));
+    auto relative_to_value = relative_to_converted_to_value(relative_to);
 
     // 21. Let unbalanceResult be ? UnbalanceDurationRelative(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], largestUnit, relativeTo).
-    auto unbalance_result = TRY(unbalance_duration_relative(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), *largest_unit, relative_to));
+    auto unbalance_result = TRY(unbalance_duration_relative(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), *largest_unit, relative_to_value));
 
-    // FIXME: AD-HOC - this function is not up to date with latest spec.
-    PlainDate* plain_relative_to_ptr = nullptr;
-    ZonedDateTime* zoned_relative_to_ptr = nullptr;
-
-    if (relative_to.is_object()) {
-        if (is<PlainDate>(relative_to.as_object()))
-            plain_relative_to_ptr = &static_cast<PlainDate&>(relative_to.as_object());
-        else if (is<ZonedDateTime>(relative_to.as_object()))
-            zoned_relative_to_ptr = &static_cast<ZonedDateTime&>(relative_to.as_object());
-        else
-            VERIFY_NOT_REACHED();
-    }
-
-    auto calendar_record = TRY(create_calendar_methods_record_from_relative_to(vm, plain_relative_to_ptr, zoned_relative_to_ptr, { { CalendarMethod::DateAdd, CalendarMethod::DateUntil } }));
+    auto calendar_record = TRY(create_calendar_methods_record_from_relative_to(vm, relative_to.plain_relative_to, relative_to.zoned_relative_to, { { CalendarMethod::DateAdd, CalendarMethod::DateUntil } }));
     // 22. Let roundResult be (? RoundDuration(unbalanceResult.[[Years]], unbalanceResult.[[Months]], unbalanceResult.[[Weeks]], unbalanceResult.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], roundingIncrement, smallestUnit, roundingMode, relativeTo)).[[DurationRecord]].
-    auto round_result = TRY(round_duration(vm, unbalance_result.years, unbalance_result.months, unbalance_result.weeks, unbalance_result.days, duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), rounding_increment, *smallest_unit, rounding_mode, relative_to.is_object() ? &relative_to.as_object() : nullptr, calendar_record)).duration_record;
+    auto round_result = TRY(round_duration(vm, unbalance_result.years, unbalance_result.months, unbalance_result.weeks, unbalance_result.days, duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), duration->nanoseconds(), rounding_increment, *smallest_unit, rounding_mode, relative_to_value.is_object() ? &relative_to_value.as_object() : nullptr, calendar_record)).duration_record;
 
     // 23. Let adjustResult be ? AdjustRoundedDurationDays(roundResult.[[Years]], roundResult.[[Months]], roundResult.[[Weeks]], roundResult.[[Days]], roundResult.[[Hours]], roundResult.[[Minutes]], roundResult.[[Seconds]], roundResult.[[Milliseconds]], roundResult.[[Microseconds]], roundResult.[[Nanoseconds]], roundingIncrement, smallestUnit, roundingMode, relativeTo).
-    auto adjust_result = TRY(adjust_rounded_duration_days(vm, round_result.years, round_result.months, round_result.weeks, round_result.days, round_result.hours, round_result.minutes, round_result.seconds, round_result.milliseconds, round_result.microseconds, round_result.nanoseconds, rounding_increment, *smallest_unit, rounding_mode, relative_to.is_object() ? &relative_to.as_object() : nullptr));
+    auto adjust_result = TRY(adjust_rounded_duration_days(vm, round_result.years, round_result.months, round_result.weeks, round_result.days, round_result.hours, round_result.minutes, round_result.seconds, round_result.milliseconds, round_result.microseconds, round_result.nanoseconds, rounding_increment, *smallest_unit, rounding_mode, relative_to_value.is_object() ? &relative_to_value.as_object() : nullptr));
 
     // 24. Let balanceResult be ? BalanceDurationRelative(adjustResult.[[Years]], adjustResult.[[Months]], adjustResult.[[Weeks]], adjustResult.[[Days]], largestUnit, relativeTo).
-    auto balance_result = TRY(balance_duration_relative(vm, adjust_result.years, adjust_result.months, adjust_result.weeks, adjust_result.days, *largest_unit, relative_to));
+    auto balance_result = TRY(balance_duration_relative(vm, adjust_result.years, adjust_result.months, adjust_result.weeks, adjust_result.days, *largest_unit, relative_to_value));
 
     // 25. If Type(relativeTo) is Object and relativeTo has an [[InitializedTemporalZonedDateTime]] internal slot, then
-    if (relative_to.is_object() && is<ZonedDateTime>(relative_to.as_object())) {
-        auto& relative_to_zoned_date_time = static_cast<ZonedDateTime&>(relative_to.as_object());
-
+    if (relative_to.zoned_relative_to) {
         // a. Set relativeTo to ? MoveRelativeZonedDateTime(relativeTo, balanceResult.[[Years]], balanceResult.[[Months]], balanceResult.[[Weeks]], 0).
-        relative_to = TRY(move_relative_zoned_date_time(vm, relative_to_zoned_date_time, balance_result.years, balance_result.months, balance_result.weeks, 0));
+        relative_to_value = TRY(move_relative_zoned_date_time(vm, *relative_to.zoned_relative_to, balance_result.years, balance_result.months, balance_result.weeks, 0));
     }
 
     // 26. Let result be ? BalanceDuration(balanceResult.[[Days]], adjustResult.[[Hours]], adjustResult.[[Minutes]], adjustResult.[[Seconds]], adjustResult.[[Milliseconds]], adjustResult.[[Microseconds]], adjustResult.[[Nanoseconds]], largestUnit, relativeTo).
-    auto result = TRY(balance_duration(vm, balance_result.days, adjust_result.hours, adjust_result.minutes, adjust_result.seconds, adjust_result.milliseconds, adjust_result.microseconds, Crypto::SignedBigInteger { adjust_result.nanoseconds }, *largest_unit, relative_to.is_object() ? &relative_to.as_object() : nullptr));
+    auto result = TRY(balance_duration(vm, balance_result.days, adjust_result.hours, adjust_result.minutes, adjust_result.seconds, adjust_result.milliseconds, adjust_result.microseconds, Crypto::SignedBigInteger { adjust_result.nanoseconds }, *largest_unit, relative_to_value.is_object() ? &relative_to_value.as_object() : nullptr));
 
     // 27. Return ! CreateTemporalDuration(balanceResult.[[Years]], balanceResult.[[Months]], balanceResult.[[Weeks]], result.[[Days]], result.[[Hours]], result.[[Minutes]], result.[[Seconds]], result.[[Milliseconds]], result.[[Microseconds]], result.[[Nanoseconds]]).
     return MUST(create_temporal_duration(vm, balance_result.years, balance_result.months, balance_result.weeks, result.days, result.hours, result.minutes, result.seconds, result.milliseconds, result.microseconds, result.nanoseconds));
@@ -494,44 +480,30 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::total)
 
     // 6. Let relativeTo be ? ToRelativeTemporalObject(totalOf).
     auto relative_to = TRY(to_relative_temporal_object(vm, *total_of));
+    auto relative_to_value = relative_to_converted_to_value(relative_to);
 
     // 7. Let unit be ? GetTemporalUnit(totalOf, "unit", datetime, required).
     auto unit = TRY(get_temporal_unit(vm, *total_of, vm.names.unit, UnitGroup::DateTime, TemporalUnitRequired {}));
 
     // 8. Let unbalanceResult be ? UnbalanceDurationRelative(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], unit, relativeTo).
-    auto unbalance_result = TRY(unbalance_duration_relative(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), *unit, relative_to));
+    auto unbalance_result = TRY(unbalance_duration_relative(vm, duration->years(), duration->months(), duration->weeks(), duration->days(), *unit, relative_to_value));
 
     // 9. Let intermediate be undefined.
     ZonedDateTime* intermediate = nullptr;
 
     // 10. If Type(relativeTo) is Object and relativeTo has an [[InitializedTemporalZonedDateTime]] internal slot, then
-    if (relative_to.is_object() && is<ZonedDateTime>(relative_to.as_object())) {
-        auto& relative_to_zoned_date_time = static_cast<ZonedDateTime&>(relative_to.as_object());
-
+    if (relative_to.zoned_relative_to) {
         // a. Set intermediate to ? MoveRelativeZonedDateTime(relativeTo, unbalanceResult.[[Years]], unbalanceResult.[[Months]], unbalanceResult.[[Weeks]], 0).
-        intermediate = TRY(move_relative_zoned_date_time(vm, relative_to_zoned_date_time, unbalance_result.years, unbalance_result.months, unbalance_result.weeks, 0));
+        intermediate = TRY(move_relative_zoned_date_time(vm, *relative_to.zoned_relative_to, unbalance_result.years, unbalance_result.months, unbalance_result.weeks, 0));
     }
 
     // 11. Let balanceResult be ? BalanceDuration(unbalanceResult.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], unit, intermediate).
     auto balance_result = TRY(balance_duration(vm, unbalance_result.days, duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), Crypto::SignedBigInteger { duration->nanoseconds() }, *unit, intermediate));
 
     // 12. Let roundRecord be ? RoundDuration(unbalanceResult.[[Years]], unbalanceResult.[[Months]], unbalanceResult.[[Weeks]], balanceResult.[[Days]], balanceResult.[[Hours]], balanceResult.[[Minutes]], balanceResult.[[Seconds]], balanceResult.[[Milliseconds]], balanceResult.[[Microseconds]], balanceResult.[[Nanoseconds]], 1, unit, "trunc", relativeTo).
-    // FIXME: AD-HOC - this function is not up to date with latest spec.
-    PlainDate* plain_relative_to_ptr = nullptr;
-    ZonedDateTime* zoned_relative_to_ptr = nullptr;
+    auto calendar_record = TRY(create_calendar_methods_record_from_relative_to(vm, relative_to.plain_relative_to, relative_to.zoned_relative_to, { { CalendarMethod::DateAdd, CalendarMethod::DateUntil } }));
 
-    if (relative_to.is_object()) {
-        if (is<PlainDate>(relative_to.as_object()))
-            plain_relative_to_ptr = &static_cast<PlainDate&>(relative_to.as_object());
-        else if (is<ZonedDateTime>(relative_to.as_object()))
-            zoned_relative_to_ptr = &static_cast<ZonedDateTime&>(relative_to.as_object());
-        else
-            VERIFY_NOT_REACHED();
-    }
-
-    auto calendar_record = TRY(create_calendar_methods_record_from_relative_to(vm, plain_relative_to_ptr, zoned_relative_to_ptr, { { CalendarMethod::DateAdd, CalendarMethod::DateUntil } }));
-
-    auto round_record = TRY(round_duration(vm, unbalance_result.years, unbalance_result.months, unbalance_result.weeks, balance_result.days, balance_result.hours, balance_result.minutes, balance_result.seconds, balance_result.milliseconds, balance_result.microseconds, balance_result.nanoseconds, 1, *unit, "trunc"sv, relative_to.is_object() ? &relative_to.as_object() : nullptr, calendar_record));
+    auto round_record = TRY(round_duration(vm, unbalance_result.years, unbalance_result.months, unbalance_result.weeks, balance_result.days, balance_result.hours, balance_result.minutes, balance_result.seconds, balance_result.milliseconds, balance_result.microseconds, balance_result.nanoseconds, 1, *unit, "trunc"sv, relative_to_value.is_object() ? &relative_to_value.as_object() : nullptr, calendar_record));
 
     // 13. Return 𝔽(roundRecord.[[Total]]).
     return Value(round_record.total);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneMethods.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneMethods.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Temporal/TimeZone.h>
+#include <LibJS/Runtime/Temporal/TimeZoneMethods.h>
+
+namespace JS::Temporal {
+
+// 11.5.2 CreateTimeZoneMethodsRecord ( timeZone, methods ), https://tc39.es/proposal-temporal/#sec-temporal-createtimezonemethodsrecord
+ThrowCompletionOr<TimeZoneMethods> create_time_zone_methods_record(VM& vm, Variant<String, NonnullGCPtr<Object>> time_zone, ReadonlySpan<TimeZoneMethod> methods)
+{
+    // 1. Let record be the Time Zone Methods Record { [[Receiver]]: timeZone, [[GetOffsetNanosecondsFor]]: undefined, [[GetPossibleInstantsFor]]: undefined  }.
+    TimeZoneMethods record {
+        .receiver = move(time_zone),
+        .get_offset_nanoseconds_for = nullptr,
+        .get_possible_instants_for = nullptr,
+    };
+
+    // 2. For each element methodName in methods, do
+    for (TimeZoneMethod method_name : methods) {
+        // a. Perform ? TimeZoneMethodsRecordLookup(record, methodName).
+        TRY(time_zone_methods_record_lookup(vm, record, method_name));
+    }
+
+    // 3. Return record.
+    return record;
+}
+
+// 11.5.3 TimeZoneMethodsRecordLookup ( timeZoneRec, methodName ), https://tc39.es/proposal-temporal/#sec-temporal-timezonemethodsrecordlookup
+ThrowCompletionOr<void> time_zone_methods_record_lookup(VM& vm, TimeZoneMethods& time_zone_record, TimeZoneMethod method_name)
+{
+    auto& realm = *vm.current_realm();
+
+    // 1. Assert: TimeZoneMethodsRecordHasLookedUp(timeZoneRec, methodName) is false.
+    // 2. If methodName is GET-OFFSET-NANOSECONDS-FOR, then
+    //     a. If timeZoneRec.[[Receiver]] is a String, then
+    //         i. Set timeZoneRec.[[GetOffsetNanosecondsFor]] to %Temporal.TimeZone.prototype.getOffsetNanosecondsFor%.
+    //     b. Else,
+    //         i. Set timeZoneRec.[[GetOffsetNanosecondsFor]] to ? GetMethod(timeZoneRec.[[Receiver]], "getOffsetNanosecondsFor").
+    //         ii. If timeZoneRec.[[GetOffsetNanosecondsFor]] is undefined, throw a TypeError exception.
+    // 3. Else if methodName is GET-POSSIBLE-INSTANTS-FOR, then
+    //     a. If timeZoneRec.[[Receiver]] is a String, then
+    //         i. Set timeZoneRec.[[GetPossibleInstantsFor]] to %Temporal.TimeZone.prototype.getPossibleInstantsFor%.
+    //     b. Else,
+    //         i. Set timeZoneRec.[[GetPossibleInstantsFor]] to ? GetMethod(timeZoneRec.[[Receiver]], "getPossibleInstantsFor").
+    //         ii. If timeZoneRec.[[GetPossibleInstantsFor]] is undefined, throw a TypeError exception.
+    switch (method_name) {
+#define __JS_ENUMERATE(PascalName, camelName, snake_name)                                                                 \
+    case TimeZoneMethod::PascalName: {                                                                                    \
+        VERIFY(!time_zone_record.snake_name);                                                                             \
+        if (time_zone_record.receiver.has<String>()) {                                                                    \
+            const auto& time_zone_prototype = *realm.intrinsics().temporal_time_zone_prototype();                         \
+            time_zone_record.snake_name = time_zone_prototype.get_without_side_effects(vm.names.camelName).as_function(); \
+        } else {                                                                                                          \
+            Value time_zone { time_zone_record.receiver.get<NonnullGCPtr<Object>>() };                                    \
+            time_zone_record.snake_name = TRY(time_zone.get_method(vm, vm.names.camelName));                              \
+            if (!time_zone_record.snake_name)                                                                             \
+                return vm.throw_completion<TypeError>(ErrorType::IsUndefined, #camelName##sv);                            \
+        }                                                                                                                 \
+        break;                                                                                                            \
+    }
+        JS_ENUMERATE_TIME_ZONE_METHODS
+#undef __JS_ENUMERATE
+    }
+    // 4. Return UNUSED.
+    return {};
+}
+
+// 11.5.4 TimeZoneMethodsRecordHasLookedUp ( timeZoneRec, methodName ), https://tc39.es/proposal-temporal/#sec-temporal-timezonemethodsrecordhaslookedup
+bool time_zone_methods_record_has_looked_up(TimeZoneMethods const& time_zone_record, TimeZoneMethod method_name)
+{
+    // 1. If methodName is GET-OFFSET-NANOSECONDS-FOR, then
+    //     a. Let method be timeZoneRec.[[GetOffsetNanosecondsFor]].
+    // 2. Else if methodName is GET-POSSIBLE-INSTANTS-FOR, then
+    //     a. Let method be timeZoneRec.[[GetPossibleInstantsFor]].
+    // 3. If method is undefined, return false.
+    // 4. Return true.
+    switch (method_name) {
+#define __JS_ENUMERATE(PascalName, camelName, snake_name) \
+    case TimeZoneMethod::PascalName: {                    \
+        return time_zone_record.snake_name != nullptr;    \
+    }
+        JS_ENUMERATE_TIME_ZONE_METHODS
+#undef __JS_ENUMERATE
+    }
+    VERIFY_NOT_REACHED();
+}
+
+// 11.5.5 TimeZoneMethodsRecordIsBuiltin ( timeZoneRec ), https://tc39.es/proposal-temporal/#sec-temporal-timezonemethodsrecordisbuiltin
+bool time_zone_methods_record_is_builtin(TimeZoneMethods const& time_zone_record)
+{
+    // 1. If timeZoneRec.[[Receiver]] is a String, return true.
+    if (time_zone_record.receiver.has<String>())
+        return true;
+
+    // 2. Return false.
+    return false;
+}
+
+// 11.5.6 TimeZoneMethodsRecordCall ( timeZoneRec, methodName, arguments ), https://tc39.es/proposal-temporal/#sec-temporal-timezonemethodsrecordcall
+ThrowCompletionOr<Value> time_zone_methods_record_call(VM& vm, TimeZoneMethods const& time_zone_record, TimeZoneMethod method_name, ReadonlySpan<Value> arguments)
+{
+    // 1. Assert: TimeZoneMethodsRecordHasLookedUp(timeZoneRec, methodName) is true.
+    VERIFY(time_zone_methods_record_has_looked_up(time_zone_record, method_name));
+
+    // 2. Let receiver be timeZoneRec.[[Receiver]].
+    // 3. If TimeZoneMethodsRecordIsBuiltin(timeZoneRec) is true, then
+    //     a. Set receiver to ! CreateTemporalTimeZone(timeZoneRec.[[Receiver]]).
+    GCPtr<Object> receiver;
+    if (time_zone_methods_record_is_builtin(time_zone_record))
+        receiver = MUST(create_temporal_time_zone(vm, time_zone_record.receiver.get<String>()));
+    else
+        receiver = time_zone_record.receiver.get<NonnullGCPtr<Object>>();
+
+    // 4. If methodName is GET-OFFSET-NANOSECONDS-FOR, then
+    //     a. Return ? Call(timeZoneRec.[[GetOffsetNanosecondsFor]], receiver, arguments).
+    // 5. If methodName is GET-POSSIBLE-INSTANTS-FOR, then
+    //     a. Return ? Call(timeZoneRec.[[GetPossibleInstantsFor]], receiver, arguments).
+    switch (method_name) {
+#define __JS_ENUMERATE(PascalName, camelName, snake_name)                       \
+    case TimeZoneMethod::PascalName: {                                          \
+        return TRY(call(vm, time_zone_record.snake_name, receiver, arguments)); \
+    }
+        JS_ENUMERATE_TIME_ZONE_METHODS
+#undef __JS_ENUMERATE
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneMethods.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneMethods.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
+
+namespace JS::Temporal {
+
+// 11.5.1 Time Zone Methods Records, https://tc39.es/proposal-temporal/#sec-temporal-time-zone-methods-records
+struct TimeZoneMethods {
+    // The time zone object, or a string indicating a built-in time zone.
+    Variant<String, NonnullGCPtr<Object>> receiver; // [[Reciever]]
+
+    // The time zone's getOffsetNanosecondsFor method. For a built-in time zone this is always %Temporal.TimeZone.prototype.getOffsetNanosecondsFor%.
+    GCPtr<FunctionObject> get_offset_nanoseconds_for; // [[GetOffsetNanosecondsFor]]
+
+    // The time zone's getPossibleInstantsFor method. For a built-in time zone this is always %Temporal.TimeZone.prototype.getPossibleInstantsFor%.
+    GCPtr<FunctionObject> get_possible_instants_for; // [[GetPossibleInstantsFor]]
+};
+
+#define JS_ENUMERATE_TIME_ZONE_METHODS                                                           \
+    __JS_ENUMERATE(GetOffsetNanosecondsFor, getOffsetNanosecondsFor, get_offset_nanoseconds_for) \
+    __JS_ENUMERATE(GetPossibleInstantsFor, getPossibleInstantsFor, get_possible_instants_for)
+
+enum class TimeZoneMethod {
+#define __JS_ENUMERATE(PascalName, camelName, snake_name) \
+    PascalName,
+    JS_ENUMERATE_TIME_ZONE_METHODS
+#undef __JS_ENUMERATE
+};
+
+ThrowCompletionOr<void> time_zone_methods_record_lookup(VM&, TimeZoneMethods&, TimeZoneMethod);
+ThrowCompletionOr<TimeZoneMethods> create_time_zone_methods_record(VM&, Variant<String, NonnullGCPtr<Object>> time_zone, ReadonlySpan<TimeZoneMethod>);
+bool time_zone_methods_record_has_looked_up(TimeZoneMethods const&, TimeZoneMethod);
+bool time_zone_methods_record_is_builtin(TimeZoneMethods const&);
+ThrowCompletionOr<Value> time_zone_methods_record_call(VM&, TimeZoneMethods const&, TimeZoneMethod, ReadonlySpan<Value> arguments);
+
+}

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.compare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.compare.js
@@ -98,7 +98,7 @@ describe("errors", () => {
         const duration = new Temporal.Duration();
         expect(() => {
             Temporal.Duration.compare(duration, duration, { relativeTo: zonedDateTime });
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 
     test("UTC designator only allowed with bracketed time zone", () => {


### PR DESCRIPTION
This updates some more AOs to latest spec, working towards fixing a test case in test262 timing out on a call to Instance.round. No change to test262, only aligns our implementation with editorial changes (such as the "Time Zone Methods Record") to make our implementation less confusing when comparing with latest spec.