### PR TITLE
LibWeb: Set `cursor: default` for button and select elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -52,6 +52,7 @@ button, input[type=submit], input[type=button], input[type=reset], select {
     background-color: ButtonFace;
     border: 1px solid ButtonBorder;
     color: ButtonText;
+    cursor: default;
 }
 
 button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=reset]:hover, select:hover {


### PR DESCRIPTION
This prevents an IBeam cursor being shown when these elements are moused over.

Fixes: #23191