### PR TITLE
LibWeb: Allow interfaces to differentiate between a null argument and no argument

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -21,21 +21,19 @@ namespace Web::Animations {
 JS_DEFINE_ALLOCATOR(Animation);
 
 // https://www.w3.org/TR/web-animations-1/#dom-animation-animation
-JS::NonnullGCPtr<Animation> Animation::create(JS::Realm& realm, JS::GCPtr<AnimationEffect> effect, JS::GCPtr<AnimationTimeline> timeline)
+JS::NonnullGCPtr<Animation> Animation::create(JS::Realm& realm, JS::GCPtr<AnimationEffect> effect, Optional<JS::GCPtr<AnimationTimeline>> timeline)
 {
-    auto& vm = realm.vm();
-
     // 1. Let animation be a new Animation object.
     auto animation = realm.heap().allocate<Animation>(realm, realm);
 
     // 2. Run the procedure to set the timeline of an animation on animation passing timeline as the new timeline or, if
     //    a timeline argument is missing, passing the default document timeline of the Document associated with the
     //    Window that is the current global object.
-    if (vm.argument_count() < 2) {
+    if (!timeline.has_value()) {
         auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
         timeline = window.associated_document().timeline();
     }
-    animation->set_timeline(timeline);
+    animation->set_timeline(timeline.release_value());
 
     // 3. Run the procedure to set the associated effect of an animation on animation passing source as the new effect.
     animation->set_effect(effect);
@@ -43,7 +41,7 @@ JS::NonnullGCPtr<Animation> Animation::create(JS::Realm& realm, JS::GCPtr<Animat
     return animation;
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> Animation::construct_impl(JS::Realm& realm, JS::GCPtr<AnimationEffect> effect, JS::GCPtr<AnimationTimeline> timeline)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> Animation::construct_impl(JS::Realm& realm, JS::GCPtr<AnimationEffect> effect, Optional<JS::GCPtr<AnimationTimeline>> timeline)
 {
     return create(realm, effect, timeline);
 }

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -18,8 +18,8 @@ class Animation : public DOM::EventTarget {
     JS_DECLARE_ALLOCATOR(Animation);
 
 public:
-    static JS::NonnullGCPtr<Animation> create(JS::Realm&, JS::GCPtr<AnimationEffect>, JS::GCPtr<AnimationTimeline>);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> construct_impl(JS::Realm&, JS::GCPtr<AnimationEffect>, JS::GCPtr<AnimationTimeline>);
+    static JS::NonnullGCPtr<Animation> create(JS::Realm&, JS::GCPtr<AnimationEffect>, Optional<JS::GCPtr<AnimationTimeline>>);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> construct_impl(JS::Realm&, JS::GCPtr<AnimationEffect>, Optional<JS::GCPtr<AnimationTimeline>>);
 
     FlyString const& id() const { return m_id; }
     void set_id(FlyString value) { m_id = move(value); }

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -6,7 +6,7 @@
 [Exposed=Window]
 interface Animation : EventTarget {
     constructor(optional AnimationEffect? effect = null,
-                optional AnimationTimeline? timeline);
+                [ExplicitNull] optional AnimationTimeline? timeline);
 
     attribute DOMString id;
     attribute AnimationEffect? effect;


### PR DESCRIPTION
This can apply to optional, nullable parameters of platform types. This will cause the generator to generate the type as `Optional<JS::GCPtr<T>>` rather than `JS::GCPtr<T>`, allowing the implementation to differentiate between the case where the argument was not passed, and the case where null or undefined was passed.

Needing to differentiate these two cases is quite niche, hence why it is an opt-in behavior.

Closes #23220