### PR TITLE
Meta: Create output directories for cmake code generation commands

### DIFF
--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -51,6 +51,8 @@ function(compile_ipc source output)
     endif()
     add_custom_command(
         OUTPUT ${output}
+        get_filename_component(output_path ${output} DIRECTORY)
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${output_path}
         COMMAND $<TARGET_FILE:Lagom::IPCCompiler> ${source} -o ${output}.tmp
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${output}.tmp ${output}
         COMMAND "${CMAKE_COMMAND}" -E remove ${output}.tmp

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -209,6 +209,8 @@ function(invoke_generator name generator version_file header implementation)
 
     add_custom_command(
         OUTPUT "${header}" "${implementation}"
+        get_filename_component(header_path ${header} DIRECTORY)
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${header_path}
         COMMAND $<TARGET_FILE:${generator}> -h "${header}.tmp" -c "${implementation}.tmp" ${invoke_generator_arguments}
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${header}.tmp" "${header}"
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${implementation}.tmp" "${implementation}"

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -92,6 +92,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 add_custom_command(
         OUTPUT  ${generated_sources}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/ImageFormats"
         COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/TIFFGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/ImageFormats"
         DEPENDS "TIFFGenerator.py"
         VERBATIM


### PR DESCRIPTION
When using LibGfx as a library outside of serenity, the output directory for TIFFGenerator.py did not exist, causing a build failure.  This creates the directory as part of the cmake custom command.