### PR TITLE
LibWeb+LibWebView: Remove invalid HTML from Inspector, and allow `document.write` to generate invalid HTML

### DIFF
--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -302,7 +302,11 @@ const editDOMNode = domNode => {
     let editor = createDOMEditor(handleChange, cancelChange);
 
     if (type === "text") {
-        editor.value = domNode.dataset.text;
+        let emptyTextSpan = domNode.querySelector(".internal");
+
+        if (emptyTextSpan === null) {
+            editor.value = domNode.innerText;
+        }
     } else {
         editor.value = domNode.innerText;
     }

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -288,8 +288,10 @@ const editDOMNode = domNode => {
             const element = document.createElement(value);
             inspector.setDOMNodeTag(domNodeID, value);
         } else if (type === "attribute") {
+            const attributeIndex = domNode.dataset.attributeIndex;
             const attributes = parseDOMAttributes(value);
-            inspector.replaceDOMNodeAttribute(domNodeID, domNode.dataset.attributeName, attributes);
+
+            inspector.replaceDOMNodeAttribute(domNodeID, attributeIndex, attributes);
         }
     };
 
@@ -354,28 +356,17 @@ const requestContextMenu = (clientX, clientY, domNode) => {
     }
 
     let tag = null;
-    let attributeName = null;
-    let attributeValue = null;
+    let attributeIndex = null;
 
     if (type === "tag") {
         tag = domNode.dataset.tag;
     } else if (type === "attribute") {
         tag = domNode.dataset.tag;
-        attributeName = domNode.dataset.attributeName;
-        attributeValue = domNode.dataset.attributeValue;
+        attributeIndex = domNode.dataset.attributeIndex;
     }
 
     pendingEditDOMNode = domNode;
-
-    inspector.requestDOMTreeContextMenu(
-        domNodeID,
-        clientX,
-        clientY,
-        type,
-        tag,
-        attributeName,
-        attributeValue
-    );
+    inspector.requestDOMTreeContextMenu(domNodeID, clientX, clientY, type, tag, attributeIndex);
 };
 
 const executeConsoleScript = consoleInput => {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -396,7 +396,7 @@ static void generate_to_integral(SourceGenerator& scoped_generator, ParameterTyp
     VERIFY(it != idl_type_map.end());
     scoped_generator.set("cpp_type"sv, it->cpp_type);
 
-    if (!optional || optional_default_value.has_value()) {
+    if ((!optional && !parameter.type->is_nullable()) || optional_default_value.has_value()) {
         scoped_generator.append(R"~~~(
     @cpp_type@ @cpp_name@;
 )~~~");
@@ -406,7 +406,11 @@ static void generate_to_integral(SourceGenerator& scoped_generator, ParameterTyp
 )~~~");
     }
 
-    if (optional) {
+    if (parameter.type->is_nullable()) {
+        scoped_generator.append(R"~~~(
+    if (!@js_name@@js_suffix@.is_null() && !@js_name@@js_suffix@.is_undefined())
+)~~~");
+    } else if (optional) {
         scoped_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_undefined())
 )~~~");

--- a/Tests/LibWeb/Layout/expected/document-write-incomplete-tag.txt
+++ b/Tests/LibWeb/Layout/expected/document-write-incomplete-tag.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x83 children: not-inline
+      BlockContainer <p> at (8,16) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 4, rect: [8,16 30.078125x17] baseline: 13.296875
+            "Well"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,49) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <p> at (8,49) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,49 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,82) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <p> at (8,82) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 8, rect: [8,82 59.21875x17] baseline: 13.296875
+            "friends!"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,115) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x83] overflow: [8,16 784x99]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,49 784x0]
+      PaintableWithLines (BlockContainer<P>) [8,49 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,82 784x0]
+      PaintableWithLines (BlockContainer<P>) [8,82 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,115 784x0]

--- a/Tests/LibWeb/Layout/input/document-write-incomplete-tag.html
+++ b/Tests/LibWeb/Layout/input/document-write-incomplete-tag.html
@@ -1,0 +1,8 @@
+<p>Well</p>
+
+<script type="text/javascript">
+    document.write("<p");
+    document.write(">hello</p>");
+</script>
+
+<p>friends!</p>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -530,9 +530,12 @@ WebIDL::ExceptionOr<void> Document::run_the_document_write_steps(StringView inpu
     // 5. Insert input into the input stream just before the insertion point.
     m_parser->tokenizer().insert_input_at_insertion_point(input);
 
-    // 6. If there is no pending parsing-blocking script, have the HTML parser process input, one code point at a time, processing resulting tokens as they are emitted, and stopping when the tokenizer reaches the insertion point or when the processing of the tokenizer is aborted by the tree construction stage (this can happen if a script end tag token is emitted by the tokenizer).
+    // 6. If there is no pending parsing-blocking script, have the HTML parser process input, one code point at a time,
+    //    processing resulting tokens as they are emitted, and stopping when the tokenizer reaches the insertion point
+    //    or when the processing of the tokenizer is aborted by the tree construction stage (this can happen if a script
+    //    end tag token is emitted by the tokenizer).
     if (!pending_parsing_blocking_script())
-        m_parser->run();
+        m_parser->run(HTML::HTMLTokenizer::StopAtInsertionPoint::Yes);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -169,14 +169,14 @@ void HTMLParser::visit_edges(Cell::Visitor& visitor)
     m_list_of_active_formatting_elements.visit_edges(visitor);
 }
 
-void HTMLParser::run()
+void HTMLParser::run(HTMLTokenizer::StopAtInsertionPoint stop_at_insertion_point)
 {
     for (;;) {
         // FIXME: Find a better way to say that we come from Document::close() and want to process EOF.
         if (!m_tokenizer.is_eof_inserted() && m_tokenizer.is_insertion_point_reached())
             return;
 
-        auto optional_token = m_tokenizer.next_token();
+        auto optional_token = m_tokenizer.next_token(stop_at_insertion_point);
         if (!optional_token.has_value())
             break;
         auto& token = optional_token.value();
@@ -216,11 +216,11 @@ void HTMLParser::run()
     flush_character_insertions();
 }
 
-void HTMLParser::run(const AK::URL& url)
+void HTMLParser::run(const AK::URL& url, HTMLTokenizer::StopAtInsertionPoint stop_at_insertion_point)
 {
     m_document->set_url(url);
     m_document->set_source(MUST(String::from_byte_string(m_tokenizer.source())));
-    run();
+    run(stop_at_insertion_point);
     the_end(*m_document, this);
     m_document->detach_parser({});
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -53,8 +53,8 @@ public:
     static JS::NonnullGCPtr<HTMLParser> create_with_uncertain_encoding(DOM::Document&, ByteBuffer const& input);
     static JS::NonnullGCPtr<HTMLParser> create(DOM::Document&, StringView input, ByteString const& encoding);
 
-    void run();
-    void run(const AK::URL&);
+    void run(HTMLTokenizer::StopAtInsertionPoint = HTMLTokenizer::StopAtInsertionPoint::No);
+    void run(const AK::URL&, HTMLTokenizer::StopAtInsertionPoint = HTMLTokenizer::StopAtInsertionPoint::No);
 
     static void the_end(JS::NonnullGCPtr<DOM::Document>, JS::GCPtr<HTMLParser> = nullptr);
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2802,6 +2802,7 @@ HTMLTokenizer::HTMLTokenizer(StringView input, ByteString const& encoding)
 void HTMLTokenizer::insert_input_at_insertion_point(StringView input)
 {
     auto utf8_iterator_byte_offset = m_utf8_view.byte_offset_of(m_utf8_iterator);
+    auto prev_utf8_iterator_byte_offset = m_utf8_view.byte_offset_of(m_prev_utf8_iterator);
 
     // FIXME: Implement a InputStream to handle insertion_point and iterators.
     StringBuilder builder {};
@@ -2812,6 +2813,7 @@ void HTMLTokenizer::insert_input_at_insertion_point(StringView input)
 
     m_utf8_view = Utf8View(m_decoded_input);
     m_utf8_iterator = m_utf8_view.iterator_at_byte_offset(utf8_iterator_byte_offset);
+    m_prev_utf8_iterator = m_utf8_view.iterator_at_byte_offset(prev_utf8_iterator_byte_offset);
 
     m_insertion_point.position += input.length();
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2805,9 +2805,9 @@ void HTMLTokenizer::insert_input_at_insertion_point(StringView input)
 
     // FIXME: Implement a InputStream to handle insertion_point and iterators.
     StringBuilder builder {};
-    builder.append(m_decoded_input.substring(0, m_insertion_point.position));
+    builder.append(m_decoded_input.substring_view(0, m_insertion_point.position));
     builder.append(input);
-    builder.append(m_decoded_input.substring(m_insertion_point.position));
+    builder.append(m_decoded_input.substring_view(m_insertion_point.position));
     m_decoded_input = builder.to_byte_string();
 
     m_utf8_view = Utf8View(m_decoded_input);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -248,7 +248,7 @@ HTMLToken::Position HTMLTokenizer::nth_last_position(size_t n)
     return m_source_positions.at(m_source_positions.size() - 1 - n);
 }
 
-Optional<HTMLToken> HTMLTokenizer::next_token()
+Optional<HTMLToken> HTMLTokenizer::next_token(StopAtInsertionPoint stop_at_insertion_point)
 {
     if (!m_source_positions.is_empty()) {
         auto last_position = m_source_positions.last();
@@ -263,6 +263,9 @@ _StartOfFunction:
         return {};
 
     for (;;) {
+        if (stop_at_insertion_point == StopAtInsertionPoint::Yes && is_insertion_point_reached())
+            return {};
+
         auto current_input_character = next_code_point();
         switch (m_state) {
             // 13.2.5.1 Data state, https://html.spec.whatwg.org/multipage/parsing.html#data-state

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -111,7 +111,11 @@ public:
 #undef __ENUMERATE_TOKENIZER_STATE
     };
 
-    Optional<HTMLToken> next_token();
+    enum class StopAtInsertionPoint {
+        No,
+        Yes,
+    };
+    Optional<HTMLToken> next_token(StopAtInsertionPoint = StopAtInsertionPoint::No);
 
     void set_parser(Badge<HTMLParser>, HTMLParser& parser) { m_parser = &parser; }
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -61,14 +61,14 @@ void Inspector::add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<DOM::Named
     global_object().browsing_context()->page().client().inspector_did_add_dom_node_attributes(node_id, attributes);
 }
 
-void Inspector::replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes)
+void Inspector::replace_dom_node_attribute(i32 node_id, WebIDL::UnsignedLongLong attribute_index, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes)
 {
-    global_object().browsing_context()->page().client().inspector_did_replace_dom_node_attribute(node_id, name, replacement_attributes);
+    global_object().browsing_context()->page().client().inspector_did_replace_dom_node_attribute(node_id, static_cast<size_t>(attribute_index), replacement_attributes);
 }
 
-void Inspector::request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<String> const& attribute_name, Optional<String> const& attribute_value)
+void Inspector::request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index)
 {
-    global_object().browsing_context()->page().client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag, attribute_name, attribute_value);
+    global_object().browsing_context()->page().client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag, attribute_index.map([](auto index) { return static_cast<size_t>(index); }));
 }
 
 void Inspector::execute_console_script(String const& script)

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -8,6 +8,7 @@
 
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::Internals {
 
@@ -24,9 +25,9 @@ public:
     void set_dom_node_text(i32 node_id, String const& text);
     void set_dom_node_tag(i32 node_id, String const& tag);
     void add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<DOM::NamedNodeMap> attributes);
-    void replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes);
+    void replace_dom_node_attribute(i32 node_id, WebIDL::UnsignedLongLong attribute_index, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes);
 
-    void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<String> const& attribute_name, Optional<String> const& attribute_value);
+    void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index);
 
     void execute_console_script(String const& script);
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -8,9 +8,9 @@
     undefined setDOMNodeText(long nodeID, DOMString text);
     undefined setDOMNodeTag(long nodeID, DOMString tag);
     undefined addDOMNodeAttributes(long nodeID, NamedNodeMap attributes);
-    undefined replaceDOMNodeAttribute(long nodeID, DOMString name, NamedNodeMap replacementAttributes);
+    undefined replaceDOMNodeAttribute(long nodeID, unsigned long long attributeIndex, NamedNodeMap replacementAttributes);
 
-    undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tag, DOMString? attributeName, DOMString? attributeValue);
+    undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tag, unsigned long long? attributeIndex);
 
     undefined executeConsoleScript(DOMString script);
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -298,8 +298,8 @@ public:
     virtual void inspector_did_set_dom_node_text([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& text) { }
     virtual void inspector_did_set_dom_node_tag([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& tag) { }
     virtual void inspector_did_add_dom_node_attributes([[maybe_unused]] i32 node_id, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> attributes) { }
-    virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& name, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }
-    virtual void inspector_did_request_dom_tree_context_menu([[maybe_unused]] i32 node_id, [[maybe_unused]] CSSPixelPoint position, [[maybe_unused]] String const& type, [[maybe_unused]] Optional<String> const& tag, [[maybe_unused]] Optional<String> const& attribute_name, [[maybe_unused]] Optional<String> const& attribute_value) { }
+    virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] size_t attribute_index, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }
+    virtual void inspector_did_request_dom_tree_context_menu([[maybe_unused]] i32 node_id, [[maybe_unused]] CSSPixelPoint position, [[maybe_unused]] String const& type, [[maybe_unused]] Optional<String> const& tag, [[maybe_unused]] Optional<size_t> const& attribute_index) { }
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
 
     virtual void schedule_repaint() = 0;

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -485,7 +485,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             deprecated_text = escape_html_entities(deprecated_text);
 
             auto text = MUST(Web::Infra::strip_and_collapse_whitespace(deprecated_text));
-            builder.appendff("<span data-node-type=\"text\" data-text=\"{}\" class=\"hoverable editable\" {}>", text, data_attributes.string_view());
+            builder.appendff("<span data-node-type=\"text\" class=\"hoverable editable\" {}>", data_attributes.string_view());
 
             if (text.is_empty())
                 builder.appendff("<span class=\"internal\">{}</span>", name);

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -542,7 +542,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
                 builder.appendff("<span data-node-type=\"attribute\" data-tag=\"{}\" data-attribute-index={} class=\"editable\">", tag, dom_node_attributes.size());
                 builder.appendff("<span class=\"attribute-name\">{}</span>", name);
                 builder.append('=');
-                builder.appendff("<span class=\"attribute-value\">\"{}\"</span>", value_string);
+                builder.appendff("<span class=\"attribute-value\">\"{}\"</span>", escape_html_entities(value_string));
                 builder.append("</span>"sv);
 
                 dom_node_attributes.empend(MUST(String::from_byte_string(name)), MUST(String::from_byte_string(value_string)));

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -5,9 +5,12 @@
  */
 
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/JsonValue.h>
 #include <AK/StringView.h>
+#include <AK/Vector.h>
 #include <LibGfx/Point.h>
+#include <LibWebView/Attribute.h>
 #include <LibWebView/ViewImplementation.h>
 
 #pragma once
@@ -75,6 +78,8 @@ private:
         Optional<Attribute> attribute;
     };
     Optional<ContextMenuData> m_context_menu_data;
+
+    HashMap<int, Vector<Attribute>> m_dom_node_attributes;
 
     i32 m_highest_notified_message_index { -1 };
     i32 m_highest_received_message_index { -1 };

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -174,8 +174,8 @@ public:
     Function<void(i32, String const&)> on_inspector_set_dom_node_text;
     Function<void(i32, String const&)> on_inspector_set_dom_node_tag;
     Function<void(i32, Vector<Attribute> const&)> on_inspector_added_dom_node_attributes;
-    Function<void(i32, String const&, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
-    Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&, Optional<Attribute> const&)> on_inspector_requested_dom_tree_context_menu;
+    Function<void(i32, size_t, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
+    Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&, Optional<size_t> const&)> on_inspector_requested_dom_tree_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
     Function<SocketPair()> on_request_worker_agent;
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -923,7 +923,7 @@ void WebContentClient::inspector_did_add_dom_node_attributes(u64 page_id, i32 no
         view.on_inspector_added_dom_node_attributes(node_id, attributes);
 }
 
-void WebContentClient::inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes)
+void WebContentClient::inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, size_t attribute_index, Vector<Attribute> const& replacement_attributes)
 {
     auto maybe_view = m_views.get(page_id);
     if (!maybe_view.has_value()) {
@@ -933,10 +933,10 @@ void WebContentClient::inspector_did_replace_dom_node_attribute(u64 page_id, i32
     auto& view = *maybe_view.value();
 
     if (view.on_inspector_replaced_dom_node_attribute)
-        view.on_inspector_replaced_dom_node_attribute(node_id, name, replacement_attributes);
+        view.on_inspector_replaced_dom_node_attribute(node_id, attribute_index, replacement_attributes);
 }
 
-void WebContentClient::inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag, Optional<Attribute> const& attribute)
+void WebContentClient::inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index)
 {
     auto maybe_view = m_views.get(page_id);
     if (!maybe_view.has_value()) {
@@ -946,7 +946,7 @@ void WebContentClient::inspector_did_request_dom_tree_context_menu(u64 page_id, 
     auto& view = *maybe_view.value();
 
     if (view.on_inspector_requested_dom_tree_context_menu)
-        view.on_inspector_requested_dom_tree_context_menu(node_id, view.to_widget_position(position), type, tag, attribute);
+        view.on_inspector_requested_dom_tree_context_menu(node_id, view.to_widget_position(position), type, tag, attribute_index);
 }
 
 void WebContentClient::inspector_did_execute_console_script(u64 page_id, String const& script)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -99,8 +99,8 @@ private:
     virtual void inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(u64 page_id, i32 node_id, String const& tag) override;
     virtual void inspector_did_add_dom_node_attributes(u64 page_id, i32 node_id, Vector<Attribute> const& attributes) override;
-    virtual void inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes) override;
-    virtual void inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag, Optional<Attribute> const& attribute) override;
+    virtual void inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, size_t attribute_index, Vector<Attribute> const& replacement_attributes) override;
+    virtual void inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index) override;
     virtual void inspector_did_execute_console_script(u64 page_id, String const& script) override;
     virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent(u64 page_id) override;
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -621,18 +621,14 @@ void PageClient::inspector_did_add_dom_node_attributes(i32 node_id, JS::NonnullG
     client().async_inspector_did_add_dom_node_attributes(m_id, node_id, named_node_map_to_vector(attributes));
 }
 
-void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes)
+void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, size_t attribute_index, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes)
 {
-    client().async_inspector_did_replace_dom_node_attribute(m_id, node_id, name, named_node_map_to_vector(replacement_attributes));
+    client().async_inspector_did_replace_dom_node_attribute(m_id, node_id, attribute_index, named_node_map_to_vector(replacement_attributes));
 }
 
-void PageClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<String> const& attribute_name, Optional<String> const& attribute_value)
+void PageClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index)
 {
-    Optional<WebView::Attribute> attribute;
-    if (attribute_name.has_value() && attribute_value.has_value())
-        attribute = WebView::Attribute { *attribute_name, *attribute_value };
-
-    client().async_inspector_did_request_dom_tree_context_menu(m_id, node_id, page().css_to_device_point(position).to_type<int>(), type, tag, move(attribute));
+    client().async_inspector_did_request_dom_tree_context_menu(m_id, node_id, page().css_to_device_point(position).to_type<int>(), type, tag, attribute_index);
 }
 
 void PageClient::inspector_did_execute_console_script(String const& script)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -144,8 +144,8 @@ private:
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
     virtual void inspector_did_add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> attributes) override;
-    virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
-    virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<String> const& attribute_name, Optional<String> const& attribute_value) override;
+    virtual void inspector_did_replace_dom_node_attribute(i32 node_id, size_t attribute_index, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
+    virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
 
     Web::Layout::Viewport* layout_root();

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -87,8 +87,8 @@ endpoint WebContentClient
     inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String text) =|
     inspector_did_set_dom_node_tag(u64 page_id, i32 node_id, String tag) =|
     inspector_did_add_dom_node_attributes(u64 page_id, i32 node_id, Vector<WebView::Attribute> attributes) =|
-    inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
-    inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String type, Optional<String> tag, Optional<WebView::Attribute> attribute) =|
+    inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, size_t attribute_index, Vector<WebView::Attribute> replacement_attributes) =|
+    inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String type, Optional<String> tag, Optional<size_t> attribute_index) =|
     inspector_did_execute_console_script(u64 page_id, String script) =|
 
 }


### PR DESCRIPTION
There were 2 bugs with LibWeb and the Inspector on https://world-of-dungeons.net/:

1. `document.write` was not able to handle writing partial HTML tags. Doing so would ultimately generate invalid HTML.
2. The Inspector was unable to handle that HTML, as the HTML generated for the Inspector would itself become invalid.

This PR fixes (2) then (1). The former manifested itself in a couple places, but the end result here also nicely reduces the size of generated HTML (for example, the Inspector HTML on https://github.com/SerenityOS/serenity reduces by about 18%).

![Screenshot_20240218_144749](https://github.com/SerenityOS/serenity/assets/5600524/6be8c8e9-da29-4c47-909b-d4ade4615465)

Fixes #23241