### PR TITLE
LibGfx/ICC: Add a one-element cache for CLUT conversions

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -321,6 +321,12 @@ private:
     FloatMatrix3x3 rgb_to_xyz_matrix() const;
 
     mutable Optional<FloatMatrix3x3> m_cached_xyz_to_rgb_matrix;
+
+    struct OneElementCLUTCache {
+        Vector<u8, 4> key;
+        FloatVector3 value;
+    };
+    mutable Optional<OneElementCLUTCache> m_to_pcs_clut_cache;
 };
 
 }


### PR DESCRIPTION
Our current CLUT code is pretty slow. A one-element cache can make
it quite a bit faster for images that have long runs of a single
color, such as illustrations.

It also seems to help with photos some (in `0000711.pdf` page 1) --
I suppose even them have enough repeating pixels for it to be worth
it.

Some numbers, with `pdf --render-bench`:

`0000711.pdf --page 1` (high-res photo)
before: 2.9s
after: 2.43s

`0000277.pdf --page 19` (my nemesis PDF, large-ish illustration)
before: 2.17s
after: 0.58s (!)

`0000502.pdf --page 2` (wat hoe dat)
before: 0.66s
after: 0.27s

`0000521.pdf --page 10 ` (japanese)
before: 0.52s
after: 0.29s

`0000364.pdf --page 1` (4 min test case)
before: 0.48s
after: 0.19s

Thanks to that last one, reduces the time for
`time Meta/test_pdf.py ~/Downloads/0000` from 4m22s to 1m28s.

Helps quite a bit with https://github.com/SerenityOS/serenity/issues/23157 (but high-res photos are still too
slow).