### PR TITLE
LibWeb: Implement Animatable::get_animations()

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.cpp
@@ -61,4 +61,14 @@ Vector<JS::NonnullGCPtr<Animation>> Animatable::get_animations(Web::Animations::
     return {};
 }
 
+void Animatable::associate_with_effect(JS::NonnullGCPtr<AnimationEffect> effect)
+{
+    m_associated_effects.append(effect);
+}
+
+void Animatable::disassociate_with_effect(JS::NonnullGCPtr<AnimationEffect> effect)
+{
+    m_associated_effects.remove_first_matching([&](auto element) { return effect == element; });
+}
+
 }

--- a/Userland/Libraries/LibWeb/Animations/Animatable.h
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.h
@@ -29,6 +29,12 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> animate(Optional<JS::Handle<JS::Object>> keyframes, Variant<Empty, double, KeyframeAnimationOptions> options = {});
     Vector<JS::NonnullGCPtr<Animation>> get_animations(GetAnimationsOptions options = {});
+
+    void associate_with_effect(JS::NonnullGCPtr<AnimationEffect> effect);
+    void disassociate_with_effect(JS::NonnullGCPtr<AnimationEffect> effect);
+
+private:
+    Vector<JS::NonnullGCPtr<AnimationEffect>> m_associated_effects;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/Animatable.h
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.h
@@ -35,6 +35,7 @@ public:
 
 private:
     Vector<JS::NonnullGCPtr<AnimationEffect>> m_associated_effects;
+    bool m_is_sorted_by_composite_order { true };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -300,6 +300,15 @@ Bindings::AnimationPlayState Animation::play_state() const
     return Bindings::AnimationPlayState::Running;
 }
 
+// https://www.w3.org/TR/web-animations-1/#animation-relevant
+bool Animation::is_relevant() const
+{
+    // An animation is relevant if:
+    // - Its associated effect is current or in effect, and
+    // - Its replace state is not removed.
+    return (m_effect->is_current() || m_effect->is_in_effect()) && replace_state() != Bindings::AnimationReplaceState::Removed;
+}
+
 // https://www.w3.org/TR/web-animations-1/#replaceable-animation
 bool Animation::is_replaceable() const
 {

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -844,6 +844,8 @@ JS::NonnullGCPtr<WebIDL::Promise> Animation::current_finished_promise() const
 Animation::Animation(JS::Realm& realm)
     : DOM::EventTarget(realm)
 {
+    static unsigned int next_animation_list_order = 0;
+    m_global_animation_list_order = next_animation_list_order++;
 }
 
 void Animation::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Animations/AnimationPlaybackEvent.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
@@ -297,6 +298,44 @@ Bindings::AnimationPlayState Animation::play_state() const
     // -> Otherwise,
     //    → running
     return Bindings::AnimationPlayState::Running;
+}
+
+// https://www.w3.org/TR/web-animations-1/#replaceable-animation
+bool Animation::is_replaceable() const
+{
+    // An animation is replaceable if all of the following conditions are true:
+
+    // - The existence of the animation is not prescribed by markup. That is, it is not a CSS animation with an owning
+    //   element, nor a CSS transition with an owning element.
+    // FIXME: Check for transitions
+    if (is_css_animation() && static_cast<CSS::CSSAnimation const*>(this)->owning_element())
+        return false;
+
+    // - The animation's play state is finished.
+    if (play_state() != Bindings::AnimationPlayState::Finished)
+        return false;
+
+    // - The animation's replace state is not removed.
+    if (replace_state() == Bindings::AnimationReplaceState::Removed)
+        return false;
+
+    // - The animation is associated with a monotonically increasing timeline.
+    if (!m_timeline || !m_timeline->is_monotonically_increasing())
+        return false;
+
+    // - The animation has an associated effect.
+    if (!m_effect)
+        return false;
+
+    // - The animation's associated effect is in effect.
+    if (!m_effect->is_in_effect())
+        return false;
+
+    // - The animation's associated effect has an effect target.
+    if (!m_effect->target())
+        return false;
+
+    return true;
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-animation-play

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -50,6 +50,7 @@ public:
 
     Bindings::AnimationPlayState play_state() const;
 
+    bool is_replaceable() const;
     Bindings::AnimationReplaceState replace_state() const { return m_replace_state; }
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-pending

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -120,6 +120,8 @@ private:
     JS::NonnullGCPtr<WebIDL::Promise> current_ready_promise() const;
     JS::NonnullGCPtr<WebIDL::Promise> current_finished_promise() const;
 
+    void invalidate_effect();
+
     // https://www.w3.org/TR/web-animations-1/#dom-animation-id
     FlyString m_id;
 
@@ -164,10 +166,7 @@ private:
     // https://www.w3.org/TR/web-animations-1/#pending-pause-task
     TaskState m_pending_pause_task { TaskState::None };
 
-    // Flags used to manage the finish notification microtask and ultimately prevent more than one finish notification
-    // microtask from being queued at any given time
-    bool m_should_abort_finish_notification_microtask { false };
-    bool m_has_finish_notification_microtask_scheduled { false };
+    Optional<int> m_pending_finish_microtask_id;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -81,6 +81,8 @@ public:
     virtual AnimationClass animation_class() const { return AnimationClass::None; }
     virtual Optional<int> class_specific_composite_order(JS::NonnullGCPtr<Animation>) const { return {}; }
 
+    unsigned int global_animation_list_order() const { return m_global_animation_list_order; }
+
 protected:
     Animation(JS::Realm&);
 
@@ -118,6 +120,9 @@ private:
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-id
     FlyString m_id;
+
+    // https://www.w3.org/TR/web-animations-1/#global-animation-list
+    unsigned int m_global_animation_list_order { 0 };
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-effect
     JS::GCPtr<AnimationEffect> m_effect;

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -50,6 +50,8 @@ public:
 
     Bindings::AnimationPlayState play_state() const;
 
+    bool is_relevant() const;
+
     bool is_replaceable() const;
     Bindings::AnimationReplaceState replace_state() const { return m_replace_state; }
 

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -12,6 +12,15 @@
 
 namespace Web::Animations {
 
+// Sorted by composite order:
+// https://www.w3.org/TR/css-animations-2/#animation-composite-order
+enum class AnimationClass {
+    CSSAnimationWithOwningElement,
+    CSSTransition,
+    CSSAnimationWithoutOwningElement,
+    None,
+};
+
 // https://www.w3.org/TR/web-animations-1/#the-animation-interface
 class Animation : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(Animation, DOM::EventTarget);
@@ -68,6 +77,9 @@ public:
     void effect_timing_changed(Badge<AnimationEffect>);
 
     virtual bool is_css_animation() const { return false; }
+
+    virtual AnimationClass animation_class() const { return AnimationClass::None; }
+    virtual Optional<int> class_specific_composite_order(JS::NonnullGCPtr<Animation>) const { return {}; }
 
 protected:
     Animation(JS::Realm&);

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -61,6 +61,7 @@ public:
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-finished
     JS::NonnullGCPtr<JS::Object> finished() const { return *current_finished_promise()->promise(); }
+    bool is_finished() const { return m_is_finished; }
 
     enum class AutoRewind {
         Yes,
@@ -155,7 +156,7 @@ private:
 
     // https://www.w3.org/TR/web-animations-1/#current-finished-promise
     mutable JS::GCPtr<WebIDL::Promise> m_current_finished_promise;
-    bool m_current_finished_promise_resolved { false };
+    bool m_is_finished { false };
 
     // https://www.w3.org/TR/web-animations-1/#pending-play-task
     TaskState m_pending_play_task { TaskState::None };

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -264,6 +264,14 @@ Optional<double> AnimationEffect::active_time_using_fill(Bindings::FillMode fill
     return {};
 }
 
+// https://www.w3.org/TR/web-animations-1/#in-effect
+bool AnimationEffect::is_in_effect() const
+{
+    // An animation effect is in effect if its active time, as calculated according to the procedure in
+    // §4.8.3.1 Calculating the active time, is not unresolved.
+    return active_time().has_value();
+}
+
 // https://www.w3.org/TR/web-animations-1/#before-active-boundary-time
 double AnimationEffect::before_active_boundary_time() const
 {

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -104,6 +104,7 @@ public:
     double active_duration() const;
     Optional<double> active_time() const;
     Optional<double> active_time_using_fill(Bindings::FillMode) const;
+    bool is_in_effect() const;
 
     double before_active_boundary_time() const;
     double after_active_boundary_time() const;

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -104,6 +104,9 @@ public:
     double active_duration() const;
     Optional<double> active_time() const;
     Optional<double> active_time_using_fill(Bindings::FillMode) const;
+
+    bool is_in_play() const;
+    bool is_current() const;
     bool is_in_effect() const;
 
     double before_active_boundary_time() const;

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -23,7 +23,6 @@ void AnimationTimeline::set_current_time(Optional<double> value)
     }
 
     m_current_time = value;
-
     for (auto& animation : m_associated_animations)
         animation->notify_timeline_time_did_change();
 }

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -732,6 +732,15 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyframeEffect>> KeyframeEffect::construct_
     return effect;
 }
 
+void KeyframeEffect::set_target(DOM::Element* target)
+{
+    if (m_target_element)
+        m_target_element->disassociate_with_effect(*this);
+    m_target_element = target;
+    if (m_target_element)
+        m_target_element->associate_with_effect(*this);
+}
+
 void KeyframeEffect::set_pseudo_element(Optional<String> pseudo_element)
 {
     // On setting, sets the target pseudo-selector of the animation effect to the provided value after applying the
@@ -832,6 +841,12 @@ WebIDL::ExceptionOr<void> KeyframeEffect::set_keyframes(Optional<JS::Handle<JS::
 KeyframeEffect::KeyframeEffect(JS::Realm& realm)
     : AnimationEffect(realm)
 {
+}
+
+KeyframeEffect::~KeyframeEffect()
+{
+    if (m_target_element)
+        m_target_element->disassociate_with_effect(*this);
 }
 
 void KeyframeEffect::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -69,6 +69,8 @@ public:
     };
     static void generate_initial_and_final_frames(RefPtr<KeyFrameSet>, HashTable<CSS::PropertyID> const& animated_properties);
 
+    static int composite_order(JS::NonnullGCPtr<KeyframeEffect>, JS::NonnullGCPtr<KeyframeEffect>);
+
     static JS::NonnullGCPtr<KeyframeEffect> create(JS::Realm&);
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyframeEffect>> construct_impl(

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -82,7 +82,7 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyframeEffect>> construct_impl(JS::Realm&, JS::NonnullGCPtr<KeyframeEffect> source);
 
     DOM::Element* target() const override { return m_target_element; }
-    void set_target(DOM::Element* target) { m_target_element = target; }
+    void set_target(DOM::Element* target);
 
     Optional<String> pseudo_element() const { return m_target_pseudo_selector; }
     void set_pseudo_element(Optional<String>);
@@ -98,6 +98,7 @@ public:
 
 private:
     KeyframeEffect(JS::Realm&);
+    virtual ~KeyframeEffect() override;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
@@ -16,6 +16,49 @@ JS::NonnullGCPtr<CSSAnimation> CSSAnimation::create(JS::Realm& realm)
     return realm.heap().allocate<CSSAnimation>(realm, realm);
 }
 
+// https://www.w3.org/TR/css-animations-2/#animation-composite-order
+Optional<int> CSSAnimation::class_specific_composite_order(JS::NonnullGCPtr<Animations::Animation> other_animation) const
+{
+    auto other = JS::NonnullGCPtr { verify_cast<CSSAnimation>(*other_animation) };
+
+    // The existance of an owning element determines the animation class, so both animations should have their owning
+    // element in the same state
+    VERIFY(!m_owning_element == !other->m_owning_element);
+
+    // Within the set of CSS Animations with an owning element, two animations A and B are sorted in composite order
+    // (first to last) as follows:
+    if (m_owning_element) {
+        // 1. If the owning element of A and B differs, sort A and B by tree order of their corresponding owning elements.
+        //    With regard to pseudo-elements, the sort order is as follows:
+        //    - element
+        //    - ::marker
+        //    - ::before
+        //    - any other pseudo-elements not mentioned specifically in this list, sorted in ascending order by the Unicode
+        //      codepoints that make up each selector
+        //    - ::after
+        //    - element children
+        if (m_owning_element.ptr() != other->m_owning_element.ptr()) {
+            // FIXME: Sort by tree order
+            return {};
+        }
+
+        // 2. Otherwise, sort A and B based on their position in the computed value of the animation-name property of the
+        //    (common) owning element.
+        // FIXME: Do this when animation-name supports multiple values
+        return {};
+    }
+
+    // The composite order of CSS Animations without an owning element is based on their position in the global animation list.
+    return global_animation_list_order() - other->global_animation_list_order();
+}
+
+Animations::AnimationClass CSSAnimation::animation_class() const
+{
+    if (m_owning_element)
+        return Animations::AnimationClass::CSSAnimationWithOwningElement;
+    return Animations::AnimationClass::CSSAnimationWithoutOwningElement;
+}
+
 CSSAnimation::CSSAnimation(JS::Realm& realm)
     : Animations::Animation(realm)
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
@@ -62,6 +62,12 @@ Animations::AnimationClass CSSAnimation::animation_class() const
 CSSAnimation::CSSAnimation(JS::Realm& realm)
     : Animations::Animation(realm)
 {
+    // FIXME:
+    // CSS Animations generated using the markup defined in this specification are not added to the global animation
+    // list when they are created. Instead, these animations are appended to the global animation list at the first
+    // moment when they transition out of the idle play state after being disassociated from their owning element. CSS
+    // Animations that have been disassociated from their owning element but are still idle do not have a defined
+    // composite order.
 }
 
 void CSSAnimation::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/CSS/CSSAnimation.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSAnimation.h
@@ -24,6 +24,9 @@ public:
 
     FlyString const& animation_name() const { return id(); }
 
+    virtual Animations::AnimationClass animation_class() const override;
+    virtual Optional<int> class_specific_composite_order(JS::NonnullGCPtr<Animations::Animation> other) const override;
+
 private:
     explicit CSSAnimation(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/HTML/EventNames.h
+++ b/Userland/Libraries/LibWeb/HTML/EventNames.h
@@ -49,6 +49,7 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(emptied)                  \
     __ENUMERATE_HTML_EVENT(ended)                    \
     __ENUMERATE_HTML_EVENT(error)                    \
+    __ENUMERATE_HTML_EVENT(finish)                   \
     __ENUMERATE_HTML_EVENT(focus)                    \
     __ENUMERATE_HTML_EVENT(formdata)                 \
     __ENUMERATE_HTML_EVENT(hashchange)               \


### PR DESCRIPTION
In order to do so, we need to define animation composite ordering as well as some other misc helper methods.

Work towards #21570