### PR TITLE
LibPDF: Give CFF Glyph 0 the name .notdef

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -251,8 +251,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                 auto cid = 0;
                 TRY(cff->add_glyph(ByteString::formatted("{}", cid), move(glyphs[0])));
             } else {
-                // FIXME: Shouldn't this use resolve_sid(0, strings) (".notdef") as name?
-                TRY(cff->add_glyph(0, move(glyphs[0])));
+                TRY(cff->add_glyph(".notdef", move(glyphs[0])));
             }
             continue;
         }


### PR DESCRIPTION
This is required by the CFF spec, and is consistent with what we do for the encoding 24 lines down.

As far as I can tell, nothing in `Type1FontProgram::rasterize_glyph()` or in Type1Font.cpp implements the "If an encoding maps to a character name that does not exist in the Type 1 font pro- gram, the .notdef glyph is substituted." line from the PDF 1.7 spec (in 5.5.5 Character Encoding, Encodings for Type 1 Fonts) yet, so this does yet have an effect.