### PR TITLE
LibPDF/CFF: Fix off-by-one when reading internal encoding

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -279,8 +279,9 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                 encoding->set(0, ".notdef");
                 continue;
             }
-            if (i >= encoding_codes.size() || i >= charset_names.size())
+            if (i - 1 >= encoding_codes.size() || i - 1 >= charset_names.size()) {
                 break;
+            }
             auto code = encoding_codes[i - 1];
             auto char_name = charset_names[i - 1];
             encoding->set(code, char_name);

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -280,6 +280,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                 continue;
             }
             if (i - 1 >= encoding_codes.size() || i - 1 >= charset_names.size()) {
+                dbgln("CFF: No encoding for glyph {} onwards, encoding_codes size {} charset_names size {}", i, encoding_codes.size(), charset_names.size());
                 break;
             }
             auto code = encoding_codes[i - 1];


### PR DESCRIPTION
We use `i - 1` to index these arrays, so that's what we should use
for the bounds check as well.