### PR TITLE
LibJS: Further increase the free stack limit to 256 KiB

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -98,7 +98,7 @@ public:
     {
         // Address sanitizer (ASAN) used to check for more space but
         // currently we can't detect the stack size with it enabled.
-        return m_stack_info.size_free() < 128 * KiB;
+        return m_stack_info.size_free() < 256 * KiB;
     }
 
     // TODO: Rename this function instead of providing a second argument, now that the global object is no longer passed in.


### PR DESCRIPTION
128 KiB seems to not be enough for CI.