### PR TITLE
LibJS: Remove FLATTEN attribute from Interpreter::run_bytecode

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -258,7 +258,7 @@ ThrowCompletionOr<Value> Interpreter::run(SourceTextModule& module)
     return js_undefined();
 }
 
-FLATTEN void Interpreter::run_bytecode()
+void Interpreter::run_bytecode()
 {
     auto* locals = vm().running_execution_context().locals.data();
     auto& accumulator = this->accumulator();

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -98,7 +98,7 @@ public:
     {
         // Address sanitizer (ASAN) used to check for more space but
         // currently we can't detect the stack size with it enabled.
-        return m_stack_info.size_free() < 256 * KiB;
+        return m_stack_info.size_free() < 32 * KiB;
     }
 
     // TODO: Rename this function instead of providing a second argument, now that the global object is no longer passed in.


### PR DESCRIPTION
This is what caused stack usage to increase so much with the new BC.
Revert it for now so we can restore our old stack limit.