### PR TITLE
LibGfx/ICC+icc: Be lenient about invalid profile creation datetimes

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
+++ b/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
@@ -673,16 +673,13 @@ static ErrorOr<void> encode_header(ByteBuffer& bytes, Profile const& profile)
     raw_header.data_color_space = profile.data_color_space();
     raw_header.profile_connection_space = profile.connection_space();
 
-    time_t profile_timestamp = profile.creation_timestamp();
-    struct tm tm;
-    if (!gmtime_r(&profile_timestamp, &tm))
-        return Error::from_errno(errno);
-    raw_header.profile_creation_time.year = tm.tm_year + 1900;
-    raw_header.profile_creation_time.month = tm.tm_mon + 1;
-    raw_header.profile_creation_time.day = tm.tm_mday;
-    raw_header.profile_creation_time.hours = tm.tm_hour;
-    raw_header.profile_creation_time.minutes = tm.tm_min;
-    raw_header.profile_creation_time.seconds = tm.tm_sec;
+    DateTime profile_timestamp = profile.creation_timestamp();
+    raw_header.profile_creation_time.year = profile_timestamp.year;
+    raw_header.profile_creation_time.month = profile_timestamp.month;
+    raw_header.profile_creation_time.day = profile_timestamp.day;
+    raw_header.profile_creation_time.hours = profile_timestamp.hours;
+    raw_header.profile_creation_time.minutes = profile_timestamp.minutes;
+    raw_header.profile_creation_time.seconds = profile_timestamp.seconds;
 
     raw_header.profile_file_signature = ProfileFileSignature;
     raw_header.primary_platform = profile.primary_platform().value_or(PrimaryPlatform { 0 });

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -760,6 +760,10 @@ ErrorOr<void> Profile::check_tag_types()
     // (The macOS 13.1 /System/Library/ColorSync/Profiles/Display\ P3.icc file no longer has this quirk.)
     static constexpr Crypto::Hash::MD5::DigestType apple_p3_2015_id = { 0xe5, 0xbb, 0x0e, 0x98, 0x67, 0xbd, 0x46, 0xcd, 0x4b, 0xbe, 0x44, 0x6e, 0xbd, 0x1b, 0x75, 0x98 };
 
+    // Profile ID of the "Display P3" profile in object 881 in https://fredrikbk.com/publications/copy-and-patch.pdf
+    // (The macOS 13.1 /System/Library/ColorSync/Profiles/Display\ P3.icc file no longer has this quirk.)
+    static constexpr Crypto::Hash::MD5::DigestType apple_p3_2017_id = { 0xca, 0x1a, 0x95, 0x82, 0x25, 0x7f, 0x10, 0x4d, 0x38, 0x99, 0x13, 0xd5, 0xd1, 0xea, 0x15, 0x82 };
+
     auto has_type = [&](auto tag, std::initializer_list<TagTypeSignature> types, std::initializer_list<TagTypeSignature> v4_types) {
         if (auto type = m_tag_table.get(tag); type.has_value()) {
             auto type_matches = [&](auto wanted_type) { return type.value()->type() == wanted_type; };
@@ -914,7 +918,7 @@ ErrorOr<void> Profile::check_tag_types()
         // The v4 spec requires multiLocalizedUnicodeType for this, but I'm aware of a single file
         // that still uses the v2 'text' type here: /System/Library/ColorSync/Profiles/ITU-2020.icc on macOS 13.1.
         // https://openradar.appspot.com/radar?id=5529765549178880
-        bool has_v2_cprt_type_in_v4_file_quirk = id() == apple_itu_2020_id || id() == apple_p3_2015_id;
+        bool has_v2_cprt_type_in_v4_file_quirk = id() == apple_itu_2020_id || id() == apple_p3_2015_id || id() == apple_p3_2017_id;
         if (is_v4() && type.value()->type() != MultiLocalizedUnicodeTagData::Type && (!has_v2_cprt_type_in_v4_file_quirk || type.value()->type() != TextTagData::Type))
             return Error::from_string_literal("ICC::Profile: copyrightTag has unexpected v4 type");
         if (is_v2() && type.value()->type() != TextTagData::Type)
@@ -1103,7 +1107,7 @@ ErrorOr<void> Profile::check_tag_types()
         // The v4 spec requires multiLocalizedUnicodeType for this, but I'm aware of a single file
         // that still uses the v2 'desc' type here: /System/Library/ColorSync/Profiles/ITU-2020.icc on macOS 13.1.
         // https://openradar.appspot.com/radar?id=5529765549178880
-        bool has_v2_desc_type_in_v4_file_quirk = id() == apple_itu_2020_id || id() == apple_p3_2015_id;
+        bool has_v2_desc_type_in_v4_file_quirk = id() == apple_itu_2020_id || id() == apple_p3_2015_id || id() == apple_p3_2017_id;
         if (is_v4() && type.value()->type() != MultiLocalizedUnicodeTagData::Type && (!has_v2_desc_type_in_v4_file_quirk || type.value()->type() != TextDescriptionTagData::Type))
             return Error::from_string_literal("ICC::Profile: profileDescriptionTag has unexpected v4 type");
         if (is_v2() && type.value()->type() != TextDescriptionTagData::Type)

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -130,6 +130,22 @@ private:
     u64 m_bits = 0;
 };
 
+// Time is in UTC.
+// Per spec, month is 1-12, day is 1-31, hours is 0-23, minutes 0-59, seconds 0-59 (i.e. no leap seconds).
+// But in practice, some profiles have invalid dates, like 0-0-0 0:0:0.
+// For valid profiles, the conversion to time_t will succeed.
+struct DateTime {
+    u16 year = 1970;
+    u16 month = 1; // One-based.
+    u16 day = 1;   // One-based.
+    u16 hours = 0;
+    u16 minutes = 0;
+    u16 seconds = 0;
+
+    ErrorOr<time_t> to_time_t() const;
+    static ErrorOr<DateTime> from_time_t(time_t);
+};
+
 struct ProfileHeader {
     u32 on_disk_size { 0 };
     Optional<PreferredCMMType> preferred_cmm_type;
@@ -137,7 +153,7 @@ struct ProfileHeader {
     DeviceClass device_class {};
     ColorSpace data_color_space {};
     ColorSpace connection_space {};
-    time_t creation_timestamp { 0 };
+    DateTime creation_timestamp;
     Optional<PrimaryPlatform> primary_platform {};
     Flags flags;
     Optional<DeviceManufacturer> device_manufacturer;
@@ -219,7 +235,7 @@ public:
     ColorSpace connection_space() const { return m_header.connection_space; }
 
     u32 on_disk_size() const { return m_header.on_disk_size; }
-    time_t creation_timestamp() const { return m_header.creation_timestamp; }
+    DateTime creation_timestamp() const { return m_header.creation_timestamp; }
     Optional<PrimaryPlatform> primary_platform() const { return m_header.primary_platform; }
     Flags flags() const { return m_header.flags; }
     Optional<DeviceManufacturer> device_manufacturer() const { return m_header.device_manufacturer; }

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -18,7 +18,7 @@ static ProfileHeader rgb_header()
     header.device_class = DeviceClass::DisplayDevice;
     header.data_color_space = ColorSpace::RGB;
     header.connection_space = ColorSpace::PCSXYZ;
-    header.creation_timestamp = time(NULL);
+    header.creation_timestamp = MUST(DateTime::from_time_t(0));
     header.rendering_intent = RenderingIntent::Perceptual;
     header.pcs_illuminant = XYZ { 0.9642, 1.0, 0.8249 };
     return header;

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -506,7 +506,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* docum
         return Error { Error::Type::Internal, "Alternate color spaces in array format are not supported" };
     }
 
-    return Error { Error::Type::MalformedPDF, "Failed to load ICC color space with malformed profile and no alternate" };
+    return maybe_profile.release_error();
 }
 
 ICCBasedColorSpace::ICCBasedColorSpace(NonnullRefPtr<Gfx::ICC::Profile> profile)

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -324,7 +324,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("          device class: {}", Gfx::ICC::device_class_name(profile->device_class()));
     outln("      data color space: {}", Gfx::ICC::data_color_space_name(profile->data_color_space()));
     outln("      connection space: {}", Gfx::ICC::profile_connection_space_name(profile->connection_space()));
-    outln("creation date and time: {}", Core::DateTime::from_timestamp(profile->creation_timestamp()));
+
+    if (auto time = profile->creation_timestamp().to_time_t(); !time.is_error()) {
+        // Print in friendly localtime for valid profiles.
+        outln("creation date and time: {}", Core::DateTime::from_timestamp(time.release_value()));
+    } else {
+        outln("creation date and time: {:04}-{:02}-{:02} {:02}:{:02}:{:02} UTC (invalid)",
+            profile->creation_timestamp().year, profile->creation_timestamp().month, profile->creation_timestamp().day,
+            profile->creation_timestamp().hours, profile->creation_timestamp().minutes, profile->creation_timestamp().seconds);
+    }
+
     out_optional("      primary platform", profile->primary_platform().map([](auto platform) { return primary_platform_name(platform); }));
 
     auto flags = profile->flags();


### PR DESCRIPTION
Before, we used to reject profiles where the creation datetime was
invalid per spec. But invalid dates happen in practice (most commonly,
all fields set to 0). They don't affect profile conversion at all,
so be lenient about this, in exchange for slightly more wordy code
in the places that want to show the creation datetime.

Fixes a crash rendering page 2 of
https://fredrikbk.com/publications/copy-and-patch.pdf

---

…and two more minor ICC-related tweaks.