### PR TITLE
LibWeb: Fix infinite recursion when grid has "max-width: max-content"

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/container-max-width-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/container-max-width-max-content.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      Box <div.grid> at (8,8) content-size 100x100 [GFC] children: not-inline
+        BlockContainer <div.item> at (8,8) content-size 100x100 [BFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.grid) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/input/grid/container-max-width-max-content.html
+++ b/Tests/LibWeb/Layout/input/grid/container-max-width-max-content.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+    .grid {
+        display: grid;
+        max-width: max-content;
+    }
+
+    .item {
+        background-color: magenta;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div class="grid"><div class="item"></div></div>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1857,6 +1857,8 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
     auto const& max_width = box.computed_values().max_width();
     if (max_width.is_none())
         return true;
+    if (available_width.is_max_content() && max_width.is_max_content())
+        return true;
     if (box.is_absolutely_positioned())
         return false;
     if (max_width.contains_percentage()) {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1197,16 +1197,19 @@ void GridFormattingContext::maximize_tracks(GridDimension const dimension)
             return should_treat_max_width_as_none(grid_container(), available_size);
         return !computed_values.max_height().is_auto();
     }();
-    auto maximum_size = calculate_grid_container_maximum_size(dimension);
-    if (!should_treat_grid_container_maximum_size_as_none && grid_container_inner_size > maximum_size) {
-        for (size_t i = 0; i < tracks.size(); i++)
-            tracks[i].base_size = saved_base_sizes[i];
-        auto available_space_with_max_width = *m_available_space;
-        if (dimension == GridDimension::Column)
-            available_space_with_max_width.width = AvailableSize::make_definite(maximum_size);
-        else
-            available_space_with_max_width.height = AvailableSize::make_definite(maximum_size);
-        maximize_tracks_using_available_size(available_space_with_max_width, dimension);
+
+    if (!should_treat_grid_container_maximum_size_as_none) {
+        auto maximum_size = calculate_grid_container_maximum_size(dimension);
+        if (grid_container_inner_size > maximum_size) {
+            for (size_t i = 0; i < tracks.size(); i++)
+                tracks[i].base_size = saved_base_sizes[i];
+            auto available_space_with_max_width = *m_available_space;
+            if (dimension == GridDimension::Column)
+                available_space_with_max_width.width = AvailableSize::make_definite(maximum_size);
+            else
+                available_space_with_max_width.height = AvailableSize::make_definite(maximum_size);
+            maximize_tracks_using_available_size(available_space_with_max_width, dimension);
+        }
     }
 }
 


### PR DESCRIPTION
With this change "max-width: max-content" is treated as "none" when the available width is also "max-content". This fix prevents a stack overflow in the grid track size maximization algorithm by avoiding recursive calls to calculate_max_width() when determining the maximum grid container size.