### PR TITLE
LibWeb: Allow bypassing transient activation checks for tests

### DIFF
--- a/Tests/LibWeb/Text/input/clipboard.html
+++ b/Tests/LibWeb/Text/input/clipboard.html
@@ -16,10 +16,7 @@
 
     asyncTest((done) => {
         writeText(() => {
-            const button = document.getElementById("button");
-            internals.dispatchUserActivatedEvent(button, new Event("mousedown"));
-            button.dispatchEvent(new Event("click"));
-
+            internals.bypassNextTransientActivationTest = true;
             writeText(done);
         });
     });

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -282,6 +282,8 @@ private:
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status
     // When the Window object is created, the attribute must be set to the empty string. It does not do anything else.
     String m_status;
+
+    JS::GCPtr<Internals::Internals> m_internals;
 };
 
 void run_animation_frame_callbacks(DOM::Document&, double now);

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -89,10 +89,4 @@ void Internals::wheel(double x, double y, double delta_x, double delta_y)
     page.handle_mousewheel({ x, y }, { x, y }, 0, 0, 0, delta_x, delta_y);
 }
 
-WebIDL::ExceptionOr<bool> Internals::dispatch_user_activated_event(DOM::EventTarget& target, DOM::Event& event)
-{
-    event.set_is_trusted(true);
-    return target.dispatch_event(event);
-}
-
 }

--- a/Userland/Libraries/LibWeb/Internals/Internals.h
+++ b/Userland/Libraries/LibWeb/Internals/Internals.h
@@ -28,11 +28,14 @@ public:
     void click(double x, double y);
     void wheel(double x, double y, double delta_x, double delta_y);
 
-    WebIDL::ExceptionOr<bool> dispatch_user_activated_event(DOM::EventTarget&, DOM::Event& event);
+    bool bypass_next_transient_activation_test() const { return m_bypass_next_transient_activation_test; }
+    void set_bypass_next_transient_activation_test(bool bypass_next_transient_activation_test) { m_bypass_next_transient_activation_test = bypass_next_transient_activation_test; }
 
 private:
     explicit Internals(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
+
+    bool m_bypass_next_transient_activation_test { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Internals/Internals.idl
+++ b/Userland/Libraries/LibWeb/Internals/Internals.idl
@@ -13,6 +13,6 @@
     undefined click(double x, double y);
     undefined wheel(double x, double y, double deltaX, double deltaY);
 
-    boolean dispatchUserActivatedEvent(EventTarget target, Event event);
+    attribute boolean bypassNextTransientActivationTest;
 
 };


### PR DESCRIPTION
We have a 5 second timeout between a user-activated event occurring and an activation-gated API being invoked in order for that API to succeed. This is quite fine in normal circumstances, but the machines used in CI often exceed that limit (we see upwards of 10 seconds passing between generating the user-activated event and the API call running).

So instead of generating a user-activated event, add a hook to allow tests to bypass the very next activation check.