### PR TITLE
Ladybird/QT: Avoid round-tripping through QUrl to make Unicode URLs work again

### DIFF
--- a/Ladybird/Qt/StringUtils.cpp
+++ b/Ladybird/Qt/StringUtils.cpp
@@ -8,7 +8,8 @@
 
 AK::ByteString ak_byte_string_from_qstring(QString const& qstring)
 {
-    return AK::ByteString(qstring.toUtf8().data());
+    auto utf8_data = qstring.toUtf8();
+    return AK::ByteString(utf8_data.data(), utf8_data.size());
 }
 
 String ak_string_from_qstring(QString const& qstring)
@@ -24,10 +25,11 @@ QString qstring_from_ak_string(StringView ak_string)
 
 AK::URL ak_url_from_qstring(QString const& qstring)
 {
-    return AK::URL(qstring.toUtf8().data());
+    auto utf8_data = qstring.toUtf8();
+    return AK::URL(StringView(utf8_data.data(), utf8_data.size()));
 }
 
 AK::URL ak_url_from_qurl(QUrl const& qurl)
 {
-    return AK::URL(qurl.toString().toUtf8().data());
+    return ak_url_from_qstring(qurl.toString());
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -715,7 +715,7 @@ void Tab::copy_link_url(URL const& url)
 
 void Tab::location_edit_return_pressed()
 {
-    navigate(ak_url_from_qurl(m_location_edit->text()));
+    navigate(ak_url_from_qstring(m_location_edit->text()));
 }
 
 void Tab::open_file()


### PR DESCRIPTION
This regressed in c75bd4ed.

QUrl does some unwanted ASCII->Unicode conversion, so let's take the QString which is already in the format we want.

This PR also contains a fix for some potential undefined behavior when the byte array provided by Qt is not followed by a null terminator.