### PR TITLE
LibWeb: Don't mark heights as definite in set_content_height()

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x39 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21 children: not-inline
       Box <div.flexrow> at (11,11) content-size 778x19 flex-container(row) [FFC] children: not-inline
-        Box <div.project> at (12,12) content-size 44.03125x19 flex-container(column) flex-item [FFC] children: not-inline
+        Box <div.project> at (12,12) content-size 44.03125x17 flex-container(column) flex-item [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,12) content-size 44.03125x17 flex-item [BFC] children: inline
             frag 0 from TextNode start: 0, length: 6, rect: [12,12 44.03125x17] baseline: 13.296875
                 "pillow"
@@ -10,8 +10,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41]
-    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23] overflow: [10,10 780x22]
-      PaintableBox (Box<DIV>.flexrow) [10,10 780x21] overflow: [11,11 778x21]
-        PaintableBox (Box<DIV>.project) [11,11 46.03125x21]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23]
+      PaintableBox (Box<DIV>.flexrow) [10,10 780x21]
+        PaintableBox (Box<DIV>.project) [11,11 46.03125x19]
           PaintableWithLines (BlockContainer(anonymous)) [12,12 44.03125x17]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x69.984375 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x51.984375 flex-container(row) [FFC] children: not-inline
-      ImageBox <img> at (11,11) content-size 64x49.984375 flex-item children: not-inline
+      ImageBox <img> at (11,11) content-size 66.65625x49.984375 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.984375]
     PaintableBox (Box<BODY>) [9,9 782x53.984375]
-      ImagePaintable (ImageBox<IMG>) [10,10 66x51.984375]
+      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x51.984375]

--- a/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-reference-value.txt
+++ b/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-reference-value.txt
@@ -1,0 +1,37 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x153 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x137 children: not-inline
+      Box <div.outer> at (8,8) content-size 784x137 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.item> at (8,8) content-size 784x120 flex-item [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+            TextNode <#text>
+          BlockContainer <div.spacer> at (8,8) content-size 120x120 children: not-inline
+          BlockContainer <(anonymous)> at (8,128) content-size 784x0 children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div> at (8,128) content-size 784x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 1, length: 14, rect: [8,128 112.421875x17] baseline: 13.296875
+              "text text text"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,145) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (8,145) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x153]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x137]
+      PaintableBox (Box<DIV>.outer) [8,8 784x137]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 784x120]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+          PaintableWithLines (BlockContainer<DIV>.spacer) [8,8 120x120]
+          PaintableWithLines (BlockContainer(anonymous)) [8,128 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,128 784x17]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,145 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,145 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/percentage-flex-item-height-with-indefinite-containing-block-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/percentage-flex-item-height-with-indefinite-containing-block-height.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x136 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x120 children: not-inline
+      Box <div.flexContainer> at (8,8) content-size 784x120 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div.item> at (8,8) content-size 784x120 flex-item [BFC] children: not-inline
+          BlockContainer <div.green> at (8,8) content-size 120x120 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
+      PaintableBox (Box<DIV>.flexContainer) [8,8 784x120]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 784x120]
+          PaintableWithLines (BlockContainer<DIV>.green) [8,8 120x120]

--- a/Tests/LibWeb/Layout/input/flex/percentage-flex-basis-with-indefinite-reference-value.html
+++ b/Tests/LibWeb/Layout/input/flex/percentage-flex-basis-with-indefinite-reference-value.html
@@ -1,0 +1,30 @@
+<!doctype html><style type="text/css">
+    * {
+        outline: 1px solid black;
+    }
+    .outer {
+        display: flex;
+        flex-direction: column;
+        background: pink;
+    }
+    .item {
+        flex-shrink: 0;
+        flex-grow: 0;
+        flex-basis: 100%;
+        background: orange;
+    }
+    .spacer {
+        width: 120px;
+        height: 120px;
+        background: wheat;
+    }
+</style>
+<div class="outer">
+    <div class="item">
+        <div class="spacer"></div>
+    </div>
+    <div>
+        text text text
+    </div>
+</div>
+<div>

--- a/Tests/LibWeb/Layout/input/flex/percentage-flex-item-height-with-indefinite-containing-block-height.html
+++ b/Tests/LibWeb/Layout/input/flex/percentage-flex-item-height-with-indefinite-containing-block-height.html
@@ -1,0 +1,20 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black;
+    }
+    .flexContainer {
+        display: flex;
+        flex-direction: column;
+        background: pink;
+    }
+    .item {
+        flex-shrink: 0;
+        height: 50%;
+        background: orange;
+    }
+    .green {
+        width: 120px;
+        height: 120px;
+        background: green;
+    }
+</style><div class="flexContainer"><div class="item"><div class="green">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -455,6 +455,7 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
 void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const& available_space)
 {
     auto const& computed_values = box.computed_values();
+    auto& box_used_values = m_state.get_mutable(box);
 
     // Then work out what the height is, based on box type and CSS properties.
     CSSPixels height = 0;
@@ -499,9 +500,12 @@ void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const
         // 3. Return the bigger value of size and the normal border box size the element would have
         //    according to the CSS specification.
         height = max(size, height);
+
+        // NOTE: The height of the root element when affected by this quirk is considered to be definite.
+        box_used_values.set_has_definite_height(true);
     }
 
-    m_state.get_mutable(box).set_content_height(height);
+    box_used_values.set_content_height(height);
 }
 
 void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, LayoutMode layout_mode, AvailableSpace const& available_space)

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -549,9 +549,8 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
                 used_width_px = min_width_px;
         }
         block_container_state.set_content_width(used_width_px);
-    }
-    if (!block_container_state.has_definite_height())
         block_container_state.set_content_height(context.automatic_content_height());
+    }
 }
 
 CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Box const& box, AvailableSpace const& available_space)
@@ -774,9 +773,8 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
                 }
             }
             block_container_state.set_content_width(width);
-        }
-        if (!block_container_state.has_definite_height())
             block_container_state.set_content_height(bottom_of_lowest_margin_box);
+        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -159,6 +159,9 @@ private:
     void set_main_axis_first_margin(FlexItem&, CSSPixels margin);
     void set_main_axis_second_margin(FlexItem&, CSSPixels margin);
 
+    void set_has_definite_main_size(FlexItem&);
+    void set_has_definite_cross_size(FlexItem&);
+
     void copy_dimensions_from_flex_items_to_boxes();
 
     void generate_anonymous_flex_items();

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -509,7 +509,6 @@ void LayoutState::UsedValues::set_content_height(CSSPixels height)
         height = 0;
     }
     m_content_height = height;
-    m_has_definite_height = true;
 }
 
 void LayoutState::UsedValues::set_temporary_content_width(CSSPixels width)

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -495,6 +495,8 @@ void LayoutState::UsedValues::set_content_width(CSSPixels width)
         width = 0;
     }
     m_content_width = width;
+    // FIXME: We should not do this! Definiteness of widths should be determined early,
+    //        and not changed later (except for some special cases in flex layout..)
     m_has_definite_width = true;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -55,6 +55,9 @@ struct LayoutState {
         void set_indefinite_content_width();
         void set_indefinite_content_height();
 
+        void set_has_definite_width(bool has_definite_width) { m_has_definite_width = has_definite_width; }
+        void set_has_definite_height(bool has_definite_height) { m_has_definite_height = has_definite_height; }
+
         // NOTE: These are used by FlexFormattingContext to assign a temporary main size to items
         //       early on, so that descendants have something to resolve percentages against.
         void set_temporary_content_width(CSSPixels);


### PR DESCRIPTION
Height definiteness is now preserved as intended by CSS-SIZING-3
(assuming I've understood it correctly) and not implicitly granted by
layout algorithms when they assign height.
    
For the specific special/magical cases where some sizes become definite
during layout, the preceding commits have made them explicit in code.
    
This fixes a number of flex layout issues where we were previously
resolving percentage values against post-layout flex container heights,
but other browsers don't.

Note that `set_content_width()` still behaves the wrong way, and fixing it will be quite a task. :sweat_smile:  
