### PR TITLE
Everywhere: Prefer {:#x} over 0x{:x} in format strings

### DIFF
--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -28,7 +28,7 @@ static void dump_exception_syndrome_register(Aarch64::ESR_EL1 const& esr_el1)
     if (Aarch64::exception_class_is_data_abort(esr_el1.EC))
         dbgln("    Data Fault Status Code: {}", Aarch64::data_fault_status_code_to_string(esr_el1.ISS));
     if (Aarch64::exception_class_has_set_far(esr_el1.EC))
-        dbgln("    Faulting Virtual Address: 0x{:x}", Aarch64::FAR_EL1::read().virtual_address);
+        dbgln("    Faulting Virtual Address: {:#x}", Aarch64::FAR_EL1::read().virtual_address);
 }
 
 void dump_registers(RegisterState const& regs)
@@ -40,9 +40,9 @@ void dump_registers(RegisterState const& regs)
     Aarch64::SPSR_EL1 spsr_el1 = {};
     memcpy(&spsr_el1, (u8 const*)&regs.spsr_el1, sizeof(u64));
 
-    dbgln("Saved Program Status: (NZCV({:#b}) DAIF({:#b}) M({:#b})) / 0x{:x}", ((regs.spsr_el1 >> 28) & 0b1111), ((regs.spsr_el1 >> 6) & 0b1111), regs.spsr_el1 & 0b1111, regs.spsr_el1);
-    dbgln("Exception Link Register: 0x{:x}", regs.elr_el1);
-    dbgln("Stack Pointer (EL0): 0x{:x}", regs.sp_el0);
+    dbgln("Saved Program Status: (NZCV({:#b}) DAIF({:#b}) M({:#b})) / {:#x}", ((regs.spsr_el1 >> 28) & 0b1111), ((regs.spsr_el1 >> 6) & 0b1111), regs.spsr_el1 & 0b1111, regs.spsr_el1);
+    dbgln("Exception Link Register: {:#x}", regs.elr_el1);
+    dbgln("Stack Pointer (EL0): {:#x}", regs.sp_el0);
 
     dbgln(" x0={:p}  x1={:p}  x2={:p}  x3={:p}  x4={:p}", regs.x[0], regs.x[1], regs.x[2], regs.x[3], regs.x[4]);
     dbgln(" x5={:p}  x6={:p}  x7={:p}  x8={:p}  x9={:p}", regs.x[5], regs.x[6], regs.x[7], regs.x[8], regs.x[9]);

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -686,7 +686,7 @@ void UHCIController::get_port_status(Badge<UHCIRootHub>, u8 port, HubStatus& hub
     // UHCI ports are always powered.
     hub_port_status.status |= PORT_STATUS_PORT_POWER;
 
-    dbgln_if(UHCI_DEBUG, "UHCI: get_port_status status=0x{:04x} change=0x{:04x}", hub_port_status.status, hub_port_status.change);
+    dbgln_if(UHCI_DEBUG, "UHCI: get_port_status status={:#04x} change={:#04x}", hub_port_status.status, hub_port_status.change);
 }
 
 void UHCIController::reset_port(u8 port)
@@ -808,7 +808,7 @@ ErrorOr<void> UHCIController::clear_port_feature(Badge<UHCIRootHub>, u8 port, Hu
         return EINVAL;
     }
 
-    dbgln_if(UHCI_DEBUG, "UHCI: clear_port_feature: writing 0x{:04x} to portsc{}.", port_data, port + 1);
+    dbgln_if(UHCI_DEBUG, "UHCI: clear_port_feature: writing {:#04x} to portsc{}.", port_data, port + 1);
 
     if (port == 0)
         write_portsc1(port_data);

--- a/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
@@ -114,11 +114,11 @@ ErrorOr<size_t> UHCIRootHub::handle_control_transfer(Transfer& transfer)
 
     if constexpr (UHCI_DEBUG) {
         dbgln("UHCIRootHub: Received control transfer.");
-        dbgln("UHCIRootHub: Request Type: 0x{:02x}", request.request_type);
-        dbgln("UHCIRootHub: Request: 0x{:02x}", request.request);
-        dbgln("UHCIRootHub: Value: 0x{:04x}", request.value);
-        dbgln("UHCIRootHub: Index: 0x{:04x}", request.index);
-        dbgln("UHCIRootHub: Length: 0x{:04x}", request.length);
+        dbgln("UHCIRootHub: Request Type: {:#02x}", request.request_type);
+        dbgln("UHCIRootHub: Request: {:#02x}", request.request);
+        dbgln("UHCIRootHub: Value: {:#04x}", request.value);
+        dbgln("UHCIRootHub: Index: {:#04x}", request.index);
+        dbgln("UHCIRootHub: Length: {:#04x}", request.length);
     }
 
     size_t length = 0;

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -72,7 +72,7 @@ ErrorOr<void> Hub::enumerate_and_power_on_hub()
     if constexpr (USB_DEBUG) {
         dbgln("USB Hub Descriptor for {:04x}:{:04x}", m_vendor_id, m_product_id);
         dbgln("Number of Downstream Ports: {}", descriptor.number_of_downstream_ports);
-        dbgln("Hub Characteristics: 0x{:04x}", static_cast<u16>(descriptor.hub_characteristics));
+        dbgln("Hub Characteristics: {:#04x}", static_cast<u16>(descriptor.hub_characteristics));
         dbgln("Power On to Power Good Time: {} ms ({} * 2ms)", descriptor.power_on_to_power_good_time * 2, descriptor.power_on_to_power_good_time);
         dbgln("Hub Controller Current: {} mA", descriptor.hub_controller_current);
     }

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -63,7 +63,7 @@ UNMAP_AFTER_INIT void USBManagement::enumerate_controllers()
             dmesgln("USBManagement: Direct attached device at {} is not currently supported.", device_identifier.address());
             return;
         }
-        dmesgln("USBManagement: Unknown/unsupported controller at {} with programming interface 0x{:02x}", device_identifier.address(), device_identifier.prog_if().value());
+        dmesgln("USBManagement: Unknown/unsupported controller at {} with programming interface {:#02x}", device_identifier.address(), device_identifier.prog_if().value());
     }));
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -919,7 +919,7 @@ static constexpr Array<SpecialCasing, @special_casing_size@> s_special_case { {)
         generator.append(R"~~~(
     { @code_point@)~~~");
 
-        constexpr auto format = "0x{:x}"sv;
+        constexpr auto format = "{:#x}"sv;
         append_list_and_size(casing.lowercase_mapping, format);
         append_list_and_size(casing.uppercase_mapping, format);
         append_list_and_size(casing.titlecase_mapping, format);
@@ -944,7 +944,7 @@ static constexpr Array<CaseFolding, @case_folding_size@> s_case_folding { {)~~~"
         generator.append(R"~~~(
     { @code_point@, CaseFoldingStatus::@status@)~~~");
 
-        append_list_and_size(folding.mapping, "0x{:x}"sv);
+        append_list_and_size(folding.mapping, "{:#x}"sv);
         generator.append(" },");
     }
 

--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
@@ -69,7 +69,7 @@ ErrorOr<void> AddressRangesV5::for_each_range(Function<void(Range)> callback)
         case RangeListEntryType::EndOfList:
             return {};
         default:
-            dbgln("unsupported range list entry type: 0x{:x}", entry_type);
+            dbgln("unsupported range list entry type: {:#x}", entry_type);
             return Error::from_string_literal("Unsupported range list entry type");
         }
     }

--- a/Userland/Libraries/LibDeviceTree/Validation.cpp
+++ b/Userland/Libraries/LibDeviceTree/Validation.cpp
@@ -17,19 +17,19 @@ bool validate_flattened_device_tree(FlattenedDeviceTreeHeader const& header, Rea
 {
     if (header.magic != 0xD00DFEEDU) {
         if (verbose == Verbose::Yes)
-            warnln("FDT Header has invalid magic value 0x{:08x}. Are you sure it's a flattened device tree?", header.magic);
+            warnln("FDT Header has invalid magic value {:#08x}. Are you sure it's a flattened device tree?", header.magic);
         return false;
     }
 
     if ((header.off_mem_rsvmap & ~0x7) != header.off_mem_rsvmap) {
         if (verbose == Verbose::Yes)
-            warnln("FDT Header's MemoryReservationBlock is not 8 byte aligned! Offset: 0x{:08x}", header.off_mem_rsvmap);
+            warnln("FDT Header's MemoryReservationBlock is not 8 byte aligned! Offset: {:#08x}", header.off_mem_rsvmap);
         return false;
     }
 
     if ((header.off_dt_struct & ~0x3) != header.off_dt_struct) {
         if (verbose == Verbose::Yes)
-            warnln("FDT Header's StructureBlock is not 4 byte aligned! Offset: 0x{:08x}", header.off_dt_struct);
+            warnln("FDT Header's StructureBlock is not 4 byte aligned! Offset: {:#08x}", header.off_dt_struct);
         return false;
     }
 
@@ -116,16 +116,16 @@ bool validate_flattened_device_tree(FlattenedDeviceTreeHeader const& header, Rea
 ErrorOr<void> dump(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree)
 {
     outln("/dts-v1/;");
-    outln("// magic:               0x{:08x}", header.magic);
-    outln("// totalsize:           0x{:08x} ({})", header.totalsize, header.totalsize);
-    outln("// off_dt_struct:       0x{:08x}", header.off_dt_struct);
-    outln("// off_dt_strings:      0x{:08x}", header.off_dt_strings);
-    outln("// off_mem_rsvmap:      0x{:08x}", header.off_mem_rsvmap);
-    outln("// version:             0x{:08x}", header.version);
-    outln("// last_comp_version:   0x{:08x}", header.last_comp_version);
-    outln("// boot_cpuid_phys:     0x{:08x}", header.boot_cpuid_phys);
-    outln("// size_dt_strings:     0x{:08x}", header.size_dt_strings);
-    outln("// size_dt_struct:      0x{:08x}", header.size_dt_struct);
+    outln("// magic:               {:#08x}", header.magic);
+    outln("// totalsize:           {:#08x} ({})", header.totalsize, header.totalsize);
+    outln("// off_dt_struct:       {:#08x}", header.off_dt_struct);
+    outln("// off_dt_strings:      {:#08x}", header.off_dt_strings);
+    outln("// off_mem_rsvmap:      {:#08x}", header.off_mem_rsvmap);
+    outln("// version:             {:#08x}", header.version);
+    outln("// last_comp_version:   {:#08x}", header.last_comp_version);
+    outln("// boot_cpuid_phys:     {:#08x}", header.boot_cpuid_phys);
+    outln("// size_dt_strings:     {:#08x}", header.size_dt_strings);
+    outln("// size_dt_struct:      {:#08x}", header.size_dt_struct);
 
     if (!validate_flattened_device_tree(header, raw_device_tree, Verbose::Yes))
         return Error::from_errno(EINVAL);
@@ -134,7 +134,7 @@ ErrorOr<void> dump(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_de
     auto const* mem_reserve_block = reinterpret_cast<FlattenedDeviceTreeReserveEntry const*>(&raw_device_tree[header.off_mem_rsvmap]);
     u64 next_block_offset = header.off_mem_rsvmap + sizeof(FlattenedDeviceTreeReserveEntry);
     while ((next_block_offset < header.off_dt_struct) && (*mem_reserve_block != FlattenedDeviceTreeReserveEntry {})) {
-        outln("/memreserve/ 0x{:08x} 0x{:08x};", mem_reserve_block->address, mem_reserve_block->size);
+        outln("/memreserve/ {:#08x} {:#08x};", mem_reserve_block->address, mem_reserve_block->size);
         ++mem_reserve_block;
         next_block_offset += sizeof(FlattenedDeviceTreeReserveEntry);
     }

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.cpp
@@ -42,7 +42,7 @@ ErrorOr<void> FullBox::read_from_stream(BoxStream& stream)
 
 void FullBox::dump(String const& prepend) const
 {
-    outln("{}{} (version = {}, flags = 0x{:x})", prepend, box_type(), version, flags);
+    outln("{}{} (version = {}, flags = {:#x})", prepend, box_type(), version, flags);
 }
 
 static String add_indent(String const& string)

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1171,7 +1171,7 @@ static ErrorOr<void> read_colour_encoding(JPEGStream& stream, [[maybe_unused]] J
         context.color_transform = ColorTransform::YCCK;
         break;
     default:
-        dbgln("0x{:x} is not a specified transform flag value, ignoring", color_transform);
+        dbgln("{:#x} is not a specified transform flag value, ignoring", color_transform);
     }
 
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -294,7 +294,7 @@ static ErrorOr<VP8XHeader> decode_webp_chunk_VP8X(RIFF::Chunk const& vp8x_chunk)
     // 3 bytes height minus one
     u32 height = (vp8x_chunk[7] | (vp8x_chunk[8] << 8) | (vp8x_chunk[9] << 16)) + 1;
 
-    dbgln_if(WEBP_DEBUG, "flags 0x{:x} --{}{}{}{}{}{}, width {}, height {}",
+    dbgln_if(WEBP_DEBUG, "flags {:#x} --{}{}{}{}{}{}, width {}, height {}",
         flags,
         has_icc ? " icc" : "",
         has_alpha ? " alpha" : "",

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -328,7 +328,7 @@ ErrorOr<void, ValidationError> Validator::validate(Limits const& limits, size_t 
 template<u64 opcode>
 ErrorOr<void, ValidationError> Validator::validate_instruction(Instruction const& instruction, Stack&, bool&)
 {
-    return Errors::invalid(ByteString::formatted("instruction opcode (0x{:x}) (missing validation!)", instruction.opcode().value()));
+    return Errors::invalid(ByteString::formatted("instruction opcode ({:#x}) (missing validation!)", instruction.opcode().value()));
 }
 
 #define VALIDATE_INSTRUCTION(name) \
@@ -3774,7 +3774,7 @@ ErrorOr<void, ValidationError> Validator::validate(Instruction const& instructio
 #undef M
     default:
         is_constant = false;
-        return Errors::invalid(ByteString::formatted("instruction opcode (0x{:x})", instruction.opcode().value()));
+        return Errors::invalid(ByteString::formatted("instruction opcode ({:#x})", instruction.opcode().value()));
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -544,7 +544,7 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
         // FIXME: This is a stopgap until we implement shorthand -> longhand conversion.
         auto value = style->maybe_null_property(property_id);
         if (!value) {
-            dbgln("FIXME: ResolvedCSSStyleDeclaration::property(property_id=0x{:x}) No value for property ID in newly computed style case.", to_underlying(property_id));
+            dbgln("FIXME: ResolvedCSSStyleDeclaration::property(property_id={:#x}) No value for property ID in newly computed style case.", to_underlying(property_id));
             return {};
         }
         return StyleProperty {

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -129,7 +129,7 @@ void WebGLRenderingContextBase::active_texture(GLenum texture)
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::active_texture(texture=0x{:08x})", texture);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::active_texture(texture={:#08x})", texture);
     m_context->gl_active_texture(texture);
 }
 
@@ -138,7 +138,7 @@ void WebGLRenderingContextBase::clear(GLbitfield mask)
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::clear(mask=0x{:08x})", mask);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::clear(mask={:#08x})", mask);
     m_context->gl_clear(mask);
 
     // FIXME: This should only be done if this is targeting the front buffer.
@@ -168,7 +168,7 @@ void WebGLRenderingContextBase::clear_stencil(GLint s)
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::clear_stencil(s=0x{:08x})", s);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::clear_stencil(s={:#08x})", s);
     m_context->gl_clear_stencil(s);
 }
 
@@ -186,7 +186,7 @@ void WebGLRenderingContextBase::cull_face(GLenum mode)
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::cull_face(mode=0x{:08x})", mode);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::cull_face(mode={:#08x})", mode);
     m_context->gl_cull_face(mode);
 }
 
@@ -195,7 +195,7 @@ void WebGLRenderingContextBase::depth_func(GLenum func)
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::depth_func(func=0x{:08x})", func);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::depth_func(func={:#08x})", func);
     m_context->gl_depth_func(func);
 }
 
@@ -244,7 +244,7 @@ void WebGLRenderingContextBase::front_face(GLenum mode)
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::front_face(mode=0x{:08x})", mode);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::front_face(mode={:#08x})", mode);
     m_context->gl_front_face(mode);
 }
 
@@ -300,7 +300,7 @@ void WebGLRenderingContextBase::stencil_op(GLenum fail, GLenum zfail, GLenum zpa
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::stencil_op(fail=0x{:08x}, zfail=0x{:08x}, zpass=0x{:08x})", fail, zfail, zpass);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::stencil_op(fail={:#08x}, zfail={:#08x}, zpass={:#08x})", fail, zfail, zpass);
     m_context->gl_stencil_op_separate(GL_FRONT_AND_BACK, fail, zfail, zpass);
 }
 
@@ -309,7 +309,7 @@ void WebGLRenderingContextBase::stencil_op_separate(GLenum face, GLenum fail, GL
     if (m_context_lost)
         return;
 
-    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::stencil_op_separate(face=0x{:08x}, fail=0x{:08x}, zfail=0x{:08x}, zpass=0x{:08x})", face, fail, zfail, zpass);
+    dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::stencil_op_separate(face={:#08x}, fail={:#08x}, zfail={:#08x}, zpass={:#08x})", face, fail, zfail, zpass);
     m_context->gl_stencil_op_separate(face, fail, zfail, zpass);
 }
 

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -328,13 +328,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     out_optional("      primary platform", profile->primary_platform().map([](auto platform) { return primary_platform_name(platform); }));
 
     auto flags = profile->flags();
-    outln("                 flags: 0x{:08x}", flags.bits());
+    outln("                 flags: {:#08x}", flags.bits());
     outln("                        - {}embedded in file", flags.is_embedded_in_file() ? "" : "not ");
     outln("                        - can{} be used independently of embedded color data", flags.can_be_used_independently_of_embedded_color_data() ? "" : "not");
     if (auto unknown_icc_bits = flags.icc_bits() & ~Gfx::ICC::Flags::KnownBitsMask)
-        outln("                        other unknown ICC bits: 0x{:04x}", unknown_icc_bits);
+        outln("                        other unknown ICC bits: {:#04x}", unknown_icc_bits);
     if (auto color_management_module_bits = flags.color_management_module_bits())
-        outln("                            CMM bits: 0x{:04x}", color_management_module_bits);
+        outln("                            CMM bits: {:#04x}", color_management_module_bits);
 
     out_optional("   device manufacturer", TRY(profile->device_manufacturer().map([](auto device_manufacturer) {
         return hyperlink(device_manufacturer_url(device_manufacturer), device_manufacturer);
@@ -344,7 +344,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
 
     auto device_attributes = profile->device_attributes();
-    outln("     device attributes: 0x{:016x}", device_attributes.bits());
+    outln("     device attributes: {:#016x}", device_attributes.bits());
     outln("                        media is:");
     outln("                        - {}",
         device_attributes.media_reflectivity() == Gfx::ICC::DeviceAttributes::MediaReflectivity::Reflective ? "reflective" : "transparent");
@@ -356,7 +356,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         device_attributes.media_color() == Gfx::ICC::DeviceAttributes::MediaColor::Colored ? "colored" : "black and white");
     VERIFY((flags.icc_bits() & ~Gfx::ICC::DeviceAttributes::KnownBitsMask) == 0);
     if (auto vendor_bits = device_attributes.vendor_bits())
-        outln("                        vendor bits: 0x{:08x}", vendor_bits);
+        outln("                        vendor bits: {:#08x}", vendor_bits);
 
     outln("      rendering intent: {}", Gfx::ICC::rendering_intent_name(profile->rendering_intent()));
     outln("        pcs illuminant: {}", profile->pcs_illuminant());
@@ -523,7 +523,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         } else if (tag_data->type() == Gfx::ICC::NamedColor2TagData::Type) {
             auto& named_colors = static_cast<Gfx::ICC::NamedColor2TagData&>(*tag_data);
-            outln("    vendor specific flag: 0x{:08x}", named_colors.vendor_specific_flag());
+            outln("    vendor specific flag: {:#08x}", named_colors.vendor_specific_flag());
             outln("    common name prefix: \"{}\"", named_colors.prefix());
             outln("    common name suffix: \"{}\"", named_colors.suffix());
             outln("    {} colors:", named_colors.size());
@@ -531,11 +531,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 const auto& pcs = named_colors.pcs_coordinates(i);
 
                 // FIXME: Display decoded values? (See ICC v4 6.3.4.2 and 10.8.)
-                out("        \"{}\", PCS coordinates: 0x{:04x} 0x{:04x} 0x{:04x}", TRY(named_colors.color_name(i)), pcs.xyz.x, pcs.xyz.y, pcs.xyz.z);
+                out("        \"{}\", PCS coordinates: {:#04x} {:#04x} {:#04x}", TRY(named_colors.color_name(i)), pcs.xyz.x, pcs.xyz.y, pcs.xyz.z);
                 if (auto number_of_device_coordinates = named_colors.number_of_device_coordinates(); number_of_device_coordinates > 0) {
                     out(", device coordinates:");
                     for (size_t j = 0; j < number_of_device_coordinates; ++j)
-                        out(" 0x{:04x}", named_colors.device_coordinates(i)[j]);
+                        out(" {:#04x}", named_colors.device_coordinates(i)[j]);
                 }
                 outln();
             }
@@ -568,7 +568,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (auto name = signature.name_for_tag(tag_signature); name.has_value()) {
                 outln("    signature: {}", name.value());
             } else {
-                outln("    signature: Unknown ('{:c}{:c}{:c}{:c}' / 0x{:08x})",
+                outln("    signature: Unknown ('{:c}{:c}{:c}{:c}' / {:#08x})",
                     signature.signature() >> 24, (signature.signature() >> 16) & 0xff, (signature.signature() >> 8) & 0xff, signature.signature() & 0xff,
                     signature.signature());
             }

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -96,11 +96,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (usb_db) {
                     StringView vendor_string = usb_db->get_vendor(vendor_id);
                     StringView device_string = usb_db->get_device(vendor_id, product_id);
-                    outln("  idVendor           0x{:04x} {}", device_descriptor.get_u32("vendor_id"sv).value_or(0), vendor_string);
-                    outln("  idProduct          0x{:04x} {}", device_descriptor.get_u32("product_id"sv).value_or(0), device_string);
+                    outln("  idVendor           {:#04x} {}", device_descriptor.get_u32("vendor_id"sv).value_or(0), vendor_string);
+                    outln("  idProduct          {:#04x} {}", device_descriptor.get_u32("product_id"sv).value_or(0), device_string);
                 } else {
-                    outln("  idVendor           0x{:04x}", device_descriptor.get_u32("vendor_id"sv).value_or(0));
-                    outln("  idProduct          0x{:04x}", device_descriptor.get_u32("product_id"sv).value_or(0));
+                    outln("  idVendor           {:#04x}", device_descriptor.get_u32("vendor_id"sv).value_or(0));
+                    outln("  idProduct          {:#04x}", device_descriptor.get_u32("product_id"sv).value_or(0));
                 }
                 outln("  bcdDevice          {}", device_descriptor.get_u32("device_release_bcd"sv).value_or(0));
                 outln("  iManufacturer      {}", device_descriptor.get_u32("manufacturer_id_descriptor_index"sv).value_or(0));
@@ -116,7 +116,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     outln("    bDescriptorType  {}", configuration_descriptor.get_u32("descriptor_type"sv).value_or(0));
                     outln("    wTotalLength     {}", configuration_descriptor.get_u32("total_length"sv).value_or(0));
                     outln("    bNumInterfaces   {}", configuration_descriptor.get_u32("number_of_interfaces"sv).value_or(0));
-                    outln("    bmAttributes     0x{:02x}", configuration_descriptor.get_u32("attributes_bitmap"sv).value_or(0));
+                    outln("    bmAttributes     {:#02x}", configuration_descriptor.get_u32("attributes_bitmap"sv).value_or(0));
                     outln("    MaxPower         {}mA", configuration_descriptor.get_u32("max_power"sv).value_or(0) * 2u);
 
                     auto const& interface_descriptors = config_value.as_object().get_array("interfaces"sv).value();
@@ -153,9 +153,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                             outln("      Endpoint Descriptor:");
                             outln("        bLength            {}", endpoint_descriptor.get_u32("length"sv).value_or(0));
                             outln("        bDescriptorType    {}", endpoint_descriptor.get_u32("descriptor_type"sv).value_or(0));
-                            outln("        bEndpointAddress   0x{:02x} EP {} {}", endpoint_address, (endpoint_address & 0xFu), ((endpoint_address & 0x80u) ? "IN" : "OUT"));
-                            outln("        bmAttributes       0x{:02x}", endpoint_descriptor.get_u32("attribute_bitmap"sv).value_or(0));
-                            outln("        wMaxPacketSize     0x{:04x}", endpoint_descriptor.get_u32("max_packet_size"sv).value_or(0));
+                            outln("        bEndpointAddress   {:#02x} EP {} {}", endpoint_address, (endpoint_address & 0xFu), ((endpoint_address & 0x80u) ? "IN" : "OUT"));
+                            outln("        bmAttributes       {:#02x}", endpoint_descriptor.get_u32("attribute_bitmap"sv).value_or(0));
+                            outln("        wMaxPacketSize     {:#04x}", endpoint_descriptor.get_u32("max_packet_size"sv).value_or(0));
                             outln("        bInterval          {}", endpoint_descriptor.get_u32("polling_interval"sv).value_or(0));
                         });
                     });

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -290,7 +290,7 @@ struct Formatter<BitflagDerivative> : StandardFormatter {
             // No more BitflagOptions are available. Any remaining flags are unrecognized.
             if (had_any_output)
                 TRY(format_builder.put_literal(" | "sv));
-            format_builder.builder().appendff("0x{:x} (?)", static_cast<unsigned>(remaining));
+            format_builder.builder().appendff("{:#x} (?)", static_cast<unsigned>(remaining));
             had_any_output = true;
         }
 

--- a/Userland/Utilities/xxd.cpp
+++ b/Userland/Utilities/xxd.cpp
@@ -132,9 +132,9 @@ static void print_line_c_style(Bytes line)
 {
     out("  ");
     for (size_t i = 0; i < line.size() - 1; ++i) {
-        out("0x{:02x}, ", line[i]);
+        out("{:#02x}, ", line[i]);
     }
-    out("0x{:02x}", line[line.size() - 1]);
+    out("{:#02x}", line[line.size() - 1]);
 }
 
 static ErrorOr<String> path_to_variable_name(StringView path)


### PR DESCRIPTION
The former automatically adapts the prefix to binary and octal output, and is what we already use in the majority of cases.

Patch generated by:

    rg -l '0x\{' | xargs sed -i '' -e 's/0x{:/{:#/'

I ran it 4 times (until it stopped changing things) since each invocation only converted one instance per line.

No behavior change.