### PR TITLE
LibGfx: Tweak semantics of some SkipTables enum values

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -35,10 +35,10 @@ struct FontOptions {
         // If set, do not try to read the 'name' table. family() and variant() will return empty strings.
         Name = 1 << 0,
 
-        // If set, do not try to read the 'hmtx' table. This will make glyph_metrics() return 0 for everyting and is_fixed_width() return true.
+        // If set, tolerate a missing or broken 'hmtx' table. This will make glyph_metrics() return 0 for everyting and is_fixed_width() return true.
         Hmtx = 1 << 1,
 
-        // If set, do not try to read the 'OS/2' table. metrics(), resolve_ascender_and_descender(), weight(), width(), and slope() will return different values.
+        // If set, tolerate a missing or broken 'OS/2' table. metrics(), resolve_ascender_and_descender(), weight(), width(), and slope() will return different values.
         OS2 = 1 << 2,
     };
     u32 skip_tables { 0 };


### PR DESCRIPTION
It turns out that hmtx and OS/2 table values _are_ used when rendering OpenType for PDFs: hmtx is used for the left-side bearing value (which is read in `Painter::draw_glyph()`), and OS/2 is used for the ascender, which Type0's CIDFontType2::draw_glyph() and TrueTypeFont::draw_glyph() read.

So instead of not trying to read these tables, instead try to read them but tolerate them failing to read and ignore them then.

Follow-up to #23276.

(I've seen weird glyph positioning from not reading the hmtx table. I haven't seen any problems caused by not reading the OS/2 table yet, but since the PDF code does use the ascender value, let's read that too.)