### PR TITLE
Ports: Add app category hotkey for Milkytracker

### DIFF
--- a/Ports/milkytracker/package.sh
+++ b/Ports/milkytracker/package.sh
@@ -9,7 +9,7 @@ files=(
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2" "zlib")
 launcher_name="MilkyTracker"
-launcher_category=Media
+launcher_category=&Media
 launcher_command=/usr/local/bin/milkytracker
 
 configure() {


### PR DESCRIPTION
This was added for native apps in 4c02133ba857c92531e20bf693dfc6482756cf98, which caused a duplication of categories in this port.