### PR TITLE
LibWeb: Transition StyleComputer to Web Animations

### DIFF
--- a/Base/res/html/misc/web-animations.html
+++ b/Base/res/html/misc/web-animations.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<head>
+    <style>
+        .ball-container {
+            position: absolute;
+            width: 200px;
+            height: 400px;
+        }
+        .box {
+            position: absolute;
+            left: 300px;
+            width: 200px;
+            height: 200px;
+            background-color: blue;
+            border-radius: 10px;
+        }
+        #box1 {
+            top: 50px;
+        }
+        #box2 {
+            top: 300px;
+        }
+
+        #box3 {
+            position: absolute;
+            left: 550px;
+            width: 200px;
+            height: 200px;
+            top: 50px;
+            overflow: hidden;
+        }
+        #box3-inner {
+            width: 200px;
+            height: 450px;
+            background-color: blue;
+            border-radius: 10px;
+        }
+    </style>
+</head>
+<body>
+<svg viewBox="0 0 100 200" class="ball-container">
+    <circle id="ball0" class="ball" cx="50" cy="50" r="50" fill="rgb(220, 105, 105)"></circle>
+    <circle id="ball1" class="ball" cx="50" cy="40" r="40" fill="rgb(200, 90, 90)"></circle>
+    <circle id="ball2" class="ball" cx="50" cy="30" r="30" fill="rgb(180, 75, 75)"></circle>
+    <circle id="ball3" class="ball" cx="50" cy="20" r="20" fill="rgb(160, 60, 60)"></circle>
+    <circle id="ball4" class="ball" cx="50" cy="10" r="10" fill="rgb(140, 45, 45)"></circle>
+    <rect x="0" y="197" width="100" height="3" fill="black"></rect>
+</svg>
+<div class="box" id="box1"></div>
+<div class="box" id="box2"></div>
+<div id="box3">
+    <div id="box3-inner"></div>
+</div>
+<script>
+    for (let i = 0; i < 5; i++) {
+        const ball = document.getElementById(`ball${i}`);
+        ball.animate([
+            { transform: "translateY(0px)" },
+            { transform: `translateY(${100 + 20 * i}px)` },
+            { transform: "translateY(0px)" },
+        ], {
+            duration: 1000,
+            iterations: Infinity,
+            easing: "ease-in-out"
+        });
+    }
+
+    box1.animate({ backgroundColor: ["red"] }, {
+        duration: 2000,
+        iterations: Infinity,
+        direction: "alternate"
+    });
+
+    box2.animate({ opacity: [0] }, {
+        duration: 2000,
+        iterations: Infinity,
+        direction: "alternate",
+    });
+
+    // Discrete property animation
+    box3.animate({ overflow: ['visible'] }, {
+        duration: 2000,
+        iterations: Infinity,
+        direction: "alternate",
+    })
+</script>
+</body>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -203,6 +203,7 @@
             <li><a href="trigonometry.html">canvas + trigonometry functions</a></li>
             <li><a href="canvas-global-alpha.html">canvas globalAlpha</a></li>
             <li><a href="canvas-path2d.html">Path2D</a></li>
+            <li><a href="web-animations.html">Web Animations</a></li>
             <li><a href="webgl-clear-color-and-multiple-contexts.html">WebGL Demo - Multiple Contexts and glClear(Color)</a></li>
             <li><h3>Wasm</h3></li>
             <li><a href="mandelbrot-wasm.html">WebAssembly Mandelbrot Rendering Demo</a></li>

--- a/Userland/Libraries/LibWeb/Animations/Animatable.h
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.h
@@ -33,9 +33,13 @@ public:
     void associate_with_effect(JS::NonnullGCPtr<AnimationEffect> effect);
     void disassociate_with_effect(JS::NonnullGCPtr<AnimationEffect> effect);
 
+    JS::GCPtr<CSS::CSSStyleDeclaration const> cached_animation_name_source() const { return m_cached_animation_name_source; }
+    void set_cached_animation_name_source(JS::GCPtr<CSS::CSSStyleDeclaration const> value) { m_cached_animation_name_source = value; }
+
 private:
     Vector<JS::NonnullGCPtr<AnimationEffect>> m_associated_effects;
     bool m_is_sorted_by_composite_order { true };
+    JS::GCPtr<CSS::CSSStyleDeclaration const> m_cached_animation_name_source;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -370,6 +370,9 @@ WebIDL::ExceptionOr<void> Animation::play()
 // https://www.w3.org/TR/web-animations-1/#play-an-animation
 WebIDL::ExceptionOr<void> Animation::play_an_animation(AutoRewind auto_rewind)
 {
+    if (auto document = document_for_timing())
+        document->ensure_animation_timer();
+
     // 1. Let aborted pause be a boolean flag that is true if animation has a pending pause task, and false otherwise.
     auto aborted_pause = m_pending_pause_task == TaskState::Scheduled;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -923,6 +923,9 @@ ErrorOr<void> StyleComputer::collect_animation_into(JS::NonnullGCPtr<Animations:
 
         auto resolved_end_property = resolve_property(end_property.value());
 
+        if (resolved_end_property && !resolved_start_property)
+            resolved_start_property = CSS::property_initial_value(document().realm(), it.key);
+
         if (!resolved_start_property || !resolved_end_property)
             continue;
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -478,6 +478,11 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
     for (auto& element : m_potentially_named_elements)
         visitor.visit(element);
+
+    for (auto& event : m_pending_animation_event_queue) {
+        visitor.visit(event.event);
+        visitor.visit(event.target);
+    }
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -561,6 +561,7 @@ public:
     void append_pending_animation_event(PendingAnimationEvent const&);
     void update_animations_and_send_events(Optional<double> const& timestamp);
     void remove_replaced_animations();
+    void ensure_animation_timer();
 
     bool ready_to_run_scripts() const { return m_ready_to_run_scripts; }
 
@@ -619,6 +620,8 @@ private:
     void queue_an_intersection_observer_entry(IntersectionObserver::IntersectionObserver&, HighResolutionTime::DOMHighResTimeStamp time, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> root_bounds, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> bounding_client_rect, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> intersection_rect, bool is_intersecting, double intersection_ratio, JS::NonnullGCPtr<Element> target);
 
     Element* find_a_potential_indicated_element(FlyString const& fragment) const;
+
+    void dispatch_events_for_animation_if_necessary(JS::NonnullGCPtr<Animations::Animation>);
 
     JS::NonnullGCPtr<Page> m_page;
     OwnPtr<CSS::StyleComputer> m_style_computer;
@@ -815,6 +818,7 @@ private:
 
     // https://www.w3.org/TR/web-animations-1/#pending-animation-event-queue
     Vector<PendingAnimationEvent> m_pending_animation_event_queue;
+    RefPtr<Platform::Timer> m_animation_driver_timer;
 
     bool m_needs_to_call_page_did_load { false };
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -195,7 +195,8 @@ void EventLoop::process()
         document.evaluate_media_queries_and_report_changes();
     });
 
-    // FIXME:     10. For each fully active Document in docs, update animations and send events for that Document, passing in now as the timestamp. [WEBANIMATIONS]
+    // 10. For each fully active Document in docs, update animations and send events for that Document, passing in now as the timestamp. [WEBANIMATIONS]
+    // Note: This is handled by the document's animation timer
 
     // FIXME:     11. For each fully active Document in docs, run the fullscreen steps for that Document, passing in now as the timestamp. [FULLSCREEN]
 


### PR DESCRIPTION
This PR will fully transition `StyleComputer` to use the new Web Animations framework, meaning that calls to `Element.animate` will now produce a visual result. I tried to break this down into as many commits as possible, but at the end of the day it's a large refactor that requires a large commit.

Now that we rely on Web Animations, the `StyleComputer` has far less work to do, since we no longer need things like the fill-forward state and a container for initial styles. Also note that all of the timing function stuff was copied out in 66bd75f2b978ecc870d1b75e3ad69106bc7c9a8e. 

This is a draft for now, since I want to add a little demo to `/res/html` (or tests, but I'm not sure how well that'll work), and I'd also like to see if I can find some more websites to try. I am not confident this won't lead to some crash regressions in websites that currently work, but I suppose the best way to find those is to just get this merged and fix issues as they pop up.

And, at long last: closes #21570

cc @alimpfard, since you wrote the original animation code.