### PR TITLE
Kernel/FileSystem: Enforce proper inode locking when truncating, avoid mutex double locking in ext2 driver

### DIFF
--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -1071,9 +1071,9 @@ ErrorOr<void> Ext2FSInode::chown(UserID uid, GroupID gid)
     return {};
 }
 
-ErrorOr<void> Ext2FSInode::truncate(u64 size)
+ErrorOr<void> Ext2FSInode::truncate_locked(u64 size)
 {
-    MutexLocker locker(m_inode_lock);
+    VERIFY(m_inode_lock.is_locked());
     if (static_cast<u64>(m_raw_inode.i_size) == size)
         return {};
     TRY(resize(size));

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -42,7 +42,7 @@ private:
     virtual ErrorOr<void> decrement_link_count() override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
-    virtual ErrorOr<void> truncate(u64) override;
+    virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<int> get_block_address(int) override;
 
     ErrorOr<void> write_directory(Vector<Ext2FSDirectoryEntry>&);

--- a/Kernel/FileSystem/ISO9660FS/Inode.cpp
+++ b/Kernel/FileSystem/ISO9660FS/Inode.cpp
@@ -140,7 +140,7 @@ ErrorOr<void> ISO9660Inode::chown(UserID, GroupID)
     return EROFS;
 }
 
-ErrorOr<void> ISO9660Inode::truncate(u64)
+ErrorOr<void> ISO9660Inode::truncate_locked(u64)
 {
     return EROFS;
 }

--- a/Kernel/FileSystem/ISO9660FS/Inode.h
+++ b/Kernel/FileSystem/ISO9660FS/Inode.h
@@ -31,7 +31,7 @@ public:
     virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
-    virtual ErrorOr<void> truncate(u64) override;
+    virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<void> update_timestamps(Optional<UnixDateTime> atime, Optional<UnixDateTime> ctime, Optional<UnixDateTime> mtime) override;
 
 private:

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -97,6 +97,12 @@ ErrorOr<void> Inode::truncate(u64 size)
 ErrorOr<size_t> Inode::write_bytes(off_t offset, size_t length, UserOrKernelBuffer const& target_buffer, OpenFileDescription* open_description)
 {
     MutexLocker locker(m_inode_lock);
+    return prepare_and_write_bytes_locked(offset, length, target_buffer, open_description);
+}
+
+ErrorOr<size_t> Inode::prepare_and_write_bytes_locked(off_t offset, size_t length, UserOrKernelBuffer const& target_buffer, OpenFileDescription* open_description)
+{
+    VERIFY(m_inode_lock.is_locked());
     TRY(prepare_to_write_data());
     return write_bytes_locked(offset, length, target_buffer, open_description);
 }

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -88,6 +88,12 @@ void Inode::will_be_destroyed()
         (void)flush_metadata();
 }
 
+ErrorOr<void> Inode::truncate(u64 size)
+{
+    MutexLocker locker(m_inode_lock);
+    return truncate_locked(size);
+}
+
 ErrorOr<size_t> Inode::write_bytes(off_t offset, size_t length, UserOrKernelBuffer const& target_buffer, OpenFileDescription* open_description)
 {
     MutexLocker locker(m_inode_lock);

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -56,6 +56,7 @@ public:
     ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*);
     ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, OpenFileDescription*) const;
     ErrorOr<size_t> read_until_filled_or_end(off_t, size_t, UserOrKernelBuffer buffer, OpenFileDescription*) const;
+    ErrorOr<void> truncate(u64);
 
     virtual ErrorOr<void> attach(OpenFileDescription&) { return {}; }
     virtual void detach(OpenFileDescription&) { }
@@ -70,7 +71,6 @@ public:
     virtual ErrorOr<void> replace_child(StringView name, Inode&) = 0;
     virtual ErrorOr<void> chmod(mode_t) = 0;
     virtual ErrorOr<void> chown(UserID, GroupID) = 0;
-    virtual ErrorOr<void> truncate(u64) { return {}; }
 
     ErrorOr<NonnullRefPtr<Custody>> resolve_as_link(Credentials const&, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const;
 
@@ -123,6 +123,7 @@ protected:
 
     virtual ErrorOr<size_t> write_bytes_locked(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*) = 0;
     virtual ErrorOr<size_t> read_bytes_locked(off_t, size_t, UserOrKernelBuffer& buffer, OpenFileDescription*) const = 0;
+    virtual ErrorOr<void> truncate_locked(u64) { return {}; }
 
 private:
     ErrorOr<bool> try_apply_flock(Process const&, OpenFileDescription const&, flock const&);

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -121,6 +121,8 @@ protected:
 
     mutable Mutex m_inode_lock { "Inode"sv };
 
+    ErrorOr<size_t> prepare_and_write_bytes_locked(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*);
+
     virtual ErrorOr<size_t> write_bytes_locked(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*) = 0;
     virtual ErrorOr<size_t> read_bytes_locked(off_t, size_t, UserOrKernelBuffer& buffer, OpenFileDescription*) const = 0;
     virtual ErrorOr<void> truncate_locked(u64) { return {}; }

--- a/Kernel/FileSystem/Plan9FS/Inode.cpp
+++ b/Kernel/FileSystem/Plan9FS/Inode.cpp
@@ -284,8 +284,9 @@ ErrorOr<void> Plan9FSInode::chown(UserID, GroupID)
     return ENOTIMPL;
 }
 
-ErrorOr<void> Plan9FSInode::truncate(u64 new_size)
+ErrorOr<void> Plan9FSInode::truncate_locked(u64 new_size)
 {
+    VERIFY(m_inode_lock.is_locked());
     if (fs().m_remote_protocol_version >= Plan9FS::ProtocolVersion::v9P2000L) {
         Plan9FSMessage message { fs(), Plan9FSMessage::Type::Tsetattr };
         SetAttrMask valid = SetAttrMask::Size;

--- a/Kernel/FileSystem/Plan9FS/Inode.h
+++ b/Kernel/FileSystem/Plan9FS/Inode.h
@@ -33,7 +33,7 @@ public:
     virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
-    virtual ErrorOr<void> truncate(u64) override;
+    virtual ErrorOr<void> truncate_locked(u64) override;
 
 private:
     // ^Inode

--- a/Kernel/FileSystem/ProcFS/Inode.h
+++ b/Kernel/FileSystem/ProcFS/Inode.h
@@ -50,7 +50,7 @@ private:
     virtual ErrorOr<void> chmod(mode_t) override { return EROFS; }
     virtual ErrorOr<void> chown(UserID, GroupID) override { return EROFS; }
     virtual ErrorOr<size_t> write_bytes_locked(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*) override { return EROFS; }
-    virtual ErrorOr<void> truncate(u64) override { return EROFS; }
+    virtual ErrorOr<void> truncate_locked(u64) override { return EROFS; }
 
     // ^Inode (Silent ignore handling)
     virtual ErrorOr<void> flush_metadata() override { return {}; }

--- a/Kernel/FileSystem/RAMFS/Inode.cpp
+++ b/Kernel/FileSystem/RAMFS/Inode.cpp
@@ -361,9 +361,9 @@ ErrorOr<void> RAMFSInode::remove_child(StringView name)
     return {};
 }
 
-ErrorOr<void> RAMFSInode::truncate(u64 size)
+ErrorOr<void> RAMFSInode::truncate_locked(u64 size)
 {
-    MutexLocker locker(m_inode_lock);
+    VERIFY(m_inode_lock.is_locked());
     VERIFY(!is_directory());
 
     u64 block_index = size / DataBlock::block_size + ((size % DataBlock::block_size == 0) ? 0 : 1);

--- a/Kernel/FileSystem/RAMFS/Inode.h
+++ b/Kernel/FileSystem/RAMFS/Inode.h
@@ -34,7 +34,7 @@ public:
     virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
-    virtual ErrorOr<void> truncate(u64) override;
+    virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<void> update_timestamps(Optional<UnixDateTime> atime, Optional<UnixDateTime> ctime, Optional<UnixDateTime> mtime) override;
 
 private:

--- a/Kernel/FileSystem/SysFS/Inode.cpp
+++ b/Kernel/FileSystem/SysFS/Inode.cpp
@@ -105,8 +105,9 @@ ErrorOr<void> SysFSInode::chown(UserID, GroupID)
     return EPERM;
 }
 
-ErrorOr<void> SysFSInode::truncate(u64 size)
+ErrorOr<void> SysFSInode::truncate_locked(u64 size)
 {
+    VERIFY(m_inode_lock.is_locked());
     return m_associated_component->truncate(size);
 }
 

--- a/Kernel/FileSystem/SysFS/Inode.h
+++ b/Kernel/FileSystem/SysFS/Inode.h
@@ -34,7 +34,7 @@ protected:
     virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
-    virtual ErrorOr<void> truncate(u64) override;
+    virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<void> update_timestamps(Optional<UnixDateTime> atime, Optional<UnixDateTime> ctime, Optional<UnixDateTime> mtime) override;
 
     virtual ErrorOr<void> attach(OpenFileDescription& description) override final;


### PR DESCRIPTION
The first commit is from #23138 originally, but I also added a small fix for the ext2 driver.