### PR TITLE
LibWeb: Implement almost all of the remaining Animation prototype methods

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -489,6 +489,89 @@ WebIDL::ExceptionOr<void> Animation::play_an_animation(AutoRewind auto_rewind)
     return {};
 }
 
+// https://www.w3.org/TR/web-animations-1/#dom-animation-pause
+WebIDL::ExceptionOr<void> Animation::pause()
+{
+    // 1. If animation has a pending pause task, abort these steps.
+    if (m_pending_pause_task == TaskState::Scheduled)
+        return {};
+
+    // 2. If the play state of animation is paused, abort these steps.
+    if (play_state() == Bindings::AnimationPlayState::Paused)
+        return {};
+
+    // 3. Let seek time be a time value that is initially unresolved.
+    Optional<double> seek_time;
+
+    // 4. Let has finite timeline be true if animation has an associated timeline that is not monotonically increasing.
+    auto has_finite_timeline = m_timeline && !m_timeline->is_monotonically_increasing();
+
+    // 5. If the animation’s current time is unresolved, perform the steps according to the first matching condition
+    //    from below:
+    if (!current_time().has_value()) {
+        // -> If animation’s playback rate is ≥ 0,
+        if (playback_rate() >= 0.0) {
+            // Set seek time to zero.
+            seek_time = 0.0;
+        }
+        // -> Otherwise
+        else {
+            // If associated effect end for animation is positive infinity,
+            auto associated_effect_end = this->associated_effect_end();
+            if (isinf(associated_effect_end) && associated_effect_end > 0.0) {
+                // throw an "InvalidStateError" DOMException and abort these steps.
+                return WebIDL::InvalidStateError::create(realm(), "Cannot pause an animation with an infinite effect end"_fly_string);
+            }
+
+            // Otherwise,
+            //     Set seek time to animation’s associated effect end.
+            seek_time = associated_effect_end;
+        }
+    }
+
+    // 6. If seek time is resolved,
+    if (seek_time.has_value()) {
+        // If has finite timeline is true,
+        if (has_finite_timeline) {
+            // Set animation’s start time to seek time.
+            m_start_time = seek_time;
+        }
+        // Otherwise,
+        else {
+            // Set animation’s hold time to seek time.
+            m_hold_time = seek_time;
+        }
+    }
+
+    // 7. Let has pending ready promise be a boolean flag that is initially false.
+    auto has_pending_ready_promise = false;
+
+    // 8. If animation has a pending play task, cancel that task and let has pending ready promise be true.
+    if (m_pending_play_task == TaskState::Scheduled) {
+        m_pending_pause_task = TaskState::None;
+        has_pending_ready_promise = true;
+    }
+
+    // 9. If has pending ready promise is false, set animation’s current ready promise to a new promise in the relevant
+    //    Realm of animation.
+    if (!has_pending_ready_promise)
+        m_current_ready_promise = WebIDL::create_promise(realm());
+
+    // 10. Schedule a task to be executed at the first possible moment where both of the following conditions are true:
+    //     - the user agent has performed any processing necessary to suspend the playback of animation’s associated
+    //       effect, if any.
+    //     - the animation is associated with a timeline that is not inactive.
+    //
+    // Note: This is run_pending_pause_task()
+    m_pending_pause_task = TaskState::Scheduled;
+
+    // 11. Run the procedure to update an animation’s finished state for animation with the did seek flag set to false,
+    //     and the synchronously notify flag set to false.
+    update_finished_state(DidSeek::No, SynchronouslyNotify::No);
+
+    return {};
+}
+
 // https://www.w3.org/TR/web-animations-1/#animation-time-to-timeline-time
 Optional<double> Animation::convert_an_animation_time_to_timeline_time(Optional<double> time) const
 {
@@ -559,8 +642,7 @@ void Animation::notify_timeline_time_did_change()
     // Act on the pending play or pause task
     if (m_pending_pause_task == TaskState::Scheduled) {
         m_pending_pause_task = TaskState::None;
-        // FIXME:
-        // run_pending_pause_task();
+        run_pending_pause_task();
     }
 
     if (m_pending_play_task == TaskState::Scheduled) {
@@ -876,9 +958,40 @@ void Animation::run_pending_play_task()
     update_finished_state(DidSeek::No, SynchronouslyNotify::No);
 }
 
+// Step 10 of https://www.w3.org/TR/web-animations-1/#pause-an-animation
 void Animation::run_pending_pause_task()
 {
-    // FIXME: Implement
+    // 1. Let ready time be the time value of the timeline associated with animation at the moment when the user agent
+    //    completed processing necessary to suspend playback of animation’s associated effect.
+    // FIXME: Ideally we would save the time before the update_finished_state call in pause_an_animation() and use that
+    //        as the ready time, as step 1 indicates, however at that point the timeline will not have had it's current
+    //        time updated by the Document, so the time we would save would be incorrect if there are no other
+    //        animations running.
+    auto ready_time = m_timeline->current_time();
+
+    // Note: The timeline being active is a precondition for this method to be called
+    VERIFY(ready_time.has_value());
+
+    // 2. If animation’s start time is resolved and its hold time is not resolved, let animation’s hold time be the
+    //    result of evaluating (ready time - start time) × playback rate.
+    // Note: The hold time might be already set if the animation is finished, or if the animation has a pending play
+    //       task. In either case we want to preserve the hold time as we enter the paused state.
+    if (m_start_time.has_value() && !m_hold_time.has_value())
+        m_hold_time = (ready_time.value() - m_start_time.value()) * m_playback_rate;
+
+    // 3. Apply any pending playback rate on animation.
+    apply_any_pending_playback_rate();
+
+    // 4. Make animation’s start time unresolved.
+    m_start_time = {};
+
+    // 5. Resolve animation’s current ready promise with animation.
+    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm()) };
+    WebIDL::resolve_promise(realm(), current_ready_promise(), this);
+
+    // 6. Run the procedure to update an animation’s finished state for animation with the did seek flag set to false,
+    //    and the synchronously notify flag set to false.
+    update_finished_state(DidSeek::No, SynchronouslyNotify::No);
 }
 
 JS::NonnullGCPtr<WebIDL::Promise> Animation::current_ready_promise() const

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -697,6 +697,13 @@ WebIDL::ExceptionOr<void> Animation::pause()
     return {};
 }
 
+// https://www.w3.org/TR/web-animations-1/#dom-animation-persist
+void Animation::persist()
+{
+    // Sets this animation’s replace state to persisted.
+    set_replace_state(Bindings::AnimationReplaceState::Persisted);
+}
+
 // https://www.w3.org/TR/web-animations-1/#animation-time-to-timeline-time
 Optional<double> Animation::convert_an_animation_time_to_timeline_time(Optional<double> time) const
 {

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -359,6 +359,66 @@ void Animation::set_replace_state(Bindings::AnimationReplaceState value)
     }
 }
 
+// https://www.w3.org/TR/web-animations-1/#dom-animation-cancel
+void Animation::cancel()
+{
+    auto& realm = this->realm();
+
+    // 1. If animation’s play state is not idle, perform the following steps:
+    if (play_state() != Bindings::AnimationPlayState::Idle) {
+        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+
+        // 1. Run the procedure to reset an animation’s pending tasks on animation.
+        reset_an_animations_pending_tasks();
+
+        // 2. Reject the current finished promise with a DOMException named "AbortError".
+        auto dom_exception = WebIDL::AbortError::create(realm, "Animation was cancelled"_fly_string);
+        WebIDL::reject_promise(realm, current_finished_promise(), dom_exception);
+
+        // 3. Set the [[PromiseIsHandled]] internal slot of the current finished promise to true.
+        WebIDL::mark_promise_as_handled(current_finished_promise());
+
+        // 4. Let current finished promise be a new promise in the relevant Realm of animation.
+        m_current_finished_promise = WebIDL::create_promise(realm);
+
+        // 5. Create an AnimationPlaybackEvent, cancelEvent.
+        // 6. Set cancelEvent’s type attribute to cancel.
+        // 7. Set cancelEvent’s currentTime to null.
+        // 8. Let timeline time be the current time of the timeline with which animation is associated. If animation is
+        //    not associated with an active timeline, let timeline time be an unresolved time value.
+        // 9. Set cancelEvent’s timelineTime to timeline time. If timeline time is unresolved, set it to null.
+        AnimationPlaybackEventInit init;
+        init.timeline_time = m_timeline && !m_timeline->is_inactive() ? m_timeline->current_time() : Optional<double> {};
+        auto cancel_event = AnimationPlaybackEvent::create(realm, HTML::EventNames::cancel, init);
+
+        // 10. If animation has a document for timing, then append cancelEvent to its document for timing's pending
+        //     animation event queue along with its target, animation. If animation is associated with an active
+        //     timeline that defines a procedure to convert timeline times to origin-relative time, let the scheduled
+        //     event time be the result of applying that procedure to timeline time. Otherwise, the scheduled event time
+        //     is an unresolved time value.
+        //     Otherwise, queue a task to dispatch cancelEvent at animation. The task source for this task is the DOM
+        //     manipulation task source.
+        if (auto document = document_for_timing()) {
+            Optional<double> scheduled_event_time;
+            if (m_timeline && !m_timeline->is_inactive() && m_timeline->can_convert_a_timeline_time_to_an_origin_relative_time())
+                scheduled_event_time = m_timeline->convert_a_timeline_time_to_an_origin_relative_time(m_timeline->current_time());
+            document->append_pending_animation_event({ cancel_event, *this, scheduled_event_time });
+        } else {
+            HTML::queue_global_task(HTML::Task::Source::DOMManipulation, realm.global_object(), [this, cancel_event]() {
+                dispatch_event(cancel_event);
+            });
+        }
+    }
+
+    // 2. Make animation’s hold time unresolved.
+    m_hold_time = {};
+
+    // 3. Make animation’s start time unresolved.
+    m_start_time = {};
+
+    invalidate_effect();
+}
+
 // https://www.w3.org/TR/web-animations-1/#dom-animation-finish
 WebIDL::ExceptionOr<void> Animation::finish()
 {
@@ -956,6 +1016,36 @@ void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify sync
     }
 
     invalidate_effect();
+}
+
+// https://www.w3.org/TR/web-animations-1/#animation-reset-an-animations-pending-tasks
+void Animation::reset_an_animations_pending_tasks()
+{
+    auto& realm = this->realm();
+
+    // 1. If animation does not have a pending play task or a pending pause task, abort this procedure.
+    if (!pending())
+        return;
+
+    // 2. If animation has a pending play task, cancel that task.
+    m_pending_play_task = TaskState::None;
+
+    // 3. If animation has a pending pause task, cancel that task.
+    m_pending_pause_task = TaskState::None;
+
+    // 4. Apply any pending playback rate on animation.
+    apply_any_pending_playback_rate();
+
+    // 5. Reject animation’s current ready promise with a DOMException named "AbortError".
+    auto dom_exception = WebIDL::AbortError::create(realm, "Animation was cancelled"_fly_string);
+    WebIDL::reject_promise(realm, current_ready_promise(), dom_exception);
+
+    // 6. Set the [[PromiseIsHandled]] internal slot of animation’s current ready promise to true.
+    WebIDL::mark_promise_as_handled(current_ready_promise());
+
+    // 7. Let animation’s current ready promise be the result of creating a new resolved Promise object with value
+    //    animation in the relevant Realm of animation.
+    m_current_ready_promise = WebIDL::create_resolved_promise(realm, this);
 }
 
 // Step 12 of https://www.w3.org/TR/web-animations-1/#playing-an-animation-section

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -359,6 +359,42 @@ void Animation::set_replace_state(Bindings::AnimationReplaceState value)
     }
 }
 
+// https://www.w3.org/TR/web-animations-1/#dom-animation-onfinish
+JS::GCPtr<WebIDL::CallbackType> Animation::onfinish()
+{
+    return event_handler_attribute(HTML::EventNames::finish);
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-animation-onfinish
+void Animation::set_onfinish(JS::GCPtr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(HTML::EventNames::finish, event_handler);
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-animation-oncancel
+JS::GCPtr<WebIDL::CallbackType> Animation::oncancel()
+{
+    return event_handler_attribute(HTML::EventNames::cancel);
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-animation-oncancel
+void Animation::set_oncancel(JS::GCPtr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(HTML::EventNames::cancel, event_handler);
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-animation-onremove
+JS::GCPtr<WebIDL::CallbackType> Animation::onremove()
+{
+    return event_handler_attribute(HTML::EventNames::remove);
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-animation-onremove
+void Animation::set_onremove(JS::GCPtr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(HTML::EventNames::remove, event_handler);
+}
+
 // https://www.w3.org/TR/web-animations-1/#dom-animation-cancel
 void Animation::cancel()
 {

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -72,6 +72,7 @@ public:
     };
     WebIDL::ExceptionOr<void> play();
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);
+    WebIDL::ExceptionOr<void> pause();
 
     Optional<double> convert_an_animation_time_to_timeline_time(Optional<double>) const;
     Optional<double> convert_a_timeline_time_to_an_origin_relative_time(Optional<double>) const;

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -70,6 +70,7 @@ public:
         Yes,
         No,
     };
+    void cancel();
     WebIDL::ExceptionOr<void> finish();
     WebIDL::ExceptionOr<void> play();
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);
@@ -118,6 +119,7 @@ private:
     void apply_any_pending_playback_rate();
     WebIDL::ExceptionOr<void> silently_set_current_time(Optional<double>);
     void update_finished_state(DidSeek, SynchronouslyNotify);
+    void reset_an_animations_pending_tasks();
 
     void run_pending_play_task();
     void run_pending_pause_task();

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -70,6 +70,7 @@ public:
         Yes,
         No,
     };
+    WebIDL::ExceptionOr<void> finish();
     WebIDL::ExceptionOr<void> play();
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);
     WebIDL::ExceptionOr<void> pause();

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -66,6 +66,13 @@ public:
     JS::NonnullGCPtr<JS::Object> finished() const { return *current_finished_promise()->promise(); }
     bool is_finished() const { return m_is_finished; }
 
+    JS::GCPtr<WebIDL::CallbackType> onfinish();
+    void set_onfinish(JS::GCPtr<WebIDL::CallbackType>);
+    JS::GCPtr<WebIDL::CallbackType> oncancel();
+    void set_oncancel(JS::GCPtr<WebIDL::CallbackType>);
+    JS::GCPtr<WebIDL::CallbackType> onremove();
+    void set_onremove(JS::GCPtr<WebIDL::CallbackType>);
+
     enum class AutoRewind {
         Yes,
         No,

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -76,6 +76,7 @@ public:
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);
     WebIDL::ExceptionOr<void> pause();
     WebIDL::ExceptionOr<void> update_playback_rate(double);
+    WebIDL::ExceptionOr<void> reverse();
     void persist();
 
     Optional<double> convert_an_animation_time_to_timeline_time(Optional<double>) const;

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -75,6 +75,7 @@ public:
     WebIDL::ExceptionOr<void> play();
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);
     WebIDL::ExceptionOr<void> pause();
+    WebIDL::ExceptionOr<void> update_playback_rate(double);
     void persist();
 
     Optional<double> convert_an_animation_time_to_timeline_time(Optional<double>) const;

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -75,6 +75,7 @@ public:
     WebIDL::ExceptionOr<void> play();
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);
     WebIDL::ExceptionOr<void> pause();
+    void persist();
 
     Optional<double> convert_an_animation_time_to_timeline_time(Optional<double>) const;
     Optional<double> convert_a_timeline_time_to_an_origin_relative_time(Optional<double>) const;

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -20,9 +20,9 @@ interface Animation : EventTarget {
     readonly attribute Promise<Animation> ready;
     readonly attribute Promise<Animation> finished;
 
-    // FIXME: attribute EventHandler onfinish;
-    // FIXME: attribute EventHandler oncancel;
-    // FIXME: attribute EventHandler onremove;
+    attribute EventHandler onfinish;
+    attribute EventHandler oncancel;
+    attribute EventHandler onremove;
 
     undefined cancel();
     undefined finish();

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -27,7 +27,7 @@ interface Animation : EventTarget {
     // FIXME: undefined cancel();
     // FIXME: undefined finish();
     undefined play();
-    // FIXME: undefined pause();
+    undefined pause();
     // FIXME: undefined updatePlaybackRate(double playbackRate);
     // FIXME: undefined reverse();
     // FIXME: undefined persist();

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -29,7 +29,7 @@ interface Animation : EventTarget {
     undefined play();
     undefined pause();
     undefined updatePlaybackRate(double playbackRate);
-    // FIXME: undefined reverse();
+    undefined reverse();
     undefined persist();
     // FIXME: [CEReactions] undefined commitStyles();
 };

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -24,7 +24,7 @@ interface Animation : EventTarget {
     // FIXME: attribute EventHandler oncancel;
     // FIXME: attribute EventHandler onremove;
 
-    // FIXME: undefined cancel();
+    undefined cancel();
     undefined finish();
     undefined play();
     undefined pause();

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -30,7 +30,7 @@ interface Animation : EventTarget {
     undefined pause();
     // FIXME: undefined updatePlaybackRate(double playbackRate);
     // FIXME: undefined reverse();
-    // FIXME: undefined persist();
+    undefined persist();
     // FIXME: [CEReactions] undefined commitStyles();
 };
 

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -28,7 +28,7 @@ interface Animation : EventTarget {
     undefined finish();
     undefined play();
     undefined pause();
-    // FIXME: undefined updatePlaybackRate(double playbackRate);
+    undefined updatePlaybackRate(double playbackRate);
     // FIXME: undefined reverse();
     undefined persist();
     // FIXME: [CEReactions] undefined commitStyles();

--- a/Userland/Libraries/LibWeb/Animations/Animation.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animation.idl
@@ -25,7 +25,7 @@ interface Animation : EventTarget {
     // FIXME: attribute EventHandler onremove;
 
     // FIXME: undefined cancel();
-    // FIXME: undefined finish();
+    undefined finish();
     undefined play();
     undefined pause();
     // FIXME: undefined updatePlaybackRate(double playbackRate);


### PR DESCRIPTION
This PR omits `commitStyles()`, as it is quite a bit more complicated (and probably niche) than the other methods.

Independent of (and won't conflict with) #23311 