### PR TITLE
LibWeb: Paint page only if something that requires repaint happened

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -256,9 +256,11 @@ void EventLoop::process()
 
     // 16. For each fully active Document in docs, update the rendering or user interface of that Document and its browsing context to reflect the current state.
     for_each_fully_active_document_in_docs([&](DOM::Document& document) {
-        auto* browsing_context = document.browsing_context();
-        auto& page = browsing_context->page();
-        page.client().schedule_repaint();
+        if (document.navigable() && document.navigable()->needs_repaint()) {
+            auto* browsing_context = document.browsing_context();
+            auto& page = browsing_context->page();
+            page.client().schedule_repaint();
+        }
     });
 
     // 13. If all of the following are true

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1980,12 +1980,14 @@ void Navigable::set_viewport_rect(CSSPixelRect const& rect)
             document->set_needs_layout();
         }
         did_change = true;
+        m_needs_repaint = true;
     }
 
     if (m_viewport_scroll_offset != rect.location()) {
         m_viewport_scroll_offset = rect.location();
         scroll_offset_did_change();
         did_change = true;
+        m_needs_repaint = true;
     }
 
     if (did_change && active_document()) {
@@ -2035,6 +2037,8 @@ void Navigable::set_needs_display(CSSPixelRect const& rect)
 {
     // FIXME: Ignore updates outside the visible viewport rect.
     //        This requires accounting for fixed-position elements in the input rect, which we don't do yet.
+
+    m_needs_repaint = true;
 
     if (is<TraversableNavigable>(*this)) {
         static_cast<TraversableNavigable*>(this)->page().client().page_did_invalidate(to_top_level_rect(rect));
@@ -2128,6 +2132,8 @@ void Navigable::paint(Painting::RecordingPainter& recording_painter, PaintConfig
         }
         recording_painter.commands_list().apply_scroll_offsets(scroll_offsets_by_frame_id);
     }
+
+    m_needs_repaint = false;
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#event-uni

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2033,7 +2033,7 @@ void Navigable::set_needs_display()
     set_needs_display(viewport_rect());
 }
 
-void Navigable::set_needs_display(CSSPixelRect const& rect)
+void Navigable::set_needs_display(CSSPixelRect const&)
 {
     // FIXME: Ignore updates outside the visible viewport rect.
     //        This requires accounting for fixed-position elements in the input rect, which we don't do yet.
@@ -2041,7 +2041,8 @@ void Navigable::set_needs_display(CSSPixelRect const& rect)
     m_needs_repaint = true;
 
     if (is<TraversableNavigable>(*this)) {
-        static_cast<TraversableNavigable*>(this)->page().client().page_did_invalidate(to_top_level_rect(rect));
+        // Schedule the main thread event loop, which will, in turn, schedule a repaint.
+        Web::HTML::main_thread_event_loop().schedule();
         return;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -173,6 +173,8 @@ public:
 
     [[nodiscard]] TargetSnapshotParams snapshot_target_snapshot_params();
 
+    [[nodiscard]] bool needs_repaint() const { return m_needs_repaint; }
+
     struct PaintConfig {
         bool paint_overlay { false };
         bool should_show_line_box_borders { false };
@@ -221,6 +223,8 @@ private:
 
     CSSPixelSize m_size;
     CSSPixelPoint m_viewport_scroll_offset;
+
+    bool m_needs_repaint { false };
 };
 
 HashTable<Navigable*>& all_navigables();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -253,7 +253,6 @@ public:
     virtual void page_did_leave_tooltip_area() { }
     virtual void page_did_hover_link(const AK::URL&) { }
     virtual void page_did_unhover_link() { }
-    virtual void page_did_invalidate(CSSPixelRect const&) { }
     virtual void page_did_change_favicon(Gfx::Bitmap const&) { }
     virtual void page_did_layout() { }
     virtual void page_did_request_scroll(i32, i32) { }

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -224,11 +224,6 @@ void PageClient::set_viewport_rect(Web::DevicePixelRect const& rect)
     page().top_level_traversable()->set_viewport_rect(page().device_to_css_rect(rect));
 }
 
-void PageClient::page_did_invalidate(Web::CSSPixelRect const&)
-{
-    Web::HTML::main_thread_event_loop().schedule();
-}
-
 void PageClient::page_did_request_cursor_change(Gfx::StandardCursor cursor)
 {
     client().async_did_request_cursor_change(m_id, (u32)cursor);

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -222,7 +222,6 @@ void PageClient::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& ta
 void PageClient::set_viewport_rect(Web::DevicePixelRect const& rect)
 {
     page().top_level_traversable()->set_viewport_rect(page().device_to_css_rect(rect));
-    Web::HTML::main_thread_event_loop().schedule();
 }
 
 void PageClient::page_did_invalidate(Web::CSSPixelRect const&)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -88,7 +88,6 @@ private:
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_screen_rect; }
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }
-    virtual void page_did_invalidate(Web::CSSPixelRect const&) override;
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;
     virtual void page_did_layout() override;
     virtual void page_did_change_title(ByteString const&) override;


### PR DESCRIPTION
Resolves a performance regression from
8ba18dfd404543290774f21ee3ed6c802e3371cd, where moving paint scheduling to `EventLoop::process()` led to unnecessary repaints.

This update introduces a flag to trigger repaints only when necessary, addressing the issue where repaints previously occurred with each event loop process, irrespective of actual changes.