### PR TITLE
Meta: Set the RAM size to 1G for aarch64 in run.py 

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -707,6 +707,7 @@ def set_up_machine_devices(config: Configuration):
     if config.architecture == Arch.Aarch64:
         config.qemu_machine = "raspi3b"
         config.cpu_count = None
+        config.ram_size = "1G"  # The raspi3b machine only accepts 1G as a valid RAM size.
         config.vga_type = None
         config.display_device = None
         if config.machine_type != MachineType.CI:


### PR DESCRIPTION
This unbreaks `serenity.sh run aarch64`.

b2104361cf set the default RAM size to 2GiB, but the "raspi3b" QEMU machine only accepts 1GiB.