### PR TITLE
LibWeb: Add support for serializable objects

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
@@ -1,3 +1,8 @@
 instanceOf Blob: true
 Blob.type: text/plain
 Blob.text(): Hello, Blob!
+instanceOf File: true
+File.name: hello.txt
+File.type: text/plain
+File.text(): Hello, File!
+File.size: 12

--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
@@ -1,0 +1,3 @@
+instanceOf Blob: true
+Blob.type: text/plain
+Blob.text(): Hello, Blob!

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
@@ -7,6 +7,14 @@
         let text = await blob.text();
         println(`Blob.text(): ${text}`);
 
+        let file = structuredClone(new File(["Hello, File!"], "hello.txt", {type: "text/plain"}));
+        println(`instanceOf File: ${file instanceof File}`);
+        println(`File.name: ${file.name}`);
+        println(`File.type: ${file.type}`);
+        text = await file.text();
+        println(`File.text(): ${text}`);
+        println(`File.size: ${file.size}`);
+
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
@@ -1,0 +1,12 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        let blob = structuredClone(new Blob(["Hello, Blob!"], {type: "text/plain"}));
+        println(`instanceOf Blob: ${blob instanceof Blob}`);
+        println(`Blob.type: ${blob.type}`);
+        let text = await blob.text();
+        println(`Blob.text(): ${text}`);
+
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Bindings/Serializable.h
+++ b/Userland/Libraries/LibWeb/Bindings/Serializable.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
+
+namespace Web::Bindings {
+
+// https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects
+class Serializable {
+public:
+    virtual ~Serializable() = default;
+
+    virtual StringView interface_name() const = 0;
+
+    // https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage) = 0;
+    // https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) = 0;
+};
+
+}

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2022-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -15,6 +15,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStreamDefaultReader.h>
@@ -146,6 +147,40 @@ void Blob::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::BlobPrototype>(realm, "Blob"_fly_string));
+}
+
+WebIDL::ExceptionOr<void> Blob::serialization_steps(HTML::SerializationRecord& record, bool)
+{
+    auto& vm = this->vm();
+
+    TRY(HTML::serialize_string(vm, record, interface_name()));
+
+    //  FIXME: 1. Set serialized.[[SnapshotState]] to value’s snapshot state.
+
+    // NON-STANDARD: FileAPI spec doesn't specify that type should be serialized, although
+    //               to be conformant with other browsers this needs to be serialized.
+    TRY(HTML::serialize_string(vm, record, m_type));
+
+    // 2. Set serialized.[[ByteSequence]] to value’s underlying byte sequence.
+    TRY(HTML::serialize_bytes(vm, record, m_byte_buffer.bytes()));
+
+    return {};
+}
+
+WebIDL::ExceptionOr<void> Blob::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position)
+{
+    auto& vm = this->vm();
+
+    // FIXME: 1. Set value’s snapshot state to serialized.[[SnapshotState]].
+
+    // NON-STANDARD: FileAPI spec doesn't specify that type should be deserialized, although
+    //               to be conformant with other browsers this needs to be deserialized.
+    m_type = TRY(HTML::deserialize_string(vm, record, position));
+
+    // 2. Set value’s underlying byte sequence to serialized.[[ByteSequence]].
+    m_byte_buffer = TRY(HTML::deserialize_bytes(vm, record, position));
+
+    return {};
 }
 
 // https://w3c.github.io/FileAPI/#ref-for-dom-blob-blob

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2022-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +10,7 @@
 #include <AK/Vector.h>
 #include <LibWeb/Bindings/BlobPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Bindings/Serializable.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -26,7 +27,9 @@ struct BlobPropertyBag {
 [[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts, Optional<BlobPropertyBag> const& options = {});
 [[nodiscard]] bool is_basic_latin(StringView view);
 
-class Blob : public Bindings::PlatformObject {
+class Blob
+    : public Bindings::PlatformObject
+    , public Bindings::Serializable {
     WEB_PLATFORM_OBJECT(Blob, Bindings::PlatformObject);
     JS_DECLARE_ALLOCATOR(Blob);
 
@@ -51,6 +54,11 @@ public:
     ReadonlyBytes bytes() const { return m_byte_buffer.bytes(); }
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> get_stream();
+
+    virtual StringView interface_name() const override { return "Blob"sv; }
+
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position) override;
 
 protected:
     Blob(JS::Realm&, ByteBuffer, String type);

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -66,11 +66,11 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
 
-private:
-    explicit Blob(JS::Realm&);
-
     ByteBuffer m_byte_buffer {};
     String m_type {};
+
+private:
+    explicit Blob(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/FileAPI/File.h
+++ b/Userland/Libraries/LibWeb/FileAPI/File.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2022-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,6 +19,7 @@ class File : public Blob {
     JS_DECLARE_ALLOCATOR(File);
 
 public:
+    static JS::NonnullGCPtr<File> create(JS::Realm& realm);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> create(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> construct_impl(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
 
@@ -29,8 +30,14 @@ public:
     // https://w3c.github.io/FileAPI/#dfn-lastModified
     i64 last_modified() const { return m_last_modified; }
 
+    virtual StringView interface_name() const override { return "File"sv; }
+
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
+
 private:
     File(JS::Realm&, ByteBuffer, String file_name, String type, i64 last_modified);
+    explicit File(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -34,6 +34,7 @@
 #include <LibWeb/Bindings/Serializable.h>
 #include <LibWeb/Bindings/Transferable.h>
 #include <LibWeb/FileAPI/Blob.h>
+#include <LibWeb/FileAPI/File.h>
 #include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -927,6 +928,8 @@ private:
     {
         if (interface_name == "Blob"sv)
             return FileAPI::Blob::create(realm);
+        if (interface_name == "File"sv)
+            return FileAPI::File::create(realm);
 
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -50,6 +50,11 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& v
 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory>);
 
+WebIDL::ExceptionOr<ByteBuffer> deserialize_bytes(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
+WebIDL::ExceptionOr<String> deserialize_string(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::PrimitiveString>> deserialize_string_primitive(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::BigInt>> deserialize_big_int_primitive(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
+
 WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM& vm, JS::Value value, Vector<JS::Handle<JS::Object>> const& transfer_list);
 WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(JS::VM& vm, SerializedTransferRecord&);
 

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, Daniel Ehrenberg <dan@littledan.dev>
  * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,6 +13,8 @@
 #include <AK/Vector.h>
 #include <LibIPC/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Runtime/DataView.h>
+#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 // Structured serialize is an entirely different format from IPC because:
@@ -49,6 +52,14 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize_for_storage(JS::VM
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& vm, JS::Value, bool for_storage, SerializationMemory&);
 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory>);
+
+WebIDL::ExceptionOr<void> serialize_bytes(JS::VM& vm, Vector<u32>& vector, ReadonlyBytes bytes);
+WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, DeprecatedFlyString const& string);
+WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, String const& string);
+WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, JS::PrimitiveString const& primitive_string);
+WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, Vector<u32>& vector, JS::ArrayBuffer const& array_buffer, bool for_storage);
+template<OneOf<JS::TypedArrayBase, JS::DataView> ViewType>
+WebIDL::ExceptionOr<void> serialize_viewed_array_buffer(JS::VM& vm, Vector<u32>& vector, ViewType const& view, bool for_storage, SerializationMemory& memory);
 
 WebIDL::ExceptionOr<ByteBuffer> deserialize_bytes(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
 WebIDL::ExceptionOr<String> deserialize_string(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);


### PR DESCRIPTION
This adds the abstract class `Serializable` which platform objects decorated with the `Serializable` IDL attribute can implement to support their appropriate serialization and deserialization steps.

To introduce the concept and implementation this PR makes `Blob` and `File` from the FileAPI spec serializable.

See individual commits for more details.