### PR TITLE
LibWeb: Add missing CSSStylesheet methods

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -47,6 +47,7 @@ static bool is_platform_object(Type const& type)
         "Instance"sv,
         "IntersectionObserverEntry"sv,
         "KeyframeEffect"sv,
+        "MediaList"sv,
         "Memory"sv,
         "MessagePort"sv,
         "Module"sv,

--- a/Tests/LibWeb/Text/expected/css/CSSStyleSheet-addRule.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleSheet-addRule.txt
@@ -1,0 +1,9 @@
+addValue() return value: -1
+Rule count after calling addRule() with no arguments: 1
+Rule text: undefined { }
+Rule count after calling addRule with no index: 2
+Second rule text: .test { font-size: 14px; }
+Rule count after calling addRule with index 0: 3
+Rule text: .test { padding: 100px; }
+Exception thrown when given a negative index: IndexSizeError
+Exception thrown when index out of range: IndexSizeError

--- a/Tests/LibWeb/Text/expected/css/CSSStyleSheet-constructor.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleSheet-constructor.txt
@@ -1,0 +1,10 @@
+Empty sheet ownerNode: null
+Empty sheet ownerRule: null
+Empty sheet title is empty string: true
+Empty sheet cssRules is empty: true
+Empty sheet is disabled by default: false
+cssRules length after insertRule(): 1
+cssRules text: * { font-size: 16px; }
+rules and cssRules are the same object: true
+cssRules length after deleteRule(): 0
+Disabled sheet is disabled: true

--- a/Tests/LibWeb/Text/expected/css/CSSStyleSheet-removeRule.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleSheet-removeRule.txt
@@ -1,0 +1,12 @@
+Exception thrown when removeRule() called on empty sheet: IndexSizeError
+Rule count after adding 3 rules: 3
+Rule text: .test { padding: 10px; }
+Rule text: .test { margin: 5px; }
+Rule text: .test { font-size: 14px; }
+Rule count after calling removeRule with no arguments: 2
+Rule text: .test { margin: 5px; }
+Rule text: .test { font-size: 14px; }
+Rule count after calling removeRule with explicit index: 1
+Rule text: .test { margin: 5px; }
+Exception thrown when given a negative index: IndexSizeError
+Exception thrown when index out of range: IndexSizeError

--- a/Tests/LibWeb/Text/expected/css/CSSStyleSheet-replace.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleSheet-replace.txt
@@ -1,0 +1,7 @@
+Exception thrown when calling replace() on non-constructed stylesheet: NotAllowedError
+Number of CSS rules after replace(): 2
+Rule: .test { font-size: 14px; }
+Rule: .test2 { font-size: 16px; }
+cssRules returns the same object before and after replace(): true
+@import rule should be not appear below:
+Rule: .test { padding: 100px; }

--- a/Tests/LibWeb/Text/expected/css/CSSStyleSheet-replaceSync.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleSheet-replaceSync.txt
@@ -1,0 +1,8 @@
+Exception thrown when calling replaceSync() on non-constructed stylesheet: NotAllowedError
+Number of CSS rules after replaceSync(): 2
+Rule: .test { font-size: 14px; }
+Rule: .test2 { font-size: 16px; }
+cssRules returns the same object before and after replaceSync(): true
+@import rule should be not appear below:
+Rule: .test { padding: 100px; }
+Calling replaceSync() while the disallow modification flag set throws: NotAllowedError

--- a/Tests/LibWeb/Text/expected/css/insert-import-rule-into-constructed-stylesheet.txt
+++ b/Tests/LibWeb/Text/expected/css/insert-import-rule-into-constructed-stylesheet.txt
@@ -1,0 +1,1 @@
+Inserting an @import rule into a constructed stylesheet throws: SyntaxError

--- a/Tests/LibWeb/Text/input/css/CSSStyleSheet-addRule.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleSheet-addRule.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const sheet = new CSSStyleSheet();
+        println(`addValue() return value: ${sheet.addRule()}`);
+        println(`Rule count after calling addRule() with no arguments: ${sheet.cssRules.length}`);
+        println(`Rule text: ${sheet.cssRules[0].cssText}`);
+        sheet.addRule(".test", "font-size: 14px");
+        println(`Rule count after calling addRule with no index: ${sheet.cssRules.length}`);
+        println(`Second rule text: ${sheet.cssRules[1].cssText}`);
+        sheet.addRule(".test", "padding: 100px", 0);
+        println(`Rule count after calling addRule with index 0: ${sheet.cssRules.length}`);
+        println(`Rule text: ${sheet.cssRules[0].cssText}`);
+        try {
+            sheet.addRule(".test", "padding: 10px", -1);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when given a negative index: ${e.name}`);
+        }
+        try {
+            sheet.addRule(".test", "padding: 10px", 4);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when index out of range: ${e.name}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/CSSStyleSheet-constructor.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleSheet-constructor.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const cssRule = "* { font-size: 16px; }";
+        const sheet = new CSSStyleSheet();
+        println(`Empty sheet ownerNode: ${sheet.ownerNode}`);
+        println(`Empty sheet ownerRule: ${sheet.ownerRule}`);
+        println(`Empty sheet title is empty string: ${sheet.title === ""}`);
+        println(`Empty sheet cssRules is empty: ${sheet.cssRules.length === 0}`);
+        println(`Empty sheet is disabled by default: ${sheet.disabled}`);
+
+        sheet.insertRule(cssRule);
+        println(`cssRules length after insertRule(): ${sheet.cssRules.length}`);
+        println(`cssRules text: ${sheet.cssRules[0].cssText}`);
+
+        println(`rules and cssRules are the same object: ${sheet.cssRules === sheet.rules}`);
+
+        sheet.deleteRule(0);
+        println(`cssRules length after deleteRule(): ${sheet.cssRules.length}`);
+
+        const disabledSheet = new CSSStyleSheet({ disabled: true });
+        println(`Disabled sheet is disabled: ${disabledSheet.disabled}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/CSSStyleSheet-removeRule.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleSheet-removeRule.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const sheet = new CSSStyleSheet();
+        try {
+            sheet.removeRule();
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when removeRule() called on empty sheet: ${e.name}`);
+        }
+
+        sheet.addRule(".test", "padding: 10px");
+        sheet.addRule(".test", "margin: 5px");
+        sheet.addRule(".test", "font-size: 14px");
+        println(`Rule count after adding 3 rules: ${sheet.cssRules.length}`);
+        for (const rule of sheet.cssRules) {
+            println(`Rule text: ${rule.cssText}`);
+        }
+        sheet.removeRule();
+        println(`Rule count after calling removeRule with no arguments: ${sheet.cssRules.length}`);
+        for (const rule of sheet.cssRules) {
+            println(`Rule text: ${rule.cssText}`);
+        }
+        sheet.removeRule(1);
+        println(`Rule count after calling removeRule with explicit index: ${sheet.cssRules.length}`);
+        println(`Rule text: ${sheet.cssRules[0].cssText}`);
+        try {
+            sheet.removeRule(-1);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when given a negative index: ${e.name}`);
+        }
+        try {
+            sheet.removeRule(1);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when index out of range: ${e.name}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/CSSStyleSheet-replace.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleSheet-replace.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<style>
+    .test {
+        font-size: 12px;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const newStyle = `
+        .test {
+            font-size: 14px;
+        }
+        .test2 {
+            font-size: 16px;
+        }`;
+        const newStyle2 = `.test {
+            padding: 100px;
+        }`;
+
+        const nonConstructedSheet = document.styleSheets[0];
+        try {
+            await nonConstructedSheet.replace(newStyle);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when calling replace() on non-constructed stylesheet: ${e.name}`);
+        }
+
+        const sheet = new CSSStyleSheet();
+        const cssRules = sheet.cssRules;
+
+        await sheet.replace(newStyle);
+        println(`Number of CSS rules after replace(): ${sheet.cssRules.length}`);
+        for (const rule of sheet.cssRules) {
+            println(`Rule: ${rule.cssText}`);
+        }
+
+        const cssRulesAfterReplace = sheet.cssRules;
+        println(`cssRules returns the same object before and after replace(): ${cssRules === cssRulesAfterReplace}`);
+
+        const importRule = `@import url("test.css");`;
+        await sheet.replace(`${newStyle2} ${importRule}`);
+
+        println(`@import rule should be not appear below:`);
+        for (const rule of sheet.cssRules) {
+            println(`Rule: ${rule.cssText}`);
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/CSSStyleSheet-replaceSync.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleSheet-replaceSync.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<style>
+    .test {
+        font-size: 12px;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const newStyle = `
+        .test {
+            font-size: 14px;
+        }
+        .test2 {
+            font-size: 16px;
+        }`;
+        const newStyle2 = `.test {
+            padding: 100px;
+        }`;
+
+        const nonConstructedSheet = document.styleSheets[0];
+        try {
+            nonConstructedSheet.replaceSync(newStyle);
+            println("FAIL");
+        } catch (e) {
+            println(`Exception thrown when calling replaceSync() on non-constructed stylesheet: ${e.name}`);
+        }
+
+        const sheet = new CSSStyleSheet();
+        const cssRules = sheet.cssRules;
+
+        sheet.replaceSync(newStyle);
+        println(`Number of CSS rules after replaceSync(): ${sheet.cssRules.length}`);
+        for (const rule of sheet.cssRules) {
+            println(`Rule: ${rule.cssText}`);
+        }
+
+        const cssRulesAfterReplaceSync = sheet.cssRules;
+        println(`cssRules returns the same object before and after replaceSync(): ${cssRules === cssRulesAfterReplaceSync}`);
+
+        const importRule = `@import url("test.css");`;
+        sheet.replaceSync(`${newStyle2} ${importRule}`);
+
+        println(`@import rule should be not appear below:`);
+        for (const rule of sheet.cssRules) {
+            println(`Rule: ${rule.cssText}`);
+        }
+
+        const unresolvedPromise = sheet.replace(newStyle);
+        try {
+            sheet.replaceSync(newStyle);
+            println("FAIL");
+        } catch (e) {
+            println(`Calling replaceSync() while the disallow modification flag set throws: ${e.name}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/insert-import-rule-into-constructed-stylesheet.html
+++ b/Tests/LibWeb/Text/input/css/insert-import-rule-into-constructed-stylesheet.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        try {
+            const sheet = new CSSStyleSheet();
+            sheet.insertRule(`@import url("style-sheet-with-byte-order-mark.css")`);
+            println("FAIL");
+        } catch (e) {
+            println(`Inserting an @import rule into a constructed stylesheet throws: ${e.name}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -62,6 +62,8 @@ public:
     bool evaluate_media_queries(HTML::Window const&);
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
 
+    void set_rules(Badge<CSSStyleSheet>, Vector<JS::NonnullGCPtr<CSSRule>> rules) { m_rules = move(rules); }
+
     Function<void()> on_change;
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -140,7 +140,9 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(StringView rule, unsign
     if (!parsed_rule)
         return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_fly_string);
 
-    // FIXME: 5. If parsed rule is an @import rule, and the constructed flag is set, throw a SyntaxError DOMException.
+    // 5. If parsed rule is an @import rule, and the constructed flag is set, throw a SyntaxError DOMException.
+    if (constructed() && parsed_rule->type() == CSSRule::Type::Import)
+        return WebIDL::SyntaxError::create(realm(), "Can't insert @import rules into a constructed stylesheet."_fly_string);
 
     // 6. Return the result of invoking insert a CSS rule rule in the CSS rules at index.
     auto result = m_rules->insert_a_css_rule(parsed_rule, index);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -257,6 +257,34 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::replace_sync(StringView text)
     return {};
 }
 
+// https://drafts.csswg.org/cssom/#dom-cssstylesheet-addrule
+WebIDL::ExceptionOr<WebIDL::Long> CSSStyleSheet::add_rule(Optional<String> selector, Optional<String> style, Optional<WebIDL::UnsignedLong> index)
+{
+    // 1. Let rule be an empty string.
+    StringBuilder rule;
+
+    // 2. Append selector to rule.
+    if (selector.has_value())
+        rule.append(selector.release_value());
+
+    // 3. Append " { " to rule.
+    rule.append('{');
+
+    // 4. If block is not empty, append block, followed by a space, to rule.
+    if (style.has_value() && !style->is_empty())
+        rule.appendff("{} ", style.release_value());
+
+    // 5. Append "}" to rule.
+    rule.append('}');
+
+    // 6. Let index be optionalIndex if provided, or the number of CSS rules in the stylesheet otherwise.
+    // 7. Call insertRule(), with rule and index as arguments.
+    TRY(insert_rule(rule.string_view(), index.value_or(rules().length())));
+
+    // 8. Return -1.
+    return -1;
+}
+
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-removerule
 WebIDL::ExceptionOr<void> CSSStyleSheet::remove_rule(unsigned index)
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -286,10 +286,10 @@ WebIDL::ExceptionOr<WebIDL::Long> CSSStyleSheet::add_rule(Optional<String> selec
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-removerule
-WebIDL::ExceptionOr<void> CSSStyleSheet::remove_rule(unsigned index)
+WebIDL::ExceptionOr<void> CSSStyleSheet::remove_rule(Optional<WebIDL::UnsignedLong> index)
 {
     // The removeRule(index) method must run the same steps as deleteRule().
-    return delete_rule(index);
+    return delete_rule(index.value_or(0));
 }
 
 void CSSStyleSheet::for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -44,7 +44,6 @@ public:
 
     CSSRuleList const& rules() const { return *m_rules; }
     CSSRuleList& rules() { return *m_rules; }
-    void set_rules(CSSRuleList& rules) { m_rules = &rules; }
 
     CSSRuleList* css_rules() { return m_rules; }
     CSSRuleList const* css_rules() const { return m_rules; }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -52,6 +52,8 @@ public:
     WebIDL::ExceptionOr<void> remove_rule(unsigned index);
     WebIDL::ExceptionOr<void> delete_rule(unsigned index);
 
+    JS::NonnullGCPtr<JS::Promise> replace(String text);
+
     void for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const;
     // Returns whether the match state of any media queries changed after evaluation.
     bool evaluate_media_queries(HTML::Window const&);
@@ -70,6 +72,8 @@ public:
     JS::GCPtr<DOM::Document const> constructor_document() const { return m_constructor_document; }
     void set_constructor_document(JS::GCPtr<DOM::Document const> constructor_document) { m_constructor_document = constructor_document; }
 
+    bool disallow_modification() const { return m_disallow_modification; }
+
 private:
     CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<AK::URL> location);
 
@@ -79,6 +83,7 @@ private:
     void recalculate_namespaces();
 
     void set_constructed(bool constructed) { m_constructed = constructed; }
+    void set_disallow_modification(bool disallow_modification) { m_disallow_modification = disallow_modification; }
 
     JS::GCPtr<CSSRuleList> m_rules;
     JS::GCPtr<CSSNamespaceRule> m_default_namespace_rule;
@@ -90,6 +95,7 @@ private:
     Optional<AK::URL> m_base_url;
     JS::GCPtr<DOM::Document const> m_constructor_document;
     bool m_constructed { false };
+    bool m_disallow_modification { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/CSSRuleList.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/StyleSheet.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::CSS {
 
@@ -49,6 +50,7 @@ public:
     CSSRuleList const* css_rules() const { return m_rules; }
 
     WebIDL::ExceptionOr<unsigned> insert_rule(StringView rule, unsigned index);
+    WebIDL::ExceptionOr<WebIDL::Long> add_rule(Optional<String> selector, Optional<String> style, Optional<WebIDL::UnsignedLong> index);
     WebIDL::ExceptionOr<void> remove_rule(unsigned index);
     WebIDL::ExceptionOr<void> delete_rule(unsigned index);
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -53,6 +53,7 @@ public:
     WebIDL::ExceptionOr<void> delete_rule(unsigned index);
 
     JS::NonnullGCPtr<JS::Promise> replace(String text);
+    WebIDL::ExceptionOr<void> replace_sync(StringView text);
 
     void for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const;
     // Returns whether the match state of any media queries changed after evaluation.

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,6 +29,8 @@ public:
 
     virtual ~CSSStyleSheet() override = default;
 
+    JS::GCPtr<CSSRule const> owner_rule() const { return m_owner_css_rule; }
+    JS::GCPtr<CSSRule> owner_rule() { return m_owner_css_rule; }
     void set_owner_css_rule(CSSRule* rule) { m_owner_css_rule = rule; }
 
     virtual String type() const override { return "text/css"_string; }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -18,6 +18,12 @@ namespace Web::CSS {
 
 class CSSImportRule;
 
+struct CSSStyleSheetInit {
+    Optional<String> base_url {};
+    Variant<JS::Handle<MediaList>, String> media { String {} };
+    bool disabled { false };
+};
+
 class CSSStyleSheet final
     : public StyleSheet
     , public Weakable<CSSStyleSheet> {
@@ -26,6 +32,7 @@ class CSSStyleSheet final
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<CSSStyleSheet> create(JS::Realm&, CSSRuleList&, MediaList&, Optional<AK::URL> location);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleSheet>> construct_impl(JS::Realm&, Optional<CSSStyleSheetInit> const& options = {});
 
     virtual ~CSSStyleSheet() override = default;
 
@@ -56,6 +63,14 @@ public:
     Optional<FlyString> default_namespace() const;
     Optional<FlyString> namespace_uri(StringView namespace_prefix) const;
 
+    Optional<AK::URL> base_url() const { return m_base_url; }
+    void set_base_url(Optional<AK::URL> base_url) { m_base_url = move(base_url); }
+
+    bool constructed() const { return m_constructed; }
+
+    JS::GCPtr<DOM::Document const> constructor_document() const { return m_constructor_document; }
+    void set_constructor_document(JS::GCPtr<DOM::Document const> constructor_document) { m_constructor_document = constructor_document; }
+
 private:
     CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<AK::URL> location);
 
@@ -64,12 +79,18 @@ private:
 
     void recalculate_namespaces();
 
+    void set_constructed(bool constructed) { m_constructed = constructed; }
+
     JS::GCPtr<CSSRuleList> m_rules;
     JS::GCPtr<CSSNamespaceRule> m_default_namespace_rule;
     HashMap<FlyString, JS::GCPtr<CSSNamespaceRule>> m_namespace_rules;
 
     JS::GCPtr<StyleSheetList> m_style_sheet_list;
     JS::GCPtr<CSSRule> m_owner_css_rule;
+
+    Optional<AK::URL> m_base_url;
+    JS::GCPtr<DOM::Document const> m_constructor_document;
+    bool m_constructed { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -51,7 +51,7 @@ public:
 
     WebIDL::ExceptionOr<unsigned> insert_rule(StringView rule, unsigned index);
     WebIDL::ExceptionOr<WebIDL::Long> add_rule(Optional<String> selector, Optional<String> style, Optional<WebIDL::UnsignedLong> index);
-    WebIDL::ExceptionOr<void> remove_rule(unsigned index);
+    WebIDL::ExceptionOr<void> remove_rule(Optional<WebIDL::UnsignedLong> index);
     WebIDL::ExceptionOr<void> delete_rule(unsigned index);
 
     JS::NonnullGCPtr<JS::Promise> replace(String text);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -13,7 +13,7 @@ interface CSSStyleSheet : StyleSheet {
     unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
     undefined deleteRule(unsigned long index);
 
-    // FIXME: Promise<CSSStyleSheet> replace(USVString text);
+    Promise<CSSStyleSheet> replace(USVString text);
     // FIXME: undefined replaceSync(USVString text);
 
     // https://drafts.csswg.org/cssom/#legacy-css-style-sheet-members

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -1,11 +1,12 @@
 #import <CSS/CSSRule.idl>
 #import <CSS/CSSRuleList.idl>
+#import <CSS/MediaList.idl>
 #import <CSS/StyleSheet.idl>
 
 // https://drafts.csswg.org/cssom/#cssstylesheet
 [Exposed=Window]
 interface CSSStyleSheet : StyleSheet {
-    // FIXME: constructor(optional CSSStyleSheetInit options = {});
+    constructor(optional CSSStyleSheetInit options = {});
 
     readonly attribute CSSRule? ownerRule;
     [SameObject] readonly attribute CSSRuleList cssRules;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -7,7 +7,7 @@
 interface CSSStyleSheet : StyleSheet {
     // FIXME: constructor(optional CSSStyleSheetInit options = {});
 
-    // FIXME: readonly attribute CSSRule? ownerRule;
+    readonly attribute CSSRule? ownerRule;
     [SameObject] readonly attribute CSSRuleList cssRules;
     unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
     undefined deleteRule(unsigned long index);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -19,7 +19,7 @@ interface CSSStyleSheet : StyleSheet {
     // https://drafts.csswg.org/cssom/#legacy-css-style-sheet-members
     [SameObject, ImplementedAs=css_rules] readonly attribute CSSRuleList rules;
     long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
-    undefined removeRule(unsigned long index);
+    undefined removeRule(optional unsigned long index);
 };
 
 dictionary CSSStyleSheetInit {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -18,7 +18,7 @@ interface CSSStyleSheet : StyleSheet {
 
     // https://drafts.csswg.org/cssom/#legacy-css-style-sheet-members
     [SameObject, ImplementedAs=css_rules] readonly attribute CSSRuleList rules;
-    // FIXME: long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
+    long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
     undefined removeRule(unsigned long index);
 };
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -16,7 +16,7 @@ interface CSSStyleSheet : StyleSheet {
     // FIXME: undefined replaceSync(USVString text);
 
     // https://drafts.csswg.org/cssom/#legacy-css-style-sheet-members
-    // FIXME: [SameObject] readonly attribute CSSRuleList rules;
+    [SameObject, ImplementedAs=css_rules] readonly attribute CSSRuleList rules;
     // FIXME: long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
     undefined removeRule(unsigned long index);
 };

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -14,7 +14,7 @@ interface CSSStyleSheet : StyleSheet {
     undefined deleteRule(unsigned long index);
 
     Promise<CSSStyleSheet> replace(USVString text);
-    // FIXME: undefined replaceSync(USVString text);
+    undefined replaceSync(USVString text);
 
     // https://drafts.csswg.org/cssom/#legacy-css-style-sheet-members
     [SameObject, ImplementedAs=css_rules] readonly attribute CSSRuleList rules;

--- a/Userland/Libraries/LibWeb/CSS/MediaList.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.h
@@ -22,7 +22,7 @@ class MediaList final : public Bindings::PlatformObject {
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<MediaList> create(JS::Realm&, Vector<NonnullRefPtr<MediaQuery>>&&);
-    ~MediaList() = default;
+    virtual ~MediaList() override = default;
 
     String media_text() const;
     void set_media_text(StringView);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -105,6 +105,7 @@ class CSSRuleList;
 class CSSStyleDeclaration;
 class CSSStyleRule;
 class CSSStyleSheet;
+struct CSSStyleSheetInit;
 class CSSSupportsRule;
 class CalculatedStyleValue;
 class Clip;


### PR DESCRIPTION
This PR adds the following methods and attributes to CSSStyleSheet:
* [`ownerRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/ownerRule)
* [`rules`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/rules)
* [`CSSStyleSheet()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
* [`replace()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/replace)
* [`replaceSync()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/replaceSync)
* [`addRule()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/addRule)

I've also included some fixes in this PR to bring our implementation closer to the CSSOM specification. See the individual commits for details.

These changes increase the number of CSSOM WPT tests we pass:

Before:
Ran 168 tests finished in 337.9 seconds.
  • 55 ran as expected. 0 tests skipped.
  • 11 tests had errors unexpectedly
  • 1 tests failed unexpectedly
  • 10 tests timed out unexpectedly
  • 96 tests had unexpected subtest results
  
After:
Ran 168 tests finished in 332.0 seconds.
  • 59 ran as expected. 0 tests skipped.
  • 10 tests had errors unexpectedly
  • 1 tests failed unexpectedly
  • 10 tests timed out unexpectedly
  • 93 tests had unexpected subtest results