### PR TITLE
LibWeb: Clamp calculated border width values to zero

### DIFF
--- a/Tests/LibWeb/Layout/expected/calc-negative-border-width.txt
+++ b/Tests/LibWeb/Layout/expected/calc-negative-border-width.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 34, rect: [8,8 285.046875x17] baseline: 13.296875
+            "This should have no visible border"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]

--- a/Tests/LibWeb/Layout/input/calc-negative-border-width.html
+++ b/Tests/LibWeb/Layout/input/calc-negative-border-width.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><style>
+div {
+    font-size: 16px;
+    border: calc(-1em + 15px) solid;
+}
+</style><div>This should have no visible border</div>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -701,7 +701,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
             auto resolve_border_width = [&]() -> CSSPixels {
                 auto value = computed_style.property(width_property);
                 if (value->is_calculated())
-                    return value->as_calculated().resolve_length(*this)->to_px(*this);
+                    return max(CSSPixels { 0 }, value->as_calculated().resolve_length(*this)->to_px(*this));
                 if (value->is_length())
                     return value->as_length().length().to_px(*this);
                 if (value->is_identifier()) {


### PR DESCRIPTION
Previously, a calculated CSS border-width property with a resolved value of less than zero pixels would cause a crash.