### PR TITLE
RequestServer: Defer connection initiation to after IPC processing

### DIFF
--- a/Userland/Libraries/LibProtocol/Request.h
+++ b/Userland/Libraries/LibProtocol/Request.h
@@ -55,7 +55,7 @@ public:
     void did_request_certificates(Badge<RequestClient>);
 
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
-    void set_request_fd(Badge<RequestClient>, int fd) { m_fd = fd; }
+    void set_request_fd(Badge<RequestClient>, int fd);
 
 private:
     explicit Request(RequestClient&, i32 request_id);
@@ -73,12 +73,9 @@ private:
     };
 
     struct InternalStreamData {
-        InternalStreamData(NonnullOwnPtr<Stream> stream)
-            : read_stream(move(stream))
-        {
-        }
+        InternalStreamData() { }
 
-        NonnullOwnPtr<Stream> read_stream;
+        OwnPtr<Stream> read_stream;
         RefPtr<Core::Notifier> read_notifier;
         bool success;
         u32 total_size { 0 };

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -32,6 +32,7 @@ public:
     bool set_certificate(Badge<Request>, Request&, ByteString, ByteString);
 
 private:
+    virtual void request_started(i32, IPC::File const&) override;
     virtual void request_progress(i32, Optional<u64> const&, u64) override;
     virtual void request_finished(i32, bool, u64) override;
     virtual void certificate_requested(i32) override;

--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -71,13 +71,15 @@ void request_did_finish(URL const& url, Core::Socket const* socket)
                 connection->job_data.fail(Core::NetworkJob::Error::ConnectionFailed);
                 return;
             }
-            Core::deferred_invoke([&, url] {
-                dbgln_if(REQUESTSERVER_DEBUG, "Running next job in queue for connection {} @{}", &connection, connection->socket);
-                connection->timer.start();
-                connection->current_url = url;
-                connection->job_data = connection->request_queue.take_first();
-                connection->socket->set_notifications_enabled(true);
-                connection->job_data.start(*connection->socket);
+
+            connection->has_started = true;
+            Core::deferred_invoke([&connection = *connection, url] {
+                dbgln_if(REQUESTSERVER_DEBUG, "Running next job in queue for connection {}", &connection);
+                connection.timer.start();
+                connection.current_url = url;
+                connection.job_data = connection.request_queue.take_first();
+                connection.socket->set_notifications_enabled(true);
+                connection.job_data.start(*connection.socket);
             });
         }
     };

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -32,7 +32,7 @@ private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
 
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString const&) override;
-    virtual Messages::RequestServer::StartRequestResponse start_request(ByteString const&, URL const&, HashMap<ByteString, ByteString> const&, ByteBuffer const&, Core::ProxyData const&) override;
+    virtual void start_request(i32 request_id, ByteString const&, URL const&, HashMap<ByteString, ByteString> const&, ByteBuffer const&, Core::ProxyData const&) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(i32) override;
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, ByteString const&, ByteString const&) override;
     virtual void ensure_connection(URL const& url, ::RequestServer::CacheLevel const& cache_level) override;

--- a/Userland/Services/RequestServer/GeminiProtocol.h
+++ b/Userland/Services/RequestServer/GeminiProtocol.h
@@ -15,7 +15,7 @@ public:
     GeminiProtocol();
     virtual ~GeminiProtocol() override = default;
 
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const&, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const&, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/GeminiRequest.cpp
+++ b/Userland/Services/RequestServer/GeminiRequest.cpp
@@ -12,8 +12,8 @@
 
 namespace RequestServer {
 
-GeminiRequest::GeminiRequest(ConnectionFromClient& client, NonnullRefPtr<Gemini::Job> job, NonnullOwnPtr<Core::File>&& output_stream)
-    : Request(client, move(output_stream))
+GeminiRequest::GeminiRequest(ConnectionFromClient& client, NonnullRefPtr<Gemini::Job> job, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
+    : Request(client, move(output_stream), request_id)
     , m_job(move(job))
 {
     m_job->on_finish = [this](bool success) {
@@ -57,9 +57,9 @@ GeminiRequest::~GeminiRequest()
     m_job->cancel();
 }
 
-NonnullOwnPtr<GeminiRequest> GeminiRequest::create_with_job(Badge<GeminiProtocol>, ConnectionFromClient& client, NonnullRefPtr<Gemini::Job> job, NonnullOwnPtr<Core::File>&& output_stream)
+NonnullOwnPtr<GeminiRequest> GeminiRequest::create_with_job(Badge<GeminiProtocol>, ConnectionFromClient& client, NonnullRefPtr<Gemini::Job> job, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
 {
-    return adopt_own(*new GeminiRequest(client, move(job), move(output_stream)));
+    return adopt_own(*new GeminiRequest(client, move(job), move(output_stream), request_id));
 }
 
 }

--- a/Userland/Services/RequestServer/GeminiRequest.h
+++ b/Userland/Services/RequestServer/GeminiRequest.h
@@ -16,14 +16,14 @@ namespace RequestServer {
 class GeminiRequest final : public Request {
 public:
     virtual ~GeminiRequest() override;
-    static NonnullOwnPtr<GeminiRequest> create_with_job(Badge<GeminiProtocol>, ConnectionFromClient&, NonnullRefPtr<Gemini::Job>, NonnullOwnPtr<Core::File>&&);
+    static NonnullOwnPtr<GeminiRequest> create_with_job(Badge<GeminiProtocol>, ConnectionFromClient&, NonnullRefPtr<Gemini::Job>, NonnullOwnPtr<Core::File>&&, i32 request_id);
 
     Gemini::Job const& job() const { return *m_job; }
 
     virtual URL url() const override { return m_job->url(); }
 
 private:
-    explicit GeminiRequest(ConnectionFromClient&, NonnullRefPtr<Gemini::Job>, NonnullOwnPtr<Core::File>&&);
+    explicit GeminiRequest(ConnectionFromClient&, NonnullRefPtr<Gemini::Job>, NonnullOwnPtr<Core::File>&&, i32 request_id);
 
     virtual void set_certificate(ByteString certificate, ByteString key) override;
 

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -61,7 +61,7 @@ void init(TSelf* self, TJob job)
 }
 
 template<typename TBadgedProtocol, typename TPipeResult>
-OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ConnectionFromClient& client, ByteString const& method, const URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, TPipeResult&& pipe_result, Core::ProxyData proxy_data = {})
+OwnPtr<Request> start_request(TBadgedProtocol&& protocol, i32 request_id, ConnectionFromClient& client, ByteString const& method, const URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, TPipeResult&& pipe_result, Core::ProxyData proxy_data = {})
 {
     using TJob = typename TBadgedProtocol::Type::JobType;
     using TRequest = typename TBadgedProtocol::Type::RequestType;
@@ -99,13 +99,15 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ConnectionFromClient& 
 
     auto output_stream = MUST(Core::File::adopt_fd(pipe_result.value().write_fd, Core::File::OpenMode::Write));
     auto job = TJob::construct(move(request), *output_stream);
-    auto protocol_request = TRequest::create_with_job(forward<TBadgedProtocol>(protocol), client, (TJob&)*job, move(output_stream));
+    auto protocol_request = TRequest::create_with_job(forward<TBadgedProtocol>(protocol), client, (TJob&)*job, move(output_stream), request_id);
     protocol_request->set_request_fd(pipe_result.value().read_fd);
 
-    if constexpr (IsSame<typename TBadgedProtocol::Type, HttpsProtocol>)
-        ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, job, proxy_data);
-    else
-        ConnectionCache::get_or_create_connection(ConnectionCache::g_tcp_connection_cache, url, job, proxy_data);
+    Core::EventLoop::current().deferred_invoke([=] {
+        if constexpr (IsSame<typename TBadgedProtocol::Type, HttpsProtocol>)
+            ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, job, proxy_data);
+        else
+            ConnectionCache::get_or_create_connection(ConnectionCache::g_tcp_connection_cache, url, job, proxy_data);
+    });
 
     return protocol_request;
 }

--- a/Userland/Services/RequestServer/HttpProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpProtocol.cpp
@@ -22,9 +22,9 @@ HttpProtocol::HttpProtocol()
 {
 }
 
-OwnPtr<Request> HttpProtocol::start_request(ConnectionFromClient& client, ByteString const& method, const URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
+OwnPtr<Request> HttpProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const& method, const URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
 {
-    return Detail::start_request(Badge<HttpProtocol> {}, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
+    return Detail::start_request(Badge<HttpProtocol> {}, request_id, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }
 
 }

--- a/Userland/Services/RequestServer/HttpProtocol.h
+++ b/Userland/Services/RequestServer/HttpProtocol.h
@@ -27,7 +27,7 @@ public:
     HttpProtocol();
     ~HttpProtocol() override = default;
 
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/HttpRequest.cpp
+++ b/Userland/Services/RequestServer/HttpRequest.cpp
@@ -11,8 +11,8 @@
 
 namespace RequestServer {
 
-HttpRequest::HttpRequest(ConnectionFromClient& client, NonnullRefPtr<HTTP::Job> job, NonnullOwnPtr<Core::File>&& output_stream)
-    : Request(client, move(output_stream))
+HttpRequest::HttpRequest(ConnectionFromClient& client, NonnullRefPtr<HTTP::Job> job, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
+    : Request(client, move(output_stream), request_id)
     , m_job(job)
 {
     Detail::init(this, job);
@@ -25,9 +25,9 @@ HttpRequest::~HttpRequest()
     m_job->cancel();
 }
 
-NonnullOwnPtr<HttpRequest> HttpRequest::create_with_job(Badge<HttpProtocol>&&, ConnectionFromClient& client, NonnullRefPtr<HTTP::Job> job, NonnullOwnPtr<Core::File>&& output_stream)
+NonnullOwnPtr<HttpRequest> HttpRequest::create_with_job(Badge<HttpProtocol>&&, ConnectionFromClient& client, NonnullRefPtr<HTTP::Job> job, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
 {
-    return adopt_own(*new HttpRequest(client, move(job), move(output_stream)));
+    return adopt_own(*new HttpRequest(client, move(job), move(output_stream), request_id));
 }
 
 }

--- a/Userland/Services/RequestServer/HttpRequest.h
+++ b/Userland/Services/RequestServer/HttpRequest.h
@@ -17,7 +17,7 @@ namespace RequestServer {
 class HttpRequest final : public Request {
 public:
     virtual ~HttpRequest() override;
-    static NonnullOwnPtr<HttpRequest> create_with_job(Badge<HttpProtocol>&&, ConnectionFromClient&, NonnullRefPtr<HTTP::Job>, NonnullOwnPtr<Core::File>&&);
+    static NonnullOwnPtr<HttpRequest> create_with_job(Badge<HttpProtocol>&&, ConnectionFromClient&, NonnullRefPtr<HTTP::Job>, NonnullOwnPtr<Core::File>&&, i32);
 
     HTTP::Job& job() { return m_job; }
     HTTP::Job const& job() const { return m_job; }
@@ -25,7 +25,7 @@ public:
     virtual URL url() const override { return m_job->url(); }
 
 private:
-    explicit HttpRequest(ConnectionFromClient&, NonnullRefPtr<HTTP::Job>, NonnullOwnPtr<Core::File>&&);
+    explicit HttpRequest(ConnectionFromClient&, NonnullRefPtr<HTTP::Job>, NonnullOwnPtr<Core::File>&&, i32);
 
     NonnullRefPtr<HTTP::Job> m_job;
 };

--- a/Userland/Services/RequestServer/HttpsProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpsProtocol.cpp
@@ -22,9 +22,9 @@ HttpsProtocol::HttpsProtocol()
 {
 }
 
-OwnPtr<Request> HttpsProtocol::start_request(ConnectionFromClient& client, ByteString const& method, const URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
+OwnPtr<Request> HttpsProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const& method, const URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
 {
-    return Detail::start_request(Badge<HttpsProtocol> {}, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
+    return Detail::start_request(Badge<HttpsProtocol> {}, request_id, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }
 
 }

--- a/Userland/Services/RequestServer/HttpsProtocol.h
+++ b/Userland/Services/RequestServer/HttpsProtocol.h
@@ -27,7 +27,7 @@ public:
     HttpsProtocol();
     ~HttpsProtocol() override = default;
 
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/HttpsRequest.cpp
+++ b/Userland/Services/RequestServer/HttpsRequest.cpp
@@ -11,8 +11,8 @@
 
 namespace RequestServer {
 
-HttpsRequest::HttpsRequest(ConnectionFromClient& client, NonnullRefPtr<HTTP::HttpsJob> job, NonnullOwnPtr<Core::File>&& output_stream)
-    : Request(client, move(output_stream))
+HttpsRequest::HttpsRequest(ConnectionFromClient& client, NonnullRefPtr<HTTP::HttpsJob> job, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
+    : Request(client, move(output_stream), request_id)
     , m_job(job)
 {
     Detail::init(this, job);
@@ -30,9 +30,9 @@ HttpsRequest::~HttpsRequest()
     m_job->cancel();
 }
 
-NonnullOwnPtr<HttpsRequest> HttpsRequest::create_with_job(Badge<HttpsProtocol>&&, ConnectionFromClient& client, NonnullRefPtr<HTTP::HttpsJob> job, NonnullOwnPtr<Core::File>&& output_stream)
+NonnullOwnPtr<HttpsRequest> HttpsRequest::create_with_job(Badge<HttpsProtocol>&&, ConnectionFromClient& client, NonnullRefPtr<HTTP::HttpsJob> job, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
 {
-    return adopt_own(*new HttpsRequest(client, move(job), move(output_stream)));
+    return adopt_own(*new HttpsRequest(client, move(job), move(output_stream), request_id));
 }
 
 }

--- a/Userland/Services/RequestServer/HttpsRequest.h
+++ b/Userland/Services/RequestServer/HttpsRequest.h
@@ -16,7 +16,7 @@ namespace RequestServer {
 class HttpsRequest final : public Request {
 public:
     virtual ~HttpsRequest() override;
-    static NonnullOwnPtr<HttpsRequest> create_with_job(Badge<HttpsProtocol>&&, ConnectionFromClient&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<Core::File>&&);
+    static NonnullOwnPtr<HttpsRequest> create_with_job(Badge<HttpsProtocol>&&, ConnectionFromClient&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<Core::File>&&, i32);
 
     HTTP::HttpsJob& job() { return m_job; }
     HTTP::HttpsJob const& job() const { return m_job; }
@@ -24,7 +24,7 @@ public:
     virtual URL url() const override { return m_job->url(); }
 
 private:
-    explicit HttpsRequest(ConnectionFromClient&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<Core::File>&&);
+    explicit HttpsRequest(ConnectionFromClient&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<Core::File>&&, i32);
 
     virtual void set_certificate(ByteString certificate, ByteString key) override;
 

--- a/Userland/Services/RequestServer/Protocol.h
+++ b/Userland/Services/RequestServer/Protocol.h
@@ -18,7 +18,7 @@ public:
     virtual ~Protocol();
 
     ByteString const& name() const { return m_name; }
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) = 0;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) = 0;
 
     static Protocol* find_by_name(ByteString const&);
 

--- a/Userland/Services/RequestServer/Request.cpp
+++ b/Userland/Services/RequestServer/Request.cpp
@@ -9,12 +9,9 @@
 
 namespace RequestServer {
 
-// FIXME: What about rollover?
-static i32 s_next_id = 1;
-
-Request::Request(ConnectionFromClient& client, NonnullOwnPtr<Core::File>&& output_stream)
+Request::Request(ConnectionFromClient& client, NonnullOwnPtr<Core::File>&& output_stream, i32 request_id)
     : m_client(client)
-    , m_id(s_next_id++)
+    , m_id(request_id)
     , m_output_stream(move(output_stream))
 {
 }

--- a/Userland/Services/RequestServer/Request.h
+++ b/Userland/Services/RequestServer/Request.h
@@ -43,7 +43,7 @@ public:
     Core::File const& output_stream() const { return *m_output_stream; }
 
 protected:
-    explicit Request(ConnectionFromClient&, NonnullOwnPtr<Core::File>&&);
+    explicit Request(ConnectionFromClient&, NonnullOwnPtr<Core::File>&&, i32 request_id);
 
 private:
     ConnectionFromClient& m_client;

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -2,6 +2,7 @@
 
 endpoint RequestClient
 {
+    request_started(i32 request_id, IPC::File fd) =|
     request_progress(i32 request_id, Optional<u64> total_size, u64 downloaded_size) =|
     request_finished(i32 request_id, bool success, u64 total_size) =|
     headers_became_available(i32 request_id, HashMap<ByteString,ByteString,CaseInsensitiveStringTraits> response_headers, Optional<u32> status_code) =|

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -6,7 +6,7 @@ endpoint RequestServer
     // Test if a specific protocol is supported, e.g "http"
     is_supported_protocol(ByteString protocol) => (bool supported)
 
-    start_request(ByteString method, URL url, HashMap<ByteString,ByteString> request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) => (i32 request_id, Optional<IPC::File> response_fd)
+    start_request(i32 request_id, ByteString method, URL url, HashMap<ByteString,ByteString> request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) =|
     stop_request(i32 request_id) => (bool success)
     set_certificate(i32 request_id, ByteString certificate, ByteString key) => (bool success)
 


### PR DESCRIPTION
This makes it so the client (e.g. LibWeb, etc) can proceed to do other things while RS tries to prepare the requested connection and start it. Fixes #23306.

I don't really see any perceptible difference on most servers; connection init performance still has quite a ways to go before it can be considered "fast".