### PR TITLE
LibWeb: Increase the transient activation duration from 5ms to 5s

### DIFF
--- a/Tests/LibWeb/Text/input/clipboard.html
+++ b/Tests/LibWeb/Text/input/clipboard.html
@@ -16,7 +16,10 @@
 
     asyncTest((done) => {
         writeText(() => {
-            internals.bypassNextTransientActivationTest = true;
+            const button = document.getElementById("button");
+            internals.dispatchUserActivatedEvent(button, new Event("mousedown"));
+            button.dispatchEvent(new Event("click"));
+
             writeText(done);
         });
     });

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -604,7 +604,7 @@ bool Window::has_transient_activation() const
 {
     // The transient activation duration is expected be at most a few seconds, so that the user can possibly
     // perceive the link between an interaction with the page and the page calling the activation-gated API.
-    auto transient_activation_duration = 5;
+    static constexpr HighResolutionTime::DOMHighResTimeStamp transient_activation_duration_ms = 5000;
 
     // AD-HOC: Due to resource limitations on CI, we cannot rely on the time between the activation timestamp and the
     //         transient activation timeout being predictable. So we allow tests to indicate when they want the next
@@ -621,7 +621,7 @@ bool Window::has_transient_activation() const
     // is greater than or equal to the last activation timestamp in W
     if (current_time >= m_last_activation_timestamp) {
         // and less than the last activation timestamp in W plus the transient activation duration
-        if (current_time < m_last_activation_timestamp + transient_activation_duration) {
+        if (current_time < m_last_activation_timestamp + transient_activation_duration_ms) {
             // then W is said to have transient activation.
             return true;
         }

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -134,7 +134,6 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
         visitor.visit(mime_type_object);
     visitor.visit(m_count_queuing_strategy_size_function);
     visitor.visit(m_byte_length_queuing_strategy_size_function);
-    visitor.visit(m_internals);
 }
 
 void Window::finalize()
@@ -606,14 +605,6 @@ bool Window::has_transient_activation() const
     // perceive the link between an interaction with the page and the page calling the activation-gated API.
     static constexpr HighResolutionTime::DOMHighResTimeStamp transient_activation_duration_ms = 5000;
 
-    // AD-HOC: Due to resource limitations on CI, we cannot rely on the time between the activation timestamp and the
-    //         transient activation timeout being predictable. So we allow tests to indicate when they want the next
-    //         check for a user gesture to succeed.
-    if (m_internals && m_internals->bypass_next_transient_activation_test()) {
-        m_internals->set_bypass_next_transient_activation_test(false);
-        return true;
-    }
-
     // When the current high resolution time given W
     auto unsafe_shared_time = HighResolutionTime::unsafe_shared_current_time();
     auto current_time = HighResolutionTime::relative_high_resolution_time(unsafe_shared_time, realm().global_object());
@@ -822,11 +813,8 @@ WebIDL::ExceptionOr<void> Window::initialize_web_interfaces(Badge<WindowEnvironm
 
     if (s_inspector_object_exposed)
         define_direct_property("inspector", heap().allocate<Internals::Inspector>(realm, realm), JS::default_attributes);
-
-    if (s_internals_object_exposed) {
-        m_internals = heap().allocate<Internals::Internals>(realm, realm);
-        define_direct_property("internals", m_internals, JS::default_attributes);
-    }
+    if (s_internals_object_exposed)
+        define_direct_property("internals", heap().allocate<Internals::Internals>(realm, realm), JS::default_attributes);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -287,8 +287,6 @@ private:
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status
     // When the Window object is created, the attribute must be set to the empty string. It does not do anything else.
     String m_status;
-
-    JS::GCPtr<Internals::Internals> m_internals;
 };
 
 void run_animation_frame_callbacks(DOM::Document&, double now);

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -89,4 +89,10 @@ void Internals::wheel(double x, double y, double delta_x, double delta_y)
     page.handle_mousewheel({ x, y }, { x, y }, 0, 0, 0, delta_x, delta_y);
 }
 
+WebIDL::ExceptionOr<bool> Internals::dispatch_user_activated_event(DOM::EventTarget& target, DOM::Event& event)
+{
+    event.set_is_trusted(true);
+    return target.dispatch_event(event);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Internals/Internals.h
+++ b/Userland/Libraries/LibWeb/Internals/Internals.h
@@ -28,14 +28,11 @@ public:
     void click(double x, double y);
     void wheel(double x, double y, double delta_x, double delta_y);
 
-    bool bypass_next_transient_activation_test() const { return m_bypass_next_transient_activation_test; }
-    void set_bypass_next_transient_activation_test(bool bypass_next_transient_activation_test) { m_bypass_next_transient_activation_test = bypass_next_transient_activation_test; }
+    WebIDL::ExceptionOr<bool> dispatch_user_activated_event(DOM::EventTarget&, DOM::Event& event);
 
 private:
     explicit Internals(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
-
-    bool m_bypass_next_transient_activation_test { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Internals/Internals.idl
+++ b/Userland/Libraries/LibWeb/Internals/Internals.idl
@@ -13,6 +13,6 @@
     undefined click(double x, double y);
     undefined wheel(double x, double y, double deltaX, double deltaY);
 
-    attribute boolean bypassNextTransientActivationTest;
+    boolean dispatchUserActivatedEvent(EventTarget target, Event event);
 
 };


### PR DESCRIPTION
It seems we were errantly mixing seconds and milliseconds in this
transient activation timeout. Increase it to 5 seconds, and be explicit
about its type - DOMHighResTimeStamp is by definition milliseconds.