### PR TITLE
LibWeb: Stretch-fit flex items with aspect ratio but no fixed sizes

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x69.984375 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x51.984375 flex-container(row) [FFC] children: not-inline
-      ImageBox <img> at (11,11) content-size 66.65625x49.984375 flex-item children: not-inline
+      ImageBox <img> at (11,11) content-size 66.65625x50 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.984375]
-    PaintableBox (Box<BODY>) [9,9 782x53.984375]
-      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x51.984375]
+    PaintableBox (Box<BODY>) [9,9 782x53.984375] overflow: [10,10 780x52]
+      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x52]

--- a/Tests/LibWeb/Layout/expected/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -1,8 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
-    Box <body> at (8,8) content-size 784x784 flex-container(column) [FFC] children: not-inline
+    Box <body> at (8,8) content-size 784x784 flex-container(row) [FFC] children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 784x784 flex-item [SVG] children: not-inline
         SVGGeometryBox <rect> at (8,8) content-size 392x392 children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]

--- a/Tests/LibWeb/Layout/input/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.html
+++ b/Tests/LibWeb/Layout/input/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><style>
+    body {
+        display: flex;
+        flex-direction: row;
+    }
+</style><body><svg viewBox="0 0 24 24"><rect x=0 y=0 width=12 height=12></svg>


### PR DESCRIPTION
This solves a particular issue with SVG as flex items, where the SVG has an intrinsic aspect ratio via its viewBox, but no explicit natural width or height.

Makes all corporate sponsor logos show up on https://ziglang.org/ :^)

Before:
![Screenshot at 2024-02-25 13-19-10](https://github.com/SerenityOS/serenity/assets/5954907/93e813c8-c2d7-4a3b-b99a-d0d30a46ca77)

After:
![Screenshot at 2024-02-25 13-18-39](https://github.com/SerenityOS/serenity/assets/5954907/913da4fe-3b0e-4802-b5b8-22b80388b0fa)
