### PR TITLE
LibWeb: Fix pseudo-element animations; Apply modified animation-* properties to existing animations

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animatable.h
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.h
@@ -36,10 +36,14 @@ public:
     JS::GCPtr<CSS::CSSStyleDeclaration const> cached_animation_name_source() const { return m_cached_animation_name_source; }
     void set_cached_animation_name_source(JS::GCPtr<CSS::CSSStyleDeclaration const> value) { m_cached_animation_name_source = value; }
 
+    JS::GCPtr<Animations::Animation> cached_animation_name_animation() const { return m_cached_animation_name_animation; }
+    void set_cached_animation_name_animation(JS::GCPtr<Animations::Animation> value) { m_cached_animation_name_animation = value; }
+
 private:
     Vector<JS::NonnullGCPtr<AnimationEffect>> m_associated_effects;
     bool m_is_sorted_by_composite_order { true };
     JS::GCPtr<CSS::CSSStyleDeclaration const> m_cached_animation_name_source;
+    JS::GCPtr<Animations::Animation> m_cached_animation_name_animation;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -905,14 +905,14 @@ void Animation::notify_timeline_time_did_change()
     update_finished_state(DidSeek::No, SynchronouslyNotify::Yes);
 
     // Act on the pending play or pause task
-    if (m_pending_pause_task == TaskState::Scheduled) {
-        m_pending_pause_task = TaskState::None;
-        run_pending_pause_task();
-    }
-
     if (m_pending_play_task == TaskState::Scheduled) {
         m_pending_play_task = TaskState::None;
         run_pending_play_task();
+    }
+
+    if (m_pending_pause_task == TaskState::Scheduled) {
+        m_pending_pause_task = TaskState::None;
+        run_pending_pause_task();
     }
 }
 

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/KeyframeEffectPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleValue.h>
 
 namespace Web::Animations {
@@ -84,8 +85,12 @@ public:
     DOM::Element* target() const override { return m_target_element; }
     void set_target(DOM::Element* target);
 
-    Optional<String> pseudo_element() const { return m_target_pseudo_selector; }
-    void set_pseudo_element(Optional<String>);
+    // JS bindings
+    Optional<StringView> pseudo_element() const { return m_target_pseudo_selector->name(); }
+    WebIDL::ExceptionOr<void> set_pseudo_element(Optional<String>);
+
+    Optional<CSS::Selector::PseudoElement::Type> pseudo_element_type() const;
+    void set_pseudo_element(Optional<CSS::Selector::PseudoElement> pseudo_element) { m_target_pseudo_selector = pseudo_element; }
 
     Bindings::CompositeOperation composite() const { return m_composite; }
     void set_composite(Bindings::CompositeOperation value) { m_composite = value; }
@@ -109,7 +114,7 @@ private:
     JS::GCPtr<DOM::Element> m_target_element {};
 
     // https://www.w3.org/TR/web-animations-1/#dom-keyframeeffect-pseudoelement
-    Optional<String> m_target_pseudo_selector {};
+    Optional<CSS::Selector::PseudoElement> m_target_pseudo_selector {};
 
     // https://www.w3.org/TR/web-animations-1/#dom-keyframeeffect-composite
     Bindings::CompositeOperation m_composite { Bindings::CompositeOperation::Replace };

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -50,6 +50,10 @@
     "normal",
     "reverse"
   ],
+  "animation-play-state": [
+    "paused",
+    "running"
+  ],
   "appearance": [
     "auto",
     "button",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1074,6 +1074,8 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
             effect->set_timing_function(move(timing_function));
             effect->set_fill_mode(Animations::css_fill_mode_to_bindings_fill_mode(fill_mode));
             effect->set_playback_direction(Animations::css_animation_direction_to_bindings_playback_direction(direction));
+            if (pseudo_element.has_value())
+                effect->set_pseudo_element(Selector::PseudoElement { pseudo_element.value() });
 
             auto animation = CSSAnimation::create(realm);
             animation->set_id(animation_name.release_value());
@@ -1099,7 +1101,8 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
 
         if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
             auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());
-            TRY(collect_animation_into(keyframe_effect, style));
+            if (keyframe_effect.pseudo_element_type() == pseudo_element)
+                TRY(collect_animation_into(keyframe_effect, style));
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1059,6 +1059,12 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
                     direction = *direction_value;
             }
 
+            CSS::AnimationPlayState play_state { CSS::AnimationPlayState::Running };
+            if (auto play_state_property = style.maybe_null_property(PropertyID::AnimationPlayState); play_state_property && play_state_property->is_identifier()) {
+                if (auto play_state_value = value_id_to_animation_play_state(play_state_property->to_identifier()); play_state_value.has_value())
+                    play_state = *play_state_value;
+            }
+
             Animations::TimingFunction timing_function = Animations::ease_timing_function;
             if (auto timing_property = style.maybe_null_property(PropertyID::AnimationTimingFunction); timing_property && timing_property->is_easing())
                 timing_function = Animations::TimingFunction::from_easing_style_value(timing_property->as_easing());
@@ -1091,6 +1097,8 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
 
             HTML::TemporaryExecutionContext context(m_document->relevant_settings_object());
             animation->play().release_value_but_fixme_should_propagate_errors();
+            if (play_state == CSS::AnimationPlayState::Paused)
+                animation->pause().release_value_but_fixme_should_propagate_errors();
         }
     }
 


### PR DESCRIPTION
Fixes the button animations on https://null.com, specifically that they were always active and applied to the entire element instead of just the pseudo-elements.

Before:

https://github.com/SerenityOS/serenity/assets/28801118/c0aa4a12-69db-4984-ac8a-09ef80791433

After:

https://github.com/SerenityOS/serenity/assets/28801118/4a6fa29a-11f6-4d2d-9688-21c54b63e458