### PR TITLE
LibPDF: Let Type1Font use TrueTypePainter for standard fonts

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -141,8 +141,10 @@ PDFErrorOr<void> TrueTypePainter::draw_glyph(Gfx::Painter& painter, Gfx::FloatPo
 
 Optional<float> TrueTypePainter::get_glyph_width(u8 char_code) const
 {
-    // FIXME: Make this use the char_code lookup method used in draw_glyph().
-    return m_font->glyph_width(char_code);
+    // FIXME: Make this use the full char_code lookup method used in draw_glyph() once that's complete.
+    auto char_name = m_encoding->get_name(char_code);
+    u32 unicode = glyph_name_to_unicode(char_name).value_or(char_code);
+    return m_font->glyph_width(unicode);
 }
 
 void TrueTypePainter::set_font_size(float font_size)

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -12,6 +12,24 @@
 
 namespace PDF {
 
+class TrueTypePainter {
+public:
+    static NonnullOwnPtr<TrueTypePainter> create(Document*, NonnullRefPtr<DictObject> const&, SimpleFont const& containing_pdf_font, AK::NonnullRefPtr<Gfx::Font>, NonnullRefPtr<Encoding>);
+
+    PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float width, u8 char_code, Renderer const&);
+    Optional<float> get_glyph_width(u8 char_code) const;
+    void set_font_size(float font_size);
+
+private:
+    TrueTypePainter(AK::NonnullRefPtr<Gfx::Font>, NonnullRefPtr<Encoding>, bool encoding_is_mac_roman_or_win_ansi, bool is_nonsymbolic, Optional<u8> high_byte);
+
+    NonnullRefPtr<Gfx::Font> m_font;
+    NonnullRefPtr<Encoding> m_encoding;
+    bool m_encoding_is_mac_roman_or_win_ansi { false };
+    bool m_is_nonsymbolic { false };
+    Optional<u8> m_high_byte;
+};
+
 class TrueTypeFont : public SimpleFont {
 public:
     Optional<float> get_glyph_width(u8 char_code) const override;
@@ -25,9 +43,10 @@ protected:
 
 private:
     DeprecatedFlyString m_base_font_name;
-    RefPtr<Gfx::Font> m_font;
-    bool m_encoding_is_mac_roman_or_win_ansi { false };
-    Optional<u8> m_high_byte;
+
+    // Always non-null once initialize() has completed.
+    // FIXME: Move this class hierarchy to the usual fallible construction pattern and make this a NonnullOwnPtr.
+    OwnPtr<TrueTypePainter> m_font_painter;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -8,6 +8,7 @@
 
 #include <LibGfx/Font/ScaledFont.h>
 #include <LibPDF/Fonts/SimpleFont.h>
+#include <LibPDF/Fonts/TrueTypeFont.h>
 #include <LibPDF/Fonts/Type1FontProgram.h>
 
 namespace PDF {
@@ -34,7 +35,7 @@ protected:
 private:
     DeprecatedFlyString m_base_font_name;
     RefPtr<Type1FontProgram> m_font_program;
-    RefPtr<Gfx::Font> m_font;
+    OwnPtr<TrueTypePainter> m_fallback_font_painter;
     HashMap<Type1GlyphCacheKey, RefPtr<Gfx::Bitmap>> m_glyph_cache;
 };
 


### PR DESCRIPTION
...and for fallback fonts too.

We use Liberation Sans (a truetype font) for standard and fallback
fonts. So we should use the standard PDF algorithm for mapping bytes
to truetype glyphs. TrueTypePainter knows how to do this.

Makes the "fi" ligature in the title on page 1 of 5014.CIDFont_Spec.pdf
or the dotless-i in the title of page 2 of ThinkingInPostScript.pdf
show up.

---

RIP PostScrõpt :(