### PR TITLE
LibWeb: Implement file selection with the `<input type="file">` element

### DIFF
--- a/Ladybird/AppKit/Utilities/Conversions.h
+++ b/Ladybird/AppKit/Utilities/Conversions.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibGfx/Color.h>
@@ -18,6 +19,7 @@
 namespace Ladybird {
 
 String ns_string_to_string(NSString*);
+ByteString ns_string_to_byte_string(NSString*);
 NSString* string_to_ns_string(StringView);
 
 NSData* string_to_ns_data(StringView);

--- a/Ladybird/AppKit/Utilities/Conversions.mm
+++ b/Ladybird/AppKit/Utilities/Conversions.mm
@@ -14,6 +14,12 @@ String ns_string_to_string(NSString* string)
     return MUST(String::from_utf8({ utf8, strlen(utf8) }));
 }
 
+ByteString ns_string_to_byte_string(NSString* string)
+{
+    auto const* utf8 = [string UTF8String];
+    return ByteString(utf8, strlen(utf8));
+}
+
 NSString* string_to_ns_string(StringView string)
 {
     return [[NSString alloc] initWithData:string_to_ns_data(string) encoding:NSUTF8StringEncoding];

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -70,7 +70,7 @@ static bool is_primitive_type(ByteString const& type)
 static bool is_simple_type(ByteString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode", "Web::Cookie::Source");
+    return type.is_one_of("Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode", "Web::Cookie::Source", "Web::HTML::AllowMultipleFiles");
 }
 
 static bool is_primitive_or_simple_type(ByteString const& type)

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
@@ -140,6 +140,7 @@ source_set("HTML") {
     "PotentialCORSRequest.cpp",
     "PromiseRejectionEvent.cpp",
     "SelectItem.cpp",
+    "SelectedFile.cpp",
     "SessionHistoryEntry.cpp",
     "SharedImageRequest.cpp",
     "SourceSet.cpp",

--- a/Tests/LibWeb/Layout/expected/input-file.txt
+++ b/Tests/LibWeb/Layout/expected/input-file.txt
@@ -1,0 +1,54 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 236.65625x21] baseline: 13.296875
+      frag 1 from TextNode start: 0, length: 1, rect: [245,8 8x17] baseline: 13.296875
+          " "
+      frag 2 from BlockContainer start: 0, length: 0, rect: [253,8 255.34375x21] baseline: 13.296875
+      BlockContainer <input> at (8,8) content-size 236.65625x21 inline-block [BFC] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 94.375x17] baseline: 13.296875
+        frag 1 from Label start: 0, length: 0, rect: [116,8 128.28125x17] baseline: 13.296875
+        BlockContainer <button> at (13,10) content-size 94.375x17 inline-block [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (13,10) content-size 94.375x17 flex-container(column) [FFC] children: not-inline
+            BlockContainer <(anonymous)> at (13,10) content-size 94.375x17 flex-item [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 14, rect: [13,10 94.375x17] baseline: 13.296875
+                  "Select file..."
+              TextNode <#text>
+        Label <label> at (116,8) content-size 128.28125x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 17, rect: [116,8 128.28125x17] baseline: 13.296875
+              "No file selected."
+          TextNode <#text>
+      TextNode <#text>
+      BlockContainer <input> at (253,8) content-size 255.34375x21 inline-block [BFC] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [258,10 103.71875x17] baseline: 13.296875
+        frag 1 from Label start: 0, length: 0, rect: [371,8 137.625x17] baseline: 13.296875
+        BlockContainer <button> at (258,10) content-size 103.71875x17 inline-block [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (258,10) content-size 103.71875x17 flex-container(column) [FFC] children: not-inline
+            BlockContainer <(anonymous)> at (258,10) content-size 103.71875x17 flex-item [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 15, rect: [258,10 103.71875x17] baseline: 13.296875
+                  "Select files..."
+              TextNode <#text>
+        Label <label> at (371,8) content-size 137.625x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 18, rect: [371,8 137.625x17] baseline: 13.296875
+              "No files selected."
+          TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<INPUT>) [8,8 236.65625x21]
+        PaintableWithLines (BlockContainer<BUTTON>) [8,8 104.375x21]
+          PaintableWithLines (BlockContainer(anonymous)) [13,10 94.375x17]
+            PaintableWithLines (BlockContainer(anonymous)) [13,10 94.375x17]
+              TextPaintable (TextNode<#text>)
+        PaintableWithLines (Label<LABEL>) [112,8 132.28125x17]
+          TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<INPUT>) [253,8 255.34375x21] overflow: [253,8 255.625x21]
+        PaintableWithLines (BlockContainer<BUTTON>) [253,8 113.71875x21]
+          PaintableWithLines (BlockContainer(anonymous)) [258,10 103.71875x17]
+            PaintableWithLines (BlockContainer(anonymous)) [258,10 103.71875x17]
+              TextPaintable (TextNode<#text>)
+        PaintableWithLines (Label<LABEL>) [367,8 141.625x17]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/input-file.html
+++ b/Tests/LibWeb/Layout/input/input-file.html
@@ -1,0 +1,2 @@
+<input type="file" />
+<input type="file" multiple />

--- a/Tests/LibWeb/Text/expected/input-file.txt
+++ b/Tests/LibWeb/Text/expected/input-file.txt
@@ -1,0 +1,7 @@
+Select file...file1 Select files...4 files selected.   input1:
+file1: Contents for file1
+input2:
+file1: Contents for file1
+file2: Contents for file2
+file3: Contents for file3
+file4: Contents for file4

--- a/Tests/LibWeb/Text/expected/input-value.txt
+++ b/Tests/LibWeb/Text/expected/input-value.txt
@@ -1,4 +1,4 @@
-pass       text: "pass"
+pass    Select file...No file selected.   text: "pass"
 hidden: "pass"
 button: "pass"
 checkbox: "pass"

--- a/Tests/LibWeb/Text/input/input-file.html
+++ b/Tests/LibWeb/Text/input/input-file.html
@@ -1,0 +1,32 @@
+<input id="input1" type="file" />
+<input id="input2" type="file" multiple />
+<script src="./include.js"></script>
+<script type="text/javascript">
+    const runTest = async id => {
+        let input = document.getElementById(id);
+
+        return new Promise(resolve => {
+            input.addEventListener("input", async () => {
+                println(`${id}:`);
+
+                for (let i = 0; i < input.files.length; ++i) {
+                    const file = input.files.item(i);
+                    const text = await file.text();
+
+                    println(`${file.name}: ${text}`);
+                }
+
+                resolve();
+            });
+
+            internals.dispatchUserActivatedEvent(input, new Event("mousedown"));
+            input.showPicker();
+        });
+    };
+
+    asyncTest(async done => {
+        await runTest("input1");
+        await runTest("input2");
+        done();
+    });
+</script>

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -107,7 +107,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::create(arguments));
     auto const man_file = "/usr/share/man/man1/Applications/Browser.md"sv;
 
-    Config::pledge_domain("Browser");
+    Config::pledge_domains({ "Browser", "FileManager" });
     Config::monitor_domain("Browser");
 
     // Connect to LaunchServer immediately and let it know that we won't ask for anything other than opening
@@ -126,8 +126,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/session/%sid/portal/sql", "rw"));
     TRY(Core::System::unveil("/home", "rwc"));
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/etc/group", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
+    TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil("/bin/BrowserSettings", "x"));
     TRY(Core::System::unveil("/bin/Browser", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -389,6 +389,7 @@ set(SOURCES
     HTML/Scripting/TemporaryExecutionContext.cpp
     HTML/Scripting/WindowEnvironmentSettingsObject.cpp
     HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
+    HTML/SelectedFile.cpp
     HTML/SelectItem.cpp
     HTML/SessionHistoryEntry.cpp
     HTML/SharedImageRequest.cpp

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -26,7 +26,7 @@ label {
 }
 
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
-input:not([type=submit], input[type=button], input[type=image], input[type=reset], input[type=color], input[type=checkbox], input[type=radio], input[type=range]), textarea {
+input:not([type=submit], input[type=button], input[type=image], input[type=reset], input[type=color], input[type=checkbox], input[type=file], input[type=radio], input[type=range]), textarea {
     border: 1px solid ButtonBorder;
     min-height: 16px;
     width: attr(size ch, 20ch);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -445,6 +445,7 @@ class Path2D;
 class Plugin;
 class PluginArray;
 class PromiseRejectionEvent;
+class SelectedFile;
 class SharedImageRequest;
 class Storage;
 class SubmitEvent;
@@ -468,6 +469,7 @@ class WorkerGlobalScope;
 class WorkerLocation;
 class WorkerNavigator;
 
+enum class AllowMultipleFiles;
 enum class MediaSeekMode;
 enum class SandboxingFlagSet;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -226,6 +226,7 @@ private:
     void update_shadow_tree();
     void create_text_input_shadow_tree();
     void create_color_input_shadow_tree();
+    void create_file_input_shadow_tree();
     void create_range_input_shadow_tree();
     WebIDL::ExceptionOr<void> run_input_activation_behavior(DOM::Event const&);
     void set_checked_within_group();
@@ -254,6 +255,10 @@ private:
 
     void update_color_well_element();
     JS::GCPtr<DOM::Element> m_color_well_element;
+
+    void update_file_input_shadow_tree();
+    JS::GCPtr<DOM::Element> m_file_button;
+    JS::GCPtr<DOM::Element> m_file_label;
 
     void update_slider_thumb_element();
     JS::GCPtr<DOM::Element> m_slider_thumb;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -94,6 +94,8 @@ public:
 
     void did_pick_color(Optional<Color> picked_color);
 
+    void did_select_files(Span<SelectedFile> selected_files);
+
     JS::GCPtr<FileAPI::FileList> files();
     void set_files(JS::GCPtr<FileAPI::FileList>);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -223,6 +223,7 @@ private:
 
     static TypeAttributeState parse_type_attribute(StringView);
     void create_shadow_tree_if_needed();
+    void update_shadow_tree();
     void create_text_input_shadow_tree();
     void create_color_input_shadow_tree();
     void create_range_input_shadow_tree();

--- a/Userland/Libraries/LibWeb/HTML/SelectedFile.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SelectedFile.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <LibCore/File.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/SelectedFile.h>
+
+namespace Web::HTML {
+
+ErrorOr<SelectedFile> SelectedFile::from_file_path(ByteString const& file_path)
+{
+    // https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file):concept-input-file-path
+    // Filenames must not contain path components, even in the case that a user has selected an entire directory
+    // hierarchy or multiple files with the same name from different directories.
+    auto name = LexicalPath::basename(file_path);
+
+    auto file = TRY(Core::File::open(file_path, Core::File::OpenMode::Read));
+    return SelectedFile { move(name), IPC::File { *file } };
+}
+
+SelectedFile::SelectedFile(ByteString name, ByteBuffer contents)
+    : m_name(move(name))
+    , m_file_or_contents(move(contents))
+{
+}
+
+SelectedFile::SelectedFile(ByteString name, IPC::File file)
+    : m_name(move(name))
+    , m_file_or_contents(move(file))
+{
+}
+
+ByteBuffer SelectedFile::take_contents()
+{
+    VERIFY(m_file_or_contents.has<ByteBuffer>());
+    return move(m_file_or_contents.get<ByteBuffer>());
+}
+
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SelectedFile const& file)
+{
+    TRY(encoder.encode(file.name()));
+    TRY(encoder.encode(file.file_or_contents()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::SelectedFile> IPC::decode(Decoder& decoder)
+{
+    auto name = TRY(decoder.decode<ByteString>());
+    auto file_or_contents = TRY((decoder.decode<Variant<IPC::File, ByteBuffer>>()));
+
+    ByteBuffer contents;
+
+    if (file_or_contents.has<IPC::File>()) {
+        auto file = TRY(Core::File::adopt_fd(file_or_contents.get<IPC::File>().take_fd(), Core::File::OpenMode::Read));
+        contents = TRY(file->read_until_eof());
+    } else {
+        contents = move(file_or_contents.get<ByteBuffer>());
+    }
+
+    return Web::HTML::SelectedFile { move(name), move(contents) };
+}

--- a/Userland/Libraries/LibWeb/HTML/SelectedFile.h
+++ b/Userland/Libraries/LibWeb/HTML/SelectedFile.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
+#include <AK/Variant.h>
+#include <LibIPC/File.h>
+#include <LibIPC/Forward.h>
+
+namespace Web::HTML {
+
+enum class AllowMultipleFiles {
+    No,
+    Yes,
+};
+
+class SelectedFile {
+public:
+    static ErrorOr<SelectedFile> from_file_path(ByteString const& file_path);
+
+    SelectedFile(ByteString name, ByteBuffer contents);
+    SelectedFile(ByteString name, IPC::File file);
+
+    ByteString const& name() const { return m_name; }
+    auto const& file_or_contents() const { return m_file_or_contents; }
+    ByteBuffer take_contents();
+
+private:
+    ByteString m_name;
+    Variant<IPC::File, ByteBuffer> m_file_or_contents;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::SelectedFile const&);
+
+template<>
+ErrorOr<Web::HTML::SelectedFile> decode(Decoder&);
+
+}

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -134,12 +134,16 @@ public:
     void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
     void color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUpdateState state);
 
+    void did_request_file_picker(WeakPtr<HTML::HTMLInputElement> target, HTML::AllowMultipleFiles);
+    void file_picker_closed(Span<HTML::SelectedFile> selected_files);
+
     void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items);
     void select_dropdown_closed(Optional<String> value);
 
     enum class PendingNonBlockingDialog {
         None,
         ColorPicker,
+        FilePicker,
         Select,
     };
 
@@ -280,8 +284,8 @@ public:
     virtual void request_file(FileRequest) = 0;
 
     // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
-    virtual void page_did_request_file_picker(WeakPtr<DOM::EventTarget>, [[maybe_unused]] bool multiple) {};
     virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) {};
+    virtual void page_did_request_file_picker(Web::HTML::AllowMultipleFiles) {};
     virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) {};
 
     virtual void page_did_finish_text_test() {};

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -250,6 +250,11 @@ void ViewImplementation::color_picker_update(Optional<Color> picked_color, Web::
     client().async_color_picker_update(page_id(), picked_color, state);
 }
 
+void ViewImplementation::file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files)
+{
+    client().async_file_picker_closed(page_id(), move(selected_files));
+}
+
 void ViewImplementation::select_dropdown_closed(Optional<String> value)
 {
     client().async_select_dropdown_closed(page_id(), value);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -86,6 +86,7 @@ public:
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
     void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
+    void file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files);
     void select_dropdown_closed(Optional<String> value);
 
     void toggle_media_play_state();
@@ -164,6 +165,7 @@ public:
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
     Function<void(Color current_color)> on_request_color_picker;
+    Function<void(Web::HTML::AllowMultipleFiles)> on_request_file_picker;
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;
     Function<void(bool)> on_finish_handling_input_event;
     Function<void()> on_text_test_finish;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -806,6 +806,19 @@ void WebContentClient::did_request_color_picker(u64 page_id, Color const& curren
         view.on_request_color_picker(current_color);
 }
 
+void WebContentClient::did_request_file_picker(u64 page_id, Web::HTML::AllowMultipleFiles allow_multiple_files)
+{
+    auto maybe_view = m_views.get(page_id);
+    if (!maybe_view.has_value()) {
+        dbgln("Received request file picker for unknown page ID {}", page_id);
+        return;
+    }
+    auto& view = *maybe_view.value();
+
+    if (view.on_request_file_picker)
+        view.on_request_file_picker(allow_multiple_files);
+}
+
 void WebContentClient::did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items)
 {
     auto maybe_view = m_views.get(page_id);

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -89,6 +89,7 @@ private:
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window(u64 page_id) override;
     virtual void did_request_file(u64 page_id, ByteString const& path, i32) override;
     virtual void did_request_color_picker(u64 page_id, Color const& current_color) override;
+    virtual void did_request_file_picker(u64 page_id, Web::HTML::AllowMultipleFiles) override;
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items) override;
     virtual void did_finish_handling_input_event(u64 page_id, bool event_was_accepted) override;
     virtual void did_finish_text_test(u64 page_id) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -28,6 +28,8 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/Storage.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
@@ -1315,6 +1317,18 @@ void ConnectionFromClient::color_picker_update(u64 page_id, Optional<Color> cons
     auto& page = maybe_page.release_value();
 
     page.page().color_picker_update(picked_color, state);
+}
+
+void ConnectionFromClient::file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> const& selected_files)
+{
+    auto maybe_page = page(page_id);
+    if (!maybe_page.has_value()) {
+        dbgln("ConnectionFromClient::color_picker_update: No page with ID {}", page_id);
+        return;
+    }
+
+    auto& page = maybe_page.release_value();
+    page.page().file_picker_closed(const_cast<Vector<Web::HTML::SelectedFile>&>(selected_files));
 }
 
 void ConnectionFromClient::select_dropdown_closed(u64 page_id, Optional<String> const& value)

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -106,6 +106,7 @@ private:
     virtual void confirm_closed(u64 page_id, bool accepted) override;
     virtual void prompt_closed(u64 page_id, Optional<String> const& response) override;
     virtual void color_picker_update(u64 page_id, Optional<Color> const& picked_color, Web::HTML::ColorPickerUpdateState const& state) override;
+    virtual void file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> const& selected_files) override;
     virtual void select_dropdown_closed(u64 page_id, Optional<String> const& value) override;
 
     virtual void toggle_media_play_state(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -549,6 +549,11 @@ void PageClient::page_did_request_color_picker(Color current_color)
     client().async_did_request_color_picker(m_id, current_color);
 }
 
+void PageClient::page_did_request_file_picker(Web::HTML::AllowMultipleFiles allow_multiple_files)
+{
+    client().async_did_request_file_picker(m_id, allow_multiple_files);
+}
+
 void PageClient::page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items)
 {
     client().async_did_request_select_dropdown(m_id, page().css_to_device_point(content_position).to_type<int>(), minimum_width * device_pixels_per_css_pixel(), items);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -133,6 +133,7 @@ private:
     virtual void page_did_close_top_level_traversable() override;
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;
+    virtual void page_did_request_file_picker(Web::HTML::AllowMultipleFiles) override;
     virtual void page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void page_did_finish_text_test() override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -6,6 +6,7 @@
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/Page/Page.h>
@@ -70,6 +71,7 @@ endpoint WebContentClient
     did_request_fullscreen_window(u64 page_id) => (Gfx::IntRect window_rect)
     did_request_file(u64 page_id, ByteString path, i32 request_id) =|
     did_request_color_picker(u64 page_id, Color current_color) =|
+    did_request_file_picker(u64 page_id, Web::HTML::AllowMultipleFiles allow_multiple_files) =|
     did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) =|
     did_finish_handling_input_event(u64 page_id, bool event_was_accepted) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -6,6 +6,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
+#include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWebView/Attribute.h>
 
@@ -93,6 +94,7 @@ endpoint WebContentServer
     confirm_closed(u64 page_id, bool accepted) =|
     prompt_closed(u64 page_id, Optional<String> response) =|
     color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) =|
+    file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> selected_files) =|
     select_dropdown_closed(u64 page_id, Optional<String> value) =|
 
     toggle_media_play_state(u64 page_id) =|

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/ByteBuffer.h>
 #include <AK/ByteString.h>
 #include <AK/Function.h>
 #include <AK/JsonObject.h>
@@ -44,6 +45,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/Database.h>
@@ -433,6 +435,21 @@ static ErrorOr<TestResult> run_test(HeadlessWebContentView& view, StringView inp
         promise->resolve({});
     };
     view.on_text_test_finish = {};
+
+    view.on_request_file_picker = [&](auto allow_multiple_files) {
+        // Create some dummy files for tests.
+        Vector<Web::HTML::SelectedFile> selected_files;
+        selected_files.empend("file1"sv, MUST(ByteBuffer::copy("Contents for file1"sv.bytes())));
+
+        if (allow_multiple_files == Web::HTML::AllowMultipleFiles::Yes) {
+            selected_files.empend("file2"sv, MUST(ByteBuffer::copy("Contents for file2"sv.bytes())));
+            selected_files.empend("file3"sv, MUST(ByteBuffer::copy("Contents for file3"sv.bytes())));
+            selected_files.empend("file4"sv, MUST(ByteBuffer::copy("Contents for file4"sv.bytes())));
+        }
+
+        view.file_picker_closed(move(selected_files));
+    };
+
     view.load(URL("about:blank"sv));
     MUST(promise->await());
 


### PR DESCRIPTION
This creates a shadow tree for the default UA interface, and finishes the plumbing for using chrome-specific file pickers:

https://github.com/SerenityOS/serenity/assets/5600524/8be95db4-a78a-4794-9281-d2e5d350a3b7

Which also lets us open files on https://vscode.dev/:

https://github.com/SerenityOS/serenity/assets/5600524/de854c7c-7712-490f-b352-90a255c8232d


