### PR TITLE
LibWeb: Skip StackingContext with erroneously large rect in GPU painter

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
@@ -93,6 +93,13 @@ CommandResult CommandExecutorGPU::push_stacking_context(float opacity, bool is_f
     if (source_paintable_rect.is_empty())
         return CommandResult::SkipStackingContext;
 
+    // If, due to layout mistakes, we encounter an excessively large rectangle here, it must be skipped to prevent
+    // framebuffer allocation failure.
+    if (source_paintable_rect.width() > 10000 || source_paintable_rect.height() > 10000) {
+        dbgln("FIXME: Skipping stacking context with excessively large paintable rect: {}", source_paintable_rect);
+        return CommandResult::SkipStackingContext;
+    }
+
     m_stacking_contexts.last().stacking_context_depth++;
     painter().save();
     if (is_fixed_position) {


### PR DESCRIPTION
If the GPU painter encounters a stacking context that requires the allocation of a framebuffer so large, it is likely due to a layout mistake, for now, we can skip it instead of crashing because of a failed allocation.

Fixes https://github.com/SerenityOS/serenity/issues/22608