### PR TITLE
LibWeb: Make ImagePaintable depend less on DOM and layout nodes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/Ratio.h>
 #include <LibWeb/CSS/Size.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 #include <LibWeb/CSS/Transformation.h>
 
@@ -74,6 +75,13 @@ struct ResolvedBackdropFilter {
     bool is_none() const { return filters.size() == 0; }
 
     Vector<FilterFunction> filters;
+};
+
+struct ObjectPosition {
+    PositionEdge edge_x { PositionEdge::Left };
+    CSS::LengthPercentage offset_x { Percentage(50) };
+    PositionEdge edge_y { PositionEdge::Top };
+    CSS::LengthPercentage offset_y { Percentage(50) };
 };
 
 class InitialValues {
@@ -154,6 +162,7 @@ public:
     static Vector<Vector<String>> grid_template_areas() { return {}; }
     static CSS::Time transition_delay() { return CSS::Time::make_seconds(0); }
     static CSS::ObjectFit object_fit() { return CSS::ObjectFit::Fill; }
+    static CSS::ObjectPosition object_position() { return {}; }
     static Color outline_color() { return Color::Black; }
     static CSS::Length outline_offset() { return CSS::Length::make_px(0); }
     static CSS::OutlineStyle outline_style() { return CSS::OutlineStyle::None; }
@@ -359,6 +368,7 @@ public:
     CSS::BorderCollapse border_collapse() const { return m_inherited.border_collapse; }
     Vector<Vector<String>> const& grid_template_areas() const { return m_noninherited.grid_template_areas; }
     CSS::ObjectFit object_fit() const { return m_noninherited.object_fit; }
+    CSS::ObjectPosition object_position() const { return m_noninherited.object_position; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -548,6 +558,7 @@ protected:
         CSS::Length outline_width { InitialValues::outline_width() };
         CSS::TableLayout table_layout { InitialValues::table_layout() };
         CSS::ObjectFit object_fit { InitialValues::object_fit() };
+        CSS::ObjectPosition object_position { InitialValues::object_position() };
 
         Optional<MaskReference> mask;
         CSS::MaskType mask_type { InitialValues::mask_type() };
@@ -660,6 +671,7 @@ public:
     void set_table_layout(CSS::TableLayout value) { m_noninherited.table_layout = value; }
     void set_quotes(CSS::QuotesData value) { m_inherited.quotes = value; }
     void set_object_fit(CSS::ObjectFit value) { m_noninherited.object_fit = value; }
+    void set_object_position(CSS::ObjectPosition value) { m_noninherited.object_position = value; }
 
     void set_fill(SVGPaint value) { m_inherited.fill = value; }
     void set_stroke(SVGPaint value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -358,6 +358,7 @@ public:
     CSS::Size const& row_gap() const { return m_noninherited.row_gap; }
     CSS::BorderCollapse border_collapse() const { return m_inherited.border_collapse; }
     Vector<Vector<String>> const& grid_template_areas() const { return m_noninherited.grid_template_areas; }
+    CSS::ObjectFit object_fit() const { return m_noninherited.object_fit; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -546,6 +547,7 @@ protected:
         CSS::OutlineStyle outline_style { InitialValues::outline_style() };
         CSS::Length outline_width { InitialValues::outline_width() };
         CSS::TableLayout table_layout { InitialValues::table_layout() };
+        CSS::ObjectFit object_fit { InitialValues::object_fit() };
 
         Optional<MaskReference> mask;
         CSS::MaskType mask_type { InitialValues::mask_type() };
@@ -657,6 +659,7 @@ public:
     void set_transition_delay(CSS::Time const& transition_delay) { m_noninherited.transition_delay = transition_delay; }
     void set_table_layout(CSS::TableLayout value) { m_noninherited.table_layout = value; }
     void set_quotes(CSS::QuotesData value) { m_inherited.quotes = value; }
+    void set_object_fit(CSS::ObjectFit value) { m_noninherited.object_fit = value; }
 
     void set_fill(SVGPaint value) { m_inherited.fill = value; }
     void set_stroke(SVGPaint value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -1026,10 +1026,24 @@ Optional<CSS::ObjectFit> StyleProperties::object_fit() const
     return value_id_to_object_fit(value->to_identifier());
 }
 
-CSS::PositionStyleValue const& StyleProperties::object_position() const
+CSS::ObjectPosition StyleProperties::object_position() const
 {
     auto value = property(CSS::PropertyID::ObjectPosition);
-    return value->as_position();
+    auto const& position = value->as_position();
+    CSS::ObjectPosition object_position;
+    auto const& edge_x = position.edge_x();
+    auto const& edge_y = position.edge_y();
+    if (edge_x->is_edge()) {
+        auto const& edge = edge_x->as_edge();
+        object_position.edge_x = edge.edge();
+        object_position.offset_x = edge.offset();
+    }
+    if (edge_y->is_edge()) {
+        auto const& edge = edge_y->as_edge();
+        object_position.edge_y = edge.edge();
+        object_position.offset_y = edge.offset();
+    }
+    return object_position;
 }
 
 Optional<CSS::TableLayout> StyleProperties::table_layout() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -114,7 +114,7 @@ public:
     Vector<Vector<String>> grid_template_areas() const;
     String grid_area() const;
     Optional<CSS::ObjectFit> object_fit() const;
-    CSS::PositionStyleValue const& object_position() const;
+    CSS::ObjectPosition object_position() const;
     Optional<CSS::TableLayout> table_layout() const;
 
     static Vector<CSS::Transformation> transformations_for_style_value(StyleValue const& value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -91,6 +91,7 @@ public:
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
+    virtual JS::NonnullGCPtr<DOM::Element const> to_html_element() const override { return *this; }
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -205,6 +205,7 @@ private:
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
+    virtual JS::NonnullGCPtr<DOM::Element const> to_html_element() const override { return *this; }
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -81,6 +81,7 @@ private:
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
+    virtual JS::NonnullGCPtr<DOM::Element const> to_html_element() const override { return *this; }
 
     Representation m_representation { Representation::Unknown };
 

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -22,6 +22,12 @@ ImageBox::ImageBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr
 
 ImageBox::~ImageBox() = default;
 
+void ImageBox::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_image_provider.to_html_element());
+}
+
 void ImageBox::prepare_for_replaced_layout()
 {
     set_natural_width(m_image_provider.intrinsic_width());

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.h
@@ -32,6 +32,8 @@ public:
     void dom_node_did_update_alt_text(Badge<ImageProvider>);
 
 private:
+    virtual void visit_edges(Visitor&) override;
+
     ImageProvider const& m_image_provider;
 
     Optional<CSSPixels> m_cached_alt_text_width;

--- a/Userland/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageProvider.h
@@ -25,6 +25,8 @@ public:
     virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize) const = 0;
     virtual void set_visible_in_viewport(bool) = 0;
 
+    virtual JS::NonnullGCPtr<DOM::Element const> to_html_element() const = 0;
+
 protected:
     static void did_update_alt_text(ImageBox&);
 };

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -830,6 +830,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_math_depth(computed_style.math_depth());
     computed_values.set_quotes(computed_style.quotes());
 
+    if (auto object_fit = computed_style.object_fit(); object_fit.has_value())
+        computed_values.set_object_fit(object_fit.value());
+
     propagate_style_to_anonymous_wrappers();
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -833,6 +833,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (auto object_fit = computed_style.object_fit(); object_fit.has_value())
         computed_values.set_object_fit(object_fit.value());
 
+    computed_values.set_object_position(computed_style.object_position());
+
     propagate_style_to_anonymous_wrappers();
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -72,7 +72,6 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             auto bitmap_rect = bitmap->rect();
             auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), bitmap_rect, image_int_rect);
             auto& dom_element = verify_cast<DOM::Element>(*dom_node());
-            auto object_fit = dom_element.computed_css_values()->object_fit();
             auto bitmap_aspect_ratio = (float)bitmap_rect.height() / bitmap_rect.width();
             auto image_aspect_ratio = (float)image_rect.height().value() / image_rect.width().value();
 
@@ -80,12 +79,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             auto scale_y = 0.0f;
             Gfx::IntRect bitmap_intersect = bitmap_rect;
 
-            auto object_fit_value = CSS::InitialValues::object_fit();
-
-            if (object_fit.has_value())
-                object_fit_value = object_fit.value();
-
-            switch (object_fit_value) {
+            switch (computed_values().object_fit()) {
             case CSS::ObjectFit::Fill:
                 scale_x = (float)image_int_rect.width() / bitmap_rect.width();
                 scale_y = (float)image_int_rect.height() / bitmap_rect.height();

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -71,7 +71,6 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             auto image_int_rect = image_rect.to_type<int>();
             auto bitmap_rect = bitmap->rect();
             auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), bitmap_rect, image_int_rect);
-            auto& dom_element = verify_cast<DOM::Element>(*dom_node());
             auto bitmap_aspect_ratio = (float)bitmap_rect.height() / bitmap_rect.width();
             auto image_aspect_ratio = (float)image_rect.height().value() / image_rect.width().value();
 
@@ -121,37 +120,27 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             bitmap_intersect.set_x((bitmap_rect.width() - bitmap_intersect.width()) / 2);
             bitmap_intersect.set_y((bitmap_rect.height() - bitmap_intersect.height()) / 2);
 
-            CSS::PositionStyleValue const& object_position = dom_element.computed_css_values()->object_position();
+            auto const& object_position = computed_values().object_position();
 
             auto offset_x = 0;
-            auto const& horizontal = object_position.edge_x();
-            if (horizontal->is_edge()) {
-                auto const& horizontal_edge = horizontal->as_edge();
-                auto const& offset = horizontal_edge.offset();
-                if (horizontal_edge.edge() == CSS::PositionEdge::Left) {
-                    offset_x = offset.to_px(layout_node(), residual_horizontal).to_int();
-                    bitmap_intersect.set_x(0);
-                } else if (horizontal_edge.edge() == CSS::PositionEdge::Right) {
-                    offset_x = residual_horizontal.to_int() - offset.to_px(layout_node(), residual_horizontal).to_int();
-                }
-                if (image_int_rect.width() < scaled_bitmap_width)
-                    bitmap_intersect.set_x(-(offset_x / scale_x));
+            if (object_position.edge_x == CSS::PositionEdge::Left) {
+                offset_x = object_position.offset_x.to_px(layout_node(), residual_horizontal).to_int();
+                bitmap_intersect.set_x(0);
+            } else if (object_position.edge_x == CSS::PositionEdge::Right) {
+                offset_x = residual_horizontal.to_int() - object_position.offset_x.to_px(layout_node(), residual_horizontal).to_int();
             }
+            if (image_int_rect.width() < scaled_bitmap_width)
+                bitmap_intersect.set_x(-(offset_x / scale_x));
 
             auto offset_y = 0;
-            auto const& vertical = object_position.edge_y();
-            if (vertical->is_edge()) {
-                auto const& vertical_edge = vertical->as_edge();
-                auto const& offset = vertical_edge.offset();
-                if (vertical_edge.edge() == CSS::PositionEdge::Top) {
-                    offset_y = offset.to_px(layout_node(), residual_vertical).to_int();
-                    bitmap_intersect.set_y(0);
-                } else if (vertical_edge.edge() == CSS::PositionEdge::Bottom) {
-                    offset_y = residual_vertical.to_int() - offset.to_px(layout_node(), residual_vertical).to_int();
-                }
-                if (image_int_rect.height() < scaled_bitmap_height)
-                    bitmap_intersect.set_y(-(offset_y / scale_y));
+            if (object_position.edge_y == CSS::PositionEdge::Top) {
+                offset_y = object_position.offset_y.to_px(layout_node(), residual_vertical).to_int();
+                bitmap_intersect.set_y(0);
+            } else if (object_position.edge_y == CSS::PositionEdge::Bottom) {
+                offset_y = residual_vertical.to_int() - object_position.offset_y.to_px(layout_node(), residual_vertical).to_int();
             }
+            if (image_int_rect.height() < scaled_bitmap_height)
+                bitmap_intersect.set_y(-(offset_y / scale_y));
 
             Gfx::IntRect draw_rect = {
                 image_int_rect.x() + offset_x,

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -121,8 +121,8 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             auto scaled_bitmap_width = bitmap_rect.width() * scale_x;
             auto scaled_bitmap_height = bitmap_rect.height() * scale_y;
 
-            auto residual_horizontal = image_int_rect.width() - scaled_bitmap_width;
-            auto residual_vertical = image_int_rect.height() - scaled_bitmap_height;
+            auto residual_horizontal = CSSPixels::nearest_value_for(image_int_rect.width() - scaled_bitmap_width);
+            auto residual_vertical = CSSPixels::nearest_value_for(image_int_rect.height() - scaled_bitmap_height);
 
             bitmap_intersect.set_x((bitmap_rect.width() - bitmap_intersect.width()) / 2);
             bitmap_intersect.set_y((bitmap_rect.height() - bitmap_intersect.height()) / 2);
@@ -135,17 +135,10 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
                 auto const& horizontal_edge = horizontal->as_edge();
                 auto const& offset = horizontal_edge.offset();
                 if (horizontal_edge.edge() == CSS::PositionEdge::Left) {
-                    if (offset.is_percentage())
-                        offset_x = (double)(residual_horizontal)*offset.percentage().as_fraction();
-                    else
-                        offset_x = offset.length().to_px(layout_node()).to_int();
-
+                    offset_x = offset.to_px(layout_node(), residual_horizontal).to_int();
                     bitmap_intersect.set_x(0);
                 } else if (horizontal_edge.edge() == CSS::PositionEdge::Right) {
-                    if (offset.is_percentage())
-                        offset_x = (double)residual_horizontal - (double)(residual_horizontal)*offset.percentage().as_fraction();
-                    else
-                        offset_x = residual_horizontal - offset.length().to_px(layout_node()).to_int();
+                    offset_x = residual_horizontal.to_int() - offset.to_px(layout_node(), residual_horizontal).to_int();
                 }
                 if (image_int_rect.width() < scaled_bitmap_width)
                     bitmap_intersect.set_x(-(offset_x / scale_x));
@@ -157,17 +150,10 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
                 auto const& vertical_edge = vertical->as_edge();
                 auto const& offset = vertical_edge.offset();
                 if (vertical_edge.edge() == CSS::PositionEdge::Top) {
-                    if (offset.is_percentage())
-                        offset_y = (double)(residual_vertical)*offset.percentage().as_fraction();
-                    else
-                        offset_y = offset.length().to_px(layout_node()).to_int();
-
+                    offset_y = offset.to_px(layout_node(), residual_vertical).to_int();
                     bitmap_intersect.set_y(0);
                 } else if (vertical_edge.edge() == CSS::PositionEdge::Bottom) {
-                    if (offset.is_percentage())
-                        offset_y = (double)residual_vertical - (double)(residual_vertical)*offset.percentage().as_fraction();
-                    else
-                        offset_y = residual_vertical - offset.length().to_px(layout_node()).to_int();
+                    offset_y = residual_vertical.to_int() - offset.to_px(layout_node(), residual_vertical).to_int();
                 }
                 if (image_int_rect.height() < scaled_bitmap_height)
                     bitmap_intersect.set_y(-(offset_y / scale_y));

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
@@ -25,6 +25,7 @@ public:
 
 private:
     // ^JS::Cell
+    virtual void visit_edges(Visitor&) override;
     virtual void finalize() override;
 
     // ^Document::ViewportClient
@@ -34,6 +35,8 @@ private:
 
     bool m_renders_as_alt_text { false };
     String m_alt_text;
+
+    Layout::ImageProvider const& m_image_provider;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
@@ -30,7 +30,10 @@ private:
     // ^Document::ViewportClient
     virtual void did_set_viewport_rect(CSSPixelRect const&) final;
 
-    ImagePaintable(Layout::ImageBox const&);
+    ImagePaintable(Layout::ImageBox const&, String alt_text);
+
+    bool m_renders_as_alt_text { false };
+    String m_alt_text;
 };
 
 }


### PR DESCRIPTION
- add `object-fit` and `object-position` into `ComputedValues` and get it from there instead of reaching into DOM node.
- save alt text and image provider in image paintable to avoid reaching into layout node while painting commands recording.