### PR TITLE
LibWebView: Reduce overhead of updating a cookie's last access time

### DIFF
--- a/Userland/Libraries/LibWebView/CookieJar.h
+++ b/Userland/Libraries/LibWebView/CookieJar.h
@@ -33,6 +33,7 @@ class CookieJar {
         SQL::StatementID create_table { 0 };
         SQL::StatementID insert_cookie { 0 };
         SQL::StatementID update_cookie { 0 };
+        SQL::StatementID update_cookie_last_access_time { 0 };
         SQL::StatementID expire_cookie { 0 };
         SQL::StatementID select_cookie { 0 };
         SQL::StatementID select_all_cookies { 0 };
@@ -76,6 +77,7 @@ private:
 
     void insert_cookie_into_database(Web::Cookie::Cookie const& cookie);
     void update_cookie_in_database(Web::Cookie::Cookie const& cookie);
+    void update_cookie_last_access_time_in_database(Web::Cookie::Cookie const& cookie);
 
     using OnCookieFound = Function<void(Web::Cookie::Cookie&, Web::Cookie::Cookie)>;
     using OnCookieNotFound = Function<void(Web::Cookie::Cookie)>;


### PR DESCRIPTION
Getting a document's cookie value currently involves:

1. Doing a large `SELECT` statement and filtering the results to match the document and some query parameters based on the cookie RFC.
2. For every cookie selected this way, doing an `UPDATE` to set its last access time.
3. For every `UPDATE`, do a `DELETE` to remove all expired cookies.

There's no need to perform cookie expiration for every `UPDATE`. Instead, we can do the expiration once after all the `UPDATE`s are complete.

This reduces time spent waiting for cookies on https://twinings.co.uk from ~1.9s to ~1.3s on my machine.

Ref #23307
This is obviously not a full solution, but is a trivial change that should reduce the pain a bit.