### PR TITLE
LibWeb: Use WebIDL types where possible instead of C types

### DIFF
--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -55,9 +55,9 @@ TextEncoderEncodeIntoResult TextEncoder::encode_into(String const& source, JS::H
     auto& data = destination->viewed_array_buffer()->buffer();
 
     // 1. Let read be 0.
-    unsigned long long read = 0;
+    WebIDL::UnsignedLongLong read = 0;
     // 2. Let written be 0.
-    unsigned long long written = 0;
+    WebIDL::UnsignedLongLong written = 0;
 
     // NOTE: The AK::String is always UTF-8, so most of these steps are no-ops.
     // 3. Let encoder be an instance of the UTF-8 encoder.

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
@@ -13,13 +13,14 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebIDL/Buffers.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::Encoding {
 
 // https://encoding.spec.whatwg.org/#dictdef-textencoderencodeintoresult
 struct TextEncoderEncodeIntoResult {
-    unsigned long long read;
-    unsigned long long written;
+    WebIDL::UnsignedLongLong read;
+    WebIDL::UnsignedLongLong written;
 };
 
 // https://encoding.spec.whatwg.org/#textencoder

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.h
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.h
@@ -11,6 +11,7 @@
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/FileAPI/File.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::FileAPI {
 
@@ -23,7 +24,7 @@ public:
     virtual ~FileList() override;
 
     // https://w3c.github.io/FileAPI/#dfn-length
-    unsigned long length() const { return m_files.size(); }
+    WebIDL::UnsignedLong length() const { return m_files.size(); }
 
     // https://w3c.github.io/FileAPI/#dfn-item
     File* item(size_t index)

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1740,19 +1740,19 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value_as_number(double value)
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-stepup
-WebIDL::ExceptionOr<void> HTMLInputElement::step_up(long n)
+WebIDL::ExceptionOr<void> HTMLInputElement::step_up(WebIDL::Long n)
 {
     return step_up_or_down(false, n);
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-stepdown
-WebIDL::ExceptionOr<void> HTMLInputElement::step_down(long n)
+WebIDL::ExceptionOr<void> HTMLInputElement::step_down(WebIDL::Long n)
 {
     return step_up_or_down(true, n);
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-stepup
-WebIDL::ExceptionOr<void> HTMLInputElement::step_up_or_down(bool is_down, long n)
+WebIDL::ExceptionOr<void> HTMLInputElement::step_up_or_down(bool is_down, WebIDL::Long n)
 {
     // 1. If the stepDown() and stepUp() methods do not apply, as defined for the input element's type attribute's current state, then throw an "InvalidStateError" DOMException.
     if (!step_up_or_down_applies())

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -118,8 +118,8 @@ public:
     double value_as_number() const;
     WebIDL::ExceptionOr<void> set_value_as_number(double value);
 
-    WebIDL::ExceptionOr<void> step_up(long n = 1);
-    WebIDL::ExceptionOr<void> step_down(long n = 1);
+    WebIDL::ExceptionOr<void> step_up(WebIDL::Long n = 1);
+    WebIDL::ExceptionOr<void> step_down(WebIDL::Long n = 1);
 
     WebIDL::ExceptionOr<bool> check_validity();
     WebIDL::ExceptionOr<bool> report_validity();
@@ -221,7 +221,7 @@ private:
     double step_scale_factor() const;
     Optional<double> allowed_value_step() const;
     double step_base() const;
-    WebIDL::ExceptionOr<void> step_up_or_down(bool is_down, long n);
+    WebIDL::ExceptionOr<void> step_up_or_down(bool is_down, WebIDL::Long n);
 
     static TypeAttributeState parse_type_attribute(StringView);
     void create_shadow_tree_if_needed();

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -382,7 +382,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableElement::rows()
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-table-insertrow
-WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::insert_row(long index)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::insert_row(WebIDL::Long index)
 {
     auto rows = this->rows();
     auto rows_length = rows->length();
@@ -408,7 +408,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::ins
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-table-deleterow
-WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(long index)
+WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(WebIDL::Long index)
 {
     auto rows = this->rows();
     auto rows_length = rows->length();

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/HTMLTableRowElement.h>
 #include <LibWeb/HTML/HTMLTableSectionElement.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
@@ -40,8 +41,8 @@ public:
     JS::NonnullGCPtr<HTMLTableSectionElement> create_t_body();
 
     JS::NonnullGCPtr<DOM::HTMLCollection> rows();
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> insert_row(long index);
-    WebIDL::ExceptionOr<void> delete_row(long index);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> insert_row(WebIDL::Long index);
+    WebIDL::ExceptionOr<void> delete_row(WebIDL::Long index);
 
     // https://www.w3.org/TR/html-aria/#el-table
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::table; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -49,7 +49,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableSectionElement::rows() const
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-tbody-insertrow
-WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionElement::insert_row(long index)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionElement::insert_row(WebIDL::Long index)
 {
     auto rows_collection = rows();
     auto rows_collection_size = static_cast<long>(rows_collection->length());
@@ -73,7 +73,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionEleme
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-tbody-deleterow
-WebIDL::ExceptionOr<void> HTMLTableSectionElement::delete_row(long index)
+WebIDL::ExceptionOr<void> HTMLTableSectionElement::delete_row(WebIDL::Long index)
 {
     auto rows_collection = rows();
     auto rows_collection_size = static_cast<long>(rows_collection->length());

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
@@ -20,8 +21,8 @@ public:
     virtual ~HTMLTableSectionElement() override;
 
     JS::NonnullGCPtr<DOM::HTMLCollection> rows() const;
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> insert_row(long index);
-    WebIDL::ExceptionOr<void> delete_row(long index);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> insert_row(WebIDL::Long index);
+    WebIDL::ExceptionOr<void> delete_row(WebIDL::Long index);
 
     // https://www.w3.org/TR/html-aria/#el-tbody
     // https://www.w3.org/TR/html-aria/#el-tfoot

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -78,7 +78,7 @@ WebIDL::ExceptionOr<JS::Value> History::state() const
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-go
-WebIDL::ExceptionOr<void> History::go(long delta = 0)
+WebIDL::ExceptionOr<void> History::go(WebIDL::Long delta = 0)
 {
     // 1. Let document be this's associated Document.
 

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -10,6 +10,7 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
@@ -24,7 +25,7 @@ public:
 
     WebIDL::ExceptionOr<void> push_state(JS::Value data, String const& unused, Optional<String> const& url = {});
     WebIDL::ExceptionOr<void> replace_state(JS::Value data, String const& unused, Optional<String> const& url = {});
-    WebIDL::ExceptionOr<void> go(long delta);
+    WebIDL::ExceptionOr<void> go(WebIDL::Long delta);
     WebIDL::ExceptionOr<void> back();
     WebIDL::ExceptionOr<void> forward();
     WebIDL::ExceptionOr<u64> length() const;

--- a/Userland/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.h
@@ -6,12 +6,14 @@
 
 #pragma once
 
+#include <LibWeb/WebIDL/Types.h>
+
 namespace Web::HTML {
 
 class NavigatorConcurrentHardwareMixin {
 public:
     // https://html.spec.whatwg.org/multipage/workers.html#dom-navigator-hardwareconcurrency
-    unsigned long long hardware_concurrency() { return 1; }
+    WebIDL::UnsignedLongLong hardware_concurrency() { return 1; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -8,10 +8,11 @@
 
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/UIEvents/UIEvent.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::UIEvents {
 
-enum class WheelDeltaMode : unsigned long {
+enum class WheelDeltaMode : WebIDL::UnsignedLong {
     DOM_DELTA_PIXEL = 0,
     DOM_DELTA_LINE = 1,
     DOM_DELTA_PAGE = 2,
@@ -38,7 +39,7 @@ public:
     double delta_x() const { return m_delta_x; }
     double delta_y() const { return m_delta_y; }
     double delta_z() const { return m_delta_z; }
-    unsigned long delta_mode() const { return to_underlying(m_delta_mode); }
+    WebIDL::UnsignedLong delta_mode() const { return to_underlying(m_delta_mode); }
 
 private:
     WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);


### PR DESCRIPTION
Use the fancy WebIDL types where possible instead of C types

This commit is split of from https://github.com/SerenityOS/serenity/pull/22944 because that merge request is to big and getting stale