### PR TITLE
LibWeb+Ladybird/Qt: Improve timer precision

### DIFF
--- a/Ladybird/Qt/EventLoopImplementationQt.cpp
+++ b/Ladybird/Qt/EventLoopImplementationQt.cpp
@@ -91,6 +91,7 @@ static void qt_timer_fired(Core::TimerShouldFireWhenNotVisible should_fire_when_
 intptr_t EventLoopManagerQt::register_timer(Core::EventReceiver& object, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible)
 {
     auto timer = new QTimer;
+    timer->setTimerType(Qt::PreciseTimer);
     timer->setInterval(milliseconds);
     timer->setSingleShot(!should_reload);
     auto weak_object = object.make_weak_ptr();

--- a/Userland/Libraries/LibCore/ElapsedTimer.cpp
+++ b/Userland/Libraries/LibCore/ElapsedTimer.cpp
@@ -20,7 +20,7 @@ ElapsedTimer ElapsedTimer::start_new()
 void ElapsedTimer::start()
 {
     m_valid = true;
-    m_origin_time = m_precise ? MonotonicTime::now() : MonotonicTime::now_coarse();
+    m_origin_time = m_timer_type == TimerType::Precise ? MonotonicTime::now() : MonotonicTime::now_coarse();
 }
 
 void ElapsedTimer::reset()
@@ -36,7 +36,7 @@ i64 ElapsedTimer::elapsed_milliseconds() const
 Duration ElapsedTimer::elapsed_time() const
 {
     VERIFY(is_valid());
-    auto now = m_precise ? MonotonicTime::now() : MonotonicTime::now_coarse();
+    auto now = m_timer_type == TimerType::Precise ? MonotonicTime::now() : MonotonicTime::now_coarse();
     return now - m_origin_time;
 }
 

--- a/Userland/Libraries/LibCore/ElapsedTimer.h
+++ b/Userland/Libraries/LibCore/ElapsedTimer.h
@@ -10,12 +10,17 @@
 
 namespace Core {
 
+enum class TimerType {
+    Precise,
+    Coarse
+};
+
 class ElapsedTimer {
 public:
     static ElapsedTimer start_new();
 
-    ElapsedTimer(bool precise = false)
-        : m_precise(precise)
+    ElapsedTimer(TimerType timer_type = TimerType::Coarse)
+        : m_timer_type(timer_type)
     {
     }
 
@@ -36,7 +41,7 @@ public:
 
 private:
     MonotonicTime m_origin_time { MonotonicTime::now() };
-    bool m_precise { false };
+    TimerType m_timer_type { TimerType::Coarse };
     bool m_valid { false };
 };
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -52,7 +52,7 @@ JS::GCPtr<NavigationTiming::PerformanceTiming> Performance::timing()
 
 double Performance::time_origin() const
 {
-    return static_cast<double>(m_timer.origin_time().milliseconds());
+    return static_cast<double>(m_timer.origin_time().nanoseconds()) / 1e6;
 }
 
 // https://w3c.github.io/user-timing/#mark-method

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -23,6 +23,7 @@ JS_DEFINE_ALLOCATOR(Performance);
 Performance::Performance(HTML::Window& window)
     : DOM::EventTarget(window.realm())
     , m_window(window)
+    , m_timer(Core::TimerType::Precise)
 {
     m_timer.start();
 }

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
@@ -21,7 +21,7 @@ class Performance final : public DOM::EventTarget {
 public:
     virtual ~Performance() override;
 
-    double now() const { return static_cast<double>(m_timer.elapsed()); }
+    double now() const { return static_cast<double>(m_timer.elapsed_time().to_nanoseconds()) / 1e6; }
     double time_origin() const;
 
     JS::GCPtr<NavigationTiming::PerformanceTiming> timing();

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     }
     auto loader = maybe_loader.release_value();
 
-    Core::ElapsedTimer sample_timer { true };
+    Core::ElapsedTimer sample_timer { Core::TimerType::Precise };
     i64 total_loader_time = 0;
     int remaining_samples = sample_count > 0 ? sample_count : NumericLimits<int>::max();
     unsigned total_loaded_samples = 0;

--- a/Userland/Utilities/dd.cpp
+++ b/Userland/Utilities/dd.cpp
@@ -45,7 +45,7 @@ struct {
     size_t total_bytes_copied = 0;
     size_t total_blocks_in = 0, partial_blocks_in = 0;
     size_t total_blocks_out = 0, partial_blocks_out = 0;
-    Core::ElapsedTimer timer { true };
+    Core::ElapsedTimer timer { Core::TimerType::Precise };
 } statistics;
 
 static void closing_statistics()

--- a/Userland/Utilities/traceroute.cpp
+++ b/Userland/Utilities/traceroute.cpp
@@ -78,7 +78,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // 0: got ttl exhausted response
     // -1: error or no response
     auto try_reach_host = [&](int ttl) -> ErrorOr<int> {
-        Core::ElapsedTimer m_timer { true };
+        Core::ElapsedTimer m_timer { Core::TimerType::Precise };
         auto ttl_number = ByteString::number(ttl);
         for (auto i = 0; i < max_retries; i++) {
             icmp_request request {};


### PR DESCRIPTION
This PR includes changes that improve the accuracy and precision of timer events. See the individual commits for details.

I used the following test page to test timer precision and accuracy:

```html
<!DOCTYPE html>
<script>
    function sleepMilliseconds(delay) {
        return new Promise((resolve) => setTimeout(resolve, delay));
    }

    async function testTimerPrecision() {
        let previousTime = performance.now();
        const outputElement = document.getElementById("output");
        for (let i = 0; i < 10; ++i) {
            await sleepMilliseconds(100);
            const currentTime = performance.now();
            outputElement.appendChild(document.createTextNode(`Time elapsed: ${currentTime - previousTime} milliseconds\n`));
            previousTime = currentTime;
        }
    }
</script>
<body onload="testTimerPrecision()">
<pre id="output"></pre>
</body>
```

The results in QT Ladybird are as follows:

Before:
```
Time elapsed: 94 milliseconds
Time elapsed: 97 milliseconds
Time elapsed: 93 milliseconds
Time elapsed: 97 milliseconds
Time elapsed: 93 milliseconds
Time elapsed: 97 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 100 milliseconds
```

After:
```
Time elapsed: 101.21944400000001 milliseconds
Time elapsed: 100.653346 milliseconds
Time elapsed: 100.524011 milliseconds
Time elapsed: 100.56357700000001 milliseconds
Time elapsed: 100.51349099999999 milliseconds
Time elapsed: 100.38906799999995 milliseconds
Time elapsed: 100.70682600000009 milliseconds
Time elapsed: 100.85266200000001 milliseconds
Time elapsed: 100.93509699999993 milliseconds
Time elapsed: 100.71393 milliseconds
```

---

Results for Chrome and Firefox:

Chrome:
```
Time elapsed: 100.39999999850988 milliseconds
Time elapsed: 100.29999999701977 milliseconds
Time elapsed: 100.30000000447035 milliseconds
Time elapsed: 100.10000000149012 milliseconds
Time elapsed: 100.19999999552965 milliseconds
Time elapsed: 100.30000000447035 milliseconds
Time elapsed: 100.19999999552965 milliseconds
Time elapsed: 100.20000000298023 milliseconds
Time elapsed: 100.10000000149012 milliseconds
Time elapsed: 100.19999999552965 milliseconds
```

Firefox:
```
Time elapsed: 100 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 101 milliseconds
Time elapsed: 99 milliseconds
Time elapsed: 101 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 101 milliseconds
Time elapsed: 100 milliseconds
Time elapsed: 100 milliseconds
```

---

Note: I have tested QT Ladybird, the Serenity Browser and headless-browser and all produce similar results. I haven't tested the Cocoa chrome, as I don't have access to a Mac.