### PR TITLE
LibWeb: Implement `AbortSignal.timeout()`

### DIFF
--- a/Tests/LibWeb/Text/expected/abortsignal-timeout.txt
+++ b/Tests/LibWeb/Text/expected/abortsignal-timeout.txt
@@ -1,0 +1,2 @@
+Time passed before abort event fired is at least 10 milliseconds: true
+Reason type: TimeoutError

--- a/Tests/LibWeb/Text/input/abortsignal-timeout.html
+++ b/Tests/LibWeb/Text/input/abortsignal-timeout.html
@@ -1,0 +1,15 @@
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        const timeout_milliseconds = 10;
+        const test_start_time = performance.now();
+        const signal = AbortSignal.timeout(timeout_milliseconds);
+        signal.onabort = () => {
+            const abort_event_time = performance.now();
+            const time_taken_milliseconds = abort_event_time - test_start_time;
+            println(`Time passed before abort event fired is at least ${timeout_milliseconds} milliseconds: ${time_taken_milliseconds >= timeout_milliseconds}`);
+            println(`Reason type: ${signal.reason.name}`);
+            done();
+        };
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -11,6 +11,7 @@
 #include <LibJS/Heap/HeapFunction.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::DOM {
 
@@ -44,6 +45,7 @@ public:
     void follow(JS::NonnullGCPtr<AbortSignal> parent_signal);
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> abort(JS::VM&, JS::Value reason);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> timeout(JS::VM&, Web::WebIDL::UnsignedLongLong milliseconds);
 
 private:
     explicit AbortSignal(JS::Realm&);

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
@@ -5,7 +5,7 @@
 [Exposed=(Window,Worker), CustomVisit]
 interface AbortSignal : EventTarget {
     [NewObject] static AbortSignal abort(optional any reason);
-    // FIXME: [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+    [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
     // FIXME: [NewObject] static AbortSignal _any(sequence<AbortSignal> signals);
 
     readonly attribute boolean aborted;

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -61,6 +61,8 @@ public:
 
     void queue_the_performance_observer_task();
 
+    void run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step);
+
 protected:
     void initialize(JS::Realm&);
     void visit_edges(JS::Cell::Visitor&);
@@ -72,6 +74,7 @@ private:
         No,
     };
     i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS::MarkedVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
+    void run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key = {});
 
     IDAllocator m_timer_id_allocator;
     HashMap<int, JS::NonnullGCPtr<Timer>> m_timers;


### PR DESCRIPTION
This method returns a signal that will automatically abort after a given number of milliseconds.

Progress towards #13355