### PR TITLE
mkfs.fat: Some small improvements

### DIFF
--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -14,8 +14,7 @@ list(APPEND RECOMMENDED_TARGETS
 # FIXME: Support specifying component dependencies for utilities (e.g. WebSocket for telws)
 
 foreach(CMD_SRC ${CMD_SOURCES})
-    get_filename_component(CMD_NAME_WITH_EXTENSION ${CMD_SRC} NAME)
-    string(REPLACE ".cpp" "" CMD_NAME ${CMD_NAME_WITH_EXTENSION})
+    get_filename_component(CMD_NAME ${CMD_SRC} NAME_WLE)
     if (CMD_NAME IN_LIST SPECIAL_TARGETS)
         set(TARGET_NAME "${CMD_NAME}-bin")
     else()


### PR DESCRIPTION
The first commit cleans up the parsing of utility names in CMake (as pointed out in #22810.)
As for the utility itself, this PR adds support for filling in the free cluster count hint and allows for autodetecting a suitable FAT variant if the user doesn't specify one.