### PR TITLE
Meta: Link AK to libexecinfo on BSDs and Haiku

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -350,6 +350,10 @@ install(TARGETS LibC LibCrypt LibSystem NoCoverage EXPORT LagomTargets)
 # AK
 add_serenity_subdirectory(AK)
 lagom_lib(AK ak SOURCES ${AK_SOURCES})
+if (${CMAKE_SYSTEM_NAME} MATCHES "BSD$" OR HAIKU)
+    # BSD Platforms and Haiku have backtrace(3) in a separate library
+    target_link_libraries(AK PRIVATE execinfo)
+endif()
 
 # LibCore
 add_serenity_subdirectory(Userland/Libraries/LibCore)
@@ -361,10 +365,6 @@ endif()
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
     target_link_libraries(LibCore PRIVATE nsl socket)
-endif()
-if (${CMAKE_SYSTEM_NAME} MATCHES "BSD$" OR HAIKU)
-    # BSD Platforms and Haiku have backtrace(3) in a separate library
-    target_link_libraries(LibCore PRIVATE execinfo)
 endif()
 if (HAIKU)
     # Haiku has networking related functions in the network library


### PR DESCRIPTION
This requirement was missed when AK was split into its own library in 5945cdc054e603214e9aeea9221888d523506c83

cc @trflynn89 

Fixes #23360