### PR TITLE
Kernel/riscv64: Make the NVMe driver work on riscv64

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -68,6 +68,8 @@
 #    include <Kernel/Arch/aarch64/RPi/Framebuffer.h>
 #    include <Kernel/Arch/aarch64/RPi/Mailbox.h>
 #    include <Kernel/Arch/aarch64/RPi/MiniUART.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/Delay.h>
 #endif
 
 // Defined in the linker script
@@ -295,6 +297,8 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
 
     if (kernel_command_line().contains("dump_fdt"sv))
         dump_fdt();
+
+    init_delay_loop();
 #endif
 
     // Initialize TimeManagement before using randomness!

--- a/Kernel/Arch/riscv64/Delay.h
+++ b/Kernel/Arch/riscv64/Delay.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Arch/Delay.h>
+
+namespace Kernel {
+
+void init_delay_loop();
+
+}

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -113,6 +113,9 @@ void ProcessorBase<T>::initialize(u32)
 {
     m_deferred_call_pool.init();
 
+    // FIXME: Actually set the correct count when we support SMP on riscv64.
+    g_total_processors.store(1, AK::MemoryOrder::memory_order_release);
+
     // Enable the FPU
     auto sstatus = RISCV64::CSR::SSTATUS::read();
     sstatus.FS = RISCV64::CSR::SSTATUS::FloatingPointStatus::Initial;

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -196,7 +196,9 @@ ALWAYS_INLINE Thread* ProcessorBase<T>::current_thread()
 template<typename T>
 ALWAYS_INLINE void ProcessorBase<T>::pause()
 {
-    TODO_RISCV64();
+    // FIXME: Use the pause instruction directly (via .option arch, +zihintpause)
+    //        when we upgrade our toolchain to clang 17
+    asm volatile(".word 0x0100000f");
 }
 
 template<typename T>


### PR DESCRIPTION
This PR includes all necessary changes to make the NVMe driver work on RISC-V.