### PR TITLE
Ladybird/AppKit: Dynamically generate `Info.plist`

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -235,13 +235,16 @@ add_dependencies(ladybird ${ladybird_helper_processes})
 function(create_ladybird_bundle target_name)
     set_target_properties(${target_name} PROPERTIES
         OUTPUT_NAME "Ladybird"
-        MACOSX_BUNDLE_GUI_IDENTIFIER org.SerenityOS.Ladybird
-        MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-        MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-        MACOSX_BUNDLE_INFO_PLIST "${SERENITY_SOURCE_DIR}/Ladybird/Info.plist"
         MACOSX_BUNDLE TRUE
         WIN32_EXECUTABLE TRUE
-        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER org.SerenityOS.Ladybird
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER org.SerenityOS.${target_name}
+        MACOSX_BUNDLE_INFO_PLIST ${SERENITY_SOURCE_DIR}/Ladybird/Info.plist.in
+        MACOSX_BUNDLE_GUI_IDENTIFIER org.SerenityOS.${target_name}
+        MACOSX_BUNDLE_ICON_FILE app_icon.icns
+        MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+        MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+        MACOSX_BUNDLE_INFO_STRING ${PROJECT_DESCRIPTION}
+        MACOSX_BUNDLE_COPYRIGHT "Copyright (c) 2018-2024, the SerenityOS developers"
     )
 
     if (APPLE)

--- a/Ladybird/Info.plist.in
+++ b/Ladybird/Info.plist.in
@@ -5,19 +5,23 @@
         <key>NSPrincipalClass</key>
         <string>NSApplication</string>
         <key>CFBundleIconFile</key>
-        <string>app_icon.icns</string>
+        <string>${MACOSX_BUNDLE_ICON_FILE}</string>
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleGetInfoString</key>
-        <string>Ladybird</string>
+        <string>${MACOSX_BUNDLE_INFO_STRING}</string>
         <key>CFBundleSignature</key>
         <string></string>
         <key>CFBundleExecutable</key>
-        <string>Ladybird</string>
+        <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
         <key>CFBundleIdentifier</key>
-        <string>org.SerenityOS.Ladybird</string>
-        <key>NSPrincipalClass</key>
-        <string>NSApplication</string>
+        <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+        <key>CFBundleVersion</key>
+        <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+        <key>CFBundleShortVersionString</key>
+        <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+        <key>NSHumanReadableCopyright</key>
+        <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
         <key>NSHighResolutionCapable</key>
         <string>True</string>
         <key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
This uses CMake's built-in "target properties" to dynamically generate the macOS/iOS app bundle `Info.plist` file.

See https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE_INFO_PLIST.html