### PR TITLE
LibJS: TypedArray speedups for https://cyxx.github.io/another_js

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -181,22 +181,6 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& co
     return obj.ptr();
 }
 
-// 25.1.3.2 ArrayBufferByteLength ( arrayBuffer, order ), https://tc39.es/ecma262/#sec-arraybufferbytelength
-size_t array_buffer_byte_length(ArrayBuffer const& array_buffer, ArrayBuffer::Order)
-{
-    // FIXME: 1. If IsSharedArrayBuffer(arrayBuffer) is true and arrayBuffer has an [[ArrayBufferByteLengthData]] internal slot, then
-    // FIXME:     a. Let bufferByteLengthBlock be arrayBuffer.[[ArrayBufferByteLengthData]].
-    // FIXME:     b. Let rawLength be GetRawBytesFromSharedBlock(bufferByteLengthBlock, 0, biguint64, true, order).
-    // FIXME:     c. Let isLittleEndian be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-    // FIXME:     d. Return ℝ(RawBytesToNumeric(biguint64, rawLength, isLittleEndian)).
-
-    // 2. Assert: IsDetachedBuffer(arrayBuffer) is false.
-    VERIFY(!array_buffer.is_detached());
-
-    // 3. Return arrayBuffer.[[ArrayBufferByteLength]].
-    return array_buffer.byte_length();
-}
-
 // 25.1.3.4 DetachArrayBuffer ( arrayBuffer [ , key ] ), https://tc39.es/ecma262/#sec-detacharraybuffer
 ThrowCompletionOr<void> detach_array_buffer(VM& vm, ArrayBuffer& array_buffer, Optional<Value> key)
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -146,12 +146,27 @@ private:
 ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size);
 void copy_data_block_bytes(ByteBuffer& to_block, u64 to_index, ByteBuffer const& from_block, u64 from_index, u64 count);
 ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM&, FunctionObject& constructor, size_t byte_length, Optional<size_t> const& max_byte_length = {});
-size_t array_buffer_byte_length(ArrayBuffer const&, ArrayBuffer::Order);
 ThrowCompletionOr<void> detach_array_buffer(VM&, ArrayBuffer& array_buffer, Optional<Value> key = {});
 ThrowCompletionOr<Optional<size_t>> get_array_buffer_max_byte_length_option(VM&, Value options);
 ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(VM&, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length);
 ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM&, ArrayBuffer& array_buffer, Value new_length, PreserveResizability preserve_resizability);
 ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> allocate_shared_array_buffer(VM&, FunctionObject& constructor, size_t byte_length);
+
+// 25.1.3.2 ArrayBufferByteLength ( arrayBuffer, order ), https://tc39.es/ecma262/#sec-arraybufferbytelength
+inline size_t array_buffer_byte_length(ArrayBuffer const& array_buffer, ArrayBuffer::Order)
+{
+    // FIXME: 1. If IsSharedArrayBuffer(arrayBuffer) is true and arrayBuffer has an [[ArrayBufferByteLengthData]] internal slot, then
+    // FIXME:     a. Let bufferByteLengthBlock be arrayBuffer.[[ArrayBufferByteLengthData]].
+    // FIXME:     b. Let rawLength be GetRawBytesFromSharedBlock(bufferByteLengthBlock, 0, biguint64, true, order).
+    // FIXME:     c. Let isLittleEndian be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+    // FIXME:     d. Return ℝ(RawBytesToNumeric(biguint64, rawLength, isLittleEndian)).
+
+    // 2. Assert: IsDetachedBuffer(arrayBuffer) is false.
+    VERIFY(!array_buffer.is_detached());
+
+    // 3. Return arrayBuffer.[[ArrayBufferByteLength]].
+    return array_buffer.byte_length();
+}
 
 // 25.1.3.13 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric
 template<typename T>

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -42,6 +42,14 @@ struct DataBlock {
     }
     ByteBuffer const& buffer() const { return const_cast<DataBlock*>(this)->buffer(); }
 
+    size_t size() const
+    {
+        return byte_buffer.visit(
+            [](Empty) -> size_t { return 0u; },
+            [](ByteBuffer const& buffer) { return buffer.size(); },
+            [](ByteBuffer const* buffer) { return buffer->size(); });
+    }
+
     Variant<Empty, ByteBuffer, ByteBuffer*> byte_buffer;
     Shared is_shared = { Shared::No };
 };
@@ -57,13 +65,7 @@ public:
 
     virtual ~ArrayBuffer() override = default;
 
-    size_t byte_length() const
-    {
-        if (is_detached())
-            return 0;
-
-        return m_data_block.buffer().size();
-    }
+    size_t byte_length() const { return m_data_block.size(); }
 
     // [[ArrayBufferData]]
     ByteBuffer& buffer() { return m_data_block.buffer(); }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -668,7 +668,7 @@ u32 typed_array_length_with_known_valid_bounds(TypedArrayWithBufferWitness const
 }
 
 // 10.4.5.13 IsTypedArrayOutOfBounds ( taRecord ), https://tc39.es/ecma262/#sec-istypedarrayoutofbounds
-bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const& typed_array_record)
+bool is_typed_array_out_of_bounds_for_known_attached_array(TypedArrayWithBufferWitness const& typed_array_record)
 {
     // 1. Let O be taRecord.[[Object]].
     auto object = typed_array_record.object;
@@ -677,11 +677,7 @@ bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const& typed_array
     auto const& buffer_byte_length = typed_array_record.cached_buffer_byte_length;
 
     // 3. Assert: IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
-    VERIFY(object->viewed_array_buffer()->is_detached() == buffer_byte_length.is_detached());
-
     // 4. If bufferByteLength is detached, return true.
-    if (buffer_byte_length.is_detached())
-        return true;
 
     // 5. Let byteOffsetStart be O.[[ByteOffset]].
     auto byte_offset_start = object->byte_offset();
@@ -728,7 +724,7 @@ bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalIndex pr
     // NOTE: Bounds checking is not a synchronizing operation when O's backing buffer is a growable SharedArrayBuffer.
 
     // 6. If IsTypedArrayOutOfBounds(taRecord) is true, return false.
-    if (is_typed_array_out_of_bounds(typed_array_record))
+    if (is_typed_array_out_of_bounds_for_known_attached_array(typed_array_record))
         return false;
 
     // 7. Let length be TypedArrayLength(taRecord).

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -639,11 +639,8 @@ u32 typed_array_byte_length(TypedArrayWithBufferWitness const& typed_array_recor
 }
 
 // 10.4.5.12 TypedArrayLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraylength
-u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_record)
+u32 typed_array_length_with_known_valid_bounds(TypedArrayWithBufferWitness const& typed_array_record)
 {
-    // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
-    VERIFY(!is_typed_array_out_of_bounds(typed_array_record));
-
     // 2. Let O be taRecord.[[Object]].
     auto object = typed_array_record.object;
 
@@ -735,7 +732,7 @@ bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalIndex pr
         return false;
 
     // 7. Let length be TypedArrayLength(taRecord).
-    auto length = typed_array_length(typed_array_record);
+    auto length = typed_array_length_with_known_valid_bounds(typed_array_record);
 
     // 8. If ℝ(index) < 0 or ℝ(index) ≥ length, return false.
     if (property_index.as_index() >= length)

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -588,26 +588,19 @@ JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
 
 // 10.4.5.9 MakeTypedArrayWithBufferWitnessRecord ( obj, order ), https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord
-TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const& typed_array, ArrayBuffer::Order order)
+TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record_for_known_attached_array(TypedArrayBase const& typed_array, ArrayBuffer::Order order)
 {
     // 1. Let buffer be obj.[[ViewedArrayBuffer]].
     auto* buffer = typed_array.viewed_array_buffer();
 
-    ByteLength byte_length { 0 };
-
     // 2. If IsDetachedBuffer(buffer) is true, then
-    if (buffer->is_detached()) {
-        // a. Let byteLength be detached.
-        byte_length = ByteLength::detached();
-    }
+    //     a. Let byteLength be detached.
     // 3. Else,
-    else {
-        // a. Let byteLength be ArrayBufferByteLength(buffer, order).
-        byte_length = array_buffer_byte_length(*buffer, order);
-    }
+    //     a. Let byteLength be ArrayBufferByteLength(buffer, order).
+    auto byte_length = array_buffer_byte_length(*buffer, order);
 
     // 4. Return the TypedArray With Buffer Witness Record { [[Object]]: obj, [[CachedBufferByteLength]]: byteLength }.
-    return { .object = typed_array, .cached_buffer_byte_length = move(byte_length) };
+    return { .object = typed_array, .cached_buffer_byte_length = byte_length };
 }
 
 // 10.4.5.11 TypedArrayByteLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraybytelength
@@ -719,7 +712,7 @@ bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalIndex pr
         return false;
 
     // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, unordered).
-    auto typed_array_record = make_typed_array_with_buffer_witness_record(typed_array, ArrayBuffer::Unordered);
+    auto typed_array_record = make_typed_array_with_buffer_witness_record_for_known_attached_array(typed_array, ArrayBuffer::Unordered);
 
     // NOTE: Bounds checking is not a synchronizing operation when O's backing buffer is a growable SharedArrayBuffer.
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -94,9 +94,21 @@ struct TypedArrayWithBufferWitness {
 
 TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const&, ArrayBuffer::Order);
 u32 typed_array_byte_length(TypedArrayWithBufferWitness const&);
-u32 typed_array_length(TypedArrayWithBufferWitness const&);
 bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const&);
 bool is_valid_integer_index(TypedArrayBase const&, CanonicalIndex);
+
+// Fast-path version of TypedArrayLength when you already know the TA is within its bounds,
+// i.e. you previously checked IsTypedArrayOutOfBounds.
+u32 typed_array_length_with_known_valid_bounds(TypedArrayWithBufferWitness const&);
+
+// 10.4.5.12 TypedArrayLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraylength
+inline u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_record)
+{
+    // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
+    VERIFY(!is_typed_array_out_of_bounds(typed_array_record));
+
+    return typed_array_length_with_known_valid_bounds(typed_array_record);
+}
 
 // 10.4.5.15 TypedArrayGetElement ( O, index ), https://tc39.es/ecma262/#sec-typedarraygetelement
 template<typename T>

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -110,6 +110,18 @@ inline u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_rec
     return typed_array_length_with_known_valid_bounds(typed_array_record);
 }
 
+// Fast-path version of IsTypedArrayOutOfBounds when you already know the TA is not detached.
+bool is_typed_array_out_of_bounds_for_known_attached_array(TypedArrayWithBufferWitness const&);
+
+// 10.4.5.13 IsTypedArrayOutOfBounds ( taRecord ), https://tc39.es/ecma262/#sec-istypedarrayoutofbounds
+inline bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const& typed_array_record)
+{
+    if (typed_array_record.cached_buffer_byte_length.is_detached())
+        return true;
+
+    return is_typed_array_out_of_bounds_for_known_attached_array(typed_array_record);
+}
+
 // 10.4.5.15 TypedArrayGetElement ( O, index ), https://tc39.es/ecma262/#sec-typedarraygetelement
 template<typename T>
 inline ThrowCompletionOr<Value> typed_array_get_element(TypedArrayBase const& typed_array, CanonicalIndex property_index)

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -92,10 +92,21 @@ struct TypedArrayWithBufferWitness {
     ByteLength cached_buffer_byte_length;      // [[CachedBufferByteLength]]
 };
 
-TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const&, ArrayBuffer::Order);
 u32 typed_array_byte_length(TypedArrayWithBufferWitness const&);
 bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const&);
 bool is_valid_integer_index(TypedArrayBase const&, CanonicalIndex);
+
+// Fast-path version of MakeTypedArrayWithBufferWitnessRecord when you already know the TA is not detached.
+TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record_for_known_attached_array(TypedArrayBase const&, ArrayBuffer::Order);
+
+// 10.4.5.9 MakeTypedArrayWithBufferWitnessRecord ( obj, order ), https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord
+inline TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const& typed_array, ArrayBuffer::Order order)
+{
+    if (typed_array.viewed_array_buffer()->is_detached())
+        return { .object = typed_array, .cached_buffer_byte_length = ByteLength::detached() };
+
+    return make_typed_array_with_buffer_witness_record_for_known_attached_array(typed_array, order);
+}
 
 // Fast-path version of TypedArrayLength when you already know the TA is within its bounds,
 // i.e. you previously checked IsTypedArrayOutOfBounds.

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -13,8 +13,6 @@
 #include <AK/Vector.h>
 #include <LibIPC/Forward.h>
 #include <LibJS/Forward.h>
-#include <LibJS/Runtime/DataView.h>
-#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 // Structured serialize is an entirely different format from IPC because:

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStreamBYOBRequest.h>

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>


### PR DESCRIPTION
With some fast-pathing, inlining, and avoiding some virtuals, this overall brings the runtime percentage of `IsValidIntegerIndex` on https://cyxx.github.io/another_js from 16% to 7% on my machine.

This also reduces the runtime of test-js from 3.6s to 3.4s consistently on my machine.