### PR TITLE
LibTLS: Don't copy all root certificates during TLSv12 construction

### DIFF
--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -289,7 +289,7 @@ class DefaultRootCACertificates {
 public:
     DefaultRootCACertificates();
 
-    Vector<Certificate> const& certificates() const { return m_ca_certificates; }
+    HashMap<String, Certificate> const& certificates() const { return m_ca_certificates; }
 
     static ErrorOr<Vector<Certificate>> parse_pem_root_certificate_authorities(ByteBuffer&);
     static ErrorOr<Vector<Certificate>> load_certificates(Span<ByteString> custom_cert_paths = {});
@@ -299,7 +299,7 @@ public:
     static void set_default_certificate_paths(Span<ByteString> paths);
 
 private:
-    Vector<Certificate> m_ca_certificates;
+    HashMap<String, Certificate> m_ca_certificates;
 };
 
 }


### PR DESCRIPTION
Copying (>2kb) * (number of root certificates) every time TLS connection is made is a bit too much for my liking.

As collateral damage, the PR removes `TLS::Options::set_root_certificates &&` and `TLS::Options::default_root_certificates` as I wasn't able to specify type with commas in `OPTION_WITH_DEFAULTS` macro. (The old TLS API will probably be gone soon anyway)