### PR TITLE
LibWeb: Implement scrollbar painting

### DIFF
--- a/Tests/LibWeb/Ref/abspos-escapes-scroll-container.html
+++ b/Tests/LibWeb/Ref/abspos-escapes-scroll-container.html
@@ -6,6 +6,7 @@
     height: 200px;
     overflow: auto;
     border: 1px solid black;
+    scrollbar-width: none;
 }
 .content {
     height: 600px;

--- a/Tests/LibWeb/Ref/button-inside-scroll-container.html
+++ b/Tests/LibWeb/Ref/button-inside-scroll-container.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <link rel="match" href="reference/button-inside-scroll-container-ref.html" />
 <style>
+    * {
+        scrollbar-width: none;
+    }
+    
     #scrollable {
         height: 300px;
         overflow: scroll;

--- a/Tests/LibWeb/Ref/css-backgrounds.html
+++ b/Tests/LibWeb/Ref/css-backgrounds.html
@@ -12,6 +12,7 @@
             padding: 5px 10px 15px 20px;
             overflow: auto;
             margin-bottom: 10px;
+            scrollbar-width: none;
         }
 
         .force-scroll {

--- a/Tests/LibWeb/Ref/overflow-hidden-7.html
+++ b/Tests/LibWeb/Ref/overflow-hidden-7.html
@@ -6,6 +6,7 @@
         overflow-x: visible;
         width: 200px;
         height: 200px;
+        scrollbar-width: none;
     }
 
     .inner {

--- a/Tests/LibWeb/Ref/reference/scrollable-box-with-nested-stacking-context-ref.html
+++ b/Tests/LibWeb/Ref/reference/scrollable-box-with-nested-stacking-context-ref.html
@@ -1,4 +1,8 @@
 <style>
+    * {
+        scrollbar-width: none;
+    }
+
     #container {
         width: 300px;
         height: 500px;

--- a/Tests/LibWeb/Ref/reference/scrollable-contains-boxes-with-hidden-overflow-1-ref.html
+++ b/Tests/LibWeb/Ref/reference/scrollable-contains-boxes-with-hidden-overflow-1-ref.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <style>
+    * {
+        scrollbar-width: none;
+    }
     html {
         background: white;
     }

--- a/Tests/LibWeb/Ref/reference/scrollable-contains-boxes-with-hidden-overflow-2-ref.html
+++ b/Tests/LibWeb/Ref/reference/scrollable-contains-boxes-with-hidden-overflow-2-ref.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html><style>
+    * {
+        scrollbar-width: none;
+    }
     html {
         background: white;
     }

--- a/Tests/LibWeb/Ref/reference/scrollable-contains-boxes-with-hidden-overflow-and-opacity-ref.html
+++ b/Tests/LibWeb/Ref/reference/scrollable-contains-boxes-with-hidden-overflow-and-opacity-ref.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <style>
+    * {
+        scrollbar-width: none;
+    }
     html {
         background: white;
     }

--- a/Tests/LibWeb/Ref/scroll-using-mousewheel-event.html
+++ b/Tests/LibWeb/Ref/scroll-using-mousewheel-event.html
@@ -5,6 +5,7 @@
     overflow-y: scroll;
     width: 100px;
     height: 300px;
+    scrollbar-width: none;
 }
 
 .item {

--- a/Tests/LibWeb/Ref/scrollable-box-with-nested-stacking-context.html
+++ b/Tests/LibWeb/Ref/scrollable-box-with-nested-stacking-context.html
@@ -1,5 +1,9 @@
 <link rel="match" href="reference/scrollable-box-with-nested-stacking-context-ref.html" />
 <style>
+    * {
+        scrollbar-width: none;
+    }
+
     #scrollable-box {
         width: 300px;
         height: 500px;

--- a/Tests/LibWeb/Ref/scrollable-contains-boxes-with-hidden-overflow-1.html
+++ b/Tests/LibWeb/Ref/scrollable-contains-boxes-with-hidden-overflow-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <link rel="match" href="reference/scrollable-contains-boxes-with-hidden-overflow-1-ref.html" />
 <style>
+    * {
+        scrollbar-width: none;
+    }
     html {
         background: white;
     }

--- a/Tests/LibWeb/Ref/scrollable-contains-boxes-with-hidden-overflow-2.html
+++ b/Tests/LibWeb/Ref/scrollable-contains-boxes-with-hidden-overflow-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <link rel="match" href="reference/scrollable-contains-boxes-with-hidden-overflow-2-ref.html" />
 <style>
+    * {
+        scrollbar-width: none;
+    }
     html {
         background: white;
     }

--- a/Tests/LibWeb/Ref/scrollable-contains-boxes-with-hidden-overflow-and-opacity.html
+++ b/Tests/LibWeb/Ref/scrollable-contains-boxes-with-hidden-overflow-and-opacity.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <link rel="match" href="reference/scrollable-contains-boxes-with-hidden-overflow-and-opacity-ref.html" />
 <style>
+    * {
+        scrollbar-width: none;
+    }
+
     html {
         background: white;
     }

--- a/Tests/LibWeb/Ref/svg-inside-scroll-container.html
+++ b/Tests/LibWeb/Ref/svg-inside-scroll-container.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <link rel="match" href="reference/svg-inside-scroll-container-ref.html" />
 <style>
+    * {
+        scrollbar-width: none;
+    }
+
     #scrollable {
         height: 300px;
         overflow: scroll;

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -138,6 +138,7 @@ position: static
 quotes: auto
 right: auto
 row-gap: auto
+scrollbar-width: auto
 stop-color: rgb(0, 0, 0)
 stop-opacity: 1
 stroke: none

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -177,6 +177,8 @@ public:
     static CSS::MathShift math_shift() { return CSS::MathShift::Normal; }
     static CSS::MathStyle math_style() { return CSS::MathStyle::Normal; }
     static int math_depth() { return 0; }
+
+    static CSS::ScrollbarWidth scrollbar_width() { return CSS::ScrollbarWidth::Auto; }
 };
 
 enum class BackgroundSize {
@@ -432,6 +434,8 @@ public:
     CSS::MathStyle math_style() const { return m_inherited.math_style; }
     int math_depth() const { return m_inherited.math_depth; }
 
+    CSS::ScrollbarWidth scrollbar_width() const { return m_noninherited.scrollbar_width; }
+
     NonnullOwnPtr<ComputedValues> clone_inherited_values() const
     {
         auto clone = make<ComputedValues>();
@@ -564,6 +568,8 @@ protected:
         CSS::MaskType mask_type { InitialValues::mask_type() };
         LengthPercentage x { InitialValues::x() };
         LengthPercentage y { InitialValues::x() };
+
+        CSS::ScrollbarWidth scrollbar_width { InitialValues::scrollbar_width() };
     } m_noninherited;
 };
 
@@ -694,6 +700,8 @@ public:
     void set_math_shift(CSS::MathShift value) { m_inherited.math_shift = value; }
     void set_math_style(CSS::MathStyle value) { m_inherited.math_style = value; }
     void set_math_depth(int value) { m_inherited.math_depth = value; }
+
+    void set_scrollbar_width(CSS::ScrollbarWidth value) { m_noninherited.scrollbar_width = value; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -361,6 +361,11 @@
     "middle",
     "end"
   ],
+  "scrollbar-width": [
+    "auto",
+    "thin",
+    "none"
+  ],
   "text-align": [
     "center",
     "justify",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -2034,6 +2034,18 @@
     ],
     "percentages-resolve-to": "length"
   },
+  "scrollbar-width": {
+    "affects-layout": false,
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "auto",
+    "valid-types": [ "scrollbar-width" ],
+    "valid-identifiers": [
+      "auto",
+      "thin",
+      "none"
+    ]
+  },
   "stop-color": {
     "affects-layout": false,
     "animation-type": "by-computed-value",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -1110,4 +1110,10 @@ QuotesData StyleProperties::quotes() const
     return InitialValues::quotes();
 }
 
+Optional<CSS::ScrollbarWidth> StyleProperties::scrollbar_width() const
+{
+    auto value = property(CSS::PropertyID::ScrollbarWidth);
+    return value_id_to_scrollbar_width(value->to_identifier());
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -158,6 +158,8 @@ public:
 
     QuotesData quotes() const;
 
+    Optional<CSS::ScrollbarWidth> scrollbar_width() const;
+
     static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold);
 
 private:

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -835,6 +835,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 
     computed_values.set_object_position(computed_style.object_position());
 
+    if (auto scrollbar_width = computed_style.scrollbar_width(); scrollbar_width.has_value())
+        computed_values.set_scrollbar_width(scrollbar_width.value());
+
     propagate_style_to_anonymous_wrappers();
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -229,6 +229,13 @@ protected:
 private:
     [[nodiscard]] virtual bool is_paintable_box() const final { return true; }
 
+    enum class ScrollDirection {
+        Horizontal,
+        Vertical,
+    };
+    [[nodiscard]] Optional<CSSPixelRect> scroll_thumb_rect(ScrollDirection) const;
+    [[nodiscard]] bool is_scrollable(ScrollDirection) const;
+
     Optional<OverflowData> m_overflow_data;
 
     CSSPixelPoint m_offset;


### PR DESCRIPTION
Introduces the rendering of scroll thumbs in vertical and horizontal
directions. Currently, the thumbs are purely graphical elements that
do not respond to mouse events. Nevertheless, this is beneficial as it
makes it easier to identify elements that should respond to scrolling
events.

Painting of scrollbars uncovers numerous bugs in the calculation of
scrollable overflow rectangles highlighting all the places where
elements are made scrollable whey they shouldn't be. Positively, this
issue might motivate us to pay more attention to this problem to
eliminate unnecessary scrollbars.

Currently, the scrollbar style is uniform across all platforms: a
semi-transparent gray rectangle with rounded corners.

Also here we add `scrollbar-width: none` to all existing scrolling
ref-tests, so they keep working with this change.

<img width="665" alt="Screenshot 2024-02-28 at 10 31 39" src="https://github.com/SerenityOS/serenity/assets/45686940/76aca601-2f12-4f04-a752-8db7e705ddda">
