### PR TITLE
LibLine: Ensure suggestions are reset after ^C

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -628,8 +628,8 @@ ErrorOr<void> Editor::interrupted()
         auto stderr_stream = TRY(Core::File::standard_error());
         TRY(reposition_cursor(*stderr_stream, true));
         if (TRY(m_suggestion_display->cleanup())) {
-            m_times_tab_pressed = 0;
             TRY(reposition_cursor(*stderr_stream, true));
+            TRY(cleanup_suggestions());
         }
         TRY(stderr_stream->write_until_depleted("\r"sv.bytes()));
     }


### PR DESCRIPTION
With `cleanup_suggestions()` we ensure that all variables related to suggestions are reset, preventing the crash.

Fixes #23382

