### PR TITLE
LibWeb: Fix broken painting when corner radii clip happens inside scroll container

### DIFF
--- a/Tests/LibWeb/Ref/corner-clip-inside-scrollable.html
+++ b/Tests/LibWeb/Ref/corner-clip-inside-scrollable.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/corner-clip-inside-scrollable-ref.html" />
+<style>
+    * {
+        scrollbar-width: none;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        border: 5px solid black;
+        border-radius: 50%;
+        overflow: hidden;
+        box-sizing: border-box;
+    }
+
+    .inner-box {
+        width: 100px;
+        height: 100px;
+        background-color: magenta;
+    }
+
+    #scroll {
+        overflow: scroll;
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+</style>
+<div id="scroll">
+    <div class="box" id="a"><div class="inner-box" id="aa"></div></div>
+    <div class="box" id="b"><div class="inner-box" id="bb"></div></div>
+    <div class="box" id="c"><div class="inner-box" id="cc"></div></div>
+</div>
+<script>
+    const scroll = document.getElementById("scroll");
+    scroll.scrollTop = 100;
+</script>

--- a/Tests/LibWeb/Ref/reference/corner-clip-inside-scrollable-ref.html
+++ b/Tests/LibWeb/Ref/reference/corner-clip-inside-scrollable-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        border: 5px solid black;
+        border-radius: 50%;
+        overflow: hidden;
+        box-sizing: border-box;
+    }
+
+    .inner-box {
+        width: 100px;
+        height: 100px;
+        background-color: magenta;
+    }
+
+    #container {
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+</style>
+<div id="container">
+    <div class="box" id="a"><div class="inner-box" id="aa"></div></div>
+    <div class="box" id="b"><div class="inner-box" id="bb"></div></div>
+</div>

--- a/Userland/Libraries/LibWeb/Painting/ClipFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ClipFrame.h
@@ -28,6 +28,7 @@ struct ClipFrame : public RefCounted<ClipFrame> {
         }
         m_border_radii_clips.append(border_radii_clip);
     }
+    void clear_border_radii_clips() { m_border_radii_clips.clear(); }
 
     CSSPixelRect rect() const { return m_rect; }
     void set_rect(CSSPixelRect rect) { m_rect = rect; }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -240,8 +240,8 @@ void PaintableBox::before_paint(PaintContext& context, [[maybe_unused]] PaintPha
     if (!is_visible())
         return;
 
-    apply_scroll_offset(context, phase);
     apply_clip_overflow_rect(context, phase);
+    apply_scroll_offset(context, phase);
 }
 
 void PaintableBox::after_paint(PaintContext& context, [[maybe_unused]] PaintPhase phase) const
@@ -249,8 +249,8 @@ void PaintableBox::after_paint(PaintContext& context, [[maybe_unused]] PaintPhas
     if (!is_visible())
         return;
 
-    clear_clip_overflow_rect(context, phase);
     reset_scroll_offset(context, phase);
+    clear_clip_overflow_rect(context, phase);
 }
 
 void PaintableBox::paint(PaintContext& context, PaintPhase phase) const

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -143,6 +143,7 @@ void ViewportPaintable::refresh_clip_state()
         // Start from CSS clip property if it exists.
         Optional<CSSPixelRect> clip_rect = paintable_box.get_clip_rect();
 
+        clip_frame.clear_border_radii_clips();
         if (overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible) {
             auto overflow_clip_rect = paintable_box.compute_absolute_padding_rect_with_css_transform_applied();
             for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {


### PR DESCRIPTION
Before:

<img width="1248" alt="Screenshot 2024-02-28 at 12 04 16" src="https://github.com/SerenityOS/serenity/assets/45686940/f07b2da6-b178-459a-8e19-1aeced092f83">


After:

<img width="1252" alt="Screenshot 2024-02-28 at 12 03 42" src="https://github.com/SerenityOS/serenity/assets/45686940/cab59f6c-7697-414a-8b3b-60cf60266956">
