### PR TITLE
LibGfx: Several minor tweaks to the OpenType font loader

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -165,7 +165,7 @@ static ErrorOr<Tag> read_tag(ReadonlyBytes buffer)
 ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(ReadonlyBytes buffer, Options options)
 {
     auto tag = TRY(read_tag(buffer));
-    if (tag == Tag("ttcf")) {
+    if (tag == HeaderTag_FontCollection) {
         // It's a font collection
         FixedMemoryStream stream { buffer };
         auto ttc_header_v1 = TRY(stream.read_in_place<TTCHeaderV1>());
@@ -178,10 +178,10 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(Readonl
         auto offset = TRY(stream.read_value<BigEndian<u32>>());
         return try_load_from_offset(buffer, offset, move(options));
     }
-    if (tag == Tag("OTTO"))
+    if (tag == HeaderTag_CFFOutlines)
         return Error::from_string_literal("CFF fonts not supported yet");
 
-    if (tag.to_u32() != 0x00010000 && tag != Tag("true"))
+    if (tag != HeaderTag_TrueTypeOutlines && tag != HeaderTag_TrueTypeOutlinesApple)
         return Error::from_string_literal("Not a valid font");
 
     return try_load_from_offset(buffer, 0, move(options));

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -156,14 +156,18 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_resource(Core::Resource const& 
     return font;
 }
 
-ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(ReadonlyBytes buffer, Options options)
+static ErrorOr<Tag> read_tag(ReadonlyBytes buffer)
 {
     FixedMemoryStream stream { buffer };
+    return stream.read_value<Tag>();
+}
 
-    auto tag = TRY(stream.read_value<Tag>());
+ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(ReadonlyBytes buffer, Options options)
+{
+    auto tag = TRY(read_tag(buffer));
     if (tag == Tag("ttcf")) {
         // It's a font collection
-        TRY(stream.seek(0, SeekMode::SetPosition));
+        FixedMemoryStream stream { buffer };
         auto ttc_header_v1 = TRY(stream.read_in_place<TTCHeaderV1>());
         // FIXME: Check for major_version == 2.
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -72,6 +72,19 @@ public:
     Optional<ReadonlyBytes> control_value_program() const;
     Optional<ReadonlyBytes> glyph_program(u32 glyph_id) const;
 
+    // https://learn.microsoft.com/en-us/typography/opentype/spec/otff
+    // "OpenType fonts that contain TrueType outlines should use the value of 0x00010000 for the sfntVersion.
+    //  OpenType fonts containing CFF data (version 1 or 2) should use 0x4F54544F ('OTTO', when re-interpreted as a Tag) for sfntVersion.
+    //  Note: The Apple specification for TrueType fonts allows for 'true' and 'typ1' for sfnt version.
+    //         These version tags should not be used for OpenType fonts."
+    // "Font Collection ID string: 'ttcf' (used for fonts with CFF or CFF2 outlines as well as TrueType outlines)"
+    // The old Apple TrueType spec said "Fonts with TrueType outlines produced for OS X or iOS only are encouraged to use 'true'",
+    // so 'true' is somewhat common, especially in PDFs.
+    static constexpr Tag HeaderTag_TrueTypeOutlines = Tag::from_u32(0x00010000);
+    static constexpr Tag HeaderTag_TrueTypeOutlinesApple = Tag { "true" };
+    static constexpr Tag HeaderTag_CFFOutlines = Tag { "OTTO" };
+    static constexpr Tag HeaderTag_FontCollection = Tag { "ttcf" };
+
 private:
     struct AscenderAndDescender {
         i16 ascender;

--- a/Userland/Libraries/LibGfx/FourCC.h
+++ b/Userland/Libraries/LibGfx/FourCC.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 namespace Gfx {
 
 struct [[gnu::packed]] FourCC {

--- a/Userland/Libraries/LibGfx/FourCC.h
+++ b/Userland/Libraries/LibGfx/FourCC.h
@@ -21,6 +21,16 @@ struct [[gnu::packed]] FourCC {
         cc[3] = name[3];
     }
 
+    static constexpr FourCC from_u32(u32 value)
+    {
+        FourCC result;
+        result.cc[0] = static_cast<char>(value >> 24);
+        result.cc[1] = static_cast<char>(value >> 16);
+        result.cc[2] = static_cast<char>(value >> 8);
+        result.cc[3] = static_cast<char>(value);
+        return result;
+    }
+
     bool operator==(FourCC const&) const = default;
     bool operator!=(FourCC const&) const = default;
 


### PR DESCRIPTION
I tried implementing support for Type0 CIDFontType0 OpenType fonts in PDFs, but that works differently than I expected.

But these seem like ok changes in general, and I'll likely need them in the future.

No behavior change.