### PR TITLE
LibJS: Optimize IsValidIntegerIndex for TAs with non-resizable buffers

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -443,6 +443,15 @@ inline ThrowCompletionOr<void> put_by_value(VM& vm, Value base, Value property_k
                 }
             }
 
+            if (typed_array.kind() == TypedArrayBase::Kind::Uint32Array && value.is_integral_number()) {
+                auto integer = value.as_double();
+
+                if (AK::is_within_range<u32>(integer) && is_valid_integer_index(typed_array, canonical_index)) {
+                    fast_typed_array_set_element<u32>(typed_array, index, static_cast<u32>(integer));
+                    return {};
+                }
+            }
+
             switch (typed_array.kind()) {
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     case TypedArrayBase::Kind::ClassName:                                           \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -639,8 +639,11 @@ u32 typed_array_byte_length(TypedArrayWithBufferWitness const& typed_array_recor
 }
 
 // 10.4.5.12 TypedArrayLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraylength
-u32 typed_array_length_with_known_valid_bounds(TypedArrayWithBufferWitness const& typed_array_record)
+u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_record)
 {
+    // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
+    VERIFY(!is_typed_array_out_of_bounds(typed_array_record));
+
     // 2. Let O be taRecord.[[Object]].
     auto object = typed_array_record.object;
 
@@ -723,7 +726,7 @@ bool is_valid_integer_index_slow_case(TypedArrayBase const& typed_array, Canonic
         return false;
 
     // 7. Let length be TypedArrayLength(taRecord).
-    auto length = typed_array_length_with_known_valid_bounds(typed_array_record);
+    auto length = typed_array_length(typed_array_record);
 
     // 8. If ℝ(index) < 0 or ℝ(index) ≥ length, return false.
     if (property_index.as_index() >= length)

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -668,7 +668,7 @@ u32 typed_array_length_with_known_valid_bounds(TypedArrayWithBufferWitness const
 }
 
 // 10.4.5.13 IsTypedArrayOutOfBounds ( taRecord ), https://tc39.es/ecma262/#sec-istypedarrayoutofbounds
-bool is_typed_array_out_of_bounds_for_known_attached_array(TypedArrayWithBufferWitness const& typed_array_record)
+bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const& typed_array_record)
 {
     // 1. Let O be taRecord.[[Object]].
     auto object = typed_array_record.object;
@@ -677,7 +677,11 @@ bool is_typed_array_out_of_bounds_for_known_attached_array(TypedArrayWithBufferW
     auto const& buffer_byte_length = typed_array_record.cached_buffer_byte_length;
 
     // 3. Assert: IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
+    VERIFY(object->viewed_array_buffer()->is_detached() == buffer_byte_length.is_detached());
+
     // 4. If bufferByteLength is detached, return true.
+    if (buffer_byte_length.is_detached())
+        return true;
 
     // 5. Let byteOffsetStart be O.[[ByteOffset]].
     auto byte_offset_start = object->byte_offset();
@@ -715,7 +719,7 @@ bool is_valid_integer_index_slow_case(TypedArrayBase const& typed_array, Canonic
     // 5. NOTE: Bounds checking is not a synchronizing operation when O's backing buffer is a growable SharedArrayBuffer.
 
     // 6. If IsTypedArrayOutOfBounds(taRecord) is true, return false.
-    if (is_typed_array_out_of_bounds_for_known_attached_array(typed_array_record))
+    if (is_typed_array_out_of_bounds(typed_array_record))
         return false;
 
     // 7. Let length be TypedArrayLength(taRecord).

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -700,21 +700,12 @@ bool is_typed_array_out_of_bounds_for_known_attached_array(TypedArrayWithBufferW
 }
 
 // 10.4.5.14 IsValidIntegerIndex ( O, index ), https://tc39.es/ecma262/#sec-isvalidintegerindex
-bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalIndex property_index)
+bool is_valid_integer_index_slow_case(TypedArrayBase const& typed_array, CanonicalIndex property_index)
 {
-    // 1. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, return false.
-    if (typed_array.viewed_array_buffer()->is_detached())
-        return false;
-
-    // 2. If IsIntegralNumber(index) is false, return false.
-    // 3. If index is -0𝔽, return false.
-    if (!property_index.is_index())
-        return false;
-
     // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, unordered).
     auto typed_array_record = make_typed_array_with_buffer_witness_record_for_known_attached_array(typed_array, ArrayBuffer::Unordered);
 
-    // NOTE: Bounds checking is not a synchronizing operation when O's backing buffer is a growable SharedArrayBuffer.
+    // 5. NOTE: Bounds checking is not a synchronizing operation when O's backing buffer is a growable SharedArrayBuffer.
 
     // 6. If IsTypedArrayOutOfBounds(taRecord) is true, return false.
     if (is_typed_array_out_of_bounds_for_known_attached_array(typed_array_record))

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -111,18 +111,6 @@ inline u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_rec
     return typed_array_length_with_known_valid_bounds(typed_array_record);
 }
 
-// Fast-path version of IsTypedArrayOutOfBounds when you already know the TA is not detached.
-bool is_typed_array_out_of_bounds_for_known_attached_array(TypedArrayWithBufferWitness const&);
-
-// 10.4.5.13 IsTypedArrayOutOfBounds ( taRecord ), https://tc39.es/ecma262/#sec-istypedarrayoutofbounds
-inline bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const& typed_array_record)
-{
-    if (typed_array_record.cached_buffer_byte_length.is_detached())
-        return true;
-
-    return is_typed_array_out_of_bounds_for_known_attached_array(typed_array_record);
-}
-
 bool is_valid_integer_index_slow_case(TypedArrayBase const&, CanonicalIndex property_index);
 
 // 10.4.5.14 IsValidIntegerIndex ( O, index ), https://tc39.es/ecma262/#sec-isvalidintegerindex

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -96,21 +96,8 @@ struct TypedArrayWithBufferWitness {
 
 TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const&, ArrayBuffer::Order);
 u32 typed_array_byte_length(TypedArrayWithBufferWitness const&);
+u32 typed_array_length(TypedArrayWithBufferWitness const&);
 bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const&);
-
-// Fast-path version of TypedArrayLength when you already know the TA is within its bounds,
-// i.e. you previously checked IsTypedArrayOutOfBounds.
-u32 typed_array_length_with_known_valid_bounds(TypedArrayWithBufferWitness const&);
-
-// 10.4.5.12 TypedArrayLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraylength
-inline u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_record)
-{
-    // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
-    VERIFY(!is_typed_array_out_of_bounds(typed_array_record));
-
-    return typed_array_length_with_known_valid_bounds(typed_array_record);
-}
-
 bool is_valid_integer_index_slow_case(TypedArrayBase const&, CanonicalIndex property_index);
 
 // 10.4.5.14 IsValidIntegerIndex ( O, index ), https://tc39.es/ecma262/#sec-isvalidintegerindex

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -94,20 +94,9 @@ struct TypedArrayWithBufferWitness {
     ByteLength cached_buffer_byte_length;      // [[CachedBufferByteLength]]
 };
 
+TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const&, ArrayBuffer::Order);
 u32 typed_array_byte_length(TypedArrayWithBufferWitness const&);
 bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const&);
-
-// Fast-path version of MakeTypedArrayWithBufferWitnessRecord when you already know the TA is not detached.
-TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record_for_known_attached_array(TypedArrayBase const&, ArrayBuffer::Order);
-
-// 10.4.5.9 MakeTypedArrayWithBufferWitnessRecord ( obj, order ), https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord
-inline TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const& typed_array, ArrayBuffer::Order order)
-{
-    if (typed_array.viewed_array_buffer()->is_detached())
-        return { .object = typed_array, .cached_buffer_byte_length = ByteLength::detached() };
-
-    return make_typed_array_with_buffer_witness_record_for_known_attached_array(typed_array, order);
-}
 
 // Fast-path version of TypedArrayLength when you already know the TA is within its bounds,
 // i.e. you previously checked IsTypedArrayOutOfBounds.


### PR DESCRIPTION
If we know the TA does not have a resizable ArrayBuffer, we can avoid most of the heavy lifting that IsValidIntegerIndex performs.

On https://cyxx.github.io/another_js, this reduces the runtime of IsValidIntegerIndex from 7.1% to 3.7%.

This also reverts a few of the previous optimizations that no longer apply / provide any measurable benefit after this change. Let's err on the side of having to track fewer optimized paths (i.e. wondering which AO to call) as long as there's no quantifiable benefit.

The animations on another_js are starting to look much smoother:

https://github.com/SerenityOS/serenity/assets/5600524/2f4fb7ad-762c-4d36-8744-60638bbbf7e5

