### PR TITLE
Kernel/riscv64: Only enable interrupts in trap handler if they were on

### DIFF
--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -58,7 +58,8 @@ extern "C" void trap_handler(TrapFrame& trap_frame)
         // Exception
 
         Processor::current().enter_trap(trap_frame, false);
-        Processor::enable_interrupts();
+        if (trap_frame.regs->sstatus.SPIE == 1)
+            Processor::enable_interrupts();
 
         using enum RISCV64::CSR::SCAUSE;
         switch (scause) {


### PR DESCRIPTION
Always enabling interrupts is in hindsight obviously a bug, as trapping code that has interrupts disabled very likely expects that they stay disabled during trap handling as well.
The interrupt state will already correctly be restored on trap exit.

It would be nicer if we wouldn't have to keep interrupts disabled for potentially quite some time, but x86 is also keeping interrupts disabled if they were disabled while handling page faults.

This used to cause a panic when the following things happened:
user context switch (scheduler lock held) -> signal dispatch -> writing signal info to stack causes page fault -> while handling page faults interrupts are enabled -> timer interrupt -> deferred calls get executed -> thread block timer expects scheduler lock isn't locked -> :^(
![image](https://github.com/SerenityOS/serenity/assets/44805808/873cc701-b9fd-4f03-ae3e-98ed75d5b661)