### PR TITLE
 Kernel: Implement "negative" pledges

### DIFF
--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -30,36 +30,52 @@ ErrorOr<FlatPtr> Process::sys$pledge(Userspace<Syscall::SC_pledge_params const*>
         execpromises = TRY(get_syscall_string_fixed_buffer<all_promises_strings_length_with_spaces>(params.execpromises));
     }
 
-    auto parse_pledge = [&](auto pledge_spec, u32& mask) {
-        auto found_invalid_pledge = true;
-        pledge_spec.for_each_split_view(' ', SplitBehavior::Nothing, [&mask, &found_invalid_pledge](auto const& part) {
+    auto parse_pledge = [&](auto pledge_spec, bool& negative_only, u32& mask) {
+        auto found_invalid_pledge = false;
+        if (pledge_spec.starts_with('-'))
+            negative_only = true;
+        pledge_spec.for_each_split_view(' ', SplitBehavior::Nothing, [&mask, &negative_only, &found_invalid_pledge](auto const& part) {
+            auto name = part;
+            if (negative_only) {
+                if (!part.starts_with('-')) {
+                    found_invalid_pledge = true;
+                    return;
+                }
+                name = part.substring_view(1);
+            }
 #define __ENUMERATE_PLEDGE_PROMISE(x)   \
-    if (part == #x##sv) {               \
+    if (name == #x##sv) {               \
         mask |= (1u << (u32)Pledge::x); \
         return;                         \
     }
             ENUMERATE_PLEDGE_PROMISES
 #undef __ENUMERATE_PLEDGE_PROMISE
-            found_invalid_pledge = false;
+            found_invalid_pledge = true;
         });
         return found_invalid_pledge;
     };
 
     u32 new_promises = 0;
+    bool promises_are_negative = false;
     if (promises_provided) {
-        if (!parse_pledge(promises.representable_view(), new_promises))
+        if (parse_pledge(promises.representable_view(), promises_are_negative, new_promises))
             return EINVAL;
     }
 
     u32 new_execpromises = 0;
+    bool execpromises_are_negative = false;
     if (execpromises_provided) {
-        if (!parse_pledge(execpromises.representable_view(), new_execpromises))
+        if (parse_pledge(execpromises.representable_view(), execpromises_are_negative, new_execpromises))
             return EINVAL;
     }
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
         if (promises_provided) {
-            if (protected_data.has_promises && (new_promises & ~protected_data.promises)) {
+            if (promises_are_negative) {
+                if (!protected_data.has_promises)
+                    return EINVAL;
+                new_promises = ~new_promises & protected_data.promises;
+            } else if (protected_data.has_promises && (new_promises & ~protected_data.promises)) {
                 if (!(protected_data.promises & (1u << (u32)Pledge::no_error)))
                     return EPERM;
                 new_promises &= protected_data.promises;
@@ -67,7 +83,11 @@ ErrorOr<FlatPtr> Process::sys$pledge(Userspace<Syscall::SC_pledge_params const*>
         }
 
         if (execpromises_provided) {
-            if (protected_data.has_execpromises && (new_execpromises & ~protected_data.execpromises)) {
+            if (execpromises_are_negative) {
+                if (!protected_data.has_execpromises)
+                    return EINVAL;
+                new_execpromises = ~new_execpromises & protected_data.execpromises;
+            } else if (protected_data.has_execpromises && (new_execpromises & ~protected_data.execpromises)) {
                 if (!(protected_data.promises & (1u << (u32)Pledge::no_error)))
                     return EPERM;
                 new_execpromises &= protected_data.execpromises;

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -74,7 +74,8 @@ UnixDateTime kgettimeofday();
     __ENUMERATE_PLEDGE_PROMISE(mount)     \
     __ENUMERATE_PLEDGE_PROMISE(no_error)
 
-#define __ENUMERATE_PLEDGE_PROMISE(x) sizeof(#x) + 1 +
+// +2 = +1 for space, +1 for minus
+#define __ENUMERATE_PLEDGE_PROMISE(x) sizeof(#x) + 2 +
 // NOTE: We truncate the last space from the string as it's not needed (with 0 - 1).
 constexpr static unsigned all_promises_strings_length_with_spaces = ENUMERATE_PLEDGE_PROMISES 0 - 1;
 #undef __ENUMERATE_PLEDGE_PROMISE

--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -32,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (isatty(STDOUT_FILENO))
         use_color = true;
 
-    TRY(Core::System::pledge("stdio rpath"));
+    TRY(Core::System::pledge("-tty"));
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Print each value in a JSON file with its fully expanded key.");
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file = TRY(Core::File::open_file_or_standard_stream(path, Core::File::OpenMode::Read));
 
-    TRY(Core::System::pledge("stdio"));
+    TRY(Core::System::pledge("-rpath"));
 
     auto file_contents = TRY(file->read_until_eof());
     auto json = TRY(JsonValue::from_string(file_contents));

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -112,7 +112,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int fd = TRY(Core::System::socket(AF_INET, SOCK_RAW, IPPROTO_ICMP));
 
     TRY(Core::System::drop_privileges());
-    TRY(Core::System::pledge("stdio inet unix sigaction"));
+    TRY(Core::System::pledge("-id"));
 
     struct timeval timeout {
         1, 0
@@ -129,7 +129,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio inet sigaction"));
+    TRY(Core::System::pledge("-unix"));
 
     pid_t pid = getpid();
 

--- a/Userland/Utilities/su.cpp
+++ b/Userland/Utilities/su.cpp
@@ -52,14 +52,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return Error::from_string_literal("Incorrect or disabled password.");
     }
 
-    TRY(Core::System::pledge("stdio rpath exec id"));
+    TRY(Core::System::pledge("-tty"));
 
     TRY(account.login());
 
     if (simulate_login)
         TRY(Core::System::chdir(account.home_directory()));
 
-    TRY(Core::System::pledge("stdio exec"));
+    TRY(Core::System::pledge("-rpath -id"));
 
     TRY(Core::Environment::set("HOME"sv, account.home_directory(), Core::Environment::Overwrite::Yes));
 

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -111,7 +111,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto f = TRY(Core::File::open_file_or_standard_stream(file, Core::File::OpenMode::Read));
     if (!follow)
-        TRY(Core::System::pledge("stdio"));
+        TRY(Core::System::pledge("-rpath"));
 
     auto file_is_seekable = !f->seek(0, SeekMode::SetPosition).is_error();
     if (!file_is_seekable) {


### PR DESCRIPTION
In programs with multiple pledge() calls it is common to first pledge a
broad initial set of promises and then progressively drop promises as
they are no longer needed. Previously the only way to do this was
to re-pledge() a subset of the old promises, but this requires one to
re-specify *all but* the forfeited promises.

With this commit, we introduce the concept of "negative" pledges, for
instance:
```c++
// Initial pledge
pledge("stdio rpath wpath id", NULL);

// Stuff that needs "id" here...

// Forfeit id
pledge("-id", NULL);

// Stuff that needs rpath/wpath here...

// Forfeit rpath and wpath
pledge("-rpath -wpath", NULL);

// Only stdio remains pledged at this point.
```