### PR TITLE
LibWeb: Make `CSSConditionRule.conditionText` read-only

### DIFF
--- a/Tests/LibWeb/Text/expected/css/CSSConditionRule-conditionText-readonly.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSConditionRule-conditionText-readonly.txt
@@ -1,0 +1,4 @@
+   @media rule conditionText initial value: not all
+@media rule conditionText value after assignment: not all
+@supports rule conditionText initial value: not (unsupported-property: unsupported-value)
+@supports rule conditionText value after assignment: not (unsupported-property: unsupported-value)

--- a/Tests/LibWeb/Text/input/css/CSSConditionRule-conditionText-readonly.html
+++ b/Tests/LibWeb/Text/input/css/CSSConditionRule-conditionText-readonly.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+    @media not all {
+      div { color: red; }
+    }
+    @supports not (unsupported-property: unsupported-value) {
+        div { display: none; }
+    }
+</style>
+<div>This text shouldn't be visible</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const mediaRule = document.styleSheets[0].cssRules[0];
+        println(`@media rule conditionText initial value: ${mediaRule.conditionText}`);
+        mediaRule.conditionText = "all";
+        println(`@media rule conditionText value after assignment: ${mediaRule.conditionText}`);
+
+        const supportsRule = document.styleSheets[0].cssRules[1];
+        println(`@supports rule conditionText initial value: ${supportsRule.conditionText}`);
+        mediaRule.conditionText = "(unsupported-property: unsupported-value)";
+        println(`@supports rule conditionText value after assignment: ${supportsRule.conditionText}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
@@ -19,7 +19,6 @@ public:
     virtual ~CSSConditionRule() = default;
 
     virtual String condition_text() const = 0;
-    virtual void set_condition_text(String const&) = 0;
     virtual bool condition_matches() const = 0;
 
     virtual void for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const override;

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.idl
@@ -3,5 +3,5 @@
 // https://drafts.csswg.org/css-conditional-3/#the-cssconditionrule-interface
 [Exposed=Window]
 interface CSSConditionRule : CSSGroupingRule {
-    attribute CSSOMString conditionText;
+    readonly attribute CSSOMString conditionText;
 };

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -42,11 +42,6 @@ String CSSMediaRule::condition_text() const
     return m_media->media_text();
 }
 
-void CSSMediaRule::set_condition_text(String const& text)
-{
-    m_media->set_media_text(text);
-}
-
 // https://www.w3.org/TR/cssom-1/#serialize-a-css-rule
 String CSSMediaRule::serialized() const
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
@@ -26,7 +26,6 @@ public:
     virtual Type type() const override { return Type::Media; }
 
     virtual String condition_text() const override;
-    virtual void set_condition_text(String const&) override;
     virtual bool condition_matches() const override { return m_media->matches(); }
 
     MediaList* media() const { return m_media; }

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
@@ -35,12 +35,6 @@ String CSSSupportsRule::condition_text() const
     return m_supports->to_string();
 }
 
-void CSSSupportsRule::set_condition_text(String const& text)
-{
-    if (auto new_supports = parse_css_supports(Parser::ParsingContext { realm() }, text))
-        m_supports = new_supports.release_nonnull();
-}
-
 // https://www.w3.org/TR/cssom-1/#serialize-a-css-rule
 String CSSSupportsRule::serialized() const
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
@@ -27,7 +27,6 @@ public:
     virtual Type type() const override { return Type::Supports; }
 
     String condition_text() const override;
-    void set_condition_text(String const&) override;
     virtual bool condition_matches() const override { return m_supports->matches(); }
 
 private:


### PR DESCRIPTION
Previously, media rule conditions could be updated by assigning to `conditionText`. This change aligns our implementation with the CSSOM specification, which says `CSSConditionRule.conditionText` should be read-only.

Relevant CSSWG issue: https://github.com/w3c/csswg-drafts/issues/6819
Fixes this WPT test: https://wpt.live/css/cssom/CSSConditionRule-conditionText.html