### PR TITLE
LibWeb: Skip page scrolling for wheel events consumed by scrollable box

### DIFF
--- a/Tests/LibWeb/Text/expected/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body.txt
+++ b/Tests/LibWeb/Text/expected/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body.txt
@@ -1,0 +1,2 @@
+  scrollable.scrollTop: 100
+window.scrollY: 0

--- a/Tests/LibWeb/Text/input/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body.html
+++ b/Tests/LibWeb/Text/input/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/scroll-using-mousewheel-event-ref.html" />
+<style>
+    body {
+        border: 1px solid black;
+        margin: 0;
+    }
+
+    #scrollable {
+        width: 100px;
+        height: 100px;
+        overflow: scroll;
+        border: 1px solid black;
+        margin-bottom: 2000px;
+    }
+
+    #content {
+        width: 200px;
+        height: 200px;
+        background-color: magenta;
+    }
+</style>
+<script src="include.js"></script>
+<div id="scrollable"><div id="content"></div></div>
+<script>
+    test(() => {
+        internals.wheel(10, 10, 0, 1000);
+        const scrollable = document.getElementById("scrollable");
+        println("scrollable.scrollTop: " + scrollable.scrollTop);
+        println("window.scrollY: " + window.scrollY);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -174,10 +174,9 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, CSSPixelPoint scree
     if (paintable) {
         auto* containing_block = paintable->containing_block();
         while (containing_block) {
-            if (containing_block->is_user_scrollable()) {
-                const_cast<Painting::PaintableBox*>(containing_block->paintable_box())->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x, wheel_delta_y);
-                break;
-            }
+            auto handled_scroll_event = const_cast<Painting::PaintableBox*>(containing_block->paintable_box())->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x, wheel_delta_y);
+            if (handled_scroll_event)
+                return true;
             containing_block = containing_block->containing_block();
         }
 


### PR DESCRIPTION
Fixes the bug when we scroll both scrollable box and page.