### PR TITLE
Everywhere: Some Tuple cleanups and structured bindings for HashMaps

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -39,8 +39,8 @@ public:
     HashMap(std::initializer_list<Entry> list)
     {
         MUST(try_ensure_capacity(list.size()));
-        for (auto& item : list)
-            set(item.key, item.value);
+        for (auto& [key, value] : list)
+            set(key, value);
     }
 
     HashMap(HashMap const&) = default; // FIXME: Not OOM-safe! Use clone() instead.
@@ -274,16 +274,16 @@ public:
     {
         Vector<K> list;
         list.ensure_capacity(size());
-        for (auto& it : *this)
-            list.unchecked_append(it.key);
+        for (auto const& [key, _] : *this)
+            list.unchecked_append(key);
         return list;
     }
 
     [[nodiscard]] u32 hash() const
     {
         u32 hash = 0;
-        for (auto& it : *this) {
-            auto entry_hash = pair_int_hash(it.key.hash(), it.value.hash());
+        for (auto const& [key, value] : *this) {
+            auto entry_hash = pair_int_hash(key.hash(), value.hash());
             hash = pair_int_hash(hash, entry_hash);
         }
         return hash;
@@ -293,8 +293,9 @@ public:
     ErrorOr<HashMap<K, V, NewKeyTraits, NewValueTraits, NewIsOrdered>> clone() const
     {
         HashMap<K, V, NewKeyTraits, NewValueTraits, NewIsOrdered> hash_map_clone;
-        for (auto& it : *this)
-            TRY(hash_map_clone.try_set(it.key, it.value));
+        TRY(hash_map_clone.try_ensure_capacity(size()));
+        for (auto const& [key, value] : *this)
+            hash_map_clone.set(key, value);
         return hash_map_clone;
     }
 

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -162,8 +162,8 @@ UNMAP_AFTER_INIT void Access::rescan_hardware()
     SpinlockLocker scan_locker(m_scan_lock);
     VERIFY(m_device_identifiers.is_empty());
     ErrorOr<void> error_or_void {};
-    for (auto it = m_host_controllers.begin(); it != m_host_controllers.end(); ++it) {
-        (*it).value->enumerate_attached_devices([this, &error_or_void](EnumerableDeviceIdentifier device_identifier) -> IterationDecision {
+    for (auto& [_, host_controller] : m_host_controllers) {
+        host_controller->enumerate_attached_devices([this, &error_or_void](EnumerableDeviceIdentifier device_identifier) -> IterationDecision {
             auto device_identifier_or_error = DeviceIdentifier::from_enumerable_identifier(device_identifier);
             if (device_identifier_or_error.is_error()) {
                 error_or_void = device_identifier_or_error.release_error();

--- a/Kernel/Devices/Storage/NVMe/NVMeController.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeController.h
@@ -8,7 +8,6 @@
 
 #include <AK/OwnPtr.h>
 #include <AK/Time.h>
-#include <AK/Tuple.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Devices/Storage/NVMe/NVMeDefinitions.h>
@@ -55,11 +54,16 @@ public:
     void set_admin_queue_ready_flag() { m_admin_queue_ready = true; }
 
 private:
+    struct NSFeatures {
+        u64 namespace_size;
+        u8 lba_size;
+    };
+
     NVMeController(PCI::DeviceIdentifier const&, u32 hardware_relative_controller_id);
 
     ErrorOr<void> identify_and_init_namespaces();
     ErrorOr<void> identify_and_init_controller();
-    Tuple<u64, u8> get_ns_features(IdentifyNamespace& identify_data_struct);
+    NSFeatures get_ns_features(IdentifyNamespace& identify_data_struct);
     ErrorOr<void> create_admin_queue(QueueType queue_type);
     ErrorOr<void> create_io_queue(u8 qid, QueueType queue_type);
     void calculate_doorbell_stride()

--- a/Tests/LibSemVer/TestFromStringView.cpp
+++ b/Tests/LibSemVer/TestFromStringView.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/StringView.h>
-#include <AK/Tuple.h>
 #include <AK/Vector.h>
 #include <LibSemVer/SemVer.h>
 #include <LibTest/TestCase.h>

--- a/Tests/LibSemVer/TestSemVer.cpp
+++ b/Tests/LibSemVer/TestSemVer.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/StringView.h>
-#include <AK/Tuple.h>
 #include <AK/Vector.h>
 #include <LibSemVer/SemVer.h>
 #include <LibTest/TestCase.h>
@@ -198,7 +197,7 @@ TEST_CASE(is_greater_than) // NOLINT(readability-function-cognitive-complexity)
     EXPECT(IS_GREATER_THAN_SCENARIO("1.0.0-beta"sv, "1.0.0-alpha"sv));
     EXPECT(IS_GREATER_THAN_SCENARIO("1.0.0-0.beta"sv, "1.0.0-0.alpha"sv));
 
-    // 3. Either one is numeric, but not both, then numeric given low precendence
+    // 3. Either one is numeric, but not both, then numeric given low precedence
     EXPECT(IS_GREATER_THAN_SCENARIO("1.0.0-0.alpha"sv, "1.0.0-0.0"sv));
     EXPECT(!IS_GREATER_THAN_SCENARIO("1.0.0-0.0"sv, "1.0.0-0.alpha"sv));
 

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -10,7 +10,6 @@
 #include "MP3Types.h"
 #include <AK/BitStream.h>
 #include <AK/MemoryStream.h>
-#include <AK/Tuple.h>
 #include <LibDSP/MDCT.h>
 
 namespace Audio {

--- a/Userland/Libraries/LibGUI/Icon.h
+++ b/Userland/Libraries/LibGUI/Icon.h
@@ -23,13 +23,7 @@ public:
     Gfx::Bitmap const* bitmap_for_size(int) const;
     void set_bitmap_for_size(int, RefPtr<Gfx::Bitmap const>&&);
 
-    Vector<int> sizes() const
-    {
-        Vector<int> sizes;
-        for (auto& it : m_bitmaps)
-            sizes.append(it.key);
-        return sizes;
-    }
+    Vector<int> sizes() const { return m_bitmaps.keys(); }
 
 private:
     IconImpl() = default;

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -8,7 +8,6 @@
 #include <AK/BitStream.h>
 #include <AK/Endian.h>
 #include <AK/MemoryStream.h>
-#include <AK/Tuple.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
 #include <LibPDF/DocumentParser.h>
@@ -425,7 +424,12 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
 
     auto number_of_object_entries = dict->get_value("Size").get<int>();
 
-    Vector<Tuple<int, int>> subsections;
+    struct Subsection {
+        int start;
+        int count;
+    };
+
+    Vector<Subsection> subsections;
     if (dict->contains(CommonNames::Index)) {
         auto index_array = TRY(dict->get_array(m_document, CommonNames::Index));
         if (index_array->size() % 2 != 0)
@@ -449,9 +453,7 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
 
     size_t byte_index = 0;
 
-    for (auto const& subsection : subsections) {
-        auto start = subsection.get<0>();
-        auto count = subsection.get<1>();
+    for (auto [start, count] : subsections) {
         Vector<XRefEntry> entries;
 
         for (int i = 0; i < count; i++) {

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Tuple.h>
 #include <AK/Types.h>
 #include <LibPDF/Error.h>
 #include <LibPDF/Fonts/Type1FontProgram.h>

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <AK/Tuple.h>
 #include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Forward.h>
 #include <LibPDF/Document.h>

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -798,15 +798,15 @@ ErrorOr<Certificate> Certificate::parse_certificate(ReadonlyBytes buffer, bool)
 
 ErrorOr<String> RelativeDistinguishedName::to_string() const
 {
-#define ADD_IF_RECOGNIZED(identifier, shorthand_code)             \
-    if (it->key == identifier) {                                  \
-        cert_name.appendff("\\{}={}", shorthand_code, it->value); \
-        continue;                                                 \
+#define ADD_IF_RECOGNIZED(identifier, shorthand_code)         \
+    if (member_identifier == identifier) {                    \
+        cert_name.appendff("\\{}={}", shorthand_code, value); \
+        continue;                                             \
     }
 
     StringBuilder cert_name;
 
-    for (auto it = m_members.begin(); it != m_members.end(); ++it) {
+    for (auto const& [member_identifier, value] : m_members) {
         ADD_IF_RECOGNIZED(enum_value(AttributeType::SerialNumber), "SERIALNUMBER");
         ADD_IF_RECOGNIZED(enum_value(AttributeType::Email), "MAIL");
         ADD_IF_RECOGNIZED(enum_value(AttributeType::Title), "T");
@@ -825,7 +825,7 @@ ErrorOr<String> RelativeDistinguishedName::to_string() const
         ADD_IF_RECOGNIZED(enum_value(AttributeType::Dc), "DC");
         ADD_IF_RECOGNIZED(enum_value(AttributeType::Uid), "UID");
 
-        cert_name.appendff("\\{}={}", it->key, it->value);
+        cert_name.appendff("\\{}={}", member_identifier, value);
     }
 #undef ADD_IF_RECOGNIZED
 

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -285,7 +285,7 @@ static ErrorOr<RelativeDistinguishedName> parse_name(Crypto::ASN1::Decoder& deco
 
             auto attribute_type_string = TRY(String::join("."sv, attribute_type_oid));
             auto attribute_value_string = TRY(String::from_utf8(attribute_value));
-            TRY(rdn.set(attribute_type_string, attribute_value_string));
+            TRY(rdn.set(move(attribute_type_string), move(attribute_value_string)));
 
             EXIT_SCOPE();
         }

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -195,7 +195,7 @@ public:
 
     ErrorOr<AK::HashSetResult> set(String key, String value)
     {
-        return m_members.try_set(key, value);
+        return m_members.try_set(move(key), move(value));
     }
 
     Optional<String> get(StringView key) const
@@ -223,14 +223,9 @@ public:
         return String();
     }
 
-    String organizational_unit()
+    String organizational_unit() const
     {
-        auto entry = get(AttributeType::Ou);
-        if (entry.has_value()) {
-            return entry.value();
-        }
-
-        return String();
+        return get(AttributeType::Ou).value_or({});
     }
 
 private:

--- a/Userland/Libraries/LibTest/Randomized/Generator.h
+++ b/Userland/Libraries/LibTest/Randomized/Generator.h
@@ -13,7 +13,6 @@
 #include <AK/Random.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
-#include <AK/Tuple.h>
 
 #include <math.h>
 

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Tuple.h>
 #include <LibWeb/DOM/AccessibilityTreeNode.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -67,10 +67,10 @@ ConnectionFromClient::~ConnectionFromClient()
 
     MenuManager::the().close_all_menus_from_client({}, *this);
     auto windows = move(m_windows);
-    for (auto& window : windows) {
-        window.value->detach_client({});
-        if (window.value->type() == WindowType::Applet)
-            AppletManager::the().remove_applet(window.value);
+    for (auto& [_, window] : windows) {
+        window->detach_client({});
+        if (window->type() == WindowType::Applet)
+            AppletManager::the().remove_applet(window);
     }
 
     if (m_show_screen_number)
@@ -105,11 +105,10 @@ void ConnectionFromClient::set_menu_name(i32 menu_id, String const& name)
     }
     auto& menu = *it->value;
     menu.set_name(name);
-    for (auto& it : m_windows) {
-        auto& window = *it.value;
-        window.menubar().for_each_menu([&](Menu& other_menu) {
+    for (auto& [_, window] : m_windows) {
+        window->menubar().for_each_menu([&](Menu& other_menu) {
             if (&menu == &other_menu) {
-                window.invalidate_menubar();
+                window->invalidate_menubar();
                 return IterationDecision::Break;
             }
             return IterationDecision::Continue;
@@ -126,11 +125,10 @@ void ConnectionFromClient::set_menu_minimum_width(i32 menu_id, i32 minimum_width
     }
     auto& menu = *it->value;
     menu.set_minimum_width(minimum_width);
-    for (auto& it : m_windows) {
-        auto& window = *it.value;
-        window.menubar().for_each_menu([&](Menu& other_menu) {
+    for (auto& [_, window] : m_windows) {
+        window->menubar().for_each_menu([&](Menu& other_menu) {
             if (&menu == &other_menu) {
-                window.invalidate_menubar();
+                window->invalidate_menubar();
                 return IterationDecision::Break;
             }
             return IterationDecision::Continue;

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -64,16 +64,16 @@ public:
     template<typename Callback>
     void for_each_window(Callback callback)
     {
-        for (auto& it : m_windows) {
-            if (callback(*it.value) == IterationDecision::Break)
+        for (auto& [_, window] : m_windows) {
+            if (callback(*window) == IterationDecision::Break)
                 break;
         }
     }
     template<typename Callback>
     void for_each_menu(Callback callback)
     {
-        for (auto& it : m_menus) {
-            if (callback(*it.value) == IterationDecision::Break)
+        for (auto& [_, menu] : m_menus) {
+            if (callback(*menu) == IterationDecision::Break)
                 break;
         }
     }

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/RefPtr.h>
 #include <LibCore/Forward.h>
 #include <LibGfx/Forward.h>
@@ -101,10 +103,9 @@ public:
 
     void set_dirty(bool re_render_shadow = false)
     {
-        for (auto& it : m_rendered_cache) {
-            auto& cached = *it.value;
-            cached.m_dirty = true;
-            cached.m_shadow_dirty |= re_render_shadow;
+        for (auto& [_, cached] : m_rendered_cache) {
+            cached->m_dirty = true;
+            cached->m_shadow_dirty |= re_render_shadow;
         }
     }
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -583,8 +583,8 @@ void WindowManager::for_each_window_manager(Callback callback)
     auto& connections = WMConnectionFromClient::s_connections;
 
     // FIXME: this isn't really ordered... does it need to be?
-    for (auto it = connections.begin(); it != connections.end(); ++it) {
-        if (callback(*it->value) == IterationDecision::Break)
+    for (auto [_, connection] : connections) {
+        if (callback(connection) == IterationDecision::Break)
             return;
     }
 }

--- a/Userland/Utilities/sed.cpp
+++ b/Userland/Utilities/sed.cpp
@@ -12,7 +12,6 @@
 #include <AK/LexicalPath.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
-#include <AK/Tuple.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>


### PR DESCRIPTION
### Userland+Tests: Remove unused <AK/Tuple.h> includes


### Kernel/NVMe: Use a struct for the namespace features, instead of a Tuple


### LibPDF: Use a struct for the subsection in parse_xref_stream


### WindowServer: Prefer structured bindings when iterating over HashMaps


### LibTLS: Prefer structured bindings when iterating over HashMaps


### LibTLS: Move Strings when creating RelativeDistinguishedNames

Also cleans up the organizational_unit() helper to use `value_or({})`
instead of doing the same thing manually.

### LibGUI: Use HashMap::keys() to hand out the available sizes of icons


### Kernel/PCI: Prefer structured bindings when iterating over HashMaps

This makes `Access::rescan_hardware` look a bit nicer.

### AK/HashMap: Use structured bindings when iterating over itself
