### PR TITLE
LibWeb: Don't load fallback icon for SVG documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -107,6 +107,7 @@
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/ResizeObserver/ResizeObserver.h>
 #include <LibWeb/ResizeObserver/ResizeObserverEntry.h>
+#include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
 #include <LibWeb/SVG/TagNames.h>
@@ -2150,6 +2151,9 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
     if (readiness_value == HTML::DocumentReadyState::Complete) {
         auto navigable = this->navigable();
         if (navigable && navigable->is_traversable()) {
+            if (!is_decoded_svg()) {
+                HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this).release_value_but_fixme_should_propagate_errors();
+            }
             HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this).release_value_but_fixme_should_propagate_errors();
             navigable->traversable_navigable()->page().client().page_did_finish_loading(url());
         } else {
@@ -4766,6 +4770,11 @@ void Document::for_each_shadow_root(Function<void(DOM::ShadowRoot&)>&& callback)
 {
     for (auto& shadow_root : m_shadow_roots)
         callback(shadow_root);
+}
+
+bool Document::is_decoded_svg() const
+{
+    return is<Web::SVG::SVGDecodedImageData::SVGPageClient>(page().client());
 }
 
 // https://drafts.csswg.org/css-position-4/#add-an-element-to-the-top-layer

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -631,6 +631,9 @@ public:
 
     size_t transition_generation() const { return m_transition_generation; }
 
+    // Does document represent an embedded svg img
+    [[nodiscard]] bool is_decoded_svg() const;
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -25,39 +25,6 @@ namespace Web::SVG {
 
 JS_DEFINE_ALLOCATOR(SVGDecodedImageData);
 
-class SVGDecodedImageData::SVGPageClient final : public PageClient {
-    JS_CELL(SVGDecodedImageData::SVGPageClient, PageClient);
-
-public:
-    static JS::NonnullGCPtr<SVGPageClient> create(JS::VM& vm, Page& page)
-    {
-        return vm.heap().allocate_without_realm<SVGPageClient>(page);
-    }
-
-    virtual ~SVGPageClient() override = default;
-
-    Page& m_host_page;
-    Page* m_svg_page { nullptr };
-
-    virtual Page& page() override { return *m_svg_page; }
-    virtual Page const& page() const override { return *m_svg_page; }
-    virtual bool is_connection_open() const override { return false; }
-    virtual Gfx::Palette palette() const override { return m_host_page.client().palette(); }
-    virtual DevicePixelRect screen_rect() const override { return {}; }
-    virtual double device_pixels_per_css_pixel() const override { return 1.0; }
-    virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page.client().preferred_color_scheme(); }
-    virtual void request_file(FileRequest) override { }
-    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override { }
-    virtual void schedule_repaint() override { }
-    virtual bool is_ready_to_paint() const override { return true; }
-
-private:
-    explicit SVGPageClient(Page& host_page)
-        : m_host_page(host_page)
-    {
-    }
-};
-
 ErrorOr<JS::NonnullGCPtr<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& realm, JS::NonnullGCPtr<Page> host_page, URL::URL const& url, ByteBuffer data)
 {
     auto page_client = SVGPageClient::create(Bindings::main_thread_vm(), host_page);


### PR DESCRIPTION
Fix for issue: #23405