### PR TITLE
LibWeb: Don't crash in offset_parent() if no ancestor element found

### DIFF
--- a/Tests/LibWeb/Text/expected/Element-offsetParent-of-iframe.txt
+++ b/Tests/LibWeb/Text/expected/Element-offsetParent-of-iframe.txt
@@ -1,0 +1,1 @@
+iframe offsetParent value: null

--- a/Tests/LibWeb/Text/input/Element-offsetParent-of-iframe.html
+++ b/Tests/LibWeb/Text/input/Element-offsetParent-of-iframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    function offsetParentOfChildDocument() {
+        const frameDocument = document.querySelector("iframe").contentDocument;
+        const frameRoot = frameDocument.documentElement;
+        document.documentElement.append(frameRoot);
+        document.dispatchEvent(new CustomEvent("offsetParentCalled", { detail: { iframeOffsetParent: frameRoot.offsetParent }}));
+    }
+
+    asyncTest(done => {
+        document.addEventListener("offsetParentCalled", event => {
+            println(`iframe offsetParent value: ${event.detail.iframeOffsetParent}`);
+            done();
+        });
+    });
+</script>
+<iframe srcdoc="
+<script>
+    window.parent.offsetParentOfChildDocument();
+</script>
+">

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -205,7 +205,8 @@ JS::GCPtr<DOM::Element> HTMLElement::offset_parent() const
             return const_cast<Element*>(ancestor);
     }
 
-    VERIFY_NOT_REACHED();
+    // 3. Return null.
+    return nullptr;
 }
 
 // https://www.w3.org/TR/cssom-view-1/#dom-htmlelement-offsettop


### PR DESCRIPTION
The specification says the final step of this algorithm is to return null. Previously, the browser would crash if the content of an iframe was appended to the document before its offsetParent property was queried.

Fixes this WPT test (and probably others): [the-xhtml-syntax/parsing-xhtml-documents/adopt-while-parsing-001](http://wpt.live/html/the-xhtml-syntax/parsing-xhtml-documents/adopt-while-parsing-001.html)

This fix also prevents these WPT tests from crashing WebContent, although it doesn't fix them:
* [css/css-anchor-position/anchor-name-cross-shadow](http://wpt.live/css/css-anchor-position/anchor-name-cross-shadow.html)
* [css/css-anchor-position/anchor-name-in-shadow](http://wpt.live/css/css-anchor-position/anchor-name-in-shadow.html)
* [css/css-anchor-position/position-fallback-tree-scoped](http://wpt.live/css/css-anchor-position/position-fallback-tree-scoped.html)
* [css/cssom-view/elementsFromPoint-shadowroot](http://wpt.live/css/cssom-view/elementsFromPoint-shadowroot.html)
* [css/cssom-view/scrollIntoView-shadow](http://wpt.live/css/cssom-view/scrollIntoView-shadow.html)

I believe a more complete solution would be to implement offsetParent from [this specification](https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent). This would allow us to handle calling offsetParent for elements within a shadow root, which may fix the above 5 tests.

In the meantime, I think this change is still worth making, as it stops WebContent from crashing even if it doesn't always work as expected.