### PR TITLE
LibWeb: Empty CE reaction queue instead of destroying it on exception

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/custom-elements-throw-in-constructor.txt
+++ b/Tests/LibWeb/Text/expected/HTML/custom-elements-throw-in-constructor.txt
@@ -1,0 +1,2 @@
+   Entered TestElement constructor, throwing.
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/custom-elements-throw-in-constructor.html
+++ b/Tests/LibWeb/Text/input/HTML/custom-elements-throw-in-constructor.html
@@ -1,0 +1,20 @@
+<test-element></test-element>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        class TestElement extends HTMLElement {
+            constructor() {
+                super();
+                println("Entered TestElement constructor, throwing.");
+                throw "test";
+            }
+
+            connectedCallback() {
+                println("connectedCallback");
+            }
+        }
+
+        customElements.define("test-element", TestElement);
+        println("PASS! (Didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2030,7 +2030,8 @@ JS::ThrowCompletionOr<void> Element::upgrade_element(JS::NonnullGCPtr<HTML::Cust
         m_custom_element_definition = nullptr;
 
         // 2. Empty element's custom element reaction queue.
-        m_custom_element_reaction_queue = nullptr;
+        if (m_custom_element_reaction_queue)
+            m_custom_element_reaction_queue->clear();
 
         // 3. Rethrow the exception (thus terminating this algorithm).
         return maybe_exception.release_error();


### PR DESCRIPTION
If an exception occurs in a custom element constructor, we clear the reaction queue by destroying it, instead of emptying the Vector. https://github.com/SerenityOS/serenity/blob/3da6916383afc1c8a8b59dae38c4bc02680b50ba/Userland/Libraries/LibWeb/DOM/Element.cpp#L2033

This causes a UAF here, as async upgrades (i.e. custom elements not created by document.createElement) are performed in this loop: https://github.com/SerenityOS/serenity/blob/3da6916383afc1c8a8b59dae38c4bc02680b50ba/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp#L657

Fixes crash when loading https://github.com/SerenityOS/serenity