### PR TITLE
LibWeb: Reduce paintable tree traversals during hit-testing

### DIFF
--- a/Tests/LibWeb/Text/expected/hit_testing/positioned-z-index-0-and-floats.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/positioned-z-index-0-and-floats.txt
@@ -1,0 +1,6 @@
+  1   2    <DIV id="aa" >
+<DIV id="a" >
+<DIV id="bb" >
+<DIV id="b" >
+<DIV id="d" >
+<DIV id="container" >

--- a/Tests/LibWeb/Text/input/hit_testing/positioned-z-index-0-and-floats.html
+++ b/Tests/LibWeb/Text/input/hit_testing/positioned-z-index-0-and-floats.html
@@ -1,0 +1,66 @@
+<script src="../include.js"></script>
+<style>
+    #container {
+        background-color: #2196f3;
+        padding: 10px;
+    }
+
+    .item {
+        float: left;
+        width: 100px;
+        height: 100px;
+        background-color: yellow;
+        position: absolute;
+    }
+
+    #a {
+        left: 100px;
+    }
+
+    #b {
+        z-index: 1;
+        left: 500px;
+    }
+
+    .nested-item {
+        float: left;
+        width: 50px;
+        height: 50px;
+        background-color: yellowgreen;
+    }
+
+    #c {
+        border: 10px solid black;
+    }
+
+    #d {
+        border: 10px solid black;
+        background-color: magenta;
+    }
+
+    .wrapper {
+        float: left;
+        width: 100px;
+        height: 100px;
+        background-color: yellow;
+        position: absolute;
+    }
+</style>
+<div id="container">
+    <div class="wrapper" id="c">
+        <div class="item" id="a"><div id="aa" class="nested-item">1</div></div>
+    </div>
+    <div class="wrapper" id="d">
+        <div class="item" id="b"><div id="bb" class="nested-item">2</div></div>
+    </div>
+</div>
+<script>
+    test(() => {
+        printElement(internals.hitTest(156, 54).node);
+        printElement(internals.hitTest(200, 106).node);
+        printElement(internals.hitTest(548, 65).node);
+        printElement(internals.hitTest(576, 105).node);
+        printElement(internals.hitTest(82, 78).node);
+        printElement(internals.hitTest(403, 16).node);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -14,6 +14,8 @@
 namespace Web::Painting {
 
 class StackingContext {
+    friend class ViewportPaintable;
+
 public:
     StackingContext(Paintable&, StackingContext* parent, size_t index_in_tree_order);
 
@@ -49,6 +51,9 @@ private:
     StackingContext* const m_parent { nullptr };
     Vector<StackingContext*> m_children;
     size_t m_index_in_tree_order { 0 };
+
+    Vector<Paintable const&> m_positioned_descendants_with_stack_level_0_and_stacking_contexts;
+    Vector<Paintable const&> m_non_positioned_floating_descendants;
 
     static void paint_child(PaintContext&, StackingContext const&);
     void paint_internal(PaintContext&) const;


### PR DESCRIPTION
By storing a list of positioned and floating descendants within the stacking context tree node, we can eliminate the need for costly paintable tree traversals during hit-testing.

This optimization results in hit-testing being 2 to 2.5 times faster on https://ziglang.org/documentation/master/