### PR TITLE
LibJS/Bytecode: Handle awkward initialization case for duplicate `var`

### DIFF
--- a/Userland/Libraries/LibJS/Tests/var-scoping.js
+++ b/Userland/Libraries/LibJS/Tests/var-scoping.js
@@ -33,3 +33,18 @@ test("Issue #8198 arrow function escapes function scope", () => {
     f();
     expect(b).toBe(3);
 });
+
+test("Referencing the declared var in the initializer of a duplicate var declaration", () => {
+    function c(e) {
+        e.foo;
+    }
+    function h() {}
+    function go() {
+        var p = true;
+        var p = h() || c(p);
+        return 0;
+    }
+
+    // It's all good as long as go() doesn't throw.
+    expect(go()).toBe(0);
+});


### PR DESCRIPTION
`var` declarations can have duplicates, but duplicate `let` or `const` bindings are a syntax error.

Because of this, we can sink `let` and `const` directly into the preferred_dst if available. This is not safe for `var` since the preferred_dst may be used in the initializer.

This patch fixes the issue by simply skipping the preferred_dst optimization for `var` declarations.