### PR TITLE
LibPDF: Add support for vertical text :^)

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.cpp
+++ b/Userland/Libraries/LibPDF/CommonNames.cpp
@@ -13,5 +13,6 @@ ENUMERATE_COMMON_NAMES(ENUMERATE)
 #undef ENUMERATE
 
 DeprecatedFlyString CommonNames::IdentityH = "Identity-H";
+DeprecatedFlyString CommonNames::IdentityV = "Identity-V";
 
 }

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -206,7 +206,9 @@ public:
     ENUMERATE_COMMON_NAMES(ENUMERATE)
 #undef ENUMERATE
 
+    // Special cases where the string value isn't identical to the name.
     static DeprecatedFlyString IdentityH;
+    static DeprecatedFlyString IdentityV;
 };
 
 }

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -52,6 +52,7 @@
     X(D)                          \
     X(DCTDecode)                  \
     X(DW)                         \
+    X(DW2)                        \
     X(DamagedRowsBeforeError)     \
     X(Decode)                     \
     X(DecodeParms)                \
@@ -188,6 +189,7 @@
     X(UserUnit)                   \
     X(V)                          \
     X(W)                          \
+    X(W2)                         \
     X(WhitePoint)                 \
     X(Width)                      \
     X(Widths)                     \

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -21,6 +21,11 @@ class Renderer;
 // these tables in some cases. Skip reading these tables.
 constexpr u32 pdf_skipped_opentype_tables = OpenType::FontOptions::SkipTables::Name | OpenType::FontOptions::SkipTables::Hmtx | OpenType::FontOptions::SkipTables::OS2;
 
+enum class WritingMode {
+    Horizontal,
+    Vertical,
+};
+
 class PDFFont : public RefCounted<PDFFont> {
 public:
     static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject> const&, float font_size);
@@ -29,6 +34,8 @@ public:
 
     virtual void set_font_size(float font_size) = 0;
     virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&) = 0;
+
+    virtual WritingMode writing_mode() const { return WritingMode::Horizontal; }
 
     // TABLE 5.20 Font flags
     bool is_fixed_pitch() const { return m_flags & (1 << (1 - 1)); }

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -293,10 +293,10 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
                 auto first_code = pending_code.release_value();
                 auto last_code = value.to_int();
                 auto width = widths_array->at(i + 1).to_int();
+                i++;
+
                 for (u16 code = first_code; code <= last_code; code++)
                     widths.set(code, width);
-
-                i++;
             } else {
                 auto array = TRY(document->resolve_to<ArrayObject>(value));
                 auto code = pending_code.release_value();

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -273,12 +273,14 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
         return Error { Error::Type::MalformedPDF, "invalid /Subtype for Type 0 font" };
     }
 
+    // PDF 1.7 spec, 5.6.3 CIDFonts, Glyph Metrics in CIDFonts, and TABLE 5.14 Entries in a CIDFont dictionary
+    // "The DW entry defines the default width, which is used for all glyphs whose widths are not specified individually."
     u16 default_width = 1000;
     if (descendant_font->contains(CommonNames::DW))
         default_width = descendant_font->get_value(CommonNames::DW).to_int();
 
+    // "The W array allows the definition of widths for individual CIDs."
     HashMap<u16, u16> widths;
-
     if (descendant_font->contains(CommonNames::W)) {
         auto widths_array = MUST(descendant_font->get_array(document, CommonNames::W));
         Optional<u16> pending_code;

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -40,6 +40,16 @@ private:
     CIDSystemInfo m_system_info;
     HashMap<u16, u16> m_widths;
     u16 m_missing_width;
+
+    int m_default_position_vector_y;
+    int m_default_displacement_vector_y;
+    struct VerticalMetric {
+        int vertical_displacement_vector_y;
+        int position_vector_x;
+        int position_vector_y;
+    };
+    HashMap<u16, VerticalMetric> m_vertical_metrics;
+
     OwnPtr<CIDFontType> m_cid_font_type;
 };
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -20,6 +20,19 @@ struct CIDSystemInfo {
     u8 supplement;
 };
 
+class CIDIterator {
+public:
+    virtual ~CIDIterator() = default;
+    virtual bool has_next() const = 0;
+    virtual u32 next() = 0;
+};
+
+class Type0CMap {
+public:
+    virtual ~Type0CMap() = default;
+    virtual PDFErrorOr<NonnullOwnPtr<CIDIterator>> iterate(ReadonlyBytes) const = 0;
+};
+
 class Type0Font : public PDFFont {
 public:
     Type0Font();
@@ -51,6 +64,7 @@ private:
     HashMap<u16, VerticalMetric> m_vertical_metrics;
 
     OwnPtr<CIDFontType> m_cid_font_type;
+    OwnPtr<Type0CMap> m_cmap;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -27,11 +27,6 @@ public:
     virtual u32 next() = 0;
 };
 
-enum class WritingMode {
-    Horizontal,
-    Vertical,
-};
-
 class Type0CMap {
 public:
     virtual ~Type0CMap() = default;
@@ -58,6 +53,7 @@ public:
 
     void set_font_size(float font_size) override;
     PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&) override;
+    WritingMode writing_mode() const override { return m_cmap->writing_mode(); }
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -27,10 +27,28 @@ public:
     virtual u32 next() = 0;
 };
 
+enum class WritingMode {
+    Horizontal,
+    Vertical,
+};
+
 class Type0CMap {
 public:
     virtual ~Type0CMap() = default;
+
+    // "(Writing mode is specified as part of the CMap because, in some cases, different shapes are used when writing horizontally and vertically.
+    //  In such cases, the horizontal and vertical variants of a CMap specify different CIDs for a given character code.)"
+    WritingMode writing_mode() const { return m_writing_mode; }
+
     virtual PDFErrorOr<NonnullOwnPtr<CIDIterator>> iterate(ReadonlyBytes) const = 0;
+
+protected:
+    Type0CMap(WritingMode writing_mode)
+        : m_writing_mode(writing_mode)
+    {
+    }
+
+    WritingMode m_writing_mode;
 };
 
 class Type0Font : public PDFFont {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -598,7 +598,10 @@ RENDERER_HANDLER(text_show_string_array)
     for (auto& element : elements) {
         if (element.has_number()) {
             float shift = element.to_float() / 1000.0f;
-            m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
+            if (text_state().font->writing_mode() == WritingMode::Horizontal)
+                m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
+            else
+                m_text_matrix.translate(0.0f, -shift * text_state().font_size);
             m_text_rendering_matrix_is_dirty = true;
         } else {
             auto str = element.get<NonnullRefPtr<Object>>()->cast<StringObject>()->string();

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -596,12 +596,8 @@ RENDERER_HANDLER(text_show_string_array)
     auto elements = MUST(m_document->resolve_to<ArrayObject>(args[0]))->elements();
 
     for (auto& element : elements) {
-        if (element.has<int>()) {
-            float shift = (float)element.get<int>() / 1000.0f;
-            m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
-            m_text_rendering_matrix_is_dirty = true;
-        } else if (element.has<float>()) {
-            float shift = element.get<float>() / 1000.0f;
+        if (element.has_number()) {
+            float shift = element.to_float() / 1000.0f;
             m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
             m_text_rendering_matrix_is_dirty = true;
         } else {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1036,9 +1036,9 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
     auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, *this));
 
     // Update text matrix.
-    auto delta_x = end_position.x() - start_position.x();
+    auto delta = end_position - start_position;
     m_text_rendering_matrix_is_dirty = true;
-    m_text_matrix.translate(delta_x * text_state().horizontal_scaling, 0.0f);
+    m_text_matrix.translate(delta);
     return {};
 }
 


### PR DESCRIPTION
Only for the named Identity-V cmap for now. As far as I can tell, in my 1000 file test sets, there are 4 files that use vertical text, and they all use Identity-V.

The drawing code is all done now, and the type0 cmap logic is now a bit abstracted away, so it's easy to add support for vertical text in more cmap encodings. (As easy as adding support for additional horizontal cmap encodings at least.)