### PR TITLE
CI: Strip binaries and libraries during the installation step, reduce ccache size

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -55,6 +55,7 @@ steps:
 
     - script: |
         CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M ${{ parameters.serenity_ccache_size }}
+        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -c
         CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -s
       displayName: 'Configure Serenity ccache'
 

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -140,7 +140,7 @@ jobs:
         - script: |
             set -e
             cmake --build .
-            cmake --install . --prefix $(Build.SourcesDirectory)/Meta/Lagom/Install
+            cmake --install . --strip --prefix $(Build.SourcesDirectory)/Meta/Lagom/Install
           displayName: 'Build'
           workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build
           env:

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -56,7 +56,7 @@ jobs:
         with_remote_data_caches: true
         ${{ if eq(parameters.os, 'macOS') }}:
           ccache_version: 2
-          serenity_ccache_size: '2G'
+        serenity_ccache_size: '2G'
 
     - ${{ if eq(parameters.os, 'Android') }}:
       - script: |


### PR DESCRIPTION
We're still hitting low disk space issues after #23404. Let's reduce disk usage even further.