### PR TITLE
LibWeb: Reduce number of glyph run copies made while painting commands recording

### DIFF
--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -100,6 +100,23 @@ struct DrawEmoji {
 
 using DrawGlyphOrEmoji = Variant<DrawGlyph, DrawEmoji>;
 
+class GlyphRun : public RefCounted<GlyphRun> {
+public:
+    GlyphRun() = default;
+    GlyphRun(Vector<Gfx::DrawGlyphOrEmoji>&& glyphs)
+        : m_glyphs(move(glyphs))
+    {
+    }
+
+    [[nodiscard]] Vector<Gfx::DrawGlyphOrEmoji> const& glyphs() const { return m_glyphs; }
+    [[nodiscard]] bool is_empty() const { return m_glyphs.is_empty(); }
+
+    void append(Gfx::DrawGlyphOrEmoji glyph) { m_glyphs.append(glyph); }
+
+private:
+    Vector<Gfx::DrawGlyphOrEmoji> m_glyphs;
+};
+
 Variant<DrawGlyph, DrawEmoji> prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIterator& it, Font const& font);
 
 template<typename Callback>

--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -26,7 +26,7 @@ void LineBox::add_fragment(Node const& layout_node, int start, int length, CSSPi
         m_fragments.last().set_width(m_fragments.last().width() + content_width);
         for (auto glyph : glyph_run) {
             glyph.visit([&](auto& glyph) { glyph.position.translate_by(fragment_width.to_float(), 0); });
-            m_fragments.last().m_glyph_run.append(glyph);
+            m_fragments.last().m_glyph_run->append(glyph);
         }
     } else {
         Vector<Gfx::DrawGlyphOrEmoji> glyph_run_copy { glyph_run };

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -19,7 +19,7 @@ class LineBoxFragment {
     friend class LineBox;
 
 public:
-    LineBoxFragment(Node const& layout_node, int start, int length, CSSPixelPoint offset, CSSPixelSize size, CSSPixels border_box_top, CSSPixels border_box_bottom, Vector<Gfx::DrawGlyphOrEmoji> glyph_run = {})
+    LineBoxFragment(Node const& layout_node, int start, int length, CSSPixelPoint offset, CSSPixelSize size, CSSPixels border_box_top, CSSPixels border_box_bottom, Vector<Gfx::DrawGlyphOrEmoji> glyphs)
         : m_layout_node(layout_node)
         , m_start(start)
         , m_length(length)
@@ -27,7 +27,7 @@ public:
         , m_size(size)
         , m_border_box_top(border_box_top)
         , m_border_box_bottom(border_box_bottom)
-        , m_glyph_run(move(glyph_run))
+        , m_glyph_run(adopt_ref(*new Gfx::GlyphRun(move(glyphs))))
     {
     }
 
@@ -60,7 +60,7 @@ public:
 
     bool is_atomic_inline() const;
 
-    Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run() const { return m_glyph_run; }
+    Gfx::GlyphRun const& glyph_run() const { return *m_glyph_run; }
 
 private:
     JS::NonnullGCPtr<Node const> m_layout_node;
@@ -71,7 +71,7 @@ private:
     CSSPixels m_border_box_top { 0 };
     CSSPixels m_border_box_bottom { 0 };
     CSSPixels m_baseline { 0 };
-    Vector<Gfx::DrawGlyphOrEmoji> m_glyph_run;
+    NonnullRefPtr<Gfx::GlyphRun> m_glyph_run;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/Command.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Command.cpp
@@ -11,12 +11,8 @@ namespace Web::Painting {
 
 void DrawGlyphRun::translate_by(Gfx::IntPoint const& offset)
 {
-    for (auto& glyph : glyph_run) {
-        glyph.visit([&](auto& glyph) {
-            glyph.translate_by(offset.to_type<float>());
-        });
-    }
     rect.translate_by(offset);
+    translation.translate_by(offset.to_type<float>());
 }
 
 Gfx::IntRect PaintOuterBoxShadow::bounding_rect() const

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -38,7 +38,7 @@
 namespace Web::Painting {
 
 struct DrawGlyphRun {
-    Vector<Gfx::DrawGlyphOrEmoji> glyph_run;
+    NonnullRefPtr<Gfx::GlyphRun> glyph_run;
     Color color;
     Gfx::IntRect rect;
     Gfx::FloatPoint translation;

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -42,6 +42,7 @@ struct DrawGlyphRun {
     Color color;
     Gfx::IntRect rect;
     Gfx::FloatPoint translation;
+    double scale { 1 };
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
 

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -41,6 +41,7 @@ struct DrawGlyphRun {
     Vector<Gfx::DrawGlyphOrEmoji> glyph_run;
     Color color;
     Gfx::IntRect rect;
+    Gfx::FloatPoint translation;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
 

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -24,15 +24,17 @@ CommandExecutorCPU::CommandExecutorCPU(Gfx::Bitmap& bitmap)
         .scaling_mode = {} });
 }
 
-CommandResult CommandExecutorCPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color)
+CommandResult CommandExecutorCPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color, Gfx::FloatPoint translation)
 {
     auto& painter = this->painter();
     for (auto& glyph_or_emoji : glyph_run) {
+        auto transformed_glyph = glyph_or_emoji;
+        transformed_glyph.visit([&](auto& glyph) { glyph.position.translate_by(translation); });
         if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
-            auto& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
+            auto& glyph = transformed_glyph.get<Gfx::DrawGlyph>();
             painter.draw_glyph(glyph.position, glyph.code_point, *glyph.font, color);
         } else {
-            auto& emoji = glyph_or_emoji.get<Gfx::DrawEmoji>();
+            auto& emoji = transformed_glyph.get<Gfx::DrawEmoji>();
             painter.draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *emoji.font);
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -24,12 +24,15 @@ CommandExecutorCPU::CommandExecutorCPU(Gfx::Bitmap& bitmap)
         .scaling_mode = {} });
 }
 
-CommandResult CommandExecutorCPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color, Gfx::FloatPoint translation)
+CommandResult CommandExecutorCPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color, Gfx::FloatPoint translation, double scale)
 {
     auto& painter = this->painter();
     for (auto& glyph_or_emoji : glyph_run) {
         auto transformed_glyph = glyph_or_emoji;
-        transformed_glyph.visit([&](auto& glyph) { glyph.position.translate_by(translation); });
+        transformed_glyph.visit([&](auto& glyph) {
+            glyph.position = glyph.position.scaled(scale).translated(translation);
+            glyph.font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(scale));
+        });
         if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
             auto& glyph = transformed_glyph.get<Gfx::DrawGlyph>();
             painter.draw_glyph(glyph.position, glyph.code_point, *glyph.font, color);

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
@@ -13,7 +13,7 @@ namespace Web::Painting {
 
 class CommandExecutorCPU : public CommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&) override;
+    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation) override;
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
@@ -13,7 +13,7 @@ namespace Web::Painting {
 
 class CommandExecutorCPU : public CommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation) override;
+    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation, double scale) override;
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
@@ -31,9 +31,16 @@ CommandExecutorGPU::~CommandExecutorGPU()
     painter().flush(m_target_bitmap);
 }
 
-CommandResult CommandExecutorGPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color)
+CommandResult CommandExecutorGPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color, Gfx::FloatPoint translation)
 {
-    painter().draw_glyph_run(glyph_run, color);
+    Vector<Gfx::DrawGlyphOrEmoji> transformed_glyph_run;
+    transformed_glyph_run.ensure_capacity(glyph_run.size());
+    for (auto& glyph : glyph_run) {
+        auto transformed_glyph = glyph;
+        transformed_glyph.visit([&](auto& glyph) { glyph.position.translate_by(translation); });
+        transformed_glyph_run.append(transformed_glyph);
+    }
+    painter().draw_glyph_run(transformed_glyph_run, color);
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
@@ -31,13 +31,16 @@ CommandExecutorGPU::~CommandExecutorGPU()
     painter().flush(m_target_bitmap);
 }
 
-CommandResult CommandExecutorGPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color, Gfx::FloatPoint translation)
+CommandResult CommandExecutorGPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color, Gfx::FloatPoint translation, double scale)
 {
     Vector<Gfx::DrawGlyphOrEmoji> transformed_glyph_run;
     transformed_glyph_run.ensure_capacity(glyph_run.size());
     for (auto& glyph : glyph_run) {
         auto transformed_glyph = glyph;
-        transformed_glyph.visit([&](auto& glyph) { glyph.position.translate_by(translation); });
+        transformed_glyph.visit([&](auto& glyph) {
+            glyph.position = glyph.position.scaled(scale).translated(translation);
+            glyph.font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(scale));
+        });
         transformed_glyph_run.append(transformed_glyph);
     }
     painter().draw_glyph_run(transformed_glyph_run, color);

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
@@ -14,7 +14,7 @@ namespace Web::Painting {
 
 class CommandExecutorGPU : public CommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&) override;
+    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation) override;
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
@@ -14,7 +14,7 @@ namespace Web::Painting {
 
 class CommandExecutorGPU : public CommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation) override;
+    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation, double scale) override;
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;

--- a/Userland/Libraries/LibWeb/Painting/CommandList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.cpp
@@ -87,7 +87,7 @@ void CommandList::execute(CommandExecutor& executor)
 
         auto result = command.visit(
             [&](DrawGlyphRun const& command) {
-                return executor.draw_glyph_run(command.glyph_run, command.color);
+                return executor.draw_glyph_run(command.glyph_run, command.color, command.translation);
             },
             [&](DrawText const& command) {
                 return executor.draw_text(command.rect, command.raw_text, command.alignment, command.color,

--- a/Userland/Libraries/LibWeb/Painting/CommandList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.cpp
@@ -48,10 +48,12 @@ void CommandList::execute(CommandExecutor& executor)
         for (auto& command_with_scroll_id : m_commands) {
             auto& command = command_with_scroll_id.command;
             if (command.has<DrawGlyphRun>()) {
+                auto scale = command.get<DrawGlyphRun>().scale;
                 for (auto const& glyph_or_emoji : command.get<DrawGlyphRun>().glyph_run) {
                     if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
                         auto const& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
-                        unique_glyphs.ensure(glyph.font, [] { return HashTable<u32> {}; }).set(glyph.code_point);
+                        auto const& font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(scale));
+                        unique_glyphs.ensure(&font, [] { return HashTable<u32> {}; }).set(glyph.code_point);
                     }
                 }
             }
@@ -87,7 +89,7 @@ void CommandList::execute(CommandExecutor& executor)
 
         auto result = command.visit(
             [&](DrawGlyphRun const& command) {
-                return executor.draw_glyph_run(command.glyph_run, command.color, command.translation);
+                return executor.draw_glyph_run(command.glyph_run, command.color, command.translation, command.scale);
             },
             [&](DrawText const& command) {
                 return executor.draw_text(command.rect, command.raw_text, command.alignment, command.color,

--- a/Userland/Libraries/LibWeb/Painting/CommandList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.cpp
@@ -49,7 +49,7 @@ void CommandList::execute(CommandExecutor& executor)
             auto& command = command_with_scroll_id.command;
             if (command.has<DrawGlyphRun>()) {
                 auto scale = command.get<DrawGlyphRun>().scale;
-                for (auto const& glyph_or_emoji : command.get<DrawGlyphRun>().glyph_run) {
+                for (auto const& glyph_or_emoji : command.get<DrawGlyphRun>().glyph_run->glyphs()) {
                     if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
                         auto const& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
                         auto const& font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(scale));
@@ -89,7 +89,7 @@ void CommandList::execute(CommandExecutor& executor)
 
         auto result = command.visit(
             [&](DrawGlyphRun const& command) {
-                return executor.draw_glyph_run(command.glyph_run, command.color, command.translation, command.scale);
+                return executor.draw_glyph_run(command.glyph_run->glyphs(), command.color, command.translation, command.scale);
             },
             [&](DrawText const& command) {
                 return executor.draw_text(command.rect, command.raw_text, command.alignment, command.color,

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -47,7 +47,7 @@ class CommandExecutor {
 public:
     virtual ~CommandExecutor() = default;
 
-    virtual CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&) = 0;
+    virtual CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation) = 0;
     virtual CommandResult draw_text(Gfx::IntRect const&, String const&, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) = 0;
     virtual CommandResult fill_rect(Gfx::IntRect const&, Color const&) = 0;
     virtual CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -47,7 +47,7 @@ class CommandExecutor {
 public:
     virtual ~CommandExecutor() = default;
 
-    virtual CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation) = 0;
+    virtual CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation, double scale) = 0;
     virtual CommandResult draw_text(Gfx::IntRect const&, String const&, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) = 0;
     virtual CommandResult fill_rect(Gfx::IntRect const&, Color const&) = 0;
     virtual CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -668,23 +668,15 @@ void paint_text_fragment(PaintContext& context, Layout::TextNode const& text_nod
         auto text = text_node.text_for_rendering();
 
         DevicePixelPoint baseline_start { fragment_absolute_device_rect.x(), fragment_absolute_device_rect.y() + context.rounded_device_pixels(fragment.baseline()) };
-        Vector<Gfx::DrawGlyphOrEmoji> scaled_glyph_run;
-        scaled_glyph_run.ensure_capacity(fragment.glyph_run().size());
-        for (auto glyph : fragment.glyph_run()) {
-            glyph.visit([&](auto& glyph) {
-                glyph.font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(context.device_pixels_per_css_pixel()));
-                glyph.position = glyph.position.scaled(context.device_pixels_per_css_pixel());
-            });
-            scaled_glyph_run.append(move(glyph));
-        }
-        painter.draw_text_run(baseline_start.to_type<int>(), scaled_glyph_run, text_node.computed_values().color(), fragment_absolute_device_rect.to_type<int>());
+        auto scale = context.device_pixels_per_css_pixel();
+        painter.draw_text_run(baseline_start.to_type<int>(), fragment.glyph_run(), text_node.computed_values().color(), fragment_absolute_device_rect.to_type<int>(), scale);
 
         auto selection_rect = context.enclosing_device_rect(fragment.selection_rect(text_node.first_available_font())).to_type<int>();
         if (!selection_rect.is_empty()) {
             painter.fill_rect(selection_rect, CSS::SystemColor::highlight());
             RecordingPainterStateSaver saver(painter);
             painter.add_clip_rect(selection_rect);
-            painter.draw_text_run(baseline_start.to_type<int>(), scaled_glyph_run, CSS::SystemColor::highlight_text(), fragment_absolute_device_rect.to_type<int>());
+            painter.draw_text_run(baseline_start.to_type<int>(), fragment.glyph_run(), CSS::SystemColor::highlight_text(), fragment_absolute_device_rect.to_type<int>(), scale);
         }
 
         paint_text_decoration(context, text_node, fragment);

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -38,7 +38,7 @@ public:
 
     CSSPixelRect const absolute_rect() const;
 
-    Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run() const { return m_glyph_run; }
+    Gfx::GlyphRun const& glyph_run() const { return *m_glyph_run; }
 
     CSSPixelRect selection_rect(Gfx::Font const&) const;
 
@@ -55,7 +55,7 @@ private:
     int m_start;
     int m_length;
     Painting::BorderRadiiData m_border_radii_data;
-    Vector<Gfx::DrawGlyphOrEmoji> m_glyph_run;
+    NonnullRefPtr<Gfx::GlyphRun> m_glyph_run;
     Vector<ShadowData> m_shadows;
     bool m_contained_by_inline_node { false };
 };

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -206,11 +206,11 @@ void RecordingPainter::draw_signed_distance_field(Gfx::IntRect const& dst_rect, 
     });
 }
 
-void RecordingPainter::draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect, double scale)
+void RecordingPainter::draw_text_run(Gfx::IntPoint baseline_start, Gfx::GlyphRun const& glyph_run, Color color, Gfx::IntRect const& rect, double scale)
 {
     auto transformed_baseline_start = state().translation.map(baseline_start).to_type<float>();
     append(DrawGlyphRun {
-        .glyph_run = Vector<Gfx::DrawGlyphOrEmoji> { glyph_run },
+        .glyph_run = glyph_run,
         .color = color,
         .rect = state().translation.map(rect),
         .translation = transformed_baseline_start,

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -206,7 +206,7 @@ void RecordingPainter::draw_signed_distance_field(Gfx::IntRect const& dst_rect, 
     });
 }
 
-void RecordingPainter::draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect)
+void RecordingPainter::draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect, double scale)
 {
     auto transformed_baseline_start = state().translation.map(baseline_start).to_type<float>();
     append(DrawGlyphRun {
@@ -214,6 +214,7 @@ void RecordingPainter::draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::Dra
         .color = color,
         .rect = state().translation.map(rect),
         .translation = transformed_baseline_start,
+        .scale = scale,
     });
 }
 

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -209,16 +209,11 @@ void RecordingPainter::draw_signed_distance_field(Gfx::IntRect const& dst_rect, 
 void RecordingPainter::draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect)
 {
     auto transformed_baseline_start = state().translation.map(baseline_start).to_type<float>();
-    Vector<Gfx::DrawGlyphOrEmoji> translated_glyph_run;
-    translated_glyph_run.ensure_capacity(glyph_run.size());
-    for (auto glyph : glyph_run) {
-        glyph.visit([&](auto& glyph) { glyph.position.translate_by(transformed_baseline_start); });
-        translated_glyph_run.append(glyph);
-    }
     append(DrawGlyphRun {
-        .glyph_run = move(translated_glyph_run),
+        .glyph_run = Vector<Gfx::DrawGlyphOrEmoji> { glyph_run },
         .color = color,
         .rect = state().translation.map(rect),
+        .translation = transformed_baseline_start,
     });
 }
 

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -100,7 +100,7 @@ public:
     void draw_signed_distance_field(Gfx::IntRect const& dst_rect, Color color, Gfx::GrayscaleBitmap const& sdf, float smoothing);
 
     // Streamlined text drawing routine that does no wrapping/elision/alignment.
-    void draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect, double scale);
+    void draw_text_run(Gfx::IntPoint baseline_start, Gfx::GlyphRun const& glyph_run, Color color, Gfx::IntRect const& rect, double scale);
 
     void add_clip_rect(Gfx::IntRect const& rect);
 

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -100,7 +100,7 @@ public:
     void draw_signed_distance_field(Gfx::IntRect const& dst_rect, Color color, Gfx::GrayscaleBitmap const& sdf, float smoothing);
 
     // Streamlined text drawing routine that does no wrapping/elision/alignment.
-    void draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect);
+    void draw_text_run(Gfx::IntPoint baseline_start, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, Gfx::IntRect const& rect, double scale);
 
     void add_clip_rect(Gfx::IntRect const& rect);
 

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -590,8 +590,8 @@ void paint_text_shadow(PaintContext& context, PaintableFragment const& fragment,
     auto fragment_baseline = context.rounded_device_pixels(fragment.baseline()).value();
 
     Vector<Gfx::DrawGlyphOrEmoji> scaled_glyph_run;
-    scaled_glyph_run.ensure_capacity(fragment.glyph_run().size());
-    for (auto glyph : fragment.glyph_run()) {
+    scaled_glyph_run.ensure_capacity(fragment.glyph_run().glyphs().size());
+    for (auto glyph : fragment.glyph_run().glyphs()) {
         glyph.visit([&](auto& glyph) {
             glyph.font = *glyph.font->with_size(glyph.font->point_size() * static_cast<float>(context.device_pixels_per_css_pixel()));
             glyph.position = glyph.position.scaled(context.device_pixels_per_css_pixel());


### PR DESCRIPTION
Before these changes, each glyph run was copied:
1. In paint_text_fragment() to scale position and font of each glyph by device pixel size.
2. In RecordingPainter::draw_glyph_run() to shift each glyph position by painter's transform.

Now, neither of these copies occurs and instead we save scale and offset in the painting command to apply it later when commands are executed.

Also, we do not copy the vector of glyphs from the layout tree into paintables tree and painting commands. Instead, we allocate ref-counted objects that are shared between them.