### PR TITLE
LibJS: Port over some Temporal AOs to use TimeZoneMethodsRecord

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -438,12 +438,13 @@ ThrowCompletionOr<double> calculate_offset_shift(VM& vm, Value relative_to_value
         return 0.0;
 
     auto& relative_to = static_cast<ZonedDateTime&>(relative_to_value.as_object());
+    auto time_zone_record = TRY(create_time_zone_methods_record(vm, NonnullGCPtr<Object> { relative_to.time_zone() }, { { TimeZoneMethod::GetOffsetNanosecondsFor } }));
 
     // 2. Let instant be ! CreateTemporalInstant(relativeTo.[[Nanoseconds]]).
     auto* instant = MUST(create_temporal_instant(vm, relative_to.nanoseconds()));
 
     // 3. Let offsetBefore be ? GetOffsetNanosecondsFor(relativeTo.[[TimeZone]], instant).
-    auto offset_before = TRY(get_offset_nanoseconds_for(vm, &relative_to.time_zone(), *instant));
+    auto offset_before = TRY(get_offset_nanoseconds_for(vm, time_zone_record, *instant));
 
     // 4. Let after be ? AddZonedDateTime(relativeTo.[[Nanoseconds]], relativeTo.[[TimeZone]], relativeTo.[[Calendar]], y, mon, w, d, 0, 0, 0, 0, 0, 0).
     auto* after = TRY(add_zoned_date_time(vm, relative_to.nanoseconds(), &relative_to.time_zone(), relative_to.calendar(), years, months, weeks, days, 0, 0, 0, 0, 0, 0));
@@ -452,7 +453,7 @@ ThrowCompletionOr<double> calculate_offset_shift(VM& vm, Value relative_to_value
     auto* instant_after = MUST(create_temporal_instant(vm, *after));
 
     // 6. Let offsetAfter be ? GetOffsetNanosecondsFor(relativeTo.[[TimeZone]], instantAfter).
-    auto offset_after = TRY(get_offset_nanoseconds_for(vm, &relative_to.time_zone(), *instant_after));
+    auto offset_after = TRY(get_offset_nanoseconds_for(vm, time_zone_record, *instant_after));
 
     // 7. Return offsetAfter - offsetBefore.
     return offset_after - offset_before;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -300,8 +300,10 @@ ThrowCompletionOr<String> temporal_instant_to_string(VM& vm, Instant& instant, V
     }
     // 9. Else,
     else {
+        auto time_zone_record = TRY(create_time_zone_methods_record(vm, NonnullGCPtr<Object> { time_zone.as_object() }, { { TimeZoneMethod::GetOffsetNanosecondsFor } }));
+
         // a. Let offsetNs be ? GetOffsetNanosecondsFor(timeZone, instant).
-        auto offset_ns = TRY(get_offset_nanoseconds_for(vm, time_zone, instant));
+        auto offset_ns = TRY(get_offset_nanoseconds_for(vm, time_zone_record, instant));
 
         // b. Let timeZoneString be ! FormatISOTimeZoneOffsetString(offsetNs).
         time_zone_string = MUST_OR_THROW_OOM(format_iso_time_zone_offset_string(vm, offset_ns));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -596,7 +596,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_zoned_date_time)
     }
 
     // 7. Let instant be ? BuiltinTimeZoneGetInstantFor(timeZone, temporalDateTime, "compatible").
-    auto* instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *temporal_date_time, "compatible"sv));
+    auto instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *temporal_date_time, "compatible"sv));
 
     // 8. Return ! CreateTemporalZonedDateTime(instant.[[Nanoseconds]], timeZone, temporalDate.[[Calendar]]).
     return MUST(create_temporal_zoned_date_time(vm, instant->nanoseconds(), *time_zone, temporal_date->calendar()));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -674,7 +674,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::to_zoned_date_time)
     auto disambiguation = TRY(to_temporal_disambiguation(vm, options));
 
     // 6. Let instant be ? BuiltinTimeZoneGetInstantFor(timeZone, dateTime, disambiguation).
-    auto* instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, date_time, disambiguation));
+    auto instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, date_time, disambiguation));
 
     // 7. Return ! CreateTemporalZonedDateTime(instant.[[Nanoseconds]], timeZone, dateTime.[[Calendar]]).
     return MUST(create_temporal_zoned_date_time(vm, instant->nanoseconds(), *time_zone, date_time->calendar()));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -411,7 +411,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::to_zoned_date_time)
     auto* temporal_date_time = TRY(create_temporal_date_time(vm, temporal_date->iso_year(), temporal_date->iso_month(), temporal_date->iso_day(), temporal_time->iso_hour(), temporal_time->iso_minute(), temporal_time->iso_second(), temporal_time->iso_millisecond(), temporal_time->iso_microsecond(), temporal_time->iso_nanosecond(), temporal_date->calendar()));
 
     // 11. Let instant be ? BuiltinTimeZoneGetInstantFor(timeZone, temporalDateTime, "compatible").
-    auto* instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *temporal_date_time, "compatible"sv));
+    auto instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *temporal_date_time, "compatible"sv));
 
     // 12. Return ! CreateTemporalZonedDateTime(instant.[[Nanoseconds]], timeZone, temporalDate.[[Calendar]]).
     return MUST(create_temporal_zoned_date_time(vm, instant->nanoseconds(), *time_zone, temporal_date->calendar()));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -384,7 +384,7 @@ ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM& 
 }
 
 // 11.6.11 BuiltinTimeZoneGetInstantFor ( timeZone, dateTime, disambiguation ), https://tc39.es/proposal-temporal/#sec-temporal-builtintimezonegetinstantfor
-ThrowCompletionOr<Instant*> builtin_time_zone_get_instant_for(VM& vm, Value time_zone, PlainDateTime& date_time, StringView disambiguation)
+ThrowCompletionOr<NonnullGCPtr<Instant>> builtin_time_zone_get_instant_for(VM& vm, Value time_zone, PlainDateTime& date_time, StringView disambiguation)
 {
     // 1. Assert: dateTime has an [[InitializedTemporalDateTime]] internal slot.
 
@@ -396,7 +396,7 @@ ThrowCompletionOr<Instant*> builtin_time_zone_get_instant_for(VM& vm, Value time
 }
 
 // 11.6.12 DisambiguatePossibleInstants ( possibleInstants, timeZone, dateTime, disambiguation ), https://tc39.es/proposal-temporal/#sec-temporal-disambiguatepossibleinstants
-ThrowCompletionOr<Instant*> disambiguate_possible_instants(VM& vm, MarkedVector<Instant*> const& possible_instants, Value time_zone, PlainDateTime& date_time, StringView disambiguation)
+ThrowCompletionOr<NonnullGCPtr<Instant>> disambiguate_possible_instants(VM& vm, MarkedVector<NonnullGCPtr<Instant>> const& possible_instants, Value time_zone, PlainDateTime& date_time, StringView disambiguation)
 {
     // 1. Assert: dateTime has an [[InitializedTemporalDateTime]] internal slot.
 
@@ -514,7 +514,7 @@ ThrowCompletionOr<Instant*> disambiguate_possible_instants(VM& vm, MarkedVector<
 }
 
 // 11.6.13 GetPossibleInstantsFor ( timeZone, dateTime ), https://tc39.es/proposal-temporal/#sec-temporal-getpossibleinstantsfor
-ThrowCompletionOr<MarkedVector<Instant*>> get_possible_instants_for(VM& vm, Value time_zone, PlainDateTime& date_time)
+ThrowCompletionOr<MarkedVector<NonnullGCPtr<Instant>>> get_possible_instants_for(VM& vm, Value time_zone, PlainDateTime& date_time)
 {
     // 1. Assert: dateTime has an [[InitializedTemporalDateTime]] internal slot.
 
@@ -525,7 +525,7 @@ ThrowCompletionOr<MarkedVector<Instant*>> get_possible_instants_for(VM& vm, Valu
     auto iterator = TRY(get_iterator(vm, possible_instants, IteratorHint::Sync));
 
     // 4. Let list be a new empty List.
-    auto list = MarkedVector<Instant*> { vm.heap() };
+    auto list = MarkedVector<NonnullGCPtr<Instant>> { vm.heap() };
 
     // 5. Let next be true.
     GCPtr<Object> next;
@@ -550,7 +550,7 @@ ThrowCompletionOr<MarkedVector<Instant*>> get_possible_instants_for(VM& vm, Valu
             }
 
             // iii. Append nextValue to the end of the List list.
-            list.append(static_cast<Instant*>(&next_value.as_object()));
+            list.append(verify_cast<Instant>(next_value.as_object()));
         }
     } while (next != nullptr);
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -46,7 +46,7 @@ BigInt* get_named_time_zone_previous_transition(VM&, StringView time_zone_identi
 ThrowCompletionOr<String> format_time_zone_offset_string(VM&, double offset_nanoseconds);
 ThrowCompletionOr<String> format_iso_time_zone_offset_string(VM&, double offset_nanoseconds);
 ThrowCompletionOr<Object*> to_temporal_time_zone(VM&, Value temporal_time_zone_like);
-ThrowCompletionOr<double> get_offset_nanoseconds_for(VM&, Value time_zone, Instant&);
+ThrowCompletionOr<double> get_offset_nanoseconds_for(VM& vm, TimeZoneMethods const& time_zone_record, Instant const& instant);
 ThrowCompletionOr<String> builtin_time_zone_get_offset_string_for(VM&, Value time_zone, Instant&);
 ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM&, Value time_zone, Instant&, Object& calendar);
 ThrowCompletionOr<NonnullGCPtr<Instant>> builtin_time_zone_get_instant_for(VM&, Value time_zone, PlainDateTime&, StringView disambiguation);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -50,7 +50,7 @@ ThrowCompletionOr<double> get_offset_nanoseconds_for(VM& vm, TimeZoneMethods con
 ThrowCompletionOr<String> builtin_time_zone_get_offset_string_for(VM&, Value time_zone, Instant&);
 ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM&, Value time_zone, Instant&, Object& calendar);
 ThrowCompletionOr<NonnullGCPtr<Instant>> builtin_time_zone_get_instant_for(VM&, Value time_zone, PlainDateTime&, StringView disambiguation);
-ThrowCompletionOr<NonnullGCPtr<Instant>> disambiguate_possible_instants(VM&, MarkedVector<NonnullGCPtr<Instant>> const& possible_instants, Value time_zone, PlainDateTime&, StringView disambiguation);
+ThrowCompletionOr<NonnullGCPtr<Instant>> disambiguate_possible_instants(VM&, MarkedVector<NonnullGCPtr<Instant>> const& possible_instants, TimeZoneMethods const&, PlainDateTime&, StringView disambiguation);
 ThrowCompletionOr<MarkedVector<NonnullGCPtr<Instant>>> get_possible_instants_for(VM&, TimeZoneMethods const&, PlainDateTime const&);
 ThrowCompletionOr<bool> time_zone_equals(VM&, Object& one, Object& two);
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -49,9 +49,9 @@ ThrowCompletionOr<Object*> to_temporal_time_zone(VM&, Value temporal_time_zone_l
 ThrowCompletionOr<double> get_offset_nanoseconds_for(VM&, Value time_zone, Instant&);
 ThrowCompletionOr<String> builtin_time_zone_get_offset_string_for(VM&, Value time_zone, Instant&);
 ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM&, Value time_zone, Instant&, Object& calendar);
-ThrowCompletionOr<Instant*> builtin_time_zone_get_instant_for(VM&, Value time_zone, PlainDateTime&, StringView disambiguation);
-ThrowCompletionOr<Instant*> disambiguate_possible_instants(VM&, MarkedVector<Instant*> const& possible_instants, Value time_zone, PlainDateTime&, StringView disambiguation);
-ThrowCompletionOr<MarkedVector<Instant*>> get_possible_instants_for(VM&, Value time_zone, PlainDateTime&);
+ThrowCompletionOr<NonnullGCPtr<Instant>> builtin_time_zone_get_instant_for(VM&, Value time_zone, PlainDateTime&, StringView disambiguation);
+ThrowCompletionOr<NonnullGCPtr<Instant>> disambiguate_possible_instants(VM&, MarkedVector<NonnullGCPtr<Instant>> const& possible_instants, Value time_zone, PlainDateTime&, StringView disambiguation);
+ThrowCompletionOr<MarkedVector<NonnullGCPtr<Instant>>> get_possible_instants_for(VM&, Value time_zone, PlainDateTime&);
 ThrowCompletionOr<bool> time_zone_equals(VM&, Object& one, Object& two);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -51,7 +51,7 @@ ThrowCompletionOr<String> builtin_time_zone_get_offset_string_for(VM&, Value tim
 ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(VM&, Value time_zone, Instant&, Object& calendar);
 ThrowCompletionOr<NonnullGCPtr<Instant>> builtin_time_zone_get_instant_for(VM&, Value time_zone, PlainDateTime&, StringView disambiguation);
 ThrowCompletionOr<NonnullGCPtr<Instant>> disambiguate_possible_instants(VM&, MarkedVector<NonnullGCPtr<Instant>> const& possible_instants, Value time_zone, PlainDateTime&, StringView disambiguation);
-ThrowCompletionOr<MarkedVector<NonnullGCPtr<Instant>>> get_possible_instants_for(VM&, Value time_zone, PlainDateTime&);
+ThrowCompletionOr<MarkedVector<NonnullGCPtr<Instant>>> get_possible_instants_for(VM&, TimeZoneMethods const&, PlainDateTime const&);
 ThrowCompletionOr<bool> time_zone_equals(VM&, Object& one, Object& two);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -52,7 +52,7 @@ ThrowCompletionOr<BigInt const*> interpret_iso_date_time_offset(VM& vm, i32 year
     // 3. If offsetBehaviour is wall or offsetOption is "ignore", then
     if (offset_behavior == OffsetBehavior::Wall || offset_option == "ignore"sv) {
         // a. Let instant be ? BuiltinTimeZoneGetInstantFor(timeZone, dateTime, disambiguation).
-        auto* instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *date_time, disambiguation));
+        auto instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *date_time, disambiguation));
 
         // b. Return instant.[[Nanoseconds]].
         return &instant->nanoseconds();
@@ -84,7 +84,7 @@ ThrowCompletionOr<BigInt const*> interpret_iso_date_time_offset(VM& vm, i32 year
     auto possible_instants = TRY(get_possible_instants_for(vm, time_zone, *date_time));
 
     // 8. For each element candidate of possibleInstants, do
-    for (auto* candidate : possible_instants) {
+    for (auto candidate : possible_instants) {
         // a. Let candidateNanoseconds be ? GetOffsetNanosecondsFor(timeZone, candidate).
         auto candidate_nanoseconds = TRY(get_offset_nanoseconds_for(vm, time_zone, *candidate));
 
@@ -112,7 +112,7 @@ ThrowCompletionOr<BigInt const*> interpret_iso_date_time_offset(VM& vm, i32 year
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidZonedDateTimeOffset);
 
     // 10. Let instant be ? DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation).
-    auto* instant = TRY(disambiguate_possible_instants(vm, possible_instants, time_zone, *date_time, disambiguation));
+    auto instant = TRY(disambiguate_possible_instants(vm, possible_instants, time_zone, *date_time, disambiguation));
 
     // 11. Return instant.[[Nanoseconds]].
     return &instant->nanoseconds();
@@ -392,7 +392,7 @@ ThrowCompletionOr<BigInt*> add_zoned_date_time(VM& vm, BigInt const& epoch_nanos
     auto* intermediate_date_time = TRY(create_temporal_date_time(vm, added_date->iso_year(), added_date->iso_month(), added_date->iso_day(), temporal_date_time->iso_hour(), temporal_date_time->iso_minute(), temporal_date_time->iso_second(), temporal_date_time->iso_millisecond(), temporal_date_time->iso_microsecond(), temporal_date_time->iso_nanosecond(), calendar));
 
     // 10. Let intermediateInstant be ? BuiltinTimeZoneGetInstantFor(timeZone, intermediateDateTime, "compatible").
-    auto* intermediate_instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *intermediate_date_time, "compatible"sv));
+    auto intermediate_instant = TRY(builtin_time_zone_get_instant_for(vm, time_zone, *intermediate_date_time, "compatible"sv));
 
     // 11. Return ? AddInstant(intermediateInstant.[[Nanoseconds]], hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
     return add_instant(vm, intermediate_instant->nanoseconds(), hours, minutes, seconds, milliseconds, microseconds, nanoseconds);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -113,7 +113,7 @@ ThrowCompletionOr<BigInt const*> interpret_iso_date_time_offset(VM& vm, i32 year
         return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidZonedDateTimeOffset);
 
     // 10. Let instant be ? DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation).
-    auto instant = TRY(disambiguate_possible_instants(vm, possible_instants, time_zone, *date_time, disambiguation));
+    auto instant = TRY(disambiguate_possible_instants(vm, possible_instants, time_zone_record, *date_time, disambiguation));
 
     // 11. Return instant.[[Nanoseconds]].
     return &instant->nanoseconds();

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -81,7 +81,8 @@ ThrowCompletionOr<BigInt const*> interpret_iso_date_time_offset(VM& vm, i32 year
     VERIFY(offset_option.is_one_of("prefer"sv, "reject"sv));
 
     // 7. Let possibleInstants be ? GetPossibleInstantsFor(timeZone, dateTime).
-    auto possible_instants = TRY(get_possible_instants_for(vm, time_zone, *date_time));
+    auto time_zone_record = TRY(create_time_zone_methods_record(vm, NonnullGCPtr<Object> { time_zone.as_object() }, { { TimeZoneMethod::GetPossibleInstantsFor } }));
+    auto possible_instants = TRY(get_possible_instants_for(vm, time_zone_record, *date_time));
 
     // 8. For each element candidate of possibleInstants, do
     for (auto candidate : possible_instants) {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -538,10 +538,10 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::hours_in_day_getter)
     auto* tomorrow = TRY(create_temporal_date_time(vm, tomorrow_fields.year, tomorrow_fields.month, tomorrow_fields.day, 0, 0, 0, 0, 0, 0, *iso_calendar));
 
     // 13. Let todayInstant be ? BuiltinTimeZoneGetInstantFor(timeZone, today, "compatible").
-    auto* today_instant = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *today, "compatible"sv));
+    auto today_instant = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *today, "compatible"sv));
 
     // 14. Let tomorrowInstant be ? BuiltinTimeZoneGetInstantFor(timeZone, tomorrow, "compatible").
-    auto* tomorrow_instant = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *tomorrow, "compatible"sv));
+    auto tomorrow_instant = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *tomorrow, "compatible"sv));
 
     // 15. Let diffNs be tomorrowInstant.[[Nanoseconds]] - todayInstant.[[Nanoseconds]].
     auto diff_ns = tomorrow_instant->nanoseconds().big_integer().minus(today_instant->nanoseconds().big_integer());
@@ -1041,7 +1041,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::round)
     auto* dt_start = TRY(create_temporal_date_time(vm, temporal_date_time->iso_year(), temporal_date_time->iso_month(), temporal_date_time->iso_day(), 0, 0, 0, 0, 0, 0, *iso_calendar));
 
     // 15. Let instantStart be ? BuiltinTimeZoneGetInstantFor(timeZone, dtStart, "compatible").
-    auto* instant_start = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *dt_start, "compatible"sv));
+    auto instant_start = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *dt_start, "compatible"sv));
 
     // 16. Let startNs be instantStart.[[Nanoseconds]].
     auto& start_ns = instant_start->nanoseconds();
@@ -1175,7 +1175,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::start_of_day)
     auto* start_date_time = TRY(create_temporal_date_time(vm, temporal_date_time->iso_year(), temporal_date_time->iso_month(), temporal_date_time->iso_day(), 0, 0, 0, 0, 0, 0, calendar));
 
     // 8. Let startInstant be ? BuiltinTimeZoneGetInstantFor(timeZone, startDateTime, "compatible").
-    auto* start_instant = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *start_date_time, "compatible"sv));
+    auto start_instant = TRY(builtin_time_zone_get_instant_for(vm, &time_zone, *start_date_time, "compatible"sv));
 
     // 9. Return ! CreateTemporalZonedDateTime(startInstant.[[Nanoseconds]], timeZone, calendar).
     return MUST(create_temporal_zoned_date_time(vm, start_instant->nanoseconds(), time_zone, calendar));

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Instant/Instant.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Instant/Instant.prototype.toString.js
@@ -67,6 +67,6 @@ describe("errors", () => {
         const instant = new Temporal.Instant(0n);
         expect(() => {
             instant.toString({ timeZone: {} });
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDate.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDate.js
@@ -55,6 +55,6 @@ describe("errors", () => {
     test("custom time zone doesn't have a getOffsetNanosecondsFor function", () => {
         expect(() => {
             Temporal.Now.plainDate({}, {});
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateISO.js
@@ -52,6 +52,6 @@ describe("errors", () => {
     test("custom time zone doesn't have a getOffsetNanosecondsFor function", () => {
         expect(() => {
             Temporal.Now.plainDateISO({});
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
@@ -104,6 +104,6 @@ describe("errors", () => {
     test("custom time zone doesn't have a getOffsetNanosecondsFor function", () => {
         expect(() => {
             Temporal.Now.plainDateTime({}, {});
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
@@ -94,6 +94,6 @@ describe("errors", () => {
     test("custom time zone doesn't have a getOffsetNanosecondsFor function", () => {
         expect(() => {
             Temporal.Now.plainDateTimeISO({});
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainTimeISO.js
@@ -39,6 +39,6 @@ describe("errors", () => {
     test("custom time zone doesn't have a getOffsetNanosecondsFor function", () => {
         expect(() => {
             Temporal.Now.plainTimeISO({});
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.from.js
@@ -41,7 +41,7 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             Temporal.PlainDate.from(zonedDateTime);
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 
     test("invalid date time string", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.from.js
@@ -175,7 +175,7 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             Temporal.PlainDateTime.from(zonedDateTime);
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 
     test("string must not contain a UTC designator", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.from.js
@@ -53,7 +53,7 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             Temporal.PlainTime.from(zonedDateTime);
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 
     test("string must not contain a UTC designator", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getPlainDateTimeFor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getPlainDateTimeFor.js
@@ -35,7 +35,7 @@ describe("errors", () => {
         const instant = new Temporal.Instant(1n);
         expect(() => {
             timeZone.getPlainDateTimeFor(instant);
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 
     test("this value must be a Temporal.TimeZone object", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.getISOFields.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.getISOFields.js
@@ -51,6 +51,6 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             zonedDateTime.getISOFields();
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.offset.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.offset.js
@@ -23,6 +23,6 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             zonedDateTime.offset;
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.offsetNanoseconds.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.offsetNanoseconds.js
@@ -23,6 +23,6 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             zonedDateTime.offsetNanoseconds;
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toJSON.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toJSON.js
@@ -22,6 +22,6 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             zonedDateTime.toJSON();
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toLocaleString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toLocaleString.js
@@ -22,6 +22,6 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             zonedDateTime.toLocaleString();
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toString.js
@@ -156,7 +156,7 @@ describe("errors", () => {
         const zonedDateTime = new Temporal.ZonedDateTime(0n, {});
         expect(() => {
             zonedDateTime.toString();
-        }).toThrowWithMessage(TypeError, "null is not a function");
+        }).toThrowWithMessage(TypeError, "getOffsetNanosecondsFor is undefined");
     });
 
     test("calendarName option must be one of 'auto', 'always', 'never', 'critical'", () => {


### PR DESCRIPTION
This catches up the API of some AOs closer to the latest version of the spec. Split out from my branch continuing work towards fixing some Duration.Round test cases, as the amount of changes in there has been ballooning. No change to test262, but does improve some exception messages.