### PR TITLE
LibWeb: Do not invalidate elements with animations in the CSS cascade

### DIFF
--- a/Tests/LibWeb/Text/expected/css/changing-animation-name-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/changing-animation-name-crash.txt
@@ -1,0 +1,2 @@
+   before: rule1
+after: rule2

--- a/Tests/LibWeb/Text/input/css/changing-animation-name-crash.html
+++ b/Tests/LibWeb/Text/input/css/changing-animation-name-crash.html
@@ -1,0 +1,20 @@
+<style>
+    #foo {
+        animation-name: rule1;
+    }
+    @keyframes rule1 { }
+    @keyframes rule2 { }
+</style>
+<div id="foo"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const foo = document.getElementById("foo");
+        println(`before: ${getComputedStyle(foo).getPropertyValue("animation-name")}`);
+        foo.style.setProperty("animation-name", "rule2");
+        requestAnimationFrame(() => {
+            println(`after: ${getComputedStyle(foo).getPropertyValue("animation-name")}`);
+            done();
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -77,7 +77,11 @@ public:
         Yes,
         No,
     };
-    void cancel();
+    enum class ShouldInvalidate {
+        Yes,
+        No,
+    };
+    void cancel(ShouldInvalidate = ShouldInvalidate::Yes);
     WebIDL::ExceptionOr<void> finish();
     WebIDL::ExceptionOr<void> play();
     WebIDL::ExceptionOr<void> play_an_animation(AutoRewind);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1395,7 +1395,7 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
             if (source_declaration != element.cached_animation_name_source()) {
                 // This animation name is new, so we need to create a new animation for it.
                 if (auto existing_animation = element.cached_animation_name_animation())
-                    existing_animation->cancel();
+                    existing_animation->cancel(Animations::Animation::ShouldInvalidate::No);
                 element.set_cached_animation_name_source(source_declaration);
 
                 auto effect = Animations::KeyframeEffect::create(realm);
@@ -1422,7 +1422,7 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
     } else {
         // If the element had an existing animation, cancel it
         if (auto existing_animation = element.cached_animation_name_animation()) {
-            existing_animation->cancel();
+            existing_animation->cancel(Animations::Animation::ShouldInvalidate::No);
             element.set_cached_animation_name_animation({});
             element.set_cached_animation_name_source({});
         }


### PR DESCRIPTION
See the note added to Animation::cancel for more info. Fixes a regression on shopify.com.