### PR TITLE
LibHTTP: Disable finish repeat timer before deferring job completion

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -621,6 +621,7 @@ void Job::finish_up()
         return;
     }
 
+    stop_timer();
     m_has_scheduled_finish = true;
     auto response = HttpResponse::create(m_code, move(m_headers), m_received_size);
     deferred_invoke([this, response = move(response)] {


### PR DESCRIPTION
It was possible to reach this via the timer itself (when the client is only slightly busy), and then to have the timer fire before the deferred invocation fires.
This commit removes the race by disabling the timer when the final deferred-accept state is reached.