### PR TITLE
LibWeb: Do not issue `change` event for every update of color input

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -348,7 +348,7 @@ void HTMLInputElement::did_edit_text_node(Badge<BrowsingContext>)
     });
 }
 
-void HTMLInputElement::did_pick_color(Optional<Color> picked_color)
+void HTMLInputElement::did_pick_color(Optional<Color> picked_color, ColorPickerUpdateState state)
 {
     // https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
     // For input elements without a defined input activation behavior, but to which these events apply
@@ -371,14 +371,16 @@ void HTMLInputElement::did_pick_color(Optional<Color> picked_color)
         });
 
         // and any time the user commits the change, the user agent must queue an element task on the user interaction task source
-        queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-            // given the input element
-            // FIXME: to set its user interacted to true
-            // and fire an event named change at the input element, with the bubbles attribute initialized to true.
-            auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
-            change_event->set_bubbles(true);
-            dispatch_event(*change_event);
-        });
+        if (state == ColorPickerUpdateState::Closed) {
+            queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
+                // given the input element
+                // FIXME: to set its user interacted to true
+                // and fire an event named change at the input element, with the bubbles attribute initialized to true.
+                auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
+                change_event->set_bubbles(true);
+                dispatch_event(*change_event);
+            });
+        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -11,6 +11,7 @@
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/FileAPI/FileList.h>
+#include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Layout/ImageProvider.h>
@@ -92,7 +93,7 @@ public:
 
     bool is_mutable() const { return m_is_mutable; }
 
-    void did_pick_color(Optional<Color> picked_color);
+    void did_pick_color(Optional<Color> picked_color, ColorPickerUpdateState state);
 
     void did_select_files(Span<SelectedFile> selected_files);
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -337,7 +337,7 @@ void Page::color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUp
 
         if (m_pending_non_blocking_dialog_target) {
             auto& input_element = verify_cast<HTML::HTMLInputElement>(*m_pending_non_blocking_dialog_target);
-            input_element.did_pick_color(move(picked_color));
+            input_element.did_pick_color(move(picked_color), state);
             if (state == HTML::ColorPickerUpdateState::Closed)
                 m_pending_non_blocking_dialog_target.clear();
         }


### PR DESCRIPTION
Per spec, the change event shall only be issued once the change is finally committed by the user, that is by closing the color picker window. Previously this was not implemented and both `input` and `change` events occurred.