### PR TITLE
Keymap: Draw the current keymap text with the correct theme color

### DIFF
--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -12,6 +12,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Process.h>
+#include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 
 KeymapStatusWidget::KeymapStatusWidget() = default;
@@ -75,5 +76,5 @@ void KeymapStatusWidget::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
     painter.clear_rect(event.rect(), Gfx::Color::Transparent);
-    painter.draw_text(rect(), m_current_keymap.substring_view(0, 2), Gfx::TextAlignment::Center);
+    painter.draw_text(rect(), m_current_keymap.substring_view(0, 2), Gfx::TextAlignment::Center, palette().window_text());
 }


### PR DESCRIPTION
Otherwise it is dark and hard to read against dark themes.

Before:
![before](https://github.com/SerenityOS/serenity/assets/5600524/dfe74f39-116c-4ba1-b227-4591350f3afe)

After:
![after](https://github.com/SerenityOS/serenity/assets/5600524/41813014-3f5c-4878-a207-5db9cb4b56f1)
