### PR TITLE
Escalator: Allow failed password attempts to be retried

### DIFF
--- a/Userland/Applications/Escalator/EscalatorWindow.h
+++ b/Userland/Applications/Escalator/EscalatorWindow.h
@@ -36,7 +36,7 @@ public:
 private:
     EscalatorWindow(StringView executable, Vector<StringView> arguments, Options const& options);
 
-    ErrorOr<void> check_password();
+    bool check_password();
 
     Vector<StringView> m_arguments;
     StringView m_executable;


### PR DESCRIPTION
There is a limit of 3 attempts before quitting, but the user can try again after that.

The error messages now display to help the user understand the issue.