### PR TITLE
LibWeb: Extract serialization and deserialization logic into separate helpers

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-object-primitives.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-object-primitives.txt
@@ -11,6 +11,7 @@ Error
 URIError: hello
 {"1":2,"a":"b"}
 1,4,aaaa
+
 true
 1
 true

--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-object-primitives.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-object-primitives.txt
@@ -3,6 +3,7 @@ false
 123
 123.456
 This is a String object
+
 9007199254740991
 1692748800000
 /abc/gimsuy

--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-primitives.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-primitives.txt
@@ -5,4 +5,5 @@ false
 123
 123.456
 9007199254740991
+
 This is a string

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-object-primitives.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-object-primitives.html
@@ -6,6 +6,7 @@
         println(structuredClone(new Number(123)));
         println(structuredClone(new Number(123.456)));
         println(structuredClone(new String("This is a String object")));
+        println(structuredClone(new String("")));
         println(structuredClone(BigInt("0x1fffffffffffff")));
         println(structuredClone(Date.UTC(2023, 7, 23)));
         println(structuredClone(/abc/gimsuy));

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-object-primitives.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-object-primitives.html
@@ -14,6 +14,7 @@
         println(structuredClone(new URIError("hello")));
         println(structuredClone(JSON.stringify({"a": "b", 1: 2})));
         println(structuredClone([1, 4, "aaaa"]));
+        println(structuredClone([]));
         println(structuredClone(new Set(["a", "b", "c"])).has("b"));
         println(structuredClone(new Map([["a", 0], ["b", 1], ["c", 2]])).get("b"));
 

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-primitives.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-primitives.html
@@ -8,6 +8,7 @@
         println(structuredClone(123));
         println(structuredClone(123.456));
         println(structuredClone(BigInt("0x1fffffffffffff")))
+        println(structuredClone(""));
         println(structuredClone("This is a string"));
     });
 </script>

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -153,8 +153,6 @@ WebIDL::ExceptionOr<void> Blob::serialization_steps(HTML::SerializationRecord& r
 {
     auto& vm = this->vm();
 
-    TRY(HTML::serialize_string(vm, record, interface_name()));
-
     //  FIXME: 1. Set serialized.[[SnapshotState]] to value’s snapshot state.
 
     // NON-STANDARD: FileAPI spec doesn't specify that type should be serialized, although

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -91,8 +91,6 @@ WebIDL::ExceptionOr<void> File::serialization_steps(HTML::SerializationRecord& r
 {
     auto& vm = this->vm();
 
-    TRY(HTML::serialize_string(vm, record, interface_name()));
-
     // FIXME: 1. Set serialized.[[SnapshotState]] to value’s snapshot state.
 
     // NON-STANDARD: FileAPI spec doesn't specify that type should be serialized, although

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -106,7 +106,7 @@ WebIDL::ExceptionOr<void> File::serialization_steps(HTML::SerializationRecord& r
     TRY(HTML::serialize_string(vm, record, m_name));
 
     // 4. Set serialized.[[LastModified]] to the value of value’s lastModified attribute.
-    record.append(bit_cast<u32*>(&m_last_modified), 2);
+    HTML::serialize_i64(record, m_last_modified);
 
     return {};
 }
@@ -128,10 +128,7 @@ WebIDL::ExceptionOr<void> File::deserialization_steps(ReadonlySpan<u32> const& r
     m_name = TRY(HTML::deserialize_string(vm, record, position));
 
     // 4. Initialize the value of value’s lastModified attribute to serialized.[[LastModified]].
-    u32 bits[2] = {};
-    bits[0] = record[position++];
-    bits[1] = record[position++];
-    m_last_modified = *bit_cast<i64*>(&bits);
+    m_last_modified = HTML::deserialize_i64(record, position);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -306,6 +306,8 @@ public:
 
             m_serialized.append(ValueTag::SerializableObject);
 
+            TRY(serialize_string(m_vm, m_serialized, serializable.interface_name()));
+
             // 1. Perform the serialization steps for value's primary interface, given value, serialized, and forStorage.
             TRY(serializable.serialization_steps(m_serialized, m_for_storage));
         }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -70,6 +70,15 @@ WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, Vector<u32>& vector
 template<OneOf<JS::TypedArrayBase, JS::DataView> ViewType>
 WebIDL::ExceptionOr<void> serialize_viewed_array_buffer(JS::VM& vm, Vector<u32>& vector, ViewType const& view, bool for_storage, SerializationMemory& memory);
 
+bool deserialize_boolean_primitive(ReadonlySpan<u32> const& serialized, size_t& position);
+double deserialize_number_primitive(ReadonlySpan<u32> const& serialized, size_t& position);
+JS::NonnullGCPtr<JS::BooleanObject> deserialize_boolean_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+JS::NonnullGCPtr<JS::NumberObject> deserialize_number_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::BigIntObject>> deserialize_big_int_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::StringObject>> deserialize_string_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+JS::NonnullGCPtr<JS::Date> deserialize_date_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::RegExpObject>> deserialize_reg_exp_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+
 WebIDL::ExceptionOr<ByteBuffer> deserialize_bytes(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
 WebIDL::ExceptionOr<String> deserialize_string(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::PrimitiveString>> deserialize_string_primitive(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -61,6 +61,8 @@ WebIDL::ExceptionOr<void> serialize_big_int_object(JS::VM& vm, SerializationReco
 WebIDL::ExceptionOr<void> serialize_string_object(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
 void serialize_date_object(SerializationRecord& serialized, JS::Value& value);
 WebIDL::ExceptionOr<void> serialize_reg_exp_object(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
+void serialize_u64(SerializationRecord& serialized, u64 value);
+void serialize_i64(SerializationRecord& serialized, i64 value);
 
 WebIDL::ExceptionOr<void> serialize_bytes(JS::VM& vm, Vector<u32>& vector, ReadonlyBytes bytes);
 WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, DeprecatedFlyString const& string);
@@ -78,6 +80,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::BigIntObject>> deserialize_big_int_obje
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::StringObject>> deserialize_string_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
 JS::NonnullGCPtr<JS::Date> deserialize_date_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::RegExpObject>> deserialize_reg_exp_object(JS::Realm& realm, ReadonlySpan<u32> const& serialized, size_t& position);
+u64 deserialize_u64(ReadonlySpan<u32> const& serialized, size_t& position);
+i64 deserialize_i64(ReadonlySpan<u32> const& serialized, size_t& position);
 
 WebIDL::ExceptionOr<ByteBuffer> deserialize_bytes(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
 WebIDL::ExceptionOr<String> deserialize_string(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -51,6 +51,17 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& v
 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory>);
 
+void serialize_boolean_primitive(SerializationRecord& serialized, JS::Value& value);
+void serialize_number_primitive(SerializationRecord& serialized, JS::Value& value);
+WebIDL::ExceptionOr<void> serialize_big_int_primitive(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
+WebIDL::ExceptionOr<void> serialize_string_primitive(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
+void serialize_boolean_object(SerializationRecord& serialized, JS::Value& value);
+void serialize_number_object(SerializationRecord& serialized, JS::Value& value);
+WebIDL::ExceptionOr<void> serialize_big_int_object(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
+WebIDL::ExceptionOr<void> serialize_string_object(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
+void serialize_date_object(SerializationRecord& serialized, JS::Value& value);
+WebIDL::ExceptionOr<void> serialize_reg_exp_object(JS::VM& vm, SerializationRecord& serialized, JS::Value& value);
+
 WebIDL::ExceptionOr<void> serialize_bytes(JS::VM& vm, Vector<u32>& vector, ReadonlyBytes bytes);
 WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, DeprecatedFlyString const& string);
 WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, String const& string);


### PR DESCRIPTION
To avoid differing logic for serializing and deserializing similar types, move the logic into separate helpers.

Adds security checks like VERIFY to avoid reading past the end of the serialized data. If we try to read past the end of the serialized data, either our program logic is wrong or our serialized data has somehow been corrupted. Therefore, at least currently, it is better to crash by VERIFYing.

Also, added tests to prove that we can serialize and deserialize empty string + empty arrays.

PR spun out from review comment: https://github.com/SerenityOS/serenity/pull/23323#discussion_r1501944154