### PR TITLE
Run: Don't wait for child process to end when adding it to history

### DIFF
--- a/Userland/Applications/Run/RunWindow.h
+++ b/Userland/Applications/Run/RunWindow.h
@@ -32,6 +32,7 @@ private:
     ByteString history_file_path();
     ErrorOr<void> load_history();
     ErrorOr<void> save_history();
+    void prepend_history(ByteString const& input);
 
     Vector<ByteString> m_path_history;
     NonnullRefPtr<GUI::ItemListModel<ByteString>> m_path_history_model;


### PR DESCRIPTION
Should resolve #5587.

When we try to start a long-running child process (e.g. a GUI app) using a combination of the POSIX spawn and waitpid API, the Run process ends up waiting for it to end before making any changes to the path history. This leads to some confusion when trying to fire up another Run process only to see that it did not save the path to this program.

This PR resolves this by saving the path after it was created using the POSIX spawn API and removes it from the history list if it fails while the Run process waits for it to exit.

I tested both the `run_as_launch()` and `run_as_command()` and it appears to do the job.