### PR TITLE
LibJS/Bytecode: Make more primitives be constant operands

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1024,14 +1024,15 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> ArrayExpression::ge
     if (all_of(m_elements, [](auto element) { return !element || is<PrimitiveLiteral>(*element); })) {
         // If all elements are constant primitives, we can just emit a single instruction to initialize the array,
         // instead of emitting instructions to manually evaluate them one-by-one
-        auto values = MUST(FixedArray<Value>::create(m_elements.size()));
+        Vector<Value> values;
+        values.resize(m_elements.size());
         for (auto i = 0u; i < m_elements.size(); ++i) {
             if (!m_elements[i])
                 continue;
             values[i] = static_cast<PrimitiveLiteral const&>(*m_elements[i]).value();
         }
         auto dst = choose_dst(generator, preferred_dst);
-        generator.emit<Bytecode::Op::NewPrimitiveArray>(dst, move(values));
+        generator.emit_with_extra_value_slots<Bytecode::Op::NewPrimitiveArray>(values.size(), dst, values);
         return dst;
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -279,7 +279,7 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> NullLiteral::genera
     return generator.add_constant(js_null());
 }
 
-Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> BigIntLiteral::generate_bytecode(Bytecode::Generator& generator, Optional<Bytecode::Operand> preferred_dst) const
+Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> BigIntLiteral::generate_bytecode(Bytecode::Generator& generator, [[maybe_unused]] Optional<Bytecode::Operand> preferred_dst) const
 {
     Bytecode::Generator::SourceLocationScope scope(generator, *this);
     // 1. Return the NumericValue of NumericLiteral as defined in 12.8.3.
@@ -293,10 +293,7 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> BigIntLiteral::gene
             return MUST(Crypto::SignedBigInteger::from_base(2, m_value.substring(2, m_value.length() - 3)));
         return MUST(Crypto::SignedBigInteger::from_base(10, m_value.substring(0, m_value.length() - 1)));
     }();
-
-    auto dst = choose_dst(generator, preferred_dst);
-    generator.emit<Bytecode::Op::NewBigInt>(dst, integer);
-    return dst;
+    return generator.add_constant(BigInt::create(generator.vm(), move(integer)), Bytecode::Generator::DeduplicateConstant::No);
 }
 
 Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> StringLiteral::generate_bytecode(Bytecode::Generator& generator, [[maybe_unused]] Optional<Bytecode::Operand> preferred_dst) const

--- a/Userland/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.cpp
@@ -50,4 +50,11 @@ void Executable::dump() const
     warnln("");
 }
 
+void Executable::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto constant : constants)
+        visitor.visit(constant);
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2024, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -75,6 +75,9 @@ public:
     DeprecatedFlyString const& get_identifier(IdentifierTableIndex index) const { return identifier_table->get(index); }
 
     void dump() const;
+
+private:
+    virtual void visit_edges(Visitor&) override;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -15,16 +15,18 @@
 
 namespace JS::Bytecode {
 
-Generator::Generator()
-    : m_string_table(make<StringTable>())
+Generator::Generator(VM& vm)
+    : m_vm(vm)
+    , m_string_table(make<StringTable>())
     , m_identifier_table(make<IdentifierTable>())
     , m_regex_table(make<RegexTable>())
+    , m_constants(vm.heap())
 {
 }
 
 CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::generate(VM& vm, ASTNode const& node, ReadonlySpan<FunctionParameter> parameters, FunctionKind enclosing_function_kind)
 {
-    Generator generator;
+    Generator generator(vm);
 
     for (auto const& parameter : parameters) {
         if (auto const* identifier = parameter.binding.get_pointer<NonnullRefPtr<Identifier const>>();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -25,6 +25,8 @@ namespace JS::Bytecode {
 
 class Generator {
 public:
+    VM& vm() { return m_vm; }
+
     enum class SurroundingScopeKind {
         Global,
         Function,
@@ -261,6 +263,8 @@ public:
     }
 
 private:
+    VM& m_vm;
+
     enum class JumpType {
         Continue,
         Break,
@@ -268,7 +272,7 @@ private:
     void generate_scoped_jump(JumpType);
     void generate_labelled_jump(JumpType, DeprecatedFlyString const& label);
 
-    Generator();
+    explicit Generator(VM&);
     ~Generator() = default;
 
     void grow(size_t);
@@ -286,7 +290,7 @@ private:
     NonnullOwnPtr<StringTable> m_string_table;
     NonnullOwnPtr<IdentifierTable> m_identifier_table;
     NonnullOwnPtr<RegexTable> m_regex_table;
-    Vector<Value> m_constants;
+    MarkedVector<Value> m_constants;
 
     u32 m_next_register { Register::reserved_register_count };
     u32 m_next_block { 1 };

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -81,12 +81,12 @@ public:
         op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
     }
 
-    template<typename OpType, typename... Args>
-    void emit_with_extra_operand_slots(size_t extra_operand_slots, Args&&... args)
+    template<typename OpType, typename ExtraSlotType, typename... Args>
+    void emit_with_extra_slots(size_t extra_slot_count, Args&&... args)
     {
         VERIFY(!is_current_block_terminated());
 
-        size_t size_to_allocate = round_up_to_power_of_two(sizeof(OpType) + extra_operand_slots * sizeof(Operand), alignof(void*));
+        size_t size_to_allocate = round_up_to_power_of_two(sizeof(OpType) + extra_slot_count * sizeof(ExtraSlotType), alignof(void*));
         size_t slot_offset = m_current_basic_block->size();
         grow(size_to_allocate);
         void* slot = m_current_basic_block->data() + slot_offset;
@@ -95,6 +95,18 @@ public:
             m_current_basic_block->terminate({});
         auto* op = static_cast<OpType*>(slot);
         op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
+    }
+
+    template<typename OpType, typename... Args>
+    void emit_with_extra_operand_slots(size_t extra_operand_slots, Args&&... args)
+    {
+        emit_with_extra_slots<OpType, Operand>(extra_operand_slots, forward<Args>(args)...);
+    }
+
+    template<typename OpType, typename... Args>
+    void emit_with_extra_value_slots(size_t extra_operand_slots, Args&&... args)
+    {
+        emit_with_extra_slots<OpType, Value>(extra_operand_slots, forward<Args>(args)...);
     }
 
     struct ReferenceOperands {

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -82,7 +82,6 @@
     O(Mov)                             \
     O(Mul)                             \
     O(NewArray)                        \
-    O(NewBigInt)                       \
     O(NewClass)                        \
     O(NewFunction)                     \
     O(NewObject)                       \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -88,7 +88,6 @@
     O(NewObject)                       \
     O(NewPrimitiveArray)               \
     O(NewRegExp)                       \
-    O(NewString)                       \
     O(NewTypeError)                    \
     O(Not)                             \
     O(PostfixDecrement)                \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -63,6 +63,8 @@ static ByteString format_operand(StringView name, Operand operand, Bytecode::Exe
             builder.appendff("Int32({})", value.as_i32());
         else if (value.is_double())
             builder.appendff("Double({})", value.as_double());
+        else if (value.is_string())
+            builder.appendff("String(\"{}\")", value.as_string().utf8_string_view());
         else if (value.is_undefined())
             builder.append("Undefined"sv);
         else if (value.is_null())
@@ -899,12 +901,6 @@ ThrowCompletionOr<void> IteratorToArray::execute_impl(Bytecode::Interpreter& int
     return {};
 }
 
-ThrowCompletionOr<void> NewString::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    interpreter.set(dst(), PrimitiveString::create(interpreter.vm(), interpreter.current_executable().get_string(m_string)));
-    return {};
-}
-
 ThrowCompletionOr<void> NewObject::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
@@ -1654,13 +1650,6 @@ ByteString IteratorToArray::to_byte_string_impl(Bytecode::Executable const& exec
     return ByteString::formatted("IteratorToArray {}, {}",
         format_operand("dst"sv, dst(), executable),
         format_operand("iterator"sv, iterator(), executable));
-}
-
-ByteString NewString::to_byte_string_impl(Bytecode::Executable const& executable) const
-{
-    return ByteString::formatted("NewString {}, \"{}\"",
-        format_operand("dst"sv, dst(), executable),
-        executable.string_table->get(m_string));
 }
 
 ByteString NewObject::to_byte_string_impl(Bytecode::Executable const& executable) const

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -63,6 +63,8 @@ static ByteString format_operand(StringView name, Operand operand, Bytecode::Exe
             builder.appendff("Int32({})", value.as_i32());
         else if (value.is_double())
             builder.appendff("Double({})", value.as_double());
+        else if (value.is_bigint())
+            builder.appendff("BigInt({})", value.as_bigint().to_byte_string());
         else if (value.is_string())
             builder.appendff("String(\"{}\")", value.as_string().utf8_string_view());
         else if (value.is_undefined())
@@ -854,13 +856,6 @@ static ThrowCompletionOr<Value> typeof_(VM& vm, Value value)
 
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DEFINE_COMMON_UNARY_OP)
 
-ThrowCompletionOr<void> NewBigInt::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    auto& vm = interpreter.vm();
-    interpreter.set(dst(), BigInt::create(vm, m_bigint));
-    return {};
-}
-
 ThrowCompletionOr<void> NewArray::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto array = MUST(Array::create(interpreter.realm(), 0));
@@ -1611,13 +1606,6 @@ ByteString Mov::to_byte_string_impl(Bytecode::Executable const& executable) cons
     return ByteString::formatted("Mov {}, {}",
         format_operand("dst"sv, m_dst, executable),
         format_operand("src"sv, m_src, executable));
-}
-
-ByteString NewBigInt::to_byte_string_impl(Bytecode::Executable const& executable) const
-{
-    return ByteString::formatted("NewBigInt {}, {}",
-        format_operand("dst"sv, dst(), executable),
-        m_bigint.to_base_deprecated(10));
 }
 
 ByteString NewArray::to_byte_string_impl(Bytecode::Executable const& executable) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -136,26 +136,6 @@ JS_ENUMERATE_COMMON_BINARY_OPS_WITH_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
 #undef JS_DECLARE_COMMON_UNARY_OP
 
-class NewString final : public Instruction {
-public:
-    NewString(Operand dst, StringTableIndex string)
-        : Instruction(Type::NewString, sizeof(*this))
-        , m_dst(dst)
-        , m_string(string)
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-
-    Operand dst() const { return m_dst; }
-    StringTableIndex index() const { return m_string; }
-
-private:
-    Operand m_dst;
-    StringTableIndex m_string;
-};
-
 class NewObject final : public Instruction {
 public:
     explicit NewObject(Operand dst)

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -239,26 +239,6 @@ private:
     Operand m_excluded_names[];
 };
 
-class NewBigInt final : public Instruction {
-public:
-    NewBigInt(Operand dst, Crypto::SignedBigInteger bigint)
-        : Instruction(Type::NewBigInt, sizeof(*this))
-        , m_dst(dst)
-        , m_bigint(move(bigint))
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-
-    Operand dst() const { return m_dst; }
-    Crypto::SignedBigInteger const& bigint() const { return m_bigint; }
-
-private:
-    Operand m_dst;
-    Crypto::SignedBigInteger m_bigint;
-};
-
 // NOTE: This instruction is variable-width depending on the number of elements!
 class NewArray final : public Instruction {
 public:


### PR DESCRIPTION
- `string` literals now become constant operands in bytecode
- `BigInt` literals now become constant operands in bytecode
- Bonus: `NewPrimitiveArray` is now a variable-length instruction