### PR TITLE
Kernel/riscv64: Don't hard-code the page fault reason on RISC-V

### DIFF
--- a/Kernel/Arch/PageFault.cpp
+++ b/Kernel/Arch/PageFault.cpp
@@ -120,7 +120,8 @@ void PageFault::handle(RegisterState& regs)
                 auto fault_address_string = KString::formatted("{:p}", fault_address);
                 auto fault_address_view = fault_address_string.is_error() ? ""sv : fault_address_string.value()->view();
                 (void)current_process.try_set_coredump_property("fault_address"sv, fault_address_view);
-                (void)current_process.try_set_coredump_property("fault_type"sv, type() == PageFault::Type::PageNotPresent ? "NotPresent"sv : "ProtectionViolation"sv);
+                if (type() != PageFault::Type::Unknown)
+                    (void)current_process.try_set_coredump_property("fault_type"sv, type() == PageFault::Type::PageNotPresent ? "NotPresent"sv : "ProtectionViolation"sv);
                 StringView fault_access;
                 if (is_instruction_fetch())
                     fault_access = "Execute"sv;

--- a/Kernel/Arch/PageFault.h
+++ b/Kernel/Arch/PageFault.h
@@ -50,6 +50,7 @@ public:
     enum class Type {
         PageNotPresent = PageFaultFlags::NotPresent,
         ProtectionViolation = PageFaultFlags::ProtectionViolation,
+        Unknown,
     };
 
     enum class Access {
@@ -90,7 +91,7 @@ public:
     bool is_instruction_fetch() const { return m_is_instruction_fetch; }
 
 private:
-    Type m_type;
+    Type m_type = Type::Unknown;
     Access m_access;
     ExecutionMode m_execution_mode;
     bool m_is_reserved_bit_violation { false };

--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -94,9 +94,8 @@ extern "C" void trap_handler(TrapFrame& trap_frame)
             else if (scause == StoreOrAMOPageFault)
                 fault.set_access(PageFault::Access::Write);
 
-            // FIXME: RISC-V doesn't tell you *why* a memory access failed, only the original access type (r/w/x).
-            //        So either detect the correct type by walking the page table or rewrite MM to not depend on the processor-provided reason.
-            fault.set_type(PageFault::Type::ProtectionViolation);
+            // RISC-V doesn't tell you the reason why a page fault occurred, so we don't use PageFault::set_type() here.
+            // The RISC-V implementation of Region::handle_fault() works without a correct PageFault::type().
 
             fault.handle(*trap_frame.regs);
             break;

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -81,8 +81,8 @@ static TitleAndText build_backtrace(Coredump::Reader const& coredump, ELF::Core:
     auto fault_address = metadata.get("fault_address");
     auto fault_type = metadata.get("fault_type");
     auto fault_access = metadata.get("fault_access");
-    if (fault_address.has_value() && fault_type.has_value() && fault_access.has_value()) {
-        builder.appendff("{} fault on {} at address {}", fault_type.value(), fault_access.value(), fault_address.value());
+    if (fault_address.has_value() && fault_access.has_value()) {
+        builder.appendff("{} fault on {} at address {}", fault_type.value_or("Page"), fault_access.value(), fault_address.value());
         constexpr FlatPtr malloc_scrub_pattern = explode_byte(MALLOC_SCRUB_BYTE);
         constexpr FlatPtr free_scrub_pattern = explode_byte(FREE_SCRUB_BYTE);
         auto raw_fault_address = AK::StringUtils::convert_to_uint_from_hex(fault_address.value().substring_view(2));


### PR DESCRIPTION
With this PR, #23364 and #23359 merged and using u-boot to boot serenity, we now panic during the `exec` for SystemServer!