### PR TITLE
LibWeb: Support more interpolations and add an interpolation test

### DIFF
--- a/Tests/LibWeb/Text/expected/css/box-shadow-resolves-length-functions.txt
+++ b/Tests/LibWeb/Text/expected/css/box-shadow-resolves-length-functions.txt
@@ -1,1 +1,1 @@
-0 calc(5px - 10px) 0 calc(2px + 3px) => #000000ff 0px -5px 0px 5px
+0 calc(5px - 10px) 0 calc(2px + 3px) => rgb(0, 0, 0) 0px -5px 0px 5px

--- a/Tests/LibWeb/Text/expected/interpolation-longhand-properties.txt
+++ b/Tests/LibWeb/Text/expected/interpolation-longhand-properties.txt
@@ -1,0 +1,23 @@
+   At time 400:
+  accent-color: rgb(78, 88, 99)
+  align-content: flex-start
+  animation-duration: auto
+  aspect-ratio: 1.54415 / 1
+  background-color: rgb(78, 88, 99)
+  background-repeat: repeat no-repeat
+  bottom: auto
+  box-shadow: rgb(163, 82, 142) 40px 80px 126px 0px inset, rgba(0, 0, 72, 0.4) 20px 4px 8px 12px
+  color: rgb(163, 82, 142)
+  transform: matrix(1, 0, 0, 1, 40, 40)
+
+At time 750:
+  accent-color: rgb(147, 157, 168)
+  align-content: space-between
+  animation-duration: auto
+  aspect-ratio: 1.36506 / 1
+  background-color: rgb(147, 157, 168)
+  background-repeat: space space
+  bottom: 100%
+  box-shadow: rgb(81, 71, 210) 75px 150px 227.5px 0px, rgba(0, 0, 174, 0.749) 37.5px 7.5px 15px 22.5px
+  color: rgb(81, 71, 210)
+  transform: matrix(1, 0, 0, 1, 75, 75)

--- a/Tests/LibWeb/Text/input/interpolation-longhand-properties.html
+++ b/Tests/LibWeb/Text/input/interpolation-longhand-properties.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<div id="foo"></div>
+<script src="./include.js"></script>
+<script>
+    test(() => {
+        // FIXME: Test the following properties or types when we support them:
+        //        - repeatable-list types
+        //        - Length types with mixed percentage/unit (e.g. 10% -> 200px)
+        //        - color types with alpha
+        //        - color types with different color spaces
+        //        - backdrop-filter
+        const properties = {
+            accentColor: {
+                from: "rgb(10 20 30)",
+                to: "rgb(200 210 220)",
+            },
+            alignContent: {
+                from: "flex-start",
+                to: "space-between",
+            },
+            animationDuration: {
+                from: "1s",
+                to: "2s",
+            },
+            aspectRatio: {
+                from: "16 / 9",
+                to: "5 / 4",
+            },
+            backgroundColor: {
+                from: "rgb(10 20 30)",
+                to: "rgb(200 210 220)",
+            },
+            backgroundRepeat: {
+                from: "repeat-x",
+                to: "space",
+            },
+            // by-computed-value properties with 'auto' are discrete
+            bottom: {
+                from: "auto",
+                to: "100%",
+            },
+            boxShadow: {
+                from: "red 0px 0px 10px inset",
+                to: "blue 100px 200px 300px, blue 50px 10px 20px 30px",
+            },
+            color: {
+                from: "red",
+                to: "blue",
+            },
+            transform: {
+                from: "translate(0px, 0px)",
+                to: "translate(100px, 100px)",
+            },
+        };
+
+        const keyframe1 = {};
+        const keyframe2 = {};
+        for (const [property, value] of Object.entries(properties)) {
+            keyframe1[property] = value.from;
+            keyframe2[property] = value.to;
+        }
+
+        const foo = document.getElementById("foo");
+        const animation = foo.animate(
+            [keyframe1, keyframe2],
+            { duration: 1000, iterations: 1 },
+        );
+
+        for (let testNum = 0; testNum < 2; testNum++) {
+            const time = testNum === 0 ? 400 : 750;
+            animation.currentTime = time;
+            const style = getComputedStyle(foo);
+
+            println(`At time ${time}:`)
+            for (let property of Object.keys(properties)) {
+                property = property.replace(/([A-Z])/, "-$1").toLowerCase();
+                println(`  ${property}: ${style.getPropertyValue(property)}`);
+            }
+
+            println("");
+        }
+    })
+</script>

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -375,3 +375,18 @@ ErrorOr<void> AK::Formatter<Gfx::Color>::format(FormatBuilder& builder, Gfx::Col
 {
     return Formatter<StringView>::format(builder, value.to_byte_string());
 }
+
+ErrorOr<void> AK::Formatter<Gfx::YUV>::format(FormatBuilder& builder, Gfx::YUV value)
+{
+    return Formatter<FormatString>::format(builder, "{} {} {}"sv, value.y, value.u, value.v);
+}
+
+ErrorOr<void> AK::Formatter<Gfx::HSV>::format(FormatBuilder& builder, Gfx::HSV value)
+{
+    return Formatter<FormatString>::format(builder, "{} {} {}"sv, value.hue, value.saturation, value.value);
+}
+
+ErrorOr<void> AK::Formatter<Gfx::Oklab>::format(FormatBuilder& builder, Gfx::Oklab value)
+{
+    return Formatter<FormatString>::format(builder, "{} {} {}"sv, value.L, value.a, value.b);
+}

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -626,6 +626,21 @@ struct Formatter<Gfx::Color> : public Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder&, Gfx::Color);
 };
 
+template<>
+struct Formatter<Gfx::YUV> : public Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder&, Gfx::YUV);
+};
+
+template<>
+struct Formatter<Gfx::HSV> : public Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder&, Gfx::HSV);
+};
+
+template<>
+struct Formatter<Gfx::Oklab> : public Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder&, Gfx::Oklab);
+};
+
 }
 
 namespace IPC {

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -184,7 +184,7 @@ String Length::to_string() const
 {
     if (is_auto())
         return "auto"_string;
-    return MUST(String::formatted("{}{}", m_value, unit_name()));
+    return MUST(String::formatted("{:.5}{}", m_value, unit_name()));
 }
 
 char const* Length::unit_name() const

--- a/Userland/Libraries/LibWeb/CSS/Ratio.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.cpp
@@ -24,7 +24,7 @@ bool Ratio::is_degenerate() const
 
 String Ratio::to_string() const
 {
-    return MUST(String::formatted("{} / {}", m_first_value, m_second_value));
+    return MUST(String::formatted("{:.5} / {:.5}", m_first_value, m_second_value));
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Serialize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.cpp
@@ -144,7 +144,7 @@ void serialize_a_srgb_value(StringBuilder& builder, Color color)
     if (color.alpha() == 255)
         builder.appendff("rgb({}, {}, {})"sv, color.red(), color.green(), color.blue());
     else
-        builder.appendff("rgba({}, {}, {}, {})"sv, color.red(), color.green(), color.blue(), (float)(color.alpha()) / 255.0f);
+        builder.appendff("rgba({}, {}, {}, {:.4})"sv, color.red(), color.green(), color.blue(), (float)(color.alpha()) / 255.0f);
 }
 
 String escape_a_character(u32 character)

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1141,26 +1141,8 @@ static ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> interpolate_proper
     case AnimationType::None:
         return to;
     case AnimationType::Custom: {
-        if (property_id == PropertyID::Transform) {
-            // Try to optimize same-function interpolation
-            if (from.is_transformation() && to.is_transformation()) {
-                auto& from_transform = from.as_transformation();
-                auto& to_transform = to.as_transformation();
-                if (from_transform.transform_function() == to_transform.transform_function()) {
-                    auto from_input_values = from_transform.values();
-                    auto to_input_values = to_transform.values();
-                    if (from_input_values.size() == to_input_values.size()) {
-                        StyleValueVector interpolated_values;
-                        interpolated_values.ensure_capacity(from_input_values.size());
-                        for (size_t i = 0; i < from_input_values.size(); ++i)
-                            interpolated_values.append(TRY(interpolate_value(element, *from_input_values[i], *to_input_values[i], delta)));
-
-                        return TransformationStyleValue::create(from_transform.transform_function(), move(interpolated_values));
-                    }
-                }
-            }
+        if (property_id == PropertyID::Transform)
             return interpolate_transform(element, from, to, delta);
-        }
 
         // FIXME: Handle all custom animatable properties
         [[fallthrough]];

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1069,6 +1069,8 @@ static ErrorOr<NonnullRefPtr<StyleValue const>> interpolate_value(DOM::Element& 
     case StyleValue::Type::Angle:
         return AngleStyleValue::create(Angle::make_degrees(interpolate_raw(from.as_angle().angle().to_degrees(), to.as_angle().angle().to_degrees(), delta)));
     case StyleValue::Type::Color: {
+        // https://drafts.csswg.org/css-color/#interpolation-space
+        // If the host syntax does not define what color space interpolation should take place in, it defaults to Oklab.
         auto from_color = from.as_color().color();
         auto to_color = to.as_color().color();
         auto from_oklab = from_color.to_oklab();

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -7,14 +7,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "ShadowStyleValue.h"
+#include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 
 namespace Web::CSS {
 
 String ShadowStyleValue::to_string() const
 {
     StringBuilder builder;
-    builder.appendff("{} {} {} {} {}", m_properties.color.to_string(), m_properties.offset_x->to_string(), m_properties.offset_y->to_string(), m_properties.blur_radius->to_string(), m_properties.spread_distance->to_string());
+    serialize_a_srgb_value(builder, m_properties.color);
+    builder.appendff(" {} {} {} {}", m_properties.offset_x->to_string(), m_properties.offset_y->to_string(), m_properties.blur_radius->to_string(), m_properties.spread_distance->to_string());
     if (m_properties.placement == ShadowPlacement::Inner)
         builder.append(" inset"sv);
     return MUST(builder.to_string());


### PR DESCRIPTION
For all of the decimal changes (except color) I couldn't really find a spec that mandates any required precision, so I just copied what Firefox seems to do, which is limit the output to 5 decimal places. 