### PR TITLE
Ladybird/AppKit: Use full scroll precision for wheel events

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1251,7 +1251,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         delta_x *= [self scrollView].horizontalLineScroll;
         delta_y *= [self scrollView].verticalLineScroll;
     }
-    m_web_view_bridge->mouse_wheel_event(position, screen_position, button, modifiers, delta_x, delta_y);
+    m_web_view_bridge->mouse_wheel_event(position, screen_position, button, modifiers, { delta_x, delta_y });
 }
 
 - (void)mouseDown:(NSEvent*)event

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -110,9 +110,10 @@ void WebViewBridge::mouse_move_event(Gfx::IntPoint position, Gfx::IntPoint scree
     client().async_mouse_move(m_client_state.page_index, to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), 0, to_underlying(button), modifiers);
 }
 
-void WebViewBridge::mouse_wheel_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers, int wheel_delta_x, int wheel_delta_y)
+void WebViewBridge::mouse_wheel_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers, Gfx::FloatPoint wheel_delta)
 {
-    client().async_mouse_wheel(m_client_state.page_index, to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), to_underlying(button), to_underlying(button), modifiers, wheel_delta_x, wheel_delta_y);
+    auto delta = wheel_delta.to_type<Web::DevicePixels>();
+    client().async_mouse_wheel(m_client_state.page_index, to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), to_underlying(button), to_underlying(button), modifiers, delta.x(), delta.y());
 }
 
 void WebViewBridge::mouse_double_click_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -44,7 +44,7 @@ public:
     void mouse_down_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
     void mouse_up_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
     void mouse_move_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
-    void mouse_wheel_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier, int, int);
+    void mouse_wheel_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier, Gfx::FloatPoint);
     void mouse_double_click_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
 
     void key_down_event(KeyCode, KeyModifier, u32);


### PR DESCRIPTION
Previously we would narrow `CGFloat` to `int` before passing it to `async_mouse_move`, now we let `Web::DevicePixels` deal with the underlying type and it's precision.