### PR TITLE
Browser+LibWebView: Avoid double-activation of hotkeys, and protect Inspector against being doubly loaded

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -718,10 +718,6 @@ void BrowserWindow::event(Core::Event& event)
     case GUI::Event::Resize:
         broadcast_window_size(static_cast<GUI::ResizeEvent&>(event).size());
         break;
-    case GUI::Event::KeyDown:
-        // FIXME: add support for hotkeys *within* ladybird
-        event.ignore();
-        break;
     default:
         break;
     }

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -118,6 +118,7 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
     m_inspector_web_view.use_native_user_style_sheet();
 
     m_inspector_web_view.on_inspector_loaded = [this]() {
+        m_inspector_loaded = true;
         inspect();
 
         m_content_web_view.js_console_request_messages(0);
@@ -191,6 +192,8 @@ InspectorClient::~InspectorClient()
 
 void InspectorClient::inspect()
 {
+    if (!m_inspector_loaded)
+        return;
     if (m_dom_tree_loaded)
         return;
 

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -70,6 +70,7 @@ private:
     Optional<i32> m_body_node_id;
     Optional<i32> m_pending_selection;
 
+    bool m_inspector_loaded { false };
     bool m_dom_tree_loaded { false };
 
     struct ContextMenuData {


### PR DESCRIPTION
This reverts commit 2e8ff1855c470094bf6aa6448cbe8173f1d79f92.

We had some awkward timing around the merging of this commit and commit
b073fdd5707277d0cc23c75f494ae31a5242705e. With both commits in tree, we
are now processing hotkey activations twice. For example, ctrl+t will
open 2 tabs.