### PR TITLE
LibWeb: Skip elements without layout node in collect_animation_into()

### DIFF
--- a/Tests/LibWeb/Text/expected/animate-percentage-transform-on-display-none-box.txt
+++ b/Tests/LibWeb/Text/expected/animate-percentage-transform-on-display-none-box.txt
@@ -1,0 +1,1 @@
+   box.style.transform: none

--- a/Tests/LibWeb/Text/input/animate-percentage-transform-on-display-none-box.html
+++ b/Tests/LibWeb/Text/input/animate-percentage-transform-on-display-none-box.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        background-color: magenta;
+        display: none;
+    }
+</style>
+<script src="include.js"></script>
+<body>
+    <div id="box"></div>
+</body>
+<script>
+    test(() => {
+        const animation = box.animate([
+            { transform: 'translateX(0px)' },
+            { transform: 'translateX(100%)' }
+        ], {
+            duration: 2000,
+            iterations: 1
+        });
+
+        animation.currentTime = 0;
+        const style = getComputedStyle(box);
+        println(`box.style.transform: ${style.transform}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1240,6 +1240,9 @@ static ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> interpolate_proper
 
 ErrorOr<void> StyleComputer::collect_animation_into(JS::NonnullGCPtr<Animations::KeyframeEffect> effect, StyleProperties& style_properties) const
 {
+    if (!effect->target()->layout_node())
+        return {};
+
     auto animation = effect->associated_animation();
     if (!animation)
         return {};


### PR DESCRIPTION
This fixes crashing caused by attempting to resolve percentage transforms against a missing paintable box.

cc @mattco98 