### PR TITLE
LibWeb: Start adding support for viewport relative values in SVG geometry elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
+++ b/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
           SVGGeometryBox <rect> at (8,8) content-size 1x1 children: not-inline
           TextNode <#text>
-          SVGGeometryBox <circle> at (8.09375,8.09375) content-size 0.796875x0.796875 children: not-inline
+          SVGGeometryBox <circle> at (8.09375,8.09375) content-size 0.8125x0.8125 children: not-inline
           TextNode <#text>
         TextNode <#text>
         SVGGeometryBox <rect> at (8,8) content-size 200x200 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-circle-percentage-attr.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-circle-percentage-attr.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x366 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x350 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x350] baseline: 350
+      SVGSVGBox <svg> at (8,8) content-size 784x350 [SVG] children: not-inline
+        SVGGeometryBox <circle> at (250,28) content-size 300x300 children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x366]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x350]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x350]
+        SVGPathPaintable (SVGGeometryBox<circle>) [250,28 300x300]

--- a/Tests/LibWeb/Layout/input/svg/svg-circle-percentage-attr.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-circle-percentage-attr.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><svg height="350" width="100%"><circle
+  cx="50%"
+  cy="170"
+  r="150"
+  fill="black"
+></circle></svg>

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -52,6 +52,8 @@ column-count: auto
 column-gap: auto
 content: normal
 cursor: auto
+cx: 0px
+cy: 0px
 direction: ltr
 display: block
 fill: rgb(0, 0, 0)
@@ -81,7 +83,7 @@ grid-row-start: auto
 grid-template-areas: 
 grid-template-columns: 
 grid-template-rows: 
-height: 1411px
+height: 1445px
 image-rendering: auto
 inset-block-end: auto
 inset-block-start: auto
@@ -136,8 +138,11 @@ padding-top: 0px
 pointer-events: auto
 position: static
 quotes: auto
+r: 0px
 right: auto
 row-gap: auto
+rx: auto
+ry: auto
 scrollbar-width: auto
 stop-color: rgb(0, 0, 0)
 stop-opacity: 1

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -170,6 +170,13 @@ public:
     static CSS::TableLayout table_layout() { return CSS::TableLayout::Auto; }
     static QuotesData quotes() { return QuotesData { .type = QuotesData::Type::Auto }; }
     static CSS::TransformBox transform_box() { return CSS::TransformBox::ViewBox; }
+
+    // https://www.w3.org/TR/SVG/geometry.html
+    static LengthPercentage cx() { return CSS::Length::make_px(0); }
+    static LengthPercentage cy() { return CSS::Length::make_px(0); }
+    static LengthPercentage r() { return CSS::Length::make_px(0); }
+    static LengthPercentage rx() { return CSS::Length::make_auto(); }
+    static LengthPercentage ry() { return CSS::Length::make_auto(); }
     static LengthPercentage x() { return CSS::Length::make_px(0); }
     static LengthPercentage y() { return CSS::Length::make_px(0); }
 
@@ -407,6 +414,12 @@ public:
     CSS::TextAnchor text_anchor() const { return m_inherited.text_anchor; }
     Optional<MaskReference> const& mask() const { return m_noninherited.mask; }
     CSS::MaskType mask_type() const { return m_noninherited.mask_type; }
+
+    LengthPercentage const& cx() const { return m_noninherited.cx; }
+    LengthPercentage const& cy() const { return m_noninherited.cy; }
+    LengthPercentage const& r() const { return m_noninherited.r; }
+    LengthPercentage const& rx() const { return m_noninherited.ry; }
+    LengthPercentage const& ry() const { return m_noninherited.ry; }
     LengthPercentage const& x() const { return m_noninherited.x; }
     LengthPercentage const& y() const { return m_noninherited.y; }
 
@@ -566,6 +579,12 @@ protected:
 
         Optional<MaskReference> mask;
         CSS::MaskType mask_type { InitialValues::mask_type() };
+
+        LengthPercentage cx { InitialValues::cx() };
+        LengthPercentage cy { InitialValues::cy() };
+        LengthPercentage r { InitialValues::r() };
+        LengthPercentage rx { InitialValues::rx() };
+        LengthPercentage ry { InitialValues::ry() };
         LengthPercentage x { InitialValues::x() };
         LengthPercentage y { InitialValues::x() };
 
@@ -694,6 +713,12 @@ public:
     void set_outline_width(CSS::Length value) { m_noninherited.outline_width = value; }
     void set_mask(MaskReference value) { m_noninherited.mask = value; }
     void set_mask_type(CSS::MaskType value) { m_noninherited.mask_type = value; }
+
+    void set_cx(LengthPercentage cx) { m_noninherited.cx = cx; }
+    void set_cy(LengthPercentage cy) { m_noninherited.cy = cy; }
+    void set_r(LengthPercentage r) { m_noninherited.r = r; }
+    void set_rx(LengthPercentage rx) { m_noninherited.rx = rx; }
+    void set_ry(LengthPercentage ry) { m_noninherited.ry = ry; }
     void set_x(LengthPercentage x) { m_noninherited.x = x; }
     void set_y(LengthPercentage y) { m_noninherited.y = y; }
 

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -765,6 +765,34 @@
       "cursor"
     ]
   },
+  "cx": {
+    "__comment": "This is an SVG 2 geometry property, see: https://www.w3.org/TR/SVG/geometry.html#CX.",
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "0",
+    "valid-types": [
+      "length [-∞,∞]",
+      "percentage [-∞,∞]"
+    ],
+    "percentages-resolve-to": "length",
+    "quirks": [
+      "unitless-length"
+    ]
+  },
+  "cy": {
+    "__comment": "This is an SVG 2 geometry property, see: https://www.w3.org/TR/SVG/geometry.html#CY.",
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "0",
+    "valid-types": [
+      "length [-∞,∞]",
+      "percentage [-∞,∞]"
+    ],
+    "percentages-resolve-to": "length",
+    "quirks": [
+      "unitless-length"
+    ]
+  },
   "direction": {
     "animation-type": "none",
     "inherited": true,
@@ -2005,6 +2033,20 @@
       "none"
     ]
   },
+  "r": {
+    "__comment": "This is an SVG 2 geometry property, see: https://www.w3.org/TR/SVG/geometry.html#R.",
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "0",
+    "valid-types": [
+      "length [-∞,∞]",
+      "percentage [-∞,∞]"
+    ],
+    "percentages-resolve-to": "length",
+    "quirks": [
+      "unitless-length"
+    ]
+  },
   "right": {
     "animation-type": "by-computed-value",
     "inherited": false,
@@ -2033,6 +2075,40 @@
       "auto"
     ],
     "percentages-resolve-to": "length"
+  },
+  "rx": {
+    "__comment": "This is an SVG 2 geometry property, see: https://www.w3.org/TR/SVG/geometry.html#RX.",
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "auto",
+    "valid-types": [
+      "length [-∞,∞]",
+      "percentage [-∞,∞]"
+    ],
+    "valid-identifiers": [
+      "auto"
+    ],
+    "percentages-resolve-to": "length",
+    "quirks": [
+      "unitless-length"
+    ]
+  },
+  "ry": {
+    "__comment": "This is an SVG 2 geometry property, see: https://www.w3.org/TR/SVG/geometry.html#RY.",
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "auto",
+    "valid-types": [
+      "length [-∞,∞]",
+      "percentage [-∞,∞]"
+    ],
+    "valid-identifiers": [
+      "auto"
+    ],
+    "percentages-resolve-to": "length",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "scrollbar-width": {
     "affects-layout": false,

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -753,10 +753,21 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_grid_template_areas(computed_style.grid_template_areas());
     computed_values.set_grid_auto_flow(computed_style.grid_auto_flow());
 
+    if (auto cx_value = computed_style.length_percentage(CSS::PropertyID::Cx); cx_value.has_value())
+        computed_values.set_cx(*cx_value);
+    if (auto cy_value = computed_style.length_percentage(CSS::PropertyID::Cy); cy_value.has_value())
+        computed_values.set_cy(*cy_value);
+    if (auto r_value = computed_style.length_percentage(CSS::PropertyID::R); r_value.has_value())
+        computed_values.set_r(*r_value);
+    if (auto rx_value = computed_style.length_percentage(CSS::PropertyID::Rx); rx_value.has_value())
+        computed_values.set_rx(*rx_value);
+    if (auto ry_value = computed_style.length_percentage(CSS::PropertyID::Ry); ry_value.has_value())
+        computed_values.set_ry(*ry_value);
     if (auto x_value = computed_style.length_percentage(CSS::PropertyID::X); x_value.has_value())
         computed_values.set_x(*x_value);
     if (auto y_value = computed_style.length_percentage(CSS::PropertyID::Y); y_value.has_value())
         computed_values.set_y(*y_value);
+
     auto fill = computed_style.property(CSS::PropertyID::Fill);
     if (fill->has_color())
         computed_values.set_fill(fill->to_color(*this));

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -40,11 +40,8 @@ void SVGCircleElement::attribute_changed(FlyString const& name, Optional<String>
     }
 }
 
-Gfx::Path& SVGCircleElement::get_path()
+Gfx::Path SVGCircleElement::get_path(CSSPixelSize viewport_size)
 {
-    if (m_path.has_value())
-        return m_path.value();
-
     float cx = m_center_x.value_or(0);
     float cy = m_center_y.value_or(0);
     float r = m_radius.value_or(0);
@@ -52,10 +49,8 @@ Gfx::Path& SVGCircleElement::get_path()
     Gfx::Path path;
 
     // A zero radius disables rendering.
-    if (r == 0) {
-        m_path = move(path);
-        return m_path.value();
-    }
+    if (r == 0)
+        return {};
 
     bool large_arc = false;
     bool sweep = true;
@@ -75,8 +70,7 @@ Gfx::Path& SVGCircleElement::get_path()
     // 5. arc with a segment-completing close path operation.
     path.arc_to({ cx + r, cy }, r, large_arc, sweep);
 
-    m_path = move(path);
-    return m_path.value();
+    return path;
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#CircleElementCXAttribute

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -20,7 +20,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
     JS::NonnullGCPtr<SVGAnimatedLength> cx() const;
     JS::NonnullGCPtr<SVGAnimatedLength> cy() const;
@@ -30,8 +30,6 @@ private:
     SVGCircleElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Optional<Gfx::Path> m_path;
 
     Optional<float> m_center_x;
     Optional<float> m_center_y;

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -18,7 +18,7 @@ class SVGCircleElement final : public SVGGeometryElement {
 public:
     virtual ~SVGCircleElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
+    virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
@@ -30,10 +30,6 @@ private:
     SVGCircleElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Optional<float> m_center_x;
-    Optional<float> m_center_y;
-    Optional<float> m_radius;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -30,24 +30,17 @@ void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<String
 
     if (name == SVG::AttributeNames::cx) {
         m_center_x = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::cy) {
         m_center_y = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::rx) {
         m_radius_x = AttributeParser::parse_positive_length(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::ry) {
         m_radius_y = AttributeParser::parse_positive_length(value.value_or(String {}));
-        m_path.clear();
     }
 }
 
-Gfx::Path& SVGEllipseElement::get_path()
+Gfx::Path SVGEllipseElement::get_path(CSSPixelSize)
 {
-    if (m_path.has_value())
-        return m_path.value();
-
     float rx = m_radius_x.value_or(0);
     float ry = m_radius_y.value_or(0);
     float cx = m_center_x.value_or(0);
@@ -55,10 +48,8 @@ Gfx::Path& SVGEllipseElement::get_path()
     Gfx::Path path;
 
     // A computed value of zero for either dimension, or a computed value of auto for both dimensions, disables rendering of the element.
-    if (rx == 0 || ry == 0) {
-        m_path = move(path);
-        return m_path.value();
-    }
+    if (rx == 0 || ry == 0)
+        return path;
 
     Gfx::FloatSize radii = { rx, ry };
     double x_axis_rotation = 0;
@@ -80,8 +71,7 @@ Gfx::Path& SVGEllipseElement::get_path()
     // 5. arc with a segment-completing close path operation.
     path.elliptical_arc_to({ cx + rx, cy }, radii, x_axis_rotation, large_arc, sweep);
 
-    m_path = move(path);
-    return m_path.value();
+    return path;
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementCXAttribute

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -20,7 +20,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
     JS::NonnullGCPtr<SVGAnimatedLength> cx() const;
     JS::NonnullGCPtr<SVGAnimatedLength> cy() const;
@@ -31,8 +31,6 @@ private:
     SVGEllipseElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Optional<Gfx::Path> m_path;
 
     Optional<float> m_center_x;
     Optional<float> m_center_y;

--- a/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.h
@@ -18,7 +18,7 @@ class SVGGeometryElement : public SVGGraphicsElement {
 public:
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    virtual Gfx::Path& get_path() = 0;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) = 0;
 
     float get_total_length();
     JS::NonnullGCPtr<Geometry::DOMPoint> get_point_at_length(float distance);

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
@@ -5,15 +5,63 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/PercentageOr.h>
 #include <LibWeb/SVG/SVGLength.h>
 
 namespace Web::SVG {
 
 JS_DEFINE_ALLOCATOR(SVGLength);
 
+// Same as SVGLength.idl
+constexpr unsigned short SVG_LENGTHTYPE_UNKNOWN = 0;
+constexpr unsigned short SVG_LENGTHTYPE_NUMBER = 1;
+constexpr unsigned short SVG_LENGTHTYPE_PERCENTAGE = 2;
+constexpr unsigned short SVG_LENGTHTYPE_EMS = 3;
+constexpr unsigned short SVG_LENGTHTYPE_EXS = 4;
+constexpr unsigned short SVG_LENGTHTYPE_PX = 5;
+constexpr unsigned short SVG_LENGTHTYPE_CM = 6;
+constexpr unsigned short SVG_LENGTHTYPE_MM = 7;
+constexpr unsigned short SVG_LENGTHTYPE_IN = 8;
+constexpr unsigned short SVG_LENGTHTYPE_PT = 9;
+constexpr unsigned short SVG_LENGTHTYPE_PC = 10;
+
 JS::NonnullGCPtr<SVGLength> SVGLength::create(JS::Realm& realm, u8 unit_type, float value)
 {
     return realm.heap().allocate<SVGLength>(realm, realm, unit_type, value);
+}
+
+JS::NonnullGCPtr<SVGLength> SVGLength::from_length_percentage(JS::Realm& realm, CSS::LengthPercentage const& length_percentage)
+{
+    // FIXME: We can't tell if a CSS::LengthPercentage was a unitless length.
+    (void)SVG_LENGTHTYPE_NUMBER;
+    if (length_percentage.is_percentage())
+        return SVGLength::create(realm, SVG_LENGTHTYPE_PERCENTAGE, length_percentage.percentage().value());
+    if (length_percentage.is_length())
+        return SVGLength::create(
+            realm, [&] {
+                switch (length_percentage.length().type()) {
+                case CSS::Length::Type::Em:
+                    return SVG_LENGTHTYPE_EMS;
+                case CSS::Length::Type::Ex:
+                    return SVG_LENGTHTYPE_EXS;
+                case CSS::Length::Type::Px:
+                    return SVG_LENGTHTYPE_PX;
+                case CSS::Length::Type::Cm:
+                    return SVG_LENGTHTYPE_CM;
+                case CSS::Length::Type::Mm:
+                    return SVG_LENGTHTYPE_MM;
+                case CSS::Length::Type::In:
+                    return SVG_LENGTHTYPE_IN;
+                case CSS::Length::Type::Pt:
+                    return SVG_LENGTHTYPE_PT;
+                case CSS::Length::Type::Pc:
+                    return SVG_LENGTHTYPE_PC;
+                default:
+                    return SVG_LENGTHTYPE_UNKNOWN;
+                }
+            }(),
+            length_percentage.length().raw_value());
+    return SVGLength::create(realm, SVG_LENGTHTYPE_UNKNOWN, 0);
 }
 
 SVGLength::SVGLength(JS::Realm& realm, u8 unit_type, float value)

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.h
@@ -25,6 +25,8 @@ public:
     float value() const { return m_value; }
     WebIDL::ExceptionOr<void> set_value(float value);
 
+    [[nodiscard]] static JS::NonnullGCPtr<SVGLength> from_length_percentage(JS::Realm&, CSS::LengthPercentage const&);
+
 private:
     SVGLength(JS::Realm&, u8 unit_type, float value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -30,24 +30,17 @@ void SVGLineElement::attribute_changed(FlyString const& name, Optional<String> c
 
     if (name == SVG::AttributeNames::x1) {
         m_x1 = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::y1) {
         m_y1 = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::x2) {
         m_x2 = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::y2) {
         m_y2 = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     }
 }
 
-Gfx::Path& SVGLineElement::get_path()
+Gfx::Path SVGLineElement::get_path(CSSPixelSize)
 {
-    if (m_path.has_value())
-        return m_path.value();
-
     Gfx::Path path;
     float x1 = m_x1.value_or(0);
     float y1 = m_y1.value_or(0);
@@ -60,8 +53,7 @@ Gfx::Path& SVGLineElement::get_path()
     // 2. perform an absolute lineto operation to absolute location (x2,y2)
     path.line_to({ x2, y2 });
 
-    m_path = move(path);
-    return m_path.value();
+    return path;
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementX1Attribute

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -20,7 +20,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
     JS::NonnullGCPtr<SVGAnimatedLength> x1() const;
     JS::NonnullGCPtr<SVGAnimatedLength> y1() const;
@@ -31,8 +31,6 @@ private:
     SVGLineElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Optional<Gfx::Path> m_path;
 
     Optional<float> m_x1;
     Optional<float> m_y1;

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -99,10 +99,8 @@ void SVGPathElement::attribute_changed(FlyString const& name, Optional<String> c
 {
     SVGGeometryElement::attribute_changed(name, value);
 
-    if (name == "d") {
+    if (name == "d")
         m_instructions = AttributeParser::parse_path_data(value.value_or(String {}));
-        m_path.clear();
-    }
 }
 
 Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction> instructions)
@@ -273,12 +271,9 @@ Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction> instructions
     return path;
 }
 
-Gfx::Path& SVGPathElement::get_path()
+Gfx::Path SVGPathElement::get_path(CSSPixelSize)
 {
-    if (!m_path.has_value()) {
-        m_path = path_from_path_instructions(m_instructions);
-    }
-    return m_path.value();
+    return path_from_path_instructions(m_instructions);
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -22,7 +22,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
 private:
     SVGPathElement(DOM::Document&, DOM::QualifiedName);
@@ -30,7 +30,6 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     Vector<PathInstruction> m_instructions;
-    Optional<Gfx::Path> m_path;
 };
 
 Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction>);

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -28,23 +28,16 @@ void SVGPolygonElement::attribute_changed(FlyString const& name, Optional<String
 {
     SVGGeometryElement::attribute_changed(name, value);
 
-    if (name == SVG::AttributeNames::points) {
+    if (name == SVG::AttributeNames::points)
         m_points = AttributeParser::parse_points(value.value_or(String {}));
-        m_path.clear();
-    }
 }
 
-Gfx::Path& SVGPolygonElement::get_path()
+Gfx::Path SVGPolygonElement::get_path(CSSPixelSize)
 {
-    if (m_path.has_value())
-        return m_path.value();
-
     Gfx::Path path;
 
-    if (m_points.is_empty()) {
-        m_path = move(path);
-        return m_path.value();
-    }
+    if (m_points.is_empty())
+        return path;
 
     // 1. perform an absolute moveto operation to the first coordinate pair in the list of points
     path.move_to(m_points.first());
@@ -56,8 +49,7 @@ Gfx::Path& SVGPolygonElement::get_path()
     // 3. perform a closepath command
     path.close();
 
-    m_path = move(path);
-    return m_path.value();
+    return path;
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
@@ -19,14 +19,12 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
 private:
     SVGPolygonElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Optional<Gfx::Path> m_path;
 
     Vector<Gfx::FloatPoint> m_points;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -28,23 +28,16 @@ void SVGPolylineElement::attribute_changed(FlyString const& name, Optional<Strin
 {
     SVGGeometryElement::attribute_changed(name, value);
 
-    if (name == SVG::AttributeNames::points) {
+    if (name == SVG::AttributeNames::points)
         m_points = AttributeParser::parse_points(value.value_or(String {}));
-        m_path.clear();
-    }
 }
 
-Gfx::Path& SVGPolylineElement::get_path()
+Gfx::Path SVGPolylineElement::get_path(CSSPixelSize)
 {
-    if (m_path.has_value())
-        return m_path.value();
-
     Gfx::Path path;
 
-    if (m_points.is_empty()) {
-        m_path = move(path);
-        return m_path.value();
-    }
+    if (m_points.is_empty())
+        return path;
 
     // 1. perform an absolute moveto operation to the first coordinate pair in the list of points
     path.move_to(m_points.first());
@@ -53,8 +46,7 @@ Gfx::Path& SVGPolylineElement::get_path()
     for (size_t point_index = 1; point_index < m_points.size(); ++point_index)
         path.line_to(m_points[point_index]);
 
-    m_path = move(path);
-    return m_path.value();
+    return path;
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
@@ -19,14 +19,12 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
 private:
     SVGPolylineElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Optional<Gfx::Path> m_path;
 
     Vector<Gfx::FloatPoint> m_points;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -32,30 +32,21 @@ void SVGRectElement::attribute_changed(FlyString const& name, Optional<String> c
 
     if (name == SVG::AttributeNames::x) {
         m_x = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::y) {
         m_y = AttributeParser::parse_coordinate(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::width) {
         m_width = AttributeParser::parse_positive_length(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::height) {
         m_height = AttributeParser::parse_positive_length(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::rx) {
         m_radius_x = AttributeParser::parse_length(value.value_or(String {}));
-        m_path.clear();
     } else if (name == SVG::AttributeNames::ry) {
         m_radius_y = AttributeParser::parse_length(value.value_or(String {}));
-        m_path.clear();
     }
 }
 
-Gfx::Path& SVGRectElement::get_path()
+Gfx::Path SVGRectElement::get_path(CSSPixelSize)
 {
-    if (m_path.has_value())
-        return m_path.value();
-
     float width = m_width.value_or(0);
     float height = m_height.value_or(0);
     float x = m_x.value_or(0);
@@ -63,10 +54,8 @@ Gfx::Path& SVGRectElement::get_path()
 
     Gfx::Path path;
     // If width or height is zero, rendering is disabled.
-    if (width == 0 && height == 0) {
-        m_path = move(path);
-        return m_path.value();
-    }
+    if (width == 0 || height == 0)
+        return path;
 
     auto corner_radii = calculate_used_corner_radius_values();
     float rx = corner_radii.width();
@@ -116,8 +105,7 @@ Gfx::Path& SVGRectElement::get_path()
     if (rx > 0 && ry > 0)
         path.elliptical_arc_to({ x + rx, y }, corner_radii, x_axis_rotation, large_arc_flag, sweep_flag);
 
-    m_path = move(path);
-    return m_path.value();
+    return path;
 }
 
 Gfx::FloatSize SVGRectElement::calculate_used_corner_radius_values() const

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
@@ -20,7 +20,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Gfx::Path& get_path() override;
+    virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
     JS::NonnullGCPtr<SVGAnimatedLength> x() const;
     JS::NonnullGCPtr<SVGAnimatedLength> y() const;
@@ -35,8 +35,6 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     Gfx::FloatSize calculate_used_corner_radius_values() const;
-
-    Optional<Gfx::Path> m_path;
 
     Optional<float> m_x;
     Optional<float> m_y;

--- a/Userland/Libraries/LibWeb/SVG/SVGViewport.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGViewport.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Math.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/ViewBox.h>
 
@@ -17,5 +18,12 @@ public:
     virtual Optional<PreserveAspectRatio> preserve_aspect_ratio() const = 0;
     virtual ~SVGViewport() = default;
 };
+
+inline CSSPixels normalized_diagonal_length(CSSPixelSize viewport_size)
+{
+    if (viewport_size.width() == viewport_size.height())
+        return viewport_size.width();
+    return sqrt((viewport_size.width() * viewport_size.width()) + (viewport_size.height() * viewport_size.height())) / CSSPixels::nearest_value_for(AK::Sqrt2<float>);
+}
 
 }


### PR DESCRIPTION
This PR adds the basic plumbing for SVG geometry properties and viewport relative values, then uses them to support percentages in SVG `<circle>` element attributes. The same fixes can be made to other SVG geometry elements, but those are left as a TODO.

Fixes #23121