### PR TITLE
Kernel/NVMe: Fix calculation of "Maximum Queue Entries Supported" field

### DIFF
--- a/Kernel/Devices/Storage/NVMe/NVMeDefinitions.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeDefinitions.h
@@ -54,7 +54,7 @@ static constexpr u8 CAP_DBL_SHIFT = 32;
 static constexpr u8 CAP_DBL_MASK = 0xf;
 static constexpr u8 CAP_TO_SHIFT = 24;
 static constexpr u64 CAP_TO_MASK = 0xff << CAP_TO_SHIFT;
-static constexpr u16 MQES(u64 cap)
+static constexpr u32 MQES(u64 cap)
 {
     return (cap & 0xffff) + 1;
 }


### PR DESCRIPTION
The value of this field is incremented by one, as a value of 0 for this field means 1 entry supported.

A value of 0xffff for CAP.MQES would incorrectly by truncated to 0x0000, if we don't increase the bit width of the return type.

The RVVM RISC-V emulator sets this field to 0xffff.