### PR TITLE
PDFViewer: Hide the rendering diagnostics window by default

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -48,6 +48,7 @@ PDFViewer::PDFViewer()
     m_page_view_mode = static_cast<PageViewMode>(Config::read_i32("PDFViewer"sv, "Display"sv, "PageMode"sv, 0));
     m_rendering_preferences.show_clipping_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowClippingPaths"sv, false);
     m_rendering_preferences.show_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowImages"sv, true);
+    m_rendering_preferences.show_diagnostics = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, false);
     m_rendering_preferences.clip_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipImages"sv, true);
     m_rendering_preferences.clip_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipPaths"sv, true);
     m_rendering_preferences.clip_text = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipText"sv, true);
@@ -167,6 +168,13 @@ void PDFViewer::set_current_page(u32 current_page)
 {
     m_current_page_index = current_page;
     vertical_scrollbar().set_value(m_page_dimension_cache.render_info[current_page].total_height_before_this_page);
+    update();
+}
+
+void PDFViewer::set_show_rendering_diagnostics(bool show_diagnostics)
+{
+    m_rendering_preferences.show_diagnostics = show_diagnostics;
+    Config::write_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, show_diagnostics);
     update();
 }
 

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -62,6 +62,8 @@ public:
 
     PageViewMode page_view_mode() const { return m_page_view_mode; }
     void set_page_view_mode(PageViewMode);
+    bool show_rendering_diagnostics() const { return m_rendering_preferences.show_diagnostics; }
+    void set_show_rendering_diagnostics(bool);
     bool show_clipping_paths() const { return m_rendering_preferences.show_clipping_paths; }
     void set_show_clipping_paths(bool);
     bool show_images() const { return m_rendering_preferences.show_images; }

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -14,6 +14,7 @@
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/NumericInput.h>
+#include <LibGUI/Splitter.h>
 #include <LibGUI/Widget.h>
 
 class PDFViewer;
@@ -39,6 +40,7 @@ private:
     RefPtr<PDFViewer> m_viewer;
     RefPtr<SidebarWidget> m_sidebar;
     NonnullRefPtr<PagedErrorsModel> m_paged_errors_model;
+    RefPtr<GUI::VerticalSplitter> m_vertical_splitter;
     RefPtr<GUI::TreeView> m_errors_tree_view;
     RefPtr<GUI::NumericInput> m_page_text_box;
     RefPtr<GUI::Label> m_total_page_label;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -89,6 +89,7 @@ struct GraphicsState {
 struct RenderingPreferences {
     bool show_clipping_paths { false };
     bool show_images { true };
+    bool show_diagnostics { false };
 
     bool clip_images { true };
     bool clip_paths { true };


### PR DESCRIPTION
You can enable it in the Debug menu and we will remember your choice.