### PR TITLE
LibCore: Fix `AK_OS_ANDROID` build

### DIFF
--- a/Userland/Libraries/LibCore/Environment.cpp
+++ b/Userland/Libraries/LibCore/Environment.cpp
@@ -93,7 +93,7 @@ Optional<StringView> get(StringView name, [[maybe_unused]] SecureOnly secure)
     builder.append('\0');
     // Note the explicit null terminators above.
 
-#if defined(AK_OS_MACOS)
+#if defined(AK_OS_MACOS) || defined(AK_OS_ANDROID)
     char* result = ::getenv(builder.string_view().characters_without_null_termination());
 #else
     char* result;


### PR DESCRIPTION
b9dc2d7 accidentally broke Android builds, this fixes that regression.

A lot more than this is obviously broken in ladybird android land, this PR is strictly referring to LibCore.