### PR TITLE
LibWeb: Account for absolutely positioned table wrappers

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/absolute-positioning-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/absolute-positioning-alignment.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (8,8) content-size 784x532 [BFC] children: not-inline
+    BlockContainer <body> at (16,16) content-size 768x516 children: not-inline
+      Box <div.container> at (24,24) content-size 500x500 positioned flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        TableWrapper <(anonymous)> at (24,199) content-size 100x150 positioned [BFC] children: not-inline
+          Box <div.table.left> at (27,202) content-size 94x144 table-box [TFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        TableWrapper <(anonymous)> at (424,199) content-size 100x150 positioned [BFC] children: not-inline
+          Box <div.table.right> at (427,202) content-size 94x144 table-box [TFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        TableWrapper <(anonymous)> at (199,24) content-size 150x100 positioned [BFC] children: not-inline
+          Box <div.table.top> at (202,27) content-size 144x94 table-box [TFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        TableWrapper <(anonymous)> at (199,424) content-size 150x100 positioned [BFC] children: not-inline
+          Box <div.table.bottom> at (202,427) content-size 144x94 table-box [TFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (16,532) content-size 768x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [5,5 790x538]
+    PaintableWithLines (BlockContainer<BODY>) [13,13 774x522]
+      PaintableBox (Box<DIV>.container) [21,21 506x506]
+        PaintableWithLines (TableWrapper(anonymous)) [24,199 100x150]
+          PaintableBox (Box<DIV>.table.left) [24,199 100x150]
+        PaintableWithLines (TableWrapper(anonymous)) [424,199 100x150]
+          PaintableBox (Box<DIV>.table.right) [424,199 100x150]
+        PaintableWithLines (TableWrapper(anonymous)) [199,24 150x100]
+          PaintableBox (Box<DIV>.table.top) [199,24 150x100]
+        PaintableWithLines (TableWrapper(anonymous)) [199,424 150x100]
+          PaintableBox (Box<DIV>.table.bottom) [199,424 150x100]
+      PaintableWithLines (BlockContainer(anonymous)) [16,532 768x0]

--- a/Tests/LibWeb/Layout/input/table/absolute-positioning-alignment.html
+++ b/Tests/LibWeb/Layout/input/table/absolute-positioning-alignment.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<style>
+    * {
+        margin: 5px;
+        padding: 0;
+        border: 3px solid black;
+    }
+    .container {
+        display: flex;
+        position: relative;
+        width: 500px;
+        height: 500px;
+    }
+    .table {
+        display: table;
+        position: absolute;
+        background: green;
+        margin: auto;
+    }
+    .right {
+        top: 0;
+        bottom: 0;
+        right: 0;
+        width: 100px;
+        height: 150px;
+    }
+    .left {
+        top: 0;
+        bottom: 0;
+        width: 100px;
+        height: 150px;
+    }
+    .top {
+        left: 0;
+        right: 0;
+        width: 150px;
+        height: 100px;
+    }
+    .bottom {
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 150px;
+        height: 100px;
+    }
+</style>
+<div class=container>
+    <div class="table left"></div>
+    <div class="table right"></div>
+    <div class="table top"></div>
+    <div class="table bottom"></div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -69,8 +69,6 @@ private:
 
     void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&);
 
-    CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&);
-
     void layout_viewport(LayoutMode, AvailableSpace const&);
 
     void layout_block_level_children(BlockContainer const&, LayoutMode, AvailableSpace const&);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -50,6 +50,9 @@ public:
 
     static bool creates_block_formatting_context(Box const&);
 
+    CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&);
+    CSSPixels compute_table_box_height_inside_table_wrapper(Box const&, AvailableSpace const&);
+
     CSSPixels compute_width_for_replaced_element(Box const&, AvailableSpace const&) const;
     CSSPixels compute_height_for_replaced_element(Box const&, AvailableSpace const&) const;
 


### PR DESCRIPTION
Table wrappers don't quite behave the same as most elements, in that their computed height and width are not meant to be used for layout. Instead, we now calculate suitable widths and heights based on the contents of the table wrapper when performing absolute layout.

Fixes the layout of
http://wpt.live/css/css-position/position-absolute-center-007.html