### PR TITLE
Ports/zlib: Switch to tarball copies hosted on GitHub

### DIFF
--- a/Ports/zlib/package.sh
+++ b/Ports/zlib/package.sh
@@ -3,7 +3,7 @@ port='zlib'
 version='1.3.1'
 useconfigure='true'
 files=(
-    "https://www.zlib.net/fossils/zlib-${version}.tar.gz#9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
+    "https://github.com/madler/zlib/releases/download/v${version}/zlib-${version}.tar.gz#9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 )
 
 configure() {


### PR DESCRIPTION
zlib.net uses DDoS protection, which results in broken downloads whenever a browser validation page is served instead. The tarballs that are uploaded to GitHub releases are identical with the ones that are served on zlib.net.

Fixes #23458.