### PR TITLE
LibJS/Bytecode: Don't fuse unrelated compare and jump in peephole pass

### DIFF
--- a/Userland/Libraries/LibJS/Tests/optimizer-bugs.js
+++ b/Userland/Libraries/LibJS/Tests/optimizer-bugs.js
@@ -1,0 +1,10 @@
+test("Don't fuse unrelated jump and compare", () => {
+    function go(a) {
+        a < 3;
+        a &&= 1;
+
+        a < 3;
+        a ||= 1;
+    }
+    go();
+});


### PR DESCRIPTION
Fixes an issue where https://x.com/awesomekling crashed on load. :^)