### PR TITLE
LibWeb: Always check paintable boxes children during hit-testing

### DIFF
--- a/Tests/LibWeb/Text/expected/hit_testing/box-outside-of-abspos-containing-block-border-rect.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/box-outside-of-abspos-containing-block-border-rect.txt
@@ -1,0 +1,1 @@
+Run   Clicked!

--- a/Tests/LibWeb/Text/expected/hit_testing/open-details-by-clicking-on-triangle.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/open-details-by-clicking-on-triangle.txt
@@ -1,0 +1,1 @@
+here be bugsyou can't see me   toggle open

--- a/Tests/LibWeb/Text/input/hit_testing/box-outside-of-abspos-containing-block-border-rect.html
+++ b/Tests/LibWeb/Text/input/hit_testing/box-outside-of-abspos-containing-block-border-rect.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><style>
+body {
+    margin: 0;
+}
+
+* {
+    border: 1px solid black;
+}
+
+nav {
+    position: absolute;
+    height: 600px;
+}
+
+nav > div {
+    height: 100%;
+}
+</style><nav><div></div><button id="btn">Run</button></nav>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        btn.onclick = () => {
+            println("Clicked!");
+            done();
+        };
+        internals.click(20, 615);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/hit_testing/open-details-by-clicking-on-triangle.html
+++ b/Tests/LibWeb/Text/input/hit_testing/open-details-by-clicking-on-triangle.html
@@ -1,0 +1,16 @@
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<details id="details"><summary><span>here be bugs</span></summary><span>you can't see me</span></details>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        details.ontoggle = (event) => {
+            println(`toggle ${event.newState}`);
+            done();
+        };
+        internals.click(5, 5);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -861,9 +861,6 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
         return stacking_context()->hit_test(position, type, callback);
     }
 
-    if (!absolute_border_box_rect().contains(position_adjusted_by_scroll_offset.x(), position_adjusted_by_scroll_offset.y()))
-        return TraversalDecision::Continue;
-
     for (auto const* child = last_child(); child; child = child->previous_sibling()) {
         auto z_index = child->computed_values().z_index();
         if (child->layout_node().is_positioned() && z_index.value_or(0) == 0)
@@ -871,6 +868,9 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
         if (child->hit_test(position, type, callback) == TraversalDecision::Break)
             return TraversalDecision::Break;
     }
+
+    if (!absolute_border_box_rect().contains(position_adjusted_by_scroll_offset.x(), position_adjusted_by_scroll_offset.y()))
+        return TraversalDecision::Continue;
 
     if (!visible_for_hit_testing())
         return TraversalDecision::Continue;


### PR DESCRIPTION
Children of a paintable box are not guaranteed to be contained within its border box. Therefore, during hit-testing, we must always check them.

Fixes https://github.com/SerenityOS/serenity/issues/23219