### PR TITLE
RequestServer: Transfer ownership of Protocols to all_protocols map

### DIFF
--- a/Ladybird/Android/src/main/cpp/RequestServerService.cpp
+++ b/Ladybird/Android/src/main/cpp/RequestServerService.cpp
@@ -37,10 +37,9 @@ ErrorOr<int> service_main(int ipc_socket, int fd_passing_socket)
 
     Core::EventLoop event_loop;
 
-    // FIXME: Don't leak these :V
-    [[maybe_unused]] auto* gemini = new RequestServer::GeminiProtocol;
-    [[maybe_unused]] auto* http = new RequestServer::HttpProtocol;
-    [[maybe_unused]] auto* https = new RequestServer::HttpsProtocol;
+    RequestServer::GeminiProtocol::install();
+    RequestServer::HttpProtocol::install();
+    RequestServer::HttpsProtocol::install();
 
     auto socket = TRY(Core::LocalSocket::adopt_fd(ipc_socket));
     auto client = TRY(RequestServer::ConnectionFromClient::try_create(move(socket)));

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -51,17 +51,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::EventLoop event_loop;
 
-    [[maybe_unused]] auto gemini = make<RequestServer::GeminiProtocol>();
-    [[maybe_unused]] auto http = make<RequestServer::HttpProtocol>();
-    [[maybe_unused]] auto https = make<RequestServer::HttpsProtocol>();
+    RequestServer::GeminiProtocol::install();
+    RequestServer::HttpProtocol::install();
+    RequestServer::HttpsProtocol::install();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ConnectionFromClient>());
     client->set_fd_passing_socket(TRY(Core::LocalSocket::adopt_fd(fd_passing_socket)));
 
-    auto result = event_loop.exec();
-
-    // FIXME: We exit instead of returning, so that protocol destructors don't get called.
-    //        The Protocol base class should probably do proper de-registration instead of
-    //        just VERIFY_NOT_REACHED().
-    exit(result);
+    return event_loop.exec();
 }

--- a/Userland/Services/RequestServer/GeminiProtocol.cpp
+++ b/Userland/Services/RequestServer/GeminiProtocol.cpp
@@ -38,4 +38,9 @@ OwnPtr<Request> GeminiProtocol::start_request(i32 request_id, ConnectionFromClie
     return protocol_request;
 }
 
+void GeminiProtocol::install()
+{
+    Protocol::install(adopt_own(*new GeminiProtocol()));
+}
+
 }

--- a/Userland/Services/RequestServer/GeminiProtocol.h
+++ b/Userland/Services/RequestServer/GeminiProtocol.h
@@ -12,8 +12,12 @@ namespace RequestServer {
 
 class GeminiProtocol final : public Protocol {
 public:
-    GeminiProtocol();
     virtual ~GeminiProtocol() override = default;
+
+    static void install();
+
+private:
+    GeminiProtocol();
 
     virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const&, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };

--- a/Userland/Services/RequestServer/HttpProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpProtocol.cpp
@@ -27,4 +27,9 @@ OwnPtr<Request> HttpProtocol::start_request(i32 request_id, ConnectionFromClient
     return Detail::start_request(Badge<HttpProtocol> {}, request_id, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }
 
+void HttpProtocol::install()
+{
+    Protocol::install(adopt_own(*new HttpProtocol()));
+}
+
 }

--- a/Userland/Services/RequestServer/HttpProtocol.h
+++ b/Userland/Services/RequestServer/HttpProtocol.h
@@ -24,8 +24,12 @@ public:
     using JobType = HTTP::Job;
     using RequestType = HttpRequest;
 
-    HttpProtocol();
     ~HttpProtocol() override = default;
+
+    static void install();
+
+private:
+    HttpProtocol();
 
     virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };

--- a/Userland/Services/RequestServer/HttpsProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpsProtocol.cpp
@@ -27,4 +27,9 @@ OwnPtr<Request> HttpsProtocol::start_request(i32 request_id, ConnectionFromClien
     return Detail::start_request(Badge<HttpsProtocol> {}, request_id, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }
 
+void HttpsProtocol::install()
+{
+    Protocol::install(adopt_own(*new HttpsProtocol()));
+}
+
 }

--- a/Userland/Services/RequestServer/HttpsProtocol.h
+++ b/Userland/Services/RequestServer/HttpsProtocol.h
@@ -24,8 +24,12 @@ public:
     using JobType = HTTP::HttpsJob;
     using RequestType = HttpsRequest;
 
-    HttpsProtocol();
     ~HttpsProtocol() override = default;
+
+    static void install();
+
+private:
+    HttpsProtocol();
 
     virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };

--- a/Userland/Services/RequestServer/Protocol.h
+++ b/Userland/Services/RequestServer/Protocol.h
@@ -15,7 +15,7 @@ namespace RequestServer {
 
 class Protocol {
 public:
-    virtual ~Protocol();
+    virtual ~Protocol() = default;
 
     ByteString const& name() const { return m_name; }
     virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) = 0;
@@ -29,6 +29,8 @@ protected:
         int write_fd { -1 };
     };
     static ErrorOr<Pipe> get_pipe_for_request();
+
+    static void install(NonnullOwnPtr<Protocol>);
 
 private:
     ByteString m_name;

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -45,16 +45,11 @@ ErrorOr<int> serenity_main(Main::Arguments)
         TRY(Core::System::unveil("/home/anon", "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    [[maybe_unused]] auto gemini = make<RequestServer::GeminiProtocol>();
-    [[maybe_unused]] auto http = make<RequestServer::HttpProtocol>();
-    [[maybe_unused]] auto https = make<RequestServer::HttpsProtocol>();
+    RequestServer::GeminiProtocol::install();
+    RequestServer::HttpProtocol::install();
+    RequestServer::HttpsProtocol::install();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ConnectionFromClient>());
 
-    auto result = event_loop.exec();
-
-    // FIXME: We exit instead of returning, so that protocol destructors don't get called.
-    //        The Protocol base class should probably do proper de-registration instead of
-    //        just VERIFY_NOT_REACHED().
-    exit(result);
+    return event_loop.exec();
 }


### PR DESCRIPTION
It's no change in application behavior to have these objects owned by the function-scope static map in Protocol.cpp, while allowing us to remove some ugly FIXMEs from time immemorial.

I thought about converting this to some kind of clever `RequestServer::register_protocols({"gemini"sv, "http"sv, "https"sv})` API or something, but this seems simpler :)