### PR TITLE
LibWeb: More animation fixes

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -135,6 +135,8 @@ public:
 
     ErrorOr<void> try_ensure_capacity(size_t capacity) { return m_table.try_ensure_capacity(capacity); }
 
+    void ensure_capacity(size_t capacity) { return m_table.ensure_capacity(capacity); }
+
     Optional<typename ValueTraits::ConstPeekType> get(K const& key) const
     requires(!IsPointer<typename ValueTraits::PeekType>)
     {

--- a/Tests/LibWeb/Ref/css-keyframe-fill-forwards.html
+++ b/Tests/LibWeb/Ref/css-keyframe-fill-forwards.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<link rel="match" href="reference/css-keyframe-fill-forwards-ref.html" />
+<style>
+    #foo {
+        width: 100px;
+        height: 100px;
+        animation: anim 1s linear forwards;
+    }
+    @keyframes anim {
+        from {
+            background-color: red;
+        }
+        to {
+            background-color: blue;
+        }
+    }
+</style>
+<div id="foo"></div>
+<script>
+    document.getElementById("foo").getAnimations()[0].currentTime = 1500;
+</script>

--- a/Tests/LibWeb/Ref/css-keyframe-invalid-transform-should-not-render.html
+++ b/Tests/LibWeb/Ref/css-keyframe-invalid-transform-should-not-render.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<link rel="match" href="reference/css-keyframe-invalid-transform-should-not-render-ref.html" />
+<style>
+    #foo {
+        width: 100px;
+        height: 100px;
+        background-color: blue;
+        animation: anim 1s;
+    }
+    @keyframes anim {
+        from {
+            transform: scale(0);
+        }
+        to {
+            transform: scale(0);
+        }
+    }
+</style>
+<div id="foo"></div>
+<script>
+    document.getElementById("foo").getAnimations()[0].currentTime = 500;
+</script>

--- a/Tests/LibWeb/Ref/reference/css-keyframe-fill-forwards-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-keyframe-fill-forwards-ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<style>
+    #foo {
+        width: 100px;
+        height: 100px;
+        background-color: blue;
+    }
+</style>
+<div id="foo"></div>

--- a/Tests/LibWeb/Ref/reference/css-keyframe-invalid-transform-should-not-render-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-keyframe-invalid-transform-should-not-render-ref.html
@@ -1,0 +1,1 @@
+<!doctype html>

--- a/Tests/LibWeb/Text/expected/invalid-transform-interpolation-does-not-crash.txt
+++ b/Tests/LibWeb/Text/expected/invalid-transform-interpolation-does-not-crash.txt
@@ -1,0 +1,1 @@
+   no crash!

--- a/Tests/LibWeb/Text/input/invalid-transform-interpolation-does-not-crash.html
+++ b/Tests/LibWeb/Text/input/invalid-transform-interpolation-does-not-crash.html
@@ -1,0 +1,14 @@
+<div id="foo"></div>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        document.getElementById("foo").animate(
+            { transform: ["scale(0)", "scale(0)"] },
+            { duration: 1000 },
+        );
+        requestAnimationFrame(() => {
+            println("no crash!");
+            done();
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -534,12 +534,7 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     }
 
     if (!m_element->layout_node()) {
-        auto style_or_error = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element));
-        if (style_or_error.is_error()) {
-            dbgln("ResolvedCSSStyleDeclaration::property style computer failed");
-            return {};
-        }
-        auto style = style_or_error.release_value();
+        auto style = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element));
 
         // FIXME: This is a stopgap until we implement shorthand -> longhand conversion.
         auto value = style->maybe_null_property(property_id);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -818,13 +818,13 @@ static RefPtr<StyleValue const> interpolate_transform(DOM::Element& element, Sty
     };
 
     static constexpr auto style_value_to_matrix = [](DOM::Element& element, StyleValue const& value) -> FloatMatrix4x4 {
-        if (value.to_identifier() == ValueID::None)
-            return FloatMatrix4x4::identity();
-
         if (value.is_transformation())
             return transformation_style_value_to_matrix(element, value.as_transformation()).value_or(FloatMatrix4x4::identity());
 
-        VERIFY(value.is_value_list());
+        // This encompasses both the allowed value "none" and any invalid values
+        if (!value.is_value_list())
+            return FloatMatrix4x4::identity();
+
         auto matrix = FloatMatrix4x4::identity();
         for (auto const& value_element : value.as_value_list().values()) {
             if (value_element->is_transformation()) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1400,7 +1400,7 @@ static void apply_animation_properties(DOM::Document& document, StyleProperties&
     effect.set_playback_direction(Animations::css_animation_direction_to_bindings_playback_direction(direction));
 
     HTML::TemporaryExecutionContext context(document.relevant_settings_object());
-    if (play_state == CSS::AnimationPlayState::Running && animation.play_state() != Bindings::AnimationPlayState::Running) {
+    if (play_state == CSS::AnimationPlayState::Running && !animation.is_relevant()) {
         animation.play().release_value_but_fixme_should_propagate_errors();
     } else if (play_state == CSS::AnimationPlayState::Paused && animation.play_state() != Bindings::AnimationPlayState::Paused) {
         animation.pause().release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -52,8 +52,8 @@ public:
 
     NonnullRefPtr<StyleProperties> create_document_style() const;
 
-    ErrorOr<NonnullRefPtr<StyleProperties>> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
-    ErrorOr<RefPtr<StyleProperties>> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
+    NonnullRefPtr<StyleProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
+    RefPtr<StyleProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
 
     // https://www.w3.org/TR/css-cascade/#origin
     enum class CascadeOrigin {
@@ -87,8 +87,8 @@ private:
     class FontLoader;
     struct MatchingFontCandidate;
 
-    ErrorOr<RefPtr<StyleProperties>> compute_style_impl(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, ComputeStyleMode) const;
-    ErrorOr<void> compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
+    RefPtr<StyleProperties> compute_style_impl(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, ComputeStyleMode) const;
+    void compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     RefPtr<Gfx::FontCascadeList const> font_matching_algorithm(FontFaceKey const& key, float font_size_in_pt) const;
@@ -136,7 +136,7 @@ private:
 
     RuleCache const& rule_cache_for_cascade_origin(CascadeOrigin) const;
 
-    ErrorOr<void> collect_animation_into(JS::NonnullGCPtr<Animations::KeyframeEffect> animation, StyleProperties& style_properties) const;
+    void collect_animation_into(JS::NonnullGCPtr<Animations::KeyframeEffect> animation, StyleProperties& style_properties) const;
 
     OwnPtr<RuleCache> m_author_rule_cache;
     OwnPtr<RuleCache> m_user_rule_cache;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -572,8 +572,7 @@ Element::RequiredInvalidationAfterStyleChange Element::recompute_style()
     set_needs_style_update(false);
     VERIFY(parent());
 
-    // FIXME propagate errors
-    auto new_computed_css_values = MUST(document().style_computer().compute_style(*this));
+    auto new_computed_css_values = document().style_computer().compute_style(*this);
 
     // Tables must not inherit -libweb-* values for text-align.
     // FIXME: Find the spec for this.

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -27,7 +27,7 @@ private:
 
     i32 calculate_list_item_index(DOM::Node&);
 
-    ErrorOr<void> create_layout_tree(DOM::Node&, Context&);
+    void create_layout_tree(DOM::Node&, Context&);
 
     void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(node); }
     void pop_parent() { m_ancestor_stack.take_last(); }
@@ -49,7 +49,7 @@ private:
         Prepend,
     };
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
-    ErrorOr<void> create_pseudo_element_if_needed(DOM::Element&, CSS::Selector::PseudoElement::Type, AppendOrPrepend);
+    void create_pseudo_element_if_needed(DOM::Element&, CSS::Selector::PseudoElement::Type, AppendOrPrepend);
 
     JS::GCPtr<Layout::Node> m_layout_root;
     Vector<JS::NonnullGCPtr<Layout::NodeWithStyle>> m_ancestor_stack;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -481,7 +481,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
                 for (auto& child : element->children_as_vector())
                     elements_to_visit.enqueue(child.ptr());
                 if (element->is_element()) {
-                    auto styles = doc->style_computer().compute_style(*static_cast<Web::DOM::Element*>(element)).release_value_but_fixme_should_propagate_errors();
+                    auto styles = doc->style_computer().compute_style(*static_cast<Web::DOM::Element*>(element));
                     dbgln("+ Element {}", element->debug_description());
                     auto& properties = styles->properties();
                     for (size_t i = 0; i < properties.size(); ++i)
@@ -704,7 +704,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, i32 node_id, Optional<W
             // FIXME: Pseudo-elements only exist as Layout::Nodes, which don't have style information
             //        in a format we can use. So, we run the StyleComputer again to get the specified
             //        values, and have to ignore the computed values and custom properties.
-            auto pseudo_element_style = MUST(page.page().focused_context().active_document()->style_computer().compute_style(element, pseudo_element));
+            auto pseudo_element_style = page.page().focused_context().active_document()->style_computer().compute_style(element, pseudo_element);
             ByteString computed_values = serialize_json(pseudo_element_style);
             ByteString resolved_values = "{}";
             ByteString custom_properties_json = serialize_custom_properties_json(element, pseudo_element);


### PR DESCRIPTION
Fixes #23473, fixes #23471. Also fixes an overly-excited button on [shopify.com](https://shopify.com) (the hover animation was blinking on and off). Note that it uses transitions to animate on hover, so the fact that it now no longer animates at all is expected. 