### PR TITLE
LibGfx/CCITT: Fix most PDF files from 0000.zip

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -450,7 +450,7 @@ ErrorOr<ReferenceLine> decode_single_ccitt_2d_line(BigEndianInputBitStream& inpu
             TRY(decoded_bits.write_bits(current_color == ccitt_white ? 0u : 1u, 1));
 
         column = change.column + offset;
-        current_color = change.color;
+        current_color = invert(current_color);
         remainder_from_pass_mode = 0;
 
         TRY(current_line.try_empend(current_color, column));

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -436,7 +436,7 @@ ErrorOr<ReferenceLine> decode_single_ccitt_2d_line(BigEndianInputBitStream& inpu
                 reference_line.take_first();
                 continue;
             }
-            if (change.color != current_color)
+            if (change.color != current_color || change.column == image_width)
                 next_change = change;
             else
                 offset++;

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -316,7 +316,7 @@ PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes bytes, RefPtr<DictObje
     //        achieve to decode images that have it. Figure out what to do with it.
     (void)end_of_block;
 
-    if (require_end_of_line || encoded_byte_align || damaged_rows_before_error > 0 || rows == 0)
+    if (require_end_of_line || encoded_byte_align || damaged_rows_before_error > 0)
         return Error::rendering_unsupported_error("Unimplemented option for the CCITTFaxDecode Filter");
 
     ByteBuffer decoded {};


### PR DESCRIPTION
`test_pdf` diff:

Before:
```
Rendering of feature not supported: Unimplemented option for the CCITTFaxDecode Filter, in 46 files, on 331 pages, 657 times
  0000/0000084.pdf 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78
  0000/0000605.pdf 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49
  0000/0000286.pdf 1 2 3 4 5 6 7 8 9 10 11 12 13 14 (2x) 15 (2x) 16 17 (6x) 18 19 21 22 23 (2x) 24 (2x) 25 (2x) 26
  0000/0000031.pdf 1 (3x) 2 3 4 (3x) 5 (4x) 6 (4x) 7 (4x) 8 (4x) 9 (4x) 10 (3x) 11 (4x) 12 (4x) 13 (4x) 14 (4x) 15 (4x) 16
  0000/0000001.pdf 1 2 3 4 5 6 7 8 9 10 11 12 13
  0000/0000476.pdf 1 2 3 4 5 6 7 8 9 10 11 12
  0000/0000374.pdf 1 2 (2x) 3 4 (2x) 5 6 7 8 9 10 11
  0000/0000871.pdf 1 2 3 4 5 6 7 8 9 10 11
  0000/0000008.pdf 1 2 3 4 5 6 7 8 9 10
  0000/0000402.pdf 1 2 3 4 5 6 7 8 9 10
  0000/0000404.pdf 1 2 3 4 5 6 7 8 9
  0000/0000238.pdf 1 2 3 4 5 6 7 8
  0000/0000548.pdf 2 3 4 5 6 7 8 9
  0000/0000736.pdf 1 2 3 4 5 6
  0000/0000462.pdf 63 74 81 95 121
  0000/0000948.pdf 1 (3x) 2 (7x) 3 (22x) 5 9 (3x)
  0000/0000650.pdf 19 22 30 (2x) 31
  0000/0000694.pdf 1 2 3 4
  0000/0000725.pdf 1 (2x) 2 (3x) 3 (3x) 4 (3x)
  0000/0000932.pdf 1 2 3 4
  0000/0000460.pdf 2 3 4
  0000/0000522.pdf 12 (6x) 13 (4x) 362 (2x)
  0000/0000628.pdf 36 (32x) 37 (32x) 38 (16x)
  0000/0000646.pdf 8 (13x) 9 (12x) 10 (16x)
  0000/0000125.pdf 1 2 (2x)
  0000/0000347.pdf 13 (49x) 14 (20x)
  0000/0000527.pdf 1 (2x) 2 (2x)
  0000/0000828.pdf 11 12
  0000/0000947.pdf 1 2
  0000/0000973.pdf 12 13
  0000/0000054.pdf 1
  0000/0000065.pdf 2
  0000/0000222.pdf 1
  0000/0000259.pdf 11
  0000/0000398.pdf 1 (3x)
  0000/0000425.pdf 1
  0000/0000515.pdf 1
  0000/0000550.pdf 1 (2x)
  0000/0000568.pdf 40
  0000/0000659.pdf 1 (5x)
  0000/0000704.pdf 1 (11x)
  0000/0000776.pdf 1
  0000/0000798.pdf 1
  0000/0000867.pdf 1 (2x)
  0000/0000954.pdf 1
  0000/0000976.pdf 1 (28x)

Internal error while processing PDF file: CCITTDecoder: Corrupted stream, in 10 files, on 32 pages, 33 times
  0000/0000196.pdf 1 2 3 8 10 11 12 14 16 17 19 21
  0000/0000598.pdf 1 2 3 4
  0000/0000608.pdf 3 4 29 40
  0000/0000711.pdf 66 68 70
  0000/0000826.pdf 30 45 112
  0000/0000935.pdf 6 7
  0000/0000237.pdf 1
  0000/0000465.pdf 2
  0000/0000560.pdf 6 (2x)
  0000/0000769.pdf 6

762 files without issues (76.2%)
```

After:
```
Internal error while processing PDF file: CCITTDecoder: Unable to find the correct mode, in 1 files, on 10 pages, 10 times
  0000/0000001.pdf 2 3 4 6 7 8 9 10 11 12

Rendering of feature not supported: Unimplemented option for the CCITTFaxDecode Filter, in 1 files, on 11 pages, 11 times
  0000/0000871.pdf 1 2 3 4 5 6 7 8 9 10 11

802 files without issues (80.2%)
```


And some images:
(from https://github.com/SerenityOS/serenity/pull/23301#issuecomment-1959421289)

0000031.pdf page 2
Before:
![out_pdf_31-2](https://github.com/SerenityOS/serenity/assets/26030965/3c62d7fb-a00e-4797-b30a-be86b185fade)

After:
![out_pdf_31-2](https://github.com/SerenityOS/serenity/assets/26030965/79c0dbf9-85da-4782-bd03-08a883f67a70)

0000374.pdf page 2
Before:
![out_pdf_374-2](https://github.com/SerenityOS/serenity/assets/26030965/c2d0884a-7345-498a-9318-fa24b55cae64)
After:
![out_pdf_374-2](https://github.com/SerenityOS/serenity/assets/26030965/332076fa-f634-4c7c-80d3-ffb8da0049f8)

0000462.pdf page 63
Before:
![out_pdf_462-63](https://github.com/SerenityOS/serenity/assets/26030965/30f3873c-be43-40c0-a97e-f06f96d3b722)
After:![out_pdf_462-63](https://github.com/SerenityOS/serenity/assets/26030965/71bd7f88-bd03-4438-a06c-9450fed21a93)


0000650.pdf page 19
Before:
![out_pdf_650-19](https://github.com/SerenityOS/serenity/assets/26030965/d15fb9dd-657a-4394-9c83-82eca676b2d1)
After:
![out_pdf_650-19](https://github.com/SerenityOS/serenity/assets/26030965/1eed5dae-3fd9-49b7-8d3f-3510bb770f95)
