### PR TITLE
Ladybird/Qt: Explicitly ignore wheel events with the ctrl key pressed

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -364,6 +364,11 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 
 void WebContentView::wheelEvent(QWheelEvent* event)
 {
+    if (event->modifiers().testFlag(Qt::ControlModifier)) {
+        event->ignore();
+        return;
+    }
+
     enqueue_native_event(Web::MouseEvent::Type::MouseWheel, *event);
 }
 
@@ -699,7 +704,7 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
     int wheel_delta_x = 0;
     int wheel_delta_y = 0;
 
-    if (type == Web::MouseEvent::Type::MouseWheel && !event.modifiers().testFlag(Qt::ControlModifier)) {
+    if (type == Web::MouseEvent::Type::MouseWheel) {
         auto const& wheel_event = static_cast<QWheelEvent const&>(event);
 
         if (auto pixel_delta = -wheel_event.pixelDelta(); !pixel_delta.isNull()) {


### PR DESCRIPTION
This allows ctrl+wheel events to zoom in and out of the page. This was ported incorrectly in commit c1476c3405518871be7a8f5f4feb0670d1051df8.