### PR TITLE
WebContent: Update mouse event data when coalescing consecutive events

### DIFF
--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -56,7 +56,6 @@ executable("ladybird_executable") {
     "SQLServer",
     "WebContent",
     "WebDriver",
-    "WebSocket",
     "WebWorker",
   ]
   deps = [
@@ -325,7 +324,6 @@ if (current_os != "mac") {
       "SQLServer",
       "WebContent",
       "WebDriver",
-      "WebSocket",
       "WebWorker",
     ]
     sources = [

--- a/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
@@ -68,7 +68,6 @@ executable("WebContent") {
       "//Ladybird/Qt/EventLoopImplementationQtEventTarget.cpp",
       "//Ladybird/Qt/RequestManagerQt.cpp",
       "//Ladybird/Qt/StringUtils.cpp",
-      "//Ladybird/Qt/WebSocketClientManagerQt.cpp",
       "//Ladybird/Qt/WebSocketImplQt.cpp",
       "//Ladybird/Qt/WebSocketQt.cpp",
     ]


### PR DESCRIPTION
When we coalesce mouse wheel events, we need to be sure to include the
previous event's wheel deltas. This was errantly excluded in commit
baf359354b4f55b33372951a2a60f797ad071071.