### PR TITLE
LibWeb: Apply transform origin in Element::get_client_rects()

### DIFF
--- a/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-css-transform.txt
+++ b/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-css-transform.txt
@@ -1,1 +1,1 @@
-       {"x":68,"y":118,"width":100,"height":100,"top":118,"right":168,"bottom":218,"left":68}
+       {"x":18,"y":68,"width":200,"height":200,"top":68,"right":218,"bottom":268,"left":18}

--- a/Tests/LibWeb/Text/input/element-get-bounding-client-rect-css-transform.html
+++ b/Tests/LibWeb/Text/input/element-get-bounding-client-rect-css-transform.html
@@ -13,7 +13,7 @@
         width: 100px;
         height: 100px;
         opacity: 0.1;
-        transform: translate(10px, 10px);
+        transform: translate(10px, 10px) scale(2);
     }
 </style>
 <div class="transform-1">


### PR DESCRIPTION
This fixes #23003

The select element uses the `get_bounding_client_rect()` for the location where it places the dropdown. In `get_client_rects()` the transform origin wasn't applied so when scaling the element the rects where not correct.

CC @kalenikaliaksandr 