### PR TITLE
LibPDF: Make truetype fonts marked as symbol fonts actually work

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -39,10 +39,15 @@ public:
     // TABLE 5.20 Font flags
     bool is_fixed_pitch() const { return m_flags & (1 << (1 - 1)); }
     bool is_serif() const { return m_flags & (1 << (2 - 1)); }
-    bool is_symbolic() const { return m_flags & (1 << (3 - 1)); }
+
+    static constexpr unsigned Symbolic = 1 << (3 - 1);
+    bool is_symbolic() const { return m_flags & Symbolic; }
+
     bool is_script() const { return m_flags & (1 << (4 - 1)); }
+
     // Note: No bit position 5.
-    bool is_nonsymbolic() const { return m_flags & (1 << (6 - 1)); }
+    static constexpr unsigned NonSymbolic = 1 << (6 - 1);
+    bool is_nonsymbolic() const { return m_flags & NonSymbolic; }
     bool is_italic() const { return m_flags & (1 << (7 - 1)); }
     // Note: Big jump in bit positions.
     bool is_all_cap() const { return m_flags & (1 << (17 - 1)); }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -54,6 +54,10 @@ PDFErrorOr<void> Type1Font::initialize(Document* document, NonnullRefPtr<DictObj
         auto font = TRY(replacement_for(base_font_name().to_lowercase(), font_size));
 
         auto effective_encoding = encoding();
+        bool is_standard_14_font = base_font_name() == "Helvetica" || base_font_name() == "Helvetica-Bold" || base_font_name() == "Helvetica-Oblique" || base_font_name() == "Helvetica-BoldOblique"
+            || base_font_name() == "Times-Roman" || base_font_name() == "Times-Bold" || base_font_name() == "Times-Italic" || base_font_name() == "Times-BoldItalic"
+            || base_font_name() == "Courier" || base_font_name() == "Courier-Bold" || base_font_name() == "Courier-Oblique" || base_font_name() == "Courier-BoldOblique"
+            || base_font_name() == "Symbol" || base_font_name() == "ZapfDingbats";
         if (!effective_encoding) {
             // PDF 1.7 spec, APPENDIX D Character Sets and Encodings
             // "Sections D.4, “Symbol Set and Encoding,” and D.5, “ZapfDingbats Set and Encoding,”
@@ -73,7 +77,12 @@ PDFErrorOr<void> Type1Font::initialize(Document* document, NonnullRefPtr<DictObj
                 effective_encoding = Encoding::standard_encoding();
         }
 
-        // FIXME: For the standard 14 fonts, set some m_flags bits (symbolic/nonsymbolic, italic, bold, fixed pitch, serif).
+        if (is_standard_14_font) {
+            // We use the Liberation fonts as a replacement for the standard 14 fonts, and they're all non-symbolic.
+            m_flags = (m_flags | NonSymbolic) & ~Symbolic;
+
+            // FIXME: Set more m_flags bits (symbolic/nonsymbolic, italic, bold, fixed pitch, serif).
+        }
 
         m_fallback_font_painter = TrueTypePainter::create(document, dict, *this, *font, *effective_encoding, base_font_name() == "ZapfDingbats"sv);
     }


### PR DESCRIPTION
Turns out the spec didn't mean that the whole range is populated, but that one of these ranges is populated. So take the argmax.

As fallout, explicitly mark the Liberation fonts as nonsymbolic when we use them for the 14 standard fonts. Else, we'd regress "PostScrõpt", since the Liberation fonts would otherwise go down the "is symbolic or doesn't have explicit encoding" codepath, since the standard fonts usually don't have an explicit encoding.

As a fallout from _that_, since the 14 standard fonts now go down the regular truetype rendering path, and since we don't implement lookup by postscript name yet, glyphs not present in Liberation now cause text to stop rendering with a diag, instead of rendering a "glyph not found" symbol. That isn't super common, only an additional 4 files appear for the "'post' table not yet implemented" diag. Since we'll implement that soon, this seems fine until then.