### PR TITLE
Ladybird: Include Userland/ in for Applications that use LibWeb

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -204,6 +204,7 @@ add_executable(headless-browser
     Utilities.cpp)
 
 target_include_directories(headless-browser PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(headless-browser PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
 target_link_libraries(headless-browser PRIVATE AK LibCore LibWeb LibWebView LibWebSocket LibCrypto LibFileSystem LibGemini LibHTTP LibImageDecoderClient LibJS LibGfx LibMain LibTLS LibIPC LibDiff LibProtocol)
 
 if (ANDROID)

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -46,6 +46,7 @@ else()
     endif()
     add_library(webcontent ${LIB_TYPE} ${WEBCONTENT_SOURCES})
     target_include_directories(webcontent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+    target_include_directories(webcontent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
     target_include_directories(webcontent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
     target_link_libraries(webcontent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView LibImageDecoderClient)
     target_sources(webcontent PUBLIC FILE_SET ladybird TYPE HEADERS
@@ -78,6 +79,7 @@ else()
 endif()
 
 target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
 target_include_directories(WebContent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(WebContent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView)
 

--- a/Ladybird/WebWorker/CMakeLists.txt
+++ b/Ladybird/WebWorker/CMakeLists.txt
@@ -17,8 +17,10 @@ set(WEBWORKER_SOURCES
 add_library(webworker STATIC ${WEBWORKER_SOURCES})
 
 target_include_directories(webworker PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+target_include_directories(webworker PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
 target_include_directories(webworker PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(webworker PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibProtocol LibWeb LibWebView LibLocale LibImageDecoderClient LibMain)
 
 add_executable(WebWorker main.cpp)
+target_include_directories(WebWorker PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
 target_link_libraries(WebWorker PRIVATE webworker)


### PR DESCRIPTION
After ea682207d099654dd0c5d1ed399e2060c4de1533, we need Userland/ included directly in these application executables. This only impacts the build with Ladybird/CMakeLists.txt as the top level CMakeLists, as the Lagom/ directory includes Userland/ globally.