### PR TITLE
LibWeb: Improve the layout of absolutely positioned flex items

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-flex-margin-limits-1.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flex-margin-limits-1.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      Box <div.container> at (8,8) content-size 100x100 positioned flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.bottom-left> at (18,48) content-size 50x50 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>.container) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>.bottom-left) [8,38 70x70]

--- a/Tests/LibWeb/Layout/expected/abspos-flex-margin-limits-2.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flex-margin-limits-2.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      Box <div.container> at (8,8) content-size 100x100 positioned flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.top-right> at (48,18) content-size 50x50 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>.container) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>.top-right) [38,8 70x70]

--- a/Tests/LibWeb/Layout/expected/abspos-flexbox-with-auto-width.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flexbox-with-auto-width.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div#containing-block> at (8,8) content-size 200x100 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 200x0 children: inline
+          TextNode <#text>
+        Box <div#inner-flex> at (8,8) content-size 200x0 flex-container(row) [FFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+          BlockContainer <div> at (83,8) content-size 50x100 positioned [BFC] children: not-inline
+            BlockContainer <(anonymous)> at (83,8) content-size 50x0 children: inline
+              TextNode <#text>
+            BlockContainer <span> at (83,8) content-size 50x0 children: not-inline
+            BlockContainer <(anonymous)> at (83,8) content-size 50x0 children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 200x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>#containing-block) [8,8 200x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 200x0]
+        PaintableBox (Box<DIV>#inner-flex) [8,8 200x0] overflow: [83,8 50x100]
+          PaintableWithLines (BlockContainer<DIV>) [83,8 50x100]
+            PaintableWithLines (BlockContainer(anonymous)) [83,8 50x0]
+            PaintableWithLines (BlockContainer<SPAN>) [83,8 50x0]
+            PaintableWithLines (BlockContainer(anonymous)) [83,8 50x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 200x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -32,15 +32,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.end> at (38,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (48,308) content-size 150x50 positioned [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [48,308 26.1875x17] baseline: 13.296875
+        BlockContainer <div> at (48,298) content-size 150x50 positioned [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [48,298 26.1875x17] baseline: 13.296875
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.flex-end> at (208,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (218,308) content-size 150x50 positioned [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 8, rect: [218,308 61.765625x17] baseline: 13.296875
+        BlockContainer <div> at (218,298) content-size 150x50 positioned [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 8, rect: [218,298 61.765625x17] baseline: 13.296875
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -60,8 +60,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.self-end> at (38,378) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (48,478) content-size 150x50 positioned [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 8, rect: [48,478 61.40625x17] baseline: 13.296875
+        BlockContainer <div> at (48,468) content-size 150x50 positioned [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 8, rect: [48,468 61.40625x17] baseline: 13.296875
               "self-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -82,11 +82,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableBox (Box<DIV>.outer.flex-start) [538,28 170x170] overflow: [548,38 170x150]
         PaintableWithLines (BlockContainer<DIV>) [548,38 170x70]
           TextPaintable (TextNode<#text>)
-      PaintableBox (Box<DIV>.outer.end) [28,198 170x170] overflow: [38,208 170x160]
-        PaintableWithLines (BlockContainer<DIV>) [38,298 170x70]
+      PaintableBox (Box<DIV>.outer.end) [28,198 170x170] overflow: [38,208 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [38,288 170x70]
           TextPaintable (TextNode<#text>)
-      PaintableBox (Box<DIV>.outer.flex-end) [198,198 170x170] overflow: [208,208 170x160]
-        PaintableWithLines (BlockContainer<DIV>) [208,298 170x70]
+      PaintableBox (Box<DIV>.outer.flex-end) [198,198 170x170] overflow: [208,208 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [208,288 170x70]
           TextPaintable (TextNode<#text>)
       PaintableBox (Box<DIV>.outer.center) [368,198 170x170] overflow: [378,208 170x150]
         PaintableWithLines (BlockContainer<DIV>) [378,248 170x70]
@@ -94,6 +94,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableBox (Box<DIV>.outer.self-start) [538,198 170x170] overflow: [548,208 170x150]
         PaintableWithLines (BlockContainer<DIV>) [548,208 170x70]
           TextPaintable (TextNode<#text>)
-      PaintableBox (Box<DIV>.outer.self-end) [28,368 170x170] overflow: [38,378 170x160]
-        PaintableWithLines (BlockContainer<DIV>) [38,468 170x70]
+      PaintableBox (Box<DIV>.outer.self-end) [28,368 170x170] overflow: [38,378 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [38,458 170x70]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x570 [BFC] children: not-inline
-    BlockContainer <body> at (8,70) content-size 784x492 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x986 [BFC] children: not-inline
+    BlockContainer <body> at (8,70) content-size 784x908 children: not-inline
       BlockContainer <p.min-inline-test> at (8,70) content-size 784x200 children: inline
         frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76] baseline: 58.984375
             "KK"
@@ -13,15 +13,26 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from TextNode start: 0, length: 2, rect: [8,486 85.859375x76] baseline: 58.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,632) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,632) content-size 784x76 children: inline
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+      BlockContainer <p.inline-size-test> at (8,778) content-size 400x200 children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [8,778 85.859375x76] baseline: 58.984375
+            "KK"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,1048) content-size 784x0 children: inline
         TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x632]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x570] overflow: [0,0 800x632]
-    PaintableWithLines (BlockContainer<BODY>) [8,70 784x492] overflow: [8,70 784x562]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1048]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x986] overflow: [0,0 800x1048]
+    PaintableWithLines (BlockContainer<BODY>) [8,70 784x908] overflow: [8,70 784x978]
       PaintableWithLines (BlockContainer<P>.min-inline-test) [8,70 784x200]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,340 784x76]
       PaintableWithLines (BlockContainer<P>.max-inline-test) [8,486 100x76]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,632 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,632 784x76]
+      PaintableWithLines (BlockContainer<P>.inline-size-test) [8,778 400x200]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,1048 784x0]

--- a/Tests/LibWeb/Layout/input/abspos-flex-margin-limits-1.html
+++ b/Tests/LibWeb/Layout/input/abspos-flex-margin-limits-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+.container {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: red;
+    display: flex;
+    align-items: end;
+}
+.bottom-left {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    margin-top: 500px;
+    background: green;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<div class="container">
+  <div class="bottom-left"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/abspos-flex-margin-limits-2.html
+++ b/Tests/LibWeb/Layout/input/abspos-flex-margin-limits-2.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+.container {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: red;
+    display: flex;
+    justify-content: end;
+}
+.top-right {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    margin-left: 500px;
+    background: green;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<div class="container">
+  <div class="top-right"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/abspos-flexbox-with-auto-width.html
+++ b/Tests/LibWeb/Layout/input/abspos-flexbox-with-auto-width.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+#containing-block {
+  width: 200px;
+  height: 100px;
+  background: red;
+}
+
+#inner-flex {
+  display: flex;
+  justify-content: center;
+}
+
+span {
+  display: block;
+  width: 50px;
+}
+</style>
+<div id="containing-block">
+  <div id="inner-flex">
+    <div style="position: absolute; height: 100px; background: green;">
+      <span></span>
+    </div>
+  </div>
+</div>

--- a/Tests/LibWeb/Layout/input/inline-size.html
+++ b/Tests/LibWeb/Layout/input/inline-size.html
@@ -19,7 +19,14 @@
     max-inline-size: 100px;
     writing-mode: horizontal-tb;
 }
+.inline-size-test {
+    background: blue;
+    inline-size: 400px;
+    height: 200px;
+}
 </style>
 <p class="min-inline-test">KK</p>
 <br>
 <p class="max-inline-test">KK</p>
+<br>
+<p class="inline-size-test">KK</p>

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -85,6 +85,7 @@ grid-template-columns:
 grid-template-rows: 
 height: 1445px
 image-rendering: auto
+inline-size: auto
 inset-block-end: auto
 inset-block-start: auto
 inset-inline-end: auto

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1307,6 +1307,13 @@
       "image-rendering"
     ]
   },
+  "inline-size": {
+      "logical-alias-for": [
+        "width"
+      ],
+      "initial": "auto",
+      "max-values": 1
+  },
   "inset": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -374,6 +374,8 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
             return PropertyID::PaddingLeft;
         case PropertyID::PaddingInlineEnd:
             return PropertyID::PaddingRight;
+        case PropertyID::InlineSize:
+            return PropertyID::Width;
         case PropertyID::InsetBlockStart:
             return PropertyID::Top;
         case PropertyID::InsetBlockEnd:

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2106,14 +2106,19 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     CSSPixels cross_offset = 0;
     CSSPixels half_line_size = inner_cross_size(m_flex_container_state) / 2;
 
+    auto cross_to_px = [&](CSS::LengthPercentage const& length_percentage) -> CSSPixels {
+        return length_percentage.to_px(box, m_flex_container_state.content_width());
+    };
+
     auto const& box_state = m_state.get(box);
-    CSSPixels cross_margin_before = is_row_layout() ? box_state.margin_top : box_state.margin_left;
-    CSSPixels cross_margin_after = is_row_layout() ? box_state.margin_bottom : box_state.margin_right;
-    CSSPixels cross_border_before = is_row_layout() ? box_state.border_top : box_state.border_left;
-    CSSPixels cross_border_after = is_row_layout() ? box_state.border_bottom : box_state.border_right;
-    CSSPixels cross_padding_after = is_row_layout() ? box_state.padding_bottom : box_state.padding_right;
-    CSSPixels main_border_before = is_row_layout() ? box_state.border_left : box_state.border_top;
-    CSSPixels main_border_after = is_row_layout() ? box_state.border_right : box_state.border_bottom;
+    CSSPixels cross_margin_before = is_row_layout() ? cross_to_px(box.computed_values().margin().top()) : cross_to_px(box.computed_values().margin().left());
+    CSSPixels cross_margin_after = is_row_layout() ? cross_to_px(box.computed_values().margin().bottom()) : cross_to_px(box.computed_values().margin().right());
+    CSSPixels cross_border_before = is_row_layout() ? box.computed_values().border_top().width : box.computed_values().border_left().width;
+    CSSPixels cross_border_after = is_row_layout() ? box.computed_values().border_bottom().width : box.computed_values().border_right().width;
+    CSSPixels cross_padding_before = is_row_layout() ? cross_to_px(box.computed_values().padding().top()) : cross_to_px(box.computed_values().padding().left());
+    CSSPixels cross_padding_after = is_row_layout() ? cross_to_px(box.computed_values().padding().bottom()) : cross_to_px(box.computed_values().padding().right());
+    CSSPixels main_border_before = is_row_layout() ? box.computed_values().border_left().width : box.computed_values().border_top().width;
+    CSSPixels main_border_after = is_row_layout() ? box.computed_values().border_right().width : box.computed_values().border_bottom().width;
 
     switch (alignment_for_item(box)) {
     case CSS::AlignItems::Baseline:
@@ -2124,15 +2129,15 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     case CSS::AlignItems::SelfStart:
     case CSS::AlignItems::Stretch:
     case CSS::AlignItems::Normal:
-        cross_offset = -half_line_size + cross_margin_before;
+        cross_offset = -half_line_size;
         break;
     case CSS::AlignItems::End:
     case CSS::AlignItems::SelfEnd:
     case CSS::AlignItems::FlexEnd:
-        cross_offset = half_line_size - inner_cross_size(box_state) - cross_margin_after - cross_border_after - cross_padding_after;
+        cross_offset = half_line_size - inner_cross_size(box_state) - (cross_margin_before + cross_margin_after) - (cross_border_before + cross_border_after) - (cross_padding_before + cross_padding_after);
         break;
     case CSS::AlignItems::Center:
-        cross_offset = -((inner_cross_size(box_state) + cross_border_before + cross_border_after) / 2);
+        cross_offset = -((inner_cross_size(box_state) + cross_margin_after + cross_margin_before + cross_border_before + cross_border_after + cross_padding_before + cross_padding_after) / 2);
         break;
     default:
         break;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2110,6 +2110,10 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
         return length_percentage.to_px(box, m_flex_container_state.content_width());
     };
 
+    auto main_to_px = [&](CSS::LengthPercentage const& length_percentage) -> CSSPixels {
+        return length_percentage.to_px(box, m_flex_container_state.content_width());
+    };
+
     auto const& box_state = m_state.get(box);
     CSSPixels cross_margin_before = is_row_layout() ? cross_to_px(box.computed_values().margin().top()) : cross_to_px(box.computed_values().margin().left());
     CSSPixels cross_margin_after = is_row_layout() ? cross_to_px(box.computed_values().margin().bottom()) : cross_to_px(box.computed_values().margin().right());
@@ -2117,8 +2121,12 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     CSSPixels cross_border_after = is_row_layout() ? box.computed_values().border_bottom().width : box.computed_values().border_right().width;
     CSSPixels cross_padding_before = is_row_layout() ? cross_to_px(box.computed_values().padding().top()) : cross_to_px(box.computed_values().padding().left());
     CSSPixels cross_padding_after = is_row_layout() ? cross_to_px(box.computed_values().padding().bottom()) : cross_to_px(box.computed_values().padding().right());
+    CSSPixels main_margin_before = is_row_layout() ? main_to_px(box.computed_values().margin().left()) : main_to_px(box.computed_values().margin().top());
+    CSSPixels main_margin_after = is_row_layout() ? main_to_px(box.computed_values().margin().right()) : main_to_px(box.computed_values().margin().bottom());
     CSSPixels main_border_before = is_row_layout() ? box.computed_values().border_left().width : box.computed_values().border_top().width;
     CSSPixels main_border_after = is_row_layout() ? box.computed_values().border_right().width : box.computed_values().border_bottom().width;
+    CSSPixels main_padding_before = is_row_layout() ? main_to_px(box.computed_values().padding().left()) : main_to_px(box.computed_values().padding().top());
+    CSSPixels main_padding_after = is_row_layout() ? main_to_px(box.computed_values().padding().right()) : main_to_px(box.computed_values().padding().bottom());
 
     switch (alignment_for_item(box)) {
     case CSS::AlignItems::Baseline:
@@ -2172,12 +2180,12 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     case CSS::JustifyContent::SpaceAround:
     case CSS::JustifyContent::SpaceEvenly:
         pack_from_end = false;
-        main_offset = (inner_main_size(m_flex_container_state) - inner_main_size(box_state) - main_border_before - main_border_after) / 2;
+        main_offset = (inner_main_size(m_flex_container_state) - inner_main_size(box_state) - main_margin_before - main_margin_after - main_border_before - main_border_after - main_padding_before - main_padding_after) / 2;
         break;
     }
 
     if (pack_from_end)
-        main_offset += inner_main_size(m_flex_container_state) - inner_main_size(box_state) - main_border_before - main_border_after;
+        main_offset += inner_main_size(m_flex_container_state) - inner_main_size(box_state) - main_margin_before - main_margin_after - main_border_before - main_border_after - main_padding_before - main_padding_after;
 
     auto static_position_offset = is_row_layout() ? CSSPixelPoint { main_offset, cross_offset } : CSSPixelPoint { cross_offset, main_offset };
 


### PR DESCRIPTION
As a whole, this PR fixes the following Web Platform Tests:
http://wpt.live/css/css-position/position-absolute-center-001.html
http://wpt.live/css/css-position/position-absolute-center-003.html
http://wpt.live/css/css-position/position-absolute-center-004.html

...and as a bonus, this also fixes some very subtle layout issues with `flex/abspos-flex-child-static-position-with-align-items.html`