### PR TITLE
LibCrypto: Store ASN1 certificate timestamps as UnixDateTime

### DIFF
--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
@@ -6,6 +6,7 @@
 
 #include "CertificateStoreWidget.h"
 #include <AK/String.h>
+#include <LibCore/DateTime.h>
 #include <LibCrypto/ASN1/PEM.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibFileSystemAccessClient/Client.h>
@@ -74,7 +75,7 @@ GUI::Variant CertificateStoreModel::data(GUI::ModelIndex const& index, GUI::Mode
         return issued_by;
     }
     case Column::Expire:
-        return cert.validity.not_after.to_byte_string("%Y-%m-%d"sv);
+        return Core::DateTime::from_timestamp(cert.validity.not_after.seconds_since_epoch()).to_byte_string("%Y-%m-%d"sv);
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibCrypto/ASN1/ASN1.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/ASN1.cpp
@@ -119,7 +119,7 @@ ByteString type_name(Type type)
     return "InvalidType";
 }
 
-Optional<Core::DateTime> parse_utc_time(StringView time)
+Optional<UnixDateTime> parse_utc_time(StringView time)
 {
     // YYMMDDhhmm[ss]Z or YYMMDDhhmm[ss](+|-)hhmm
     GenericLexer lexer(time);
@@ -164,10 +164,10 @@ Optional<Core::DateTime> parse_utc_time(StringView time)
     if (offset_hours.has_value() || offset_minutes.has_value())
         dbgln("FIXME: Implement UTCTime with offset!");
 
-    return Core::DateTime::create(full_year, month.value(), day.value(), hour.value(), minute.value(), full_seconds);
+    return UnixDateTime::from_unix_time_parts(full_year, month.value(), day.value(), hour.value(), minute.value(), full_seconds, 0);
 }
 
-Optional<Core::DateTime> parse_generalized_time(StringView time)
+Optional<UnixDateTime> parse_generalized_time(StringView time)
 {
     // YYYYMMDDhh[mm[ss[.fff]]] or YYYYMMDDhh[mm[ss[.fff]]]Z or YYYYMMDDhh[mm[ss[.fff]]](+|-)hhmm
     GenericLexer lexer(time);
@@ -177,6 +177,7 @@ Optional<Core::DateTime> parse_generalized_time(StringView time)
     auto hour = lexer.consume(2).to_number<unsigned>();
     Optional<unsigned> minute, seconds, milliseconds, offset_hours, offset_minutes;
     [[maybe_unused]] bool negative_offset = false;
+
     if (!lexer.is_eof()) {
         if (lexer.consume_specific('Z'))
             goto done_parsing;
@@ -233,7 +234,6 @@ done_parsing:;
     if (offset_hours.has_value() || offset_minutes.has_value())
         dbgln("FIXME: Implement GeneralizedTime with offset!");
 
-    // Unceremoniously drop the milliseconds on the floor.
-    return Core::DateTime::create(year.value(), month.value(), day.value(), hour.value(), minute.value_or(0), seconds.value_or(0));
+    return UnixDateTime::from_unix_time_parts(year.value(), month.value(), day.value(), hour.value(), minute.value_or(0), seconds.value_or(0), milliseconds.value_or(0));
 }
 }

--- a/Userland/Libraries/LibCrypto/ASN1/ASN1.h
+++ b/Userland/Libraries/LibCrypto/ASN1/ASN1.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <AK/Time.h>
 #include <AK/Types.h>
-#include <LibCore/DateTime.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
 namespace Crypto::ASN1 {
@@ -75,7 +75,7 @@ ByteString kind_name(Kind);
 ByteString class_name(Class);
 ByteString type_name(Type);
 
-Optional<Core::DateTime> parse_utc_time(StringView);
-Optional<Core::DateTime> parse_generalized_time(StringView);
+Optional<UnixDateTime> parse_utc_time(StringView);
+Optional<UnixDateTime> parse_generalized_time(StringView);
 
 }

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -296,7 +296,7 @@ static ErrorOr<RelativeDistinguishedName> parse_name(Crypto::ASN1::Decoder& deco
     return rdn;
 }
 
-static ErrorOr<Core::DateTime> parse_time(Crypto::ASN1::Decoder& decoder, Vector<StringView> current_scope)
+static ErrorOr<UnixDateTime> parse_time(Crypto::ASN1::Decoder& decoder, Vector<StringView> current_scope)
 {
     // Time ::= Choice {
     //     utc_time     UTCTime,

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -9,9 +9,9 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
+#include <AK/Time.h>
 #include <AK/Types.h>
 #include <LibCore/ConfigFile.h>
-#include <LibCore/DateTime.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/PK/RSA.h>
 #include <LibTLS/Extensions.h>
@@ -233,8 +233,8 @@ private:
 };
 
 struct Validity {
-    Core::DateTime not_before;
-    Core::DateTime not_after;
+    UnixDateTime not_before;
+    UnixDateTime not_after;
 };
 
 class SubjectPublicKey {

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -104,15 +104,15 @@ void TLSv12::consume(ReadonlyBytes record)
 
 bool Certificate::is_valid() const
 {
-    auto now = Core::DateTime::now();
+    auto now = UnixDateTime::now();
 
     if (now < validity.not_before) {
-        dbgln("certificate expired (not yet valid, signed for {})", validity.not_before.to_byte_string());
+        dbgln("certificate expired (not yet valid, signed for {})", Core::DateTime::from_timestamp(validity.not_before.seconds_since_epoch()));
         return false;
     }
 
     if (validity.not_after < now) {
-        dbgln("certificate expired (expiry date {})", validity.not_after.to_byte_string());
+        dbgln("certificate expired (expiry date {})", Core::DateTime::from_timestamp(validity.not_after.seconds_since_epoch()));
         return false;
     }
 


### PR DESCRIPTION
We are currently using `Core::DateTime`, which is meant to represent local time. However, we are doing no conversion between the parsed time in UTC and local time, so we end up comparing time stamps from different time zones.

Instead, store the parsed times as `UnixDateTime`, which is UTC. Then we can always compare the parsed times against the current UTC time.

This also lets us store parsed milliseconds.

Fixes #23502