### PR TITLE
LibWeb: Allow selecting select options without value

### DIFF
--- a/Base/res/html/misc/select.html
+++ b/Base/res/html/misc/select.html
@@ -28,6 +28,17 @@
         Value: <span id="a-value">?</span>
     </p>
 
+    <p>Basic select with no values:</p>
+    <p>
+        <select>
+            <option value="">One</option>
+            <option value="">Two</option>
+            <option value="">Three</option>
+            <option value="">Four</option>
+            <option value="">Five</option>
+        </select>
+    </p>
+
     <p>Basic select with separators:</p>
     <p>
         <select onchange="document.getElementById('b-value').textContent = this.value" style="width: 50%;">

--- a/Base/res/html/misc/select.html
+++ b/Base/res/html/misc/select.html
@@ -72,19 +72,16 @@
                 <option value="8.01.1">Lecture 01: Powers of Ten
                 <option value="8.01.2">Lecture 02: 1D Kinematics
                 <option value="8.01.3">Lecture 03: Vectors
-                <hr>
                 <option value="8.01.4">Lecture 04: Random
-            <optgroup label="8.02 Electricity and Magnetism">
+            <optgroup label="8.02 Electricity and Magnetism (disabled)" disabled>
                 <option value="8.02.1">Lecture 01: What holds our world together?
                 <option value="8.02.2">Lecture 02: Electric Field
                 <option value="8.02.3">Lecture 03: Electric Flux
-                <hr>
                 <option value="8.02.4">Lecture 04: Random
             <optgroup label="8.03 Physics III: Vibrations and Waves">
                 <option value="8.03.1">Lecture 01: Periodic Phenomenon
                 <option value="8.03.2">Lecture 02: Beats
                 <option value="8.03.3">Lecture 03: Forced Oscillations with Damping
-                <hr>
                 <option value="8.03.4">Lecture 04: Random
         </select>
         Value: <span id="c-value">?</span>

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -714,7 +714,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         auto add_menu_item = [self](Web::HTML::SelectItemOption const& item_option) {
             NSMenuItem* menuItem = [[NSMenuItem alloc]
                 initWithTitle:Ladybird::string_to_ns_string(item_option.label)
-                       action:@selector(selectDropdownAction:)
+                       action:item_option.disabled ? nil : @selector(selectDropdownAction:)
                 keyEquivalent:@""];
             menuItem.representedObject = [NSNumber numberWithUnsignedInt:item_option.id];
             menuItem.state = item_option.selected ? NSControlStateValueOn : NSControlStateValueOff;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -711,9 +711,9 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [self.select_dropdown removeAllItems];
         self.select_dropdown.minimumWidth = minimum_width;
 
-        auto add_menu_item = [self](Web::HTML::SelectItemOption const& item_option) {
+        auto add_menu_item = [self](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
             NSMenuItem* menuItem = [[NSMenuItem alloc]
-                initWithTitle:Ladybird::string_to_ns_string(item_option.label)
+                initWithTitle:Ladybird::string_to_ns_string(in_option_group ? MUST(String::formatted("    {}", item_option.label)) : item_option.label)
                        action:item_option.disabled ? nil : @selector(selectDropdownAction:)
                 keyEquivalent:@""];
             menuItem.representedObject = [NSNumber numberWithUnsignedInt:item_option.id];
@@ -731,11 +731,11 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
                 [self.select_dropdown addItem:subtitle];
 
                 for (auto const& item_option : item_option_group.items)
-                    add_menu_item(item_option);
+                    add_menu_item(item_option, true);
             }
 
             if (item.has<Web::HTML::SelectItemOption>())
-                add_menu_item(item.get<Web::HTML::SelectItemOption>());
+                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
 
             if (item.has<Web::HTML::SelectItemSeparator>())
                 [self.select_dropdown addItem:[NSMenuItem separatorItem]];

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -336,6 +336,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             QAction* action = new QAction(qstring_from_ak_string(item_option.label), this);
             action->setCheckable(true);
             action->setChecked(item_option.selected);
+            action->setDisabled(item_option.disabled);
             action->setData(QVariant(static_cast<uint>(item_option.id)));
             QObject::connect(action, &QAction::triggered, this, &Tab::select_dropdown_action);
             m_select_dropdown->addAction(action);

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -332,8 +332,8 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_select_dropdown->clear();
         m_select_dropdown->setMinimumWidth(minimum_width / view().device_pixel_ratio());
 
-        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option) {
-            QAction* action = new QAction(qstring_from_ak_string(item_option.label), this);
+        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
+            QAction* action = new QAction(qstring_from_ak_string(in_option_group ? MUST(String::formatted("    {}", item_option.label)) : item_option.label), this);
             action->setCheckable(true);
             action->setChecked(item_option.selected);
             action->setDisabled(item_option.disabled);
@@ -350,11 +350,11 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
                 m_select_dropdown->addAction(subtitle);
 
                 for (auto const& item_option : item_option_group.items)
-                    add_menu_item(item_option);
+                    add_menu_item(item_option, true);
             }
 
             if (item.has<Web::HTML::SelectItemOption>())
-                add_menu_item(item.get<Web::HTML::SelectItemOption>());
+                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
 
             if (item.has<Web::HTML::SelectItemSeparator>())
                 m_select_dropdown->addSeparator();

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -65,8 +65,6 @@ signals:
     void audio_play_state_changed(int id, Web::HTML::AudioPlayState);
 
 private:
-    void select_dropdown_add_item(QMenu* menu, Web::HTML::SelectItem const& item);
-
     virtual void resizeEvent(QResizeEvent*) override;
     virtual bool event(QEvent*) override;
 

--- a/Tests/LibWeb/Text/expected/select.txt
+++ b/Tests/LibWeb/Text/expected/select.txt
@@ -3,3 +3,4 @@
 3. "two"
 4. 3
 5. "three"
+6. "Three"

--- a/Tests/LibWeb/Text/input/select.html
+++ b/Tests/LibWeb/Text/input/select.html
@@ -9,7 +9,7 @@
         // 1. Get select value of unedited
         testPart(() => {
             const select = document.createElement('select');
-            // FIXME: Remove selected attribute (currently this is needed because the DIN children are not loaded to select first item in test run)
+            // FIXME: Remove selected attribute (currently this is needed because the children are not loaded to select first item in test run)
             select.innerHTML = `
                 <option value="one" selected>One</option>
                 <option value="two">Two</option>
@@ -21,7 +21,7 @@
         // 2. Get select selectedIndex
         testPart(() => {
             const select = document.createElement('select');
-            // FIXME: Remove selected attribute (currently this is needed because the DIN children are not loaded to select first item in test run)
+            // FIXME: Remove selected attribute (currently this is needed because the children are not loaded to select first item in test run)
             select.innerHTML = `
                 <option value="one" selected>One</option>
                 <option value="two">Two</option>
@@ -60,6 +60,17 @@
                 <option value="one">One</option>
                 <option value="two">Two</option>
                 <option value="three" selected>Three</option>
+            `;
+            return select.value;
+        });
+
+        // 6. Get select value without option values
+        testPart(() => {
+            const select = document.createElement('select');
+            select.innerHTML = `
+                <option>One</option>
+                <option>Two</option>
+                <option selected>Three</option>
             `;
             return select.value;
         });

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -661,6 +661,7 @@ Tab::Tab(BrowserWindow& window)
             });
             action->set_checkable(true);
             action->set_checked(item_option.selected);
+            action->set_enabled(!item_option.disabled);
             m_select_dropdown->add_action(action);
         };
 

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -654,8 +654,8 @@ Tab::Tab(BrowserWindow& window)
         m_select_dropdown->remove_all_actions();
         m_select_dropdown->set_minimum_width(minimum_width);
 
-        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option) {
-            auto action = GUI::Action::create(item_option.label.to_byte_string(), [this, item_option](GUI::Action&) {
+        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
+            auto action = GUI::Action::create(in_option_group ? ByteString::formatted("    {}", item_option.label) : item_option.label.to_byte_string(), [this, item_option](GUI::Action&) {
                 m_select_dropdown_closed_by_action = true;
                 view().select_dropdown_closed(item_option.id);
             });
@@ -673,11 +673,11 @@ Tab::Tab(BrowserWindow& window)
                 m_select_dropdown->add_action(subtitle);
 
                 for (auto const& item_option : item_option_group.items)
-                    add_menu_item(item_option);
+                    add_menu_item(item_option, true);
             }
 
             if (item.has<Web::HTML::SelectItemOption>())
-                add_menu_item(item.get<Web::HTML::SelectItemOption>());
+                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
 
             if (item.has<Web::HTML::SelectItemSeparator>())
                 m_select_dropdown->add_separator();

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -109,8 +109,6 @@ private:
     void update_status(Optional<String> text_override = {}, i32 count_waiting = 0);
     void close_sub_widgets();
 
-    void select_dropdown_add_item(GUI::Menu& menu, Web::HTML::SelectItem const& item);
-
     WebView::History m_history;
 
     RefPtr<WebView::OutOfProcessWebView> m_web_content_view;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -290,7 +290,7 @@ void HTMLSelectElement::activation_behavior(DOM::Event const&)
             for (auto const& child : opt_group_element.children_as_vector()) {
                 if (is<HTMLOptionElement>(*child)) {
                     auto& option_element = verify_cast<HTMLOptionElement>(*child);
-                    option_group_items.append(SelectItemOption { id_counter++, strip_newlines(option_element.text_content()), option_element.value(), option_element.selected(), option_element });
+                    option_group_items.append(SelectItemOption { id_counter++, strip_newlines(option_element.text_content()), option_element.value(), option_element.selected(), option_element.disabled(), option_element });
                 }
             }
             m_select_items.append(SelectItemOptionGroup { opt_group_element.get_attribute(AttributeNames::label).value_or(String {}), option_group_items });
@@ -298,7 +298,7 @@ void HTMLSelectElement::activation_behavior(DOM::Event const&)
 
         if (is<HTMLOptionElement>(*child)) {
             auto& option_element = verify_cast<HTMLOptionElement>(*child);
-            m_select_items.append(SelectItemOption { id_counter++, strip_newlines(option_element.text_content()), option_element.value(), option_element.selected(), option_element });
+            m_select_items.append(SelectItemOption { id_counter++, strip_newlines(option_element.text_content()), option_element.value(), option_element.selected(), option_element.disabled(), option_element });
         }
 
         if (is<HTMLHRElement>(*child))

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLOptionsCollection.h>
+#include <LibWeb/HTML/SelectItem.h>
 
 namespace Web::HTML {
 
@@ -78,7 +79,7 @@ public:
     virtual void form_associated_element_was_inserted() override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;
 
-    void did_select_value(Optional<String> value);
+    void did_select_item(Optional<u32> const& id);
 
 private:
     HTMLSelectElement(DOM::Document&, DOM::QualifiedName);
@@ -93,9 +94,11 @@ private:
 
     void create_shadow_tree_if_needed();
     void update_inner_text_element();
+    void queue_input_and_change_events();
 
     JS::GCPtr<HTMLOptionsCollection> m_options;
     bool m_is_open { false };
+    Vector<SelectItem> m_select_items;
     JS::GCPtr<DOM::Element> m_inner_text_element;
     JS::GCPtr<DOM::Element> m_chevron_icon_element;
 };

--- a/Userland/Libraries/LibWeb/HTML/SelectItem.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SelectItem.cpp
@@ -15,6 +15,7 @@ ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SelectItemOption const& i
     TRY(encoder.encode(item.label));
     TRY(encoder.encode(item.value));
     TRY(encoder.encode(item.selected));
+    TRY(encoder.encode(item.disabled));
     return {};
 }
 
@@ -25,7 +26,8 @@ ErrorOr<Web::HTML::SelectItemOption> IPC::decode(Decoder& decoder)
     auto label = TRY(decoder.decode<String>());
     auto value = TRY(decoder.decode<String>());
     auto selected = TRY(decoder.decode<bool>());
-    return Web::HTML::SelectItemOption { id, move(label), move(value), selected };
+    auto disabled = TRY(decoder.decode<bool>());
+    return Web::HTML::SelectItemOption { id, move(label), move(value), selected, disabled };
 }
 
 template<>

--- a/Userland/Libraries/LibWeb/HTML/SelectItem.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SelectItem.cpp
@@ -9,23 +9,49 @@
 #include <LibIPC/Encoder.h>
 
 template<>
-ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SelectItem const& select_item)
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SelectItemOption const& item)
 {
-    TRY(encoder.encode(select_item.type));
-    TRY(encoder.encode(select_item.label));
-    TRY(encoder.encode(select_item.value));
-    TRY(encoder.encode(select_item.items));
-    TRY(encoder.encode(select_item.selected));
+    TRY(encoder.encode(item.id));
+    TRY(encoder.encode(item.label));
+    TRY(encoder.encode(item.value));
+    TRY(encoder.encode(item.selected));
     return {};
 }
 
 template<>
-ErrorOr<Web::HTML::SelectItem> IPC::decode(Decoder& decoder)
+ErrorOr<Web::HTML::SelectItemOption> IPC::decode(Decoder& decoder)
 {
-    auto type = TRY(decoder.decode<Web::HTML::SelectItem::Type>());
-    auto label = TRY(decoder.decode<Optional<String>>());
-    auto value = TRY(decoder.decode<Optional<String>>());
-    auto items = TRY(decoder.decode<Optional<Vector<Web::HTML::SelectItem>>>());
+    auto id = TRY(decoder.decode<u32>());
+    auto label = TRY(decoder.decode<String>());
+    auto value = TRY(decoder.decode<String>());
     auto selected = TRY(decoder.decode<bool>());
-    return Web::HTML::SelectItem { type, move(label), move(value), move(items), selected };
+    return Web::HTML::SelectItemOption { id, move(label), move(value), selected };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SelectItemOptionGroup const& item)
+{
+    TRY(encoder.encode(item.label));
+    TRY(encoder.encode(item.items));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::SelectItemOptionGroup> IPC::decode(Decoder& decoder)
+{
+    auto label = TRY(decoder.decode<String>());
+    auto items = TRY(decoder.decode<Vector<Web::HTML::SelectItemOption>>());
+    return Web::HTML::SelectItemOptionGroup { move(label), move(items) };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder&, Web::HTML::SelectItemSeparator const&)
+{
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::SelectItemSeparator> IPC::decode(Decoder&)
+{
+    return Web::HTML::SelectItemSeparator {};
 }

--- a/Userland/Libraries/LibWeb/HTML/SelectItem.h
+++ b/Userland/Libraries/LibWeb/HTML/SelectItem.h
@@ -8,31 +8,47 @@
 
 #include <AK/String.h>
 #include <LibIPC/Forward.h>
+#include <LibWeb/HTML/HTMLOptionElement.h>
 
 namespace Web::HTML {
 
-struct SelectItem {
-    enum class Type {
-        OptionGroup,
-        Option,
-        Separator,
-    };
-
-    Type type;
-    Optional<String> label = {};
-    Optional<String> value = {};
-    Optional<Vector<SelectItem>> items = {};
-    bool selected = false;
+struct SelectItemOption {
+    u32 id { 0 };
+    String label {};
+    String value {};
+    bool selected { false };
+    JS::GCPtr<HTMLOptionElement> option_element {};
 };
+
+struct SelectItemOptionGroup {
+    String label = {};
+    Vector<SelectItemOption> items = {};
+};
+
+struct SelectItemSeparator { };
+
+using SelectItem = Variant<SelectItemOption, SelectItemOptionGroup, SelectItemSeparator>;
 
 }
 
 namespace IPC {
 
 template<>
-ErrorOr<void> encode(Encoder&, Web::HTML::SelectItem const&);
+ErrorOr<void> encode(Encoder&, Web::HTML::SelectItemOption const&);
 
 template<>
-ErrorOr<Web::HTML::SelectItem> decode(Decoder&);
+ErrorOr<Web::HTML::SelectItemOption> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::SelectItemOptionGroup const&);
+
+template<>
+ErrorOr<Web::HTML::SelectItemOptionGroup> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::SelectItemSeparator const&);
+
+template<>
+ErrorOr<Web::HTML::SelectItemSeparator> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/SelectItem.h
+++ b/Userland/Libraries/LibWeb/HTML/SelectItem.h
@@ -17,6 +17,7 @@ struct SelectItemOption {
     String label {};
     String value {};
     bool selected { false };
+    bool disabled { false };
     JS::GCPtr<HTMLOptionElement> option_element {};
 };
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -377,14 +377,14 @@ void Page::did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, 
     }
 }
 
-void Page::select_dropdown_closed(Optional<String> value)
+void Page::select_dropdown_closed(Optional<u32> const& selected_item_id)
 {
     if (m_pending_non_blocking_dialog == PendingNonBlockingDialog::Select) {
         m_pending_non_blocking_dialog = PendingNonBlockingDialog::None;
 
         if (m_pending_non_blocking_dialog_target) {
             auto& select_element = verify_cast<HTML::HTMLSelectElement>(*m_pending_non_blocking_dialog_target);
-            select_element.did_select_value(move(value));
+            select_element.did_select_item(selected_item_id);
             m_pending_non_blocking_dialog_target.clear();
         }
     }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -141,7 +141,7 @@ public:
     void file_picker_closed(Span<HTML::SelectedFile> selected_files);
 
     void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items);
-    void select_dropdown_closed(Optional<String> value);
+    void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
     enum class PendingNonBlockingDialog {
         None,

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -290,9 +290,9 @@ void ViewImplementation::file_picker_closed(Vector<Web::HTML::SelectedFile> sele
     client().async_file_picker_closed(page_id(), move(selected_files));
 }
 
-void ViewImplementation::select_dropdown_closed(Optional<String> value)
+void ViewImplementation::select_dropdown_closed(Optional<u32> const& selected_item_id)
 {
-    client().async_select_dropdown_closed(page_id(), value);
+    client().async_select_dropdown_closed(page_id(), selected_item_id);
 }
 
 void ViewImplementation::toggle_media_play_state()

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -95,7 +95,7 @@ public:
     void prompt_closed(Optional<String> response);
     void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
     void file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files);
-    void select_dropdown_closed(Optional<String> value);
+    void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
     void toggle_media_play_state();
     void toggle_media_mute_state();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1043,10 +1043,10 @@ void ConnectionFromClient::file_picker_closed(u64 page_id, Vector<Web::HTML::Sel
         page->page().file_picker_closed(const_cast<Vector<Web::HTML::SelectedFile>&>(selected_files));
 }
 
-void ConnectionFromClient::select_dropdown_closed(u64 page_id, Optional<String> const& value)
+void ConnectionFromClient::select_dropdown_closed(u64 page_id, Optional<u32> const& selected_item_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().select_dropdown_closed(value);
+        page->page().select_dropdown_closed(selected_item_id);
 }
 
 void ConnectionFromClient::toggle_media_play_state(u64 page_id)

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -104,7 +104,7 @@ private:
     virtual void prompt_closed(u64 page_id, Optional<String> const& response) override;
     virtual void color_picker_update(u64 page_id, Optional<Color> const& picked_color, Web::HTML::ColorPickerUpdateState const& state) override;
     virtual void file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> const& selected_files) override;
-    virtual void select_dropdown_closed(u64 page_id, Optional<String> const& value) override;
+    virtual void select_dropdown_closed(u64 page_id, Optional<u32> const& selected_item_id) override;
 
     virtual void toggle_media_play_state(u64 page_id) override;
     virtual void toggle_media_mute_state(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -434,9 +434,9 @@ void PageClient::color_picker_update(Optional<Color> picked_color, Web::HTML::Co
     page().color_picker_update(picked_color, state);
 }
 
-void PageClient::select_dropdown_closed(Optional<String> value)
+void PageClient::select_dropdown_closed(Optional<u32> const& selected_item_id)
 {
-    page().select_dropdown_closed(value);
+    page().select_dropdown_closed(selected_item_id);
 }
 
 Web::WebIDL::ExceptionOr<void> PageClient::toggle_media_play_state()

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -62,7 +62,7 @@ public:
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
     void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
-    void select_dropdown_closed(Optional<String> value);
+    void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
     void set_user_style(String source);
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -91,7 +91,7 @@ endpoint WebContentServer
     prompt_closed(u64 page_id, Optional<String> response) =|
     color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) =|
     file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> selected_files) =|
-    select_dropdown_closed(u64 page_id, Optional<String> value) =|
+    select_dropdown_closed(u64 page_id, Optional<u32> selected_item_id) =|
 
     toggle_media_play_state(u64 page_id) =|
     toggle_media_mute_state(u64 page_id) =|


### PR DESCRIPTION
Currently the `<select>` dropdown ipc uses the option value attr to find which option is selected. This won't work when options don't have values or when multiple options have the same value. Also the `SelectItem` contained so weird recursive structures that are imposible to create with HTML. So I refactored `SelectItem` as a variant, and gave the options a unique id. That id is send back to `HTMLSelectElement` so it can find out exactly which option element is selected.

So now you can select the items in this select for example:
```html
<select>
    <option value="">Lorem ipsum dolor sit amet.</option>
    <option value="">Beatae minus sunt quae dolor.</option>
    <option value="">Inventore nulla doloremque corrupti in?</option>
    <option value="">Laudantium, error. Beatae, itaque sit!</option>
    <option value="">Adipisci a harum dolores molestiae!</option>
</select>
```

I also updated the styling of a `<option>` in a `<optgroup>` a bit by giving the label some indent like other browsers do. And I fixed a bug where the `disabled` attr was ignored.