### PR TITLE
LibGfx: Make mime-based image loaders not throw away their error either

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -557,7 +557,7 @@ TEST_CASE(test_ppm)
 TEST_CASE(test_targa_bottom_left)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("tga/buggie-bottom-left-uncompressed.tga"sv)));
-    EXPECT(TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
+    EXPECT(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes()));
     auto plugin_decoder = TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
 
     TRY_OR_FAIL(expect_single_frame(*plugin_decoder));
@@ -566,7 +566,7 @@ TEST_CASE(test_targa_bottom_left)
 TEST_CASE(test_targa_top_left)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("tga/buggie-top-left-uncompressed.tga"sv)));
-    EXPECT(TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
+    EXPECT(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes()));
     auto plugin_decoder = TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
 
     TRY_OR_FAIL(expect_single_frame(*plugin_decoder));
@@ -575,7 +575,7 @@ TEST_CASE(test_targa_top_left)
 TEST_CASE(test_targa_bottom_left_compressed)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("tga/buggie-bottom-left-compressed.tga"sv)));
-    EXPECT(TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
+    EXPECT(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes()));
     auto plugin_decoder = TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
 
     TRY_OR_FAIL(expect_single_frame(*plugin_decoder));
@@ -584,7 +584,7 @@ TEST_CASE(test_targa_bottom_left_compressed)
 TEST_CASE(test_targa_top_left_compressed)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("tga/buggie-top-left-compressed.tga"sv)));
-    EXPECT(TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
+    EXPECT(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes()));
     auto plugin_decoder = TRY_OR_FAIL(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
 
     TRY_OR_FAIL(expect_single_frame(*plugin_decoder));

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
@@ -64,7 +64,7 @@ static ErrorOr<OwnPtr<ImageDecoderPlugin>> probe_and_sniff_for_appropriate_plugi
 static OwnPtr<ImageDecoderPlugin> probe_and_sniff_for_appropriate_plugin_with_known_mime_type(StringView mime_type, ReadonlyBytes bytes)
 {
     struct ImagePluginWithMIMETypeInitializer {
-        ErrorOr<bool> (*validate_before_create)(ReadonlyBytes) = nullptr;
+        bool (*validate_before_create)(ReadonlyBytes) = nullptr;
         ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> (*create)(ReadonlyBytes) = nullptr;
         StringView mime_type;
     };
@@ -76,7 +76,7 @@ static OwnPtr<ImageDecoderPlugin> probe_and_sniff_for_appropriate_plugin_with_kn
     for (auto& plugin : s_initializers_with_mime_type) {
         if (plugin.mime_type != mime_type)
             continue;
-        auto validation_result = plugin.validate_before_create(bytes).release_value_but_fixme_should_propagate_errors();
+        auto validation_result = plugin.validate_before_create(bytes);
         if (!validation_result)
             continue;
         auto plugin_decoder = plugin.create(bytes);

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -91,11 +91,13 @@ ErrorOr<void> TGAImageDecoderPlugin::decode_tga_header()
     return {};
 }
 
-ErrorOr<bool> TGAImageDecoderPlugin::validate_before_create(ReadonlyBytes data)
+bool TGAImageDecoderPlugin::validate_before_create(ReadonlyBytes data)
 {
     FixedMemoryStream stream { data };
-    auto header = TRY(stream.read_value<Gfx::TGAHeader>());
-    return !ensure_header_validity(header, data.size()).is_error();
+    auto header_or_err = stream.read_value<Gfx::TGAHeader>();
+    if (header_or_err.is_error())
+        return false;
+    return !ensure_header_validity(header_or_err.release_value(), data.size()).is_error();
 }
 
 ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> TGAImageDecoderPlugin::create(ReadonlyBytes data)

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -76,9 +76,9 @@ IntSize TGAImageDecoderPlugin::size()
 
 static ErrorOr<void> ensure_header_validity(TGAHeader const& header, size_t whole_image_stream_size)
 {
-    auto bytes_remaining = whole_image_stream_size - sizeof(TGAHeader);
     if ((header.bits_per_pixel % 8) != 0 || header.bits_per_pixel < 8 || header.bits_per_pixel > 32)
         return Error::from_string_literal("Invalid bit depth");
+    auto bytes_remaining = whole_image_stream_size - sizeof(TGAHeader);
     if (header.data_type_code == TGADataType::UncompressedRGB && bytes_remaining < static_cast<u64>(header.width) * header.height * (header.bits_per_pixel / 8))
         return Error::from_string_literal("Not enough data to read an image with the expected size");
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -14,7 +14,7 @@ struct TGALoadingContext;
 
 class TGAImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
-    static ErrorOr<bool> validate_before_create(ReadonlyBytes);
+    static bool validate_before_create(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
     virtual ~TGAImageDecoderPlugin() override;


### PR DESCRIPTION
Small follow-up to #23489.