### PR TITLE
LibJS: Reimplement TemporalTimeToString() PlainTime AO to spec

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1425,6 +1425,17 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_well_formed)
     return PrimitiveString::create(vm, MUST(result.to_string()));
 }
 
+// 22.1.3.17.3 ToZeroPaddedDecimalString ( n, minLength ), https://tc39.es/ecma262/#sec-tozeropaddeddecimalstring
+ThrowCompletionOr<String> to_zero_padded_decimal_string(VM& vm, size_t n, size_t min_length)
+{
+    // 1. Let S be the String representation of n, formatted as a decimal number.
+    auto string = TRY_OR_THROW_OOM(vm, String::formatted("{}", n));
+
+    // 2. Return StringPad(S, minLength, "0", start).
+    auto padded_utf16_string = pad_string(Utf16String::create(string.bytes_as_string_view()), min_length, Utf16String::create("0"sv), PadPlacement::Start);
+    return padded_utf16_string.to_utf8();
+}
+
 // 22.1.3.32.1 TrimString ( string, where ), https://tc39.es/ecma262/#sec-trimstring
 ThrowCompletionOr<String> trim_string(VM& vm, Value input_value, TrimMode where)
 {

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -20,6 +20,7 @@ struct CodePoint {
 Optional<size_t> string_index_of(Utf16View const& string, Utf16View const& search_value, size_t from_index);
 CodePoint code_point_at(Utf16View const& string, size_t position);
 static constexpr Utf8View whitespace_characters = Utf8View("\x09\x0A\x0B\x0C\x0D\x20\xC2\xA0\xE1\x9A\x80\xE2\x80\x80\xE2\x80\x81\xE2\x80\x82\xE2\x80\x83\xE2\x80\x84\xE2\x80\x85\xE2\x80\x86\xE2\x80\x87\xE2\x80\x88\xE2\x80\x89\xE2\x80\x8A\xE2\x80\xAF\xE2\x81\x9F\xE3\x80\x80\xE2\x80\xA8\xE2\x80\xA9\xEF\xBB\xBF"sv);
+ThrowCompletionOr<String> to_zero_padded_decimal_string(VM&, size_t n, size_t min_length);
 ThrowCompletionOr<String> trim_string(VM&, Value string, TrimMode where);
 
 class StringPrototype final : public StringObject {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -166,6 +166,7 @@ ThrowCompletionOr<void> reject_object_with_calendar_or_time_zone(VM&, Object&);
 ThrowCompletionOr<String> format_seconds_string_part(VM&, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, Variant<StringView, u8> const& precision);
 double sign(double);
 double sign(Crypto::SignedBigInteger const&);
+ThrowCompletionOr<String> format_fractional_seconds(VM&, u64 sub_second_nanoseconds, Variant<StringView, u8> precision);
 UnsignedRoundingMode get_unsigned_rounding_mode(StringView rounding_mode, bool is_negative);
 double apply_unsigned_rounding_mode(double x, double r1, double r2, Optional<UnsignedRoundingMode> const&);
 Crypto::SignedBigInteger apply_unsigned_rounding_mode(Crypto::SignedDivisionResult const&, Crypto::SignedBigInteger const& r1, Crypto::SignedBigInteger const& r2, Optional<UnsignedRoundingMode> const&, Crypto::UnsignedBigInteger const& increment);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -167,6 +167,13 @@ ThrowCompletionOr<String> format_seconds_string_part(VM&, u8 second, u16 millise
 double sign(double);
 double sign(Crypto::SignedBigInteger const&);
 ThrowCompletionOr<String> format_fractional_seconds(VM&, u64 sub_second_nanoseconds, Variant<StringView, u8> precision);
+
+enum class Style {
+    Separated,
+    Unseparated
+};
+ThrowCompletionOr<String> format_time_string(VM& vm, u8 hour, u8 minute, u8 second, u64 sub_second_nanoseconds, Variant<StringView, u8> precision, Optional<Style> style = {});
+
 UnsignedRoundingMode get_unsigned_rounding_mode(StringView rounding_mode, bool is_negative);
 double apply_unsigned_rounding_mode(double x, double r1, double r2, Optional<UnsignedRoundingMode> const&);
 Crypto::SignedBigInteger apply_unsigned_rounding_mode(Crypto::SignedDivisionResult const&, Crypto::SignedBigInteger const& r1, Crypto::SignedBigInteger const& r2, Optional<UnsignedRoundingMode> const&, Crypto::UnsignedBigInteger const& increment);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
@@ -447,14 +447,11 @@ ThrowCompletionOr<String> temporal_time_to_string(VM& vm, u8 hour, u8 minute, u8
 {
     // 1. Assert: hour, minute, second, millisecond, microsecond and nanosecond are integers.
 
-    // 2. Let hour be ToZeroPaddedDecimalString(hour, 2).
-    // 3. Let minute be ToZeroPaddedDecimalString(minute, 2).
+    // 2. Let subSecondNanoseconds be millisecond × 10**6 + microsecond × 10**3 + nanosecond.
+    u64 sub_second_nanoseconds = millisecond * 1'000'000 + microsecond * 1'000 + nanosecond;
 
-    // 4. Let seconds be ! FormatSecondsStringPart(second, millisecond, microsecond, nanosecond, precision).
-    auto seconds = MUST_OR_THROW_OOM(format_seconds_string_part(vm, second, millisecond, microsecond, nanosecond, precision));
-
-    // 5. Return the string-concatenation of hour, the code unit 0x003A (COLON), minute, and seconds.
-    return TRY_OR_THROW_OOM(vm, String::formatted("{:02}:{:02}{}", hour, minute, seconds));
+    // 3. Return FormatTimeString(hour, minute, second, subSecondNanoseconds, precision).
+    return format_time_string(vm, hour, minute, second, sub_second_nanoseconds, precision);
 }
 
 // 4.5.10 CompareTemporalTime ( h1, min1, s1, ms1, mus1, ns1, h2, min2, s2, ms2, mus2, ns2 ), https://tc39.es/proposal-temporal/#sec-temporal-comparetemporaltime


### PR DESCRIPTION
This commit adds and modernizes a few areas of the Temporal AO spec, notably the TemporalTimeToString() AO as it effects the output of Temporal.PlainTime.prototype.{toString(), toLocaleString(), toJSON()}. From looking at the spec and running the JS tests, it looks like this is just a refactor.