### PR TITLE
AK+LibGfx+LibGUI: Handle carriage returns better when drawing and measuring text

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -68,12 +68,12 @@ Vector<StringView> StringView::split_view(StringView separator, SplitBehavior sp
     return parts;
 }
 
-Vector<StringView> StringView::lines(bool consider_cr) const
+Vector<StringView> StringView::lines(ConsiderCarriageReturn consider_carriage_return) const
 {
     if (is_empty())
         return {};
 
-    if (!consider_cr)
+    if (consider_carriage_return == ConsiderCarriageReturn::No)
         return split_view('\n', SplitBehavior::KeepEmpty);
 
     Vector<StringView> v;

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -235,7 +235,11 @@ public:
     // 0.29, the spec defines a line ending as "a newline (U+000A), a carriage
     // return (U+000D) not followed by a newline, or a carriage return and a
     // following newline.".
-    [[nodiscard]] Vector<StringView> lines(bool consider_cr = true) const;
+    enum class ConsiderCarriageReturn {
+        No,
+        Yes,
+    };
+    [[nodiscard]] Vector<StringView> lines(ConsiderCarriageReturn = ConsiderCarriageReturn::Yes) const;
 
     // Create a new substring view of this string view, starting either at the beginning of
     // the given substring view, or after its end, and continuing until the end of this string

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -240,6 +240,7 @@ public:
         Yes,
     };
     [[nodiscard]] Vector<StringView> lines(ConsiderCarriageReturn = ConsiderCarriageReturn::Yes) const;
+    [[nodiscard]] size_t count_lines(ConsiderCarriageReturn = ConsiderCarriageReturn::Yes) const;
 
     // Create a new substring view of this string view, starting either at the beginning of
     // the given substring view, or after its end, and continuing until the end of this string

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -105,6 +105,24 @@ TEST_CASE(lines)
     EXPECT_EQ(test_string_vector.at(2).is_empty(), true);
 }
 
+TEST_CASE(count_lines)
+{
+    EXPECT_EQ(""sv.count_lines(), 1u);
+    EXPECT_EQ("foo"sv.count_lines(), 1u);
+
+    EXPECT_EQ("foo\nbar"sv.count_lines(), 2u);
+    EXPECT_EQ("foo\rbar"sv.count_lines(), 2u);
+    EXPECT_EQ("foo\rbar"sv.count_lines(StringView::ConsiderCarriageReturn::No), 1u);
+    EXPECT_EQ("foo\r\nbar"sv.count_lines(), 2u);
+    EXPECT_EQ("foo\r\nbar"sv.count_lines(StringView::ConsiderCarriageReturn::No), 2u);
+
+    EXPECT_EQ("foo\nbar\nbax"sv.count_lines(), 3u);
+    EXPECT_EQ("foo\rbar\rbaz"sv.count_lines(), 3u);
+    EXPECT_EQ("foo\rbar\rbaz"sv.count_lines(StringView::ConsiderCarriageReturn::No), 1u);
+    EXPECT_EQ("foo\r\nbar\r\nbaz"sv.count_lines(), 3u);
+    EXPECT_EQ("foo\r\nbar\r\nbaz"sv.count_lines(StringView::ConsiderCarriageReturn::No), 3u);
+}
+
 TEST_CASE(find)
 {
     auto test_string_view = "aabbcc_xy_ccbbaa"sv;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -425,7 +425,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
             StringView urls { data.data(), data.size() };
             Vector<Position> source_positions, target_positions;
 
-            for (auto& line : urls.lines(false)) {
+            for (auto& line : urls.lines(StringView::ConsiderCarriageReturn::No)) {
                 auto position = m_sheet->position_from_url(line);
                 if (position.has_value())
                     source_positions.append(position.release_value());

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -29,9 +29,9 @@ public:
     {
         m_label->set_text(move(tooltip));
         int tooltip_width = m_label->effective_min_size().width().as_int() + 10;
-        int line_count = m_label->text().count("\n"sv);
+        int line_count = m_label->text().bytes_as_string_view().count_lines();
         int font_size = m_label->font().pixel_size_rounded_up();
-        int tooltip_height = font_size * (1 + line_count) + ((font_size + 1) / 2) * line_count + 8;
+        int tooltip_height = font_size * line_count + ((font_size + 1) / 2) * (line_count - 1) + 8;
 
         Gfx::IntRect desktop_rect = Desktop::the().rect();
         if (tooltip_width > desktop_rect.width())

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -96,7 +96,7 @@ int Label::text_calculated_preferred_width() const
 
 int Label::text_calculated_preferred_height() const
 {
-    return static_cast<int>(ceilf(font().preferred_line_height()) * (m_text.count("\n"sv) + 1));
+    return static_cast<int>(ceilf(font().preferred_line_height()) * m_text.bytes_as_string_view().count_lines());
 }
 
 Optional<UISize> Label::calculated_preferred_size() const

--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -73,8 +73,11 @@ Vector<ByteString, 32> TextLayout::wrap_lines(TextElision elision, TextWrapping 
 
             continue;
         }
-        case '\n':
-        case '\r': {
+        case '\r':
+            if (it.peek(1) == static_cast<u32>('\n'))
+                ++it;
+            [[fallthrough]];
+        case '\n': {
             if (current_block_type.has_value()) {
                 blocks.append({
                     current_block_type.value(),

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -303,7 +303,7 @@ public:
     {
         return m_view.visit(
             [](StringView view) {
-                auto views = view.lines(false);
+                auto views = view.lines(StringView::ConsiderCarriageReturn::No);
                 Vector<RegexStringView> new_views;
                 for (auto& view : views)
                     new_views.empend(view);


### PR DESCRIPTION
We were previously splitting lines on `\r` (while over-splitting lines on `\r\n`), but not considering `\r` at all when computing the height of the widget containing the split text. So when we drew text from the web containing `\r`, we would draw text that didn't fit in its container:
![before](https://github.com/SerenityOS/serenity/assets/5600524/71ebd2ca-179f-4287-a204-4fb55f2ff47e)

Now we handle `\r` and `\r\n` correctly:
![after](https://github.com/SerenityOS/serenity/assets/5600524/e1930557-bab4-46d2-804c-c45a47bdbe08)
