### PR TITLE
LibWeb: Don't crash when visiting about:srcdoc

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1388,8 +1388,12 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         document_state->set_navigable_target_name(target_name());
 
         // 5. If url matches about:blank or is about:srcdoc, then set documentState's origin to documentState's initiator origin.
-        //   FIXME: should this say "matches about:srcdoc"
-        if (url_matches_about_blank(url) || url == "about:srcdoc"sv) {
+        if (url_matches_about_blank(url) || url_matches_about_srcdoc(url)) {
+            // document_resource cannot have an Empty if the url is about:srcdoc since we rely on document_resource
+            // having a String to call create_navigation_params_from_a_srcdoc_resource
+            if (url_matches_about_srcdoc(url) && document_resource.has<Empty>()) {
+                document_state->set_resource({ String {} });
+            }
             // 1. Set documentState's origin to initiatorOriginSnapshot.
             document_state->set_origin(document_state->initiator_origin());
 


### PR DESCRIPTION
When navigating to about:srcdoc we try to populate the session history by calling populate_session_history_entry_document, if the resource is an about:srcdoc this method will rely on the document_resource in the SessionHistoryEntry to have a String in order for it call the right method to create navigation params.

However when navigating to about:srcdoc directly, document_resource will have an Empty, this leads populate_session_history_entry_document to call the wrong method to create navigation params.

This fixes the issue by populating document_resource with an empty string if it has an Empty and we're dealing with an about:srcdoc.

Issue: #23216