### PR TITLE
LibWeb: Isolate style sheets of elements in shadow tree

### DIFF
--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x46 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x28 children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x26] baseline: 28
-      BlockContainer <input> at (11,11) content-size 200x26 inline-block [BFC] children: not-inline
-        Box <div> at (13,12) content-size 196x24 flex-container(row) [FFC] children: not-inline
-          BlockContainer <div> at (14,13) content-size 194x22 flex-item [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x44 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x26 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x24] baseline: 26
+      BlockContainer <input> at (11,11) content-size 200x24 inline-block [BFC] children: not-inline
+        Box <div> at (13,12) content-size 196x22 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (13,12) content-size 196x22 flex-item [BFC] children: inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
-    PaintableWithLines (BlockContainer<BODY>) [9,9 782x30]
-      PaintableWithLines (BlockContainer<INPUT>) [10,10 202x28]
-        PaintableBox (Box<DIV>) [11,11 200x26]
-          PaintableWithLines (BlockContainer<DIV>) [13,12 196x24]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x46]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x28]
+      PaintableWithLines (BlockContainer<INPUT>) [10,10 202x26]
+        PaintableBox (Box<DIV>) [11,11 200x24]
+          PaintableWithLines (BlockContainer<DIV>) [13,12 196x22]

--- a/Tests/LibWeb/Text/expected/shadow-root-adopted-style-sheets.txt
+++ b/Tests/LibWeb/Text/expected/shadow-root-adopted-style-sheets.txt
@@ -1,0 +1,1 @@
+  border of #test = (2px solid rgb(173, 255, 47))

--- a/Tests/LibWeb/Text/expected/shadow-root-style-sheets.txt
+++ b/Tests/LibWeb/Text/expected/shadow-root-style-sheets.txt
@@ -1,0 +1,2 @@
+  shadow.styleSheets.length=1
+document.styleSheets.length=0

--- a/Tests/LibWeb/Text/input/shadow-root-adopted-style-sheets.html
+++ b/Tests/LibWeb/Text/input/shadow-root-adopted-style-sheets.html
@@ -1,0 +1,37 @@
+<script src="include.js"></script>
+<style>
+    #test {
+        border: 10px solid black;
+    }
+</style>
+<my-custom-element></my-custom-element>
+<script>
+    test(() => {
+        class MyCustomElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadow = this.attachShadow({ mode: 'open' });
+
+                const test = document.createElement('div');
+                test.setAttribute('id', 'test');
+
+                const sheet = new CSSStyleSheet();
+                sheet.replaceSync(`
+                #test {
+                    width: 100px;
+                    height: 100px;
+                    background-color: magenta;
+                    border: 2px solid greenyellow;
+                }`);
+
+                shadow.adoptedStyleSheets = [sheet];
+                shadow.appendChild(test);
+
+                const testComputedStyle = getComputedStyle(test);
+                println(`border of #test = (${testComputedStyle.getPropertyValue("border")})`);
+            }
+        }
+
+        customElements.define('my-custom-element', MyCustomElement);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/shadow-root-style-sheets.html
+++ b/Tests/LibWeb/Text/input/shadow-root-style-sheets.html
@@ -1,0 +1,18 @@
+<script src="include.js"></script>
+<my-custom-element></my-custom-element>
+<script>
+    test(() => {
+        class MyCustomElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadow = this.attachShadow({ mode: 'open' });
+                const style = document.createElement('style');
+                shadow.appendChild(style);
+                println(`shadow.styleSheets.length=${shadow.styleSheets.length}`);
+                println(`document.styleSheets.length=${document.styleSheets.length}`);
+            }
+        }
+
+        customElements.define('my-custom-element', MyCustomElement);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -135,6 +135,7 @@ set(SOURCES
     DOM/AbortSignal.cpp
     DOM/AbstractRange.cpp
     DOM/AccessibilityTreeNode.cpp
+    DOM/AdoptedStyleSheets.cpp
     DOM/Attr.cpp
     DOM/CDATASection.cpp
     DOM/CharacterData.cpp

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -20,7 +20,18 @@
 
 namespace Web::CSS {
 
+// https://www.w3.org/TR/css-cascade/#origin
+enum class CascadeOrigin {
+    Author,
+    User,
+    UserAgent,
+    Animation,
+    Transition,
+};
+
 struct MatchingRule {
+    CascadeOrigin cascade_origin;
+    JS::GCPtr<DOM::ShadowRoot const> shadow_root;
     JS::GCPtr<CSSStyleRule const> rule;
     JS::GCPtr<CSSStyleSheet const> sheet;
     size_t style_sheet_index { 0 };
@@ -54,15 +65,6 @@ public:
 
     NonnullRefPtr<StyleProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
     RefPtr<StyleProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
-
-    // https://www.w3.org/TR/css-cascade/#origin
-    enum class CascadeOrigin {
-        Author,
-        User,
-        UserAgent,
-        Animation,
-        Transition,
-    };
 
     Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>) const;
 

--- a/Userland/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/DOM/AdoptedStyleSheets.h>
+#include <LibWeb/DOM/Document.h>
+
+namespace Web::DOM {
+
+JS::NonnullGCPtr<WebIDL::ObservableArray> create_adopted_style_sheets_list(Document& document)
+{
+    auto adopted_style_sheets = WebIDL::ObservableArray::create(document.realm());
+    adopted_style_sheets->set_on_set_an_indexed_value_callback([&document](JS::Value& value) -> WebIDL::ExceptionOr<void> {
+        auto& vm = document.vm();
+        if (!value.is_object())
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "CSSStyleSheet");
+        auto& object = value.as_object();
+        if (!is<CSS::CSSStyleSheet>(object))
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "CSSStyleSheet");
+        auto& style_sheet = static_cast<CSS::CSSStyleSheet&>(object);
+
+        // The set an indexed value algorithm for adoptedStyleSheets, given value and index, is the following:
+        // 1. If value’s constructed flag is not set, or its constructor document is not equal to this
+        //    DocumentOrShadowRoot's node document, throw a "NotAllowedError" DOMException.
+        if (!style_sheet.constructed())
+            return WebIDL::NotAllowedError::create(document.realm(), "StyleSheet's constructed flag is not set."_fly_string);
+        if (!style_sheet.constructed() || style_sheet.constructor_document().ptr() != &document)
+            return WebIDL::NotAllowedError::create(document.realm(), "Sharing a StyleSheet between documents is not allowed."_fly_string);
+
+        document.style_computer().load_fonts_from_sheet(style_sheet);
+        document.style_computer().invalidate_rule_cache();
+        document.invalidate_style();
+        return {};
+    });
+    adopted_style_sheets->set_on_delete_an_indexed_value_callback([&document]() -> WebIDL::ExceptionOr<void> {
+        document.style_computer().invalidate_rule_cache();
+        document.invalidate_style();
+        return {};
+    });
+
+    return adopted_style_sheets;
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AdoptedStyleSheets.h
+++ b/Userland/Libraries/LibWeb/DOM/AdoptedStyleSheets.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Forward.h>
+#include <LibWeb/WebIDL/ObservableArray.h>
+
+namespace Web::DOM {
+
+JS::NonnullGCPtr<WebIDL::ObservableArray> create_adopted_style_sheets_list(Document& document);
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4628,13 +4628,9 @@ void Document::for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& ca
         callback(*style_sheet);
 
     if (m_adopted_style_sheets) {
-        for (auto& entry : m_adopted_style_sheets->indexed_properties()) {
-            auto value_and_attributes = m_adopted_style_sheets->indexed_properties().storage()->get(entry.index());
-            if (value_and_attributes.has_value()) {
-                auto& style_sheet = verify_cast<CSS::CSSStyleSheet>(value_and_attributes->value.as_object());
-                callback(style_sheet);
-            }
-        }
+        m_adopted_style_sheets->for_each<CSS::CSSStyleSheet>([&](auto& style_sheet) {
+            callback(style_sheet);
+        });
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -31,6 +31,7 @@
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/VisualViewport.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
+#include <LibWeb/DOM/AdoptedStyleSheets.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CDATASection.h>
 #include <LibWeb/DOM/Comment.h>
@@ -4562,40 +4563,6 @@ bool Document::has_skipped_resize_observations()
 
     // 2. Return false.
     return false;
-}
-
-static JS::NonnullGCPtr<WebIDL::ObservableArray> create_adopted_style_sheets_list(Document& document)
-{
-    auto adopted_style_sheets = WebIDL::ObservableArray::create(document.realm());
-    adopted_style_sheets->set_on_set_an_indexed_value_callback([&document](JS::Value& value) -> WebIDL::ExceptionOr<void> {
-        auto& vm = document.vm();
-        if (!value.is_object())
-            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "CSSStyleSheet");
-        auto& object = value.as_object();
-        if (!is<CSS::CSSStyleSheet>(object))
-            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "CSSStyleSheet");
-        auto& style_sheet = static_cast<CSS::CSSStyleSheet&>(object);
-
-        // The set an indexed value algorithm for adoptedStyleSheets, given value and index, is the following:
-        // 1. If value’s constructed flag is not set, or its constructor document is not equal to this
-        //    DocumentOrShadowRoot's node document, throw a "NotAllowedError" DOMException.
-        if (!style_sheet.constructed())
-            return WebIDL::NotAllowedError::create(document.realm(), "StyleSheet's constructed flag is not set."_fly_string);
-        if (!style_sheet.constructed() || style_sheet.constructor_document().ptr() != &document)
-            return WebIDL::NotAllowedError::create(document.realm(), "Sharing a StyleSheet between documents is not allowed."_fly_string);
-
-        document.style_computer().load_fonts_from_sheet(style_sheet);
-        document.style_computer().invalidate_rule_cache();
-        document.invalidate_style();
-        return {};
-    });
-    adopted_style_sheets->set_on_delete_an_indexed_value_callback([&document]() -> WebIDL::ExceptionOr<void> {
-        document.style_computer().invalidate_rule_cache();
-        document.invalidate_style();
-        return {};
-    });
-
-    return adopted_style_sheets;
 }
 
 JS::NonnullGCPtr<WebIDL::ObservableArray> Document::adopted_style_sheets() const

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -486,6 +486,9 @@ void Document::visit_edges(Cell::Visitor& visitor)
     }
 
     visitor.visit(m_adopted_style_sheets);
+
+    for (auto& shadow_root : m_shadow_roots)
+        visitor.visit(shadow_root);
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection
@@ -4599,6 +4602,24 @@ void Document::for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& ca
             callback(style_sheet);
         });
     }
+}
+
+void Document::register_shadow_root(Badge<DOM::ShadowRoot>, DOM::ShadowRoot& shadow_root)
+{
+    m_shadow_roots.append(shadow_root);
+}
+
+void Document::unregister_shadow_root(Badge<DOM::ShadowRoot>, DOM::ShadowRoot& shadow_root)
+{
+    m_shadow_roots.remove_all_matching([&](auto& item) {
+        return item.ptr() == &shadow_root;
+    });
+}
+
+void Document::for_each_shadow_root(Function<void(DOM::ShadowRoot&)>&& callback)
+{
+    for (auto& shadow_root : m_shadow_roots)
+        callback(shadow_root);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -604,6 +604,10 @@ public:
     JS::NonnullGCPtr<WebIDL::ObservableArray> adopted_style_sheets() const;
     WebIDL::ExceptionOr<void> set_adopted_style_sheets(JS::Value);
 
+    void register_shadow_root(Badge<DOM::ShadowRoot>, DOM::ShadowRoot&);
+    void unregister_shadow_root(Badge<DOM::ShadowRoot>, DOM::ShadowRoot&);
+    void for_each_shadow_root(Function<void(DOM::ShadowRoot&)>&& callback);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -840,6 +844,8 @@ private:
     bool m_needs_to_resolve_paint_only_properties { true };
 
     mutable JS::GCPtr<WebIDL::ObservableArray> m_adopted_style_sheets;
+
+    Vector<JS::NonnullGCPtr<DOM::ShadowRoot>> m_shadow_roots;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -4,6 +4,7 @@
 #import <DOM/Comment.idl>
 #import <DOM/DOMImplementation.idl>
 #import <DOM/DocumentFragment.idl>
+#import <DOM/DocumentOrShadowRoot.idl>
 #import <DOM/DocumentType.idl>
 #import <DOM/Element.idl>
 #import <DOM/Event.idl>
@@ -94,9 +95,6 @@ interface Document : Node {
     [CEReactions, NewObject] Node importNode(Node node, optional boolean deep = false);
     [CEReactions, ImplementedAs=adopt_node_binding] Node adoptNode(Node node);
 
-    [ImplementedAs=style_sheets_for_bindings] readonly attribute StyleSheetList styleSheets;
-    attribute any adoptedStyleSheets;
-
     readonly attribute DOMString compatMode;
     readonly attribute DocumentType? doctype;
 
@@ -141,3 +139,4 @@ dictionary ElementCreationOptions {
 };
 Document includes ParentNode;
 Document includes GlobalEventHandlers;
+Document includes DocumentOrShadowRoot;

--- a/Userland/Libraries/LibWeb/DOM/DocumentOrShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentOrShadowRoot.idl
@@ -1,0 +1,8 @@
+#import <CSS/StyleSheetList.idl>
+
+// https://dom.spec.whatwg.org/#documentorshadowroot
+interface mixin DocumentOrShadowRoot {
+    // https://w3c.github.io/csswg-drafts/cssom/#extensions-to-the-document-or-shadow-root-interface
+    [SameObject, ImplementedAs=style_sheets_for_bindings] readonly attribute StyleSheetList styleSheets;
+    attribute any adoptedStyleSheets;
+};

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2379,4 +2379,13 @@ auto Element::ensure_custom_element_reaction_queue() -> CustomElementReactionQue
     return *m_custom_element_reaction_queue;
 }
 
+CSS::StyleSheetList& Element::document_or_shadow_root_style_sheets()
+{
+    auto& root_node = root();
+    if (is<DOM::ShadowRoot>(root_node))
+        return static_cast<DOM::ShadowRoot&>(root_node).style_sheets();
+
+    return document().style_sheets();
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -183,6 +183,8 @@ public:
 
     CSS::CSSStyleDeclaration* style_for_bindings();
 
+    CSS::StyleSheetList& document_or_shadow_root_style_sheets();
+
     WebIDL::ExceptionOr<String> inner_html() const;
     WebIDL::ExceptionOr<void> set_inner_html(StringView);
 

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -105,4 +105,16 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_adopted_style_sheets(JS::Value new_val
     return {};
 }
 
+void ShadowRoot::for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const
+{
+    for (auto& style_sheet : style_sheets().sheets())
+        callback(*style_sheet);
+
+    if (m_adopted_style_sheets) {
+        m_adopted_style_sheets->for_each<CSS::CSSStyleSheet>([&](auto& style_sheet) {
+            callback(style_sheet);
+        });
+    }
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -19,7 +19,14 @@ ShadowRoot::ShadowRoot(Document& document, Element& host, Bindings::ShadowRootMo
     : DocumentFragment(document)
     , m_mode(mode)
 {
+    document.register_shadow_root({}, *this);
     set_host(&host);
+}
+
+void ShadowRoot::finalize()
+{
+    Base::finalize();
+    document().unregister_shadow_root({}, *this);
 }
 
 void ShadowRoot::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -42,6 +42,8 @@ public:
     JS::NonnullGCPtr<WebIDL::ObservableArray> adopted_style_sheets() const;
     WebIDL::ExceptionOr<void> set_adopted_style_sheets(JS::Value);
 
+    virtual void finalize() override;
+
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/DOM/DocumentFragment.h>
+#include <LibWeb/WebIDL/ObservableArray.h>
 
 namespace Web::DOM {
 
@@ -33,6 +34,17 @@ public:
     WebIDL::ExceptionOr<String> inner_html() const;
     WebIDL::ExceptionOr<void> set_inner_html(StringView);
 
+    CSS::StyleSheetList& style_sheets();
+    CSS::StyleSheetList const& style_sheets() const;
+
+    CSS::StyleSheetList* style_sheets_for_bindings() { return &style_sheets(); }
+
+    JS::NonnullGCPtr<WebIDL::ObservableArray> adopted_style_sheets() const;
+    WebIDL::ExceptionOr<void> set_adopted_style_sheets(JS::Value);
+
+protected:
+    virtual void visit_edges(Cell::Visitor&) override;
+
 private:
     ShadowRoot(Document&, Element& host, Bindings::ShadowRootMode);
     virtual void initialize(JS::Realm&) override;
@@ -46,6 +58,9 @@ private:
     Bindings::SlotAssignmentMode m_slot_assignment { Bindings::SlotAssignmentMode::Named };
     bool m_delegates_focus { false };
     bool m_available_to_element_internals { false };
+
+    JS::GCPtr<CSS::StyleSheetList> m_style_sheets;
+    mutable JS::GCPtr<WebIDL::ObservableArray> m_adopted_style_sheets;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -42,6 +42,8 @@ public:
     JS::NonnullGCPtr<WebIDL::ObservableArray> adopted_style_sheets() const;
     WebIDL::ExceptionOr<void> set_adopted_style_sheets(JS::Value);
 
+    void for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
+
     virtual void finalize() override;
 
 protected:

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -1,4 +1,5 @@
 #import <DOM/DocumentFragment.idl>
+#import <DOM/DocumentOrShadowRoot.idl>
 #import <DOM/InnerHTML.idl>
 
 // https://dom.spec.whatwg.org/#shadowroot
@@ -12,6 +13,7 @@ interface ShadowRoot : DocumentFragment {
 };
 
 ShadowRoot includes InnerHTML;
+ShadowRoot includes DocumentOrShadowRoot;
 
 enum ShadowRootMode { "open", "closed" };
 enum SlotAssignmentMode { "manual", "named" };

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -33,7 +33,7 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
     // 2. If element has an associated CSS style sheet, remove the CSS style sheet in question.
 
     if (m_associated_css_style_sheet) {
-        remove_a_css_style_sheet(style_element.document(), *m_associated_css_style_sheet);
+        remove_a_css_style_sheet(style_element.document_or_shadow_root_style_sheets(), *m_associated_css_style_sheet);
 
         // FIXME: This should probably be handled by StyleSheet::set_owner_node().
         m_associated_css_style_sheet = nullptr;
@@ -61,7 +61,7 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
 
     // 6. Create a CSS style sheet with the following properties...
     create_a_css_style_sheet(
-        style_element.document(),
+        style_element.document_or_shadow_root_style_sheets(),
         "text/css"_string,
         &style_element,
         style_element.attribute(HTML::AttributeNames::media).value_or({}),
@@ -77,10 +77,10 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
 }
 
 // https://www.w3.org/TR/cssom/#remove-a-css-style-sheet
-void StyleElementUtils::remove_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet)
+void StyleElementUtils::remove_a_css_style_sheet(CSS::StyleSheetList& style_sheets, CSS::CSSStyleSheet& sheet)
 {
     // 1. Remove the CSS style sheet from the list of document or shadow root CSS style sheets.
-    document.style_sheets().remove_sheet(sheet);
+    style_sheets.remove_sheet(sheet);
 
     // 2. Set the CSS style sheet’s parent CSS style sheet, owner node and owner CSS rule to null.
     sheet.set_parent_css_style_sheet(nullptr);
@@ -89,7 +89,7 @@ void StyleElementUtils::remove_a_css_style_sheet(DOM::Document& document, CSS::C
 }
 
 // https://www.w3.org/TR/cssom/#create-a-css-style-sheet
-void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
+void StyleElementUtils::create_a_css_style_sheet(CSS::StyleSheetList& style_sheets, String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
 {
     // 1. Create a new CSS style sheet object and set its properties as specified.
     // FIXME: We receive `sheet` from the caller already. This is weird.
@@ -105,14 +105,14 @@ void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, String
     sheet.set_location(move(location));
 
     // 2. Then run the add a CSS style sheet steps for the newly created CSS style sheet.
-    add_a_css_style_sheet(document, sheet);
+    add_a_css_style_sheet(style_sheets, sheet);
 }
 
 // https://www.w3.org/TR/cssom/#add-a-css-style-sheet
-void StyleElementUtils::add_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet)
+void StyleElementUtils::add_a_css_style_sheet(CSS::StyleSheetList& style_sheets, CSS::CSSStyleSheet& sheet)
 {
     // 1. Add the CSS style sheet to the list of document or shadow root CSS style sheets at the appropriate location. The remainder of these steps deal with the disabled flag.
-    document.style_sheets().add_sheet(sheet);
+    style_sheets.add_sheet(sheet);
 
     // 2. If the disabled flag is set, then return.
     if (sheet.disabled())

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/StyleElementUtils.h>
 #include <LibWeb/Infra/Strings.h>

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -20,9 +20,9 @@ public:
     CSS::CSSStyleSheet const* sheet() const { return m_associated_css_style_sheet; }
 
 private:
-    void remove_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet);
-    void create_a_css_style_sheet(DOM::Document& document, String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet);
-    void add_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet);
+    void remove_a_css_style_sheet(CSS::StyleSheetList&, CSS::CSSStyleSheet& sheet);
+    void create_a_css_style_sheet(CSS::StyleSheetList&, String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet);
+    void add_a_css_style_sheet(CSS::StyleSheetList&, CSS::CSSStyleSheet& sheet);
 
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet
     JS::GCPtr<CSS::CSSStyleSheet> m_associated_css_style_sheet;

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/WebIDL/ObservableArray.h>
 
 namespace Web::DOM {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
+#include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
@@ -112,7 +113,7 @@ void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> 
     // FIXME: Handle alternate stylesheets properly
     if (m_relationship & Relationship::Stylesheet && !(m_relationship & Relationship::Alternate)) {
         if (name == HTML::AttributeNames::disabled && m_loaded_style_sheet)
-            document().style_sheets().remove_sheet(*m_loaded_style_sheet);
+            document_or_shadow_root_style_sheets().remove_sheet(*m_loaded_style_sheet);
 
         // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:fetch-and-process-the-linked-resource
         // The appropriate times to fetch and process this type of link are:
@@ -311,7 +312,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
 
     // 3. If el has an associated CSS style sheet, remove the CSS style sheet.
     if (m_loaded_style_sheet) {
-        document().style_sheets().remove_sheet(*m_loaded_style_sheet);
+        document_or_shadow_root_style_sheets().remove_sheet(*m_loaded_style_sheet);
         m_loaded_style_sheet = nullptr;
     }
 

--- a/Userland/Libraries/LibWeb/WebIDL/ObservableArray.h
+++ b/Userland/Libraries/LibWeb/WebIDL/ObservableArray.h
@@ -28,6 +28,18 @@ public:
     JS::ThrowCompletionOr<void> append(JS::Value value);
     void clear();
 
+    template<typename T, typename Callback>
+    void for_each(Callback callback)
+    {
+        for (auto& entry : indexed_properties()) {
+            auto value_and_attributes = indexed_properties().storage()->get(entry.index());
+            if (value_and_attributes.has_value()) {
+                auto& style_sheet = verify_cast<T>(value_and_attributes->value.as_object());
+                callback(style_sheet);
+            }
+        }
+    }
+
     explicit ObservableArray(Object& prototype);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;


### PR DESCRIPTION
- Support `ShadowRoot.styleSheets`
- Support `ShadowRoot.adoptedStyleSheets`
- Use style sheets from shadow root in StyleComputer if element belongs to shadow tree

Fixes https://github.com/SerenityOS/serenity/issues/23410