### PR TITLE
LibGfx: Replace FLATTEN with ALWAYS_INLINE for `draw_glyph()` overload

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1351,7 +1351,7 @@ void Painter::draw_scaled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& s
     }
 }
 
-FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Color color)
+ALWAYS_INLINE void Painter::draw_glyph(FloatPoint point, u32 code_point, Color color)
 {
     draw_glyph(point, code_point, font(), color);
 }


### PR DESCRIPTION
While IMO, the change makes sense on its own as flattening this function will just duplicate the code from `draw_glyph()` with no benefits, this is not what motivated this patch.

When compiling with debug information and ASAN, GCC 13.2 would issue this warning:

Userland/Libraries/LibGfx/Painter.cpp: In member function ‘void Gfx::Pai nter::draw_glyph(Gfx::FloatPoint, u32, Gfx::Color)’: Userland/Libraries/LibGfx/Painter.cpp:1354:14: note: variable tracking s ize limit exceeded with ‘-fvar-tracking-assignments’, retrying without
 1354 | FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_poin
t, Color color)
      |              ^~~~~~~

From what I've read online, this is caused by some limit on the number of symbols in the compiler's internal data structures. People at Google have fixed this warning by splitting functions:
https://codereview.chromium.org/1164893003

While getting us rid of the warning, it also drastically improves compilation time. Going from 1min27 to 59s on my machine.


---

For reference, this is a profile of the build of `image` with the debug profile and the sanitizers enabled. Patch is already applied.
![image](https://github.com/SerenityOS/serenity/assets/26030965/4a39def1-2ff8-4936-baf1-038ab6e57427)
