### PR TITLE
AK: Iterate the bytes of a URL query with an unsigned type

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -714,7 +714,7 @@ ErrorOr<String> URLParser::percent_encode_after_encoding(StringView input, URL::
     StringBuilder output;
 
     // 3. For each byte of encodeOutput converted to a byte sequence:
-    for (auto byte : input) {
+    for (u8 byte : input) {
         // 1. If spaceAsPlus is true and byte is 0x20 (SP), then append U+002B (+) to output and continue.
         if (space_as_plus && byte == ' ') {
             output.append('+');

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -438,6 +438,15 @@ TEST_CASE(unicode)
     EXPECT(!url.fragment().has_value());
 }
 
+TEST_CASE(query_with_non_ascii)
+{
+    URL url { "http://example.com/?utf8=✓"sv };
+    EXPECT(url.is_valid());
+    EXPECT_EQ(url.serialize_path(), "/"sv);
+    EXPECT_EQ(url.query(), "utf8=%E2%9C%93");
+    EXPECT(!url.fragment().has_value());
+}
+
 TEST_CASE(complete_file_url_with_base)
 {
     URL url { "file:///home/index.html" };


### PR DESCRIPTION
Otherwise, we percent-encode negative signed chars incorrectly. For example, https://www.strava.com/login contains the following hidden <input> field:

    <input name="utf8" type="hidden" value="✓" />

On submitting the form, we would percent-encode that field as:

    utf8=%-1E%-64%-6D

Which would cause us to receive an HTTP 500 response. We now properly percent-encode that field as:

    utf8=%E2%9C%93

And can login to Strava :^)