### PR TITLE
LibWeb: Disable animations tests that depend on consistent timing

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,3 +1,5 @@
 [Skipped]
 Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html
+Text/input/WebAnimations/animation-properties/playbackRate.html
+Text/input/WebAnimations/animation-properties/startTime.html


### PR DESCRIPTION
These are flaky on CI, so disable them for now.