### PR TITLE
HexEditor: Group bytes in 4s, for better readability

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -242,9 +242,24 @@ void HexEditor::update_content_size()
 
 void HexEditor::set_bytes_per_row(size_t bytes_per_row)
 {
-    if (bytes_per_row == m_bytes_per_row)
+    if (bytes_per_row == this->bytes_per_row())
         return;
-    m_bytes_per_row = bytes_per_row;
+    set_groups_per_row(ceil_div(bytes_per_row, m_bytes_per_group));
+}
+
+void HexEditor::set_bytes_per_group(size_t bytes_per_group)
+{
+    if (bytes_per_group == m_bytes_per_group)
+        return;
+    m_bytes_per_group = bytes_per_group;
+    update_content_size();
+}
+
+void HexEditor::set_groups_per_row(size_t groups_per_row)
+{
+    if (groups_per_row == m_groups_per_row)
+        return;
+    m_groups_per_row = groups_per_row;
     update_content_size();
 }
 
@@ -299,7 +314,7 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
 
         auto byte_x = (absolute_x - hex_text_start_x) / cell_width();
         auto byte_y = (absolute_y - hex_start_y) / line_height();
-        auto offset = (byte_y * m_bytes_per_row) + byte_x;
+        auto offset = (byte_y * bytes_per_row()) + byte_x;
 
         if (offset >= m_document->size())
             return {};
@@ -315,7 +330,7 @@ Optional<HexEditor::OffsetData> HexEditor::offset_at(Gfx::IntPoint position) con
 
         auto byte_x = (absolute_x - text_text_start_x) / character_width();
         auto byte_y = (absolute_y - text_start_y) / line_height();
-        auto offset = (byte_y * m_bytes_per_row) + byte_x;
+        auto offset = (byte_y * bytes_per_row()) + byte_x;
 
         if (offset >= m_document->size())
             return {};

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -707,14 +707,14 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             // 4. Annotations
             // 5. Null bytes
             // 6. Regular formatting
-            auto determine_background_color = [&](EditMode edit_mode) -> Gfx::Color {
+            auto determine_background_color = [&](EditMode edit_mode) -> Optional<Gfx::Color> {
                 if (selected)
                     return cell.modified ? palette().selection().inverted() : palette().selection();
                 if (byte_position == m_position && m_edit_mode != edit_mode)
                     return palette().inactive_selection();
                 if (annotation.has_value())
                     return annotation->background_color;
-                return palette().color(background_role());
+                return {};
             };
             auto determine_text_color = [&](EditMode edit_mode) -> Gfx::Color {
                 if (cell.modified)
@@ -729,13 +729,14 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
                     return palette().color(ColorRole::PlaceholderText);
                 return palette().color(foreground_role());
             };
-            Gfx::Color background_color_hex = determine_background_color(EditMode::Hex);
-            Gfx::Color background_color_text = determine_background_color(EditMode::Text);
-            Gfx::Color text_color_hex = determine_text_color(EditMode::Hex);
-            Gfx::Color text_color_text = determine_text_color(EditMode::Text);
+            auto background_color_hex = determine_background_color(EditMode::Hex);
+            auto background_color_text = determine_background_color(EditMode::Text);
+            auto text_color_hex = determine_text_color(EditMode::Hex);
+            auto text_color_text = determine_text_color(EditMode::Text);
             auto& font = cell.modified ? this->font().bold_variant() : this->font();
 
-            painter.fill_rect(background_rect, background_color_hex);
+            if (background_color_hex.has_value())
+                painter.fill_rect(background_rect, *background_color_hex);
 
             Gfx::IntRect text_display_rect {
                 static_cast<int>(text_area_text_start_x + column * character_width()),
@@ -774,7 +775,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
                 static_cast<int>(line_height()),
             };
 
-            painter.fill_rect(text_background_rect, background_color_text);
+            if (background_color_text.has_value())
+                painter.fill_rect(text_background_rect, *background_color_text);
 
             if (m_edit_mode == EditMode::Text)
                 draw_cursor_rect();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -55,7 +55,12 @@ public:
     bool copy_selected_hex_to_clipboard();
     bool copy_selected_hex_to_clipboard_as_c_code();
 
-    size_t bytes_per_row() const { return m_bytes_per_row; }
+    size_t bytes_per_group() const { return m_bytes_per_group; }
+    void set_bytes_per_group(size_t);
+    size_t groups_per_row() const { return m_groups_per_row; }
+    void set_groups_per_row(size_t);
+    size_t bytes_per_row() const { return m_groups_per_row * m_bytes_per_group; }
+    // FIXME: Deprecated! Set bytes_per_group or groups_per_row instead
     void set_bytes_per_row(size_t);
 
     void set_position(size_t position);
@@ -88,7 +93,8 @@ protected:
 private:
     size_t m_line_spacing { 4 };
     size_t m_content_length { 0 };
-    size_t m_bytes_per_row { 16 };
+    size_t m_bytes_per_group { 4 };
+    size_t m_groups_per_row { 4 };
     bool m_in_drag_select { false };
     Selection m_selection;
     size_t m_position { 0 };
@@ -107,14 +113,14 @@ private:
 
     void scroll_position_into_view(size_t position);
 
-    size_t total_rows() const { return ceil_div(m_content_length, m_bytes_per_row); }
+    size_t total_rows() const { return ceil_div(m_content_length, bytes_per_row()); }
     size_t line_height() const { return font().pixel_size_rounded_up() + m_line_spacing; }
     size_t character_width() const { return font().glyph_fixed_width(); }
     size_t cell_width() const { return character_width() * 3; }
 
     int offset_area_width() const { return m_padding + font().width_rounded_up("0X12345678"sv) + m_padding; }
-    int hex_area_width() const { return m_padding + m_bytes_per_row * cell_width() + m_padding; }
-    int text_area_width() const { return m_padding + m_bytes_per_row * character_width() + m_padding; }
+    int hex_area_width() const { return m_padding + bytes_per_row() * cell_width() + m_padding; }
+    int text_area_width() const { return m_padding + bytes_per_row() * character_width() + m_padding; }
 
     struct OffsetData {
         size_t offset;

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -116,10 +116,23 @@ private:
     size_t total_rows() const { return ceil_div(m_content_length, bytes_per_row()); }
     size_t line_height() const { return font().pixel_size_rounded_up() + m_line_spacing; }
     size_t character_width() const { return font().glyph_fixed_width(); }
-    size_t cell_width() const { return character_width() * 3; }
+    size_t cell_gap() const { return character_width() / 2; }
+    size_t cell_width() const { return character_width() * 2 + cell_gap(); }
+    size_t group_gap() const { return character_width() * 1.5; }
+    size_t group_width() const
+    {
+        return (character_width() * 2 * bytes_per_group())
+            + (cell_gap() * (bytes_per_group() - 1))
+            + group_gap();
+    }
 
     int offset_area_width() const { return m_padding + font().width_rounded_up("0X12345678"sv) + m_padding; }
-    int hex_area_width() const { return m_padding + bytes_per_row() * cell_width() + m_padding; }
+    int hex_area_width() const
+    {
+        return m_padding
+            + groups_per_row() * group_width() - group_gap()
+            + m_padding;
+    }
     int text_area_width() const { return m_padding + bytes_per_row() * character_width() + m_padding; }
 
     struct OffsetData {


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/9123767f-8564-4e5b-bf86-6edd35468665)

Add an extra gap every 4 bytes, to make it easier to keep track of where you are.

Slightly unintentionally, the gap is also visible when selecting, but I think this is actually a nice feature. I don't know if other people will share that opinion though. :laughing: 

![image](https://github.com/SerenityOS/serenity/assets/222642/04915570-70b2-416e-8b8c-82a11d5514d6)