### PR TITLE
AK: Introduce AK::enumerate similar to C++23's std::views::enumerate

### DIFF
--- a/AK/Enumerate.h
+++ b/AK/Enumerate.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+
+namespace AK {
+
+namespace Detail {
+template<typename Iterable>
+class Enumerator {
+    using IteratorType = decltype(declval<Iterable>().begin());
+    using ValueType = decltype(*declval<IteratorType>());
+
+    struct Enumeration {
+        size_t index { 0 };
+        ValueType value;
+    };
+
+public:
+    Enumerator(Iterable&& iterable)
+        : m_iterable(forward<Iterable>(iterable))
+        , m_iterator(m_iterable.begin())
+        , m_end(m_iterable.end())
+    {
+    }
+
+    Enumerator const& begin() const { return *this; }
+    Enumerator const& end() const { return *this; }
+
+    Enumeration operator*() { return { m_index, *m_iterator }; }
+    Enumeration operator*() const { return { m_index, *m_iterator }; }
+
+    bool operator!=(Enumerator const&) const { return m_iterator != m_end; }
+
+    void operator++()
+    {
+        ++m_index;
+        ++m_iterator;
+    }
+
+private:
+    Iterable m_iterable;
+
+    size_t m_index { 0 };
+    IteratorType m_iterator;
+    IteratorType const m_end;
+};
+}
+
+template<typename T>
+auto enumerate(T&& range)
+{
+    return Detail::Enumerator<T> { forward<T>(range) };
+}
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::enumerate;
+#endif

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/CFGBuildingPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/CFGBuildingPass.cpp
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Compiler/Passes/CFGBuildingPass.h"
+#include <AK/Enumerate.h>
+
 #include "AST/AST.h"
+#include "Compiler/Passes/CFGBuildingPass.h"
 #include "Function.h"
 
 namespace JSSpecCompiler {
@@ -37,9 +39,7 @@ RecursionDecision CFGBuildingPass::on_entry(Tree tree)
     if (auto if_else_if_chain = as<IfElseIfChain>(tree); if_else_if_chain) {
         auto* end_block = create_empty_block();
 
-        for (size_t i = 0; i < if_else_if_chain->branches_count(); ++i) {
-            auto current_condition = if_else_if_chain->m_conditions[i];
-
+        for (auto [i, current_condition] : enumerate(if_else_if_chain->m_conditions)) {
             run_in_subtree(current_condition);
             will_be_used_as_expression(current_condition);
             auto* condition_block = exchange_current_with_empty();

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -25,6 +25,7 @@ set(AK_TEST_SOURCES
     TestDoublyLinkedList.cpp
     TestEndian.cpp
     TestEnumBits.cpp
+    TestEnumerate.cpp
     TestFind.cpp
     TestFixedArray.cpp
     TestFixedPoint.cpp

--- a/Tests/AK/TestEnumerate.cpp
+++ b/Tests/AK/TestEnumerate.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Enumerate.h>
+#include <AK/Span.h>
+#include <AK/Vector.h>
+
+struct IndexAndValue {
+    size_t index;
+    int value;
+
+    bool operator==(IndexAndValue const&) const = default;
+};
+
+TEST_CASE(enumerate)
+{
+    {
+        Vector<IndexAndValue> result;
+        for (auto [i, value] : enumerate(Vector { 1, 2, 3, 4 })) {
+            result.append({ i, value });
+        }
+        EXPECT_EQ(result, (Vector<IndexAndValue> { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 3, 4 } }));
+    }
+
+    {
+        Vector<IndexAndValue> result;
+        Vector<int> values = { 9, 8, 7, 6 };
+        for (auto [i, value] : enumerate(values)) {
+            static_assert(SameAs<decltype(value), int&>);
+            result.append({ i, value });
+            value = static_cast<int>(i);
+        }
+        EXPECT_EQ(result, (Vector<IndexAndValue> { { 0, 9 }, { 1, 8 }, { 2, 7 }, { 3, 6 } }));
+        EXPECT_EQ(values, (Vector<int> { 0, 1, 2, 3 }));
+    }
+
+    {
+        Vector<IndexAndValue> result;
+        Vector<int> const& values = { 9, 8, 7, 6 };
+        for (auto [i, value] : enumerate(values)) {
+            static_assert(SameAs<decltype(value), int const&>);
+            result.append({ i, value });
+        }
+        EXPECT_EQ(result, (Vector<IndexAndValue> { { 0, 9 }, { 1, 8 }, { 2, 7 }, { 3, 6 } }));
+    }
+}


### PR DESCRIPTION
I'm sick of writing C-style loops in JSSC every time I need an index too.

I don't want to fully port JSSC to `enumerate` just yet since it will conflict with my main JSSC dev branch. I've changed one such loop though in order to not break the "unused code" rule.

The `AK::enumerate` itself is modeled loosely after C++23's std::views::enumerate but little attention was paid to the value categories and constness. We can always iterate on it in-tree when these things become an issue. First commit also introduces a bunch of stuff ~~inspired~~ copied from Ranges TS but leaves them as an implementation detail.