### PR TITLE
LibWeb: Stop animation updates after navigating from document

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -48,7 +48,7 @@ AnimationTimeline::AnimationTimeline(JS::Realm& realm)
 {
 }
 
-AnimationTimeline::~AnimationTimeline()
+void AnimationTimeline::finalize()
 {
     if (m_associated_document)
         m_associated_document->disassociate_with_timeline(*this);

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.h
@@ -35,10 +35,10 @@ public:
 
 protected:
     AnimationTimeline(JS::Realm&);
-    virtual ~AnimationTimeline() override;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
 
     // https://www.w3.org/TR/web-animations-1/#dom-animationtimeline-currenttime
     Optional<double> m_current_time {};

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3127,6 +3127,9 @@ void Document::did_stop_being_active_document_in_navigable()
         if (document_observer->document_became_inactive())
             document_observer->document_became_inactive()->function()();
     }
+
+    if (m_animation_driver_timer)
+        m_animation_driver_timer->stop();
 }
 
 void Document::increment_throw_on_dynamic_markup_insertion_counter(Badge<HTML::HTMLParser>)

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4023,7 +4023,7 @@ void Document::ensure_animation_timer()
 {
     constexpr static auto timer_delay_ms = 1000 / 60;
     if (!m_animation_driver_timer) {
-        m_animation_driver_timer = Platform::Timer::create_repeating(timer_delay_ms, [this] {
+        m_animation_driver_timer = MUST(Core::Timer::create_repeating(timer_delay_ms, [this] {
             bool has_animations = false;
             for (auto& timeline : m_associated_animation_timelines) {
                 if (!timeline->associated_animations().is_empty()) {
@@ -4042,7 +4042,7 @@ void Document::ensure_animation_timer()
                 for (auto& animation : timeline->associated_animations())
                     dispatch_events_for_animation_if_necessary(animation);
             }
-        });
+        }));
     }
 
     m_animation_driver_timer->start();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -828,7 +828,7 @@ private:
 
     // https://www.w3.org/TR/web-animations-1/#pending-animation-event-queue
     Vector<PendingAnimationEvent> m_pending_animation_event_queue;
-    RefPtr<Platform::Timer> m_animation_driver_timer;
+    RefPtr<Core::Timer> m_animation_driver_timer;
 
     bool m_needs_to_call_page_did_load { false };
 


### PR DESCRIPTION
Fixes leakage of document in animation driver callback and animation updates running for inactive documents.