### PR TITLE
Ladybird/Qt: Adjust the Inspector context menu by the device pixel ratio

### DIFF
--- a/Ladybird/Qt/InspectorWidget.cpp
+++ b/Ladybird/Qt/InspectorWidget.cpp
@@ -97,14 +97,14 @@ InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
         m_edit_node_action->setText("&Edit text");
         m_copy_node_action->setText("&Copy text");
 
-        m_dom_node_text_context_menu->exec(to_widget_position(position));
+        m_dom_node_text_context_menu->exec(m_inspector_view->map_point_to_global_position(position));
     };
 
     m_inspector_client->on_requested_dom_node_tag_context_menu = [this](auto position, auto const& tag) {
         m_edit_node_action->setText(qstring_from_ak_string(MUST(String::formatted("&Edit \"{}\"", tag))));
         m_copy_node_action->setText("&Copy HTML");
 
-        m_dom_node_tag_context_menu->exec(to_widget_position(position));
+        m_dom_node_tag_context_menu->exec(m_inspector_view->map_point_to_global_position(position));
     };
 
     m_inspector_client->on_requested_dom_node_attribute_context_menu = [this](auto position, auto const&, WebView::Attribute const& attribute) {
@@ -117,7 +117,7 @@ InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
             attribute.value, MAX_ATTRIBUTE_VALUE_LENGTH,
             attribute.value.bytes_as_string_view().length() > MAX_ATTRIBUTE_VALUE_LENGTH ? "..."sv : ""sv))));
 
-        m_dom_node_attribute_context_menu->exec(to_widget_position(position));
+        m_dom_node_attribute_context_menu->exec(m_inspector_view->map_point_to_global_position(position));
     };
 
     setLayout(new QVBoxLayout);
@@ -189,12 +189,6 @@ void InspectorWidget::closeEvent(QCloseEvent* event)
 {
     event->accept();
     m_inspector_client->clear_selection();
-}
-
-QPoint InspectorWidget::to_widget_position(Gfx::IntPoint position) const
-{
-    auto widget_position = m_inspector_view->mapTo(this, QPoint { position.x(), position.y() });
-    return mapToGlobal(widget_position);
 }
 
 }

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -38,8 +38,6 @@ private:
     bool event(QEvent*) override;
     void closeEvent(QCloseEvent*) override;
 
-    QPoint to_widget_position(Gfx::IntPoint) const;
-
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -271,7 +271,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             select_dropdown_add_item(m_select_dropdown, item);
         }
 
-        m_select_dropdown->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
+        m_select_dropdown->exec(view().map_point_to_global_position(content_position));
     };
 
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);
@@ -406,7 +406,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             search_selected_text_action->setVisible(false);
         }
 
-        m_page_context_menu->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
+        m_page_context_menu->exec(view().map_point_to_global_position(content_position));
     };
 
     auto* open_link_action = new QAction("&Open", this);
@@ -450,7 +450,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             break;
         }
 
-        m_link_context_menu->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
+        m_link_context_menu->exec(view().map_point_to_global_position(content_position));
     };
 
     auto* open_image_action = new QAction("&Open Image", this);
@@ -503,7 +503,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_image_context_menu_url = image_url;
         m_image_context_menu_bitmap = shareable_bitmap;
 
-        m_image_context_menu->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
+        m_image_context_menu->exec(view().map_point_to_global_position(content_position));
     };
 
     m_media_context_menu_play_icon = load_icon_from_uri("resource://icons/16x16/play.png"sv);
@@ -619,7 +619,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_media_context_menu_controls_action->setChecked(menu.has_user_agent_controls);
         m_media_context_menu_loop_action->setChecked(menu.is_looping);
 
-        auto screen_position = view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio());
+        auto screen_position = view().map_point_to_global_position(content_position);
         if (menu.is_video)
             m_video_context_menu->exec(screen_position);
         else

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -644,6 +644,11 @@ Web::DevicePixelRect WebContentView::viewport_rect() const
     return m_viewport_rect.to_type<Web::DevicePixels>();
 }
 
+QPoint WebContentView::map_point_to_global_position(Gfx::IntPoint position) const
+{
+    return mapToGlobal(QPoint { position.x(), position.y() } / device_pixel_ratio());
+}
+
 Gfx::IntPoint WebContentView::to_content_position(Gfx::IntPoint widget_position) const
 {
     return widget_position.translated(max(0, horizontalScrollBar()->value()), max(0, verticalScrollBar()->value()));

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -81,6 +81,8 @@ public:
 
     using ViewImplementation::client;
 
+    QPoint map_point_to_global_position(Gfx::IntPoint) const;
+
 signals:
     void urls_dropped(QList<QUrl> const&);
 


### PR DESCRIPTION
Otherwise, the context menu is very out of position on devices with a
device pixel ratio other than 1.