### PR TITLE
LibGfx/JBIG2: Start implementing the generic region decoding procedure

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -546,9 +546,14 @@ static ErrorOr<void> decode_page_information(JBIG2LoadingContext& context, Segme
     return {};
 }
 
-static ErrorOr<void> decode_end_of_page(JBIG2LoadingContext&, SegmentData const&)
+static ErrorOr<void> decode_end_of_page(JBIG2LoadingContext&, SegmentData const& segment)
 {
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode end of page yet");
+    // 7.4.9 End of page segment syntax
+    if (segment.data.size() != 0)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: End of page segment has non-zero size");
+    // FIXME: If the page had unknown height, check that previous segment was end-of-stripe.
+    // FIXME: Maybe mark page as completed and error if we see more segments for it?
+    return {};
 }
 
 static ErrorOr<void> decode_end_of_stripe(JBIG2LoadingContext&, SegmentData const&)


### PR DESCRIPTION
If the "MMR" bit is set, the generic region decoding procedure just
uses ITU-T T.6 (2D CCITT), which we already have an implementation of.
In practice, this is used almost never in .jbig2 files and in none of
the PDFs I have.

The two files that do use MMR are:

1.) JBIG2_ConformanceData-A20180829/F01_200_TT9.jb2
2) 042_3.jb2 from the ghostpdl tests

The first uses an immediate _lossless_ generic region, which we don't
implement yet (but I think it should just forward to the normal
immediate generic region code? Not in this commit, though). The second
uses a regular immediate generic region, and we can decode it now:

    Build/lagom/bin/image -o out.png \
        path/to/ghostpdl/tests/jbig2/042_3.jb2