### PR TITLE
LibWasm+AK: Make validation faster

### DIFF
--- a/AK/COWVector.h
+++ b/AK/COWVector.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2021-2024, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/Vector.h>
+
+namespace AK {
+
+template<typename T>
+class COWVector {
+    struct Detail : RefCounted<Detail> {
+        Vector<T> m_members;
+    };
+
+public:
+    COWVector()
+        : m_detail(make_ref_counted<Detail>())
+    {
+    }
+
+    COWVector(std::initializer_list<T> entries)
+        : m_detail(make_ref_counted<Detail>())
+    {
+        for (auto& entry : entries)
+            m_detail->m_members.append(entry);
+    }
+
+    COWVector(COWVector const&) = default;
+    COWVector(COWVector&&) = default;
+
+    COWVector& operator=(COWVector const&) = default;
+    COWVector& operator=(COWVector&&) = default;
+
+    Vector<T> release() &&
+    {
+        if (m_detail->ref_count() == 1)
+            return exchange(m_detail->m_members, Vector<T>());
+
+        return m_detail->m_members;
+    }
+
+    void append(T const& value)
+    {
+        return append(T { value });
+    }
+
+    void append(T&& value)
+    {
+        copy();
+        m_detail->m_members.append(move(value));
+    }
+
+    void extend(Vector<T>&& values)
+    {
+        copy();
+        m_detail->m_members.extend(move(values));
+    }
+
+    void extend(Vector<T> const& values)
+    {
+        copy();
+        m_detail->m_members.extend(values);
+    }
+
+    void extend(COWVector<T> const& values)
+    {
+        copy();
+        m_detail->m_members.extend(values.m_detail->m_members);
+    }
+
+    void resize(size_t size)
+    {
+        copy();
+        m_detail->m_members.resize(size);
+    }
+
+    void ensure_capacity(size_t capacity)
+    {
+        if (m_detail->m_members.capacity() >= capacity)
+            return;
+
+        copy();
+        m_detail->m_members.ensure_capacity(capacity);
+    }
+
+    void prepend(T value)
+    {
+        copy();
+        m_detail->m_members.prepend(move(value));
+    }
+
+    template<typename... Args>
+    void empend(Args&&... args)
+    {
+        copy();
+        m_detail->m_members.empend(forward<Args>(args)...);
+    }
+
+    void clear()
+    {
+        if (m_detail->ref_count() > 1)
+            m_detail = make_ref_counted<Detail>();
+        else
+            m_detail->m_members.clear();
+    }
+
+    T& at(size_t index)
+    {
+        // We're handing out a mutable reference, so make sure we own the data exclusively.
+        copy();
+        return m_detail->m_members.at(index);
+    }
+
+    T const& at(size_t index) const
+    {
+        return m_detail->m_members.at(index);
+    }
+
+    T& operator[](size_t index)
+    {
+        // We're handing out a mutable reference, so make sure we own the data exclusively.
+        copy();
+        return m_detail->m_members[index];
+    }
+
+    T const& operator[](size_t index) const
+    {
+        return m_detail->m_members[index];
+    }
+
+    size_t capacity() const
+    {
+        return m_detail->m_members.capacity();
+    }
+
+    size_t size() const
+    {
+        return m_detail->m_members.size();
+    }
+
+    bool is_empty() const
+    {
+        return m_detail->m_members.is_empty();
+    }
+
+    T const& first() const
+    {
+        return m_detail->m_members.first();
+    }
+
+    T const& last() const
+    {
+        return m_detail->m_members.last();
+    }
+
+private:
+    void copy()
+    {
+        if (m_detail->ref_count() <= 1)
+            return;
+        auto new_detail = make_ref_counted<Detail>();
+        new_detail->m_members = m_detail->m_members;
+        m_detail = new_detail;
+    }
+
+    NonnullRefPtr<Detail> m_detail;
+};
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::COWVector;
+#endif

--- a/AK/COWVector.h
+++ b/AK/COWVector.h
@@ -110,7 +110,7 @@ public:
             m_detail->m_members.clear();
     }
 
-    T& at(size_t index)
+    T& mutable_at(size_t index)
     {
         // We're handing out a mutable reference, so make sure we own the data exclusively.
         copy();
@@ -120,13 +120,6 @@ public:
     T const& at(size_t index) const
     {
         return m_detail->m_members.at(index);
-    }
-
-    T& operator[](size_t index)
-    {
-        // We're handing out a mutable reference, so make sure we own the data exclusively.
-        copy();
-        return m_detail->m_members[index];
     }
 
     T const& operator[](size_t index) const

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -332,7 +332,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, 
 ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     if (input.match_index < state.capture_group_matches.size()) {
-        auto& group = state.capture_group_matches[input.match_index];
+        auto& group = state.capture_group_matches.mutable_at(input.match_index);
         auto group_id = id();
         if (group_id >= group.size())
             group.resize(group_id + 1);
@@ -352,19 +352,19 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput co
     }
 
     if (id() >= state.capture_group_matches.at(input.match_index).size()) {
-        state.capture_group_matches.at(input.match_index).ensure_capacity(id());
+        state.capture_group_matches.mutable_at(input.match_index).ensure_capacity(id());
         auto capacity = state.capture_group_matches.at(input.match_index).capacity();
         for (size_t i = state.capture_group_matches.at(input.match_index).size(); i <= capacity; ++i)
-            state.capture_group_matches.at(input.match_index).empend();
+            state.capture_group_matches.mutable_at(input.match_index).empend();
     }
 
-    state.capture_group_matches.at(input.match_index).at(id()).left_column = state.string_position;
+    state.capture_group_matches.mutable_at(input.match_index).at(id()).left_column = state.string_position;
     return ExecutionResult::Continue;
 }
 
 ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
-    auto& match = state.capture_group_matches.at(input.match_index).at(id());
+    auto& match = state.capture_group_matches.mutable_at(input.match_index).at(id());
     auto start_position = match.left_column;
     if (state.string_position < start_position) {
         dbgln("Right capture group {} is before left capture group {}!", state.string_position, start_position);
@@ -391,7 +391,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput c
 
 ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
-    auto& match = state.capture_group_matches.at(input.match_index).at(id());
+    auto& match = state.capture_group_matches.mutable_at(input.match_index).at(id());
     auto start_position = match.left_column;
     if (state.string_position < start_position)
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -1051,7 +1051,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Repeat::execute(MatchInput const&, MatchSta
 
     if (id() >= state.repetition_marks.size())
         state.repetition_marks.resize(id() + 1);
-    auto& repetition_mark = state.repetition_marks.at(id());
+    auto& repetition_mark = state.repetition_marks.mutable_at(id());
 
     if (repetition_mark == count() - 1) {
         repetition_mark = 0;
@@ -1068,7 +1068,7 @@ ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, Mat
     if (id() >= state.repetition_marks.size())
         state.repetition_marks.resize(id() + 1);
 
-    state.repetition_marks.at(id()) = 0;
+    state.repetition_marks.mutable_at(id()) = 0;
     return ExecutionResult::Continue;
 }
 

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -11,6 +11,7 @@
 #include <AK/Error.h>
 
 #include <AK/ByteString.h>
+#include <AK/COWVector.h>
 #include <AK/DeprecatedFlyString.h>
 #include <AK/HashMap.h>
 #include <AK/MemMem.h>
@@ -24,135 +25,6 @@
 #include <AK/Vector.h>
 
 namespace regex {
-
-template<typename T>
-class COWVector {
-    struct Detail : RefCounted<Detail> {
-        Vector<T> m_members;
-    };
-
-public:
-    COWVector()
-        : m_detail(make_ref_counted<Detail>())
-    {
-    }
-
-    COWVector(COWVector const&) = default;
-    COWVector(COWVector&&) = default;
-
-    COWVector& operator=(COWVector const&) = default;
-    COWVector& operator=(COWVector&&) = default;
-
-    Vector<T> release() &&
-    {
-        if (m_detail->ref_count() == 1)
-            return exchange(m_detail->m_members, Vector<T>());
-
-        return m_detail->m_members;
-    }
-
-    void append(T const& value)
-    {
-        return append(T { value });
-    }
-
-    void append(T&& value)
-    {
-        copy();
-        m_detail->m_members.append(move(value));
-    }
-
-    void resize(size_t size)
-    {
-        copy();
-        m_detail->m_members.resize(size);
-    }
-
-    void ensure_capacity(size_t capacity)
-    {
-        if (m_detail->m_members.capacity() >= capacity)
-            return;
-
-        copy();
-        m_detail->m_members.ensure_capacity(capacity);
-    }
-
-    template<typename... Args>
-    void empend(Args&&... args)
-    {
-        copy();
-        m_detail->m_members.empend(forward<Args>(args)...);
-    }
-
-    void clear()
-    {
-        if (m_detail->ref_count() > 1)
-            m_detail = make_ref_counted<Detail>();
-        else
-            m_detail->m_members.clear();
-    }
-
-    T& at(size_t index)
-    {
-        // We're handing out a mutable reference, so make sure we own the data exclusively.
-        copy();
-        return m_detail->m_members.at(index);
-    }
-
-    T const& at(size_t index) const
-    {
-        return m_detail->m_members.at(index);
-    }
-
-    T& operator[](size_t index)
-    {
-        // We're handing out a mutable reference, so make sure we own the data exclusively.
-        copy();
-        return m_detail->m_members[index];
-    }
-
-    T const& operator[](size_t index) const
-    {
-        return m_detail->m_members[index];
-    }
-
-    size_t capacity() const
-    {
-        return m_detail->m_members.capacity();
-    }
-
-    size_t size() const
-    {
-        return m_detail->m_members.size();
-    }
-
-    bool is_empty() const
-    {
-        return m_detail->m_members.is_empty();
-    }
-
-    T const& first() const
-    {
-        return m_detail->m_members.first();
-    }
-
-    T const& last() const
-    {
-        return m_detail->m_members.last();
-    }
-
-private:
-    void copy()
-    {
-        if (m_detail->ref_count() <= 1)
-            return;
-        auto new_detail = make_ref_counted<Detail>();
-        new_detail->m_members = m_detail->m_members;
-        m_detail = new_detail;
-    }
-
-    NonnullRefPtr<Detail> m_detail;
-};
 
 class RegexStringView {
 public:

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -157,9 +157,9 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
         for (size_t j = 0; j < c_match_preallocation_count; ++j) {
             state.matches.empend();
             state.capture_group_matches.empend();
-            state.capture_group_matches.at(j).ensure_capacity(capture_groups_count);
+            state.capture_group_matches.mutable_at(j).ensure_capacity(capture_groups_count);
             for (size_t k = 0; k < capture_groups_count; ++k)
-                state.capture_group_matches.at(j).unchecked_append({});
+                state.capture_group_matches.mutable_at(j).unchecked_append({});
         }
     }
 
@@ -169,9 +169,9 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
 
         VERIFY(start_position + state.string_position - start_position <= input.view.length());
         if (input.regex_options.has_flag_set(AllFlags::StringCopyMatches)) {
-            state.matches.at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position).to_byte_string(), input.line, start_position, input.global_offset + start_position };
+            state.matches.mutable_at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position).to_byte_string(), input.line, start_position, input.global_offset + start_position };
         } else { // let the view point to the original string ...
-            state.matches.at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position), input.line, start_position, input.global_offset + start_position };
+            state.matches.mutable_at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position), input.line, start_position, input.global_offset + start_position };
         }
     };
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -551,7 +551,7 @@ void Linker::link(HashMap<Linker::Name, ExternValue> const& exports)
         m_unresolved_imports.remove(entry);
 }
 
-AK::Result<Vector<ExternValue>, LinkError> Linker::finish()
+AK::ErrorOr<Vector<ExternValue>, LinkError> Linker::finish()
 {
     populate();
     if (!m_unresolved_imports.is_empty()) {

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -604,7 +604,7 @@ private:
     Vector<EntryType, 1024> m_data;
 };
 
-using InstantiationResult = AK::Result<NonnullOwnPtr<ModuleInstance>, InstantiationError>;
+using InstantiationResult = AK::ErrorOr<NonnullOwnPtr<ModuleInstance>, InstantiationError>;
 
 class AbstractMachine {
 public:
@@ -655,7 +655,7 @@ public:
         return m_unresolved_imports;
     }
 
-    AK::Result<Vector<ExternValue>, LinkError> finish();
+    AK::ErrorOr<Vector<ExternValue>, LinkError> finish();
 
 private:
     void populate();

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -307,7 +307,7 @@ void BytecodeInterpreter::binary_numeric_operation(Configuration& configuration,
     auto lhs = lhs_ptr->to<PopTypeLHS>();
     PushType result;
     auto call_result = Operator { forward<Args>(args)... }(lhs.value(), rhs.value());
-    if constexpr (IsSpecializationOf<decltype(call_result), AK::Result>) {
+    if constexpr (IsSpecializationOf<decltype(call_result), AK::ErrorOr>) {
         if (call_result.is_error()) {
             trap_if_not(false, call_result.error());
             return;
@@ -328,7 +328,7 @@ void BytecodeInterpreter::unary_operation(Configuration& configuration, Args&&..
     auto value = entry_ptr->to<PopType>();
     auto call_result = Operator { forward<Args>(args)... }(*value);
     PushType result;
-    if constexpr (IsSpecializationOf<decltype(call_result), AK::Result>) {
+    if constexpr (IsSpecializationOf<decltype(call_result), AK::ErrorOr>) {
         if (call_result.is_error()) {
             trap_if_not(false, call_result.error());
             return;

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -58,8 +58,8 @@ struct Divide {
             Checked value(lhs);
             value /= rhs;
             if (value.has_overflow())
-                return AK::Result<Lhs, StringView>("Integer division overflow"sv);
-            return AK::Result<Lhs, StringView>(value.value());
+                return AK::ErrorOr<Lhs, StringView>("Integer division overflow"sv);
+            return AK::ErrorOr<Lhs, StringView>(value.value());
         }
     }
 
@@ -71,12 +71,12 @@ struct Modulo {
     auto operator()(Lhs lhs, Rhs rhs) const
     {
         if (rhs == 0)
-            return AK::Result<Lhs, StringView>("Integer division overflow"sv);
+            return AK::ErrorOr<Lhs, StringView>("Integer division overflow"sv);
         if constexpr (IsSigned<Lhs>) {
             if (rhs == -1)
-                return AK::Result<Lhs, StringView>(0); // Spec weirdness right here, signed division overflow is ignored.
+                return AK::ErrorOr<Lhs, StringView>(0); // Spec weirdness right here, signed division overflow is ignored.
         }
-        return AK::Result<Lhs, StringView>(lhs % rhs);
+        return AK::ErrorOr<Lhs, StringView>(lhs % rhs);
     }
 
     static StringView name() { return "%"sv; }
@@ -479,7 +479,7 @@ struct Floor {
 
 struct Truncate {
     template<typename Lhs>
-    AK::Result<Lhs, StringView> operator()(Lhs lhs) const
+    AK::ErrorOr<Lhs, StringView> operator()(Lhs lhs) const
     {
         if constexpr (IsSame<Lhs, float>)
             return truncf(lhs);
@@ -536,7 +536,7 @@ struct Wrap {
 template<typename ResultT>
 struct CheckedTruncate {
     template<typename Lhs>
-    AK::Result<ResultT, StringView> operator()(Lhs lhs) const
+    AK::ErrorOr<ResultT, StringView> operator()(Lhs lhs) const
     {
         if (isnan(lhs) || isinf(lhs)) // "undefined", let's just trap.
             return "Truncation undefined behavior"sv;

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -38,7 +38,8 @@ ErrorOr<void, ValidationError> Validator::validate(Module& module)
     m_context = {};
 
     module.for_each_section_of_type<TypeSection>([this](TypeSection const& section) {
-        m_context.types = section.types();
+        for (auto& type : section.types())
+            m_context.types.append(type);
     });
 
     module.for_each_section_of_type<ImportSection>([&](ImportSection const& section) {
@@ -90,23 +91,23 @@ ErrorOr<void, ValidationError> Validator::validate(Module& module)
     module.for_each_section_of_type<TableSection>([this](TableSection const& section) {
         m_context.tables.ensure_capacity(m_context.tables.size() + section.tables().size());
         for (auto& table : section.tables())
-            m_context.tables.unchecked_append(table.type());
+            m_context.tables.append(table.type());
     });
     module.for_each_section_of_type<MemorySection>([this](MemorySection const& section) {
         m_context.memories.ensure_capacity(m_context.memories.size() + section.memories().size());
         for (auto& memory : section.memories())
-            m_context.memories.unchecked_append(memory.type());
+            m_context.memories.append(memory.type());
     });
 
     module.for_each_section_of_type<GlobalSection>([this](GlobalSection const& section) {
         m_context.globals.ensure_capacity(m_context.globals.size() + section.entries().size());
         for (auto& global : section.entries())
-            m_context.globals.unchecked_append(global.type());
+            m_context.globals.append(global.type());
     });
     module.for_each_section_of_type<ElementSection>([this](ElementSection const& section) {
         m_context.elements.ensure_capacity(section.segments().size());
         for (auto& segment : section.segments())
-            m_context.elements.unchecked_append(segment.type);
+            m_context.elements.append(segment.type);
     });
     module.for_each_section_of_type<DataSection>([this](DataSection const& section) {
         m_context.datas.resize(section.data().size());

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -38,8 +38,7 @@ ErrorOr<void, ValidationError> Validator::validate(Module& module)
     m_context = {};
 
     module.for_each_section_of_type<TypeSection>([this](TypeSection const& section) {
-        for (auto& type : section.types())
-            m_context.types.append(type);
+        m_context.types.extend(section.types());
     });
 
     module.for_each_section_of_type<ImportSection>([&](ImportSection const& section) {

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/COWVector.h>
 #include <AK/Debug.h>
 #include <AK/HashTable.h>
 #include <AK/SourceLocation.h>
@@ -17,15 +18,15 @@
 namespace Wasm {
 
 struct Context {
-    Vector<FunctionType> types;
-    Vector<FunctionType> functions;
-    Vector<TableType> tables;
-    Vector<MemoryType> memories;
-    Vector<GlobalType> globals;
-    Vector<ValueType> elements;
-    Vector<bool> datas;
-    Vector<ValueType> locals;
-    Vector<ResultType> labels;
+    COWVector<FunctionType> types;
+    COWVector<FunctionType> functions;
+    COWVector<TableType> tables;
+    COWVector<MemoryType> memories;
+    COWVector<GlobalType> globals;
+    COWVector<ValueType> elements;
+    COWVector<bool> datas;
+    COWVector<ValueType> locals;
+    COWVector<ResultType> labels;
     Optional<ResultType> return_;
     AK::HashTable<FunctionIndex> references;
     size_t imported_function_count { 0 };
@@ -345,7 +346,7 @@ private:
     Vector<ChildScopeKind> m_entered_scopes;
     Vector<BlockDetails> m_block_details;
     Vector<FunctionType> m_entered_blocks;
-    Vector<GlobalType> m_globals_without_internal_globals;
+    COWVector<GlobalType> m_globals_without_internal_globals;
 };
 
 }

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -28,7 +28,7 @@ static auto parse_vector(Stream& stream)
 {
     ScopeLogger<WASM_BINPARSER_DEBUG> logger;
     if constexpr (requires { T::parse(stream); }) {
-        using ResultT = typename decltype(T::parse(stream))::ValueType;
+        using ResultT = typename decltype(T::parse(stream))::ResultType;
         auto count_or_error = stream.read_value<LEB128<size_t>>();
         if (count_or_error.is_error())
             return ParseResult<Vector<ResultT>> { with_eof_check(stream, ParseError::ExpectedSize) };

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -61,7 +61,7 @@ enum class ParseError {
 ByteString parse_error_to_byte_string(ParseError);
 
 template<typename T>
-using ParseResult = Result<T, ParseError>;
+using ParseResult = ErrorOr<T, ParseError>;
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, TypeIndex);
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, FunctionIndex);


### PR DESCRIPTION
This applies more specifically to large wasm modules (so basically most of them in the wild), with lots of blocks and branches.

In a local test, validation perf improvement of up to 85% has been observed. effects are probably minimal overall, but startup times should be significantly shorter.