### PR TITLE
LibWeb: Use less of JS::Handle in CustomElements

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -250,6 +250,7 @@ set(SOURCES
     HTML/CORSSettingAttribute.cpp
     HTML/CrossOrigin/AbstractOperations.cpp
     HTML/CrossOrigin/Reporting.cpp
+    HTML/CustomElements/CustomElementDefinition.cpp
     HTML/CustomElements/CustomElementName.cpp
     HTML/CustomElements/CustomElementReactionNames.cpp
     HTML/CustomElements/CustomElementRegistry.cpp

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1910,7 +1910,7 @@ void Element::enqueue_a_custom_element_callback_reaction(FlyString const& callba
     if (callback_iterator == definition->lifecycle_callbacks().end())
         return;
 
-    if (callback_iterator->value.is_null())
+    if (!callback_iterator->value)
         return;
 
     // 4. If callbackName is "attributeChangedCallback", then:

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.cpp
@@ -11,6 +11,7 @@ namespace Web::HTML {
 void CustomElementDefinition::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_constructor);
     for (auto& callback : m_lifecycle_callbacks)
         visitor.visit(callback.value);
 }

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
+
+namespace Web::HTML {
+
+void CustomElementDefinition::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto& callback : m_lifecycle_callbacks)
+        visitor.visit(callback.value);
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.h
@@ -51,7 +51,7 @@ private:
     CustomElementDefinition(String const& name, String const& local_name, WebIDL::CallbackType& constructor, Vector<String>&& observed_attributes, LifecycleCallbacksStorage&& lifecycle_callbacks, bool form_associated, bool disable_internals, bool disable_shadow)
         : m_name(name)
         , m_local_name(local_name)
-        , m_constructor(JS::make_handle(constructor))
+        , m_constructor(constructor)
         , m_observed_attributes(move(observed_attributes))
         , m_lifecycle_callbacks(move(lifecycle_callbacks))
         , m_form_associated(form_associated)
@@ -74,7 +74,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-constructor
     // A Web IDL CustomElementConstructor callback function type value wrapping the custom element constructor
-    JS::Handle<WebIDL::CallbackType> m_constructor;
+    JS::NonnullGCPtr<WebIDL::CallbackType> m_constructor;
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-observed-attributes
     // A list of observed attributes

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.h
@@ -20,7 +20,7 @@ class CustomElementDefinition : public JS::Cell {
     JS_CELL(CustomElementDefinition, JS::Cell);
     JS_DECLARE_ALLOCATOR(CustomElementDefinition);
 
-    using LifecycleCallbacksStorage = OrderedHashMap<FlyString, JS::Handle<WebIDL::CallbackType>>;
+    using LifecycleCallbacksStorage = OrderedHashMap<FlyString, JS::GCPtr<WebIDL::CallbackType>>;
     using ConstructionStackStorage = Vector<Variant<JS::Handle<DOM::Element>, AlreadyConstructedCustomElementMarker>>;
 
     static JS::NonnullGCPtr<CustomElementDefinition> create(JS::Realm& realm, String const& name, String const& local_name, WebIDL::CallbackType& constructor, Vector<String>&& observed_attributes, LifecycleCallbacksStorage&& lifecycle_callbacks, bool form_associated, bool disable_internals, bool disable_shadow)
@@ -59,6 +59,8 @@ private:
         , m_disable_shadow(disable_shadow)
     {
     }
+
+    virtual void visit_edges(Visitor& visitor) override;
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-name
     // A name

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -201,14 +201,14 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
             // 2. If callbackValue is not undefined, then set the value of the entry in lifecycleCallbacks with key callbackName to the result of converting callbackValue to the Web IDL Function callback type. Rethrow any exceptions from the conversion.
             if (!callback_value.is_undefined()) {
                 auto callback = TRY(convert_value_to_callback_function(vm, callback_value));
-                lifecycle_callbacks.set(callback_name, JS::make_handle(callback));
+                lifecycle_callbacks.set(callback_name, callback);
             }
         }
 
         // 5. If the value of the entry in lifecycleCallbacks with key "attributeChangedCallback" is not null, then:
         auto attribute_changed_callback_iterator = lifecycle_callbacks.find(CustomElementReactionNames::attributeChangedCallback);
         VERIFY(attribute_changed_callback_iterator != lifecycle_callbacks.end());
-        if (!attribute_changed_callback_iterator->value.is_null()) {
+        if (attribute_changed_callback_iterator->value) {
             // 1. Let observedAttributesIterable be ? Get(constructor, "observedAttributes").
             auto observed_attributes_iterable = TRY(constructor->callback->get(JS::PropertyKey { "observedAttributes" }));
 
@@ -253,7 +253,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 
                 // 2. If callbackValue is not undefined, then set the value of the entry in lifecycleCallbacks with key callbackName to the result of converting callbackValue to the Web IDL Function callback type. Rethrow any exceptions from the conversion.
                 if (!callback_value.is_undefined())
-                    lifecycle_callbacks.set(callback_name, JS::make_handle(TRY(convert_value_to_callback_function(vm, callback_value))));
+                    lifecycle_callbacks.set(callback_name, TRY(convert_value_to_callback_function(vm, callback_value)));
             }
         }
 

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
@@ -47,7 +47,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#when-defined-promise-map
     // Every CustomElementRegistry also has a when-defined promise map, mapping valid custom element names to promises. It is used to implement the whenDefined() method.
-    OrderedHashMap<String, JS::Handle<JS::Promise>> m_when_defined_promise_map;
+    OrderedHashMap<String, JS::NonnullGCPtr<JS::Promise>> m_when_defined_promise_map;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
@@ -36,9 +36,10 @@ private:
     CustomElementRegistry(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
 
     // Every CustomElementRegistry has a set of custom element definitions, initially empty. In general, algorithms in this specification look up elements in the registry by any of name, local name, or constructor.
-    Vector<JS::Handle<CustomElementDefinition>> m_custom_element_definitions;
+    Vector<JS::NonnullGCPtr<CustomElementDefinition>> m_custom_element_definitions;
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition-is-running
     // Every CustomElementRegistry also has an element definition is running flag which is used to prevent reentrant invocations of element definition. It is initially unset.


### PR DESCRIPTION
Tiny bit of progress towards not leaking everything on Github.