### PR TITLE
Snake: Set Snake as default skin

### DIFF
--- a/Userland/Games/Snake/Game.cpp
+++ b/Userland/Games/Snake/Game.cpp
@@ -66,7 +66,7 @@ ErrorOr<NonnullRefPtr<Game>> Game::try_create()
     }
 
     auto color = Color::from_argb(Config::read_u32("Snake"sv, "Snake"sv, "BaseColor"sv, Color(Color::Green).value()));
-    auto skin_name = TRY(String::from_byte_string(Config::read_string("Snake"sv, "Snake"sv, "SnakeSkin"sv, "Classic"sv)));
+    auto skin_name = TRY(String::from_byte_string(Config::read_string("Snake"sv, "Snake"sv, "SnakeSkin"sv, "Snake"sv)));
     auto skin = TRY(SnakeSkin::create(skin_name, color));
 
     return adopt_nonnull_ref_or_enomem(new (nothrow) Game(move(food_bitmaps), color, skin_name, move(skin)));

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -59,7 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     game.set_focus(true);
 
     auto high_score = Config::read_u32("Snake"sv, "Snake"sv, "HighScore"sv, 0);
-    auto snake_skin_name = Config::read_string("Snake"sv, "Snake"sv, "SnakeSkin"sv, "Classic"sv);
+    auto snake_skin_name = Config::read_string("Snake"sv, "Snake"sv, "SnakeSkin"sv, "Snake"sv);
 
     auto& statusbar = *widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar"sv);
     statusbar.set_text(0, "Score: 0"_string);


### PR DESCRIPTION
Recently, @OfficialPixelBrush remade the *Snake* image skin (#23467).

As the best looking skin, it deserves to be the default.
Another benefit is the color of the sprites align with the game's icon.

_**Before:**_
<img src="https://github.com/SerenityOS/serenity/assets/7754483/5f2ed801-db5c-4087-b49c-b6d394176c5f" width="400">

_**After:**_
<img src="https://github.com/SerenityOS/serenity/assets/7754483/fbe3fe8e-4dbd-44a9-8913-63a784b7903f" width="400">