### PR TITLE
LibWeb: Implement the `window.opener` attribute

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-opener.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-opener.txt
@@ -1,0 +1,5 @@
+  window.opener initial value: null
+window.opener after setting to "test": test
+iframe contentWindow.opener initial value is the current window object: true
+iframe contentWindow.opener after setting to null: null
+iframe contentWindow.opener after setting to "test": test

--- a/Tests/LibWeb/Text/input/HTML/Window-opener.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-opener.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<iframe name="testFrame"></iframe>
+<script>    
+    asyncTest(done => {
+        println(`window.opener initial value: ${window.opener}`);
+        window.opener = "test";
+        println(`window.opener after setting to "test": ${window.opener}`);
+        const frame = document.querySelector("iframe");
+        frame.onload = () => {
+            println(`iframe contentWindow.opener initial value is the current window object: ${frame.contentWindow.opener === window}`);
+            frame.contentWindow.opener = null;
+            println(`iframe contentWindow.opener after setting to null: ${frame.contentWindow.opener}`);
+            frame.contentWindow.opener = "test";
+            println(`iframe contentWindow.opener after setting to "test": ${frame.contentWindow.opener}`);
+            done();
+        }
+        window.open("about:srcdoc", "testFrame");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -144,6 +144,8 @@ public:
     JS::NonnullGCPtr<WindowProxy> frames() const;
     u32 length();
     JS::GCPtr<WindowProxy const> top() const;
+    JS::GCPtr<WindowProxy const> opener() const;
+    WebIDL::ExceptionOr<void> set_opener(JS::Value);
     JS::GCPtr<WindowProxy const> parent() const;
     JS::GCPtr<DOM::Element const> frame_element() const;
     WebIDL::ExceptionOr<JS::GCPtr<WindowProxy>> open(Optional<String> const& url, Optional<String> const& target, Optional<String> const& features);

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -35,6 +35,7 @@ interface Window : EventTarget {
     [Replaceable] readonly attribute WindowProxy frames;
     [Replaceable] readonly attribute unsigned long length;
     [LegacyUnforgeable] readonly attribute WindowProxy? top;
+    attribute any opener;
     [Replaceable] readonly attribute WindowProxy? parent;
     readonly attribute Element? frameElement;
     WindowProxy? open(optional USVString url = "", optional DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");


### PR DESCRIPTION
This PR adds the [`window.opener`](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener) attribute, which returns a reference to the window that opened the current window.

This property is used in a fair number of [WPT tests](https://github.com/search?q=repo%3Aweb-platform-tests%2Fwpt+opener+language%3AJavaScript&type=code) and was previously causing tests to time out where it was used.

