### PR TITLE
LibWeb::HTML: Fix cursor paint even if input html element is empty

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -378,6 +378,10 @@ void BrowsingContext::set_cursor_position(JS::NonnullGCPtr<DOM::Position> positi
 
     m_cursor_position = position;
 
+    // NOTE: the cursor does not get painted in HTML Input element if no text is present
+    if (m_cursor_position && m_cursor_position->node()->text_content()->is_empty())
+        m_cursor_position->node()->set_text_content(MUST(String::formatted(" ")));
+
     if (m_cursor_position && m_cursor_position->node()->paintable())
         m_cursor_position->node()->paintable()->set_needs_display();
 


### PR DESCRIPTION
Currently, when we focus on html input element in the browser, the cursor does not get drawn/shown. Since `m_cursor_position->node()->paintable()` returns nullptr if text content of input element is empty therefore we set `m_cursor_position->node()->set_text_content` to " ".

**Bug:**

https://github.com/SerenityOS/serenity/assets/15072510/cc4023f9-7058-459b-8d13-3fbf4cbb235c

**Fix:**

https://github.com/SerenityOS/serenity/assets/15072510/7935a411-dc1b-427e-b5df-41f9b1a7f4ab



