### PR TITLE
LibWeb: Support SubtleCrypto.exportKey for RSA-OAEP in JsonWebKey format

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -38,6 +38,7 @@ static bool is_platform_object(Type const& type)
         "CanvasGradient"sv,
         "CanvasPattern"sv,
         "CanvasRenderingContext2D"sv,
+        "CryptoKey"sv,
         "Document"sv,
         "DocumentType"sv,
         "EventTarget"sv,

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/Crypto/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/Crypto/BUILD.gn
@@ -6,6 +6,7 @@ source_set("Crypto") {
     "Crypto.h",
     "CryptoAlgorithms.cpp",
     "CryptoAlgorithms.h",
+    "CryptoBindings.cpp",
     "CryptoBindings.h",
     "CryptoKey.cpp",
     "CryptoKey.h",

--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-exportKey.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-exportKey.txt
@@ -1,0 +1,13 @@
+exportKey with RSA-OAEP algorithm
+exportedPublicKey kwt: RSA
+exportedPublicKey alg: RSA-OAEP-256
+exportedPublicKey exponent: AQAB
+exportedPublicKey key_ops: encrypt,wrapKey
+exportedPublicKey ext: true
+exportedPrivateKey kwt: RSA
+exportedPrivateKey alg: RSA-OAEP-256
+exportedPrivateKey exponent: AQAB
+exportedPrivateKey key_ops: decrypt,unwrapKey
+exportedPrivateKey ext: true
+FIXME: exportedPublicKey2: 4649584d45
+exportKey spki private key: InvalidAccessError Key is not public

--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-generateKey.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-generateKey.txt
@@ -1,11 +1,11 @@
 generateKey with RSA-OAEP algorithm
 publicKey: [object CryptoKey]
-publicKey algorithm: {"name":"RSA-OAEP","modulusLength":512,"publicExponent":{"0":1,"1":0,"2":1},"hash":"SHA-256"}
+publicKey algorithm: {"name":"RSA-OAEP","modulusLength":256,"publicExponent":{"0":1,"1":0,"2":1},"hash":"SHA-256"}
 publicKey type: public
 publicKey extractable: true
 publicKey usages: encrypt,wrapKey
 privateKey: [object CryptoKey]
-privateKey algorithm: {"name":"RSA-OAEP","modulusLength":512,"publicExponent":{"0":1,"1":0,"2":1},"hash":"SHA-256"}
+privateKey algorithm: {"name":"RSA-OAEP","modulusLength":256,"publicExponent":{"0":1,"1":0,"2":1},"hash":"SHA-256"}
 privateKey type: private
 privateKey extractable: true
 privateKey usages: decrypt,unwrapKey

--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-generateKey.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-generateKey.txt
@@ -1,11 +1,11 @@
 generateKey with RSA-OAEP algorithm
 publicKey: [object CryptoKey]
-publicKey algorithm: {"name":"RSA-OAEP","modulusLength":512,"publicExponent":{"0":0,"1":1,"2":0},"hash":"SHA-256"}
+publicKey algorithm: {"name":"RSA-OAEP","modulusLength":512,"publicExponent":{"0":1,"1":0,"2":1},"hash":"SHA-256"}
 publicKey type: public
 publicKey extractable: true
 publicKey usages: encrypt,wrapKey
 privateKey: [object CryptoKey]
-privateKey algorithm: {"name":"RSA-OAEP","modulusLength":512,"publicExponent":{"0":0,"1":1,"2":0},"hash":"SHA-256"}
+privateKey algorithm: {"name":"RSA-OAEP","modulusLength":512,"publicExponent":{"0":1,"1":0,"2":1},"hash":"SHA-256"}
 privateKey type: private
 privateKey extractable: true
 privateKey usages: decrypt,unwrapKey

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-exportKey.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-exportKey.html
@@ -1,0 +1,52 @@
+<script src="../include.js"></script>
+<script>
+    function bufferToHex(buffer) {
+        return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, "0")).join("");
+    }
+
+    asyncTest(async done => {
+        let algorithm = {
+            name: "RSA-OAEP",
+            modulusLength: 512,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        };
+
+        println("exportKey with RSA-OAEP algorithm");
+
+        let key = await window.crypto.subtle.generateKey(algorithm, true, [
+            "encrypt",
+            "decrypt",
+            "wrapKey",
+            "unwrapKey",
+        ]);
+
+        // FIXME: Create a roundtrip test that starts with a key object and imports it, then exports it.
+
+        let exportedPublicKey = await window.crypto.subtle.exportKey("jwk", key.publicKey);
+        println(`exportedPublicKey kwt: ${exportedPublicKey.kty}`);
+        println(`exportedPublicKey alg: ${exportedPublicKey.alg}`);
+        println(`exportedPublicKey exponent: ${exportedPublicKey.e}`);
+        println(`exportedPublicKey key_ops: ${exportedPublicKey.key_ops}`);
+        println(`exportedPublicKey ext: ${exportedPublicKey.ext}`);
+
+        let exportedPrivateKey = await window.crypto.subtle.exportKey("jwk", key.privateKey);
+        println(`exportedPrivateKey kwt: ${exportedPrivateKey.kty}`);
+        println(`exportedPrivateKey alg: ${exportedPrivateKey.alg}`);
+        println(`exportedPrivateKey exponent: ${exportedPrivateKey.e}`);
+        println(`exportedPrivateKey key_ops: ${exportedPrivateKey.key_ops}`);
+        println(`exportedPrivateKey ext: ${exportedPrivateKey.ext}`);
+
+        let exportedPublicKey2 = await window.crypto.subtle.exportKey("spki", key.publicKey);
+        println(`FIXME: exportedPublicKey2: ${bufferToHex(exportedPublicKey2)}`);
+
+        try {
+            let exportedPrivateKey2 = await window.crypto.subtle.exportKey("spki", key.privateKey);
+            println("FAIL: Shouldn't be able to export private key as spki");
+        } catch (e) {
+            println(`exportKey spki private key: ${e.name} ${e.message}`);
+        }
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-generateKey.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-generateKey.html
@@ -5,11 +5,11 @@
     }
 
     asyncTest(async done => {
-
-        // FIXME: Generate a key with module lengths longer than 512, when they don't take an eternity to generate.
+        // FIXME: Generate a key with module lengths longer than 256, when they don't take an eternity to generate.
+        //        This is #23561
         let algorithm = {
             name: "RSA-OAEP",
-            modulusLength: 512,
+            modulusLength: 256,
             publicExponent: new Uint8Array([1, 0, 1]),
             hash: "SHA-256",
         };
@@ -17,11 +17,12 @@
         println("generateKey with RSA-OAEP algorithm");
         var key = undefined;
         try {
-            key = await window.crypto.subtle.generateKey(
-                algorithm,
-                true,
-                ["encrypt", "decrypt", "wrapKey", "unwrapKey"]
-            );
+            key = await window.crypto.subtle.generateKey(algorithm, true, [
+                "encrypt",
+                "decrypt",
+                "wrapKey",
+                "unwrapKey",
+            ]);
         } catch (e) {
             println(`FAIL: ${e}`);
         }
@@ -41,22 +42,23 @@
 
         println("invalid usages throw");
         try {
-            const key2 = await window.crypto.subtle.generateKey(
-                algorithm,
-                true,
-                ["encrypt", "decrypt", "wrapKey", "unwrapKey", "sign"]
-            );
+            const key2 = await window.crypto.subtle.generateKey(algorithm, true, [
+                "encrypt",
+                "decrypt",
+                "wrapKey",
+                "unwrapKey",
+                "sign",
+            ]);
         } catch (e) {
             println(`Error: ${e}`);
         }
 
         println("no usages for private key throws");
         try {
-            const key3 = await window.crypto.subtle.generateKey(
-                algorithm,
-                true,
-                ["encrypt", "wrapKey"]
-            );
+            const key3 = await window.crypto.subtle.generateKey(algorithm, true, [
+                "encrypt",
+                "wrapKey",
+            ]);
         } catch (e) {
             println(`Error: ${e}`);
         }

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     Clipboard/Clipboard.cpp
     Crypto/Crypto.cpp
     Crypto/CryptoAlgorithms.cpp
+    Crypto/CryptoBindings.cpp
     Crypto/KeyAlgorithms.cpp
     Crypto/CryptoKey.cpp
     Crypto/SubtleCrypto.cpp

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -57,6 +57,8 @@ static ::Crypto::UnsignedBigInteger big_integer_from_api_big_integer(JS::GCPtr<J
     return result;
 }
 
+AlgorithmParams::~AlgorithmParams() = default;
+
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AlgorithmParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
@@ -64,8 +66,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AlgorithmParams::from_valu
     auto name = TRY(object.get("name"));
     auto name_string = TRY(name.to_string(vm));
 
-    return adopt_own(*new AlgorithmParams { .name = name_string });
+    return adopt_own(*new AlgorithmParams { name_string });
 }
+
+PBKDF2Params::~PBKDF2Params() = default;
 
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> PBKDF2Params::from_value(JS::VM& vm, JS::Value value)
 {
@@ -96,8 +100,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> PBKDF2Params::from_value(J
         hash = HashAlgorithmIdentifier { hash_object };
     }
 
-    return adopt_own<AlgorithmParams>(*new PBKDF2Params { { name }, salt, iterations, hash.downcast<HashAlgorithmIdentifier>() });
+    return adopt_own<AlgorithmParams>(*new PBKDF2Params { name, salt, iterations, hash.downcast<HashAlgorithmIdentifier>() });
 }
+
+RsaKeyGenParams::~RsaKeyGenParams() = default;
 
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaKeyGenParams::from_value(JS::VM& vm, JS::Value value)
 {
@@ -117,8 +123,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaKeyGenParams::from_valu
 
     public_exponent = static_cast<JS::Uint8Array&>(public_exponent_value.as_object());
 
-    return adopt_own<AlgorithmParams>(*new RsaKeyGenParams { { name }, modulus_length, big_integer_from_api_big_integer(public_exponent) });
+    return adopt_own<AlgorithmParams>(*new RsaKeyGenParams { name, modulus_length, big_integer_from_api_big_integer(public_exponent) });
 }
+
+RsaHashedKeyGenParams::~RsaHashedKeyGenParams() = default;
 
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedKeyGenParams::from_value(JS::VM& vm, JS::Value value)
 {
@@ -148,7 +156,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedKeyGenParams::fro
         hash = HashAlgorithmIdentifier { hash_object };
     }
 
-    return adopt_own<AlgorithmParams>(*new RsaHashedKeyGenParams { { { name }, modulus_length, big_integer_from_api_big_integer(public_exponent) }, hash.get<HashAlgorithmIdentifier>() });
+    return adopt_own<AlgorithmParams>(*new RsaHashedKeyGenParams { name, modulus_length, big_integer_from_api_big_integer(public_exponent), hash.get<HashAlgorithmIdentifier>() });
 }
 
 // https://w3c.github.io/webcrypto/#rsa-oaep-operations

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -25,6 +25,12 @@ using KeyDataType = Variant<JS::Handle<WebIDL::BufferSource>, Bindings::JsonWebK
 
 // https://w3c.github.io/webcrypto/#algorithm-overview
 struct AlgorithmParams {
+    virtual ~AlgorithmParams();
+    explicit AlgorithmParams(String name)
+        : name(move(name))
+    {
+    }
+
     String name;
 
     static JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> from_value(JS::VM&, JS::Value);
@@ -32,6 +38,15 @@ struct AlgorithmParams {
 
 // https://w3c.github.io/webcrypto/#pbkdf2-params
 struct PBKDF2Params : public AlgorithmParams {
+    virtual ~PBKDF2Params() override;
+    PBKDF2Params(String name, JS::Handle<WebIDL::BufferSource> salt, u32 iterations, HashAlgorithmIdentifier hash)
+        : AlgorithmParams(move(name))
+        , salt(move(salt))
+        , iterations(iterations)
+        , hash(move(hash))
+    {
+    }
+
     JS::Handle<WebIDL::BufferSource> salt;
     u32 iterations;
     HashAlgorithmIdentifier hash;
@@ -41,6 +56,15 @@ struct PBKDF2Params : public AlgorithmParams {
 
 // https://w3c.github.io/webcrypto/#dfn-RsaKeyGenParams
 struct RsaKeyGenParams : public AlgorithmParams {
+    virtual ~RsaKeyGenParams() override;
+
+    RsaKeyGenParams(String name, u32 modulus_length, ::Crypto::UnsignedBigInteger public_exponent)
+        : AlgorithmParams(move(name))
+        , modulus_length(modulus_length)
+        , public_exponent(move(public_exponent))
+    {
+    }
+
     u32 modulus_length;
     // NOTE that the raw data is going to be in Big Endian u8[] format
     ::Crypto::UnsignedBigInteger public_exponent;
@@ -50,6 +74,14 @@ struct RsaKeyGenParams : public AlgorithmParams {
 
 // https://w3c.github.io/webcrypto/#dfn-RsaHashedKeyGenParams
 struct RsaHashedKeyGenParams : public RsaKeyGenParams {
+    virtual ~RsaHashedKeyGenParams() override;
+
+    RsaHashedKeyGenParams(String name, u32 modulus_length, ::Crypto::UnsignedBigInteger public_exponent, HashAlgorithmIdentifier hash)
+        : RsaKeyGenParams(move(name), modulus_length, move(public_exponent))
+        , hash(move(hash))
+    {
+    }
+
     HashAlgorithmIdentifier hash;
 
     static JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> from_value(JS::VM&, JS::Value);

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -106,6 +106,11 @@ public:
         return WebIDL::NotSupportedError::create(m_realm, "generateKey is not supported"_fly_string);
     }
 
+    virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> export_key(Bindings::KeyFormat, JS::NonnullGCPtr<CryptoKey>)
+    {
+        return WebIDL::NotSupportedError::create(m_realm, "exportKey is not supported"_fly_string);
+    }
+
     static NonnullOwnPtr<AlgorithmMethods> create(JS::Realm& realm) { return adopt_own(*new AlgorithmMethods(realm)); }
 
 protected:
@@ -120,6 +125,7 @@ protected:
 class RSAOAEP : public AlgorithmMethods {
 public:
     virtual WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<CryptoKeyPair>>> generate_key(AlgorithmParams const&, bool, Vector<Bindings::KeyUsage> const&) override;
+    virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> export_key(Bindings::KeyFormat, JS::NonnullGCPtr<CryptoKey>) override;
 
     static NonnullOwnPtr<AlgorithmMethods> create(JS::Realm& realm) { return adopt_own(*new RSAOAEP(realm)); }
 
@@ -155,5 +161,7 @@ private:
     {
     }
 };
+
+ErrorOr<String> base64_url_uint_encode(::Crypto::UnsignedBigInteger);
 
 }

--- a/Userland/Libraries/LibWeb/Crypto/CryptoBindings.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoBindings.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Crypto/CryptoBindings.h>
+
+namespace Web::Bindings {
+
+JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> JsonWebKey::to_object(JS::Realm& realm)
+{
+    auto& vm = realm.vm();
+    auto object = JS::Object::create(realm, realm.intrinsics().object_prototype());
+
+    if (kty.has_value())
+        TRY(object->create_data_property("kty", JS::PrimitiveString::create(vm, kty.value())));
+
+    if (use.has_value())
+        TRY(object->create_data_property("use", JS::PrimitiveString::create(vm, use.value())));
+
+    if (key_ops.has_value()) {
+        auto key_ops_array = JS::Array::create_from<String>(realm, key_ops.value().span(), [&](auto& key_usage) -> JS::Value {
+            return JS::PrimitiveString::create(realm.vm(), key_usage);
+        });
+        TRY(object->create_data_property("key_ops", move(key_ops_array)));
+    }
+
+    if (alg.has_value())
+        TRY(object->create_data_property("alg", JS::PrimitiveString::create(vm, alg.value())));
+
+    if (ext.has_value())
+        TRY(object->create_data_property("ext", JS::Value(ext.value())));
+
+    if (crv.has_value())
+        TRY(object->create_data_property("crv", JS::PrimitiveString::create(vm, crv.value())));
+
+    if (x.has_value())
+        TRY(object->create_data_property("x", JS::PrimitiveString::create(vm, x.value())));
+
+    if (y.has_value())
+        TRY(object->create_data_property("y", JS::PrimitiveString::create(vm, y.value())));
+
+    if (d.has_value())
+        TRY(object->create_data_property("d", JS::PrimitiveString::create(vm, d.value())));
+
+    if (n.has_value())
+        TRY(object->create_data_property("n", JS::PrimitiveString::create(vm, n.value())));
+
+    if (e.has_value())
+        TRY(object->create_data_property("e", JS::PrimitiveString::create(vm, e.value())));
+
+    if (p.has_value())
+        TRY(object->create_data_property("p", JS::PrimitiveString::create(vm, p.value())));
+
+    if (q.has_value())
+        TRY(object->create_data_property("q", JS::PrimitiveString::create(vm, q.value())));
+
+    if (dp.has_value())
+        TRY(object->create_data_property("dp", JS::PrimitiveString::create(vm, dp.value())));
+
+    if (dq.has_value())
+        TRY(object->create_data_property("dq", JS::PrimitiveString::create(vm, dq.value())));
+
+    if (qi.has_value())
+        TRY(object->create_data_property("qi", JS::PrimitiveString::create(vm, qi.value())));
+
+    if (oth.has_value()) {
+        TODO();
+    }
+
+    if (k.has_value())
+        TRY(object->create_data_property("k", JS::PrimitiveString::create(vm, k.value())));
+
+    return object;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Crypto/CryptoBindings.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoBindings.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, stelar7 <dudedbz@gmail.com>
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,8 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibJS/Runtime/Object.h>
-#include <LibWeb/WebIDL/Buffers.h>
+#include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
 // FIXME: Generate these from IDL
 namespace Web::Bindings {
@@ -42,6 +42,8 @@ struct JsonWebKey {
     Optional<String> qi;
     Optional<Vector<RsaOtherPrimesInfo>> oth;
     Optional<String> k;
+
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> to_object(JS::Realm&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Crypto/CryptoKey.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoKey.h
@@ -39,6 +39,8 @@ public:
     void set_algorithm(JS::NonnullGCPtr<Object> algorithm) { m_algorithm = move(algorithm); }
     void set_usages(Vector<Bindings::KeyUsage>);
 
+    InternalKeyData const& handle() const { return m_key_data; }
+
 private:
     CryptoKey(JS::Realm&, InternalKeyData);
     virtual void initialize(JS::Realm&) override;
@@ -50,7 +52,7 @@ private:
     JS::NonnullGCPtr<Object> m_usages;
 
     Vector<Bindings::KeyUsage> m_key_usages;
-    InternalKeyData m_key_data;
+    InternalKeyData m_key_data; // [[handle]]
 };
 
 // https://w3c.github.io/webcrypto/#ref-for-dfn-CryptoKeyPair-2

--- a/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
@@ -90,15 +90,16 @@ WebIDL::ExceptionOr<void> RsaKeyAlgorithm::set_public_exponent(::Crypto::Unsigne
 
     auto bytes = TRY_OR_THROW_OOM(vm, ByteBuffer::create_uninitialized(exponent.trimmed_byte_length()));
 
-    bool const strip_leading_zeroes = true;
-    auto data_size = exponent.export_data(bytes.span(), strip_leading_zeroes);
+    bool const remove_leading_zeroes = true;
+    auto data_size = exponent.export_data(bytes.span(), remove_leading_zeroes);
+    auto data_slice = bytes.bytes().slice(bytes.size() - data_size, data_size);
 
     // The BigInteger typedef from the WebCrypto spec requires the bytes in the Uint8Array be ordered in Big Endian
 
     Vector<u8, 32> byte_swapped_data;
     byte_swapped_data.ensure_capacity(data_size);
     for (size_t i = 0; i < data_size; ++i)
-        byte_swapped_data.append(bytes[data_size - i - 1]);
+        byte_swapped_data.append(data_slice[data_size - i - 1]);
 
     m_public_exponent = TRY(JS::Uint8Array::create(realm, byte_swapped_data.size()));
     m_public_exponent->viewed_array_buffer()->buffer().overwrite(0, byte_swapped_data.data(), byte_swapped_data.size());

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
@@ -14,7 +14,6 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Bindings/SubtleCryptoPrototype.h>
 #include <LibWeb/Crypto/CryptoAlgorithms.h>
-#include <LibWeb/Crypto/CryptoBindings.h>
 #include <LibWeb/Crypto/CryptoKey.h>
 
 namespace Web::Crypto {
@@ -39,6 +38,7 @@ public:
     JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> generate_key(AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
 
     JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> import_key(Bindings::KeyFormat format, KeyDataType key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> export_key(Bindings::KeyFormat format, JS::NonnullGCPtr<CryptoKey> key);
 
 private:
     explicit SubtleCrypto(JS::Realm&);

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.idl
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.idl
@@ -57,7 +57,7 @@ interface SubtleCrypto {
     // FIXME: Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, unsigned long length);
 
     Promise<CryptoKey> importKey(KeyFormat format, (BufferSource or JsonWebKey) keyData,  AlgorithmIdentifier algorithm, boolean extractable, sequence<KeyUsage> keyUsages);
-    // FIXME: Promise<any> exportKey(KeyFormat format, CryptoKey key);
+    Promise<any> exportKey(KeyFormat format, CryptoKey key);
 
     // FIXME: Promise<any> wrapKey(KeyFormat format, CryptoKey key, CryptoKey wrappingKey, AlgorithmIdentifier wrapAlgorithm);
     // FIXME: Promise<CryptoKey> unwrapKey(KeyFormat format, BufferSource wrappedKey, CryptoKey unwrappingKey, AlgorithmIdentifier unwrapAlgorithm, AlgorithmIdentifier unwrappedKeyAlgorithm, boolean extractable, sequence<KeyUsage> keyUsages);


### PR DESCRIPTION
With a bonus ASAN/UBSAN fix, and a boog fix for the previous PR.

Part of #23484