### PR TITLE
MacPDF: Add "Show Images" debug menu entry

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
@@ -30,5 +30,6 @@
 - (IBAction)toggleClipImages:(id)sender;
 - (IBAction)toggleClipPaths:(id)sender;
 - (IBAction)toggleClipText:(id)sender;
+- (IBAction)toggleShowImages:(id)sender;
 
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -181,6 +181,10 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
         [item setState:_preferences.clip_text ? NSControlStateValueOn : NSControlStateValueOff];
         return _doc ? YES : NO;
     }
+    if ([item action] == @selector(toggleShowImages:)) {
+        [item setState:_preferences.show_images ? NSControlStateValueOn : NSControlStateValueOff];
+        return _doc ? YES : NO;
+    }
     return NO;
 }
 
@@ -212,6 +216,14 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
 {
     if (_doc) {
         _preferences.clip_text = !_preferences.clip_text;
+        [self invalidateCachedBitmap];
+    }
+}
+
+- (IBAction)toggleShowImages:(id)sender
+{
+    if (_doc) {
+        _preferences.show_images = !_preferences.show_images;
         [self invalidateCachedBitmap];
     }
 }

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)toggleClipImages:(id)sender;
 - (IBAction)toggleClipPaths:(id)sender;
 - (IBAction)toggleClipText:(id)sender;
+- (IBAction)toggleShowImages:(id)sender;
 - (IBAction)showGoToPageDialog:(id)sender;
 
 - (void)pdfDidInitialize;

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -159,6 +159,11 @@
     [_pdfView toggleClipText:sender];
 }
 
+- (IBAction)toggleShowImages:(id)sender
+{
+    [_pdfView toggleShowImages:sender];
+}
+
 - (IBAction)showGoToPageDialog:(id)sender
 {
     auto alert = [[NSAlert alloc] init];

--- a/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
+++ b/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -670,13 +670,13 @@
                                     <action selector="toggleShowClippingPaths:" target="-1" id="ZXz-gM-52n"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Clip Images" id="os0-En-UkL">
+                            <menuItem title="Clip Images" state="on" id="os0-En-UkL">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleClipImages:" target="-1" id="bHz-O3-V8K"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Clip Paths" id="KB8-Ld-jv8">
+                            <menuItem title="Clip Paths" state="on" id="KB8-Ld-jv8">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleClipPaths:" target="-1" id="pZu-tJ-RFh"/>
@@ -686,6 +686,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleClipText:" target="-1" id="qxg-tH-KXd"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show images" state="on" id="ArW-nr-ktv">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleShowImages:" target="-1" id="mNE-9J-Nle"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
PDFViewer has this, and it's useful for PDFs that have the same text both as a scanned bitmap in the background as well as using vector text in the foreground.

xib changes: Added a new menu entry connected to `toggleShowImages:`, and also toggled the initial state of two menu entries. (The latter part has no effect when the program runs since we dynamically update this state, but it makes the menu entries show their initial state in Xcode's menu editor.)