### PR TITLE
LibGfx/JBIG2: Simplify and restrict adaptive template pixel reading

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -599,6 +599,8 @@ static ErrorOr<void> decode_immediate_generic_region(JBIG2LoadingContext& contex
     // 7.4.6.3 Generic region segment AT flags
     GenericRegionDecodingInputParameters::AdaptiveTemplatePixel adaptive_template_pixels[12];
     if (!uses_mmr) {
+        dbgln_if(JBIG2_DEBUG, "Non-MMR generic region, GBTEMPLATE={} TPGDON={} EXTTEMPLATE={}", arithmetic_coding_template, typical_prediction_generic_decoding_on, uses_extended_reference_template);
+
         if (arithmetic_coding_template == 0 && !uses_extended_reference_template) {
             if (data.size() < 8)
                 return Error::from_string_literal("JBIG2ImageDecoderPlugin: No adaptive template data");


### PR DESCRIPTION
EXTTEMPLATE=1 was added later and doesn't seem to be used much in
practice -- it doesn't appear in no simple generic regions in any PDF
I tested so far at least. Since the spec contradicts itself on what
to do with these as far as I can tell, error out on them for now and
then add support once we find actual files using this, so that we can
check our implementation actually works.

Deduplicate the data reading for the different cases, and
zero-initialize all adaptive template pixels to zero to make that
possible.

Other than prohibiting EXTTEMPLATE=1, no behavior change.