### PR TITLE
Userland/mount: Fix srcobfuscate => srchidden when printing mounts

### DIFF
--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -184,7 +184,7 @@ static ErrorOr<void> print_mounts()
         if (mount_flags & MS_NOREGULAR)
             out(",noregular");
         if (mount_flags & MS_SRCHIDDEN)
-            out(",srcobfuscate");
+            out(",srchidden");
         if (mount_flags & MS_NOEXEC)
             out(",noexec");
         if (mount_flags & MS_NOSUID)


### PR DESCRIPTION
Fixes 0734de9f9a1f3cd945e9df230eb52fc475810b53.
By mistake, I forgot to change this instance to "srchidden", so let's fix this.