### PR TITLE
LibWeb: Add fast path for animated style properties update

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/Performance.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -1315,8 +1316,8 @@ JS::NonnullGCPtr<WebIDL::Promise> Animation::current_finished_promise() const
 void Animation::invalidate_effect()
 {
     if (m_effect) {
-        if (auto target = m_effect->target())
-            target->invalidate_style();
+        if (auto target = m_effect->target(); target && target->paintable())
+            target->paintable()->set_needs_display();
     }
 }
 

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -49,11 +49,6 @@ Bindings::PlaybackDirection css_animation_direction_to_bindings_playback_directi
     }
 }
 
-JS::NonnullGCPtr<AnimationEffect> AnimationEffect::create(JS::Realm& realm)
-{
-    return realm.heap().allocate<AnimationEffect>(realm, realm);
-}
-
 OptionalEffectTiming EffectTiming::to_optional_effect_timing() const
 {
     return {

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -67,8 +67,6 @@ class AnimationEffect : public Bindings::PlatformObject {
 public:
     static RefPtr<CSS::StyleValue const> parse_easing_string(JS::Realm& realm, StringView value);
 
-    static JS::NonnullGCPtr<AnimationEffect> create(JS::Realm&);
-
     EffectTiming get_timing() const;
     ComputedEffectTiming get_computed_timing() const;
     WebIDL::ExceptionOr<void> update_timing(OptionalEffectTiming timing = {});

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -146,6 +146,8 @@ public:
     virtual DOM::Element* target() const { return {}; }
     virtual bool is_keyframe_effect() const { return false; }
 
+    virtual void update_style_properties() = 0;
+
 protected:
     AnimationEffect(JS::Realm&);
     virtual ~AnimationEffect() = default;

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -103,6 +103,8 @@ public:
 
     virtual bool is_keyframe_effect() const override { return true; }
 
+    virtual void update_style_properties() override;
+
 private:
     KeyframeEffect(JS::Realm&);
     virtual ~KeyframeEffect() override = default;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -166,6 +166,8 @@ public:
         static RequiredInvalidationAfterStyleChange full() { return { true, true, true, true }; }
     };
 
+    static Element::RequiredInvalidationAfterStyleChange compute_required_invalidation(CSS::StyleProperties const& old_style, CSS::StyleProperties const& new_style);
+
     RequiredInvalidationAfterStyleChange recompute_style();
 
     Optional<CSS::Selector::PseudoElement::Type> use_pseudo_element() const { return m_use_pseudo_element; }
@@ -178,6 +180,8 @@ public:
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }
     void set_computed_css_values(RefPtr<CSS::StyleProperties>);
     NonnullRefPtr<CSS::StyleProperties> resolved_css_values();
+
+    void reset_animated_css_properties();
 
     CSS::CSSStyleDeclaration const* inline_style() const;
 


### PR DESCRIPTION
Patch up existing style properties instead of using the regular style invalidation path, which requires rule matching for each element in the invalidated subtree.

Special handling is required for:
- !important properties: this change introduces a flag used to skip the update of animated properties overridden by !important.
- inherited animated properties: for now, these are invalidated by traversing animated element's subtree to propagate the update.
- if an animation has ended, patching is not possible, and complete invalidation of the element's style is required to remove cascaded animated properties.