### PR TITLE
Ladybird+LibWeb: Support the `accept` attribute on `<input type=file>` elements

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -210,7 +210,7 @@ public:
         return size();
     }
 
-    [[nodiscard]] bool constexpr contains_slow(T const& value) const
+    [[nodiscard]] constexpr bool contains_slow(T const& value) const
     {
         for (size_t i = 0; i < size(); ++i) {
             if (at(i) == value)
@@ -219,7 +219,7 @@ public:
         return false;
     }
 
-    [[nodiscard]] bool constexpr starts_with(ReadonlySpan<T> other) const
+    [[nodiscard]] constexpr bool starts_with(ReadonlySpan<T> other) const
     {
         if (size() < other.size())
             return false;
@@ -227,7 +227,7 @@ public:
         return TypedTransfer<T>::compare(data(), other.data(), other.size());
     }
 
-    [[nodiscard]] size_t constexpr matching_prefix_length(ReadonlySpan<T> other) const
+    [[nodiscard]] constexpr size_t matching_prefix_length(ReadonlySpan<T> other) const
     {
         auto maximum_length = min(size(), other.size());
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -210,10 +210,11 @@ public:
         return size();
     }
 
-    [[nodiscard]] constexpr bool contains_slow(T const& value) const
+    template<typename V>
+    [[nodiscard]] constexpr bool contains_slow(V const& value) const
     {
         for (size_t i = 0; i < size(); ++i) {
-            if (at(i) == value)
+            if (Traits<RemoveReference<T>>::equals(at(i), value))
                 return true;
         }
         return false;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -626,7 +626,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [panel makeKeyAndOrderFront:nil];
     };
 
-    m_web_view_bridge->on_request_file_picker = [self](auto allow_multiple_files) {
+    m_web_view_bridge->on_request_file_picker = [self](auto const&, auto allow_multiple_files) {
         auto* panel = [NSOpenPanel openPanel];
         [panel setCanChooseFiles:YES];
         [panel setCanChooseDirectories:NO];

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -149,7 +149,7 @@ elseif (APPLE)
         AppKit/Utilities/Conversions.mm
     )
     target_include_directories(ladybird PRIVATE AppKit)
-    target_link_libraries(ladybird PRIVATE "-framework Cocoa" LibUnicode)
+    target_link_libraries(ladybird PRIVATE "-framework Cocoa -framework UniformTypeIdentifiers" LibUnicode)
     target_compile_options(ladybird PRIVATE
         -fobjc-arc
         -Wno-deprecated-anon-enum-enum-conversion # Required for CGImageCreate

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -232,7 +232,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_dialog = nullptr;
     };
 
-    view().on_request_file_picker = [this](auto allow_multiple_files) {
+    view().on_request_file_picker = [this](auto const&, auto allow_multiple_files) {
         Vector<Web::HTML::SelectedFile> selected_files;
 
         auto create_selected_file = [&](auto const& qfile_path) {

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -134,7 +134,10 @@ executable("ladybird_executable") {
       "//Userland",
     ]
 
-    frameworks = [ "Cocoa.framework" ]
+    frameworks = [
+      "Cocoa.framework",
+      "UniformTypeIdentifiers.framework",
+    ]
   }
 
   if (current_os != "mac") {

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
@@ -31,6 +31,7 @@ source_set("HTML") {
     "ErrorEvent.cpp",
     "EventHandler.cpp",
     "EventNames.cpp",
+    "FileFilter.cpp",
     "Focus.cpp",
     "FormAssociatedElement.cpp",
     "FormControlInfrastructure.cpp",

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -138,3 +138,24 @@ TEST_CASE(starts_with)
     ReadonlyBytes hey_bytes_u8 { hey_array, 3 };
     EXPECT(bytes.starts_with(hey_bytes_u8));
 }
+
+TEST_CASE(contains_slow)
+{
+    Vector<String> list { "abc"_string, "def"_string, "ghi"_string };
+    auto span = list.span();
+
+    EXPECT(span.contains_slow("abc"_string));
+    EXPECT(span.contains_slow("abc"sv));
+
+    EXPECT(span.contains_slow("def"_string));
+    EXPECT(span.contains_slow("def"sv));
+
+    EXPECT(span.contains_slow("ghi"_string));
+    EXPECT(span.contains_slow("ghi"sv));
+
+    EXPECT(!span.contains_slow("whf"_string));
+    EXPECT(!span.contains_slow("whf"sv));
+
+    EXPECT(!span.contains_slow(String {}));
+    EXPECT(!span.contains_slow(StringView {}));
+}

--- a/Tests/LibWeb/Text/expected/input-file-accept.txt
+++ b/Tests/LibWeb/Text/expected/input-file-accept.txt
@@ -1,0 +1,12 @@
+Select file...file1 Select files...4 files selected. Select file...file1.cpp Select files...2 files selected.   input1:
+file1: text/plain: Contents for file1
+input2:
+file1: text/plain: Contents for file1
+file2: text/plain: Contents for file2
+file3: text/plain: Contents for file3
+file4: text/plain: Contents for file4
+input3:
+file1.cpp: text/plain: int main() {{ return 1; }}
+input4:
+file1.cpp: text/plain: int main() {{ return 1; }}
+file2.cpp: text/plain: int main() {{ return 2; }}

--- a/Tests/LibWeb/Text/input/input-file-accept.html
+++ b/Tests/LibWeb/Text/input/input-file-accept.html
@@ -1,0 +1,34 @@
+<input id="input1" type="file" accept="text/plain" />
+<input id="input2" type="file" accept="text/plain" multiple />
+<input id="input3" type="file" accept=".cpp" />
+<input id="input4" type="file" accept=".cpp" multiple />
+<script src="./include.js"></script>
+<script type="text/javascript">
+    const runTest = async id => {
+        let input = document.getElementById(id);
+
+        return new Promise(resolve => {
+            input.addEventListener("input", async () => {
+                println(`${id}:`);
+
+                for (let file of input.files) {
+                    const text = await file.text();
+                    println(`${file.name}: ${file.type}: ${text}`);
+                }
+
+                resolve();
+            });
+
+            internals.dispatchUserActivatedEvent(input, new Event("mousedown"));
+            input.showPicker();
+        });
+    };
+
+    asyncTest(async done => {
+        await runTest("input1");
+        await runTest("input2");
+        await runTest("input3");
+        await runTest("input4");
+        done();
+    });
+</script>

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -556,7 +556,7 @@ Tab::Tab(BrowserWindow& window)
         m_dialog = nullptr;
     };
 
-    view().on_request_file_picker = [this](auto allow_multiple_files) {
+    view().on_request_file_picker = [this](auto const&, auto allow_multiple_files) {
         // FIXME: GUI::FilePicker does not allow selecting multiple files at once.
         (void)allow_multiple_files;
 

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -168,14 +168,14 @@ Optional<StringView> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes bytes)
     return {};
 }
 
-Optional<StringView> get_description_from_mime_type(StringView mime_name)
+Optional<MimeType const&> get_mime_type_data(StringView mime_name)
 {
     for (auto const& mime_type : s_registered_mime_type) {
         if (mime_name == mime_type.name)
-            return mime_type.description;
+            return mime_type;
     }
 
-    return OptionalNone {};
+    return {};
 }
 
 Optional<StringView> guess_mime_type_based_on_sniffed_bytes(Core::File& file)

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -61,6 +61,6 @@ struct MimeType {
     u64 offset { 0 };
 };
 
-Optional<StringView> get_description_from_mime_type(StringView);
+Optional<MimeType const&> get_mime_type_data(StringView);
 
 }

--- a/Userland/Libraries/LibGUI/FileTypeFilter.h
+++ b/Userland/Libraries/LibGUI/FileTypeFilter.h
@@ -23,9 +23,19 @@ struct FileTypeFilter {
         return FileTypeFilter { "All Files", {} };
     }
 
+    static FileTypeFilter audio_files()
+    {
+        return FileTypeFilter { "Audio Files", Vector<ByteString> { "flac", "m3u", "m3u8", "m4a", "m4b", "m4r", "mid", "midi", "mka", "mp3", "mpga", "oga", "ogg", "opus", "spx", "vlc", "wav", "wax", "wma", "wmx", "wvx" } };
+    }
+
     static FileTypeFilter image_files()
     {
         return FileTypeFilter { "Image Files", Vector<ByteString> { "png", "gif", "bmp", "dip", "pam", "pbm", "pgm", "ppm", "ico", "iff", "jb2", "jbig2", "jpeg", "jpg", "jxl", "dds", "qoi", "tif", "tiff", "webp", "tvg" } };
+    }
+
+    static FileTypeFilter video_files()
+    {
+        return FileTypeFilter { "Video Files", Vector<ByteString> { "avf", "avi", "flv", "m4u", "m4v", "mk3d", "mkv", "mov", "movie", "mp4", "mpeg", "mpg", "ogg", "ogv", "vob", "webm", "wmv" } };
     }
 };
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -268,6 +268,7 @@ set(SOURCES
     HTML/EventLoop/Task.cpp
     HTML/EventLoop/TaskQueue.cpp
     HTML/EventNames.cpp
+    HTML/FileFilter.cpp
     HTML/Focus.cpp
     HTML/FormAssociatedElement.cpp
     HTML/FormControlInfrastructure.cpp

--- a/Userland/Libraries/LibWeb/HTML/FileFilter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FileFilter.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/FileFilter.h>
+
+namespace Web::HTML {
+
+void FileFilter::add_filter(FilterType filter)
+{
+    if (!filters.contains_slow(filter))
+        filters.append(move(filter));
+}
+
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::FileFilter::MimeType const& mime_type)
+{
+    TRY(encoder.encode(mime_type.value));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::FileFilter::MimeType> IPC::decode(Decoder& decoder)
+{
+    auto value = TRY(decoder.decode<String>());
+    return Web::HTML::FileFilter::MimeType { move(value) };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::FileFilter::Extension const& extension)
+{
+    TRY(encoder.encode(extension.value));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::FileFilter::Extension> IPC::decode(Decoder& decoder)
+{
+    auto value = TRY(decoder.decode<String>());
+    return Web::HTML::FileFilter::Extension { move(value) };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::FileFilter const& filter)
+{
+    TRY(encoder.encode(filter.filters));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::FileFilter> IPC::decode(Decoder& decoder)
+{
+    auto filters = TRY(decoder.decode<Vector<Web::HTML::FileFilter::FilterType>>());
+    return Web::HTML::FileFilter { move(filters) };
+}

--- a/Userland/Libraries/LibWeb/HTML/FileFilter.h
+++ b/Userland/Libraries/LibWeb/HTML/FileFilter.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibIPC/Forward.h>
+
+namespace Web::HTML {
+
+struct FileFilter {
+    enum class FileType {
+        Audio,
+        Image,
+        Video,
+    };
+
+    struct MimeType {
+        bool operator==(MimeType const&) const = default;
+        String value;
+    };
+
+    struct Extension {
+        bool operator==(Extension const&) const = default;
+        String value;
+    };
+
+    using FilterType = Variant<FileType, MimeType, Extension>;
+
+    void add_filter(FilterType);
+
+    Vector<FilterType> filters;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::FileFilter::MimeType const&);
+
+template<>
+ErrorOr<Web::HTML::FileFilter::MimeType> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::FileFilter::Extension const&);
+
+template<>
+ErrorOr<Web::HTML::FileFilter::Extension> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::FileFilter const&);
+
+template<>
+ErrorOr<Web::HTML::FileFilter> decode(Decoder&);
+
+}

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -12,6 +12,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/FileAPI/FileList.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Layout/ImageProvider.h>
@@ -101,6 +102,8 @@ public:
 
     JS::GCPtr<FileAPI::FileList> files();
     void set_files(JS::GCPtr<FileAPI::FileList>);
+
+    FileFilter parse_accept_attribute() const;
 
     // NOTE: User interaction
     // https://html.spec.whatwg.org/multipage/input.html#update-the-file-selection

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -344,13 +344,13 @@ void Page::color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUp
     }
 }
 
-void Page::did_request_file_picker(WeakPtr<HTML::HTMLInputElement> target, HTML::AllowMultipleFiles allow_multiple_files)
+void Page::did_request_file_picker(WeakPtr<HTML::HTMLInputElement> target, HTML::FileFilter accepted_file_types, HTML::AllowMultipleFiles allow_multiple_files)
 {
     if (m_pending_non_blocking_dialog == PendingNonBlockingDialog::None) {
         m_pending_non_blocking_dialog = PendingNonBlockingDialog::FilePicker;
         m_pending_non_blocking_dialog_target = move(target);
 
-        m_client->page_did_request_file_picker(allow_multiple_files);
+        m_client->page_did_request_file_picker(move(accepted_file_types), allow_multiple_files);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -31,6 +31,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
 #include <LibWeb/HTML/WebViewHints.h>
@@ -134,7 +135,7 @@ public:
     void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
     void color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUpdateState state);
 
-    void did_request_file_picker(WeakPtr<HTML::HTMLInputElement> target, HTML::AllowMultipleFiles);
+    void did_request_file_picker(WeakPtr<HTML::HTMLInputElement> target, HTML::FileFilter accepted_file_types, HTML::AllowMultipleFiles);
     void file_picker_closed(Span<HTML::SelectedFile> selected_files);
 
     void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items);
@@ -285,7 +286,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
     virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) {};
-    virtual void page_did_request_file_picker(Web::HTML::AllowMultipleFiles) {};
+    virtual void page_did_request_file_picker([[maybe_unused]] HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) {};
     virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) {};
 
     virtual void page_did_finish_text_test() {};

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -18,6 +18,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWebView/Forward.h>
@@ -170,7 +171,7 @@ public:
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
     Function<void(Color current_color)> on_request_color_picker;
-    Function<void(Web::HTML::AllowMultipleFiles)> on_request_file_picker;
+    Function<void(Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles)> on_request_file_picker;
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;
     Function<void(Web::KeyEvent const&)> on_finish_handling_key_event;
     Function<void()> on_text_test_finish;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -806,7 +806,7 @@ void WebContentClient::did_request_color_picker(u64 page_id, Color const& curren
         view.on_request_color_picker(current_color);
 }
 
-void WebContentClient::did_request_file_picker(u64 page_id, Web::HTML::AllowMultipleFiles allow_multiple_files)
+void WebContentClient::did_request_file_picker(u64 page_id, Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple_files)
 {
     auto maybe_view = m_views.get(page_id);
     if (!maybe_view.has_value()) {
@@ -816,7 +816,7 @@ void WebContentClient::did_request_file_picker(u64 page_id, Web::HTML::AllowMult
     auto& view = *maybe_view.value();
 
     if (view.on_request_file_picker)
-        view.on_request_file_picker(allow_multiple_files);
+        view.on_request_file_picker(accepted_file_types, allow_multiple_files);
 }
 
 void WebContentClient::did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -9,6 +9,7 @@
 #include <AK/HashMap.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <WebContent/WebContentClientEndpoint.h>
@@ -89,7 +90,7 @@ private:
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window(u64 page_id) override;
     virtual void did_request_file(u64 page_id, ByteString const& path, i32) override;
     virtual void did_request_color_picker(u64 page_id, Color const& current_color) override;
-    virtual void did_request_file_picker(u64 page_id, Web::HTML::AllowMultipleFiles) override;
+    virtual void did_request_file_picker(u64 page_id, Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles) override;
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items) override;
     virtual void did_finish_handling_input_event(u64 page_id, bool event_was_accepted) override;
     virtual void did_finish_text_test(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -549,9 +549,9 @@ void PageClient::page_did_request_color_picker(Color current_color)
     client().async_did_request_color_picker(m_id, current_color);
 }
 
-void PageClient::page_did_request_file_picker(Web::HTML::AllowMultipleFiles allow_multiple_files)
+void PageClient::page_did_request_file_picker(Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple_files)
 {
-    client().async_did_request_file_picker(m_id, allow_multiple_files);
+    client().async_did_request_file_picker(m_id, move(accepted_file_types), allow_multiple_files);
 }
 
 void PageClient::page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -10,6 +10,7 @@
 
 #include <LibAccelGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <WebContent/Forward.h>
@@ -133,7 +134,7 @@ private:
     virtual void page_did_close_top_level_traversable() override;
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;
-    virtual void page_did_request_file_picker(Web::HTML::AllowMultipleFiles) override;
+    virtual void page_did_request_file_picker(Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) override;
     virtual void page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void page_did_finish_text_test() override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -6,6 +6,7 @@
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/WebViewHints.h>
@@ -71,7 +72,7 @@ endpoint WebContentClient
     did_request_fullscreen_window(u64 page_id) => (Gfx::IntRect window_rect)
     did_request_file(u64 page_id, ByteString path, i32 request_id) =|
     did_request_color_picker(u64 page_id, Color current_color) =|
-    did_request_file_picker(u64 page_id, Web::HTML::AllowMultipleFiles allow_multiple_files) =|
+    did_request_file_picker(u64 page_id, Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple_files) =|
     did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) =|
     did_finish_handling_input_event(u64 page_id, bool event_was_accepted) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -168,17 +168,17 @@ static constexpr Array s_pattern_with_specialized_functions {
 
 static ErrorOr<Optional<String>> get_description_from_mime_type(StringView mime, StringView path)
 {
-    auto const description = Core::get_description_from_mime_type(mime);
+    auto const mime_type = Core::get_mime_type_data(mime);
 
-    if (!description.has_value())
+    if (!mime_type.has_value())
         return OptionalNone {};
 
     for (auto const& pattern : s_pattern_with_specialized_functions) {
         if (mime.matches(pattern.matching_pattern))
-            return pattern.details(*description, path);
+            return pattern.details(mime_type->description, path);
     }
 
-    return description_only(*description, path);
+    return description_only(mime_type->description, path);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)


### PR DESCRIPTION
As used by GitHub's file upload:
<img width="1056" alt="Screenshot 2024-03-14 at 10 56 46 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/ff2e5a9e-db8a-4e18-9316-08936a70919a">
