### PR TITLE
LibSQL: Parse column constraints

### DIFF
--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -180,6 +180,8 @@ private:
     ByteString m_collation_name;
 };
 
+class ReferencesColumnConstraint : public ColumnConstraint { };
+
 class GeneratedColumnConstraint : public ColumnConstraint {
 public:
     enum class ComputationStrategy {

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -90,6 +90,26 @@ private:
     Optional<ByteString> m_name;
 };
 
+class PrimaryKeyColumnConstraint : public ColumnConstraint {
+public:
+    PrimaryKeyColumnConstraint(Optional<ByteString> name, Order order, ConflictResolution conflict_resolution, bool autoincrement)
+        : ColumnConstraint(move(name))
+        , m_order(move(order))
+        , m_conflict_resolution(move(conflict_resolution))
+        , m_autoincrement(autoincrement)
+    {
+    }
+
+    Order const& order() const { return m_order; }
+    ConflictResolution const& conflict_resolution() const { return m_conflict_resolution; }
+    bool is_autoincrement() const { return m_autoincrement; }
+
+private:
+    Order m_order;
+    ConflictResolution m_conflict_resolution;
+    bool m_autoincrement;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
     ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -152,6 +152,20 @@ private:
     NonnullRefPtr<Expression> m_expression;
 };
 
+class CollateColumnConstraint : public ColumnConstraint {
+public:
+    CollateColumnConstraint(Optional<ByteString> name, ByteString collation_name)
+        : ColumnConstraint(move(name))
+        , m_collation_name(move(collation_name))
+    {
+    }
+
+    ByteString const& collation_name() const { return m_collation_name; }
+
+private:
+    ByteString m_collation_name;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
     ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -152,6 +152,20 @@ private:
     NonnullRefPtr<Expression> m_expression;
 };
 
+class DefaultColumnConstraint : public ColumnConstraint {
+public:
+    DefaultColumnConstraint(Optional<ByteString> name, NonnullRefPtr<Expression> expression)
+        : ColumnConstraint(move(name))
+        , m_expression(move(expression))
+    {
+    }
+
+    NonnullRefPtr<Expression> const& expression() const { return m_expression; }
+
+private:
+    NonnullRefPtr<Expression> m_expression;
+};
+
 class CollateColumnConstraint : public ColumnConstraint {
 public:
     CollateColumnConstraint(Optional<ByteString> name, ByteString collation_name)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -124,6 +124,20 @@ private:
     ConflictResolution m_conflict_resolution;
 };
 
+class UniqueColumnConstraint : public ColumnConstraint {
+public:
+    UniqueColumnConstraint(Optional<ByteString> name, ConflictResolution conflict_resolution)
+        : ColumnConstraint(move(name))
+        , m_conflict_resolution(move(conflict_resolution))
+    {
+    }
+
+    ConflictResolution const& conflict_resolution() const { return m_conflict_resolution; }
+
+private:
+    ConflictResolution m_conflict_resolution;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
     ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -138,6 +138,20 @@ private:
     ConflictResolution m_conflict_resolution;
 };
 
+class CheckColumnConstraint : public ColumnConstraint {
+public:
+    CheckColumnConstraint(Optional<ByteString> name, NonnullRefPtr<Expression> expression)
+        : ColumnConstraint(move(name))
+        , m_expression(move(expression))
+    {
+    }
+
+    NonnullRefPtr<Expression> const& expression() const { return m_expression; }
+
+private:
+    NonnullRefPtr<Expression> m_expression;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
     ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -110,6 +110,20 @@ private:
     bool m_autoincrement;
 };
 
+class NotNullColumnConstraint : public ColumnConstraint {
+public:
+    NotNullColumnConstraint(Optional<ByteString> name, ConflictResolution conflict_resolution)
+        : ColumnConstraint(move(name))
+        , m_conflict_resolution(move(conflict_resolution))
+    {
+    }
+
+    ConflictResolution const& conflict_resolution() const { return m_conflict_resolution; }
+
+private:
+    ConflictResolution m_conflict_resolution;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
     ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -180,6 +180,28 @@ private:
     ByteString m_collation_name;
 };
 
+class GeneratedColumnConstraint : public ColumnConstraint {
+public:
+    enum class ComputationStrategy {
+        Virtual,
+        Stored,
+    };
+
+    GeneratedColumnConstraint(Optional<ByteString> name, NonnullRefPtr<Expression> expression, ComputationStrategy computation_strategy)
+        : ColumnConstraint(move(name))
+        , m_expression(move(expression))
+        , m_computation_strategy(move(computation_strategy))
+    {
+    }
+
+    NonnullRefPtr<Expression> const& expression() const { return m_expression; }
+    ComputationStrategy const& computation_strategy() const { return m_computation_strategy; }
+
+private:
+    NonnullRefPtr<Expression> m_expression;
+    ComputationStrategy m_computation_strategy;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
     ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -69,20 +69,36 @@ private:
     Vector<NonnullRefPtr<SignedNumber>> m_signed_numbers;
 };
 
+class ColumnConstraint : public ASTNode {
+public:
+    ColumnConstraint(Optional<ByteString> name)
+        : m_name(move(name))
+    {
+    }
+
+    Optional<ByteString> const& name() const { return m_name; }
+
+private:
+    Optional<ByteString> m_name;
+};
+
 class ColumnDefinition : public ASTNode {
 public:
-    ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name)
+    ColumnDefinition(ByteString name, NonnullRefPtr<TypeName> type_name, RefPtr<ColumnConstraint> column_constraint)
         : m_name(move(name))
         , m_type_name(move(type_name))
+        , m_column_constraint(move(column_constraint))
     {
     }
 
     ByteString const& name() const { return m_name; }
     NonnullRefPtr<TypeName> const& type_name() const { return m_type_name; }
+    RefPtr<ColumnConstraint> const& column_constraint() const { return m_column_constraint; }
 
 private:
     ByteString m_name;
     NonnullRefPtr<TypeName> m_type_name;
+    RefPtr<ColumnConstraint> m_column_constraint;
 };
 
 class CommonTableExpression : public ASTNode {

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -69,6 +69,14 @@ private:
     Vector<NonnullRefPtr<SignedNumber>> m_signed_numbers;
 };
 
+enum class ConflictResolution {
+    Abort,
+    Fail,
+    Ignore,
+    Replace,
+    Rollback,
+};
+
 class ColumnConstraint : public ASTNode {
 public:
     ColumnConstraint(Optional<ByteString> name)
@@ -940,14 +948,6 @@ private:
     ByteString m_schema_name;
     ByteString m_table_name;
     bool m_is_error_if_table_does_not_exist;
-};
-
-enum class ConflictResolution {
-    Abort,
-    Fail,
-    Ignore,
-    Replace,
-    Rollback,
 };
 
 class Insert : public Statement {

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -920,7 +920,11 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         auto is_auto_increment = consume_if(TokenType::Autoincrement);
         return create_ast_node<PrimaryKeyColumnConstraint>(move(name), move(order), move(conflict_resolution), is_auto_increment);
     }
-
+    if (consume_if(TokenType::Not)) {
+        consume(TokenType::Null);
+        auto conflict_resolution = parse_conflict_resolution();
+        return create_ast_node<NotNullColumnConstraint>(move(name), move(conflict_resolution));
+    }
     return {};
 }
 

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -929,6 +929,10 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         auto conflict_resolution = parse_conflict_resolution();
         return create_ast_node<UniqueColumnConstraint>(move(name), move(conflict_resolution));
     }
+    if (consume_if(TokenType::Check)) {
+        auto expression = parse_expression();
+        return create_ast_node<CheckColumnConstraint>(move(name), move(expression));
+    }
     return {};
 }
 

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -933,6 +933,20 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         auto expression = parse_expression();
         return create_ast_node<CheckColumnConstraint>(move(name), move(expression));
     }
+    if (consume_if(TokenType::Default)) {
+        if (consume_if(TokenType::ParenOpen)) {
+            auto expression = parse_expression();
+            consume(TokenType::ParenClose);
+            return create_ast_node<DefaultColumnConstraint>(move(name), move(expression));
+        }
+        auto maybe_expression = parse_literal_value_expression();
+        if (maybe_expression.is_null()) {
+            expected("a literal value"sv);
+            return {};
+        }
+        auto expression = maybe_expression.release_nonnull();
+        return create_ast_node<DefaultColumnConstraint>(move(name), move(expression));
+    }
     if (consume_if(TokenType::Collate)) {
         auto collation_name = consume(TokenType::Identifier).value();
         return create_ast_node<CollateColumnConstraint>(move(name), move(collation_name));

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -925,6 +925,10 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         auto conflict_resolution = parse_conflict_resolution();
         return create_ast_node<NotNullColumnConstraint>(move(name), move(conflict_resolution));
     }
+    if (consume_if(TokenType::Unique)) {
+        auto conflict_resolution = parse_conflict_resolution();
+        return create_ast_node<UniqueColumnConstraint>(move(name), move(conflict_resolution));
+    }
     return {};
 }
 

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -901,7 +901,17 @@ NonnullRefPtr<ColumnDefinition> Parser::parse_column_definition()
         // https://www.sqlite.org/datatype3.html: If no type is specified then the column has affinity BLOB.
         : create_ast_node<TypeName>("BLOB", Vector<NonnullRefPtr<SignedNumber>> {});
 
-    // FIXME: Parse "column-constraint".
+    auto column_constraint = parse_column_constraint();
+    return create_ast_node<ColumnDefinition>(move(name), move(type_name), move(column_constraint));
+}
+
+RefPtr<ColumnConstraint> Parser::parse_column_constraint()
+{
+    // https://sqlite.org/syntax/column-constraint.html
+    Optional<ByteString> name = {};
+    if (consume_if(TokenType::Constraint)) {
+        name = consume(TokenType::Identifier).value();
+    }
 
     return create_ast_node<ColumnDefinition>(move(name), move(type_name));
 }

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -933,6 +933,10 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         auto expression = parse_expression();
         return create_ast_node<CheckColumnConstraint>(move(name), move(expression));
     }
+    if (consume_if(TokenType::Collate)) {
+        auto collation_name = consume(TokenType::Identifier).value();
+        return create_ast_node<CollateColumnConstraint>(move(name), move(collation_name));
+    }
     return {};
 }
 

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -1083,8 +1083,7 @@ NonnullRefPtr<OrderingTerm> Parser::parse_ordering_term()
         collation_name = consume(TokenType::Identifier).value();
     }
 
-    Order order = consume_if(TokenType::Desc) ? Order::Descending : Order::Ascending;
-    consume_if(TokenType::Asc); // ASC is the default, so ignore it if specified.
+    Order order = parse_order();
 
     Nulls nulls = order == Order::Ascending ? Nulls::First : Nulls::Last;
     if (consume_if(TokenType::Nulls)) {
@@ -1130,6 +1129,13 @@ ConflictResolution Parser::parse_conflict_resolution()
     }
 
     return ConflictResolution::Abort;
+}
+
+Order Parser::parse_order()
+{
+    auto order = consume_if(TokenType::Desc) ? Order::Descending : Order::Ascending;
+    consume_if(TokenType::Asc); // ASC is the default, so ignore it if specified.
+    return order;
 }
 
 Token Parser::consume()

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -951,6 +951,9 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         auto collation_name = consume(TokenType::Identifier).value();
         return create_ast_node<CollateColumnConstraint>(move(name), move(collation_name));
     }
+    if (match(TokenType::References)) {
+        // FIXME: foreign-key-clause
+    }
     if (consume_if(TokenType::Generated)) {
         consume(TokenType::Always);
     }

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -913,7 +913,15 @@ RefPtr<ColumnConstraint> Parser::parse_column_constraint()
         name = consume(TokenType::Identifier).value();
     }
 
-    return create_ast_node<ColumnDefinition>(move(name), move(type_name));
+    if (consume_if(TokenType::Primary)) {
+        consume(TokenType::Key);
+        auto order = parse_order();
+        auto conflict_resolution = parse_conflict_resolution();
+        auto is_auto_increment = consume_if(TokenType::Autoincrement);
+        return create_ast_node<PrimaryKeyColumnConstraint>(move(name), move(order), move(conflict_resolution), is_auto_increment);
+    }
+
+    return {};
 }
 
 NonnullRefPtr<TypeName> Parser::parse_type_name()

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -1113,7 +1113,7 @@ void Parser::parse_schema_and_table_name(ByteString& schema_name, ByteString& ta
 ConflictResolution Parser::parse_conflict_resolution()
 {
     // https://sqlite.org/lang_conflict.html
-    if (consume_if(TokenType::Or)) {
+    if (consume_if(TokenType::On)) {
         if (consume_if(TokenType::Abort))
             return ConflictResolution::Abort;
         if (consume_if(TokenType::Fail))

--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -89,6 +89,7 @@ private:
     RefPtr<Expression> parse_in_expression(NonnullRefPtr<Expression> expression, bool invert_expression);
 
     NonnullRefPtr<ColumnDefinition> parse_column_definition();
+    RefPtr<ColumnConstraint> parse_column_constraint();
     NonnullRefPtr<TypeName> parse_type_name();
     NonnullRefPtr<SignedNumber> parse_signed_number();
     NonnullRefPtr<CommonTableExpression> parse_common_table_expression();

--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -101,6 +101,7 @@ private:
     void parse_schema_and_table_name(ByteString& schema_name, ByteString& table_name);
     ConflictResolution parse_conflict_resolution();
     Order parse_order();
+    GeneratedColumnConstraint::ComputationStrategy parse_computation_strategy();
 
     template<typename ParseCallback>
     void parse_comma_separated_list(bool surrounded_by_parentheses, ParseCallback&& parse_callback)

--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -100,6 +100,7 @@ private:
     NonnullRefPtr<OrderingTerm> parse_ordering_term();
     void parse_schema_and_table_name(ByteString& schema_name, ByteString& table_name);
     ConflictResolution parse_conflict_resolution();
+    Order parse_order();
 
     template<typename ParseCallback>
     void parse_comma_separated_list(bool surrounded_by_parentheses, ParseCallback&& parse_callback)

--- a/Userland/Libraries/LibSQL/AST/Token.h
+++ b/Userland/Libraries/LibSQL/AST/Token.h
@@ -144,6 +144,7 @@ namespace SQL::AST {
     __ENUMERATE_SQL_TOKEN("SCHEMA", Schema, Keyword)                      \
     __ENUMERATE_SQL_TOKEN("SELECT", Select, Keyword)                      \
     __ENUMERATE_SQL_TOKEN("SET", Set, Keyword)                            \
+    __ENUMERATE_SQL_TOKEN("STORED", Stored, Keyword)                      \
     __ENUMERATE_SQL_TOKEN("TABLE", Table, Keyword)                        \
     __ENUMERATE_SQL_TOKEN("TEMP", Temp, Keyword)                          \
     __ENUMERATE_SQL_TOKEN("TEMPORARY", Temporary, Keyword)                \


### PR DESCRIPTION
This PR allows us to successfully parse all column constraints except the foreign key clause. We don't use the column constraint information yet, but now we don't show an error when a script contains this syntax.