### PR TITLE
LibWeb/CSS: Preserve color names when serializing color StyleValues 

### DIFF
--- a/Tests/LibWeb/Text/expected/css/CSSRule-cssText-preserve-color-names.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSRule-cssText-preserve-color-names.txt
@@ -1,0 +1,4 @@
+#lowercase { stop-color: cyan; }
+#uppercase { background-color: magenta; }
+#mixed-case { border-color: yellow; }
+#hex-value-not-preserved { color: rgb(170, 187, 204); }

--- a/Tests/LibWeb/Text/expected/css/PropertyOwningCSSStyleDeclaration-serialized-custom-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/PropertyOwningCSSStyleDeclaration-serialized-custom-properties.txt
@@ -1,1 +1,1 @@
-test { --color: red; color: rgb(255, 0, 0); }
+test { --color: red; color: red; }

--- a/Tests/LibWeb/Text/input/css/CSSRule-cssText-preserve-color-names.html
+++ b/Tests/LibWeb/Text/input/css/CSSRule-cssText-preserve-color-names.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+    #lowercase {
+        stop-color: cyan;
+    }
+    #uppercase {
+        background-color: MAGENTA;
+    }
+    #mixed-case {
+        border-color: YELLow;
+    }
+    #hex-value-not-preserved {
+        color: #AABBCC;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const rules = document.styleSheets[0].cssRules;
+        for (const rule of rules) {
+            println(rule.cssText);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2499,14 +2499,18 @@ Optional<Color> Parser::parse_color(ComponentValue const& component_value)
 RefPtr<StyleValue> Parser::parse_color_value(ComponentValue const& component_value)
 {
     auto color = parse_color(component_value);
+    if (component_value.is(Token::Type::Ident)) {
+        auto ident = component_value.token().ident();
+        if (color.has_value())
+            return NamedColorStyleValue::create(color.value(), ident);
+
+        auto ident_value_id = value_id_from_string(ident);
+        if (ident_value_id.has_value() && IdentifierStyleValue::is_color(ident_value_id.value()))
+            return IdentifierStyleValue::create(ident_value_id.value());
+    }
+
     if (color.has_value())
         return ColorStyleValue::create(color.value());
-
-    if (component_value.is(Token::Type::Ident)) {
-        auto ident = value_id_from_string(component_value.token().ident());
-        if (ident.has_value() && IdentifierStyleValue::is_color(ident.value()))
-            return IdentifierStyleValue::create(ident.value());
-    }
 
     return nullptr;
 }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -194,6 +194,19 @@ static RefPtr<StyleValue const> style_value_for_shadow(Vector<ShadowData> const&
     return StyleValueList::create(move(style_values), StyleValueList::Separator::Comma);
 }
 
+static RefPtr<StyleValue const> style_value_for_svg_paint(Optional<SVGPaint> maybe_svg_paint)
+{
+    if (!maybe_svg_paint.has_value())
+        return IdentifierStyleValue::create(ValueID::None);
+
+    auto svg_paint = maybe_svg_paint.release_value();
+    if (svg_paint.is_color())
+        return ColorStyleValue::create(svg_paint.as_color());
+    if (svg_paint.is_url())
+        return URLStyleValue::create(svg_paint.as_url());
+    VERIFY_NOT_REACHED();
+}
+
 RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
 {
     // A limited number of properties have special rules for producing their "resolved value".
@@ -234,9 +247,15 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         return ColorStyleValue::create(layout_node.computed_values().color());
     case PropertyID::OutlineColor:
         return ColorStyleValue::create(layout_node.computed_values().outline_color());
+    case PropertyID::StopColor:
+        return ColorStyleValue::create(layout_node.computed_values().stop_color());
     case PropertyID::TextDecorationColor:
         return ColorStyleValue::create(layout_node.computed_values().text_decoration_color());
         // NOTE: text-shadow isn't listed, but is computed the same as box-shadow.
+    case PropertyID::Fill:
+        return style_value_for_svg_paint(layout_node.computed_values().fill());
+    case PropertyID::Stroke:
+        return style_value_for_svg_paint(layout_node.computed_values().stroke());
     case PropertyID::TextShadow:
         return style_value_for_shadow(layout_node.computed_values().text_shadow());
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.cpp
@@ -37,4 +37,14 @@ String ColorStyleValue::to_string() const
     return serialize_a_srgb_value(m_color);
 }
 
+ValueComparingNonnullRefPtr<ColorStyleValue> NamedColorStyleValue::create(Color color, FlyString const& color_name)
+{
+    return adopt_ref(*new (nothrow) NamedColorStyleValue(color, color_name));
+}
+
+String NamedColorStyleValue::to_string() const
+{
+    return MUST(m_color_name.to_string().to_lowercase());
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.h
@@ -3,12 +3,14 @@
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibGfx/Color.h>
 #include <LibWeb/CSS/StyleValue.h>
 
@@ -26,14 +28,32 @@ public:
 
     bool properties_equal(ColorStyleValue const& other) const { return m_color == other.m_color; }
 
-private:
+protected:
     explicit ColorStyleValue(Color color)
         : StyleValueWithDefaultOperators(Type::Color)
         , m_color(color)
     {
     }
 
+private:
     Color m_color;
+};
+
+class NamedColorStyleValue : public ColorStyleValue {
+public:
+    static ValueComparingNonnullRefPtr<ColorStyleValue> create(Color, FlyString const& color_name);
+    virtual ~NamedColorStyleValue() = default;
+
+    virtual String to_string() const override;
+
+private:
+    NamedColorStyleValue(Color color, FlyString const& color_name)
+        : ColorStyleValue(color)
+        , m_color_name(color_name)
+    {
+    }
+
+    FlyString m_color_name;
 };
 
 }


### PR DESCRIPTION
Previously, calling `CSSStyleRule.cssText` on a rule using a named color would give the computed RGB value. This commit introduces `NamedColorStyleValue`, which is identical to `ColorStyleValue`, except it preserves the color name.

This allows us to pass more CSSOM WPT tests (and probably others too).

Before:

Ran 179 tests finished in 264.3 seconds.
  • 65 ran as expected. 0 tests skipped.
  • 10 tests had errors unexpectedly
  • 1 tests failed unexpectedly
  • 10 tests timed out unexpectedly
  • 98 tests had unexpected subtest results

After:

Ran 179 tests finished in 259.8 seconds.
  • 72 ran as expected. 0 tests skipped.
  • 10 tests had errors unexpectedly
  • 1 tests failed unexpectedly
  • 10 tests timed out unexpectedly
  • 91 tests had unexpected subtest results
