### PR TITLE
LibJS+LibWeb: Change JobCallback to be GC-allocated

### DIFF
--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -222,7 +222,7 @@ class WeakContainer;
 class WrappedFunction;
 enum class DeclarationKind;
 struct AlreadyResolved;
-struct JobCallback;
+class JobCallback;
 struct ModuleRequest;
 struct ModuleWithSpecifier;
 

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -28,23 +28,23 @@ public:
 
     void add_finalization_record(Cell& target, Value held_value, Cell* unregister_token);
     bool remove_by_token(Cell& unregister_token);
-    ThrowCompletionOr<void> cleanup(Optional<JobCallback> = {});
+    ThrowCompletionOr<void> cleanup(GCPtr<JobCallback> = {});
 
     virtual void remove_dead_cells(Badge<Heap>) override;
 
     Realm& realm() { return *m_realm; }
     Realm const& realm() const { return *m_realm; }
 
-    JobCallback& cleanup_callback() { return m_cleanup_callback; }
-    JobCallback const& cleanup_callback() const { return m_cleanup_callback; }
+    JobCallback& cleanup_callback() { return *m_cleanup_callback; }
+    JobCallback const& cleanup_callback() const { return *m_cleanup_callback; }
 
 private:
-    FinalizationRegistry(Realm&, JobCallback, Object& prototype);
+    FinalizationRegistry(Realm&, NonnullGCPtr<JobCallback>, Object& prototype);
 
     virtual void visit_edges(Visitor& visitor) override;
 
     NonnullGCPtr<Realm> m_realm;
-    JobCallback m_cleanup_callback;
+    NonnullGCPtr<JobCallback> m_cleanup_callback;
 
     struct FinalizationRecord {
         GCPtr<Cell> target;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -47,7 +47,7 @@ JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::cleanup_some)
     // IMPLEMENTATION DEFINED: The specification for this function hasn't been updated to accommodate for JobCallback records.
     //                         This just follows how the constructor immediately converts the callback to a JobCallback using HostMakeJobCallback.
     // 4. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
-    TRY(finalization_registry->cleanup(callback.is_undefined() ? Optional<JobCallback> {} : vm.host_make_job_callback(callback.as_function())));
+    TRY(finalization_registry->cleanup(callback.is_undefined() ? GCPtr<JobCallback> {} : vm.host_make_job_callback(callback.as_function())));
 
     // 5. Return undefined.
     return js_undefined();

--- a/Userland/Libraries/LibJS/Runtime/JobCallback.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JobCallback.cpp
@@ -5,26 +5,36 @@
  */
 
 #include <LibJS/Runtime/AbstractOperations.h>
-#include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/JobCallback.h>
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(JobCallback);
+
+JS::NonnullGCPtr<JobCallback> JobCallback::create(JS::VM& vm, FunctionObject& callback, OwnPtr<CustomData> custom_data)
+{
+    return vm.heap().allocate_without_realm<JobCallback>(callback, move(custom_data));
+}
+
+void JobCallback::visit_edges(Visitor& visitor)
+{
+    visitor.visit(m_callback);
+}
+
 // 9.5.2 HostMakeJobCallback ( callback ), https://tc39.es/ecma262/#sec-hostmakejobcallback
-JobCallback make_job_callback(FunctionObject& callback)
+JS::NonnullGCPtr<JobCallback> make_job_callback(FunctionObject& callback)
 {
     // 1. Return the JobCallback Record { [[Callback]]: callback, [[HostDefined]]: empty }.
-    return { make_handle(&callback) };
+    return JobCallback::create(callback.vm(), callback, {});
 }
 
 // 9.5.3 HostCallJobCallback ( jobCallback, V, argumentsList ), https://tc39.es/ecma262/#sec-hostcalljobcallback
-ThrowCompletionOr<Value> call_job_callback(VM& vm, JobCallback& job_callback, Value this_value, ReadonlySpan<Value> arguments_list)
+ThrowCompletionOr<Value> call_job_callback(VM& vm, JS::NonnullGCPtr<JobCallback> job_callback, Value this_value, ReadonlySpan<Value> arguments_list)
 {
     // 1. Assert: IsCallable(jobCallback.[[Callback]]) is true.
-    VERIFY(!job_callback.callback.is_null());
 
     // 2. Return ? Call(jobCallback.[[Callback]], V, argumentsList).
-    return call(vm, job_callback.callback.cell(), this_value, arguments_list);
+    return call(vm, job_callback->callback(), this_value, arguments_list);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -300,7 +300,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GCPtr<Promise
 
     // 3. If IsCallable(onFulfilled) is false, then
     //     a. Let onFulfilledJobCallback be empty.
-    Optional<JobCallback> on_fulfilled_job_callback;
+    GCPtr<JobCallback> on_fulfilled_job_callback;
 
     // 4. Else,
     if (on_fulfilled.is_function()) {
@@ -311,7 +311,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GCPtr<Promise
 
     // 5. If IsCallable(onRejected) is false, then
     //     a. Let onRejectedJobCallback be empty.
-    Optional<JobCallback> on_rejected_job_callback;
+    GCPtr<JobCallback> on_rejected_job_callback;
 
     // 6. Else,
     if (on_rejected.is_function()) {

--- a/Userland/Libraries/LibJS/Runtime/PromiseJobs.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseJobs.h
@@ -21,6 +21,6 @@ struct PromiseJob {
 
 // NOTE: These return a PromiseJob to prevent awkward casting at call sites.
 PromiseJob create_promise_reaction_job(VM&, PromiseReaction&, Value argument);
-PromiseJob create_promise_resolve_thenable_job(VM&, Promise&, Value thenable, JobCallback then);
+PromiseJob create_promise_resolve_thenable_job(VM&, Promise&, Value thenable, JS::NonnullGCPtr<JobCallback> then);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
@@ -12,12 +12,12 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(PromiseReaction);
 
-NonnullGCPtr<PromiseReaction> PromiseReaction::create(VM& vm, Type type, GCPtr<PromiseCapability> capability, Optional<JobCallback> handler)
+NonnullGCPtr<PromiseReaction> PromiseReaction::create(VM& vm, Type type, GCPtr<PromiseCapability> capability, GCPtr<JobCallback> handler)
 {
     return vm.heap().allocate_without_realm<PromiseReaction>(type, capability, move(handler));
 }
 
-PromiseReaction::PromiseReaction(Type type, GCPtr<PromiseCapability> capability, Optional<JobCallback> handler)
+PromiseReaction::PromiseReaction(Type type, GCPtr<PromiseCapability> capability, GCPtr<JobCallback> handler)
     : m_type(type)
     , m_capability(capability)
     , m_handler(move(handler))
@@ -28,6 +28,7 @@ void PromiseReaction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_capability);
+    visitor.visit(m_handler);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -24,24 +24,24 @@ public:
         Reject,
     };
 
-    static NonnullGCPtr<PromiseReaction> create(VM& vm, Type type, GCPtr<PromiseCapability> capability, Optional<JobCallback> handler);
+    static NonnullGCPtr<PromiseReaction> create(VM& vm, Type type, GCPtr<PromiseCapability> capability, JS::GCPtr<JobCallback> handler);
 
     virtual ~PromiseReaction() = default;
 
     Type type() const { return m_type; }
     GCPtr<PromiseCapability> capability() const { return m_capability; }
 
-    Optional<JobCallback>& handler() { return m_handler; }
-    Optional<JobCallback> const& handler() const { return m_handler; }
+    JS::GCPtr<JobCallback> handler() { return m_handler; }
+    JS::GCPtr<JobCallback const> handler() const { return m_handler; }
 
 private:
-    PromiseReaction(Type type, GCPtr<PromiseCapability> capability, Optional<JobCallback> handler);
+    PromiseReaction(Type type, GCPtr<PromiseCapability> capability, JS::GCPtr<JobCallback> handler);
 
     virtual void visit_edges(Visitor&) override;
 
     Type m_type;
     GCPtr<PromiseCapability> m_capability;
-    Optional<JobCallback> m_handler;
+    JS::GCPtr<JobCallback> m_handler;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -255,7 +255,7 @@ public:
     Function<ThrowCompletionOr<Value>(JobCallback&, Value, ReadonlySpan<Value>)> host_call_job_callback;
     Function<void(FinalizationRegistry&)> host_enqueue_finalization_registry_cleanup_job;
     Function<void(Function<ThrowCompletionOr<Value>()>, Realm*)> host_enqueue_promise_job;
-    Function<JobCallback(FunctionObject&)> host_make_job_callback;
+    Function<JS::NonnullGCPtr<JobCallback>(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
     Function<ThrowCompletionOr<HandledByHost>(ArrayBuffer&, size_t)> host_resize_array_buffer;


### PR DESCRIPTION
Fixes leak caused by mutual dependency when JS::Handle<JobCallback> is owned by GC-allocated PromiseReaction.