### PR TITLE
LibWeb: Capture weak `this` ptr in HTMLTextAreaElement input callback

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -25,7 +25,11 @@ JS_DEFINE_ALLOCATOR(HTMLTextAreaElement);
 
 HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
-    , m_input_event_timer(Web::Platform::Timer::create_single_shot(0, [this]() { queue_firing_input_event(); }))
+    , m_input_event_timer(MUST(Core::Timer::create_single_shot(0, [weak_this = make_weak_ptr()]() {
+        if (!weak_this)
+            return;
+        static_cast<HTMLTextAreaElement*>(weak_this.ptr())->queue_firing_input_event();
+    })))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -8,11 +8,11 @@
 
 #pragma once
 
+#include <LibCore/Timer.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/Platform/Timer.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
@@ -119,7 +119,7 @@ private:
     JS::GCPtr<DOM::Element> m_inner_text_element;
     JS::GCPtr<DOM::Text> m_text_node;
 
-    RefPtr<Web::Platform::Timer> m_input_event_timer;
+    RefPtr<Core::Timer> m_input_event_timer;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-dirty
     bool m_dirty_value { false };


### PR DESCRIPTION
Fixes GC-leak caused by cycle dependency between input callback and HTMLTextAreaElement that owns it.