### PR TITLE
Meta: Do not place headless-browser and WebDriver in libexec

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -199,7 +199,6 @@ endfunction()
 
 add_executable(headless-browser
     ${SERENITY_SOURCE_DIR}/Userland/Utilities/headless-browser.cpp
-    ${SERENITY_SOURCE_DIR}/Userland/Services/WebContent/WebDriverConnection.cpp
     HelperProcess.cpp
     Utilities.cpp)
 
@@ -229,8 +228,11 @@ add_subdirectory(WebContent)
 add_subdirectory(WebDriver)
 add_subdirectory(WebWorker)
 
-set(ladybird_helper_processes ImageDecoder RequestServer SQLServer WebContent WebDriver WebWorker headless-browser)
+set(ladybird_helper_processes ImageDecoder RequestServer SQLServer WebContent WebWorker)
+
 add_dependencies(ladybird ${ladybird_helper_processes})
+add_dependencies(headless-browser ${ladybird_helper_processes})
+add_dependencies(WebDriver ladybird headless-browser)
 
 function(create_ladybird_bundle target_name)
     set_target_properties(${target_name} PROPERTIES
@@ -255,6 +257,9 @@ endfunction()
 
 create_ladybird_bundle(ladybird)
 set_helper_process_properties(${ladybird_helper_processes})
+if (APPLE)
+    set_helper_process_properties(headless-browser WebDriver)
+endif()
 
 include(cmake/ResourceFiles.cmake)
 set(resource_base_dir "${CMAKE_BINARY_DIR}/${IN_BUILD_PREFIX}${CMAKE_INSTALL_DATADIR}/Lagom")

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -47,17 +47,17 @@ config("ladybird_config") {
   defines = [ "AK_DONT_REPLACE_STD" ]
 }
 
+ladybird_helper_processes = [
+  "ImageDecoder",
+  "RequestServer",
+  "SQLServer",
+  "WebContent",
+  "WebWorker",
+]
+
 executable("ladybird_executable") {
   configs += [ ":ladybird_config" ]
-  data_deps = [
-    ":headless-browser",
-    "ImageDecoder",
-    "RequestServer",
-    "SQLServer",
-    "WebContent",
-    "WebDriver",
-    "WebWorker",
-  ]
+  data_deps = ladybird_helper_processes
   deps = [
     "//AK",
     "//Userland/Libraries/LibCore",
@@ -178,13 +178,12 @@ executable("headless-browser") {
     "//Userland/Libraries/LibWebSocket",
     "//Userland/Libraries/LibWebView",
   ]
+  data_deps = ladybird_helper_processes
   sources = [
-    "//Userland/Services/WebContent/WebDriverConnection.cpp",
     "//Userland/Utilities/headless-browser.cpp",
     "HelperProcess.cpp",
     "Utilities.cpp",
   ]
-  output_dir = "$root_out_dir/libexec"
 }
 
 fonts = [
@@ -331,13 +330,13 @@ if (current_os != "mac") {
     ]
     sources = [
       "$root_out_dir/bin/Ladybird",
+      "$root_out_dir/bin/WebDriver",
+      "$root_out_dir/bin/headless-browser",
       "$root_out_dir/libexec/ImageDecoder",
       "$root_out_dir/libexec/RequestServer",
       "$root_out_dir/libexec/SQLServer",
       "$root_out_dir/libexec/WebContent",
-      "$root_out_dir/libexec/WebDriver",
       "$root_out_dir/libexec/WebWorker",
-      "$root_out_dir/libexec/headless-browser",
     ]
     outputs = [ "{{bundle_executable_dir}}/{{source_file_part}}" ]
   }

--- a/Meta/gn/secondary/Ladybird/WebDriver/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/WebDriver/BUILD.gn
@@ -6,7 +6,10 @@ executable("WebDriver") {
     "//Userland/Services",
     "//Ladybird",
   ]
-  data_deps = [ "//Ladybird:headless-browser" ]
+  data_deps = [
+    "//Ladybird:headless-browser",
+    "//Ladybird:ladybird_executable",
+  ]
   deps = [
     "//AK",
     "//Userland/Libraries/LibCore",
@@ -27,5 +30,4 @@ executable("WebDriver") {
     "//Userland/Services/WebDriver/WebContentConnection.cpp",
     "main.cpp",
   ]
-  output_dir = "$root_out_dir/libexec"
 }

--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -11,7 +11,7 @@ then
 fi
 
 
-: "${WEBDRIVER_BINARY:=$(env PATH="${SERENITY_SOURCE_DIR}/Build/lagom/bin/Ladybird.app/Contents/MacOS:${SERENITY_SOURCE_DIR}/Build/lagom/libexec:${SERENITY_SOURCE_DIR}/Meta/Lagom/Build/libexec:${PATH}" \
+: "${WEBDRIVER_BINARY:=$(env PATH="${SERENITY_SOURCE_DIR}/Build/lagom/bin/Ladybird.app/Contents/MacOS:${SERENITY_SOURCE_DIR}/Build/lagom/bin:${SERENITY_SOURCE_DIR}/Meta/Lagom/Build/bin:${PATH}" \
                          which WebDriver)}"
 update_expectations_metadata=false
 remove_wpt_repository=false

--- a/Tests/LibWeb/rebaseline-libweb-test
+++ b/Tests/LibWeb/rebaseline-libweb-test
@@ -17,4 +17,4 @@ expected_dir=$(echo $input_dir | sed s/input/expected/)
 test_name=$(basename $t .html)
 cd $SERENITY_SOURCE_DIR/Build/lagom
 mkdir -p $expected_dir
-./libexec/headless-browser $mode_flag --layout-test-mode $input_dir/$test_name.html > $expected_dir/$test_name.txt
+./bin/headless-browser $mode_flag --layout-test-mode $input_dir/$test_name.html > $expected_dir/$test_name.txt


### PR DESCRIPTION
These are standalone applications meant to be run by the user directly, as opposed to other libexec processes which are programmatically forked by the browser. To do this, we simply remove these processes from the `ladybird_helper_processes` list. We must also explicitly list the dependencies for these processes.