### PR TITLE
LibWeb: A couple of shortcut handling fixes

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -700,7 +700,7 @@ bool EventHandler::focus_previous_element()
 
 constexpr bool should_ignore_keydown_event(u32 code_point, u32 modifiers)
 {
-    if (modifiers & (KeyModifier::Mod_Ctrl | KeyModifier::Mod_Alt))
+    if (modifiers & (KeyModifier::Mod_Ctrl | KeyModifier::Mod_Alt | KeyModifier::Mod_Super))
         return true;
 
     // FIXME: There are probably also keys with non-zero code points that should be filtered out.

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -856,9 +856,6 @@ bool EventHandler::handle_keydown(KeyCode key, u32 modifiers, u32 code_point)
             m_browsing_context->increment_cursor_position_offset();
             return true;
         }
-
-        // NOTE: Because modifier keys should be ignored, we need to return true.
-        return true;
     }
 
     // FIXME: Work out and implement the difference between this and keydown.


### PR DESCRIPTION
* Handle super key combos the same as ctrl key combos for macOS
* Allow chromes to handle shortcuts after ignoring a key combo when an editable node has focus

Regarding the second commit, I have a WIP branch that continues the work of #23483 and will make these methods return an enum status - rather than having to keep remembering what true/false means here.