### PR TITLE
LibWeb: Update paint-only props only when needed in get_client_rects()

### DIFF
--- a/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-scroll-offset.txt
+++ b/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-scroll-offset.txt
@@ -1,0 +1,3 @@
+     {"x":18,"y":518,"width":100,"height":100,"top":518,"right":118,"bottom":618,"left":18}
+{"x":18,"y":418,"width":100,"height":100,"top":418,"right":118,"bottom":518,"left":18}
+{"x":18,"y":318,"width":100,"height":100,"top":318,"right":118,"bottom":418,"left":18}

--- a/Tests/LibWeb/Text/input/element-get-bounding-client-rect-scroll-offset.html
+++ b/Tests/LibWeb/Text/input/element-get-bounding-client-rect-scroll-offset.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+    body {
+        height: 2000px;
+    }
+
+    #box {
+        margin-top: 500px;
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+
+    #scrollable {
+        width: 400px;
+        height: 400px;
+        overflow: scroll;
+        border: 10px solid black;
+    }
+</style>
+<div id="scrollable">
+    <div id="box"></div>
+</div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let rectBeforeScroll = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(rectBeforeScroll));
+        document.getElementById("scrollable").scrollTop = 100;
+        let rectAfterScroll = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(rectAfterScroll));
+        document.getElementById("scrollable").scrollTop = 200;
+        let rectAfterScroll2 = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(rectAfterScroll2));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -926,10 +926,8 @@ JS::NonnullGCPtr<Geometry::DOMRectList> Element::get_client_rects() const
     VERIFY(navigable);
     auto viewport_offset = navigable->viewport_scroll_offset();
 
-    if (document().paintable()) {
-        // NOTE: Make sure CSS transforms are resolved before it is used to calculate the rect position.
-        const_cast<Painting::ViewportPaintable*>(document().paintable())->resolve_paint_only_properties();
-    }
+    // NOTE: Make sure CSS transforms are resolved before it is used to calculate the rect position.
+    const_cast<Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     Gfx::AffineTransform transform;
     for (auto const* containing_block = this->paintable_box(); containing_block; containing_block = containing_block->containing_block()) {


### PR DESCRIPTION
There is no need to unconditionally resolve them whenever the function is called.