### PR TITLE
LibGfx: Simplify path storage and tidy up APIs

### DIFF
--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -144,7 +144,7 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::fill_internal(Painter& painter, Pa
     if (m_clip.is_empty())
         return;
 
-    auto& lines = path.split_lines();
+    auto lines = path.split_lines();
     if (lines.is_empty())
         return;
 

--- a/Userland/Libraries/LibGfx/Font/VectorFont.h
+++ b/Userland/Libraries/LibGfx/Font/VectorFont.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
 #include <LibGfx/Font/Font.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -279,10 +279,10 @@ public:
                     path.line_to(TRY(read_point()));
                     break;
                 case PathCommand::HorizontalLine:
-                    path.line_to({ TRY(read_unit()), path.segments().last()->point().y() });
+                    path.line_to({ TRY(read_unit()), path.last_point().y() });
                     break;
                 case PathCommand::VerticalLine:
-                    path.line_to({ path.segments().last()->point().x(), TRY(read_unit()) });
+                    path.line_to({ path.last_point().x(), TRY(read_unit()) });
                     break;
                 case PathCommand::CubicBezier: {
                     auto control_0 = TRY(read_point());

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -247,7 +247,7 @@ RENDERER_HANDLER(path_move)
 
 RENDERER_HANDLER(path_line)
 {
-    VERIFY(!m_current_path.segments().is_empty());
+    VERIFY(!m_current_path.is_empty());
     m_current_path.line_to(map(args[0].to_float(), args[1].to_float()));
     return {};
 }
@@ -265,8 +265,8 @@ RENDERER_HANDLER(path_cubic_bezier_curve)
 RENDERER_HANDLER(path_cubic_bezier_curve_no_first_control)
 {
     VERIFY(args.size() == 4);
-    VERIFY(!m_current_path.segments().is_empty());
-    auto current_point = (*m_current_path.segments().rbegin())->point();
+    VERIFY(!m_current_path.is_empty());
+    auto current_point = m_current_path.last_point();
     m_current_path.cubic_bezier_curve_to(
         current_point,
         map(args[0].to_float(), args[1].to_float()),
@@ -277,7 +277,7 @@ RENDERER_HANDLER(path_cubic_bezier_curve_no_first_control)
 RENDERER_HANDLER(path_cubic_bezier_curve_no_second_control)
 {
     VERIFY(args.size() == 4);
-    VERIFY(!m_current_path.segments().is_empty());
+    VERIFY(!m_current_path.is_empty());
     auto first_control_point = map(args[0].to_float(), args[1].to_float());
     auto second_control_point = map(args[2].to_float(), args[3].to_float());
     m_current_path.cubic_bezier_curve_to(

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
@@ -129,7 +129,8 @@ WebIDL::ExceptionOr<void> CanvasPath::arc_to(double x1, double y1, double x2, do
 
     // 2. Ensure there is a subpath for (x1, y1).
     auto transform = active_transform();
-    m_path.ensure_subpath(transform.map(Gfx::FloatPoint { x1, y1 }));
+    if (m_path.is_empty())
+        m_path.move_to(transform.map(Gfx::FloatPoint { x1, y1 }));
 
     // 3. If radius is negative, then throw an "IndexSizeError" DOMException.
     if (radius < 0)

--- a/Userland/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.cpp
@@ -42,9 +42,9 @@ Path2D::Path2D(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, String>> c
     auto path_instructions = SVG::AttributeParser::parse_path_data(path->get<String>());
     auto svg_path = SVG::path_from_path_instructions(path_instructions);
 
-    if (!svg_path.segments().is_empty()) {
+    if (!svg_path.is_empty()) {
         // 5. Let (x, y) be the last point in svgPath.
-        auto xy = svg_path.segments().last()->point();
+        auto xy = svg_path.last_point();
 
         // 6. Add all the subpaths, if any, from svgPath to output.
         this->path() = move(svg_path);
@@ -70,7 +70,7 @@ WebIDL::ExceptionOr<void> Path2D::add_path(JS::NonnullGCPtr<Path2D> path, Geomet
     // The addPath(path, transform) method, when invoked on a Path2D object a, must run these steps:
 
     // 1. If the Path2D object path has no subpaths, then return.
-    if (path->path().segments().is_empty())
+    if (path->path().is_empty())
         return {};
 
     // 2. Let matrix be the result of creating a DOMMatrix from the 2D dictionary transform.
@@ -85,11 +85,11 @@ WebIDL::ExceptionOr<void> Path2D::add_path(JS::NonnullGCPtr<Path2D> path, Geomet
     auto copy = path->path().copy_transformed(Gfx::AffineTransform { static_cast<float>(matrix->m11()), static_cast<float>(matrix->m12()), static_cast<float>(matrix->m21()), static_cast<float>(matrix->m22()), static_cast<float>(matrix->m41()), static_cast<float>(matrix->m42()) });
 
     // 6. Let (x, y) be the last point in the last subpath of c.
-    auto xy = copy.segments().last()->point();
+    auto xy = copy.last_point();
 
     // 7. Add all the subpaths in c to a.
     // FIXME: Is this correct?
-    this->path().add_path(copy);
+    this->path().append_path(copy);
 
     // 8. Create a new subpath in a with (x, y) as the only point in the subpath.
     this->move_to(xy.x(), xy.y());

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -111,7 +111,7 @@ Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction> instructions
 
     for (auto& instruction : instructions) {
         // If the first path element uses relative coordinates, we treat them as absolute by making them relative to (0, 0).
-        auto last_point = path.segments().is_empty() ? Gfx::FloatPoint { 0, 0 } : path.segments().last()->point();
+        auto last_point = path.last_point();
 
         auto& absolute = instruction.absolute;
         auto& data = instruction.data;


### PR DESCRIPTION
Rather than make path segments virtual and refcounted let's store `Gfx::Path`s as a list of `FloatPoints` and a separate list of commands.

This reduces the size of paths, for example, a `MoveTo` goes from 24 bytes to 9 bytes (one point + a single byte command), and removes a layer of indirection when accessing segments. A nice little bonus is transforming a path can now be done by applying the transform to all points in the path (without looking at the commands).

Alongside this there's been a few minor API changes:

- `path.segments()` has been removed
  * All current uses could be replaced by a new `path.is_empty()` API
  * There's also now an iterator for looping over `Gfx::Path` segments
- `path.add_path(other_path)` has been removed
  * This was a duplicate of `path.append_path(other_path)`
- `path.ensure_subpath(point)` has been removed
  * Had one use and is equivalent to an `is_empty()` check + `move_to()`
- `path.close()` and `path.close_all_subpaths()` assume an implicit `moveto 0,0` if there's no `moveto` at the start of a path (for consistency with `path.segmentize_path()`).

Only the last point could change behaviour (though in LibWeb/SVGs all paths start with a `moveto` as per the spec, it's only possible to construct a path without a starting `moveto` via LibGfx APIs).