### PR TITLE
LibWeb: Ensure progress element attributes behave correctly

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-detached.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-detached.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
@@ -1,0 +1,8 @@
+value attribute initial value: 0
+max attribute initial value: 1
+value attribute after setting value attribute to -1: 0
+max attribute after setting max attribute to -1: 1
+value attribute after setting value attribute to 50: 1
+value attribute after setting max attribute to 100: 50
+max attribute after setting max attribute to 100: 100
+value attribute after setting max attribute to 101: 100

--- a/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
@@ -6,3 +6,6 @@ value attribute after setting value attribute to 50: 1
 value attribute after setting max attribute to 100: 50
 max attribute after setting max attribute to 100: 100
 value attribute after setting max attribute to 101: 100
+value attribute after setting value attribute to -1: 0
+value attribute after setting max attribute to 0: 0
+max attribute after setting max attribute to 0: 1

--- a/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-detached.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-detached.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const progressElement = document.createElement("progress");
+        progressElement.max = 100;
+        progressElement.value = 50;
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-set-attributes.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-set-attributes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const progressElement = document.createElement("progress");
+        println(`value attribute initial value: ${progressElement.value}`);
+        println(`max attribute initial value: ${progressElement.max}`);
+        progressElement.value = -1;
+        println(`value attribute after setting value attribute to -1: ${progressElement.value}`);
+        progressElement.max = -1;
+        println(`max attribute after setting max attribute to -1: ${progressElement.max}`);
+        progressElement.value = 50;
+        println(`value attribute after setting value attribute to 50: ${progressElement.value}`);
+        progressElement.max = 100;
+        println(`value attribute after setting max attribute to 100: ${progressElement.value}`);
+        println(`max attribute after setting max attribute to 100: ${progressElement.max}`);
+        progressElement.value = 101;
+        println(`value attribute after setting max attribute to 101: ${progressElement.value}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-set-attributes.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-set-attributes.html
@@ -16,5 +16,10 @@
         println(`max attribute after setting max attribute to 100: ${progressElement.max}`);
         progressElement.value = 101;
         println(`value attribute after setting max attribute to 101: ${progressElement.value}`);
+        progressElement.value = -1;
+        println(`value attribute after setting value attribute to -1: ${progressElement.value}`);
+        progressElement.max = 0;
+        println(`value attribute after setting max attribute to 0: ${progressElement.value}`);
+        println(`max attribute after setting max attribute to 0: ${progressElement.max}`);
     });
 </script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -114,7 +114,8 @@ void HTMLProgressElement::create_shadow_tree_if_needed()
 
 void HTMLProgressElement::update_progress_value_element()
 {
-    MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", position() * 100))));
+    if (m_progress_value_element)
+        MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", position() * 100))));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -48,7 +48,7 @@ double HTMLProgressElement::value() const
 
 WebIDL::ExceptionOr<void> HTMLProgressElement::set_value(double value)
 {
-    if (value < 0 || value > max())
+    if (value < 0)
         return {};
 
     TRY(set_attribute(HTML::AttributeNames::value, MUST(String::number(value))));

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -49,7 +49,7 @@ double HTMLProgressElement::value() const
 WebIDL::ExceptionOr<void> HTMLProgressElement::set_value(double value)
 {
     if (value < 0)
-        return {};
+        value = 0;
 
     TRY(set_attribute(HTML::AttributeNames::value, MUST(String::number(value))));
     update_progress_value_element();
@@ -69,7 +69,7 @@ double HTMLProgressElement::max() const
 WebIDL::ExceptionOr<void> HTMLProgressElement::set_max(double value)
 {
     if (value <= 0)
-        return {};
+        value = 1;
 
     TRY(set_attribute(HTML::AttributeNames::max, MUST(String::number(value))));
     update_progress_value_element();


### PR DESCRIPTION
This PR changes to the progress element `max` and `value` attribute behavior to align it with the specification and other browsers.

See individual commits for details.