### PR TITLE
LibWeb: Skip cells layout in table box width calculation

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1577,11 +1577,9 @@ void TableFormattingContext::finish_grid_initialization(TableGrid const& table_g
     }
 }
 
-void TableFormattingContext::run(Box const& box, LayoutMode layout_mode, AvailableSpace const& available_space)
+void TableFormattingContext::run_until_width_calculation(Box const& box, AvailableSpace const& available_space)
 {
     m_available_space = available_space;
-
-    auto total_captions_height = run_caption_layout(layout_mode, CSS::CaptionSide::Top);
 
     // Determine the number of rows/columns the table requires.
     finish_grid_initialization(TableGrid::calculate_row_column_grid(box, m_cells, m_rows));
@@ -1603,6 +1601,15 @@ void TableFormattingContext::run(Box const& box, LayoutMode layout_mode, Availab
 
     // Compute the width of the table.
     compute_table_width();
+}
+
+void TableFormattingContext::run(Box const& box, LayoutMode layout_mode, AvailableSpace const& available_space)
+{
+    m_available_space = available_space;
+
+    auto total_captions_height = run_caption_layout(layout_mode, CSS::CaptionSide::Top);
+
+    run_until_width_calculation(box, available_space);
 
     if (available_space.width.is_intrinsic_sizing_constraint() && !available_space.height.is_intrinsic_sizing_constraint()) {
         return;

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -23,6 +23,8 @@ public:
     explicit TableFormattingContext(LayoutState&, Box const&, FormattingContext* parent);
     ~TableFormattingContext();
 
+    void run_until_width_calculation(Box const&, AvailableSpace const& available_space);
+
     virtual void run(Box const&, LayoutMode, AvailableSpace const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
@@ -146,7 +148,7 @@ private:
     static TableFormattingContext::ConflictingEdge const& winning_conflicting_edge(TableFormattingContext::ConflictingEdge const& a, TableFormattingContext::ConflictingEdge const& b);
 
     static const CSS::BorderData& border_data_conflicting_edge(ConflictingEdge const& conflicting_edge);
-    static const Painting::PaintableBox::BorderDataWithElementKind border_data_with_element_kind_from_conflicting_edge(ConflictingEdge const& conflicting_edge);
+    static Painting::PaintableBox::BorderDataWithElementKind const border_data_with_element_kind_from_conflicting_edge(ConflictingEdge const& conflicting_edge);
 
     class BorderConflictFinder {
     public:


### PR DESCRIPTION
There is no need to run full table layout if we are only interested in calculating its width. New layout mode is needed because we can't tell if it's possible to early return only by looking at available space.

This change reduces `compute_table_box_width_inside_table_wrapper()` from ~30% to ~15% in profiles of "File changed" pages on github.