### PR TITLE
LibGfx+LibPDF: Support CCITT3 1D images in PDFs

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -596,12 +596,18 @@ ErrorOr<ByteBuffer> decode_ccitt_group3(ReadonlyBytes bytes, u32 image_width, u3
         // NOTE: For whatever reason, the last EOL doesn't seem to be included
 
         for (u32 i = 0; i < image_height; ++i) {
-            TRY(read_eol(*bit_stream, options.use_fill_bits));
+            if (options.require_end_of_line == Group3Options::RequireEndOfLine::Yes)
+                TRY(read_eol(*bit_stream, options.use_fill_bits));
             TRY(decode_single_ccitt3_1d_line(*bit_stream, *decoded_bits, image_width));
+            if (options.encoded_byte_aligned == Group3Options::EncodedByteAligned::Yes)
+                bit_stream->align_to_byte_boundary();
         }
 
         return decoded_bytes;
     }
+
+    if (options.require_end_of_line == Group3Options::RequireEndOfLine::No || options.encoded_byte_aligned == Group3Options::EncodedByteAligned::Yes)
+        return Error::from_string_literal("CCITTDecoder: Unsupported option for CCITT3 2D decoding");
 
     TRY(decode_single_ccitt3_2d_block(*bit_stream, *decoded_bits, image_width, image_height, options.use_fill_bits));
     return decoded_bytes;

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
@@ -43,9 +43,24 @@ struct Group3Options {
         Yes = 1,
     };
 
+    // Addition from the PDF specification
+    enum class RequireEndOfLine : u8 {
+        No = 0,
+        Yes = 1,
+    };
+
+    enum class EncodedByteAligned : u8 {
+        No = 0,
+        Yes = 1,
+    };
+
     Mode dimensions = Mode::OneDimension;
     Compression compression = Compression::Compressed;
     UseFillBits use_fill_bits = UseFillBits::No;
+
+    // Default values are set to be compatible with the CCITT specification
+    RequireEndOfLine require_end_of_line = RequireEndOfLine::Yes;
+    EncodedByteAligned encoded_byte_aligned = EncodedByteAligned::No;
 };
 
 ErrorOr<ByteBuffer> decode_ccitt_group3(ReadonlyBytes bytes, u32 image_width, u32 image_height, Group3Options const& options);


### PR DESCRIPTION
Fixes #23623

It was way harder than expected, I had to add two very small options to the decoder.
The PR is more than three times bigger than the size I called...

@nico