### PR TITLE
LibWeb: Enable sub deserialization and add {,de}serialization steps for CryptoKey, DOMQuad, and FileList

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-FileList.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-FileList.txt
@@ -1,0 +1,5 @@
+Select files...4 files selected.   input1:
+file1: text/plain: Contents for file1
+file2: text/plain: Contents for file2
+file3: text/plain: Contents for file3
+file4: text/plain: Contents for file4

--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
@@ -20,3 +20,8 @@ instanceOf DOMRectReadOnly: true
 DOMRectReadOnly: {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
 instanceOf DOMRect: true
 DOMRect: {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
+instanceOf CryptoKey: true
+CryptoKey.type: "secret"
+CryptoKey.extractable: false
+CryptoKey.algorithm: {"name":"PBKDF2"}
+CryptoKey.usages: ["deriveKey","deriveBits"]

--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-serializable-objects.txt
@@ -20,6 +20,8 @@ instanceOf DOMRectReadOnly: true
 DOMRectReadOnly: {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
 instanceOf DOMRect: true
 DOMRect: {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
+instanceOf DOMQuad: true
+DOMQuad: {"p1":{"x":10,"y":20,"z":30,"w":40},"p2":{"x":50,"y":60,"z":70,"w":80},"p3":{"x":90,"y":100,"z":110,"w":120},"p4":{"x":130,"y":140,"z":150,"w":160}}
 instanceOf CryptoKey: true
 CryptoKey.type: "secret"
 CryptoKey.extractable: false

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-FileList.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-FileList.html
@@ -1,0 +1,32 @@
+<input id="input1" type="file" multiple />
+<script src="../include.js"></script>
+<script>
+    const runTest = async id => {
+        let input = document.getElementById(id);
+
+        return new Promise(resolve => {
+            input.addEventListener("input", async () => {
+                println(`${id}:`);
+
+                let files = structuredClone(input.files);
+
+                for (let file of input.files) {
+                    const text = await file.text();
+
+                    println(`${file.name}: ${file.type}: ${text}`);
+                }
+
+                resolve();
+            });
+
+            internals.dispatchUserActivatedEvent(input, new Event("mousedown"));
+            input.showPicker();
+        });
+    }
+
+    asyncTest(async done => {
+        await runTest("input1");
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
@@ -43,6 +43,10 @@
         println(`instanceOf DOMRect: ${domRect instanceof DOMRect}`);
         println(`DOMRect: ${JSON.stringify(domRect)}`);
 
+        let domQuad = structuredClone(new DOMQuad(new DOMPoint(10, 20, 30, 40), new DOMPoint(50, 60, 70, 80), new DOMPoint(90, 100, 110, 120), new DOMPoint(130, 140, 150, 160)));
+        println(`instanceOf DOMQuad: ${domQuad instanceof DOMQuad}`);
+        println(`DOMQuad: ${JSON.stringify(domQuad)}`);
+
         let cryptoKey = await window.crypto.subtle.importKey(
             "raw",
             new TextEncoder().encode("password"),

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
@@ -43,6 +43,20 @@
         println(`instanceOf DOMRect: ${domRect instanceof DOMRect}`);
         println(`DOMRect: ${JSON.stringify(domRect)}`);
 
+        let cryptoKey = await window.crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode("password"),
+            { name: "PBKDF2" },
+            false,
+            ["deriveBits", "deriveKey"]
+        );
+        let clonedCryptoKey = structuredClone(cryptoKey);
+        println(`instanceOf CryptoKey: ${clonedCryptoKey instanceof CryptoKey}`);
+        println(`CryptoKey.type: ${JSON.stringify(clonedCryptoKey.type)}`);
+        println(`CryptoKey.extractable: ${JSON.stringify(clonedCryptoKey.extractable)}`);
+        println(`CryptoKey.algorithm: ${JSON.stringify(clonedCryptoKey.algorithm)}`);
+        println(`CryptoKey.usages: ${JSON.stringify(clonedCryptoKey.usages)}`);
+
         done();
     });
 </script>

--- a/Userland/Libraries/LibWeb/Bindings/Serializable.h
+++ b/Userland/Libraries/LibWeb/Bindings/Serializable.h
@@ -21,7 +21,7 @@ public:
     // https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps
     virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) = 0;
     // https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps
-    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) = 0;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position, HTML::DeserializationMemory&) = 0;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/Serializable.h
+++ b/Userland/Libraries/LibWeb/Bindings/Serializable.h
@@ -19,7 +19,7 @@ public:
     virtual StringView interface_name() const = 0;
 
     // https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps
-    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage) = 0;
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) = 0;
     // https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps
     virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) = 0;
 };

--- a/Userland/Libraries/LibWeb/Crypto/CryptoKey.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoKey.h
@@ -12,11 +12,14 @@
 #include <LibWeb/Bindings/CryptoKeyPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Bindings/Serializable.h>
 #include <LibWeb/Crypto/CryptoBindings.h>
 
 namespace Web::Crypto {
 
-class CryptoKey final : public Bindings::PlatformObject {
+class CryptoKey final
+    : public Bindings::PlatformObject
+    , public Bindings::Serializable {
     WEB_PLATFORM_OBJECT(CryptoKey, Bindings::PlatformObject);
     JS_DECLARE_ALLOCATOR(CryptoKey);
 
@@ -24,6 +27,7 @@ public:
     using InternalKeyData = Variant<ByteBuffer, Bindings::JsonWebKey, ::Crypto::PK::RSAPublicKey<>, ::Crypto::PK::RSAPrivateKey<>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<CryptoKey> create(JS::Realm&, InternalKeyData);
+    [[nodiscard]] static JS::NonnullGCPtr<CryptoKey> create(JS::Realm&);
 
     virtual ~CryptoKey() override;
 
@@ -41,8 +45,14 @@ public:
 
     InternalKeyData const& handle() const { return m_key_data; }
 
+    virtual StringView interface_name() const override { return "CryptoKey"sv; }
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage, HTML::SerializationMemory&) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position, HTML::DeserializationMemory&) override;
+
 private:
     CryptoKey(JS::Realm&, InternalKeyData);
+    explicit CryptoKey(JS::Realm&);
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -149,7 +149,7 @@ void Blob::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Blob);
 }
 
-WebIDL::ExceptionOr<void> Blob::serialization_steps(HTML::SerializationRecord& record, bool)
+WebIDL::ExceptionOr<void> Blob::serialization_steps(HTML::SerializationRecord& record, bool, HTML::SerializationMemory&)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -165,7 +165,7 @@ WebIDL::ExceptionOr<void> Blob::serialization_steps(HTML::SerializationRecord& r
     return {};
 }
 
-WebIDL::ExceptionOr<void> Blob::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position)
+WebIDL::ExceptionOr<void> Blob::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position, HTML::DeserializationMemory&)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -57,7 +57,7 @@ public:
 
     virtual StringView interface_name() const override { return "Blob"sv; }
 
-    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage, HTML::SerializationMemory&) override;
     virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -58,7 +58,7 @@ public:
     virtual StringView interface_name() const override { return "Blob"sv; }
 
     virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage, HTML::SerializationMemory&) override;
-    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position, HTML::DeserializationMemory&) override;
 
 protected:
     Blob(JS::Realm&, ByteBuffer, String type);

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -109,7 +109,7 @@ WebIDL::ExceptionOr<void> File::serialization_steps(HTML::SerializationRecord& r
     return {};
 }
 
-WebIDL::ExceptionOr<void> File::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position)
+WebIDL::ExceptionOr<void> File::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position, HTML::DeserializationMemory&)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -87,7 +87,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::construct_impl(JS::Realm& real
     return create(realm, file_bits, file_name, options);
 }
 
-WebIDL::ExceptionOr<void> File::serialization_steps(HTML::SerializationRecord& record, bool)
+WebIDL::ExceptionOr<void> File::serialization_steps(HTML::SerializationRecord& record, bool, HTML::SerializationMemory&)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/FileAPI/File.h
+++ b/Userland/Libraries/LibWeb/FileAPI/File.h
@@ -32,7 +32,7 @@ public:
 
     virtual StringView interface_name() const override { return "File"sv; }
 
-    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage, HTML::SerializationMemory&) override;
     virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
 
 private:

--- a/Userland/Libraries/LibWeb/FileAPI/File.h
+++ b/Userland/Libraries/LibWeb/FileAPI/File.h
@@ -33,7 +33,7 @@ public:
     virtual StringView interface_name() const override { return "File"sv; }
 
     virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& record, bool for_storage, HTML::SerializationMemory&) override;
-    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position, HTML::DeserializationMemory&) override;
 
 private:
     File(JS::Realm&, ByteBuffer, String file_name, String type, i64 last_modified);

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.cpp
@@ -18,9 +18,20 @@ JS::NonnullGCPtr<FileList> FileList::create(JS::Realm& realm, Vector<JS::Nonnull
     return realm.heap().allocate<FileList>(realm, realm, move(files));
 }
 
+JS::NonnullGCPtr<FileList> FileList::create(JS::Realm& realm)
+{
+    return realm.heap().allocate<FileList>(realm, realm);
+}
+
 FileList::FileList(JS::Realm& realm, Vector<JS::NonnullGCPtr<File>>&& files)
     : Bindings::PlatformObject(realm)
     , m_files(move(files))
+{
+    m_legacy_platform_object_flags = LegacyPlatformObjectFlags { .supports_indexed_properties = 1 };
+}
+
+FileList::FileList(JS::Realm& realm)
+    : Bindings::PlatformObject(realm)
 {
     m_legacy_platform_object_flags = LegacyPlatformObjectFlags { .supports_indexed_properties = 1 };
 }
@@ -57,6 +68,36 @@ void FileList::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     for (auto file : m_files)
         visitor.visit(file);
+}
+
+WebIDL::ExceptionOr<void> FileList::serialization_steps(HTML::SerializationRecord& serialized, bool for_storage, HTML::SerializationMemory& memory)
+{
+    auto& vm = this->vm();
+
+    // 1. Set serialized.[[Files]] to an empty list.
+    // 2. For each file in value, append the sub-serialization of file to serialized.[[Files]].
+    HTML::serialize_primitive_type(serialized, m_files.size());
+    for (auto& file : m_files)
+        serialized.extend(TRY(HTML::structured_serialize_internal(vm, file, for_storage, memory)));
+
+    return {};
+}
+
+WebIDL::ExceptionOr<void> FileList::deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position, HTML::DeserializationMemory& memory)
+{
+    auto& vm = this->vm();
+    auto& realm = *vm.current_realm();
+
+    // 1. For each file of serialized.[[Files]], add the sub-deserialization of file to value.
+    auto size = HTML::deserialize_primitive_type<size_t>(serialized, position);
+    for (size_t i = 0; i < size; ++i) {
+        auto deserialized_record = TRY(HTML::structured_deserialize_internal(vm, serialized, realm, memory, position));
+        if (deserialized_record.value.has_value() && is<File>(deserialized_record.value.value().as_object()))
+            m_files.append(dynamic_cast<File&>(deserialized_record.value.release_value().as_object()));
+        position = deserialized_record.position;
+    }
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.h
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.h
@@ -15,12 +15,16 @@
 
 namespace Web::FileAPI {
 
-class FileList : public Bindings::PlatformObject {
+class FileList
+    : public Bindings::PlatformObject
+    , public Bindings::Serializable {
     WEB_PLATFORM_OBJECT(FileList, Bindings::PlatformObject);
     JS_DECLARE_ALLOCATOR(FileList);
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<FileList> create(JS::Realm&, Vector<JS::NonnullGCPtr<File>>&&);
+    [[nodiscard]] static JS::NonnullGCPtr<FileList> create(JS::Realm&);
+
     virtual ~FileList() override;
 
     // https://w3c.github.io/FileAPI/#dfn-length
@@ -41,8 +45,13 @@ public:
     virtual bool is_supported_property_index(u32 index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
 
+    virtual StringView interface_name() const override { return "FileList"sv; }
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord& serialized, bool for_storage, HTML::SerializationMemory&) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position, HTML::DeserializationMemory&) override;
+
 private:
     FileList(JS::Realm&, Vector<JS::NonnullGCPtr<File>>&&);
+    explicit FileList(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -698,7 +698,7 @@ WebIDL::ExceptionOr<String> DOMMatrixReadOnly::to_string() const
 }
 
 // https://drafts.fxtf.org/geometry/#structured-serialization
-WebIDL::ExceptionOr<void> DOMMatrixReadOnly::serialization_steps(HTML::SerializationRecord& serialized, bool)
+WebIDL::ExceptionOr<void> DOMMatrixReadOnly::serialization_steps(HTML::SerializationRecord& serialized, bool, HTML::SerializationMemory&)
 {
     HTML::serialize_primitive_type(serialized, m_is_2d);
     // 1. If value’s is 2D is true:

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -759,7 +759,7 @@ WebIDL::ExceptionOr<void> DOMMatrixReadOnly::serialization_steps(HTML::Serializa
 }
 
 // https://drafts.fxtf.org/geometry/#structured-serialization
-WebIDL::ExceptionOr<void> DOMMatrixReadOnly::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position)
+WebIDL::ExceptionOr<void> DOMMatrixReadOnly::deserialization_steps(ReadonlySpan<u32> const& record, size_t& position, HTML::DeserializationMemory&)
 {
     bool is_2d = HTML::deserialize_primitive_type<bool>(record, position);
     // 1. If serialized.[[Is2D]] is true:

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
@@ -115,7 +115,7 @@ public:
     WebIDL::ExceptionOr<String> to_string() const;
 
     virtual StringView interface_name() const override { return "DOMMatrixReadOnly"sv; }
-    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
     virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
@@ -116,7 +116,7 @@ public:
 
     virtual StringView interface_name() const override { return "DOMMatrixReadOnly"sv; }
     virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
-    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const& record, size_t& position, HTML::DeserializationMemory&) override;
 
 protected:
     DOMMatrixReadOnly(JS::Realm&, double m11, double m12, double m21, double m22, double m41, double m42);

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
@@ -79,7 +79,7 @@ WebIDL::ExceptionOr<void> DOMPointReadOnly::serialization_steps(HTML::Serializat
     return {};
 }
 
-WebIDL::ExceptionOr<void> DOMPointReadOnly::deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position)
+WebIDL::ExceptionOr<void> DOMPointReadOnly::deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position, HTML::DeserializationMemory&)
 {
     // 1. Set value’s x coordinate to serialized.[[X]].
     m_x = HTML::deserialize_primitive_type<double>(serialized, position);

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
@@ -65,7 +65,7 @@ void DOMPointReadOnly::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(DOMPointReadOnly);
 }
 
-WebIDL::ExceptionOr<void> DOMPointReadOnly::serialization_steps(HTML::SerializationRecord& serialized, bool)
+WebIDL::ExceptionOr<void> DOMPointReadOnly::serialization_steps(HTML::SerializationRecord& serialized, bool, HTML::SerializationMemory&)
 {
     // 1. Set serialized.[[X]] to value’s x coordinate.
     HTML::serialize_primitive_type(serialized, m_x);

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
@@ -46,7 +46,7 @@ public:
 
     virtual StringView interface_name() const override { return "DOMPointReadOnly"sv; }
     virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
-    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position, HTML::DeserializationMemory&) override;
 
 protected:
     DOMPointReadOnly(JS::Realm&, double x, double y, double z, double w);

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
@@ -45,7 +45,7 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPoint>> matrix_transform(DOMMatrixInit&) const;
 
     virtual StringView interface_name() const override { return "DOMPointReadOnly"sv; }
-    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
     virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
@@ -16,12 +16,26 @@ JS::NonnullGCPtr<DOMQuad> DOMQuad::construct_impl(JS::Realm& realm, DOMPointInit
     return realm.heap().allocate<DOMQuad>(realm, realm, p1, p2, p3, p4);
 }
 
+JS::NonnullGCPtr<DOMQuad> DOMQuad::create(JS::Realm& realm)
+{
+    return realm.heap().allocate<DOMQuad>(realm, realm);
+}
+
 DOMQuad::DOMQuad(JS::Realm& realm, DOMPointInit const& p1, DOMPointInit const& p2, DOMPointInit const& p3, DOMPointInit const& p4)
     : PlatformObject(realm)
     , m_p1(DOMPoint::from_point(realm.vm(), p1))
     , m_p2(DOMPoint::from_point(realm.vm(), p2))
     , m_p3(DOMPoint::from_point(realm.vm(), p3))
     , m_p4(DOMPoint::from_point(realm.vm(), p4))
+{
+}
+
+DOMQuad::DOMQuad(JS::Realm& realm)
+    : PlatformObject(realm)
+    , m_p1(DOMPoint::create(realm))
+    , m_p2(DOMPoint::create(realm))
+    , m_p3(DOMPoint::create(realm))
+    , m_p4(DOMPoint::create(realm))
 {
 }
 
@@ -82,6 +96,53 @@ JS::NonnullGCPtr<DOMRect> DOMQuad::get_bounds() const
 
     // 7. Return bounds.
     return bounds;
+}
+
+// https://drafts.fxtf.org/geometry/#structured-serialization
+WebIDL::ExceptionOr<void> DOMQuad::serialization_steps(HTML::SerializationRecord& serialzied, bool for_storage, HTML::SerializationMemory& memory)
+{
+    auto& vm = this->vm();
+    // 1. Set serialized.[[P1]] to the sub-serialization of value’s point 1.
+    serialzied.extend(TRY(HTML::structured_serialize_internal(vm, m_p1, for_storage, memory)));
+    // 2. Set serialized.[[P2]] to the sub-serialization of value’s point 2.
+    serialzied.extend(TRY(HTML::structured_serialize_internal(vm, m_p2, for_storage, memory)));
+    // 3. Set serialized.[[P3]] to the sub-serialization of value’s point 3.
+    serialzied.extend(TRY(HTML::structured_serialize_internal(vm, m_p3, for_storage, memory)));
+    // 4. Set serialized.[[P4]] to the sub-serialization of value’s point 4.
+    serialzied.extend(TRY(HTML::structured_serialize_internal(vm, m_p4, for_storage, memory)));
+
+    return {};
+}
+
+// https://drafts.fxtf.org/geometry/#structured-serialization
+WebIDL::ExceptionOr<void> DOMQuad::deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position, HTML::DeserializationMemory& memory)
+{
+    auto& realm = this->realm();
+    // 1. Set value’s point 1 to the sub-deserialization of serialized.[[P1]].
+    auto deserialized_record = TRY(HTML::structured_deserialize_internal(vm(), serialized, realm, memory, position));
+    if (deserialized_record.value.has_value() && is<DOMPoint>(deserialized_record.value.value().as_object()))
+        m_p1 = dynamic_cast<DOMPoint&>(deserialized_record.value.release_value().as_object());
+    position = deserialized_record.position;
+
+    // 2. Set value’s point 2 to the sub-deserialization of serialized.[[P2]].
+    deserialized_record = TRY(HTML::structured_deserialize_internal(vm(), serialized, realm, memory, position));
+    if (deserialized_record.value.has_value() && is<DOMPoint>(deserialized_record.value.value().as_object()))
+        m_p2 = dynamic_cast<DOMPoint&>(deserialized_record.value.release_value().as_object());
+    position = deserialized_record.position;
+
+    // 3. Set value’s point 3 to the sub-deserialization of serialized.[[P3]].
+    deserialized_record = TRY(HTML::structured_deserialize_internal(vm(), serialized, realm, memory, position));
+    if (deserialized_record.value.has_value() && is<DOMPoint>(deserialized_record.value.value().as_object()))
+        m_p3 = dynamic_cast<DOMPoint&>(deserialized_record.value.release_value().as_object());
+    position = deserialized_record.position;
+
+    // 4. Set value’s point 4 to the sub-deserialization of serialized.[[P4]].
+    deserialized_record = TRY(HTML::structured_deserialize_internal(vm(), serialized, realm, memory, position));
+    if (deserialized_record.value.has_value() && is<DOMPoint>(deserialized_record.value.value().as_object()))
+        m_p4 = dynamic_cast<DOMPoint&>(deserialized_record.value.release_value().as_object());
+    position = deserialized_record.position;
+
+    return {};
 }
 
 void DOMQuad::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Geometry/DOMQuad.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMQuad.h
@@ -22,12 +22,15 @@ struct DOMQuadInit {
 };
 
 // https://drafts.fxtf.org/geometry/#domquad
-class DOMQuad : public Bindings::PlatformObject {
+class DOMQuad
+    : public Bindings::PlatformObject
+    , public Bindings::Serializable {
     WEB_PLATFORM_OBJECT(DOMQuad, Bindings::PlatformObject);
     JS_DECLARE_ALLOCATOR(DOMQuad);
 
 public:
     static JS::NonnullGCPtr<DOMQuad> construct_impl(JS::Realm&, DOMPointInit const& p1, DOMPointInit const& p2, DOMPointInit const& p3, DOMPointInit const& p4);
+    static JS::NonnullGCPtr<DOMQuad> create(JS::Realm& realm);
 
     virtual ~DOMQuad() override;
 
@@ -41,8 +44,13 @@ public:
 
     JS::NonnullGCPtr<DOMRect> get_bounds() const;
 
+    virtual StringView interface_name() const override { return "DOMQuad"sv; }
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position, HTML::DeserializationMemory&) override;
+
 private:
     DOMQuad(JS::Realm&, DOMPointInit const& p1, DOMPointInit const& p2, DOMPointInit const& p3, DOMPointInit const& p4);
+    explicit DOMQuad(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
@@ -65,7 +65,7 @@ WebIDL::ExceptionOr<void> DOMRectReadOnly::serialization_steps(HTML::Serializati
 }
 
 // https://drafts.fxtf.org/geometry/#structured-serialization
-WebIDL::ExceptionOr<void> DOMRectReadOnly::deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position)
+WebIDL::ExceptionOr<void> DOMRectReadOnly::deserialization_steps(ReadonlySpan<u32> const& serialized, size_t& position, HTML::DeserializationMemory&)
 {
     // 1. Set value’s x coordinate to serialized.[[X]].
     auto x = HTML::deserialize_primitive_type<double>(serialized, position);

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
@@ -51,7 +51,7 @@ void DOMRectReadOnly::initialize(JS::Realm& realm)
 }
 
 // https://drafts.fxtf.org/geometry/#structured-serialization
-WebIDL::ExceptionOr<void> DOMRectReadOnly::serialization_steps(HTML::SerializationRecord& serialized, bool)
+WebIDL::ExceptionOr<void> DOMRectReadOnly::serialization_steps(HTML::SerializationRecord& serialized, bool, HTML::SerializationMemory&)
 {
     // 1. Set serialized.[[X]] to value’s x coordinate.
     HTML::serialize_primitive_type(serialized, this->x());

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
@@ -71,7 +71,7 @@ public:
 
     virtual StringView interface_name() const override { return "DOMRectReadOnly"sv; }
     virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
-    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
+    virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position, HTML::DeserializationMemory&) override;
 
 protected:
     DOMRectReadOnly(JS::Realm&, double x, double y, double width, double height);

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
@@ -70,7 +70,7 @@ public:
     }
 
     virtual StringView interface_name() const override { return "DOMRectReadOnly"sv; }
-    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage) override;
+    virtual WebIDL::ExceptionOr<void> serialization_steps(HTML::SerializationRecord&, bool for_storage, HTML::SerializationMemory&) override;
     virtual WebIDL::ExceptionOr<void> deserialization_steps(ReadonlySpan<u32> const&, size_t& position) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -315,7 +315,7 @@ public:
             TRY(serialize_string(m_vm, m_serialized, serializable.interface_name()));
 
             // 1. Perform the serialization steps for value's primary interface, given value, serialized, and forStorage.
-            TRY(serializable.serialization_steps(m_serialized, m_for_storage));
+            TRY(serializable.serialization_steps(m_serialized, m_for_storage, m_memory));
         }
 
         // 20. Otherwise, if value is a platform object, then throw a "DataCloneError" DOMException.

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -36,6 +36,7 @@
 #include <LibWeb/Crypto/CryptoKey.h>
 #include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/FileAPI/File.h>
+#include <LibWeb/FileAPI/FileList.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/Geometry/DOMMatrixReadOnly.h>
 #include <LibWeb/Geometry/DOMPoint.h>
@@ -974,6 +975,8 @@ private:
             return FileAPI::Blob::create(realm);
         if (interface_name == "File"sv)
             return FileAPI::File::create(realm);
+        if (interface_name == "FileList"sv)
+            return FileAPI::FileList::create(realm);
         if (interface_name == "DOMMatrixReadOnly"sv)
             return Geometry::DOMMatrixReadOnly::create(realm);
         if (interface_name == "DOMMatrix"sv)

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -307,7 +307,7 @@ public:
             deep = true;
         }
 
-        // FIXME: 19. Otherwise, if value is a platform object that is a serializable object:
+        // 19. Otherwise, if value is a platform object that is a serializable object:
         else if (value.is_object() && is<Bindings::Serializable>(value.as_object())) {
             auto& serializable = dynamic_cast<Bindings::Serializable&>(value.as_object());
 

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -949,7 +949,7 @@ public:
             else {
                 // 1. Perform the appropriate deserialization steps for the interface identified by serialized.[[Type]], given serialized, value, and targetRealm.
                 auto& serializable = dynamic_cast<Bindings::Serializable&>(value.as_object());
-                TRY(serializable.deserialization_steps(m_serialized, m_position));
+                TRY(serializable.deserialization_steps(m_serialized, m_position, m_memory));
             }
         }
 

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -40,6 +40,7 @@
 #include <LibWeb/Geometry/DOMMatrixReadOnly.h>
 #include <LibWeb/Geometry/DOMPoint.h>
 #include <LibWeb/Geometry/DOMPointReadOnly.h>
+#include <LibWeb/Geometry/DOMQuad.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/Geometry/DOMRectReadOnly.h>
 #include <LibWeb/HTML/MessagePort.h>
@@ -987,6 +988,8 @@ private:
             return Geometry::DOMRect::create(realm);
         if (interface_name == "CryptoKey"sv)
             return Crypto::CryptoKey::create(realm);
+        if (interface_name == "DOMQuad"sv)
+            return Geometry::DOMQuad::create(realm);
 
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/Serializable.h>
 #include <LibWeb/Bindings/Transferable.h>
+#include <LibWeb/Crypto/CryptoKey.h>
 #include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/FileAPI/File.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
@@ -984,6 +985,8 @@ private:
             return Geometry::DOMRectReadOnly::create(realm);
         if (interface_name == "DOMRect"sv)
             return Geometry::DOMRect::create(realm);
+        if (interface_name == "CryptoKey"sv)
+            return Crypto::CryptoKey::create(realm);
 
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -41,6 +41,11 @@ struct DeserializedTransferRecord {
     Vector<JS::Handle<JS::Object>> transferred_values;
 };
 
+struct DeserializedRecord {
+    Optional<JS::Value> value;
+    size_t position;
+};
+
 enum class TransferType : u8 {
     MessagePort,
 };
@@ -50,6 +55,7 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize_for_storage(JS::VM
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& vm, JS::Value, bool for_storage, SerializationMemory&);
 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory>);
+WebIDL::ExceptionOr<DeserializedRecord> structured_deserialize_internal(JS::VM& vm, ReadonlySpan<u32> const& serialized, JS::Realm& target_realm, DeserializationMemory& memory, Optional<size_t> position = {});
 
 void serialize_boolean_primitive(SerializationRecord& serialized, JS::Value& value);
 void serialize_number_primitive(SerializationRecord& serialized, JS::Value& value);


### PR DESCRIPTION
This enables sub deserialization by adding the function `structured_deserialize_internal()`, we already have `structured_serialize_internal()` so no further changes is needed to enable sub serialization.

`SerializationMemory` and `DeserializationMemory` are now forwarded to `Serializable::serialization_steps()` and `Serializable::deserialization_steps()` to be used in the context of sub serialization and deseralization.

This adds serialization and deserialization steps to CryptoKey, DOMQuad, and FileList.