### PR TITLE
LibWeb: Iterative fast path for non-recursive selectors

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -14,12 +14,12 @@ namespace Web::CSS {
 
 JS_DEFINE_ALLOCATOR(CSSStyleRule);
 
-JS::NonnullGCPtr<CSSStyleRule> CSSStyleRule::create(JS::Realm& realm, Vector<NonnullRefPtr<Web::CSS::Selector>>&& selectors, CSSStyleDeclaration& declaration)
+JS::NonnullGCPtr<CSSStyleRule> CSSStyleRule::create(JS::Realm& realm, Vector<NonnullRefPtr<Web::CSS::Selector>>&& selectors, PropertyOwningCSSStyleDeclaration& declaration)
 {
     return realm.heap().allocate<CSSStyleRule>(realm, realm, move(selectors), declaration);
 }
 
-CSSStyleRule::CSSStyleRule(JS::Realm& realm, Vector<NonnullRefPtr<Selector>>&& selectors, CSSStyleDeclaration& declaration)
+CSSStyleRule::CSSStyleRule(JS::Realm& realm, Vector<NonnullRefPtr<Selector>>&& selectors, PropertyOwningCSSStyleDeclaration& declaration)
     : CSSRule(realm)
     , m_selectors(move(selectors))
     , m_declaration(declaration)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -19,12 +19,12 @@ class CSSStyleRule final : public CSSRule {
     JS_DECLARE_ALLOCATOR(CSSStyleRule);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<CSSStyleRule> create(JS::Realm&, Vector<NonnullRefPtr<Selector>>&&, CSSStyleDeclaration&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSStyleRule> create(JS::Realm&, Vector<NonnullRefPtr<Selector>>&&, PropertyOwningCSSStyleDeclaration&);
 
     virtual ~CSSStyleRule() override = default;
 
     Vector<NonnullRefPtr<Selector>> const& selectors() const { return m_selectors; }
-    CSSStyleDeclaration const& declaration() const { return m_declaration; }
+    PropertyOwningCSSStyleDeclaration const& declaration() const { return m_declaration; }
 
     virtual Type type() const override { return Type::Style; }
 
@@ -34,14 +34,14 @@ public:
     CSSStyleDeclaration* style();
 
 private:
-    CSSStyleRule(JS::Realm&, Vector<NonnullRefPtr<Selector>>&&, CSSStyleDeclaration&);
+    CSSStyleRule(JS::Realm&, Vector<NonnullRefPtr<Selector>>&&, PropertyOwningCSSStyleDeclaration&);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
     virtual String serialized() const override;
 
     Vector<NonnullRefPtr<Selector>> m_selectors;
-    JS::NonnullGCPtr<CSSStyleDeclaration> m_declaration;
+    JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration> m_declaration;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -686,6 +686,8 @@ static bool fast_matches_simple_selector(CSS::Selector::SimpleSelector const& si
         return simple_selector.name() == element.id();
     case CSS::Selector::SimpleSelector::Type::Attribute:
         return matches_attribute(simple_selector.attribute(), style_sheet_for_rule, element);
+    case CSS::Selector::SimpleSelector::Type::PseudoClass:
+        return matches_pseudo_class(simple_selector.pseudo_class(), style_sheet_for_rule, element, nullptr);
     default:
         VERIFY_NOT_REACHED();
     }
@@ -765,7 +767,28 @@ bool can_use_fast_matches(CSS::Selector const& selector)
         }
 
         for (auto const& simple_selector : compound_selector.simple_selectors) {
-            if (simple_selector.type != CSS::Selector::SimpleSelector::Type::TagName
+            if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass) {
+                auto const pseudo_class = simple_selector.pseudo_class().type;
+                if (pseudo_class != CSS::PseudoClass::FirstChild
+                    && pseudo_class != CSS::PseudoClass::LastChild
+                    && pseudo_class != CSS::PseudoClass::OnlyChild
+                    && pseudo_class != CSS::PseudoClass::Hover
+                    && pseudo_class != CSS::PseudoClass::Active
+                    && pseudo_class != CSS::PseudoClass::Focus
+                    && pseudo_class != CSS::PseudoClass::FocusVisible
+                    && pseudo_class != CSS::PseudoClass::FocusWithin
+                    && pseudo_class != CSS::PseudoClass::Link
+                    && pseudo_class != CSS::PseudoClass::AnyLink
+                    && pseudo_class != CSS::PseudoClass::Visited
+                    && pseudo_class != CSS::PseudoClass::LocalLink
+                    && pseudo_class != CSS::PseudoClass::Empty
+                    && pseudo_class != CSS::PseudoClass::Root
+                    && pseudo_class != CSS::PseudoClass::Enabled
+                    && pseudo_class != CSS::PseudoClass::Disabled
+                    && pseudo_class != CSS::PseudoClass::Checked) {
+                    return false;
+                }
+            } else if (simple_selector.type != CSS::Selector::SimpleSelector::Type::TagName
                 && simple_selector.type != CSS::Selector::SimpleSelector::Type::Universal
                 && simple_selector.type != CSS::Selector::SimpleSelector::Type::Class
                 && simple_selector.type != CSS::Selector::SimpleSelector::Type::Id

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2024, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,5 +12,8 @@
 namespace Web::SelectorEngine {
 
 bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type> = {}, JS::GCPtr<DOM::ParentNode const> scope = {});
+
+[[nodiscard]] bool fast_matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&);
+[[nodiscard]] bool can_use_fast_matches(CSS::Selector const&);
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -730,7 +730,7 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
     auto properties_for_revert = style.properties();
 
     for (auto const& match : matching_rules) {
-        for (auto const& property : verify_cast<PropertyOwningCSSStyleDeclaration>(match.rule->declaration()).properties()) {
+        for (auto const& property : match.rule->declaration().properties()) {
             if (important != property.important)
                 continue;
 
@@ -772,7 +772,7 @@ static void cascade_custom_properties(DOM::Element& element, Optional<CSS::Selec
 {
     size_t needed_capacity = 0;
     for (auto const& matching_rule : matching_rules)
-        needed_capacity += verify_cast<PropertyOwningCSSStyleDeclaration>(matching_rule.rule->declaration()).custom_properties().size();
+        needed_capacity += matching_rule.rule->declaration().custom_properties().size();
 
     if (!pseudo_element.has_value()) {
         if (auto const inline_style = element.inline_style())
@@ -783,7 +783,7 @@ static void cascade_custom_properties(DOM::Element& element, Optional<CSS::Selec
     custom_properties.ensure_capacity(needed_capacity);
 
     for (auto const& matching_rule : matching_rules) {
-        for (auto const& it : verify_cast<PropertyOwningCSSStyleDeclaration>(matching_rule.rule->declaration()).custom_properties())
+        for (auto const& it : matching_rule.rule->declaration().custom_properties())
             custom_properties.set(it.key, it.value);
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -41,6 +41,7 @@ struct MatchingRule {
     CascadeOrigin cascade_origin;
     bool contains_pseudo_element { false };
     bool contains_root_pseudo_class { false };
+    bool can_use_fast_matches { false };
 };
 
 struct FontFaceKey {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -374,19 +374,6 @@ Vector<String> Element::get_attribute_names() const
     return names;
 }
 
-bool Element::has_class(FlyString const& class_name, CaseSensitivity case_sensitivity) const
-{
-    if (case_sensitivity == CaseSensitivity::CaseSensitive) {
-        return any_of(m_classes, [&](auto& it) {
-            return it == class_name;
-        });
-    } else {
-        return any_of(m_classes, [&](auto& it) {
-            return it.equals_ignoring_ascii_case(class_name);
-        });
-    }
-}
-
 JS::GCPtr<Layout::Node> Element::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
 {
     if (local_name() == "noscript" && document().is_scripting_enabled())

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -454,6 +454,22 @@ private:
 template<>
 inline bool Node::fast_is<Element>() const { return is_element(); }
 
+inline Element* Node::parent_element()
+{
+    auto* parent = this->parent();
+    if (!parent || !is<Element>(parent))
+        return nullptr;
+    return static_cast<Element*>(parent);
+}
+
+inline Element const* Node::parent_element() const
+{
+    auto const* parent = this->parent();
+    if (!parent || !is<Element>(parent))
+        return nullptr;
+    return static_cast<Element const*>(parent);
+}
+
 WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -470,6 +470,18 @@ inline Element const* Node::parent_element() const
     return static_cast<Element const*>(parent);
 }
 
+inline bool Element::has_class(FlyString const& class_name, CaseSensitivity case_sensitivity) const
+{
+    if (case_sensitivity == CaseSensitivity::CaseSensitive) {
+        return any_of(m_classes, [&](auto& it) {
+            return it == class_name;
+        });
+    }
+    return any_of(m_classes, [&](auto& it) {
+        return it.equals_ignoring_ascii_case(class_name);
+    });
+}
+
 WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -330,20 +330,6 @@ bool Node::is_connected() const
     return shadow_including_root().is_document();
 }
 
-Element* Node::parent_element()
-{
-    if (!parent() || !is<Element>(parent()))
-        return nullptr;
-    return verify_cast<Element>(parent());
-}
-
-Element const* Node::parent_element() const
-{
-    if (!parent() || !is<Element>(parent()))
-        return nullptr;
-    return verify_cast<Element>(parent());
-}
-
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
 WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child) const
 {

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -694,15 +694,14 @@ ErrorOr<void> dump_style_rule(StringBuilder& builder, CSS::CSSStyleRule const& r
     }
     indent(builder, indent_levels);
     builder.append("  Declarations:\n"sv);
-    auto& style_declaration = verify_cast<CSS::PropertyOwningCSSStyleDeclaration>(rule.declaration());
-    for (auto& property : style_declaration.properties()) {
+    for (auto& property : rule.declaration().properties()) {
         indent(builder, indent_levels);
         builder.appendff("    {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string());
         if (property.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');
     }
-    for (auto& property : style_declaration.custom_properties()) {
+    for (auto& property : rule.declaration().custom_properties()) {
         indent(builder, indent_levels);
         builder.appendff("    {}: '{}'", property.key, property.value.value->to_string());
         if (property.value.important == CSS::Important::Yes)


### PR DESCRIPTION
This PR introduces a fast path version of `SelectorEngine` that only works for kinda-trivial non-recursive selectors.

Instead of recursing, it evaluates selectors through a combination of iteration and backtracking (for descendant combinators).

All these changes combined give us a 20% speed-up on the "descendant and child combinators" subtest of StyleBench.

The kind of selectors we can evaluate with the fast path are extremely common on the web. 56% of selectors evaluated while loading our GitHub repo are now done this way.