### PR TITLE
LibGfx: Output an SVG compatible string from `Path::to_byte_string()`

### DIFF
--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -291,40 +291,30 @@ void Path::close_all_subpaths()
 
 ByteString Path::to_byte_string() const
 {
+    // Dumps this path as an SVG compatible string.
     StringBuilder builder;
-    builder.append("Path { "sv);
+    if (is_empty() || m_commands.first() != PathSegment::MoveTo)
+        builder.append("M 0,0"sv);
     for (auto segment : *this) {
+        if (!builder.is_empty())
+            builder.append(' ');
         switch (segment.command()) {
         case PathSegment::MoveTo:
-            builder.append("MoveTo"sv);
+            builder.append('M');
             break;
         case PathSegment::LineTo:
-            builder.append("LineTo"sv);
+            builder.append('L');
             break;
         case PathSegment::QuadraticBezierCurveTo:
-            builder.append("QuadraticBezierCurveTo"sv);
+            builder.append('Q');
             break;
         case PathSegment::CubicBezierCurveTo:
-            builder.append("CubicBezierCurveTo"sv);
+            builder.append('C');
             break;
         }
-        builder.appendff("({}", segment.point());
-
-        switch (segment.command()) {
-        case PathSegment::QuadraticBezierCurveTo:
-            builder.appendff(", {}"sv, segment.through());
-            break;
-        case PathSegment::CubicBezierCurveTo:
-            builder.appendff(", {}"sv, segment.through_0());
-            builder.appendff(", {}"sv, segment.through_1());
-            break;
-        default:
-            break;
-        }
-
-        builder.append(") "sv);
+        for (auto point : segment.points())
+            builder.appendff(" {},{}", point.x(), point.y());
     }
-    builder.append('}');
     return builder.to_byte_string();
 }
 

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -44,6 +44,7 @@ public:
         VERIFY(m_command == Command::CubicBezierCurveTo);
         return m_points[1];
     }
+    ALWAYS_INLINE ReadonlySpan<FloatPoint> points() const { return m_points; }
 
     static constexpr int points_per_command(Command command)
     {

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -166,13 +166,13 @@ public:
 
     void quadratic_bezier_curve_to(FloatPoint through, FloatPoint point)
     {
-        append_segment<PathSegment::QuadraticBezierCurveTo>(point, through);
+        append_segment<PathSegment::QuadraticBezierCurveTo>(through, point);
         invalidate_split_lines();
     }
 
     void cubic_bezier_curve_to(FloatPoint c1, FloatPoint c2, FloatPoint p2)
     {
-        append_segment<PathSegment::CubicBezierCurveTo>(p2, c1, c2);
+        append_segment<PathSegment::CubicBezierCurveTo>(c1, c2, p2);
         invalidate_split_lines();
     }
 
@@ -254,14 +254,14 @@ private:
     void segmentize_path();
 
     template<PathSegment::Command command, typename... Args>
-    void append_segment(FloatPoint point, Args&&... args)
+    void append_segment(Args&&... args)
     {
-        constexpr auto point_count = sizeof...(Args) + 1;
+        constexpr auto point_count = sizeof...(Args);
         static_assert(point_count == PathSegment::points_per_command(command));
-        m_commands.append(command);
-        // Place the current path point after any extra control points so `m_points.last()` is always the last point.
-        FloatPoint points[] { args..., point };
+        FloatPoint points[] { args... };
+        // Note: This should maintain the invariant that `m_points.last()` is always the last point in the path.
         m_points.append(points, point_count);
+        m_commands.append(command);
     }
 
     Vector<FloatPoint> m_points {};


### PR DESCRIPTION
This is much more useful than the previous format, as you can now just paste the path into a site like https://svg-path-visualizer.netlify.app/ to debug issues.
