### PR TITLE
LibWeb: Let HTMLCollection cache its element list

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -97,6 +97,11 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> construct_impl(JS::Realm&);
     virtual ~Document() override;
 
+    // AD-HOC: This number increments whenever a node is added or removed from the document, or an element attribute changes.
+    //         It can be used as a crude invalidation mechanism for caches that depend on the DOM structure.
+    u64 dom_tree_version() const { return m_dom_tree_version; }
+    void bump_dom_tree_version() { ++m_dom_tree_version; }
+
     WebIDL::ExceptionOr<void> populate_with_html_head_and_body();
 
     JS::GCPtr<Selection::Selection> get_selection() const;
@@ -846,6 +851,8 @@ private:
     mutable JS::GCPtr<WebIDL::ObservableArray> m_adopted_style_sheets;
 
     Vector<JS::NonnullGCPtr<DOM::ShadowRoot>> m_shadow_roots;
+
+    u64 m_dom_tree_version { 0 };
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -437,6 +437,8 @@ void Element::run_attribute_change_steps(FlyString const& local_name, Optional<S
     // AD-HOC: Run our own internal attribute change handler.
     attribute_changed(local_name, value);
     invalidate_style_after_attribute_change(local_name);
+
+    document().bump_dom_tree_version();
 }
 
 void Element::attribute_changed(FlyString const& name, Optional<String> const& value)

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -60,6 +60,9 @@ protected:
 private:
     virtual void visit_edges(Cell::Visitor&) override;
 
+    mutable u64 m_cached_dom_tree_version { 0 };
+    mutable Vector<JS::NonnullGCPtr<Element>> m_cached_elements;
+
     JS::NonnullGCPtr<ParentNode> m_root;
     Function<bool(Element const&)> m_filter;
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -207,6 +207,8 @@ void Node::set_text_content(Optional<String> const& maybe_content)
 
     document().invalidate_style();
     document().invalidate_layout();
+
+    document().bump_dom_tree_version();
 }
 
 // https://dom.spec.whatwg.org/#dom-node-nodevalue
@@ -510,6 +512,8 @@ void Node::insert_before(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child, boo
     invalidate_style();
 
     document().invalidate_layout();
+
+    document().bump_dom_tree_version();
 }
 
 // https://dom.spec.whatwg.org/#concept-node-pre-insert
@@ -703,6 +707,8 @@ void Node::remove(bool suppress_observers)
     // In the future, we should find a way to only invalidate the parts that actually need it.
     document().invalidate_style();
     document().invalidate_layout();
+
+    document().bump_dom_tree_version();
 }
 
 // https://dom.spec.whatwg.org/#concept-node-replace


### PR DESCRIPTION
Use a new DOM tree version mechanism to allow `HTMLCollection` to
remember its internal list of elements instead of rebuilding it on
every access.
    
This avoids thousands of full DOM walks while loading our GitHub repo.
    
Also ~15% speed-up on jQuery subtests in Speedometer 3.0 :^)