### PR TITLE
LibWeb: Use ErrorOr to propagate SVG attribute parsing errors 

### DIFF
--- a/Tests/LibWeb/Ref/reference/svg-invalid-number-arguments-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-invalid-number-arguments-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x1="0" y1="0" x2="10" y2="0" stroke="black" />
+</svg>

--- a/Tests/LibWeb/Ref/reference/svg-path-incomplete-args-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-path-incomplete-args-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<div>
+    <svg width="800" height="100">
+        <text x="0" y="50" font-size="1em">This should be drawn</text>
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <g stroke="black">
+            <path d="M 0 50 A 30 20, 0, 0 0, 90 50" />    
+            <path stroke-width="5" d="M 50 0 V 50" />            
+        </g>
+    </svg>
+</div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>
+<div><svg width="100" height="100"></svg></div>

--- a/Tests/LibWeb/Ref/reference/svg-polygon-with-incomplete-points-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-polygon-with-incomplete-points-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<svg viewBox="0 0 10 10" width="100" height="100"></svg>
+<svg viewBox="0 0 10 10" width="100" height="100"></svg>
+<svg viewBox="0 0 10 10" width="100" height="100"></svg>
+<svg viewBox="0 0 10 10" width="100" height="100"></svg>
+<svg viewBox="0 0 10 10" width="100" height="100"></svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10 10,0" />
+</svg>

--- a/Tests/LibWeb/Ref/svg-invalid-number-arguments.html
+++ b/Tests/LibWeb/Ref/svg-invalid-number-arguments.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/svg-invalid-number-arguments-ref.html" />
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="-" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="+" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="." stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="--" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="++" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="+." stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2="-." stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2=".+" stroke="black" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <line x2="10" y2=".-" stroke="black" />
+</svg>

--- a/Tests/LibWeb/Ref/svg-path-incomplete-args.html
+++ b/Tests/LibWeb/Ref/svg-path-incomplete-args.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/svg-path-incomplete-args-ref.html" />
+<div>
+    <svg width="800" height="100">
+        <g stroke="black">
+            <path d="invalid" />
+        </g>
+        <text x="0" y="50" font-size="1em">This should be drawn</text>
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <g stroke="black">
+            <path d="M 0 50 A 30 20, 0, 0 0, 90 50 this elliptical arc should be drawn" />        
+            <path stroke-width="5" d="M 50 0 V 50 this vertical line should be drawn" />        
+        </g>
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <!--This won't be drawn since paths should start with an M command-->
+        <path stroke="black" d="V10" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 VH 10" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 L 10" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" stroke-width="5" fill="transparent" d="M 10 10 C 20" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" stroke-width="5" fill="transparent" d="M 10 10 C 20 20, 40 20" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" stroke-width="5" fill="transparent" d="M 10 10 C 20 20, 40 20, 50" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" stroke-width="5" d="M 0 50 L 10" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 A" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 A 30" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 A 30 20," />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 A 30 20, 0" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path d="M 0 50 A 30 20, 0, 0" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 A 30 20, 0, 0 0" />
+    </svg>
+</div>
+<div>
+    <svg width="100" height="100">
+        <path stroke="black" d="M 0 50 A 30 20, 0, 0 0, 90" />
+    </svg>
+</div>

--- a/Tests/LibWeb/Ref/svg-polygon-with-incomplete-points.html
+++ b/Tests/LibWeb/Ref/svg-polygon-with-incomplete-points.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/svg-polygon-with-incomplete-points-ref.html" />
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points=" " />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="," />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="10" />        
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="10," />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10 10," />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10 10" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0 0 0 10 10 10 10 invalid" />
+</svg>
+<svg viewBox="0 0 10 10" width="100" height="100">
+    <polygon points="0,0 0,10 10,10 10,0 a complete rectangle should be drawn here" />
+</svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -73,9 +73,9 @@ Optional<CSSPixelFraction> SVGSVGBox::calculate_intrinsic_aspect_ratio() const
         auto const& viewbox = dom_node().view_box().value();
 
         // 2. return viewbox.width / viewbox.height
-        auto height = CSSPixels::nearest_value_for(viewbox.height);
-        if (height != 0)
-            return CSSPixels::nearest_value_for(viewbox.width) / CSSPixels::nearest_value_for(viewbox.height);
+        auto viewbox_height = CSSPixels::nearest_value_for(viewbox.height);
+        if (viewbox_height != 0)
+            return CSSPixels::nearest_value_for(viewbox.width) / viewbox_height;
 
         return {};
     }

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -262,7 +262,7 @@ void AttributeParser::parse_elliptical_arc()
     parse_whitespace();
 
     while (true) {
-        m_instructions.append({ PathInstructionType::EllipticalArc, absolute, parse_elliptical_arg_argument() });
+        m_instructions.append({ PathInstructionType::EllipticalArc, absolute, parse_elliptical_arc_argument() });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -342,7 +342,7 @@ Vector<float> AttributeParser::parse_coordinate_pair_triplet()
     return coordinates;
 }
 
-Vector<float> AttributeParser::parse_elliptical_arg_argument()
+Vector<float> AttributeParser::parse_elliptical_arc_argument()
 {
     Vector<float> numbers;
     numbers.append(parse_number());

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -159,33 +160,33 @@ public:
 private:
     AttributeParser(StringView source);
 
-    void parse_drawto();
-    void parse_moveto();
+    ErrorOr<void> parse_drawto();
+    ErrorOr<void> parse_moveto();
     void parse_closepath();
-    void parse_lineto();
-    void parse_horizontal_lineto();
-    void parse_vertical_lineto();
-    void parse_curveto();
-    void parse_smooth_curveto();
-    void parse_quadratic_bezier_curveto();
-    void parse_smooth_quadratic_bezier_curveto();
-    void parse_elliptical_arc();
+    ErrorOr<void> parse_lineto();
+    ErrorOr<void> parse_horizontal_lineto();
+    ErrorOr<void> parse_vertical_lineto();
+    ErrorOr<void> parse_curveto();
+    ErrorOr<void> parse_smooth_curveto();
+    ErrorOr<void> parse_quadratic_bezier_curveto();
+    ErrorOr<void> parse_smooth_quadratic_bezier_curveto();
+    ErrorOr<void> parse_elliptical_arc();
 
     Optional<Vector<Transform>> parse_transform();
 
-    float parse_length();
-    float parse_coordinate();
-    Vector<float> parse_coordinate_pair();
-    Vector<float> parse_coordinate_sequence();
-    Vector<Vector<float>> parse_coordinate_pair_sequence();
-    Vector<float> parse_coordinate_pair_double();
-    Vector<float> parse_coordinate_pair_triplet();
-    Vector<float> parse_elliptical_arc_argument();
+    ErrorOr<float> parse_length();
+    ErrorOr<float> parse_coordinate();
+    ErrorOr<Vector<float>> parse_coordinate_pair();
+    ErrorOr<Vector<float>> parse_coordinate_sequence();
+    ErrorOr<Vector<Vector<float>>> parse_coordinate_pair_sequence();
+    ErrorOr<Vector<float>> parse_coordinate_pair_double();
+    ErrorOr<Vector<float>> parse_coordinate_pair_triplet();
+    ErrorOr<Vector<float>> parse_elliptical_arc_argument();
     void parse_whitespace(bool must_match_once = false);
     void parse_comma_whitespace();
-    float parse_number();
-    float parse_nonnegative_number();
-    float parse_flag();
+    ErrorOr<float> parse_number();
+    ErrorOr<float> parse_nonnegative_number();
+    ErrorOr<float> parse_flag();
     // -1 if negative, +1 otherwise
     int parse_sign();
 
@@ -197,7 +198,7 @@ private:
     bool match(char c) const { return !done() && ch() == c; }
 
     bool done() const { return m_lexer.is_eof(); }
-    char ch() const { return m_lexer.peek(); }
+    char ch(size_t offset = 0) const { return m_lexer.peek(offset); }
     char consume() { return m_lexer.consume(); }
 
     GenericLexer m_lexer;

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.h
@@ -180,7 +180,7 @@ private:
     Vector<Vector<float>> parse_coordinate_pair_sequence();
     Vector<float> parse_coordinate_pair_double();
     Vector<float> parse_coordinate_pair_triplet();
-    Vector<float> parse_elliptical_arg_argument();
+    Vector<float> parse_elliptical_arc_argument();
     void parse_whitespace(bool must_match_once = false);
     void parse_comma_whitespace();
     float parse_number();


### PR DESCRIPTION
If an unexpected token is encountered when parsing an SVG attribute it is now immediately propagated with ErrorOr. Previously, some situations where an unexpected token was encountered could cause a crash.

This was a significant source of errors when fuzzing with Domato. After this change I haven't seen any crashes from `AttributeParser`.

As this PR was getting quite large I've left some things out. Here's some things we should do at some point
* Propagate all possible errors from `transform` functions - I left `parse_transform()` alone, as it wasn't causing crashes. It should be updated to propagate all possible errors, instead of being overly lenient.
* Report errors to the user - currently, we don't propagate parsing errors outside of `AttributeParser`. [The specification says](https://www.w3.org/TR/SVG2/conform.html#ErrorProcessing) we should allow the UA to report errors, so we should expose these errors to the caller.
* Parsing errors should probably contain some more context that would be useful for the user to know.

I also took the opportunity to sneak in a small fix for an earlier SVG change I made, where we were calculating the same value unnecessarily.

Apologies for the large commit. It was difficult to split this up without introducing intermediate bugs.