### PR TITLE
LibWeb: Use correct prototype chain for DOMException, and make looking at them in the console a lot more pleasant

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2741,7 +2741,14 @@ void @class_name@::initialize(JS::Realm& realm)
 
 )~~~");
 
-    if (interface.prototype_base_class == "ObjectPrototype") {
+    if (interface.name == "DOMException"sv) {
+        generator.append(R"~~~(
+
+    set_prototype(realm.intrinsics().error_prototype());
+)~~~");
+    }
+
+    else if (interface.prototype_base_class == "ObjectPrototype") {
         generator.append(R"~~~(
 
     set_prototype(realm.intrinsics().object_prototype());

--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-generateKey.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-generateKey.txt
@@ -10,6 +10,6 @@ privateKey type: private
 privateKey extractable: true
 privateKey usages: decrypt,unwrapKey
 invalid usages throw
-Error: [object DOMException]
+Error: SyntaxError: Invalid key usage 'sign'
 no usages for private key throws
-Error: [object DOMException]
+Error: SyntaxError: usages must not be empty

--- a/Tests/LibWeb/Text/expected/abortsignal-abort.txt
+++ b/Tests/LibWeb/Text/expected/abortsignal-abort.txt
@@ -1,4 +1,4 @@
 Aborted: true
-Reason: "[object DOMException]"
+Reason: "AbortError: Aborted without reason"
 Aborted: true
 Reason: "This is a test"

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/Value.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
+#include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::HTML {
 
@@ -25,11 +26,19 @@ void report_exception_to_console(JS::Value value, JS::Realm& realm, ErrorInPromi
         auto message = object.get_without_side_effects(vm.names.message).value_or(JS::js_undefined());
         if (name.is_accessor() || message.is_accessor()) {
             // The result is not going to be useful, let's just print the value. This affects DOMExceptions, for example.
-            dbgln("\033[31;1mUnhandled JavaScript exception{}:\033[0m {}", error_in_promise == ErrorInPromise::Yes ? " (in promise)" : "", JS::Value(&object));
+            if (is<WebIDL::DOMException>(object)) {
+                auto const& exception = static_cast<WebIDL::DOMException const&>(object);
+                dbgln("\033[31;1mUnhandled JavaScript exception{}:\033[0m {}: {}", error_in_promise == ErrorInPromise::Yes ? " (in promise)" : "", exception.name(), exception.message());
+            } else {
+                dbgln("\033[31;1mUnhandled JavaScript exception{}:\033[0m {}", error_in_promise == ErrorInPromise::Yes ? " (in promise)" : "", JS::Value(&object));
+            }
         } else {
             dbgln("\033[31;1mUnhandled JavaScript exception{}:\033[0m [{}] {}", error_in_promise == ErrorInPromise::Yes ? " (in promise)" : "", name, message);
         }
         if (is<JS::Error>(object)) {
+            // FIXME: We should be doing this for DOMException as well
+            //        https://webidl.spec.whatwg.org/#js-DOMException-specialness
+            //        "Additionally, if an implementation gives native Error objects special powers or nonstandard properties (such as a stack property), it should also expose those on DOMException objects."
             auto const& error_value = static_cast<JS::Error const&>(object);
             dbgln("{}", error_value.stack_string(JS::CompactTraceback::Yes));
             console.report_exception(error_value, error_in_promise == ErrorInPromise::Yes);


### PR DESCRIPTION
As mandated in the WebIDL spec:
https://webidl.spec.whatwg.org/#js-DOMException-specialness