### PR TITLE
AK+base64: Performance improvements for base64 encoding and decoding

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -117,7 +117,7 @@ ErrorOr<String> encode_base64_impl(ReadonlyBytes input)
         TRY(output.try_append(out3));
     }
 
-    return output.to_string();
+    return output.to_string_without_validation();
 }
 
 ErrorOr<ByteBuffer> decode_base64(StringView input)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -552,6 +552,8 @@ if (BUILD_LAGOM)
             lagom_utility(adjtime SOURCES ../../Userland/Utilities/adjtime.cpp LIBS LibMain)
         endif()
 
+        lagom_utility(base64 SOURCES ../../Userland/Utilities/base64.cpp LIBS LibMain)
+
         # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem
         #        for Lagom on Apple M1
         if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" AND NOT EMSCRIPTEN)


### PR DESCRIPTION
Using http://mattmahoney.net/dc/enwik8.zip (100MB unzipped) as a test:

Encoding runtime decreases from 1.192s to 0.303s (74.6% faster)
Decoding runtime decreases from 0.917s to 0.469s (48.9% faster)