### PR TITLE
LibGfx/JBIG2: Initial support for symbol and text segments :^)

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -356,6 +356,7 @@ TEST_CASE(test_jbig2_decode)
     Array test_inputs = {
         TEST_INPUT("jbig2/bitmap.jbig2"sv),
         TEST_INPUT("jbig2/bitmap-tpgdon.jbig2"sv),
+        TEST_INPUT("jbig2/bitmap-symbol.jbig2"sv),
     };
 
     for (auto test_input : test_inputs) {

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -325,6 +325,17 @@ TEST_CASE(test_jbig2_size)
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(399, 400));
 }
 
+TEST_CASE(test_jbig2_black_47x23)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("jbig2/black_47x23.jbig2"sv)));
+    EXPECT(Gfx::JBIG2ImageDecoderPlugin::sniff(file->bytes()));
+    auto plugin_decoder = TRY_OR_FAIL(Gfx::JBIG2ImageDecoderPlugin::create(file->bytes()));
+
+    auto frame = TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 47, 23 }));
+    for (auto pixel : *frame.image)
+        EXPECT_EQ(pixel, Gfx::Color(Gfx::Color::Black).value());
+}
+
 TEST_CASE(test_jbig2_white_47x23)
 {
     auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("jbig2/white_47x23.jbig2"sv)));

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -345,11 +345,6 @@ struct SegmentHeader {
     Optional<u32> data_length;
 };
 
-struct SegmentData {
-    SegmentHeader header;
-    ReadonlyBytes data;
-};
-
 class BitBuffer {
 public:
     static ErrorOr<NonnullOwnPtr<BitBuffer>> create(size_t width, size_t height);
@@ -433,6 +428,11 @@ BitBuffer::BitBuffer(ByteBuffer bits, size_t width, size_t height, size_t pitch)
     , m_pitch(pitch)
 {
 }
+
+struct SegmentData {
+    SegmentHeader header;
+    ReadonlyBytes data;
+};
 
 // 7.4.8.5 Page segment flags
 enum class CombinationOperator {

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -768,6 +768,11 @@ static ErrorOr<void> warn_about_multiple_pages(JBIG2LoadingContext& context)
     return {};
 }
 
+struct AdaptiveTemplatePixel {
+    i8 x { 0 };
+    i8 y { 0 };
+};
+
 // 6.2.2 Input parameters
 struct GenericRegionDecodingInputParameters {
     bool is_modified_modified_read { false }; // "MMR" in spec.
@@ -778,10 +783,6 @@ struct GenericRegionDecodingInputParameters {
     bool is_extended_reference_template_used { false }; // "EXTTEMPLATE" in spec.
     Optional<NonnullOwnPtr<BitBuffer>> skip_pattern;    // "USESKIP", "SKIP" in spec.
 
-    struct AdaptiveTemplatePixel {
-        i8 x { 0 };
-        i8 y { 0 };
-    };
     Array<AdaptiveTemplatePixel, 12> adaptive_template_pixels; // "GBATX" / "GBATY" in spec.
     // FIXME: GBCOLS, GBCOMBOP, COLEXTFLAG
 };
@@ -952,7 +953,7 @@ static ErrorOr<void> decode_immediate_generic_region(JBIG2LoadingContext& contex
     data = data.slice(sizeof(flags));
 
     // 7.4.6.3 Generic region segment AT flags
-    Array<GenericRegionDecodingInputParameters::AdaptiveTemplatePixel, 12> adaptive_template_pixels {};
+    Array<AdaptiveTemplatePixel, 12> adaptive_template_pixels {};
     if (!uses_mmr) {
         dbgln_if(JBIG2_DEBUG, "Non-MMR generic region, GBTEMPLATE={} TPGDON={} EXTTEMPLATE={}", arithmetic_coding_template, typical_prediction_generic_decoding_on, uses_extended_reference_template);
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1665,11 +1665,6 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     return {};
 }
 
-static ErrorOr<void> decode_immediate_lossless_text_region(JBIG2LoadingContext&, SegmentData const&)
-{
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode immediate lossless text region yet");
-}
-
 static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData const&)
 {
     return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode pattern dictionary yet");
@@ -1943,10 +1938,13 @@ static ErrorOr<void> decode_data(JBIG2LoadingContext& context)
             TRY(decode_intermediate_text_region(context, segment));
             break;
         case SegmentType::ImmediateTextRegion:
-            TRY(decode_immediate_text_region(context, segment));
-            break;
         case SegmentType::ImmediateLosslessTextRegion:
-            TRY(decode_immediate_lossless_text_region(context, segment));
+            // 7.4.3 Text region segment syntax
+            // "The data parts of all three of the text region segment types ("intermediate text region", "immediate text region" and
+            //  "immediate lossless text region") are coded identically, but are acted upon differently, see 8.2."
+            // But 8.2 only describes a difference between intermediate and immediate regions as far as I can tell,
+            // and calling the immediate text region handler for immediate lossless text regions seems to do the right thing (?).
+            TRY(decode_immediate_text_region(context, segment));
             break;
         case SegmentType::PatternDictionary:
             TRY(decode_pattern_dictionary(context, segment));

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.h
@@ -22,8 +22,8 @@ namespace JBIG2 {
 class ArithmeticDecoder {
 public:
     struct Context {
-        u8 I;      // Index I stored for context CX (E.2.4)
-        u8 is_mps; // "More probable symbol" (E.1.1). 0 or 1.
+        u8 I { 0 };      // Index I stored for context CX (E.2.4)
+        u8 is_mps { 0 }; // "More probable symbol" (E.1.1). 0 or 1.
     };
 
     static ErrorOr<ArithmeticDecoder> initialize(ReadonlyBytes data);
@@ -55,15 +55,15 @@ private:
     void BYTEIN();
 
     u8 B(size_t offset = 0) const; // Byte pointed to by BP.
-    size_t BP;                     // Pointer into compressed data.
+    size_t BP { 0 };               // Pointer into compressed data.
 
     // E.3.1 Decoder code register conventions
-    u32 C; // Consists of u16 C_high, C_low.
-    u16 A; // Current value of the fraction. Fixed precision; 0x8000 is equivalent to 0.75.
+    u32 C { 0 }; // Consists of u16 C_high, C_low.
+    u16 A { 0 }; // Current value of the fraction. Fixed precision; 0x8000 is equivalent to 0.75.
 
-    u8 CT; // Count of the number of bits in C.
+    u8 CT { 0 }; // Count of the number of bits in C.
 
-    Context* CX;
+    Context* CX { nullptr };
     static u8& I(Context* cx) { return cx->I; }
     static u8& MPS(Context* cx) { return cx->is_mps; }
     static u16 Qe(u16);


### PR DESCRIPTION
Symbol segments store a bunch of small bitmaps associated with an ID, and text segments draw small bitmaps in a symbol segment at various (x,y) locations on the page. While many things are stubbed out, this is enough to be able to read the PDF available at https://www.google.com/books/edition/Paradise_Lost/6qdbAAAAQAAJ (and possibly many other PDFs on Google Books, but this is the only one I've tried so far) :^)

It's also enough to be able to decode the test input over in #23659. I'll add that as a unit test once this PR, that PR, and #23658 are in (it's a one-line addition then).