### PR TITLE
Kernel: Introduce the EFIPrekernel

### DIFF
--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -144,10 +144,10 @@ static void setup_quickmap_page_table(PageBumpAllocator& allocator, u64* root_ta
 {
     // FIXME: Rename boot_pd_kernel_pt1023 to quickmap_page_table
     // FIXME: Rename KERNEL_PT1024_BASE to quickmap_page_table_address
-    auto kernel_pt1024_base = VirtualAddress(*adjust_by_mapping_base(&kernel_mapping_base) + KERNEL_PT1024_OFFSET);
+    auto kernel_pt1024_base = VirtualAddress(*adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) + KERNEL_PT1024_OFFSET);
 
     auto quickmap_page_table = PhysicalAddress((PhysicalPtr)insert_page_table(allocator, root_table, kernel_pt1024_base));
-    *adjust_by_mapping_base(&boot_pd_kernel_pt1023) = (PageTableEntry*)quickmap_page_table.offset(KERNEL_MAPPING_BASE).get();
+    *adjust_by_mapping_base(&g_boot_info.boot_pd_kernel_pt1023) = (PageTableEntry*)quickmap_page_table.offset(KERNEL_MAPPING_BASE).get();
 }
 
 static void build_mappings(PageBumpAllocator& allocator, u64* root_table)
@@ -254,24 +254,28 @@ static u64* get_page_directory_table(u64* root_table, VirtualAddress virtual_add
 
 static void setup_kernel_page_directory(u64* root_table)
 {
-    auto kernel_page_directory = (PhysicalPtr)get_page_directory(root_table, VirtualAddress { *adjust_by_mapping_base(&kernel_mapping_base) });
+    auto kernel_page_directory = (PhysicalPtr)get_page_directory(root_table, VirtualAddress { *adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) });
     if (!kernel_page_directory)
         panic_without_mmu("Could not find kernel page directory!"sv);
 
-    *adjust_by_mapping_base(&boot_pd_kernel) = PhysicalAddress(kernel_page_directory);
+    *adjust_by_mapping_base(&g_boot_info.boot_pd_kernel) = PhysicalAddress(kernel_page_directory);
 
     // FIXME: Rename boot_pml4t to something architecture agnostic.
-    *adjust_by_mapping_base(&boot_pml4t) = PhysicalAddress((PhysicalPtr)root_table);
+    *adjust_by_mapping_base(&g_boot_info.boot_pml4t) = PhysicalAddress((PhysicalPtr)root_table);
 
     // FIXME: Rename to directory_table or similar
-    *adjust_by_mapping_base(&boot_pdpt) = PhysicalAddress((PhysicalPtr)get_page_directory_table(root_table, VirtualAddress { *adjust_by_mapping_base(&kernel_mapping_base) }));
+    *adjust_by_mapping_base(&g_boot_info.boot_pdpt) = PhysicalAddress((PhysicalPtr)get_page_directory_table(root_table, VirtualAddress { *adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) }));
 }
 
 void init_page_tables()
 {
-    *adjust_by_mapping_base(&physical_to_virtual_offset) = KERNEL_MAPPING_BASE;
-    *adjust_by_mapping_base(&kernel_mapping_base) = KERNEL_MAPPING_BASE;
-    *adjust_by_mapping_base(&kernel_load_base) = KERNEL_MAPPING_BASE;
+    *adjust_by_mapping_base(&g_boot_info.boot_method) = BootMethod::Multiboot1;
+    adjust_by_mapping_base(&g_boot_info.boot_method_specific)->pre_init.~PreInitBootInfo();
+    new (adjust_by_mapping_base(&g_boot_info.boot_method_specific.multiboot1)) Multiboot1BootInfo;
+
+    *adjust_by_mapping_base(&g_boot_info.physical_to_virtual_offset) = KERNEL_MAPPING_BASE;
+    *adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) = KERNEL_MAPPING_BASE;
+    *adjust_by_mapping_base(&g_boot_info.kernel_load_base) = KERNEL_MAPPING_BASE;
 
     PageBumpAllocator allocator(adjust_by_mapping_base((u64*)page_tables_phys_start), adjust_by_mapping_base((u64*)page_tables_phys_end));
     auto root_table = allocator.take_page();

--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -73,7 +73,7 @@ ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspac
     directory->m_root_table = TRY(MM.allocate_physical_page());
 
     directory->m_directory_table = TRY(MM.allocate_physical_page());
-    auto kernel_pd_index = (kernel_mapping_base >> 30) & 0x1ffu;
+    auto kernel_pd_index = (g_boot_info.kernel_mapping_base >> 30) & 0x1ffu;
     for (size_t i = 0; i < kernel_pd_index; i++) {
         directory->m_directory_pages[i] = TRY(MM.allocate_physical_page());
     }
@@ -107,15 +107,17 @@ PageDirectory::PageDirectory() = default;
 
 UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 {
+    VERIFY(g_boot_info.boot_method == BootMethod::Multiboot1);
+
     // Adopt the page tables already set up by boot.S
-    dmesgln("MM: boot_pml4t @ {}", boot_pml4t);
-    m_root_table = PhysicalRAMPage::create(boot_pml4t, MayReturnToFreeList::No);
-    dmesgln("MM: boot_pdpt @ {}", boot_pdpt);
-    dmesgln("MM: boot_pd0 @ {}", boot_pd0);
-    dmesgln("MM: boot_pd_kernel @ {}", boot_pd_kernel);
-    m_directory_table = PhysicalRAMPage::create(boot_pdpt, MayReturnToFreeList::No);
-    m_directory_pages[0] = PhysicalRAMPage::create(boot_pd0, MayReturnToFreeList::No);
-    m_directory_pages[(kernel_mapping_base >> 30) & 0x1ff] = PhysicalRAMPage::create(boot_pd_kernel, MayReturnToFreeList::No);
+    dmesgln("MM: boot_pml4t @ {}", g_boot_info.boot_pml4t);
+    m_root_table = PhysicalRAMPage::create(g_boot_info.boot_pml4t, MayReturnToFreeList::No);
+    dmesgln("MM: boot_pdpt @ {}", g_boot_info.boot_pdpt);
+    dmesgln("MM: boot_pd0 @ {}", g_boot_info.boot_method_specific.multiboot1.boot_pd0);
+    dmesgln("MM: boot_pd_kernel @ {}", g_boot_info.boot_pd_kernel);
+    m_directory_table = PhysicalRAMPage::create(g_boot_info.boot_pdpt, MayReturnToFreeList::No);
+    m_directory_pages[0] = PhysicalRAMPage::create(g_boot_info.boot_method_specific.multiboot1.boot_pd0, MayReturnToFreeList::No);
+    m_directory_pages[(g_boot_info.kernel_mapping_base >> 30) & 0x1ff] = PhysicalRAMPage::create(g_boot_info.boot_pd_kernel, MayReturnToFreeList::No);
 }
 
 PageDirectory::~PageDirectory()

--- a/Kernel/Arch/aarch64/RPi/Framebuffer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Framebuffer.cpp
@@ -119,16 +119,14 @@ void Framebuffer::initialize()
 {
     auto& framebuffer = the();
     if (framebuffer.initialized()) {
-        multiboot_framebuffer_addr = PhysicalAddress((PhysicalPtr)framebuffer.gpu_buffer());
-        multiboot_framebuffer_width = framebuffer.width();
-        multiboot_framebuffer_height = framebuffer.height();
-        multiboot_framebuffer_pitch = framebuffer.pitch();
+        VERIFY(g_boot_info.boot_method == BootMethod::Multiboot1);
+        g_boot_info.boot_framebuffer.paddr = PhysicalAddress((PhysicalPtr)framebuffer.gpu_buffer());
+        g_boot_info.boot_framebuffer.width = framebuffer.width();
+        g_boot_info.boot_framebuffer.height = framebuffer.height();
+        g_boot_info.boot_framebuffer.pitch = framebuffer.pitch();
 
-        // NOTE: The required pixel format for MULTIBOOT_FRAMEBUFFER_TYPE_RGB is actually BGRx8888.
         VERIFY(framebuffer.pixel_order() == PixelOrder::BGR);
-        multiboot_framebuffer_type = MULTIBOOT_FRAMEBUFFER_TYPE_RGB;
-
-        multiboot_flags |= MULTIBOOT_INFO_FRAMEBUFFER_INFO;
+        g_boot_info.boot_framebuffer.type = BootFramebufferType::BGRx8888;
     }
 }
 

--- a/Kernel/Arch/aarch64/RPi/MMIO.h
+++ b/Kernel/Arch/aarch64/RPi/MMIO.h
@@ -26,7 +26,7 @@ public:
     // FIXME: The MMIO region is currently mapped at kernel_mapping_base + peripheral_base_address(),
     //        but the code should be changed to use the MemoryManager to map the physical memory instead
     //        of pre-mapping the whole MMIO region.
-    u32 volatile* peripheral_address(FlatPtr offset) { return (u32 volatile*)(kernel_mapping_base + m_base_address.get() + offset); }
+    u32 volatile* peripheral_address(FlatPtr offset) { return (u32 volatile*)(g_boot_info.kernel_mapping_base + m_base_address.get() + offset); }
     template<class T>
     T volatile* peripheral(FlatPtr offset) { return (T volatile*)peripheral_address(offset); }
 

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -66,7 +66,7 @@ SECTIONS
     .bss ALIGN(4K) (NOLOAD) : AT (ADDR(.bss) - KERNEL_MAPPING_BASE)
     {
 	start_of_bss = .;
-        *(.bss)
+        *(.bss*)
 	end_of_bss = .;
 
         . = ALIGN(4K);

--- a/Kernel/Arch/aarch64/pre_init.cpp
+++ b/Kernel/Arch/aarch64/pre_init.cpp
@@ -45,7 +45,7 @@ extern "C" [[noreturn]] void pre_init()
     // in high virtual memory.
     asm volatile(
         "mov x0, %[base] \n"
-        "add sp, sp, x0 \n" ::[base] "r"(kernel_mapping_base)
+        "add sp, sp, x0 \n" ::[base] "r"(g_boot_info.kernel_mapping_base)
         : "x0");
 
     // We can now unmap the identity map as everything is running in high virtual memory at this point.

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -134,32 +134,16 @@ ALWAYS_INLINE static Processor& bsp_processor()
 // Once multi-tasking is ready, we spawn a new thread that starts in the
 // init_stage2() function. Initialization continues there.
 
-extern "C" {
-READONLY_AFTER_INIT PhysicalAddress start_of_prekernel_image;
-READONLY_AFTER_INIT PhysicalAddress end_of_prekernel_image;
-READONLY_AFTER_INIT size_t physical_to_virtual_offset;
-READONLY_AFTER_INIT FlatPtr kernel_mapping_base;
-READONLY_AFTER_INIT FlatPtr kernel_load_base;
-READONLY_AFTER_INIT PhysicalAddress boot_pml4t;
-READONLY_AFTER_INIT PhysicalAddress boot_pdpt;
-READONLY_AFTER_INIT PhysicalAddress boot_pd0;
-READONLY_AFTER_INIT PhysicalAddress boot_pd_kernel;
-READONLY_AFTER_INIT Memory::PageTableEntry* boot_pd_kernel_pt1023;
-READONLY_AFTER_INIT StringView kernel_cmdline;
-READONLY_AFTER_INIT u32 multiboot_flags;
-READONLY_AFTER_INIT multiboot_memory_map_t* multiboot_memory_map;
-READONLY_AFTER_INIT size_t multiboot_memory_map_count;
-READONLY_AFTER_INIT PhysicalAddress multiboot_framebuffer_addr;
-READONLY_AFTER_INIT u32 multiboot_framebuffer_pitch;
-READONLY_AFTER_INIT u32 multiboot_framebuffer_width;
-READONLY_AFTER_INIT u32 multiboot_framebuffer_height;
-READONLY_AFTER_INIT u8 multiboot_framebuffer_bpp;
-READONLY_AFTER_INIT u8 multiboot_framebuffer_type;
-READONLY_AFTER_INIT PhysicalAddress multiboot_module_physical_ptr;
-READONLY_AFTER_INIT size_t multiboot_module_length;
-}
-
 Atomic<Graphics::Console*> g_boot_console;
+
+#if ARCH(X86_64)
+extern "C" u32 gdt64ptr;
+extern "C" u16 code64_sel;
+#endif
+
+READONLY_AFTER_INIT static StringView s_kernel_cmdline;
+
+READONLY_AFTER_INIT constinit BootInfo g_boot_info;
 
 #if ARCH(AARCH64)
 READONLY_AFTER_INIT static u8 s_command_line_buffer[512];
@@ -168,31 +152,10 @@ READONLY_AFTER_INIT static u8 s_command_line_buffer[512];
 extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_unused]] BootInfo const& boot_info)
 {
 #if ARCH(X86_64)
-    start_of_prekernel_image = PhysicalAddress { boot_info.start_of_prekernel_image };
-    end_of_prekernel_image = PhysicalAddress { boot_info.end_of_prekernel_image };
-    physical_to_virtual_offset = boot_info.physical_to_virtual_offset;
-    kernel_mapping_base = boot_info.kernel_mapping_base;
-    kernel_load_base = boot_info.kernel_load_base;
-    gdt64ptr = boot_info.gdt64ptr;
-    code64_sel = boot_info.code64_sel;
-    boot_pml4t = PhysicalAddress { boot_info.boot_pml4t };
-    boot_pdpt = PhysicalAddress { boot_info.boot_pdpt };
-    boot_pd0 = PhysicalAddress { boot_info.boot_pd0 };
-    boot_pd_kernel = PhysicalAddress { boot_info.boot_pd_kernel };
-    boot_pd_kernel_pt1023 = (Memory::PageTableEntry*)boot_info.boot_pd_kernel_pt1023;
-    char const* cmdline = (char const*)boot_info.kernel_cmdline;
-    kernel_cmdline = StringView { cmdline, strlen(cmdline) };
-    multiboot_flags = boot_info.multiboot_flags;
-    multiboot_memory_map = (multiboot_memory_map_t*)boot_info.multiboot_memory_map;
-    multiboot_memory_map_count = boot_info.multiboot_memory_map_count;
-    multiboot_module_physical_ptr = PhysicalAddress { boot_info.multiboot_module_physical_ptr };
-    multiboot_module_length = boot_info.multiboot_module_length;
-    multiboot_framebuffer_addr = PhysicalAddress { boot_info.multiboot_framebuffer_addr };
-    multiboot_framebuffer_pitch = boot_info.multiboot_framebuffer_pitch;
-    multiboot_framebuffer_width = boot_info.multiboot_framebuffer_width;
-    multiboot_framebuffer_height = boot_info.multiboot_framebuffer_height;
-    multiboot_framebuffer_bpp = boot_info.multiboot_framebuffer_bpp;
-    multiboot_framebuffer_type = boot_info.multiboot_framebuffer_type;
+    g_boot_info = boot_info;
+    gdt64ptr = boot_info.arch_specific.gdt64ptr;
+    code64_sel = boot_info.arch_specific.code64_sel;
+    s_kernel_cmdline = boot_info.cmdline;
 #elif ARCH(AARCH64)
     // FIXME: For the aarch64 platforms, we should get the information by parsing a device tree instead of using multiboot.
     auto [ram_base, ram_size] = RPi::Mailbox::the().query_lower_arm_memory_range();
@@ -212,32 +175,32 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
         },
         // FIXME: VideoCore only reports the first 1GB of RAM, the rest only shows up in the device tree.
     };
-    multiboot_memory_map = mmap;
-    multiboot_memory_map_count = 2;
+    g_boot_info.boot_method_specific.multiboot1.memory_map = mmap;
+    g_boot_info.boot_method_specific.multiboot1.memory_map_count = 2;
 
-    multiboot_module_length = 0;
+    g_boot_info.boot_method_specific.multiboot1.module_length = 0;
     // FIXME: Read the /chosen/bootargs property.
-    kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
+    s_kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
 #elif ARCH(RISCV64)
     auto maybe_command_line = get_command_line_from_fdt();
     if (maybe_command_line.is_error())
-        kernel_cmdline = "serial_debug"sv;
+        s_kernel_cmdline = "serial_debug"sv;
     else
-        kernel_cmdline = maybe_command_line.value();
+        s_kernel_cmdline = maybe_command_line.value();
 #endif
 
     setup_serial_debug();
 
     // We need to copy the command line before kmalloc is initialized,
     // as it may overwrite parts of multiboot!
-    CommandLine::early_initialize(kernel_cmdline);
+    CommandLine::early_initialize(s_kernel_cmdline);
 
     new (&bsp_processor()) Processor();
     bsp_processor().early_initialize(0);
 
 #if ARCH(RISCV64)
     // We implicitly assume the boot hart is hart 0 above and below
-    VERIFY(boot_info.mhartid == 0);
+    VERIFY(boot_info.arch_specific.boot_hart_id == 0);
 #endif
 
     // Invoke the constructors needed for the kernel heap
@@ -263,8 +226,8 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
     // If the bootloader didn't provide a framebuffer, then set up an initial text console.
     // We do so we can see the output on the screen as soon as possible.
     if (!kernel_command_line().is_early_boot_console_disabled()) {
-        if ((multiboot_flags & MULTIBOOT_INFO_FRAMEBUFFER_INFO) && !multiboot_framebuffer_addr.is_null() && multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
-            g_boot_console = &try_make_lock_ref_counted<Graphics::BootFramebufferConsole>(multiboot_framebuffer_addr, multiboot_framebuffer_width, multiboot_framebuffer_height, multiboot_framebuffer_pitch).value().leak_ref();
+        if (!g_boot_info.boot_framebuffer.paddr.is_null() && g_boot_info.boot_framebuffer.type == BootFramebufferType::BGRx8888) {
+            g_boot_console = &try_make_lock_ref_counted<Graphics::BootFramebufferConsole>(g_boot_info.boot_framebuffer.paddr, g_boot_info.boot_framebuffer.width, g_boot_info.boot_framebuffer.height, g_boot_info.boot_framebuffer.pitch).value().leak_ref();
         } else {
             dbgln("No early framebuffer console available, initializing dummy console");
             g_boot_console = &try_make_lock_ref_counted<Graphics::BootDummyConsole>().value().leak_ref();
@@ -512,7 +475,7 @@ UNMAP_AFTER_INIT void setup_serial_debug()
     // serial_debug will output all the dbgln() data to COM1 at
     // 8-N-1 57600 baud. this is particularly useful for debugging the boot
     // process on live hardware.
-    if (kernel_cmdline.contains("serial_debug"sv)) {
+    if (s_kernel_cmdline.contains("serial_debug"sv)) {
         set_serial_debug_enabled(true);
     }
 }

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -235,9 +235,9 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
     }
     dmesgln("Starting SerenityOS...");
 
-#if ARCH(X86_64)
     MM.unmap_prekernel();
 
+#if ARCH(X86_64)
     // Ensure that the safemem sections are not empty. This could happen if the linker accidentally discards the sections.
     VERIFY(+start_of_safemem_text != +end_of_safemem_text);
     VERIFY(+start_of_safemem_atomic_text != +end_of_safemem_atomic_text);

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -185,6 +185,10 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
     if (boot_info.boot_method == BootMethod::EFI) {
         g_boot_info = boot_info;
         s_kernel_cmdline = "serial_debug root=nvme:0:1:0 nvme_poll"sv;
+        asm volatile(R"(
+            la t0, asm_trap_handler
+            csrw stvec, t0
+        )");
     } else {
         auto maybe_command_line = get_command_line_from_fdt();
         if (maybe_command_line.is_error())

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -182,11 +182,15 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
     // FIXME: Read the /chosen/bootargs property.
     s_kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
 #elif ARCH(RISCV64)
-    auto maybe_command_line = get_command_line_from_fdt();
-    if (maybe_command_line.is_error())
-        s_kernel_cmdline = "serial_debug"sv;
-    else
-        s_kernel_cmdline = maybe_command_line.value();
+    if (boot_info.boot_method == BootMethod::EFI) {
+        g_boot_info = boot_info;
+    } else {
+        auto maybe_command_line = get_command_line_from_fdt();
+        if (maybe_command_line.is_error())
+            s_kernel_cmdline = "serial_debug"sv;
+        else
+            s_kernel_cmdline = maybe_command_line.value();
+    }
 #endif
 
     setup_serial_debug();

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -184,6 +184,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
 #elif ARCH(RISCV64)
     if (boot_info.boot_method == BootMethod::EFI) {
         g_boot_info = boot_info;
+        s_kernel_cmdline = "serial_debug root=nvme:0:1:0 nvme_poll"sv;
     } else {
         auto maybe_command_line = get_command_line_from_fdt();
         if (maybe_command_line.is_error())

--- a/Kernel/Arch/riscv64/CPU.cpp
+++ b/Kernel/Arch/riscv64/CPU.cpp
@@ -19,21 +19,21 @@ alignas(PAGE_SIZE) __attribute__((section(".bss.fdt"))) u8 s_fdt_storage[fdt_sto
 
 ErrorOr<void> unflatten_fdt()
 {
-    *s_device_tree = TRY(DeviceTree::DeviceTree::parse({ s_fdt_storage, fdt_storage_size }));
+    *s_device_tree = TRY(DeviceTree::DeviceTree::parse({ s_fdt_storage, g_boot_info.flattened_devicetree_size }));
     return {};
 }
 
 void dump_fdt()
 {
     auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
-    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
+    auto fdt = ReadonlyBytes(s_fdt_storage, g_boot_info.flattened_devicetree_size);
     MUST(DeviceTree::dump(header, fdt));
 }
 
 ErrorOr<StringView> get_command_line_from_fdt()
 {
     auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
-    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
+    auto fdt = ReadonlyBytes(s_fdt_storage, g_boot_info.flattened_devicetree_size);
     return TRY(DeviceTree::slow_get_property("/chosen/bootargs"sv, header, fdt)).as_string();
 }
 

--- a/Kernel/Arch/riscv64/CPU.cpp
+++ b/Kernel/Arch/riscv64/CPU.cpp
@@ -17,21 +17,35 @@ namespace Kernel {
 
 alignas(PAGE_SIZE) __attribute__((section(".bss.fdt"))) u8 s_fdt_storage[fdt_storage_size];
 
+static Singleton<OwnPtr<Memory::Region>> s_fdt_region;
+static VirtualAddress s_fdt_addr { nullptr };
+
 ErrorOr<void> unflatten_fdt()
 {
-    *s_device_tree = TRY(DeviceTree::DeviceTree::parse({ s_fdt_storage, g_boot_info.flattened_devicetree_size }));
+    if (g_boot_info.boot_method == BootMethod::PreInit) {
+        s_fdt_addr = VirtualAddress { &s_fdt_storage };
+    } else {
+        auto fdt_region_size = TRY(Memory::page_round_up(g_boot_info.flattened_devicetree_size + g_boot_info.flattened_devicetree_paddr.offset_in_page()));
+        *s_fdt_region = TRY(MM.allocate_mmio_kernel_region(g_boot_info.flattened_devicetree_paddr.page_base(), fdt_region_size, {}, Memory::Region::Access::Read));
+
+        s_fdt_addr = (*s_fdt_region)->vaddr().offset(g_boot_info.flattened_devicetree_paddr.offset_in_page());
+    }
+
+    *s_device_tree = TRY(DeviceTree::DeviceTree::parse({ s_fdt_addr.as_ptr(), g_boot_info.flattened_devicetree_size }));
+
     return {};
 }
 
 void dump_fdt()
 {
-    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
-    auto fdt = ReadonlyBytes(s_fdt_storage, g_boot_info.flattened_devicetree_size);
+    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(s_fdt_addr.as_ptr());
+    auto fdt = ReadonlyBytes(s_fdt_addr.as_ptr(), g_boot_info.flattened_devicetree_size);
     MUST(DeviceTree::dump(header, fdt));
 }
 
 ErrorOr<StringView> get_command_line_from_fdt()
 {
+    VERIFY(g_boot_info.boot_method == BootMethod::PreInit);
     auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
     auto fdt = ReadonlyBytes(s_fdt_storage, g_boot_info.flattened_devicetree_size);
     return TRY(DeviceTree::slow_get_property("/chosen/bootargs"sv, header, fdt)).as_string();

--- a/Kernel/Arch/riscv64/CPU.cpp
+++ b/Kernel/Arch/riscv64/CPU.cpp
@@ -15,8 +15,6 @@ static Singleton<OwnPtr<DeviceTree::DeviceTree>> s_device_tree;
 
 namespace Kernel {
 
-BootInfo s_boot_info;
-
 alignas(PAGE_SIZE) __attribute__((section(".bss.fdt"))) u8 s_fdt_storage[fdt_storage_size];
 
 ErrorOr<void> unflatten_fdt()

--- a/Kernel/Arch/riscv64/CPU.h
+++ b/Kernel/Arch/riscv64/CPU.h
@@ -16,6 +16,8 @@ VALIDATE_IS_RISCV64()
 namespace Kernel {
 
 constexpr size_t fdt_storage_size = 2 * MiB;
+
+// Unused when booting via UEFI
 extern u8 s_fdt_storage[fdt_storage_size];
 
 // FIXME: These should move to an architecture independent location,

--- a/Kernel/Arch/riscv64/CPU.h
+++ b/Kernel/Arch/riscv64/CPU.h
@@ -20,8 +20,6 @@ extern u8 s_fdt_storage[fdt_storage_size];
 
 // FIXME: These should move to an architecture independent location,
 //        once we need device tree parsing in other architectures, like aarch64
-extern BootInfo s_boot_info;
-
 ErrorOr<void> unflatten_fdt();
 void dump_fdt();
 ErrorOr<StringView> get_command_line_from_fdt();

--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -141,10 +141,10 @@ static UNMAP_AFTER_INIT void insert_entries_for_memory_range(PageBumpAllocator& 
 
 static UNMAP_AFTER_INIT void setup_quickmap_page_table(PageBumpAllocator& allocator, u64* root_table)
 {
-    auto kernel_pt1024_base = VirtualAddress { *adjust_by_mapping_base(&kernel_mapping_base) + KERNEL_PT1024_OFFSET };
+    auto kernel_pt1024_base = VirtualAddress { *adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) + KERNEL_PT1024_OFFSET };
 
     auto quickmap_page_table = PhysicalAddress { bit_cast<PhysicalPtr>(insert_page_table(allocator, root_table, kernel_pt1024_base)) };
-    *adjust_by_mapping_base(&boot_pd_kernel_pt1023) = bit_cast<PageTableEntry*>(quickmap_page_table.offset(calculate_physical_to_link_time_address_offset()).get());
+    *adjust_by_mapping_base(&g_boot_info.boot_pd_kernel_pt1023) = bit_cast<PageTableEntry*>(quickmap_page_table.offset(calculate_physical_to_link_time_address_offset()).get());
 }
 
 static UNMAP_AFTER_INIT void build_mappings(PageBumpAllocator& allocator, u64* root_table)
@@ -162,16 +162,16 @@ static UNMAP_AFTER_INIT void build_mappings(PageBumpAllocator& allocator, u64* r
 
 static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
 {
-    auto kernel_page_directory = bit_cast<PhysicalPtr>(get_page_directory(root_table, VirtualAddress { *adjust_by_mapping_base(&kernel_mapping_base) }));
+    auto kernel_page_directory = bit_cast<PhysicalPtr>(get_page_directory(root_table, VirtualAddress { *adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) }));
     if (kernel_page_directory == 0)
         panic_without_mmu("Could not find kernel page directory!"sv);
 
-    *adjust_by_mapping_base(&boot_pd_kernel) = PhysicalAddress { kernel_page_directory };
+    *adjust_by_mapping_base(&g_boot_info.boot_pd_kernel) = PhysicalAddress { kernel_page_directory };
 
     // There is no level 4 table in Sv39
-    *adjust_by_mapping_base(&boot_pml4t) = PhysicalAddress { 0 };
+    *adjust_by_mapping_base(&g_boot_info.boot_pml4t) = PhysicalAddress { 0 };
 
-    *adjust_by_mapping_base(&boot_pdpt) = PhysicalAddress { bit_cast<PhysicalPtr>(root_table) };
+    *adjust_by_mapping_base(&g_boot_info.boot_pdpt) = PhysicalAddress { bit_cast<PhysicalPtr>(root_table) };
 }
 
 // This function has to fit into one page as it will be identity mapped.
@@ -220,14 +220,14 @@ static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
     VERIFY_NOT_REACHED();
 }
 
-[[noreturn]] UNMAP_AFTER_INIT void init_page_tables_and_jump_to_init(FlatPtr mhartid, PhysicalPtr fdt_phys_addr)
+[[noreturn]] UNMAP_AFTER_INIT void init_page_tables_and_jump_to_init(FlatPtr boot_hart_id, PhysicalPtr flattened_devicetree_paddr)
 {
     if (RISCV64::CSR::SATP::read().MODE != RISCV64::CSR::SATP::Mode::Bare)
         panic_without_mmu("Kernel booted with MMU enabled"sv);
 
     // Copy the FDT to a known location
-    DeviceTree::FlattenedDeviceTreeHeader* fdt_header = bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(fdt_phys_addr);
-    u8* fdt_storage = bit_cast<u8*>(fdt_phys_addr);
+    DeviceTree::FlattenedDeviceTreeHeader* fdt_header = bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(flattened_devicetree_paddr);
+    u8* fdt_storage = bit_cast<u8*>(flattened_devicetree_paddr);
     if (fdt_header->totalsize > fdt_storage_size)
         panic_without_mmu("Passed FDT is bigger than the internal storage"sv);
     for (size_t o = 0; o < fdt_header->totalsize; o += 1) {
@@ -235,11 +235,14 @@ static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
         adjust_by_mapping_base(s_fdt_storage)[o] = fdt_storage[o];
     }
 
-    *adjust_by_mapping_base(&physical_to_virtual_offset) = calculate_physical_to_link_time_address_offset();
-    *adjust_by_mapping_base(&kernel_mapping_base) = KERNEL_MAPPING_BASE;
-    *adjust_by_mapping_base(&kernel_load_base) = KERNEL_MAPPING_BASE;
+    *adjust_by_mapping_base(&g_boot_info.boot_method) = BootMethod::PreInit;
 
-    *adjust_by_mapping_base(&s_boot_info) = { .mhartid = mhartid, .fdt_phys_addr = fdt_phys_addr };
+    *adjust_by_mapping_base(&g_boot_info.physical_to_virtual_offset) = calculate_physical_to_link_time_address_offset();
+    *adjust_by_mapping_base(&g_boot_info.kernel_mapping_base) = KERNEL_MAPPING_BASE;
+    *adjust_by_mapping_base(&g_boot_info.kernel_load_base) = KERNEL_MAPPING_BASE;
+
+    *adjust_by_mapping_base(&g_boot_info.arch_specific.boot_hart_id) = boot_hart_id;
+    *adjust_by_mapping_base(&g_boot_info.flattened_devicetree_paddr) = PhysicalAddress { flattened_devicetree_paddr };
 
     PageBumpAllocator allocator(adjust_by_mapping_base(reinterpret_cast<u64*>(page_tables_phys_start)), adjust_by_mapping_base(reinterpret_cast<u64*>(page_tables_phys_end)));
     auto* root_table = allocator.take_page();
@@ -263,7 +266,7 @@ static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
         .MODE = RISCV64::CSR::SATP::Mode::Sv39,
     };
 
-    enable_paging(s_boot_info, bit_cast<FlatPtr>(satp), &enable_paging_level0_table[enable_paging_vpn_0]);
+    enable_paging(g_boot_info, bit_cast<FlatPtr>(satp), &enable_paging_level0_table[enable_paging_vpn_0]);
 }
 
 }

--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -188,11 +188,11 @@ static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
         "   csrw satp, %[satp] \n"
         "   sfence.vma \n"
 
-        // Continue execution at high virtual address, by using an absolute jump.
-        "   ld t0, 3f \n"
+        // Continue execution at high virtual address.
+        "   lla t0, 2f \n"
+        "   add t0, t0, %[offset] \n"
         "   jr t0 \n"
-        "3: .dword 4f \n"
-        "4: \n"
+        "2: \n"
 
         // Add kernel_mapping_base to the stack pointer, such that it is also using the mapping in high virtual memory.
         "   add sp, sp, %[offset] \n"

--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -243,6 +243,7 @@ static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
 
     *adjust_by_mapping_base(&g_boot_info.arch_specific.boot_hart_id) = boot_hart_id;
     *adjust_by_mapping_base(&g_boot_info.flattened_devicetree_paddr) = PhysicalAddress { flattened_devicetree_paddr };
+    *adjust_by_mapping_base(&g_boot_info.flattened_devicetree_size) = fdt_header->totalsize;
 
     PageBumpAllocator allocator(adjust_by_mapping_base(reinterpret_cast<u64*>(page_tables_phys_start)), adjust_by_mapping_base(reinterpret_cast<u64*>(page_tables_phys_end)));
     auto* root_table = allocator.take_page();

--- a/Kernel/Arch/riscv64/MMU.h
+++ b/Kernel/Arch/riscv64/MMU.h
@@ -14,6 +14,6 @@ VALIDATE_IS_RISCV64()
 
 namespace Kernel::Memory {
 
-[[noreturn]] void init_page_tables_and_jump_to_init(FlatPtr mhartid, PhysicalPtr fdt_phys_addr);
+[[noreturn]] void init_page_tables_and_jump_to_init(FlatPtr boot_hart_id, PhysicalPtr flattened_devicetree_paddr);
 
 }

--- a/Kernel/Arch/riscv64/MMU.h
+++ b/Kernel/Arch/riscv64/MMU.h
@@ -14,6 +14,49 @@ VALIDATE_IS_RISCV64()
 
 namespace Kernel::Memory {
 
+// Documentation for RISC-V Virtual Memory:
+// The RISC-V Instruction Set Manual, Volume II: Privileged Architecture
+// https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
+
+// Currently, only the Sv39 (3 level paging) virtual memory system is implemented
+
+// Figure 4.19-4.21
+constexpr size_t PAGE_TABLE_SHIFT = 12;
+constexpr size_t PAGE_TABLE_SIZE = 1LU << PAGE_TABLE_SHIFT;
+
+constexpr size_t PADDR_PPN_OFFSET = PAGE_TABLE_SHIFT;
+constexpr size_t VADDR_VPN_OFFSET = PAGE_TABLE_SHIFT;
+constexpr size_t PTE_PPN_OFFSET = 10;
+
+constexpr size_t PPN_SIZE = 26 + 9 + 9;
+constexpr size_t VPN_SIZE = 9 + 9 + 9;
+
+constexpr size_t VPN_2_OFFSET = 30;
+constexpr size_t VPN_1_OFFSET = 21;
+constexpr size_t VPN_0_OFFSET = 12;
+
+constexpr size_t PPN_MASK = (1LU << PPN_SIZE) - 1;
+constexpr size_t PTE_PPN_MASK = PPN_MASK << PTE_PPN_OFFSET;
+
+constexpr size_t PAGE_TABLE_INDEX_BITS = 9;
+constexpr size_t PAGE_TABLE_INDEX_MASK = (1 << PAGE_TABLE_INDEX_BITS) - 1;
+
+constexpr size_t PAGE_OFFSET_BITS = 12;
+
+constexpr size_t LEVELS = 3;
+
+enum class PageTableEntryBits {
+    Valid = 1 << 0,
+    Readable = 1 << 1,
+    Writeable = 1 << 2,
+    Executable = 1 << 3,
+    UserAllowed = 1 << 4,
+    Global = 1 << 5,
+    Accessed = 1 << 6,
+    Dirty = 1 << 7,
+};
+AK_ENUM_BITWISE_OPERATORS(PageTableEntryBits);
+
 [[noreturn]] void init_page_tables_and_jump_to_init(FlatPtr boot_hart_id, PhysicalPtr flattened_devicetree_paddr);
 
 }

--- a/Kernel/Arch/riscv64/PageDirectory.cpp
+++ b/Kernel/Arch/riscv64/PageDirectory.cpp
@@ -43,7 +43,7 @@ ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspac
     directory->m_process = &process;
 
     directory->m_directory_table = TRY(MM.allocate_physical_page());
-    auto kernel_pd_index = (kernel_mapping_base >> VPN_2_OFFSET) & PAGE_TABLE_INDEX_MASK;
+    auto kernel_pd_index = (g_boot_info.kernel_mapping_base >> VPN_2_OFFSET) & PAGE_TABLE_INDEX_MASK;
     for (size_t i = 0; i < kernel_pd_index; i++) {
         directory->m_directory_pages[i] = TRY(MM.allocate_physical_page());
     }
@@ -97,10 +97,10 @@ PageDirectory::PageDirectory() = default;
 
 UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 {
-    dmesgln("MM: boot_pdpt @ {}", boot_pdpt);
-    dmesgln("MM: boot_pd_kernel @ {}", boot_pd_kernel);
-    m_directory_table = PhysicalRAMPage::create(boot_pdpt, MayReturnToFreeList::No);
-    m_directory_pages[(kernel_mapping_base >> VPN_2_OFFSET) & PAGE_TABLE_INDEX_MASK] = PhysicalRAMPage::create(boot_pd_kernel, MayReturnToFreeList::No);
+    dmesgln("MM: boot_pdpt @ {}", g_boot_info.boot_pdpt);
+    dmesgln("MM: boot_pd_kernel @ {}", g_boot_info.boot_pd_kernel);
+    m_directory_table = PhysicalRAMPage::create(g_boot_info.boot_pdpt, MayReturnToFreeList::No);
+    m_directory_pages[(g_boot_info.kernel_mapping_base >> VPN_2_OFFSET) & PAGE_TABLE_INDEX_MASK] = PhysicalRAMPage::create(g_boot_info.boot_pd_kernel, MayReturnToFreeList::No);
 }
 
 PageDirectory::~PageDirectory()

--- a/Kernel/Arch/riscv64/PageDirectory.h
+++ b/Kernel/Arch/riscv64/PageDirectory.h
@@ -11,6 +11,8 @@
 #include <AK/RefPtr.h>
 
 #include <Kernel/Forward.h>
+
+#include <Kernel/Arch/riscv64/MMU.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/PhysicalAddress.h>
 #include <Kernel/Memory/PhysicalRAMPage.h>
@@ -19,44 +21,6 @@
 VALIDATE_IS_RISCV64()
 
 namespace Kernel::Memory {
-
-// Documentation for RISC-V Virtual Memory:
-// The RISC-V Instruction Set Manual, Volume II: Privileged Architecture
-// https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
-
-// Currently, only the Sv39 (3 level paging) virtual memory system is implemented
-
-// Figure 4.19-4.21
-constexpr size_t PAGE_TABLE_SHIFT = 12;
-constexpr size_t PAGE_TABLE_SIZE = 1LU << PAGE_TABLE_SHIFT;
-
-constexpr size_t PADDR_PPN_OFFSET = PAGE_TABLE_SHIFT;
-constexpr size_t VADDR_VPN_OFFSET = PAGE_TABLE_SHIFT;
-constexpr size_t PTE_PPN_OFFSET = 10;
-
-constexpr size_t PPN_SIZE = 26 + 9 + 9;
-constexpr size_t VPN_SIZE = 9 + 9 + 9;
-
-constexpr size_t VPN_2_OFFSET = 30;
-constexpr size_t VPN_1_OFFSET = 21;
-constexpr size_t VPN_0_OFFSET = 12;
-
-constexpr size_t PPN_MASK = (1LU << PPN_SIZE) - 1;
-constexpr size_t PTE_PPN_MASK = PPN_MASK << PTE_PPN_OFFSET;
-
-constexpr size_t PAGE_TABLE_INDEX_MASK = 0x1ff;
-
-enum class PageTableEntryBits {
-    Valid = 1 << 0,
-    Readable = 1 << 1,
-    Writeable = 1 << 2,
-    Executable = 1 << 3,
-    UserAllowed = 1 << 4,
-    Global = 1 << 5,
-    Accessed = 1 << 6,
-    Dirty = 1 << 7,
-};
-AK_ENUM_BITWISE_OPERATORS(PageTableEntryBits);
 
 class PageDirectoryEntry {
 public:

--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -91,6 +91,7 @@ SECTIONS
         end_of_kernel_ksyms = .;
     } :ksyms
 
+    /* The bss has to be in its own program header so the prekernel doesn't have to copy segments */
     .bss ALIGN(4K) (NOLOAD) :
     {
         start_of_bss = .;

--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -6,15 +6,18 @@
 
 ENTRY(start)
 
+#define PF_X 0x1
+#define PF_W 0x2
+#define PF_R 0x4
+
 KERNEL_MAPPING_BASE = 0x2000000000;
 
-/* TODO: Add FLAGS to the program headers */
 PHDRS
 {
-    text PT_LOAD ;
-    data PT_LOAD ;
-    ksyms PT_LOAD ;
-    bss PT_LOAD ;
+    text PT_LOAD FLAGS(PF_R | PF_X);
+    data PT_LOAD FLAGS(PF_R | PF_W);
+    ksyms PT_LOAD FLAGS(PF_R);
+    bss PT_LOAD FLAGS(PF_R | PF_W);
 }
 
 SECTIONS

--- a/Kernel/Arch/riscv64/pre_init.cpp
+++ b/Kernel/Arch/riscv64/pre_init.cpp
@@ -43,13 +43,12 @@ UNMAP_AFTER_INIT void dbgln_without_mmu(StringView message)
     panic_without_mmu("Unexpected trap"sv);
 }
 
-extern "C" [[noreturn]] UNMAP_AFTER_INIT void pre_init(FlatPtr mhartid, PhysicalPtr fdt_phys_addr)
+extern "C" [[noreturn]] UNMAP_AFTER_INIT void pre_init(FlatPtr boot_hart_id, PhysicalPtr flattened_devicetree_paddr)
 {
-
     // Catch traps in pre_init
     RISCV64::CSR::write(RISCV64::CSR::Address::STVEC, bit_cast<FlatPtr>(&early_trap_handler));
 
-    Memory::init_page_tables_and_jump_to_init(mhartid, fdt_phys_addr);
+    Memory::init_page_tables_and_jump_to_init(boot_hart_id, flattened_devicetree_paddr);
 }
 
 }

--- a/Kernel/Arch/x86_64/Interrupts/APIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.cpp
@@ -384,7 +384,7 @@ UNMAP_AFTER_INIT void APIC::setup_ap_boot_environment()
     auto const& idtr = get_idtr();
     *APIC_INIT_VAR_PTR(FlatPtr, apic_startup_region_ptr, ap_cpu_idtr) = FlatPtr(&idtr);
 
-    *APIC_INIT_VAR_PTR(FlatPtr, apic_startup_region_ptr, ap_cpu_kernel_map_base) = FlatPtr(kernel_mapping_base);
+    *APIC_INIT_VAR_PTR(FlatPtr, apic_startup_region_ptr, ap_cpu_kernel_map_base) = FlatPtr(g_boot_info.kernel_mapping_base);
     *APIC_INIT_VAR_PTR(FlatPtr, apic_startup_region_ptr, ap_cpu_kernel_entry_function) = FlatPtr(&init_ap);
 
     // Store the BSP's CR0 and CR4 values for the APs to use

--- a/Kernel/Boot/BootInfo.h
+++ b/Kernel/Boot/BootInfo.h
@@ -6,38 +6,10 @@
 
 #pragma once
 
-#include <AK/StringView.h>
-#include <Kernel/Boot/Multiboot.h>
-#include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/VirtualAddress.h>
+#include <Kernel/Prekernel/Prekernel.h>
 
-namespace Kernel::Memory {
-class PageTableEntry;
+namespace Kernel {
+
+extern BootInfo g_boot_info;
+
 }
-
-extern "C" PhysicalAddress start_of_prekernel_image;
-extern "C" PhysicalAddress end_of_prekernel_image;
-extern "C" size_t physical_to_virtual_offset;
-extern "C" FlatPtr kernel_mapping_base;
-extern "C" FlatPtr kernel_load_base;
-#if ARCH(X86_64)
-extern "C" u32 gdt64ptr;
-extern "C" u16 code64_sel;
-#endif
-extern "C" PhysicalAddress boot_pml4t;
-extern "C" PhysicalAddress boot_pdpt;
-extern "C" PhysicalAddress boot_pd0;
-extern "C" PhysicalAddress boot_pd_kernel;
-extern "C" Kernel::Memory::PageTableEntry* boot_pd_kernel_pt1023;
-extern "C" StringView kernel_cmdline;
-extern "C" u32 multiboot_flags;
-extern "C" multiboot_memory_map_t* multiboot_memory_map;
-extern "C" size_t multiboot_memory_map_count;
-extern "C" PhysicalAddress multiboot_module_physical_ptr;
-extern "C" size_t multiboot_module_length;
-extern "C" PhysicalAddress multiboot_framebuffer_addr;
-extern "C" u32 multiboot_framebuffer_pitch;
-extern "C" u32 multiboot_framebuffer_width;
-extern "C" u32 multiboot_framebuffer_height;
-extern "C" u8 multiboot_framebuffer_bpp;
-extern "C" u8 multiboot_framebuffer_type;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -843,38 +843,29 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     target_link_libraries(Kernel PRIVATE kernel_heap clang_rt.builtins)
 endif()
 
-if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+if ("${SERENITY_ARCH}" STREQUAL "aarch64")
+    set(KERNEL_ELF_OBJCOPY_TARGET "elf64-littleaarch64")
+elseif ("${SERENITY_ARCH}" STREQUAL "riscv64")
+    set(KERNEL_ELF_OBJCOPY_TARGET "elf64-littleriscv")
+elseif ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(KERNEL_ELF_OBJCOPY_TARGET "elf64-x86-64")
 endif()
 
-# In x86_64 the Kernel is linked to the Pre-kernel binary.
-if ("${SERENITY_ARCH}" STREQUAL "x86_64")
-    add_custom_command(
-        TARGET Kernel POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-        COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
-        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
-        COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
-        COMMAND ${CMAKE_OBJCOPY} --set-section-flags .heap=load Kernel Kernel_shared_object
-        COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_image --set-section-alignment .Kernel_image=4096 Kernel_shared_object Kernel.o
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
-    )
-elseif ("${SERENITY_ARCH}" STREQUAL "aarch64" OR "${SERENITY_ARCH}" STREQUAL "riscv64")
-    add_custom_command(
-        TARGET Kernel POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-        COMMAND "${CMAKE_COMMAND}" -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
-        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
-        COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
-    )
-endif()
+# The Kernel.o file is linked to the Prekernel binary.
+add_custom_command(
+    TARGET Kernel POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+    COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
+    COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
+    COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
+    COMMAND ${CMAKE_OBJCOPY} --set-section-flags .heap=load Kernel Kernel_shared_object
+    COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_image --set-section-alignment .Kernel_image=4096 Kernel_shared_object Kernel.o
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
+)
 
 # Architectures (x86_64, aarch64, riscv64) share the same location in their respective architecture build folder.
-# In x86_64 the Kernel is linked to the Pre-kernel binary and then generates the result Kernel binary.
-# In aarch64 and riscv64 there's no Pre-kernel stage yet, so we immediately get a Kernel binary.
+# The Kernel is linked to the Pre-kernel binary and then generates the result Kernel binary.
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.debug" DESTINATION boot)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -889,7 +889,9 @@ endif()
 serenity_install_headers(Kernel)
 serenity_install_sources(Kernel)
 
-# Only x86 needs a Prekernel
+# Only x86 uses the multiboot Prekernel
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     add_subdirectory(Prekernel)
 endif()
+
+add_subdirectory(EFIPrekernel)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -861,7 +861,7 @@ add_custom_command(
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
     COMMAND ${CMAKE_OBJCOPY} --set-section-flags .heap=load Kernel Kernel_shared_object
     COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_image --set-section-alignment .Kernel_image=4096 Kernel_shared_object Kernel.o
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel_shared_object ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
 )
 
 # Architectures (x86_64, aarch64, riscv64) share the same location in their respective architecture build folder.

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -803,11 +803,20 @@ if("${SERENITY_ARCH}" STREQUAL "aarch64")
     target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/Arch/aarch64/linker.ld -nostdlib LINKER:--no-pie)
     set_target_properties(Kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Arch/aarch64/linker.ld)
 elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/linker.ld
+        COMMAND "${CMAKE_CXX_COMPILER}" ${TARGET_STRING} -E -P -x c -I${CMAKE_CURRENT_SOURCE_DIR}/.. "${CMAKE_CURRENT_SOURCE_DIR}/Arch/riscv64/linker.ld" -o "${CMAKE_CURRENT_BINARY_DIR}/linker.ld"
+        MAIN_DEPENDENCY "Arch/riscv64/linker.ld"
+        COMMENT "Preprocessing linker.ld"
+        VERBATIM
+    )
+    add_custom_target(generate_kernel_linker_script DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/linker.ld)
+
     # The final kernel binary for some reason includes temporary local symbols on riscv64 clang, which causes kernel.map to be too big to fit in its section in the kernel.
     # Explicitly pass -X to the linker to remove them.
-    target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/Arch/riscv64/linker.ld -nostdlib LINKER:--no-pie LINKER:-X)
+    target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib LINKER:--no-pie LINKER:-X)
 
-    set_target_properties(Kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Arch/riscv64/linker.ld)
+    set_target_properties(Kernel PROPERTIES LINK_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/linker.ld")
 elseif ("${SERENITY_ARCH}" STREQUAL "x86_64")
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/linker.ld

--- a/Kernel/Devices/GPU/Management.cpp
+++ b/Kernel/Devices/GPU/Management.cpp
@@ -119,14 +119,14 @@ UNMAP_AFTER_INIT ErrorOr<void> GraphicsManagement::determine_and_initialize_grap
 
 UNMAP_AFTER_INIT void GraphicsManagement::initialize_preset_resolution_generic_display_connector()
 {
-    VERIFY(!multiboot_framebuffer_addr.is_null());
-    VERIFY(multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB);
+    VERIFY(!g_boot_info.boot_framebuffer.paddr.is_null());
+    VERIFY(g_boot_info.boot_framebuffer.type == BootFramebufferType::BGRx8888);
     dmesgln("Graphics: Using a preset resolution from the bootloader, without knowing the PCI device");
     m_preset_resolution_generic_display_connector = GenericDisplayConnector::must_create_with_preset_resolution(
-        multiboot_framebuffer_addr,
-        multiboot_framebuffer_width,
-        multiboot_framebuffer_height,
-        multiboot_framebuffer_pitch);
+        g_boot_info.boot_framebuffer.paddr,
+        g_boot_info.boot_framebuffer.width,
+        g_boot_info.boot_framebuffer.height,
+        g_boot_info.boot_framebuffer.pitch);
 }
 
 UNMAP_AFTER_INIT bool GraphicsManagement::initialize()
@@ -163,11 +163,17 @@ UNMAP_AFTER_INIT bool GraphicsManagement::initialize()
         return true;
     }
 
+    bool boot_framebuffer_usable = !g_boot_info.boot_framebuffer.paddr.is_null()
+        && g_boot_info.boot_framebuffer.type == BootFramebufferType::BGRx8888;
+
+    bool use_boot_framebuffer = graphics_subsystem_mode == CommandLine::GraphicsSubsystemMode::Limited
+        && boot_framebuffer_usable;
+
     // Note: Don't try to initialize an ISA Bochs VGA adapter if PCI hardware is
     // present but the user decided to disable its usage nevertheless.
     // Otherwise we risk using the Bochs VBE driver on a wrong physical address
     // for the framebuffer.
-    if (PCI::Access::is_hardware_disabled() && !(graphics_subsystem_mode == CommandLine::GraphicsSubsystemMode::Limited && !multiboot_framebuffer_addr.is_null() && multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB)) {
+    if (PCI::Access::is_hardware_disabled() && !use_boot_framebuffer) {
 #if ARCH(X86_64)
         auto vga_isa_bochs_display_connector = BochsDisplayConnector::try_create_for_vga_isa_connector();
         if (vga_isa_bochs_display_connector) {
@@ -181,7 +187,7 @@ UNMAP_AFTER_INIT bool GraphicsManagement::initialize()
 #endif
     }
 
-    if (graphics_subsystem_mode == CommandLine::GraphicsSubsystemMode::Limited && !multiboot_framebuffer_addr.is_null() && multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
+    if (use_boot_framebuffer) {
         initialize_preset_resolution_generic_display_connector();
         return true;
     }
@@ -206,11 +212,11 @@ UNMAP_AFTER_INIT bool GraphicsManagement::initialize()
     // Note: If we failed to find any graphics device to be used natively, but the
     // bootloader prepared a framebuffer for us to use, then just create a DisplayConnector
     // for it so the user can still use the system in graphics mode.
-    // Prekernel sets the framebuffer address to 0 if MULTIBOOT_INFO_FRAMEBUFFER_INFO
-    // is not present, as there is likely never a valid framebuffer at this physical address.
+    // Prekernel sets the framebuffer address to 0 if no framebuffer is present,
+    // as there is likely never a valid framebuffer at this physical address.
     // Note: We only support RGB framebuffers. Any other format besides RGBX (and RGBA) or BGRX (and BGRA) is obsolete
     // and is not useful for us.
-    if (m_graphics_devices.is_empty() && !multiboot_framebuffer_addr.is_null() && multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
+    if (m_graphics_devices.is_empty() && boot_framebuffer_usable) {
         initialize_preset_resolution_generic_display_connector();
         return true;
     }

--- a/Kernel/EFIPrekernel/Arch/Boot.h
+++ b/Kernel/EFIPrekernel/Arch/Boot.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Prekernel/Prekernel.h>
+
+#include <Kernel/EFIPrekernel/Error.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info);
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr);
+
+}

--- a/Kernel/EFIPrekernel/Arch/MMU.h
+++ b/Kernel/EFIPrekernel/Arch/MMU.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+#include <AK/Types.h>
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+
+#include <Kernel/EFIPrekernel/Error.h>
+
+namespace Kernel::Memory {
+
+// TODO: Merge with Region::Access
+enum class Access {
+    Read = 1,
+    Write = 2,
+    Execute = 4,
+};
+AK_ENUM_BITWISE_OPERATORS(Access);
+
+EFIErrorOr<void*> allocate_empty_root_page_table();
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level = 0, bool has_to_be_new = false);
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access);
+
+}

--- a/Kernel/EFIPrekernel/Arch/aarch64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/aarch64/Boot.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
+{
+    (void)root_page_table;
+    (void)boot_info;
+    TODO();
+}
+
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
+{
+    (void)root_page_table;
+    (void)kernel_entry_vaddr;
+    (void)kernel_stack_pointer;
+    (void)boot_info_vaddr;
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/aarch64/MMU.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel::Memory {
+
+static constexpr size_t PAGE_TABLE_SIZE = PAGE_SIZE;
+
+EFIErrorOr<void*> allocate_empty_root_page_table()
+{
+    EFI::PhysicalAddress root_page_table_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &root_page_table_paddr); status != EFI::Status::Success)
+        return status;
+
+    auto* root_page_table = bit_cast<void*>(root_page_table_paddr);
+    __builtin_memset(root_page_table, 0, PAGE_TABLE_SIZE);
+
+    return root_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)paddr;
+    (void)access;
+    TODO();
+}
+
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)level;
+    (void)has_to_be_new;
+    TODO();
+}
+
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)
+{
+    for (size_t i = 0; i < page_count; i++)
+        TRY(map_single_page(root_page_table, start_vaddr + i * PAGE_SIZE, start_paddr + i * PAGE_SIZE, access));
+
+    return {};
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
+{
+    (void)root_page_table;
+    (void)boot_info;
+    TODO();
+}
+
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
+{
+    (void)root_page_table;
+    (void)kernel_entry_vaddr;
+    (void)kernel_stack_pointer;
+    (void)boot_info_vaddr;
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
@@ -6,25 +6,108 @@
 
 #include <AK/Types.h>
 
+#include <Kernel/Arch/riscv64/CSR.h>
+#include <Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+#include <Kernel/Prekernel/Prekernel.h>
+#include <Kernel/Sections.h>
+
 #include <Kernel/EFIPrekernel/Arch/Boot.h>
-#include <Kernel/EFIPrekernel/Runtime.h>
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/EFIPrekernel.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/VirtualMemoryLayout.h>
 
 namespace Kernel {
 
+// This function has to fit into one page as it will be identity mapped.
+[[gnu::aligned(PAGE_SIZE)]] [[noreturn]] static void enter_kernel_helper(FlatPtr satp, FlatPtr kernel_entry, FlatPtr kernel_sp, FlatPtr boot_info_vaddr)
+{
+    // Switch current root page table to argument 0.
+    // This will immediately take effect, but we won't crash as this function is identity mapped.
+    // Also set up a temporary trap handler to catch traps while switching page tables.
+    register FlatPtr a0 asm("a0") = boot_info_vaddr;
+    register FlatPtr sp asm("sp") = kernel_sp;
+    asm volatile(
+        R"(
+        lla t0, 1f
+        csrw stvec, t0
+
+        csrw satp, %[satp]
+        sfence.vma
+
+        li ra, 0
+        li fp, 0
+        jr %[kernel_entry]
+
+        .p2align 2
+        1: csrw sie, zero
+            wfi
+            j 1b
+        )"
+        :
+        : "r"(a0), "r"(sp), [satp] "r"(satp), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
+        : "t0");
+
+    __builtin_unreachable();
+}
+
 void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
 {
-    (void)root_page_table;
-    (void)boot_info;
-    TODO();
+    // Get the boot hart ID.
+    auto riscv_boot_protocol_guid = EFI::RISCVBootProtocol::guid;
+    EFI::RISCVBootProtocol* riscv_boot_protocol = nullptr;
+
+    if (auto status = g_efi_system_table->boot_services->locate_protocol(&riscv_boot_protocol_guid, nullptr, reinterpret_cast<void**>(&riscv_boot_protocol)); status != EFI::Status::Success)
+        PANIC("Failed to locate the RISC-V boot protocol: {}. RISC-V systems that don't support RISCV_EFI_BOOT_PROTOCOL are not supported.", status);
+
+    if (auto status = riscv_boot_protocol->get_boot_hart_id(riscv_boot_protocol, &boot_info.arch_specific.boot_hart_id); status != EFI::Status::Success)
+        PANIC("Failed to get the RISC-V boot hart ID: {}", status);
+
+    if (boot_info.flattened_devicetree_paddr.is_null())
+        PANIC("No devicetree configuration table was found. RISC-V systems without a devicetree UEFI configuration table are not supported.");
+
+    // FIXME: This leaks < (page table levels) pages, since all active allocations after ExitBootServices are currently eternal.
+    //        We could theoretically reclaim them in the kernel.
+    // NOTE: If this map_pages ever fails, the kernel vaddr range is inside our (physical) prekernel range
+    if (auto result = Memory::map_pages(root_page_table, bit_cast<FlatPtr>(&enter_kernel_helper), bit_cast<PhysicalPtr>(&enter_kernel_helper), 1, Memory::Access::Read | Memory::Access::Execute); result.is_error())
+        PANIC("Failed to identity map the enter_kernel_helper function: {}", result.release_error());
+
+    boot_info.boot_method_specific.efi.bootstrap_page_vaddr = VirtualAddress { bit_cast<FlatPtr>(&enter_kernel_helper) };
+
+    auto maybe_kernel_page_directory = Memory::get_or_insert_page_table(root_page_table, boot_info.kernel_mapping_base, 1);
+    if (maybe_kernel_page_directory.is_error())
+        PANIC("Could not find the kernel page directory: {}", maybe_kernel_page_directory.release_error());
+
+    // There is no level 4 table in Sv39
+    boot_info.boot_pml4t = PhysicalAddress { 0 };
+
+    boot_info.boot_pdpt = PhysicalAddress { bit_cast<PhysicalPtr>(root_page_table) };
+    boot_info.boot_pd_kernel = PhysicalAddress { bit_cast<PhysicalPtr>(maybe_kernel_page_directory.value()) };
+
+    auto kernel_pt1024_base = boot_info.kernel_mapping_base + KERNEL_PT1024_OFFSET;
+
+    auto maybe_quickmap_page_table_paddr = Memory::get_or_insert_page_table(root_page_table, kernel_pt1024_base, 0, true);
+    if (maybe_quickmap_page_table_paddr.is_error())
+        PANIC("Failed to insert the quickmap page table: {}", maybe_quickmap_page_table_paddr.release_error());
+
+    boot_info.boot_pd_kernel_pt1023 = bit_cast<Memory::PageTableEntry*>(QUICKMAP_PAGE_TABLE_VADDR);
+
+    if (auto result = Memory::map_pages(root_page_table, bit_cast<FlatPtr>(boot_info.boot_pd_kernel_pt1023), bit_cast<PhysicalPtr>(maybe_quickmap_page_table_paddr.value()), 1, Memory::Access::Read | Memory::Access::Write); result.is_error())
+        PANIC("Failed to map the quickmap page table: {}", result.release_error());
 }
 
 [[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
 {
-    (void)root_page_table;
-    (void)kernel_entry_vaddr;
-    (void)kernel_stack_pointer;
-    (void)boot_info_vaddr;
-    halt();
+    RISCV64::CSR::SATP satp = {
+        .PPN = bit_cast<u64>(root_page_table) >> 12,
+        .ASID = 0,
+        .MODE = RISCV64::CSR::SATP::Mode::Sv39,
+    };
+
+    enter_kernel_helper(bit_cast<FlatPtr>(satp), kernel_entry_vaddr, kernel_stack_pointer, boot_info_vaddr);
 }
 
 }

--- a/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
@@ -23,22 +23,68 @@ EFIErrorOr<void*> allocate_empty_root_page_table()
     return root_page_table;
 }
 
-static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+static u64* get_pte(u64* page_table, FlatPtr vaddr, size_t level)
 {
-    (void)root_page_table;
-    (void)vaddr;
-    (void)paddr;
-    (void)access;
-    TODO();
+    size_t pte_index_offset = (PAGE_TABLE_INDEX_BITS * level) + PAGE_OFFSET_BITS;
+    size_t pte_index = (vaddr >> pte_index_offset) & PAGE_TABLE_INDEX_MASK;
+
+    return &page_table[pte_index];
 }
 
 EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
 {
-    (void)root_page_table;
-    (void)vaddr;
-    (void)level;
-    (void)has_to_be_new;
-    TODO();
+    VERIFY(root_page_table != nullptr);
+
+    if (level >= LEVELS - 1)
+        return EFI::Status::InvalidParameter;
+
+    u64* current_page_table = reinterpret_cast<u64*>(root_page_table);
+
+    for (size_t current_level = LEVELS - 1; current_level > level; current_level--) {
+        u64* pte = get_pte(current_page_table, vaddr, current_level);
+
+        if ((*pte & to_underlying(PageTableEntryBits::Valid)) != 0) {
+            if (current_level - 1 == level && has_to_be_new)
+                return EFI::Status::InvalidParameter;
+
+            current_page_table = bit_cast<u64*>((*pte >> PTE_PPN_OFFSET) << PADDR_PPN_OFFSET);
+        } else {
+            EFI::PhysicalAddress new_page_table_paddr = 0;
+            if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &new_page_table_paddr); status != EFI::Status::Success)
+                return status;
+
+            __builtin_memset(bit_cast<void*>(new_page_table_paddr), 0, PAGE_TABLE_SIZE);
+
+            *pte = ((new_page_table_paddr >> PADDR_PPN_OFFSET) << PTE_PPN_OFFSET) | to_underlying(PageTableEntryBits::Valid);
+
+            current_page_table = bit_cast<u64*>(new_page_table_paddr);
+        }
+    }
+
+    return current_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    auto* page_table = TRY(get_or_insert_page_table(root_page_table, vaddr));
+    u64* pte = get_pte(bit_cast<u64*>(page_table), vaddr, 0);
+
+    if ((*pte & to_underlying(PageTableEntryBits::Valid)) != 0)
+        return EFI::Status::InvalidParameter; // already mapped
+
+    // Always set the A/D bits as we don't know if the hardware updates them automatically (i.e. if Svadu is supported).
+    // If the hardware doesn't update them automatically they act like additional permission bits.
+    PageTableEntryBits flags = PageTableEntryBits::Valid | PageTableEntryBits::Accessed | PageTableEntryBits::Dirty;
+    if (to_underlying(access & Access::Read) != 0)
+        flags |= PageTableEntryBits::Readable;
+    if (to_underlying(access & Access::Write) != 0)
+        flags |= PageTableEntryBits::Writeable;
+    if (to_underlying(access & Access::Execute) != 0)
+        flags |= PageTableEntryBits::Executable;
+
+    *pte = ((paddr >> PADDR_PPN_OFFSET) << PTE_PPN_OFFSET) | to_underlying(flags);
+
+    return {};
 }
 
 EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)

--- a/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/riscv64/MMU.h>
+
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel::Memory {
+
+EFIErrorOr<void*> allocate_empty_root_page_table()
+{
+    EFI::PhysicalAddress root_page_table_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &root_page_table_paddr); status != EFI::Status::Success)
+        return status;
+
+    auto* root_page_table = bit_cast<void*>(root_page_table_paddr);
+    __builtin_memset(root_page_table, 0, PAGE_TABLE_SIZE);
+
+    return root_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)paddr;
+    (void)access;
+    TODO();
+}
+
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)level;
+    (void)has_to_be_new;
+    TODO();
+}
+
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)
+{
+    for (size_t i = 0; i < page_count; i++)
+        TRY(map_single_page(root_page_table, start_vaddr + i * PAGE_SIZE, start_paddr + i * PAGE_SIZE, access));
+
+    return {};
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/x86_64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/x86_64/Boot.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
+{
+    (void)root_page_table;
+    (void)boot_info;
+    TODO();
+}
+
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
+{
+    (void)root_page_table;
+    (void)kernel_entry_vaddr;
+    (void)kernel_stack_pointer;
+    (void)boot_info_vaddr;
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/x86_64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/x86_64/MMU.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel::Memory {
+
+static constexpr size_t PAGE_TABLE_SIZE = PAGE_SIZE;
+
+EFIErrorOr<void*> allocate_empty_root_page_table()
+{
+    EFI::PhysicalAddress root_page_table_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &root_page_table_paddr); status != EFI::Status::Success)
+        return status;
+
+    auto* root_page_table = bit_cast<void*>(root_page_table_paddr);
+    __builtin_memset(root_page_table, 0, PAGE_TABLE_SIZE);
+
+    return root_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)paddr;
+    (void)access;
+    TODO();
+}
+
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)level;
+    (void)has_to_be_new;
+    TODO();
+}
+
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)
+{
+    for (size_t i = 0; i < page_count; i++)
+        TRY(map_single_page(root_page_table, start_vaddr + i * PAGE_SIZE, start_paddr + i * PAGE_SIZE, access));
+
+    return {};
+}
+
+}

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -1,0 +1,70 @@
+set(PREKERNEL_KERNEL_IMAGE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../Kernel_shared_object)
+configure_file(KernelImage.S.in KernelImage.S @ONLY)
+
+set(SOURCES
+    init.cpp
+
+    DebugOutput.cpp
+    Panic.cpp
+    Runtime.cpp
+    kmalloc.cpp
+
+    KernelImage.S
+
+    ../Library/MiniStdLib.cpp
+    ../Prekernel/UBSanitizer.cpp
+
+    ../../AK/Format.cpp
+    ../../AK/StringBuilder.cpp
+    ../../AK/StringUtils.cpp
+    ../../AK/StringView.cpp
+)
+
+set_source_files_properties(KernelImage.S PROPERTIES OBJECT_DEPENDS ${PREKERNEL_KERNEL_IMAGE_PATH})
+
+add_compile_definitions(PREKERNEL)
+
+add_executable(EFIPrekernel ${SOURCES})
+
+add_dependencies(EFIPrekernel Kernel)
+add_dependencies(EFIPrekernel install_libc_headers)
+
+target_compile_options(EFIPrekernel PRIVATE -fno-threadsafe-statics)
+target_link_options(EFIPrekernel PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld LINKER:--no-dynamic-linker -nostdlib)
+set_target_properties(EFIPrekernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(EFIPrekernel PRIVATE gcc)
+
+    # Prevent naively implemented string functions (like strlen) from being "optimized" into a call to themselves.
+    set_source_files_properties(../Library/MiniStdLib.cpp
+        PROPERTIES COMPILE_FLAGS "-fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    target_link_libraries(EFIPrekernel PRIVATE clang_rt.builtins)
+endif()
+
+# The PrekernelPEImageGenerator doesn't support RELR relocations.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    target_link_options(EFIPrekernel PRIVATE LINKER:-z,nopack-relative-relocs LINKER:--pack-dyn-relocs=none)
+elseif("${SERENITY_ARCH}" STREQUAL "x86_64")
+    target_link_options(EFIPrekernel PRIVATE LINKER:-z,nopack-relative-relocs)
+endif()
+
+target_link_options(EFIPrekernel PRIVATE LINKER:--no-warn-mismatch)
+
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi
+    COMMAND $<TARGET_FILE:Lagom::PrekernelPEImageGenerator> ${CMAKE_CURRENT_BINARY_DIR}/EFIPrekernel ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi
+    VERBATIM
+    DEPENDS EFIPrekernel Lagom::PrekernelPEImageGenerator
+)
+
+add_custom_target(generate_kernel_efi_image ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi DESTINATION boot)
+
+# Remove options which the Prekernel environment doesn't support.
+get_target_property(EFI_PREKERNEL_COMPILE_OPTIONS EFIPrekernel COMPILE_OPTIONS)
+list(REMOVE_ITEM EFI_PREKERNEL_COMPILE_OPTIONS "-fsanitize-coverage=trace-pc")
+list(REMOVE_ITEM EFI_PREKERNEL_COMPILE_OPTIONS "-fsanitize=kernel-address")
+set_target_properties(EFIPrekernel PROPERTIES COMPILE_OPTIONS "${EFI_PREKERNEL_COMPILE_OPTIONS}")

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
 
     DebugOutput.cpp
     Panic.cpp
+    Relocation.cpp
     Runtime.cpp
     kmalloc.cpp
 
@@ -16,6 +17,9 @@ set(SOURCES
 
     ../Library/MiniStdLib.cpp
     ../Prekernel/UBSanitizer.cpp
+
+    ../../Userland/Libraries/LibELF/Image.cpp
+    ../../Userland/Libraries/LibELF/Validation.cpp
 
     ../../AK/Format.cpp
     ../../AK/StringBuilder.cpp

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     init.cpp
 
     DebugOutput.cpp
+    DeviceTree.cpp
     Panic.cpp
     Relocation.cpp
     Runtime.cpp

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
 
     KernelImage.S
 
+    Arch/${SERENITY_ARCH}/Boot.cpp
     Arch/${SERENITY_ARCH}/MMU.cpp
 
     ../Library/MiniStdLib.cpp

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES
 
     KernelImage.S
 
+    Arch/${SERENITY_ARCH}/MMU.cpp
+
     ../Library/MiniStdLib.cpp
     ../Prekernel/UBSanitizer.cpp
 

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
 
     DebugOutput.cpp
     DeviceTree.cpp
+    GOP.cpp
     Panic.cpp
     Relocation.cpp
     Runtime.cpp

--- a/Kernel/EFIPrekernel/DebugOutput.cpp
+++ b/Kernel/EFIPrekernel/DebugOutput.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <AK/kstdio.h>
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+void ucs2_dbgln(char16_t const* message)
+{
+    if (g_efi_system_table == nullptr || g_efi_system_table->con_out == nullptr)
+        return;
+
+    g_efi_system_table->con_out->output_string(g_efi_system_table->con_out, const_cast<char16_t*>(message));
+    g_efi_system_table->con_out->output_string(g_efi_system_table->con_out, const_cast<char16_t*>(u"\r\n"));
+}
+
+}
+
+extern "C" void dbgputstr(char const* characters, size_t length)
+{
+    if (Kernel::g_efi_system_table == nullptr || Kernel::g_efi_system_table->con_out == nullptr)
+        return;
+
+    Vector<char16_t, 256> utf16_string;
+    StringView string_view { characters, length };
+
+    // FIXME: Support non-ASCII messages
+    for (auto c : string_view) {
+        if (c == '\n') {
+            if (utf16_string.try_append(u'\r').is_error())
+                return;
+        }
+
+        if (utf16_string.try_append(c).is_error())
+            return;
+    }
+
+    if (utf16_string.try_append(0).is_error())
+        return;
+
+    Kernel::g_efi_system_table->con_out->output_string(Kernel::g_efi_system_table->con_out, bit_cast<char16_t*>(utf16_string.data()));
+}

--- a/Kernel/EFIPrekernel/DebugOutput.h
+++ b/Kernel/EFIPrekernel/DebugOutput.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+void ucs2_dbgln(char16_t const* message);
+
+}

--- a/Kernel/EFIPrekernel/DeviceTree.cpp
+++ b/Kernel/EFIPrekernel/DeviceTree.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/DeviceTree.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+#include <LibDeviceTree/FlattenedDeviceTree.h>
+
+namespace Kernel {
+
+void fill_flattened_devicetree_boot_info(BootInfo* boot_info)
+{
+    // Search the flattened devicetree configuration table.
+    for (FlatPtr i = 0; i < g_efi_system_table->number_of_table_entries; i++) {
+        if (g_efi_system_table->configuration_table[i].vendor_guid == EFI::DTB_TABLE_GUID) {
+            boot_info->flattened_devicetree_paddr = PhysicalAddress { bit_cast<PhysicalPtr>(g_efi_system_table->configuration_table[i].vendor_table) };
+            break;
+        }
+    }
+
+    if (!boot_info->flattened_devicetree_paddr.is_null()) {
+        DeviceTree::FlattenedDeviceTreeHeader* fdt_header = bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(boot_info->flattened_devicetree_paddr);
+        boot_info->flattened_devicetree_size = fdt_header->totalsize;
+    }
+}
+
+}

--- a/Kernel/EFIPrekernel/DeviceTree.h
+++ b/Kernel/EFIPrekernel/DeviceTree.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Prekernel/Prekernel.h>
+
+namespace Kernel {
+
+void fill_flattened_devicetree_boot_info(BootInfo* boot_info);
+
+}

--- a/Kernel/EFIPrekernel/EFIPrekernel.h
+++ b/Kernel/EFIPrekernel/EFIPrekernel.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+namespace Kernel {
+
+struct EFIMemoryMap {
+    EFI::MemoryDescriptor* descriptor_array { nullptr };
+    EFI::PhysicalAddress descriptor_array_paddr { 0 };
+    FlatPtr descriptor_array_size { 0 };
+    FlatPtr descriptor_size { 0 };
+    FlatPtr buffer_size { 0 };
+    FlatPtr map_key { 0 };
+    u32 descriptor_version { 0 };
+};
+
+}

--- a/Kernel/EFIPrekernel/Error.h
+++ b/Kernel/EFIPrekernel/Error.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+namespace Kernel {
+
+template<typename T>
+using EFIErrorOr = ErrorOr<T, EFI::Status>;
+
+}

--- a/Kernel/EFIPrekernel/GOP.cpp
+++ b/Kernel/EFIPrekernel/GOP.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/GOP.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+void init_gop_and_fill_framebuffer_boot_info(BootInfo* boot_info)
+{
+    auto gop_guid = EFI::GraphicsOutputProtocol::guid;
+    EFI::GraphicsOutputProtocol* gop;
+    if (g_efi_system_table->boot_services->locate_protocol(&gop_guid, nullptr, reinterpret_cast<void**>(&gop)) != EFI::Status::Success) {
+        dbgln("GOP not available :^(");
+        return;
+    }
+
+    // Choose the mode with the highest pixel count.
+    EFI::GraphicsOutputModeInformation chosen_mode_info {};
+    ssize_t chosen_mode_number = -1;
+
+    // NOTE: MaxMode is the number of supported modes, not the highest mode number.
+    for (u32 mode_number = 0; mode_number < gop->mode->max_mode; mode_number++) {
+        FlatPtr size_of_mode_info;
+        EFI::GraphicsOutputModeInformation* mode_info;
+
+        if (auto status = gop->query_mode(gop, mode_number, &size_of_mode_info, &mode_info); status != EFI::Status::Success) {
+            dbgln("Error: Failed to query GOP mode {}: {}", mode_number, status);
+            return;
+        }
+
+        if (mode_info->pixel_format == EFI::GraphicsPixelFormat::BlueGreenRedReserved8BitPerColor
+            && mode_info->vertical_resolution * mode_info->horizontal_resolution > chosen_mode_info.vertical_resolution * chosen_mode_info.horizontal_resolution) {
+            chosen_mode_info = *mode_info;
+            chosen_mode_number = mode_number;
+        }
+    }
+
+    if (chosen_mode_number == -1) {
+        dbgln("No usable GOP mode found");
+        return;
+    }
+
+    if (auto status = gop->set_mode(gop, chosen_mode_number); status != EFI::Status::Success) {
+        dbgln("Error: Failed to set GOP mode {}: {}", chosen_mode_number, status);
+        return;
+    }
+
+    dbgln("Chosen GOP mode: {}x{}", chosen_mode_info.horizontal_resolution, chosen_mode_info.vertical_resolution);
+
+    boot_info->boot_framebuffer.bpp = 32;
+
+    boot_info->boot_framebuffer.paddr = PhysicalAddress { gop->mode->frame_buffer_base };
+    boot_info->boot_framebuffer.pitch = static_cast<size_t>(gop->mode->info->pixels_per_scan_line) * (boot_info->boot_framebuffer.bpp / 8);
+    boot_info->boot_framebuffer.width = gop->mode->info->horizontal_resolution;
+    boot_info->boot_framebuffer.height = gop->mode->info->vertical_resolution;
+    boot_info->boot_framebuffer.type = BootFramebufferType::BGRx8888;
+}
+
+}

--- a/Kernel/EFIPrekernel/GOP.h
+++ b/Kernel/EFIPrekernel/GOP.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Prekernel/Prekernel.h>
+
+namespace Kernel {
+
+void init_gop_and_fill_framebuffer_boot_info(BootInfo* boot_info);
+
+}

--- a/Kernel/EFIPrekernel/Globals.h
+++ b/Kernel/EFIPrekernel/Globals.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+namespace Kernel {
+
+extern EFI::Handle g_efi_image_handle;
+extern EFI::SystemTable* g_efi_system_table;
+
+}

--- a/Kernel/EFIPrekernel/KernelImage.S.in
+++ b/Kernel/EFIPrekernel/KernelImage.S.in
@@ -1,0 +1,11 @@
+// The kernel image has to be in a writable section, so we can apply relocations while EFI boot services are still available
+// (we are not allowed to change page tables until we call ExitBootServices()).
+.section .data
+
+.global start_of_kernel_image
+.global end_of_kernel_image
+
+.p2align 12
+start_of_kernel_image:
+.incbin "@PREKERNEL_KERNEL_IMAGE_PATH@"
+end_of_kernel_image:

--- a/Kernel/EFIPrekernel/Panic.cpp
+++ b/Kernel/EFIPrekernel/Panic.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+[[noreturn]] void __panic(char const* file, unsigned int line, char const* function)
+{
+    dbgln("at {}:{} in {}", file, line, function);
+
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Panic.h
+++ b/Kernel/EFIPrekernel/Panic.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+
+namespace Kernel {
+
+[[noreturn]] void __panic(char const* file, unsigned int line, char const* function);
+
+#define PANIC(...)                                                  \
+    do {                                                            \
+        ::Kernel::ucs2_dbgln(u"PREKERNEL PANIC! :^(");              \
+        dbgln(__VA_ARGS__);                                         \
+        ::Kernel::__panic(__FILE__, __LINE__, __PRETTY_FUNCTION__); \
+    } while (0)
+
+}

--- a/Kernel/EFIPrekernel/Relocation.cpp
+++ b/Kernel/EFIPrekernel/Relocation.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Relocation.h>
+
+#include <LibELF/Arch/GenericDynamicRelocationType.h>
+#include <LibELF/ELFABI.h>
+#include <LibELF/Image.h>
+
+namespace Kernel {
+
+// This function only works on ELF addresses that are not in a zero-padded area of a program header.
+static ErrorOr<Bytes> get_data_at_kernel_elf_virtual_address(ELF::Image const& kernel_elf_image, Bytes kernel_elf_image_data, FlatPtr start_vaddr, size_t size)
+{
+    ErrorOr<Bytes> result = EINVAL;
+    static Optional<ELF::Image::ProgramHeader> cached_program_header;
+
+    if (cached_program_header.has_value() && start_vaddr >= cached_program_header->vaddr().get() && start_vaddr + size < cached_program_header->vaddr().get() + cached_program_header->size_in_memory())
+        return kernel_elf_image_data.slice(cached_program_header->offset() + start_vaddr - cached_program_header->vaddr().get(), size);
+
+    kernel_elf_image.for_each_program_header([&result, kernel_elf_image_data, start_vaddr, size](ELF::Image::ProgramHeader const& program_header) {
+        if (program_header.type() == PT_LOAD
+            && start_vaddr >= program_header.vaddr().get() && start_vaddr + size <= program_header.vaddr().get() + program_header.size_in_memory()) {
+            result = kernel_elf_image_data.slice(program_header.offset() + start_vaddr - program_header.vaddr().get(), size);
+            cached_program_header = program_header;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    return result;
+}
+
+void perform_kernel_relocations(ELF::Image const& kernel_elf_image, Bytes kernel_elf_image_data, FlatPtr base_address)
+{
+    size_t dynamic_section_offset { 0 };
+    kernel_elf_image.for_each_program_header([&dynamic_section_offset](ELF::Image::ProgramHeader const& program_header) {
+        if (program_header.type() == PT_DYNAMIC) {
+            dynamic_section_offset = program_header.offset();
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    if (dynamic_section_offset == 0)
+        PANIC("Kernel image does not have a PT_DYNAMIC program header");
+
+    FlatPtr relocation_table_vaddr = 0;
+    size_t relocation_table_size = 0;
+    size_t relocation_entry_size = 0;
+    size_t number_of_relative_relocs = 0;
+
+    FlatPtr relr_relocation_table_vaddr = 0;
+    size_t relr_relocation_table_size = 0;
+
+    auto const* dynamic_section_entries = bit_cast<Elf_Dyn const*>(bit_cast<FlatPtr>(kernel_elf_image_data.data()) + dynamic_section_offset);
+    for (size_t i = 0;; i++) {
+        auto const& entry = dynamic_section_entries[i];
+
+        if (entry.d_tag == DT_NULL)
+            break;
+
+        switch (entry.d_tag) {
+        case DT_REL:
+        case DT_RELSZ:
+        case DT_RELENT:
+        case DT_RELCOUNT:
+            PANIC("DT_REL relocation tables are not supported");
+
+        case DT_RELA:
+            relocation_table_vaddr = entry.d_un.d_ptr;
+            break;
+        case DT_RELASZ:
+            relocation_table_size = entry.d_un.d_val;
+            break;
+        case DT_RELAENT:
+            relocation_entry_size = entry.d_un.d_val;
+            break;
+        case DT_RELACOUNT:
+            number_of_relative_relocs = entry.d_un.d_val;
+            break;
+
+        case DT_RELR:
+            relr_relocation_table_vaddr = entry.d_un.d_ptr;
+            break;
+        case DT_RELRSZ:
+            relr_relocation_table_size = entry.d_un.d_val;
+            break;
+        case DT_RELRENT:
+            VERIFY(entry.d_un.d_val == sizeof(FlatPtr));
+            break;
+        }
+    }
+
+    VERIFY((relocation_table_vaddr != 0 && relocation_table_size != 0 && relocation_entry_size != 0 && number_of_relative_relocs != 0)
+        || (relr_relocation_table_vaddr != 0 && relr_relocation_table_size != 0));
+
+    if (relocation_table_vaddr != 0) {
+        // We are still identity mapped, so translate the address of the relocation table.
+        auto relocation_table_data = MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, relocation_table_vaddr, relocation_table_size));
+
+        for (size_t i = 0; i < number_of_relative_relocs; i++) {
+            auto const& raw_relocation = *bit_cast<Elf_Rela const*>(bit_cast<FlatPtr>(relocation_table_data.data()) + i * relocation_entry_size);
+            ELF::Image::Relocation relocation(kernel_elf_image, raw_relocation, true);
+
+            VERIFY(relocation.type() == to_underlying(ELF::GenericDynamicRelocationType::RELATIVE));
+
+            // Elf_Rela::r_offset is a virtual address for executables, so we need to translate it as well.
+            auto* patch_ptr = bit_cast<FlatPtr*>(MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, relocation.offset(), sizeof(FlatPtr))).data());
+
+            FlatPtr relocated_address = base_address + relocation.addend();
+            __builtin_memcpy(patch_ptr, &relocated_address, sizeof(FlatPtr));
+        }
+    }
+
+    if (relr_relocation_table_vaddr != 0) {
+        auto patch_relr = [&kernel_elf_image, kernel_elf_image_data, base_address](FlatPtr patch_vaddr) {
+            auto* patch_ptr = bit_cast<FlatPtr*>(MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, patch_vaddr, sizeof(FlatPtr))).data());
+
+            FlatPtr relocated_address;
+            __builtin_memcpy(&relocated_address, patch_ptr, sizeof(FlatPtr));
+            relocated_address += base_address;
+            __builtin_memcpy(patch_ptr, &relocated_address, sizeof(FlatPtr));
+        };
+
+        auto relr_relocation_table_data = MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, relr_relocation_table_vaddr, relr_relocation_table_size));
+        auto* entries = bit_cast<Elf_Relr*>(relr_relocation_table_data.data());
+        FlatPtr patch_vaddr = 0;
+
+        for (size_t i = 0; i < relr_relocation_table_size / sizeof(FlatPtr); i++) {
+            if ((entries[i] & 1) == 0) {
+                patch_vaddr = entries[i];
+                patch_relr(patch_vaddr);
+                patch_vaddr += sizeof(FlatPtr);
+            } else {
+                auto bitmap = entries[i];
+                for (size_t j = 0; (bitmap >>= 1) != 0; j++)
+                    if ((bitmap & 1) != 0)
+                        patch_relr(patch_vaddr + j * sizeof(FlatPtr));
+
+                patch_vaddr += (8 * sizeof(FlatPtr) - 1) * sizeof(FlatPtr);
+            }
+        }
+    }
+}
+
+}

--- a/Kernel/EFIPrekernel/Relocation.h
+++ b/Kernel/EFIPrekernel/Relocation.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibELF/Image.h>
+
+namespace Kernel {
+
+void perform_kernel_relocations(ELF::Image const& kernel_elf_image, Bytes kernel_elf_image_data, FlatPtr base_address);
+
+}

--- a/Kernel/EFIPrekernel/Runtime.cpp
+++ b/Kernel/EFIPrekernel/Runtime.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+[[noreturn]] void halt()
+{
+    for (;;) {
+#if ARCH(AARCH64)
+        asm volatile("msr daifset, #2; wfi");
+#elif ARCH(RISCV64)
+        asm volatile("csrw sie, zero; wfi");
+#elif ARCH(X86_64)
+        asm volatile("cli; hlt");
+#else
+#    error Unknown architecture
+#endif
+    }
+}
+
+}

--- a/Kernel/EFIPrekernel/Runtime.h
+++ b/Kernel/EFIPrekernel/Runtime.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+[[noreturn]] void halt();
+
+}

--- a/Kernel/EFIPrekernel/VirtualMemoryLayout.h
+++ b/Kernel/EFIPrekernel/VirtualMemoryLayout.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+// Kernel virtual memory layout:
+// Kernel stack | BootInfo | Quickmap page table | EFI memory map | Kernel
+// ^ KERNEL_MAPPING_BASE
+// NOTE: If the memory map overflows into the kernel memory range, we catch that in the map_pages function (a page is not allowed to be remapped)
+
+static constexpr size_t KERNEL_STACK_SIZE = 64 * KiB;
+static_assert(KERNEL_STACK_SIZE % PAGE_SIZE == 0);
+
+static constexpr FlatPtr KERNEL_STACK_VADDR = KERNEL_MAPPING_BASE;
+static constexpr FlatPtr BOOT_INFO_VADDR = KERNEL_MAPPING_BASE + KERNEL_STACK_SIZE;
+
+static constexpr FlatPtr QUICKMAP_PAGE_TABLE_VADDR = round_up_to_power_of_two(BOOT_INFO_VADDR + sizeof(BootInfo), PAGE_SIZE);
+
+// This assumes PAGE_SIZE == PAGE_TABLE_SIZE
+static constexpr FlatPtr EFI_MEMORY_MAP_VADDR = QUICKMAP_PAGE_TABLE_VADDR + PAGE_SIZE;
+
+}

--- a/Kernel/EFIPrekernel/init.cpp
+++ b/Kernel/EFIPrekernel/init.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+// FIXME: Initialize the __stack_chk_guard with a random value via the EFI_RNG_PROTOCOL or other arch-specific methods.
+uintptr_t __stack_chk_guard __attribute__((used));
+
+namespace Kernel {
+
+extern "C" [[noreturn]] void __stack_chk_fail();
+extern "C" [[noreturn]] void __stack_chk_fail()
+{
+    PANIC("Stack protector failure, stack smashing detected!");
+}
+
+EFI::Handle g_efi_image_handle = 0;
+EFI::SystemTable* g_efi_system_table = nullptr;
+
+static_assert(EFI::EFI_PAGE_SIZE == PAGE_SIZE, "The EFIPrekernel assumes that EFI_PAGE_SIZE == PAGE_SIZE");
+
+extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table);
+extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table)
+{
+    // We use some EFI 1.10 functions from the System Table, so reject older versions.
+    static constexpr u32 efi_version_1_10 = (1 << 16) | 10;
+    if (system_table->hdr.signature != EFI::SystemTable::signature || system_table->hdr.revision < efi_version_1_10)
+        return EFI::Status::Unsupported;
+
+    g_efi_image_handle = image_handle;
+    g_efi_system_table = system_table;
+
+    // clang-format off
+    system_table->con_out->set_attribute(system_table->con_out, EFI::TextAttribute {
+        .foreground_color = EFI::TextAttribute::ForegroundColor::White,
+        .background_color = EFI::TextAttribute::BackgroundColor::Black,
+    });
+    // clang-format on
+
+    // Clear the screen. This also removes the manufacturer logo, if present.
+    system_table->con_out->clear_screen(system_table->con_out);
+
+    ucs2_dbgln(u"SerenityOS EFI Prekernel");
+
+    TODO();
+}
+
+}
+
+void __assertion_failed(char const* msg, char const* file, unsigned int line, char const* func)
+{
+    dbgln("ASSERTION FAILED: {}", msg);
+    dbgln("{}:{} in {}", file, line, func);
+    Kernel::halt();
+}

--- a/Kernel/EFIPrekernel/init.cpp
+++ b/Kernel/EFIPrekernel/init.cpp
@@ -4,17 +4,51 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Firmware/EFI/EFI.h>
-#include <Kernel/Firmware/EFI/SystemTable.h>
+#include <AK/CharacterTypes.h>
+#include <AK/UnicodeUtils.h>
 
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/Protocols/LoadedImage.h>
+#include <Kernel/Firmware/EFI/Protocols/MediaAccess.h>
+#include <Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+#include <Kernel/Memory/VirtualAddress.h>
+#include <Kernel/Prekernel/Prekernel.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
 #include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/DeviceTree.h>
+#include <Kernel/EFIPrekernel/EFIPrekernel.h>
+#include <Kernel/EFIPrekernel/Error.h>
 #include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Relocation.h>
 #include <Kernel/EFIPrekernel/Runtime.h>
+#include <Kernel/EFIPrekernel/VirtualMemoryLayout.h>
+
+#include <LibELF/ELFABI.h>
+#include <LibELF/Relocation.h>
 
 // FIXME: Initialize the __stack_chk_guard with a random value via the EFI_RNG_PROTOCOL or other arch-specific methods.
 uintptr_t __stack_chk_guard __attribute__((used));
 
+extern "C" u8 pe_image_base[];
+
+extern "C" u8 start_of_kernel_image[];
+extern "C" u8 end_of_kernel_image[];
+
 namespace Kernel {
+
+static_assert(EFI::EFI_PAGE_SIZE == PAGE_SIZE, "The EFIPrekernel assumes that EFI_PAGE_SIZE == PAGE_SIZE");
+
+EFI::Handle g_efi_image_handle = 0;
+EFI::SystemTable* g_efi_system_table = nullptr;
+
+static size_t pages_needed(size_t bytes)
+{
+    return (bytes + PAGE_SIZE - 1) / PAGE_SIZE;
+}
 
 extern "C" [[noreturn]] void __stack_chk_fail();
 extern "C" [[noreturn]] void __stack_chk_fail()
@@ -22,10 +56,106 @@ extern "C" [[noreturn]] void __stack_chk_fail()
     PANIC("Stack protector failure, stack smashing detected!");
 }
 
-EFI::Handle g_efi_image_handle = 0;
-EFI::SystemTable* g_efi_system_table = nullptr;
+static void map_kernel_image(void* root_page_table, ELF::Image const& kernel_elf_image, ReadonlyBytes kernel_elf_image_data, FlatPtr kernel_load_base)
+{
+    kernel_elf_image.for_each_program_header([root_page_table, kernel_elf_image_data, kernel_load_base](ELF::Image::ProgramHeader const& program_header) {
+        if (program_header.type() != PT_LOAD)
+            return IterationDecision::Continue;
 
-static_assert(EFI::EFI_PAGE_SIZE == PAGE_SIZE, "The EFIPrekernel assumes that EFI_PAGE_SIZE == PAGE_SIZE");
+        auto page_count = pages_needed(program_header.size_in_memory());
+
+        auto start_vaddr = kernel_load_base + program_header.vaddr().get();
+        auto start_paddr = bit_cast<PhysicalPtr>(kernel_elf_image_data.data()) + program_header.offset();
+
+        if (program_header.size_in_memory() != program_header.size_in_image()) {
+            if (program_header.size_in_image() != 0)
+                PANIC("Program headers with p_memsz != p_filesz && p_filesz != 0 are not supported");
+
+            // Allocate a zeroed memory region for the program header.
+            EFI::PhysicalAddress segment_data_paddr = 0;
+            if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, page_count, &segment_data_paddr); status != EFI::Status::Success)
+                PANIC("Failed to allocate memory for program header {}: {}", program_header.index(), status);
+
+            __builtin_memset(bit_cast<void*>(segment_data_paddr), 0, page_count * PAGE_SIZE);
+
+            start_paddr = segment_data_paddr;
+        }
+
+        VERIFY(program_header.alignment() % PAGE_SIZE == 0);
+        VERIFY(start_vaddr % PAGE_SIZE == 0);
+
+        Memory::Access access;
+        if (program_header.is_readable())
+            access |= Memory::Access::Read;
+        if (program_header.is_writable())
+            access |= Memory::Access::Write;
+        if (program_header.is_executable())
+            access |= Memory::Access::Execute;
+
+        if (auto result = Memory::map_pages(root_page_table, start_vaddr, start_paddr, page_count, access); result.is_error())
+            PANIC("Failed to map program header {}: {}", program_header.index(), result.release_error());
+
+        return IterationDecision::Continue;
+    });
+}
+
+static void get_memory_map_and_exit_boot_services(void* root_page_table, BootInfo& boot_info)
+{
+    auto* boot_services = g_efi_system_table->boot_services;
+    auto& memory_map = boot_info.boot_method_specific.efi.memory_map;
+
+    // Print this message before the first call to GetMemoryMap(), as calling OutputString() could change the memory map.
+    dbgln("Exiting EFI Boot Services...");
+
+    // Get the required size for the memory map.
+    if (auto status = boot_services->get_memory_map(&memory_map.descriptor_array_size, nullptr, &memory_map.map_key, &memory_map.descriptor_size, &memory_map.descriptor_version); status != EFI::Status::BufferTooSmall)
+        PANIC("Failed to acquire the required size for memory map: {}", status);
+
+    // Make room for 10 additional descriptors in the memory map, as the memory map could change between the first GetMemoryMap() and ExitBootServices().
+    // This also allows us to reuse the memory map even if the first call to ExitBootServices() fails.
+    // We probably shouldn't allocate memory if ExitBootServices() failed, as that might change the memory map again.
+    memory_map.descriptor_array_size = round_up_to_power_of_two(memory_map.descriptor_array_size + memory_map.descriptor_size * 10, PAGE_SIZE);
+
+    // We have to save the size here, as GetMemoryMap() overrides the value pointed to by the MemoryMap argument.
+    memory_map.buffer_size = memory_map.descriptor_array_size;
+
+    if (auto status = boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, memory_map.buffer_size / PAGE_SIZE, &memory_map.descriptor_array_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate memory for the EFI memory map: {}", status);
+
+    __builtin_memset(bit_cast<void*>(memory_map.descriptor_array_paddr), 0, memory_map.buffer_size);
+
+    if (auto result = Memory::map_pages(root_page_table, EFI_MEMORY_MAP_VADDR, memory_map.descriptor_array_paddr, memory_map.buffer_size / PAGE_SIZE, Memory::Access::Read); result.is_error())
+        PANIC("Failed to map the EFI memory map: {}", result.release_error());
+
+    // Tell the kernel the location of the EFI memory map
+    memory_map.descriptor_array = bit_cast<EFI::MemoryDescriptor*>(EFI_MEMORY_MAP_VADDR);
+
+    if (auto status = boot_services->get_memory_map(&memory_map.descriptor_array_size, bit_cast<EFI::MemoryDescriptor*>(memory_map.descriptor_array_paddr), &memory_map.map_key, &memory_map.descriptor_size, &memory_map.descriptor_version); status != EFI::Status::Success)
+        PANIC("Failed to get the EFI memory map: {}", status);
+
+    // A very crude memory leak detector
+    // We should check for leaks before calling ExitBootServices(), as we have no way of freeing them after that.
+    // Memory that should stay allocated has to directly be allocated via Allocate{Pages,Pool}().
+    kmalloc_stats stats;
+    get_kmalloc_stats(stats);
+
+    if (stats.kmalloc_call_count != stats.kfree_call_count)
+        PANIC("Memory leak(s) detected! kmalloc call count: {}, kfree call count: {}", stats.kmalloc_call_count, stats.kfree_call_count);
+
+    // From now on, we can't use any boot service or device-handle-based protocol anymore, even if ExitBootServices() failed.
+    if (auto status = boot_services->exit_boot_services(g_efi_image_handle, memory_map.map_key); status == EFI::Status::InvalidParameter) {
+        // We have to call GetMemoryMap() again, as the memory map changed between GetMemoryMap() and ExitBootServices().
+        // Memory allocation services are still allowed to be used if ExitBootServices() failed.
+        memory_map.descriptor_array_size = memory_map.buffer_size;
+        if (boot_services->get_memory_map(&memory_map.descriptor_array_size, bit_cast<EFI::MemoryDescriptor*>(memory_map.descriptor_array_paddr), &memory_map.map_key, &memory_map.descriptor_size, &memory_map.descriptor_version) != EFI::Status::Success)
+            halt();
+
+        if (boot_services->exit_boot_services(g_efi_image_handle, memory_map.map_key) != EFI::Status::Success)
+            halt();
+    } else if (status != EFI::Status::Success) {
+        halt();
+    }
+}
 
 extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table);
 extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table)
@@ -37,6 +167,8 @@ extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* s
 
     g_efi_image_handle = image_handle;
     g_efi_system_table = system_table;
+
+    auto* boot_services = system_table->boot_services;
 
     // clang-format off
     system_table->con_out->set_attribute(system_table->con_out, EFI::TextAttribute {
@@ -50,7 +182,80 @@ extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* s
 
     ucs2_dbgln(u"SerenityOS EFI Prekernel");
 
-    TODO();
+    auto loaded_image_protocol_guid = EFI::LoadedImageProtocol::guid;
+    EFI::LoadedImageProtocol* loaded_image_protocol;
+    if (auto status = boot_services->handle_protocol(image_handle, &loaded_image_protocol_guid, reinterpret_cast<void**>(&loaded_image_protocol)); status != EFI::Status::Success)
+        PANIC("Failed to get the loaded image protocol: {}", status);
+
+    VERIFY(loaded_image_protocol->image_base == pe_image_base);
+    VERIFY(bit_cast<FlatPtr>(loaded_image_protocol->image_base) % PAGE_SIZE == 0);
+
+    auto kernel_image_paddr = bit_cast<PhysicalPtr>(&start_of_kernel_image);
+    VERIFY(kernel_image_paddr % PAGE_SIZE == 0);
+    auto kernel_image_size = bit_cast<PhysicalPtr>(&end_of_kernel_image) - kernel_image_paddr;
+
+    auto maybe_root_page_table = Memory::allocate_empty_root_page_table();
+    if (maybe_root_page_table.is_error())
+        PANIC("Failed to allocate root page table: {}", maybe_root_page_table.release_error());
+
+    auto* root_page_table = maybe_root_page_table.value();
+
+    // Allocate pages for the kernel stack and map it to KERNEL_MAPPING_BASE
+    // TODO: KASLR
+    EFI::PhysicalAddress kernel_stack_paddr = 0;
+    if (auto status = system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, KERNEL_STACK_SIZE / PAGE_SIZE, &kernel_stack_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate pages for the kernel stack: {}", status);
+
+    __builtin_memset(bit_cast<void*>(kernel_stack_paddr), 0, KERNEL_STACK_SIZE);
+
+    if (auto result = Memory::map_pages(root_page_table, KERNEL_STACK_VADDR, kernel_stack_paddr, KERNEL_STACK_SIZE / PAGE_SIZE, Memory::Access::Read | Memory::Access::Write); result.is_error())
+        PANIC("Failed to map the kernel stack: {}", result.release_error());
+
+    // Allocate pages for the boot info struct and map it to KERNEL_MAPPING_BASE + KERNEL_STACK_SIZE
+    // TODO: KASLR
+    EFI::PhysicalAddress boot_info_paddr = 0;
+    if (auto status = system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, pages_needed(sizeof(BootInfo)), &boot_info_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate pages for the BootInfo struct: {}", status);
+
+    auto* boot_info = bit_cast<BootInfo*>(boot_info_paddr);
+    new (boot_info) BootInfo;
+
+    boot_info->boot_method = BootMethod::EFI;
+    boot_info->boot_method_specific.pre_init.~PreInitBootInfo();
+    new (&boot_info->boot_method_specific.efi) EFIBootInfo;
+
+    if (auto result = Memory::map_pages(root_page_table, BOOT_INFO_VADDR, boot_info_paddr, pages_needed(sizeof(BootInfo)), Memory::Access::Read); result.is_error())
+        PANIC("Failed to map the BootInfo struct: {}", result.release_error());
+
+    Bytes kernel_elf_image_data { bit_cast<u8*>(kernel_image_paddr), kernel_image_size };
+    ELF::Image kernel_elf_image { kernel_elf_image_data };
+
+    // TODO: KASLR
+    FlatPtr default_kernel_load_base = KERNEL_MAPPING_BASE + 0x200000;
+
+    boot_info->kernel_mapping_base = KERNEL_MAPPING_BASE;
+    boot_info->kernel_load_base = default_kernel_load_base;
+    boot_info->physical_to_virtual_offset = boot_info->kernel_load_base - kernel_image_paddr;
+
+    // TODO: Get the cmdline from loaded_image_protocol->load_options.
+    //       The EFI shell passes the cmdline as a NUL-terminated UCS-2 string with argv[0] being the executable path.
+    //       efibootmgr --unicode doesn't add a NUL terminator.
+
+    dbgln("Mapping the kernel image...");
+    map_kernel_image(root_page_table, kernel_elf_image, kernel_elf_image_data, boot_info->kernel_load_base);
+
+    dbgln("Performing relative relocations of the kernel image...");
+    perform_kernel_relocations(kernel_elf_image, kernel_elf_image_data, boot_info->kernel_load_base);
+
+    fill_flattened_devicetree_boot_info(boot_info);
+
+    arch_prepare_boot(root_page_table, *boot_info);
+
+    get_memory_map_and_exit_boot_services(root_page_table, *boot_info);
+
+    auto kernel_entry_vaddr = boot_info->kernel_load_base + kernel_elf_image.entry().get();
+
+    arch_enter_kernel(root_page_table, kernel_entry_vaddr, KERNEL_STACK_VADDR + KERNEL_STACK_SIZE, BOOT_INFO_VADDR);
 }
 
 }

--- a/Kernel/EFIPrekernel/init.cpp
+++ b/Kernel/EFIPrekernel/init.cpp
@@ -22,6 +22,7 @@
 #include <Kernel/EFIPrekernel/DeviceTree.h>
 #include <Kernel/EFIPrekernel/EFIPrekernel.h>
 #include <Kernel/EFIPrekernel/Error.h>
+#include <Kernel/EFIPrekernel/GOP.h>
 #include <Kernel/EFIPrekernel/Panic.h>
 #include <Kernel/EFIPrekernel/Relocation.h>
 #include <Kernel/EFIPrekernel/Runtime.h>
@@ -223,6 +224,8 @@ extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* s
     boot_info->boot_method = BootMethod::EFI;
     boot_info->boot_method_specific.pre_init.~PreInitBootInfo();
     new (&boot_info->boot_method_specific.efi) EFIBootInfo;
+
+    init_gop_and_fill_framebuffer_boot_info(boot_info);
 
     if (auto result = Memory::map_pages(root_page_table, BOOT_INFO_VADDR, boot_info_paddr, pages_needed(sizeof(BootInfo)), Memory::Access::Read); result.is_error())
         PANIC("Failed to map the BootInfo struct: {}", result.release_error());

--- a/Kernel/EFIPrekernel/kmalloc.cpp
+++ b/Kernel/EFIPrekernel/kmalloc.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/kmalloc.h>
+
+#include <Kernel/EFIPrekernel/Globals.h>
+
+static size_t s_kmalloc_call_count;
+static size_t s_kfree_call_count;
+
+void kfree_sized(void* ptr, size_t)
+{
+    if (Kernel::g_efi_system_table == nullptr || Kernel::g_efi_system_table->boot_services == nullptr)
+        return;
+
+    s_kfree_call_count++;
+    Kernel::g_efi_system_table->boot_services->free_pool(ptr);
+}
+
+void* kmalloc(size_t size)
+{
+    if (Kernel::g_efi_system_table == nullptr || Kernel::g_efi_system_table->boot_services == nullptr)
+        return nullptr;
+
+    void* ret;
+
+    s_kmalloc_call_count++;
+
+    if (Kernel::g_efi_system_table->boot_services->allocate_pool(Kernel::EFI::MemoryType::LoaderData, size, &ret) != Kernel::EFI::Status::Success)
+        return nullptr;
+
+    return ret;
+}
+
+size_t kmalloc_good_size(size_t size)
+{
+    return size;
+}
+
+void get_kmalloc_stats(kmalloc_stats& stats)
+{
+    stats.bytes_allocated = 0;
+    stats.bytes_free = 0;
+    stats.kmalloc_call_count = s_kmalloc_call_count;
+    stats.kfree_call_count = s_kfree_call_count;
+}

--- a/Kernel/EFIPrekernel/linker.ld
+++ b/Kernel/EFIPrekernel/linker.ld
@@ -1,0 +1,45 @@
+ENTRY(init)
+
+SECTIONS
+{
+    /* This is symbol is used to tell the PrekernelPEImageGenerator that the PE base address is 0 */
+    pe_image_base = .;
+
+    /* PE doesn't have segments, so PE sections behave similarly to ELF segments. */
+
+    /* PE sections have to be aligned by the section alignment specified in the windows-specific fields. We define it to be 4K.
+       So all output sections that won't be discard by PrekernelPEImageGenerator have to be properly aligned. */
+
+    /* Skip over the PE headers. The virtual addresses of all PE sections have to bigger than the size of the PE headers. */
+    . = 0x1000;
+
+    /* The output sections are named after https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#special-sections.
+       PrekernelPEImageGenerator will add the PE .reloc section by converting ELF R_*_RELATIVE relocations to PE base relocations. */
+
+    .text ALIGN(4K) :
+    {
+        *(.text*)
+    }
+
+    .rdata ALIGN(4K) :
+    {
+        *(.rodata* .srodata*)
+    }
+
+    .data ALIGN(4K) :
+    {
+        *(.data* .sdata*)
+    }
+
+    .got ALIGN(4K) :
+    {
+        *(.got.plt)
+        *(.got)
+    }
+
+    .bss ALIGN(4K) (NOLOAD) :
+    {
+        *(COMMON)
+        *(.bss* .sbss*)
+    }
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.cpp
@@ -55,7 +55,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<SysFSGlobalKernelStatsDirectory> SysFSGlobalKerne
 
         {
             auto builder = TRY(KBufferBuilder::try_create());
-            MUST(builder.appendff("{}", kernel_load_base));
+            MUST(builder.appendff("{}", g_boot_info.kernel_load_base));
             auto load_base_buffer = builder.build();
             VERIFY(load_base_buffer);
             list.append(SysFSSystemConstantInformation::must_create(*global_kernel_stats_directory, load_base_buffer.release_nonnull(), S_IRUSR, SysFSSystemConstantInformation::ReadableByJailedProcesses::No, SysFSSystemConstantInformation::NodeName::LoadBase));

--- a/Kernel/Firmware/EFI/EFI.h
+++ b/Kernel/Firmware/EFI/EFI.h
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <AK/NumericLimits.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Types.h>
+
+// UEFI uses the Microsoft calling convention on x86.
+#if ARCH(X86_64)
+#    define EFIAPI __attribute__((ms_abi))
+#else
+#    define EFIAPI
+#endif
+
+namespace Kernel::EFI {
+
+// The UEFI spec requires 4K pages to be used for all its current architectures.
+// All function arguments and struct members that refer to "pages" also assume 4K pages.
+// e.g. the AllocatePages() "Pages" argument: https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+static constexpr size_t EFI_PAGE_SIZE = 4 * KiB;
+
+// EFI Data Types: https://uefi.org/specs/UEFI/2.10/02_Overview.html#data-types
+
+// BOOLEAN, Logical Boolean. 1-byte value containing a 0 for FALSE or a 1 for TRUE. Other values are undefined.
+enum class Boolean : u8 {
+    False = 0,
+    True = 1,
+};
+
+// EFI_GUID, 128-bit buffer containing a unique identifier value. Unless otherwise specified, aligned on a 64-bit boundary.
+struct alignas(u64) GUID {
+    u32 part1;
+    u16 part2;
+    u16 part3;
+    u8 part4[8];
+
+    bool operator==(GUID const& other)
+    {
+        return __builtin_memcmp(this, &other, sizeof(GUID)) == 0;
+    }
+};
+static_assert(AssertSize<GUID, 16>());
+
+// EFI_STATUS, Status code
+// Standard status codes are defined here: https://uefi.org/specs/UEFI/2.10/Apx_D_Status_Codes.html
+static constexpr FlatPtr ERROR_MASK = 1ull << (NumericLimits<FlatPtr>::digits() - 1);
+enum class Status : FlatPtr {
+    Success = 0,
+
+    LoadError = 1 | ERROR_MASK,
+    InvalidParameter = 2 | ERROR_MASK,
+    Unsupported = 3 | ERROR_MASK,
+    BadBufferSize = 4 | ERROR_MASK,
+    BufferTooSmall = 5 | ERROR_MASK,
+    NotReady = 6 | ERROR_MASK,
+    DeviceError = 7 | ERROR_MASK,
+    WriteProtected = 8 | ERROR_MASK,
+    OutOfResources = 9 | ERROR_MASK,
+    VolumeCorrupted = 10 | ERROR_MASK,
+    VolumeFull = 11 | ERROR_MASK,
+    NoMedia = 12 | ERROR_MASK,
+    MediaChanged = 13 | ERROR_MASK,
+    NotFound = 14 | ERROR_MASK,
+    AccessDenied = 15 | ERROR_MASK,
+    NoResponse = 16 | ERROR_MASK,
+    NoMapping = 17 | ERROR_MASK,
+    Timeout = 18 | ERROR_MASK,
+    NotStarted = 19 | ERROR_MASK,
+    AlreadyStarted = 20 | ERROR_MASK,
+    Aborted = 21 | ERROR_MASK,
+    ICMPError = 22 | ERROR_MASK,
+    TFTPError = 23 | ERROR_MASK,
+    ProtocolError = 24 | ERROR_MASK,
+    IncompatibleVersion = 25 | ERROR_MASK,
+    SecurityViolation = 26 | ERROR_MASK,
+    CRCError = 27 | ERROR_MASK,
+    EndOfMedia = 28 | ERROR_MASK,
+
+    EndOfFile = 31 | ERROR_MASK,
+    InvalidLanguage = 32 | ERROR_MASK,
+    CompromisedData = 33 | ERROR_MASK,
+    IPAddressConflict = 34 | ERROR_MASK,
+    HTTPError = 35 | ERROR_MASK,
+};
+
+// EFI_HANDLE, A collection of related interfaces
+using Handle = FlatPtr;
+
+// EFI_EVENT, Handle to an event structure
+using Event = void*;
+
+// EFI_TPL, Task priority level
+using TPL = FlatPtr;
+
+// EFI_TABLE_HEADER, Data structure that precedes all of the standard EFI table types.
+// https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#id4
+struct TableHeader {
+    u64 signature;
+    u32 revision;
+    u32 header_size;
+    u32 crc32;
+    u32 reserved;
+};
+static_assert(AssertSize<TableHeader, 24>());
+
+// EFI_TIME: https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html#gettime
+struct Time {
+    u16 year;  // 1900 - 9999
+    u8 month;  // 1 - 12
+    u8 day;    // 1 - 31
+    u8 hour;   // 0 - 23
+    u8 minute; // 0 - 59
+    u8 second; // 0 - 59
+    u8 pad1;
+    u32 nanosecond; // 0 - 999,999,999
+    i16 time_zone;  // —1440 to 1440 or 2047
+    u8 daylight;
+    u8 pad2;
+};
+
+// EFI_PHYSICAL_ADDRESS: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+using PhysicalAddress = u64;
+
+// EFI_VIRTUAL_ADDRESS: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+using VirtualAddress = u64;
+
+}
+
+template<>
+struct AK::Formatter<Kernel::EFI::Status> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Kernel::EFI::Status status)
+    {
+        using enum Kernel::EFI::Status;
+        switch (status) {
+        case Success:
+            return builder.put_literal("The operation completed successfully."sv);
+        case LoadError:
+            return builder.put_literal("The image failed to load."sv);
+        case InvalidParameter:
+            return builder.put_literal("A parameter was incorrect."sv);
+        case Unsupported:
+            return builder.put_literal("The operation is not supported."sv);
+        case BadBufferSize:
+            return builder.put_literal("The buffer was not the proper size for the request."sv);
+        case BufferTooSmall:
+            return builder.put_literal("The buffer is not large enough to hold the requested data. The required buffer size is returned in the appropriate parameter when this error occurs."sv);
+        case NotReady:
+            return builder.put_literal("There is no data pending upon return."sv);
+        case DeviceError:
+            return builder.put_literal("The physical device reported an error while attempting the operation."sv);
+        case WriteProtected:
+            return builder.put_literal("The device cannot be written to."sv);
+        case OutOfResources:
+            return builder.put_literal("A resource has run out."sv);
+        case VolumeCorrupted:
+            return builder.put_literal("An inconstancy was detected on the file system causing the operating to fail."sv);
+        case VolumeFull:
+            return builder.put_literal("There is no more space on the file system."sv);
+        case NoMedia:
+            return builder.put_literal("The device does not contain any medium to perform the operation."sv);
+        case MediaChanged:
+            return builder.put_literal("The medium in the device has changed since the last access."sv);
+        case NotFound:
+            return builder.put_literal("The item was not found."sv);
+        case AccessDenied:
+            return builder.put_literal("Access was denied."sv);
+        case NoResponse:
+            return builder.put_literal("The server was not found or did not respond to the request."sv);
+        case NoMapping:
+            return builder.put_literal("A mapping to a device does not exist."sv);
+        case Timeout:
+            return builder.put_literal("The timeout time expired."sv);
+        case NotStarted:
+            return builder.put_literal("The protocol has not been started."sv);
+        case AlreadyStarted:
+            return builder.put_literal("The protocol has already been started."sv);
+        case Aborted:
+            return builder.put_literal("The operation was aborted."sv);
+        case ICMPError:
+            return builder.put_literal("An ICMP error occurred during the network operation."sv);
+        case TFTPError:
+            return builder.put_literal("A TFTP error occurred during the network operation."sv);
+        case ProtocolError:
+            return builder.put_literal("A protocol error occurred during the network operation."sv);
+        case IncompatibleVersion:
+            return builder.put_literal("The function encountered an internal version that was incompatible with a version requested by the caller."sv);
+        case SecurityViolation:
+            return builder.put_literal("The function was not performed due to a security violation."sv);
+        case CRCError:
+            return builder.put_literal("A CRC error was detected."sv);
+        case EndOfMedia:
+            return builder.put_literal("Beginning or end of media was reached"sv);
+        case EndOfFile:
+            return builder.put_literal("The end of the file was reached."sv);
+        case InvalidLanguage:
+            return builder.put_literal("The language specified was invalid."sv);
+        case CompromisedData:
+            return builder.put_literal("The security status of the data is unknown or compromised and the data must be updated or replaced to restore a valid security status."sv);
+        case IPAddressConflict:
+            return builder.put_literal("There is an address conflict address allocation"sv);
+        case HTTPError:
+            return builder.put_literal("A HTTP error occurred during the network operation."sv);
+        default:
+            TRY(builder.put_literal("(EFI::Status)"sv));
+            return builder.put_u64(to_underlying(status), 16, true);
+        }
+    }
+};

--- a/Kernel/Firmware/EFI/Protocols/ConsoleSupport.h
+++ b/Kernel/Firmware/EFI/Protocols/ConsoleSupport.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+// https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html
+
+namespace Kernel::EFI {
+
+// EFI_INPUT_KEY: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-simple-text-input-protocol-readkeystroke
+struct InputKey {
+    u16 scan_code;
+    char16_t unicode_char;
+};
+static_assert(AssertSize<InputKey, 4>());
+
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-input-protocol
+struct SimpleTextInputProtocol {
+    static constexpr GUID guid = { 0x387477c1, 0x69c7, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using InputResetFn = EFIAPI Status (*)(SimpleTextInputProtocol*, Boolean extended_verification);
+    using InputReadKeyFn = EFIAPI Status (*)(SimpleTextInputProtocol*, InputKey* key);
+
+    InputResetFn reset;
+    InputReadKeyFn read_key_stroke;
+    Event wait_for_key;
+};
+static_assert(AssertSize<SimpleTextInputProtocol, 24>());
+
+// https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-output-protocol
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setattribute
+struct [[gnu::packed]] TextAttribute {
+    enum class ForegroundColor : i32 {
+        Black = 0x00,
+        Blue = 0x01,
+        Green = 0x02,
+        Cyan = 0x03,
+        Red = 0x04,
+        Magenta = 0x05,
+        Brown = 0x06,
+        LightGray = 0x07,
+        DarkGray = 0x08,
+        LightBlue = 0x09,
+        LightGreen = 0x0a,
+        LightCyan = 0x0b,
+        LightRed = 0x0c,
+        LightMagenta = 0x0d,
+        Yellow = 0x0e,
+        White = 0x0f,
+    };
+
+    enum class BackgroundColor : i32 {
+        Black = 0x00,
+        Blue = 0x01,
+        Green = 0x02,
+        Cyan = 0x03,
+        Red = 0x04,
+        Magenta = 0x05,
+        Brown = 0x06,
+        LightGray = 0x07,
+    };
+
+    ForegroundColor foreground_color : 4;
+    BackgroundColor background_color : 3;
+    i32 : 32 - (4 + 3);
+};
+static_assert(AssertSize<TextAttribute, 4>());
+
+// SIMPLE_TEXT_OUTPUT_MODE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-output-protocol
+struct SimpleTextOutputMode {
+    i32 max_mode;
+    i32 mode;
+    TextAttribute attribute;
+    i32 cursor_column;
+    i32 cursor_row;
+    Boolean cursor_visible;
+};
+static_assert(AssertSize<SimpleTextOutputMode, 24>());
+
+// EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-output-protocol
+struct SimpleTextOutputProtocol {
+    static constexpr GUID guid = { 0x387477c2, 0x69c7, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using TextResetFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, Boolean extended_verification);
+    using TextStringFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, char16_t* string);
+    using TextTestStringFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, char16_t* string);
+    using TextQueryModeFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, FlatPtr mode_number, FlatPtr* columns, FlatPtr* rows);
+    using TextSetModeFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, FlatPtr mode_number);
+    using TextSetAttributeFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, TextAttribute attribute);
+    using TextClearScreenFn = EFIAPI Status (*)(SimpleTextOutputProtocol*);
+    using TextSetCursorPositionFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, FlatPtr column, FlatPtr row);
+    using TextEnableCursorFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, Boolean visible);
+
+    TextResetFn reset;
+    TextStringFn output_string;
+    TextTestStringFn test_string;
+    TextQueryModeFn query_mode;
+    TextSetModeFn set_mode;
+    TextSetAttributeFn set_attribute;
+    TextClearScreenFn clear_screen;
+    TextSetCursorPositionFn set_cursor_position;
+    TextEnableCursorFn enable_cursor;
+    SimpleTextOutputMode* mode;
+};
+static_assert(AssertSize<SimpleTextOutputProtocol, 80>());
+static_assert(__builtin_offsetof(SimpleTextOutputProtocol, output_string) == 8);
+
+// EFI_GRAPHICS_OUTPUT_BLT_PIXEL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+struct GraphicsOutputBltPixel {
+    u8 blue;
+    u8 green;
+    u8 red;
+    u8 reserved;
+};
+
+// EFI_GRAPHICS_OUTPUT_BLT_OPERATION: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+enum class GraphicsOutputBltOperation {
+    VideoFill,
+    VideoToBltBuffer,
+    BufferToVideo,
+    VideoToVideo,
+    Max
+};
+
+// EFI_GRAPHICS_PIXEL_FORMAT: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+enum class GraphicsPixelFormat {
+    RedGreenBlueReserved8BitPerColor,
+    BlueGreenRedReserved8BitPerColor,
+    BitMask,
+    BltOnly,
+    Max
+};
+
+// EFI_PIXEL_BITMASK: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+struct PixelBitmask {
+    u32 red_mask;
+    u32 green_mask;
+    u32 blue_mask;
+    u32 reserved_mask;
+};
+
+// EFI_GRAPHICS_OUTPUT_MODE_INFORMATION: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+struct GraphicsOutputModeInformation {
+    u32 version;
+    u32 horizontal_resolution;
+    u32 vertical_resolution;
+    GraphicsPixelFormat pixel_format;
+    PixelBitmask pixel_information;
+    u32 pixels_per_scan_line;
+};
+
+// EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol
+struct GraphicsOutputProtocolMode {
+    u32 max_mode;
+    u32 mode;
+    GraphicsOutputModeInformation* info;
+    FlatPtr size_of_info;
+    PhysicalAddress frame_buffer_base;
+    FlatPtr frame_buffer_size;
+};
+
+// EFI_GRAPHICS_OUTPUT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol
+struct GraphicsOutputProtocol {
+    static constexpr GUID guid = { 0x9042a9de, 0x23dc, 0x4a38, { 0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a } };
+
+    using QueryModeFn = EFIAPI Status (*)(GraphicsOutputProtocol*, u32 mode_number, FlatPtr* size_of_info, GraphicsOutputModeInformation** Info);
+    using SetModeFn = EFIAPI Status (*)(GraphicsOutputProtocol*, u32 mode_number);
+    using BltFn = EFIAPI Status (*)(GraphicsOutputProtocol*, GraphicsOutputBltPixel* blt_buffer, GraphicsOutputBltOperation blt_operation, FlatPtr source_x, FlatPtr source_y, FlatPtr destination_x, FlatPtr destination_y, FlatPtr width, FlatPtr height, FlatPtr delta);
+
+    QueryModeFn query_mode;
+    SetModeFn set_mode;
+    BltFn blt;
+    GraphicsOutputProtocolMode* mode;
+};
+
+}

--- a/Kernel/Firmware/EFI/Protocols/DevicePath.h
+++ b/Kernel/Firmware/EFI/Protocols/DevicePath.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+// https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html
+
+namespace Kernel::EFI {
+
+// EFI_DEVICE_PATH_PROTOCOL: https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#efi-device-path-protocol
+struct DevicePathProtocol {
+    static constexpr GUID guid = { 0x09576e91, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    u8 type;
+    u8 sub_type;
+    u8 length[2];
+};
+static_assert(AssertSize<DevicePathProtocol, 4>());
+
+// EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#device-path-from-text-protocol
+struct DevicePathFromTextProtocol {
+    static constexpr GUID guid = { 0x5c99a21, 0xc70f, 0x4ad2, { 0x8a, 0x5f, 0x35, 0xdf, 0x33, 0x43, 0xf5, 0x1e } };
+
+    using DevicePathFromTextNodeFn = EFIAPI DevicePathProtocol (*)(char16_t const* text_device_node);
+    using DevicePathFromTextPathFn = EFIAPI DevicePathProtocol (*)(char16_t const* text_device_path);
+
+    DevicePathFromTextNodeFn convert_text_to_device_node;
+    DevicePathFromTextPathFn convert_text_to_device_path;
+};
+static_assert(AssertSize<DevicePathFromTextProtocol, 16>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/LoadedImage.h
+++ b/Kernel/Firmware/EFI/Protocols/LoadedImage.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/Protocols/DevicePath.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+// https://uefi.org/specs/UEFI/2.10/09_Protocols_EFI_Loaded_Image.html
+
+namespace Kernel::EFI {
+
+// EFI_LOADED_IMAGE_PROTOCOL: https://uefi.org/specs/UEFI/2.10/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-protocol
+struct LoadedImageProtocol {
+    static constexpr GUID guid = { 0x5b1b31a1, 0x9562, 0x11d2, { 0x8e, 0x3f, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using ImageUnloadFn = EFIAPI Status (*)(Handle* image_handle);
+
+    u32 revision;
+    Handle parent_handle;
+    SystemTable* system_table;
+
+    // Source location of the image
+    Handle device_handle;
+    DevicePathProtocol* file_path;
+    void* reserved;
+
+    // Image’s load options
+    u32 load_options_size;
+    void* load_options;
+
+    // Location where image was loaded
+    void* image_base;
+    u64 image_size;
+    MemoryType image_code_type;
+    MemoryType image_data_type;
+    ImageUnloadFn unload;
+};
+static_assert(AssertSize<LoadedImageProtocol, 96>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/MediaAccess.h
+++ b/Kernel/Firmware/EFI/Protocols/MediaAccess.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+// https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html
+
+namespace Kernel::EFI {
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-protocol-open
+enum class FileOpenMode : u64 {
+    Read = 0x1,
+    Write = 0x2,
+    Create = 0x0,
+};
+AK_ENUM_BITWISE_OPERATORS(FileOpenMode)
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-protocol-open
+enum class FileAttribute : u64 {
+    None = 0x0,
+    ReadOnly = 0x1,
+    Hidden = 0x2,
+    System = 0x4,
+    Reserved = 0x8,
+    Directory = 0x10,
+    Archive = 0x20,
+};
+AK_ENUM_BITWISE_OPERATORS(FileAttribute)
+
+// EFI_FILE_INFO: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-info
+struct FileInfo {
+    static constexpr GUID guid = { 0x09576e92, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    u64 size;
+    u64 file_size;
+    u64 physical_size;
+    Time create_time;
+    Time last_access_time;
+    Time modification_time;
+    FileAttribute attribute;
+    char16_t file_name[];
+};
+
+// EFI_FILE_IO_TOKEN: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-protocol-openex
+struct FileIOToken {
+    Event event;
+    Status status;
+    FlatPtr buffer_size;
+    void* buffer;
+};
+
+// EFI_FILE_PROTOCOL: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#file-protocol
+struct FileProtocol {
+    using FileOpenFn = EFIAPI Status (*)(FileProtocol*, FileProtocol** new_handle, char16_t* file_name, FileOpenMode open_mode, FileAttribute attributes);
+    using FileCloseFn = EFIAPI Status (*)(FileProtocol*);
+    using FileDeleteFn = EFIAPI Status (*)(FileProtocol*);
+    using FileReadFn = EFIAPI Status (*)(FileProtocol*, FlatPtr* buffer_size, void* buffer);
+    using FileWriteFn = EFIAPI Status (*)(FileProtocol*, FlatPtr* buffer_size, void* buffer);
+    using FileOpenExFn = EFIAPI Status (*)(FileProtocol*, FileProtocol** new_handle, char16_t* file_name, FileOpenMode open_mode, FileAttribute attributes, FileIOToken* token);
+    using FileReadExFn = EFIAPI Status (*)(FileProtocol*, FileIOToken* token);
+    using FileWriteExFn = EFIAPI Status (*)(FileProtocol*, FileIOToken* token);
+    using FileFlushExFn = EFIAPI Status (*)(FileProtocol*, FileIOToken* token);
+    using FileSetPositionFn = EFIAPI Status (*)(FileProtocol*, u64 position);
+    using FileGetPositionFn = EFIAPI Status (*)(FileProtocol*, u64* position);
+    using FileGetInfoFn = EFIAPI Status (*)(FileProtocol*, GUID* information_type, FlatPtr* buffer_size, void* buffer);
+    using FileSetInfoFn = EFIAPI Status (*)(FileProtocol*, GUID* information_type, FlatPtr buffer_size, void* buffer);
+    using FileFlushFn = EFIAPI Status (*)(FileProtocol*);
+
+    u64 revision;
+    FileOpenFn open;
+    FileCloseFn close;
+    FileDeleteFn delete_;
+    FileReadFn read;
+    FileWriteFn write;
+    FileGetPositionFn get_position;
+    FileSetPositionFn set_position;
+    FileGetInfoFn get_info;
+    FileSetInfoFn set_info;
+    FileFlushFn flush;
+
+    // Revision 2+
+
+    FileOpenExFn open_ex;
+    FileReadExFn read_ex;
+    FileWriteExFn write_ex;
+    FileFlushExFn flush_ex;
+};
+
+// EFI_SIMPLE_FILE_SYSTEM_PROTOCOL: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#simple-file-system-protocol
+struct SimpleFileSystemProtocol {
+    static constexpr GUID guid = { 0x0964e5b22, 0x6459, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using SimpleFileSystemProtocolOpenVolumeFn = EFIAPI Status (*)(SimpleFileSystemProtocol*, FileProtocol** root);
+
+    u64 revision;
+    SimpleFileSystemProtocolOpenVolumeFn open_volume;
+};
+static_assert(AssertSize<SimpleFileSystemProtocol, 16>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h
+++ b/Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+namespace Kernel::EFI {
+
+// RISCV_EFI_BOOT_PROTOCOL: https://github.com/riscv-non-isa/riscv-uefi/releases/download/1.0.0/RISCV_UEFI_PROTOCOL-spec.pdf
+struct RISCVBootProtocol {
+    static constexpr GUID guid = { 0xccd15fec, 0x6f73, 0x4eec, { 0x83, 0x95, 0x3e, 0x69, 0xe4, 0xb9, 0x40, 0xbf } };
+
+    using GetBootHartIDFn = EFIAPI Status (*)(RISCVBootProtocol*, FlatPtr* boot_hart_id);
+
+    u64 revision;
+    GetBootHartIDFn get_boot_hart_id;
+};
+static_assert(AssertSize<RISCVBootProtocol, 16>());
+
+}

--- a/Kernel/Firmware/EFI/Services/BootServices.h
+++ b/Kernel/Firmware/EFI/Services/BootServices.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+// https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html
+
+namespace Kernel::EFI {
+
+// EFI_ALLOCATE_TYPE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+enum class AllocateType {
+    AnyPages,
+    MaxAddress,
+    Address,
+};
+
+// EFI_MEMORY_TYPE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+enum class MemoryType : u32 {
+    Reserved,
+    LoaderCode,
+    LoaderData,
+    BootServicesCode,
+    BootServicesData,
+    RuntimeServicesCode,
+    RuntimeServicesData,
+    Conventional,
+    Unusable,
+    ACPIReclaim,
+    ACPI_NVS,
+    MemoryMappedIO,
+    MemoryMappedIOPortSpace,
+    PALCode,
+    Persistent,
+    Unaccepted,
+};
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+enum class MemoryAttribute : u64 {
+    SupportsNotCachable = 0x0000000000000001,                       // UC
+    SupportsWriteCombining = 0x0000000000000002,                    // WC
+    SupportsWriteThrough = 0x0000000000000004,                      // WT
+    SupportsWriteBack = 0x0000000000000008,                         // WB
+    SupportsNotCachableExportedAndFetchAndAdd = 0x0000000000000010, // UCE
+    SupportsWriteProtection = 0x0000000000001000,                   // WP
+    SupportsReadProtection = 0x0000000000002000,                    // RP
+    SupportsExecuteProtection = 0x0000000000004000,                 // XP
+    PersistentMemory = 0x0000000000008000,                          // NV
+    MoreReliable = 0x0000000000010000,                              // MORE_RELIABLE
+    SupportsReadOnly = 0x0000000000020000,                          // RO
+    SpecificPurposeMemory = 0x0000000000040000,                     // SP
+    SupportsCryptographicProtection = 0x0000000000080000,           // CPU_CRYPTO
+    Runtime = 0x8000000000000000,                                   // RUNTIME
+    ISAValid = 0x4000000000000000,                                  // ISA_VALID
+    ISAMask = 0x0ffff00000000000,                                   // ISA_MASK
+};
+
+// EFI_MEMORY_DESCRIPTOR: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+struct MemoryDescriptor {
+    MemoryType type;
+    PhysicalAddress physical_start;
+    VirtualAddress virtual_start;
+    u64 number_of_pages;
+    MemoryAttribute attribute;
+};
+static_assert(AssertSize<MemoryDescriptor, 40>());
+
+// EFI_BOOT_SERVICES: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-boot-services-table
+struct BootServices {
+    static constexpr u64 signature = 0x56524553544f4f42;
+
+    using RaiseTPLFn = void*;
+    using RestoreTPLFn = void*;
+    using AllocatePagesFn = EFIAPI Status (*)(AllocateType type, MemoryType memory_type, FlatPtr pages, PhysicalAddress* memory);
+    using FreePagesFn = EFIAPI Status (*)(PhysicalAddress memory, FlatPtr pages);
+    using GetMemoryMapFn = EFIAPI Status (*)(FlatPtr* memory_map_size, MemoryDescriptor* memory_map, FlatPtr* map_key, FlatPtr* descriptor_size, u32* descriptor_version);
+    using AllocatePoolFn = EFIAPI Status (*)(MemoryType pool_type, FlatPtr size, void** buffer);
+    using FreePoolFn = EFIAPI Status (*)(void* buffer);
+    using CreateEventFn = void*;
+    using SetTimerFn = void*;
+    using WaitForEventFn = void*;
+    using SignalEventFn = void*;
+    using CloseEventFn = void*;
+    using CheckEventFn = void*;
+    using InstallProtocolInterfaceFn = void*;
+    using ReinstallProtocolInterfaceFn = void*;
+    using UninstallProtocolInterfaceFn = void*;
+    using HandleProtocolFn = EFIAPI Status (*)(Handle handle, GUID* protocol, void** interface);
+    using RegisterProtocolNotifyFn = void*;
+    using LocateHandleFn = void*;
+    using LocateDevicePathFn = void*;
+    using InstallConfigurationTableFn = void*;
+    using ImageUnloadFn = void*;
+    using ImageStartFn = void*;
+    using ExitFn = void*;
+    using ExitBootServicesFn = EFIAPI Status (*)(Handle image_handle, FlatPtr map_key);
+    using GetNextMonotonicCountFn = void*;
+    using StallFn = void*;
+    using SetWatchdogTimerFn = void*;
+    using ConnectControllerFn = void*;
+    using DisconnectControllerFn = void*;
+    using OpenProtocolFn = void*;
+    using CloseProtocolFn = void*;
+    using OpenProtocolInformationFn = void*;
+    using ProtocolsPerHandleFn = void*;
+    using LocateHandleBufferFn = void*;
+    using LocateProtocolFn = EFIAPI Status (*)(GUID* protocol, void* registration, void** interface);
+    using UninstallMultipleProtocolInterfacesFn = void*;
+    using CalculateCrc32Fn = void*;
+    using CopyMemFn = void*;
+    using SetMemFn = void*;
+    using CreateEventExFn = void*;
+
+    TableHeader hdr;
+
+    // EFI 1.0+
+
+    // Task Priority Services
+    RaiseTPLFn raise_tpl;
+    RestoreTPLFn restore_tpl;
+
+    // Memory Services
+    AllocatePagesFn allocate_pages;
+    FreePagesFn free_pages;
+    GetMemoryMapFn get_memory_map;
+    AllocatePoolFn allocate_pool;
+    FreePoolFn free_pool;
+
+    // Event & Timer Services
+    CreateEventFn create_event;
+    SetTimerFn set_timer;
+    WaitForEventFn wait_for_event;
+    SignalEventFn signal_event;
+    CloseEventFn close_event;
+    CheckEventFn check_event;
+
+    // Protocol Handler Services
+    InstallProtocolInterfaceFn install_protocol_interface;
+    ReinstallProtocolInterfaceFn reinstall_protocol_interface;
+    UninstallProtocolInterfaceFn uninstall_protocol_interface;
+    HandleProtocolFn handle_protocol;
+    void* reserved;
+    RegisterProtocolNotifyFn register_protocol_notify;
+    LocateHandleFn locate_handle;
+    LocateDevicePathFn locate_device_path;
+    InstallConfigurationTableFn install_configuration_table;
+
+    // Image Services
+    ImageUnloadFn load_image;
+    ImageStartFn start_image;
+    ExitFn exit;
+    ImageUnloadFn unload_image;
+    ExitBootServicesFn exit_boot_services;
+
+    // Miscellaneous Services
+    GetNextMonotonicCountFn get_next_monotonic_count;
+    StallFn stall;
+    SetWatchdogTimerFn set_watchdog_timer;
+
+    // EFI 1.1+
+
+    // DriverSupport Services
+    ConnectControllerFn connect_controller;
+    DisconnectControllerFn disconnect_controller;
+
+    // Open and Close Protocol Services
+    OpenProtocolFn open_protocol;
+    CloseProtocolFn close_protocol;
+    OpenProtocolInformationFn open_protocol_information;
+
+    // Library Services
+    ProtocolsPerHandleFn protocols_per_handle;
+    LocateHandleBufferFn locate_handle_buffer;
+    LocateProtocolFn locate_protocol;
+    UninstallMultipleProtocolInterfacesFn install_multiple_protocol_interfaces;
+    UninstallMultipleProtocolInterfacesFn uninstall_multiple_protocol_interfaces;
+
+    // 32-bit CRC Services
+    CalculateCrc32Fn calculate_crc32;
+
+    // Miscellaneous Services
+    CopyMemFn copy_mem;
+    SetMemFn set_mem;
+
+    // UEFI 2.0+
+
+    CreateEventExFn create_event_ex;
+};
+static_assert(AssertSize<BootServices, 376>());
+
+}

--- a/Kernel/Firmware/EFI/SystemTable.h
+++ b/Kernel/Firmware/EFI/SystemTable.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/Protocols/ConsoleSupport.h>
+#include <Kernel/Firmware/EFI/Services/BootServices.h>
+
+// https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html
+
+namespace Kernel::EFI {
+
+// EFI_CONFIGURATION_TABLE: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-configuration-table-properties-table
+struct ConfigurationTable {
+    GUID vendor_guid;
+    void* vendor_table;
+};
+
+// EFI_DTB_TABLE_GUID: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#devicetree-tables
+static constexpr GUID DTB_TABLE_GUID = { 0xb1b621d5, 0xf19c, 0x41a5, { 0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0 } };
+
+// EFI_SYSTEM_TABLE: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-system-table-1
+struct SystemTable {
+    static constexpr u64 signature = 0x5453595320494249;
+
+    using RuntimeServices = void;
+
+    TableHeader hdr;
+    char16_t* firmware_vendor;
+    u32 firmware_revision;
+    Handle console_in_handle;
+    SimpleTextInputProtocol* con_in;
+    Handle console_out_handle;
+    SimpleTextOutputProtocol* con_out;
+    Handle standard_error_handle;
+    SimpleTextOutputProtocol* std_err;
+    RuntimeServices* runtime_services;
+    BootServices* boot_services;
+    FlatPtr number_of_table_entries;
+    ConfigurationTable* configuration_table;
+};
+static_assert(AssertSize<SystemTable, 120>());
+
+}

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -88,9 +88,9 @@ UNMAP_AFTER_INIT static void load_kernel_symbols_from_data(Bytes buffer)
 
         // FIXME: Remove this ifdef once the aarch64 kernel is loaded by the Prekernel.
         //        Currently, the aarch64 kernel is linked at a high virtual memory address, instead
-        //        of zero, so the address of a symbol does not need to be offset by the kernel_load_base.
+        //        of zero, so the address of a symbol does not need to be offset by the g_boot_info.kernel_load_base.
 #if ARCH(X86_64)
-        ksym.address = kernel_load_base + address;
+        ksym.address = g_boot_info.kernel_load_base + address;
 #elif ARCH(AARCH64) || ARCH(RISCV64)
         ksym.address = address;
 #else
@@ -137,7 +137,7 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr frame_pointer, bool use_ksy
     MUST(AK::unwind_stack_from_frame_pointer(
         frame_pointer,
         [](FlatPtr address) -> ErrorOr<FlatPtr> {
-            if (address < kernel_mapping_base)
+            if (address < g_boot_info.kernel_mapping_base)
                 return EINVAL;
 
             FlatPtr value;
@@ -168,14 +168,14 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr frame_pointer, bool use_ksy
         if (!symbol.address)
             break;
         if (!symbol.symbol) {
-            PRINT_LINE("Kernel + {:p}", symbol.address - kernel_load_base);
+            PRINT_LINE("Kernel + {:p}", symbol.address - g_boot_info.kernel_load_base);
             continue;
         }
         size_t offset = symbol.address - symbol.symbol->address;
         if (symbol.symbol->address == g_highest_kernel_symbol_address && offset > 4096)
-            PRINT_LINE("Kernel + {:p}", symbol.address - kernel_load_base);
+            PRINT_LINE("Kernel + {:p}", symbol.address - g_boot_info.kernel_load_base);
         else
-            PRINT_LINE("Kernel + {:p}  {} +{:#x}", symbol.address - kernel_load_base, symbol.symbol->name, offset);
+            PRINT_LINE("Kernel + {:p}  {} +{:#x}", symbol.address - g_boot_info.kernel_load_base, symbol.symbol->name, offset);
     }
 }
 

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -75,11 +75,11 @@ bool MemoryManager::is_initialized()
 static UNMAP_AFTER_INIT VirtualRange kernel_virtual_range()
 {
 #if ARCH(X86_64)
-    size_t kernel_range_start = kernel_mapping_base + 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
+    size_t kernel_range_start = g_boot_info.kernel_mapping_base + 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
     return VirtualRange { VirtualAddress(kernel_range_start), KERNEL_PD_END - kernel_range_start };
 #elif ARCH(AARCH64) || ARCH(RISCV64)
     // NOTE: This is not the same as x86_64, because the aarch64 and riscv64 kernels currently don't use the pre-kernel.
-    return VirtualRange { VirtualAddress(kernel_mapping_base), KERNEL_PD_END - kernel_mapping_base };
+    return VirtualRange { VirtualAddress(g_boot_info.kernel_mapping_base), KERNEL_PD_END - g_boot_info.kernel_mapping_base };
 #else
 #    error Unknown architecture
 #endif
@@ -139,8 +139,10 @@ UNMAP_AFTER_INIT void MemoryManager::unmap_prekernel()
 {
     SpinlockLocker page_lock(kernel_page_directory().get_lock());
 
-    auto start = start_of_prekernel_image.page_base().get();
-    auto end = end_of_prekernel_image.page_base().get();
+    VERIFY(g_boot_info.boot_method == BootMethod::Multiboot1);
+
+    auto start = g_boot_info.boot_method_specific.multiboot1.start_of_prekernel_image.page_base().get();
+    auto end = g_boot_info.boot_method_specific.multiboot1.end_of_prekernel_image.page_base().get();
 
     for (auto i = start; i <= end; i += PAGE_SIZE)
         release_pte(kernel_page_directory(), VirtualAddress(i), i == end ? IsLastPTERelease::Yes : IsLastPTERelease::No);
@@ -570,15 +572,17 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_fdt(MemoryManager::GlobalD
 
 UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_multiboot(MemoryManager::GlobalData& global_data)
 {
+    VERIFY(g_boot_info.boot_method == BootMethod::Multiboot1);
+
     // Register used memory regions that we know of.
-    if (multiboot_flags & 0x4 && !multiboot_module_physical_ptr.is_null()) {
-        dmesgln("MM: Multiboot module @ {}, length={}", multiboot_module_physical_ptr, multiboot_module_length);
-        VERIFY(multiboot_module_length != 0);
-        global_data.used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::BootModule, multiboot_module_physical_ptr, multiboot_module_physical_ptr.offset(multiboot_module_length) });
+    if (g_boot_info.boot_method_specific.multiboot1.flags & 0x4 && !g_boot_info.boot_method_specific.multiboot1.module_physical_ptr.is_null()) {
+        dmesgln("MM: Multiboot module @ {}, length={}", g_boot_info.boot_method_specific.multiboot1.module_physical_ptr, g_boot_info.boot_method_specific.multiboot1.module_length);
+        VERIFY(g_boot_info.boot_method_specific.multiboot1.module_length != 0);
+        global_data.used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::BootModule, g_boot_info.boot_method_specific.multiboot1.module_physical_ptr, g_boot_info.boot_method_specific.multiboot1.module_physical_ptr.offset(g_boot_info.boot_method_specific.multiboot1.module_length) });
     }
 
-    auto* mmap_begin = multiboot_memory_map;
-    auto* mmap_end = multiboot_memory_map + multiboot_memory_map_count;
+    auto const* mmap_begin = g_boot_info.boot_method_specific.multiboot1.memory_map;
+    auto const* mmap_end = g_boot_info.boot_method_specific.multiboot1.memory_map + g_boot_info.boot_method_specific.multiboot1.memory_map_count;
 
     struct ContiguousPhysicalVirtualRange {
         PhysicalAddress lower;
@@ -586,15 +590,11 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_multiboot(MemoryManager::G
     };
 
     Optional<ContiguousPhysicalVirtualRange> last_contiguous_physical_range;
-    for (auto* mmap = mmap_begin; mmap < mmap_end; mmap++) {
+    for (auto const* mmap = mmap_begin; mmap < mmap_end; mmap++) {
         // We have to copy these onto the stack, because we take a reference to these when printing them out,
         // and doing so on a packed struct field is UB.
-        auto address = mmap->addr;
-        auto length = mmap->len;
-        ArmedScopeGuard write_back_guard = [&]() {
-            mmap->addr = address;
-            mmap->len = length;
-        };
+        auto const address = mmap->addr;
+        auto const length = mmap->len;
 
         dmesgln("MM: Multiboot mmap: address={:p}, length={}, type={}", address, length, mmap->type);
 
@@ -654,14 +654,11 @@ UNMAP_AFTER_INIT void MemoryManager::initialize_physical_pages()
                 highest_physical_address = range_end;
         }
 
-#if ARCH(X86_64)
-        // Map multiboot framebuffer
-        if ((multiboot_flags & MULTIBOOT_INFO_FRAMEBUFFER_INFO) && !multiboot_framebuffer_addr.is_null() && multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
-            PhysicalAddress multiboot_framebuffer_addr_end = multiboot_framebuffer_addr.offset(multiboot_framebuffer_height * multiboot_framebuffer_pitch);
-            if (multiboot_framebuffer_addr_end > highest_physical_address)
-                highest_physical_address = multiboot_framebuffer_addr_end;
+        if (!g_boot_info.boot_framebuffer.paddr.is_null() && g_boot_info.boot_framebuffer.type != BootFramebufferType::None) {
+            PhysicalAddress boot_framebuffer_paddr_end = g_boot_info.boot_framebuffer.paddr.offset(g_boot_info.boot_framebuffer.height * g_boot_info.boot_framebuffer.pitch);
+            if (boot_framebuffer_paddr_end > highest_physical_address)
+                highest_physical_address = boot_framebuffer_paddr_end;
         }
-#endif
 
         // Calculate how many total physical pages the array will have
         m_physical_page_entries_count = PhysicalAddress::physical_page_index(highest_physical_address.get()) + 1;
@@ -755,7 +752,7 @@ UNMAP_AFTER_INIT void MemoryManager::initialize_physical_pages()
 
             // Hook the page table into the kernel page directory
             u32 page_directory_index = (virtual_page_base_for_this_pt >> 21) & 0x1ff;
-            auto* pd = reinterpret_cast<PageDirectoryEntry*>(quickmap_page(boot_pd_kernel));
+            auto* pd = reinterpret_cast<PageDirectoryEntry*>(quickmap_page(g_boot_info.boot_pd_kernel));
             PageDirectoryEntry& pde = pd[page_directory_index];
 
             VERIFY(!pde.is_present()); // Nothing should be using this PD yet
@@ -1377,7 +1374,7 @@ PageDirectoryEntry* MemoryManager::quickmap_pd(PageDirectory& directory, size_t 
     VirtualAddress vaddr(KERNEL_QUICKMAP_PD_PER_CPU_BASE + Processor::current_id() * PAGE_SIZE);
     size_t pte_index = (vaddr.get() - KERNEL_PT1024_BASE) / PAGE_SIZE;
 
-    auto& pte = boot_pd_kernel_pt1023[pte_index];
+    auto& pte = g_boot_info.boot_pd_kernel_pt1023[pte_index];
     auto pd_paddr = directory.m_directory_pages[pdpt_index]->paddr();
     if (pte.physical_page_base() != pd_paddr.get()) {
         pte.set_physical_page_base(pd_paddr.get());
@@ -1396,7 +1393,7 @@ PageTableEntry* MemoryManager::quickmap_pt(PhysicalAddress pt_paddr)
     VirtualAddress vaddr(KERNEL_QUICKMAP_PT_PER_CPU_BASE + Processor::current_id() * PAGE_SIZE);
     size_t pte_index = (vaddr.get() - KERNEL_PT1024_BASE) / PAGE_SIZE;
 
-    auto& pte = ((PageTableEntry*)boot_pd_kernel_pt1023)[pte_index];
+    auto& pte = g_boot_info.boot_pd_kernel_pt1023[pte_index];
     if (pte.physical_page_base() != pt_paddr.get()) {
         pte.set_physical_page_base(pt_paddr.get());
         pte.set_present(true);
@@ -1416,7 +1413,7 @@ u8* MemoryManager::quickmap_page(PhysicalAddress const& physical_address)
     VirtualAddress vaddr(KERNEL_QUICKMAP_PER_CPU_BASE + Processor::current_id() * PAGE_SIZE);
     u32 pte_idx = (vaddr.get() - KERNEL_PT1024_BASE) / PAGE_SIZE;
 
-    auto& pte = ((PageTableEntry*)boot_pd_kernel_pt1023)[pte_idx];
+    auto& pte = g_boot_info.boot_pd_kernel_pt1023[pte_idx];
     if (pte.physical_page_base() != physical_address.get()) {
         pte.set_physical_page_base(physical_address.get());
         pte.set_present(true);
@@ -1434,7 +1431,7 @@ void MemoryManager::unquickmap_page()
     VERIFY(mm_data.m_quickmap_in_use.is_locked());
     VirtualAddress vaddr(KERNEL_QUICKMAP_PER_CPU_BASE + Processor::current_id() * PAGE_SIZE);
     u32 pte_idx = (vaddr.get() - KERNEL_PT1024_BASE) / PAGE_SIZE;
-    auto& pte = ((PageTableEntry*)boot_pd_kernel_pt1023)[pte_idx];
+    auto& pte = g_boot_info.boot_pd_kernel_pt1023[pte_idx];
     pte.clear();
     flush_tlb_local(vaddr);
     mm_data.m_quickmap_in_use.unlock(mm_data.m_quickmap_previous_interrupts_state);

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -74,15 +74,13 @@ bool MemoryManager::is_initialized()
 
 static UNMAP_AFTER_INIT VirtualRange kernel_virtual_range()
 {
-#if ARCH(X86_64)
+#if ARCH(AARCH64) || ARCH(RISCV64)
+    if (g_boot_info.boot_method != BootMethod::EFI)
+        return VirtualRange { VirtualAddress(g_boot_info.kernel_mapping_base), KERNEL_PD_END - g_boot_info.kernel_mapping_base };
+#endif
+
     size_t kernel_range_start = g_boot_info.kernel_mapping_base + 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
     return VirtualRange { VirtualAddress(kernel_range_start), KERNEL_PD_END - kernel_range_start };
-#elif ARCH(AARCH64) || ARCH(RISCV64)
-    // NOTE: This is not the same as x86_64, because the aarch64 and riscv64 kernels currently don't use the pre-kernel.
-    return VirtualRange { VirtualAddress(g_boot_info.kernel_mapping_base), KERNEL_PD_END - g_boot_info.kernel_mapping_base };
-#else
-#    error Unknown architecture
-#endif
 }
 
 MemoryManager::GlobalData::GlobalData()

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -36,7 +36,7 @@ constexpr FlatPtr page_round_down(FlatPtr x)
 
 inline FlatPtr virtual_to_low_physical(FlatPtr virtual_)
 {
-    return virtual_ - physical_to_virtual_offset;
+    return virtual_ - g_boot_info.physical_to_virtual_offset;
 }
 
 enum class UsedMemoryRangeType {

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -267,6 +267,7 @@ private:
 
     void protect_kernel_image();
     void parse_memory_map();
+    void parse_memory_map_efi(GlobalData&);
     void parse_memory_map_fdt(GlobalData&, u8 const* fdt_addr);
     void parse_memory_map_multiboot(GlobalData&);
     static void flush_tlb_local(VirtualAddress, size_t page_count = 1);

--- a/Kernel/Memory/PhysicalAddress.h
+++ b/Kernel/Memory/PhysicalAddress.h
@@ -24,8 +24,8 @@ public:
         return (size_t)(page_index);
     }
 
-    PhysicalAddress() = default;
-    explicit PhysicalAddress(PhysicalPtr address)
+    constexpr PhysicalAddress() = default;
+    constexpr explicit PhysicalAddress(PhysicalPtr address)
         : m_address(address)
     {
     }

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -108,7 +108,7 @@ public:
     ErrorOr<void> set_write_combine(bool);
 
     [[nodiscard]] bool is_user() const { return !is_kernel(); }
-    [[nodiscard]] bool is_kernel() const { return vaddr().get() < USER_RANGE_BASE || vaddr().get() >= kernel_mapping_base; }
+    [[nodiscard]] bool is_kernel() const { return vaddr().get() < USER_RANGE_BASE || vaddr().get() >= g_boot_info.kernel_mapping_base; }
 
     PageFaultResponse handle_fault(PageFault const&);
 

--- a/Kernel/Prekernel/Arch/ArchSpecificBootInfo.h
+++ b/Kernel/Prekernel/Arch/ArchSpecificBootInfo.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if ARCH(X86_64)
+#    include <Kernel/Prekernel/Arch/x86_64/ArchSpecificBootInfo.h>
+#elif ARCH(AARCH64)
+#    include <Kernel/Prekernel/Arch/aarch64/ArchSpecificBootInfo.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Prekernel/Arch/riscv64/ArchSpecificBootInfo.h>
+#else
+#    error Unknown architecture
+#endif

--- a/Kernel/Prekernel/Arch/aarch64/ArchSpecificBootInfo.h
+++ b/Kernel/Prekernel/Arch/aarch64/ArchSpecificBootInfo.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_AARCH64()
+
+namespace Kernel {
+
+struct ArchSpecificBootInfo {
+};
+
+}

--- a/Kernel/Prekernel/Arch/riscv64/ArchSpecificBootInfo.h
+++ b/Kernel/Prekernel/Arch/riscv64/ArchSpecificBootInfo.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+struct ArchSpecificBootInfo {
+    FlatPtr boot_hart_id;
+};
+
+}

--- a/Kernel/Prekernel/Arch/x86_64/ArchSpecificBootInfo.h
+++ b/Kernel/Prekernel/Arch/x86_64/ArchSpecificBootInfo.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_X86()
+
+namespace Kernel {
+
+struct ArchSpecificBootInfo {
+    u32 gdt64ptr;
+    u16 code64_sel;
+};
+
+}

--- a/Kernel/Prekernel/Prekernel.h
+++ b/Kernel/Prekernel/Prekernel.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,7 @@
 #    include <Kernel/Boot/Multiboot.h>
 #    include <Kernel/Memory/PhysicalAddress.h>
 #    include <Kernel/Memory/VirtualAddress.h>
+#    include <Kernel/Prekernel/Arch/ArchSpecificBootInfo.h>
 #endif
 
 #define MAX_KERNEL_SIZE 0x4000000
@@ -25,41 +27,73 @@ extern "C" multiboot_info_t* multiboot_info_ptr;
 
 namespace Kernel {
 
-#    if ARCH(X86_64)
-struct [[gnu::packed]] BootInfo {
-    u32 start_of_prekernel_image;
-    u32 end_of_prekernel_image;
-    u64 physical_to_virtual_offset;
-    u64 kernel_mapping_base;
-    u64 kernel_load_base;
-    u32 gdt64ptr;
-    u16 code64_sel;
-    u32 boot_pml4t;
-    u32 boot_pdpt;
-    u32 boot_pd0;
-    u32 boot_pd_kernel;
-    u64 boot_pd_kernel_pt1023;
-    u64 kernel_cmdline;
-    u32 multiboot_flags;
-    u64 multiboot_memory_map;
-    u32 multiboot_memory_map_count;
-    u64 multiboot_module_physical_ptr;
-    u32 multiboot_module_length;
-    u64 multiboot_framebuffer_addr;
-    u32 multiboot_framebuffer_pitch;
-    u32 multiboot_framebuffer_width;
-    u32 multiboot_framebuffer_height;
-    u8 multiboot_framebuffer_bpp;
-    u8 multiboot_framebuffer_type;
+namespace Memory {
+class PageTableEntry;
+}
+
+struct Multiboot1BootInfo {
+    u32 flags { 0 };
+    multiboot_memory_map_t const* memory_map { 0 };
+    u32 memory_map_count { 0 };
+    PhysicalAddress module_physical_ptr { 0 };
+    u32 module_length { 0 };
+
+    PhysicalAddress start_of_prekernel_image { 0 };
+    PhysicalAddress end_of_prekernel_image { 0 };
+
+    PhysicalAddress boot_pd0 { 0 };
 };
-#    elif ARCH(AARCH64)
-struct BootInfo { };
-#    elif ARCH(RISCV64)
+
+struct PreInitBootInfo {
+};
+
+enum class BootMethod {
+    Multiboot1,
+    PreInit,
+};
+
+enum class BootFramebufferType {
+    None,
+    BGRx8888,
+};
+
+struct BootFramebufferInfo {
+    PhysicalAddress paddr { 0 };
+    size_t pitch { 0 };
+    size_t width { 0 };
+    size_t height { 0 };
+    u8 bpp { 0 };
+    BootFramebufferType type { BootFramebufferType::None };
+};
+
+union BootMethodSpecificBootInfo {
+    PreInitBootInfo pre_init {};
+    Multiboot1BootInfo multiboot1;
+};
+
 struct BootInfo {
-    FlatPtr mhartid;
-    PhysicalPtr fdt_phys_addr;
+    ArchSpecificBootInfo arch_specific {};
+
+    BootMethodSpecificBootInfo boot_method_specific {};
+    BootMethod boot_method { BootMethod::PreInit };
+
+    PhysicalAddress flattened_devicetree_paddr { 0 };
+    size_t flattened_devicetree_size { 0 };
+
+    size_t physical_to_virtual_offset { 0 };
+    FlatPtr kernel_mapping_base { 0 };
+    FlatPtr kernel_load_base { 0 };
+
+    PhysicalAddress boot_pml4t { 0 };
+    PhysicalAddress boot_pdpt { 0 };
+    PhysicalAddress boot_pd_kernel { 0 };
+
+    Memory::PageTableEntry* boot_pd_kernel_pt1023 { 0 };
+
+    StringView cmdline;
+
+    BootFramebufferInfo boot_framebuffer {};
 };
-#    endif
 
 }
 #endif

--- a/Kernel/Prekernel/Prekernel.h
+++ b/Kernel/Prekernel/Prekernel.h
@@ -9,6 +9,7 @@
 
 #ifdef __cplusplus
 #    include <Kernel/Boot/Multiboot.h>
+#    include <Kernel/EFIPrekernel/EFIPrekernel.h>
 #    include <Kernel/Memory/PhysicalAddress.h>
 #    include <Kernel/Memory/VirtualAddress.h>
 #    include <Kernel/Prekernel/Arch/ArchSpecificBootInfo.h>
@@ -47,9 +48,15 @@ struct Multiboot1BootInfo {
 struct PreInitBootInfo {
 };
 
+struct EFIBootInfo {
+    EFIMemoryMap memory_map;
+    VirtualAddress bootstrap_page_vaddr;
+};
+
 enum class BootMethod {
     Multiboot1,
     PreInit,
+    EFI,
 };
 
 enum class BootFramebufferType {
@@ -69,6 +76,7 @@ struct BootFramebufferInfo {
 union BootMethodSpecificBootInfo {
     PreInitBootInfo pre_init {};
     Multiboot1BootInfo multiboot1;
+    EFIBootInfo efi;
 };
 
 struct BootInfo {

--- a/Kernel/Prekernel/UBSanitizer.cpp
+++ b/Kernel/Prekernel/UBSanitizer.cpp
@@ -15,11 +15,17 @@ extern "C" {
 
 static void print_location(SourceLocation const&)
 {
-#if ARCH(X86_64)
-    asm volatile("cli; hlt");
+    for (;;) {
+#if ARCH(AARCH64)
+        asm volatile("msr daifset, #2; wfi");
+#elif ARCH(RISCV64)
+        asm volatile("csrw sie, zero; wfi");
+#elif ARCH(X86_64)
+        asm volatile("cli; hlt");
 #else
-    for (;;) { }
+#    error Unknown architecture
 #endif
+    }
 }
 
 void __ubsan_handle_load_invalid_value(InvalidValueData const&, ValueHandle) __attribute__((used));

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -175,22 +175,34 @@ extern "C" [[noreturn]] void init()
         return (decltype(ptr))((FlatPtr)ptr + kernel_mapping_base);
     };
 
-    info.multiboot_flags = multiboot_info_ptr->flags;
-    info.multiboot_memory_map = adjust_by_mapping_base((FlatPtr)multiboot_info_ptr->mmap_addr);
-    info.multiboot_memory_map_count = multiboot_info_ptr->mmap_length / sizeof(multiboot_memory_map_t);
+    info.boot_method = BootMethod::Multiboot1;
+    info.boot_method_specific.pre_init.~PreInitBootInfo();
+    new (&info.boot_method_specific.multiboot1) Multiboot1BootInfo;
+
+    info.boot_method_specific.multiboot1.flags = multiboot_info_ptr->flags;
+    info.boot_method_specific.multiboot1.memory_map = bit_cast<multiboot_memory_map_t const*>(adjust_by_mapping_base((FlatPtr)multiboot_info_ptr->mmap_addr));
+    info.boot_method_specific.multiboot1.memory_map_count = multiboot_info_ptr->mmap_length / sizeof(multiboot_memory_map_t);
 
     if (initrd_module_start != 0 && initrd_module_end != 0) {
-        info.multiboot_module_physical_ptr = initrd_module_start;
-        info.multiboot_module_length = initrd_module_end - initrd_module_start;
+        info.boot_method_specific.multiboot1.module_physical_ptr = PhysicalAddress { initrd_module_start };
+        info.boot_method_specific.multiboot1.module_length = initrd_module_end - initrd_module_start;
     }
 
     if ((multiboot_info_ptr->flags & MULTIBOOT_INFO_FRAMEBUFFER_INFO) != 0) {
-        info.multiboot_framebuffer_addr = multiboot_info_ptr->framebuffer_addr;
-        info.multiboot_framebuffer_pitch = multiboot_info_ptr->framebuffer_pitch;
-        info.multiboot_framebuffer_width = multiboot_info_ptr->framebuffer_width;
-        info.multiboot_framebuffer_height = multiboot_info_ptr->framebuffer_height;
-        info.multiboot_framebuffer_bpp = multiboot_info_ptr->framebuffer_bpp;
-        info.multiboot_framebuffer_type = multiboot_info_ptr->framebuffer_type;
+        info.boot_framebuffer.paddr = PhysicalAddress { multiboot_info_ptr->framebuffer_addr };
+        info.boot_framebuffer.pitch = multiboot_info_ptr->framebuffer_pitch;
+        info.boot_framebuffer.width = multiboot_info_ptr->framebuffer_width;
+        info.boot_framebuffer.height = multiboot_info_ptr->framebuffer_height;
+        info.boot_framebuffer.bpp = multiboot_info_ptr->framebuffer_bpp;
+
+        switch (multiboot_info_ptr->framebuffer_type) {
+        case MULTIBOOT_FRAMEBUFFER_TYPE_RGB:
+            info.boot_framebuffer.type = BootFramebufferType::BGRx8888;
+            break;
+        default:
+            info.boot_framebuffer.type = BootFramebufferType::None;
+            break;
+        }
     }
 
     reload_cr3();
@@ -213,21 +225,23 @@ extern "C" [[noreturn]] void init()
         __builtin_memset((u8*)kernel_load_base + kernel_program_header.p_vaddr + kernel_program_header.p_filesz, 0, kernel_program_header.p_memsz - kernel_program_header.p_filesz);
     }
 
-    info.start_of_prekernel_image = (PhysicalPtr)start_of_prekernel_image;
-    info.end_of_prekernel_image = (PhysicalPtr)end_of_prekernel_image;
+    info.boot_method_specific.multiboot1.start_of_prekernel_image = PhysicalAddress { bit_cast<PhysicalPtr>(+start_of_prekernel_image) };
+    info.boot_method_specific.multiboot1.end_of_prekernel_image = PhysicalAddress { bit_cast<PhysicalPtr>(+end_of_prekernel_image) };
     info.physical_to_virtual_offset = kernel_load_base - kernel_physical_base;
     info.kernel_mapping_base = kernel_mapping_base;
     info.kernel_load_base = kernel_load_base;
 #if ARCH(X86_64)
-    info.gdt64ptr = (PhysicalPtr)gdt64ptr;
-    info.code64_sel = code64_sel;
-    info.boot_pml4t = (PhysicalPtr)boot_pml4t;
+    info.arch_specific.gdt64ptr = (PhysicalPtr)gdt64ptr;
+    info.arch_specific.code64_sel = code64_sel;
+    info.boot_pml4t = PhysicalAddress { bit_cast<PhysicalPtr>(+boot_pml4t) };
 #endif
-    info.boot_pdpt = (PhysicalPtr)boot_pdpt;
-    info.boot_pd0 = (PhysicalPtr)boot_pd0;
-    info.boot_pd_kernel = (PhysicalPtr)boot_pd_kernel;
-    info.boot_pd_kernel_pt1023 = (FlatPtr)adjust_by_mapping_base(boot_pd_kernel_pt1023);
-    info.kernel_cmdline = (FlatPtr)adjust_by_mapping_base(kernel_cmdline);
+    info.boot_pdpt = PhysicalAddress { bit_cast<PhysicalPtr>(+boot_pdpt) };
+    info.boot_method_specific.multiboot1.boot_pd0 = PhysicalAddress { bit_cast<PhysicalPtr>(+boot_pd0) };
+    info.boot_pd_kernel = PhysicalAddress { bit_cast<PhysicalPtr>(+boot_pd_kernel) };
+    info.boot_pd_kernel_pt1023 = bit_cast<Memory::PageTableEntry*>(adjust_by_mapping_base(boot_pd_kernel_pt1023));
+
+    char const* cmdline_ptr = bit_cast<char const*>(adjust_by_mapping_base(kernel_cmdline));
+    info.cmdline = StringView { cmdline_ptr, __builtin_strlen(cmdline_ptr) };
 
     asm(
         "mov %0, %%rax\n"

--- a/Kernel/Sections.h
+++ b/Kernel/Sections.h
@@ -17,9 +17,9 @@
 
 #define KERNEL_MAPPING_BASE 0x2000000000
 
-#define KERNEL_PD_END (kernel_mapping_base + KERNEL_PD_SIZE)
+#define KERNEL_PD_END (g_boot_info.kernel_mapping_base + KERNEL_PD_SIZE)
 #define KERNEL_PT1024_OFFSET 0x3FE00000
-#define KERNEL_PT1024_BASE (kernel_mapping_base + KERNEL_PT1024_OFFSET)
+#define KERNEL_PT1024_BASE (g_boot_info.kernel_mapping_base + KERNEL_PT1024_OFFSET)
 
 #define KERNEL_MAX_CPU_COUNT 64
 #define KERNEL_QUICKMAP_PT_PER_CPU_BASE (KERNEL_PT1024_BASE + (1 * KERNEL_MAX_CPU_COUNT * PAGE_SIZE))
@@ -27,4 +27,4 @@
 #define KERNEL_QUICKMAP_PER_CPU_BASE (KERNEL_PT1024_BASE + (3 * KERNEL_MAX_CPU_COUNT * PAGE_SIZE))
 
 #define USER_RANGE_BASE 0x10000
-#define USER_RANGE_CEILING (kernel_mapping_base - 0x2000000)
+#define USER_RANGE_CEILING (g_boot_info.kernel_mapping_base - 0x2000000)

--- a/Kernel/Security/AddressSanitizer.cpp
+++ b/Kernel/Security/AddressSanitizer.cpp
@@ -98,7 +98,7 @@ static bool kasan_initialized = false;
 void init(FlatPtr shadow_base)
 {
     kasan_shadow_base = shadow_base;
-    kasan_shadow_offset = shadow_base - (kernel_mapping_base >> kasan_shadow_scale_offset);
+    kasan_shadow_offset = shadow_base - (g_boot_info.kernel_mapping_base >> kasan_shadow_scale_offset);
     kasan_initialized = true;
 }
 
@@ -215,7 +215,7 @@ static void shadow_va_check(FlatPtr address, size_t size, AccessType access_type
         return;
     if (!kasan_initialized) [[unlikely]]
         return;
-    if (address < kernel_mapping_base || address >= kasan_shadow_base) [[unlikely]]
+    if (address < g_boot_info.kernel_mapping_base || address >= kasan_shadow_base) [[unlikely]]
         return;
 
     bool valid = false;

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -532,7 +532,7 @@ void Process::crash(int signal, Optional<RegisterState const&> regs, bool out_of
     if (out_of_memory) {
         dbgln("\033[31;1mOut of memory\033[m, killing: {}", *this);
     } else {
-        if (ip >= kernel_load_base && g_kernel_symbols_available.was_set()) {
+        if (ip >= g_boot_info.kernel_load_base && g_kernel_symbols_available.was_set()) {
             auto const* symbol = symbolicate_kernel_address(ip);
             dbgln("\033[31;1m{:p}  {} +{}\033[0m\n", ip, (symbol ? symbol->name : "(k?)"), (symbol ? ip - symbol->address : 0));
         } else {

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -268,3 +268,5 @@ set(XML_PARSER_DEBUG ON)
 # set(IA32_DEBUG_INTERFACE ON)
 # False positive: ANDROID_LOG_DEBUG is a log level, not a debug flag
 # set(ANDROID_LOG_DEBUG ON)
+# False positive: DEBUG_STRIPPED is a PE characteristic, not a debug flag
+# set(DEBUG_STRIPPED ON)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -398,6 +398,10 @@ lagom_lib(LibGUI_GML gui_gml
     SOURCES ${LIBGUI_GML_SOURCES}
 )
 
+# LibELF
+# This is used by the PrekernelPEImageGenerator and therefore always needed.
+add_serenity_subdirectory(Userland/Libraries/LibELF)
+
 # Manually install AK headers
 install(
     DIRECTORY "${SERENITY_PROJECT_ROOT}/AK"
@@ -495,7 +499,7 @@ if (BUILD_LAGOM)
     endif()
 
     if (NOT EMSCRIPTEN)
-        list(APPEND lagom_standard_libraries ELF X86)
+        list(APPEND lagom_standard_libraries X86)
     endif()
 
     foreach(lib IN LISTS lagom_standard_libraries)

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -13,6 +13,7 @@ endfunction()
 
 add_subdirectory(CodeGenerators)
 add_subdirectory(ConfigureComponents)
+add_subdirectory(PrekernelPEImageGenerator)
 add_subdirectory(IPCMagicLinter)
 
 if (ENABLE_JAKT)

--- a/Meta/Lagom/Tools/PrekernelPEImageGenerator/CMakeLists.txt
+++ b/Meta/Lagom/Tools/PrekernelPEImageGenerator/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES
+    main.cpp
+)
+
+lagom_tool(PrekernelPEImageGenerator LIBS LibMain LibELF)

--- a/Meta/Lagom/Tools/PrekernelPEImageGenerator/PEDefinitions.h
+++ b/Meta/Lagom/Tools/PrekernelPEImageGenerator/PEDefinitions.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/EnumBits.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
+
+// NOTE: All struct definitions in this file assume little endian.
+//       Only PE32+ (64 bit) images are supported.
+
+// The PE file offset to the value containing the offset of the PE magic.
+static constexpr size_t PE_MAGIC_OFFSET_OFFSET = 0x3c;
+
+static constexpr Array<u8, 2> DOS_MAGIC = { 'M', 'Z' };
+static constexpr Array<u8, 4> PE_MAGIC = { 'P', 'E', '\0', '\0' };
+
+// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-file-header-object-and-image
+struct [[gnu::packed]] COFFHeader {
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#machine-types
+    enum class Machine : u16 {
+        AMD64 = 0x8664,
+        ARM64 = 0xaa64,
+        RISCV64 = 0x5064,
+    };
+
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#characteristics
+    enum class Characteristics : u16 {
+        RELOCS_STRIPPED = 0x0001,
+        EXECUTABLE_IMAGE = 0x0002,
+        LINE_NUMS_STRIPPED = 0x0004,
+        LOCAL_SYMS_STRIPPED = 0x0008,
+        AGGRESSIVE_WS_TRIM = 0x0010,
+        LARGE_ADDRESS_AWARE = 0x0020,
+        BYTES_REVERSED_LO = 0x0080,
+        _32BIT_MACHINE = 0x0100,
+        DEBUG_STRIPPED = 0x0200,
+        REMOVABLE_RUN_FROM_SWAP = 0x0400,
+        NET_RUN_FROM_SWAP = 0x0800,
+        IMAGE_FILE_SYSTEM = 0x1000,
+        DLL = 0x2000,
+        UP_SYSTEM_ONLY = 0x4000,
+        BYTES_REVERSED_HI = 0x8000,
+    };
+
+    Machine machine;
+    u16 number_of_sections;
+    u32 time_date_stamp; // 32-bit time_t :^(
+    u32 pointer_to_symbol_table;
+    u32 number_of_symbols;
+    u16 size_of_optional_header;
+    Characteristics characteristics;
+};
+static_assert(AssertSize<COFFHeader, 20>());
+AK_ENUM_BITWISE_OPERATORS(COFFHeader::Characteristics)
+
+// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-image-only
+struct [[gnu::packed]] OptionalHeader {
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-standard-fields-image-only
+    struct [[gnu::packed]] StandardFields {
+        enum class Magic : u16 {
+            PE32 = 0x10b,
+            PE32Plus = 0x20b,
+        };
+
+        Magic magic;
+        u8 major_linker_version;
+        u8 minor_linker_version;
+        u32 size_of_code;
+        u32 size_of_initialized_data;
+        u32 size_of_uninitialized_data;
+        u32 address_of_entry_point;
+        u32 base_of_code;
+    };
+    static_assert(AssertSize<StandardFields, 24>());
+
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-windows-specific-fields-image-only
+    struct [[gnu::packed]] WindowsSpecificFields {
+        // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#windows-subsystem
+        enum class Subsystem : u16 {
+            EFI_APPLICATION = 10,
+        };
+
+        u64 image_base;
+        u32 section_alignment;
+        u32 file_alignment;
+        u16 major_operating_system_version;
+        u16 minor_operating_system_version;
+        u16 major_image_version;
+        u16 minor_image_version;
+        u16 major_subsystem_version;
+        u16 minor_subsystem_version;
+        u32 win32_version_value;
+        u32 size_of_image;
+        u32 size_of_headers;
+        u32 checksum;
+        Subsystem subsystem;
+        u16 dll_characteristics;
+        u64 size_of_stack_reserve;
+        u64 size_of_stack_commit;
+        u64 size_of_heap_reserve;
+        u64 size_of_heap_commit;
+        u32 loader_flags;
+        u32 number_of_rva_and_size;
+    };
+    static_assert(AssertSize<WindowsSpecificFields, 112 - 24>());
+
+    struct [[gnu::packed]] DataDirectory {
+        u32 virtual_address;
+        u32 size;
+    };
+    static_assert(AssertSize<DataDirectory, 8>());
+
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-data-directories-image-only
+    struct [[gnu::packed]] DataDirectories {
+        DataDirectory export_table;
+        DataDirectory import_table;
+        DataDirectory resource_table;
+        DataDirectory exception_table;
+        DataDirectory certificate_table;
+        DataDirectory base_relocation_table;
+        DataDirectory debug;
+        DataDirectory architecture;
+        DataDirectory global_ptr;
+        DataDirectory tls_table;
+        DataDirectory load_config_table;
+        DataDirectory bound_import;
+        DataDirectory iat;
+        DataDirectory delay_import_descriptor;
+        DataDirectory clr_runtime_header;
+        DataDirectory reserved;
+    };
+    static_assert(AssertSize<DataDirectories, 240 - 112>());
+
+    StandardFields standard_fields;
+    WindowsSpecificFields windows_specific_fields;
+    DataDirectories data_directories;
+};
+static_assert(AssertSize<OptionalHeader, 240>());
+
+// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers
+struct [[gnu::packed]] SectionHeader {
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-flags
+    enum class Characteristics : u32 {
+        NONE = 0x00000000,
+        TYPE_NO_PAD = 0x00000008,
+        CNT_CODE = 0x00000020,
+        CNT_INITIALIZED_DATA = 0x00000040,
+        CNT_UNINITIALIZED_DATA = 0x00000080,
+        LNK_OTHER = 0x00000100,
+        LNK_INFO = 0x00000200,
+        LNK_REMOVE = 0x00000800,
+        LNK_COMDAT = 0x00001000,
+        GPREL = 0x00008000,
+        MEM_PURGEABLE = 0x00020000,
+        MEM_16BIT = 0x00020000,
+        MEM_LOCKED = 0x00040000,
+        MEM_PRELOAD = 0x00080000,
+        ALIGN_1BYTES = 0x00100000,
+        ALIGN_2BYTES = 0x00200000,
+        ALIGN_4BYTES = 0x00300000,
+        ALIGN_8BYTES = 0x00400000,
+        ALIGN_16BYTES = 0x00500000,
+        ALIGN_32BYTES = 0x00600000,
+        ALIGN_64BYTES = 0x00700000,
+        ALIGN_128BYTES = 0x00800000,
+        ALIGN_256BYTES = 0x00900000,
+        ALIGN_512BYTES = 0x00a00000,
+        ALIGN_1024BYTES = 0x00b00000,
+        ALIGN_2048BYTES = 0x00c00000,
+        ALIGN_4096BYTES = 0x00d00000,
+        ALIGN_8192BYTES = 0x00e00000,
+        LNK_NRELOC_OVFL = 0x01000000,
+        MEM_DISCARDABLE = 0x02000000,
+        MEM_NOT_CACHED = 0x04000000,
+        MEM_NOT_PAGED = 0x08000000,
+        MEM_SHARED = 0x10000000,
+        MEM_EXECUTE = 0x20000000,
+        MEM_READ = 0x40000000,
+        MEM_WRITE = 0x80000000,
+    };
+
+    Array<char, 8> name;
+    u32 virtual_size;
+    u32 virtual_address;
+    u32 size_of_raw_data;
+    u32 pointer_to_raw_data;
+    u32 pointer_to_relocations;
+    u32 pointer_to_line_numbers;
+    u16 number_of_relocations;
+    u16 number_of_line_numbers;
+    Characteristics characteristics;
+};
+static_assert(AssertSize<SectionHeader, 40>());
+AK_ENUM_BITWISE_OPERATORS(SectionHeader::Characteristics)
+
+// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#special-sections
+struct SpecialSection {
+    StringView name;
+    SectionHeader::Characteristics characteristics;
+};
+
+// This array only includes special sections that may be in the Prekernel ELF.
+static constexpr Array SPECIAL_PE_SECTIONS = to_array<SpecialSection>({
+    { ".bss"sv, SectionHeader::Characteristics::CNT_UNINITIALIZED_DATA | SectionHeader::Characteristics::MEM_READ | SectionHeader::Characteristics::MEM_WRITE },
+    { ".data"sv, SectionHeader::Characteristics::CNT_INITIALIZED_DATA | SectionHeader::Characteristics::MEM_READ | SectionHeader::Characteristics::MEM_WRITE },
+    { ".rdata"sv, SectionHeader::Characteristics::CNT_INITIALIZED_DATA | SectionHeader::Characteristics::MEM_READ },
+    { ".text"sv, SectionHeader::Characteristics::CNT_CODE | SectionHeader::Characteristics::MEM_EXECUTE | SectionHeader::Characteristics::MEM_READ },
+});
+
+// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#base-relocation-block
+struct [[gnu::packed]] BaseRelocationBlockHeader {
+    u32 page_rva;
+    u32 block_size;
+};
+static_assert(AssertSize<BaseRelocationBlockHeader, 8>());
+
+struct [[gnu::packed]] BaseRelocationBlockEntry {
+    // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#base-relocation-types
+    enum class Type : u16 {
+        ABSOLUTE = 0,
+        DIR64 = 10,
+    };
+
+    u16 offset : 12;
+    Type type : 4;
+};
+static_assert(AssertSize<BaseRelocationBlockEntry, 2>());
+
+template<>
+struct AK::Traits<COFFHeader> : public AK::DefaultTraits<COFFHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+struct AK::Traits<OptionalHeader> : public AK::DefaultTraits<OptionalHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+struct AK::Traits<SectionHeader> : public AK::DefaultTraits<SectionHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+struct AK::Traits<BaseRelocationBlockHeader> : public AK::DefaultTraits<BaseRelocationBlockHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+struct AK::Traits<BaseRelocationBlockEntry> : public AK::DefaultTraits<BaseRelocationBlockEntry> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};

--- a/Meta/Lagom/Tools/PrekernelPEImageGenerator/main.cpp
+++ b/Meta/Lagom/Tools/PrekernelPEImageGenerator/main.cpp
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Endian.h>
+#include <AK/QuickSort.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/MappedFile.h>
+#include <LibELF/Image.h>
+#include <LibMain/Main.h>
+#include <time.h>
+
+#include "PEDefinitions.h"
+
+// This tool converts the Prekernel ELF to a PE32+ EFI image.
+// It does so by translating the ELF sections into PE sections while keeping the virtual memory layout of the ELF file.
+// It also converts ELF R_*_RELATIVE relocations into PE base relocations and adds them as an additional .reloc section.
+
+static constexpr size_t PE_SECTION_ALIGNMENT = 4 * KiB;
+static_assert(is_power_of_two(PE_SECTION_ALIGNMENT));
+
+// This is both the minimum and default value for OptionalHeader::WindowsSpecificFields::file_alignment.
+static constexpr size_t PE_FILE_ALIGNMENT = 512;
+static_assert(is_power_of_two(PE_FILE_ALIGNMENT));
+
+ErrorOr<ByteBuffer> translate_relocations(ELF::Image const& elf_image, Span<ELF::Image::Section const*> sorted_elf_sections, Bytes raw_elf)
+{
+    unsigned none_relocation_type;
+    unsigned relative_relocation_type;
+    switch (elf_image.machine()) {
+    case EM_AARCH64:
+        none_relocation_type = R_AARCH64_NONE;
+        relative_relocation_type = R_AARCH64_RELATIVE;
+        break;
+    case EM_RISCV:
+        none_relocation_type = R_RISCV_NONE;
+        relative_relocation_type = R_RISCV_RELATIVE;
+        break;
+    case EM_X86_64:
+        none_relocation_type = R_X86_64_NONE;
+        relative_relocation_type = R_X86_64_RELATIVE;
+        break;
+    default:
+        return Error::from_string_literal("Unsupported e_machine");
+    }
+
+    HashMap<u32, Vector<BaseRelocationBlockEntry>> base_relocation_blocks;
+
+    auto add_elf_relocation_to_pe_relocation_blocks = [&](ELF::Image::Relocation const& elf_relocation) {
+        if (elf_relocation.type() == none_relocation_type)
+            return;
+        if (elf_relocation.type() != relative_relocation_type) {
+            warnln("Unsupported relocation type: {}", elf_relocation.type());
+            VERIFY_NOT_REACHED();
+        }
+
+        // Elf_Rela::r_offset is a virtual address for executables, so we need to translate it to an offset in the ELF file.
+        FlatPtr* patch_ptr = nullptr;
+        for (auto const* elf_section : sorted_elf_sections) {
+            if (elf_relocation.offset() >= elf_section->address() && elf_relocation.offset() < elf_section->address() + elf_section->size()) {
+                auto relocation_target_offset_in_section = elf_relocation.offset() - elf_section->address();
+                patch_ptr = reinterpret_cast<FlatPtr*>(raw_elf.offset(elf_section->offset() + relocation_target_offset_in_section));
+            }
+        }
+
+        // PE doesn't use addends, so apply the ELF addends now.
+        if (elf_relocation.addend_used())
+            *patch_ptr = elf_relocation.addend();
+
+        // The PE base relocation table is split into blocks each representing a 4K page.
+        u32 page_rva = elf_relocation.offset() & ~0xfff;
+        base_relocation_blocks.ensure(page_rva).append(BaseRelocationBlockEntry {
+            .offset = static_cast<u16>(elf_relocation.offset() & 0xfff),
+            .type = BaseRelocationBlockEntry::Type::DIR64,
+        });
+    };
+
+    elf_image.for_each_section_of_type(SHT_REL, [&](ELF::Image::Section const& section) {
+        auto relocation_section = ELF::Image::RelocationSection(section);
+        relocation_section.for_each_relocation([&](ELF::Image::Relocation const& relocation) {
+            add_elf_relocation_to_pe_relocation_blocks(relocation);
+        });
+    });
+
+    elf_image.for_each_section_of_type(SHT_RELA, [&](ELF::Image::Section const& section) {
+        auto relocation_section = ELF::Image::RelocationSection(section);
+        relocation_section.for_each_relocation([&](ELF::Image::Relocation const& relocation) {
+            add_elf_relocation_to_pe_relocation_blocks(relocation);
+        });
+    });
+
+    AllocatingMemoryStream base_relocation_section_stream;
+    for (auto& [page_rva, relocations] : base_relocation_blocks) {
+        // Base Relocation Blocks have to be 32-bit aligned, so pad with a (16-bit) ABSOLUTE relocation if needed.
+        // PE base relocations of type ABSOLUTE are ignored.
+        if (relocations.size() % 2 != 0) {
+            auto padding = BaseRelocationBlockEntry {
+                .offset = 0,
+                .type = BaseRelocationBlockEntry::Type::ABSOLUTE,
+            };
+            relocations.append(padding);
+        }
+
+        auto header = BaseRelocationBlockHeader {
+            .page_rva = page_rva,
+            .block_size = static_cast<u32>(sizeof(BaseRelocationBlockHeader) + relocations.size() * sizeof(BaseRelocationBlockEntry)),
+        };
+
+        TRY(base_relocation_section_stream.write_value(header));
+
+        for (auto const& relocation : relocations)
+            TRY(base_relocation_section_stream.write_value(relocation));
+    }
+
+    return base_relocation_section_stream.read_until_eof();
+}
+
+ErrorOr<COFFHeader> generate_coff_header(ELF::Image const& elf_image, Span<ELF::Image::Section const*> sorted_elf_sections)
+{
+    COFFHeader::Machine coff_machine;
+    switch (elf_image.machine()) {
+    case EM_AARCH64:
+        coff_machine = COFFHeader::Machine::ARM64;
+        break;
+    case EM_RISCV:
+        coff_machine = COFFHeader::Machine::RISCV64;
+        break;
+    case EM_X86_64:
+        coff_machine = COFFHeader::Machine::AMD64;
+        break;
+    default:
+        return Error::from_string_literal("Unsupported e_machine");
+    }
+
+    // +1 for the .reloc section
+    u16 pe_section_count = sorted_elf_sections.size() + 1;
+
+    // COFF File Header
+    COFFHeader coff_header = {
+        .machine = coff_machine,
+        .number_of_sections = static_cast<u16>(pe_section_count),
+        .time_date_stamp = static_cast<u32>(time(nullptr)),
+        .pointer_to_symbol_table = 0,
+        .number_of_symbols = 0,
+        .size_of_optional_header = sizeof(OptionalHeader),
+        .characteristics = COFFHeader::Characteristics::EXECUTABLE_IMAGE | COFFHeader::Characteristics::LINE_NUMS_STRIPPED | COFFHeader::Characteristics::DEBUG_STRIPPED,
+    };
+
+    return coff_header;
+}
+
+ErrorOr<OptionalHeader> generate_optional_header(ELF::Image const& elf_image, Span<ELF::Image::Section const*> sorted_elf_sections, ReadonlyBytes base_relocation_section_data, u32 size_of_headers)
+{
+    Optional<u32> base_of_code;
+    u32 size_of_code = 0;
+    u32 size_of_initialized_data = 0;
+    u32 size_of_uninitialized_data = 0;
+
+    // Place the .reloc section after the last ELF section.
+    OptionalHeader::DataDirectory reloc_section_data_directory {
+        .virtual_address = static_cast<u32>(round_up_to_power_of_two(sorted_elf_sections.last()->address() + sorted_elf_sections.last()->size(), PE_SECTION_ALIGNMENT)),
+        .size = static_cast<u32>(base_relocation_section_data.size()),
+    };
+
+    for (auto const* elf_section : sorted_elf_sections) {
+        if (elf_section->name() == ".reloc"sv)
+            return Error::from_string_literal("The Prekernel ELF shouldn't have a .reloc section, as this program will generate it");
+
+        if (elf_section->name().starts_with(".text"sv)) {
+            if (!base_of_code.has_value())
+                base_of_code = elf_section->address();
+            size_of_code += round_up_to_power_of_two(elf_section->size(), PE_FILE_ALIGNMENT);
+        } else if (elf_section->name().starts_with(".rdata"sv) || elf_section->name().starts_with(".data"sv)) {
+            size_of_initialized_data += round_up_to_power_of_two(elf_section->size(), PE_FILE_ALIGNMENT);
+        } else if (elf_section->name().starts_with(".bss"sv)) {
+            size_of_uninitialized_data += round_up_to_power_of_two(elf_section->size(), PE_FILE_ALIGNMENT);
+        }
+    }
+
+    // ImageBase has to be a multiple of 64K.
+    Optional<u64> image_base;
+    elf_image.for_each_symbol([&image_base](ELF::Image::Symbol const& symbol) {
+        if (symbol.name() == "pe_image_base"sv) {
+            image_base = symbol.value();
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    // We require the PE image base to be zero, so we don't have to subtract it from every address to get the relative virtual addresses.
+    VERIFY(image_base.value() == 0);
+
+    // Optional Header
+    OptionalHeader optional_header = {
+        .standard_fields = {
+            .magic = OptionalHeader::StandardFields::Magic::PE32Plus,
+            .major_linker_version = 0,
+            .minor_linker_version = 0,
+            .size_of_code = size_of_code,
+            .size_of_initialized_data = size_of_initialized_data,
+            .size_of_uninitialized_data = size_of_uninitialized_data,
+            .address_of_entry_point = static_cast<u32>(elf_image.entry().get()),
+            .base_of_code = base_of_code.release_value(),
+        },
+        .windows_specific_fields = {
+            .image_base = image_base.value(),
+            .section_alignment = PE_SECTION_ALIGNMENT,
+            .file_alignment = PE_FILE_ALIGNMENT,
+            .major_operating_system_version = 0,
+            .minor_operating_system_version = 0,
+            .major_image_version = 0,
+            .minor_image_version = 0,
+            .major_subsystem_version = 0,
+            .minor_subsystem_version = 0,
+            .win32_version_value = 0,
+            .size_of_image = reloc_section_data_directory.virtual_address + reloc_section_data_directory.size, // The .reloc section is the last section of the PE image.
+            .size_of_headers = size_of_headers,
+            .checksum = 0, // The checksum algorithm is not publicly defined. We probably don't need to set it as edk2 PEs built with gcc don't have the checksum set either.
+            .subsystem = OptionalHeader::WindowsSpecificFields::Subsystem::EFI_APPLICATION,
+            .dll_characteristics = 0,
+            .size_of_stack_reserve = 0, // edk2 PEs built with gcc don't have these sizes set, so we probably don't need to set them either.
+            .size_of_stack_commit = 0,
+            .size_of_heap_reserve = 0,
+            .size_of_heap_commit = 0,
+            .loader_flags = 0,
+            .number_of_rva_and_size = sizeof(OptionalHeader::DataDirectories) / sizeof(u64),
+        },
+        .data_directories = {
+            .export_table = {},
+            .import_table = {},
+            .resource_table = {},
+            .exception_table = {},
+            .certificate_table = {},
+            .base_relocation_table = reloc_section_data_directory,
+            .debug = {},
+            .architecture = {},
+            .global_ptr = {},
+            .tls_table = {},
+            .load_config_table = {},
+            .bound_import = {},
+            .iat = {},
+            .delay_import_descriptor = {},
+            .clr_runtime_header = {},
+            .reserved = {},
+        },
+    };
+
+    return optional_header;
+}
+
+ErrorOr<void> write_pe_headers(Core::OutputBufferedFile& stream, COFFHeader const& coff_header, OptionalHeader const& optional_header)
+{
+    // MS-DOS Stub
+    TRY(stream.write_until_depleted(DOS_MAGIC));
+
+    // Offset to PE signature
+    TRY(stream.seek(PE_MAGIC_OFFSET_OFFSET, SeekMode::SetPosition));
+    TRY(stream.write_value(LittleEndian<u32> { PE_MAGIC_OFFSET_OFFSET + sizeof(u32) }));
+
+    // Signature
+    TRY(stream.write_until_depleted(PE_MAGIC));
+
+    TRY(stream.write_value(coff_header));
+    TRY(stream.write_value(optional_header));
+
+    return {};
+}
+
+ErrorOr<void> write_pe_sections(Core::OutputBufferedFile& stream, Span<ELF::Image::Section const*> sorted_elf_sections, ReadonlyBytes base_relocation_section_data, COFFHeader const& coff_header, OptionalHeader optional_header)
+{
+    u32 offset_for_first_raw_data = round_up_to_power_of_two(TRY(stream.tell()) + sizeof(SectionHeader) * coff_header.number_of_sections, PE_FILE_ALIGNMENT);
+
+    Vector<size_t> raw_data_offsets;
+    raw_data_offsets.ensure_capacity(sorted_elf_sections.size());
+
+    u32 current_offset_to_raw_data = offset_for_first_raw_data;
+    for (auto const* elf_section : sorted_elf_sections) {
+        u32 file_size = elf_section->type() == SHT_NOBITS ? 0 : round_up_to_power_of_two(elf_section->size(), PE_FILE_ALIGNMENT);
+
+        auto characteristics = SectionHeader::Characteristics::NONE;
+
+        for (auto const& [special_section_name, special_characteristics] : SPECIAL_PE_SECTIONS) {
+            if (special_section_name == elf_section->name()) {
+                characteristics = special_characteristics;
+                break;
+            }
+        }
+
+        if (characteristics == SectionHeader::Characteristics::NONE) {
+            // Fallback for non-special PE sections
+            characteristics |= SectionHeader::Characteristics::MEM_READ;
+            if (elf_section->is_writable())
+                characteristics |= SectionHeader::Characteristics::MEM_WRITE;
+            if (elf_section->is_executable())
+                characteristics |= SectionHeader::Characteristics::MEM_EXECUTE | SectionHeader::Characteristics::CNT_CODE;
+            characteristics |= file_size == 0 ? SectionHeader::Characteristics::CNT_UNINITIALIZED_DATA : SectionHeader::Characteristics::CNT_INITIALIZED_DATA;
+        }
+
+        SectionHeader section_header = {
+            .name = {},
+            .virtual_size = static_cast<u32>(elf_section->size()),
+            .virtual_address = static_cast<u32>(elf_section->address()),
+            .size_of_raw_data = file_size,
+            .pointer_to_raw_data = file_size == 0 ? 0 : current_offset_to_raw_data,
+            .pointer_to_relocations = 0,
+            .pointer_to_line_numbers = 0,
+            .number_of_relocations = 0,
+            .number_of_line_numbers = 0,
+            .characteristics = characteristics,
+        };
+
+        memset(&section_header.name, 0, sizeof(section_header.name));
+        memcpy(&section_header.name, elf_section->name().bytes().data(), min(elf_section->name().bytes().size(), 8));
+
+        TRY(stream.write_value(section_header));
+
+        raw_data_offsets.append(current_offset_to_raw_data);
+        current_offset_to_raw_data = round_up_to_power_of_two(current_offset_to_raw_data + file_size, PE_FILE_ALIGNMENT);
+    }
+
+    // Also add the section header for the .reloc section.
+    SectionHeader reloc_section_header = {
+        .name = { ".reloc" },
+        .virtual_size = static_cast<u32>(base_relocation_section_data.size()),
+        .virtual_address = optional_header.data_directories.base_relocation_table.virtual_address,
+        .size_of_raw_data = static_cast<u32>(base_relocation_section_data.size()),
+        .pointer_to_raw_data = current_offset_to_raw_data,
+        .pointer_to_relocations = 0,
+        .pointer_to_line_numbers = 0,
+        .number_of_relocations = 0,
+        .number_of_line_numbers = 0,
+        .characteristics = SectionHeader::Characteristics::CNT_INITIALIZED_DATA | SectionHeader::Characteristics::MEM_READ | SectionHeader::Characteristics::MEM_DISCARDABLE,
+    };
+
+    TRY(stream.write_value(reloc_section_header));
+
+    for (size_t section_index = 0; section_index < sorted_elf_sections.size(); section_index++) {
+        u32 offset_to_raw_data = raw_data_offsets[section_index];
+        auto const* elf_section = sorted_elf_sections[section_index];
+
+        TRY(stream.seek(offset_to_raw_data, SeekMode::SetPosition));
+        TRY(stream.write_until_depleted(elf_section->bytes()));
+    }
+
+    TRY(stream.seek(reloc_section_header.pointer_to_raw_data, SeekMode::SetPosition));
+    TRY(stream.write_until_depleted(base_relocation_section_data));
+
+    return {};
+}
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    Core::ArgsParser argument_parser;
+    StringView elf_file_name;
+    StringView pe_file_name;
+    argument_parser.add_positional_argument(elf_file_name, "Prekernel ELF file", "elf-file", Core::ArgsParser::Required::Yes);
+    argument_parser.add_positional_argument(pe_file_name, "Target PE32+ image file", "pe-file", Core::ArgsParser::Required::Yes);
+    argument_parser.parse(arguments);
+
+    auto elf_file = TRY(Core::File::open(elf_file_name, Core::File::OpenMode::Read));
+    auto elf_data = TRY(elf_file->read_until_eof());
+    auto const elf_image = ELF::Image(elf_data.bytes());
+    if (!elf_image.is_valid()) {
+        return Error::from_string_literal("Invalid ELF passed");
+        return -1;
+    }
+
+    VERIFY(elf_image.is_executable() || elf_image.is_dynamic());
+
+    if (elf_image.elf_class() != ELFCLASS64)
+        return Error::from_string_literal("Unsupported EI_CLASS");
+
+    if (elf_image.byte_order() != ELFDATA2LSB)
+        return Error::from_string_literal("Unsupported EI_DATA");
+
+    Vector<ELF::Image::Section> elf_sections;
+    elf_sections.ensure_capacity(elf_image.section_count());
+    elf_image.for_each_section([&elf_sections, &elf_image](ELF::Image::Section const& elf_section) {
+        // We don't support converting RELR relocations.
+        VERIFY(elf_section.type() != SHT_RELR);
+
+        // We don't have a runtime to support .{preinit,init,fini}_array sections.
+        VERIFY(elf_section.type() != SHT_INIT_ARRAY);
+        VERIFY(elf_section.type() != SHT_PREINIT_ARRAY);
+        VERIFY(elf_section.type() != SHT_FINI_ARRAY);
+
+        // Don't include some unnecessary sections in the PE image.
+        static constexpr Array section_types_to_discard = to_array<u32>({
+            SHT_SYMTAB,
+            SHT_STRTAB,
+            SHT_RELA,
+            SHT_HASH,
+            SHT_DYNAMIC,
+            SHT_NOTE,
+            SHT_REL,
+            SHT_DYNSYM,
+            SHT_GNU_HASH,
+        });
+
+        if (elf_image.machine() == EM_RISCV && elf_section.type() == SHT_RISCV_ATTRIBUTES)
+            return;
+
+        if (section_types_to_discard.contains_slow(elf_section.type()))
+            return;
+
+        // Don't add sections with address 0 or without the ALLOC flag, as they won't appear in memory.
+        if (elf_section.address() == 0 || (elf_section.flags() & SHF_ALLOC) == 0)
+            return;
+
+        // We keep the memory layout of the ELF sections when translating them to PE sections.
+        // The ELF sections therefore have to be properly aligned, as PE sections have to be aligned by the specified amount in WindowsSpecificFields::section_alignment.
+        if (elf_section.address() % PE_SECTION_ALIGNMENT != 0) {
+            warnln("Prekernel ELF section \"{}\" is not aligned on a {}-byte boundary!", elf_section.name(), PE_SECTION_ALIGNMENT);
+            warnln("Either add it to the Prekernel linker script or discard it in the PrekernelPEImageGenerator.");
+            VERIFY_NOT_REACHED();
+        }
+
+        elf_sections.append(elf_section);
+    });
+
+    // PE sections have to be sorted by their virtual_address.
+    Vector<ELF::Image::Section const*> sorted_elf_sections;
+    sorted_elf_sections.ensure_capacity(elf_sections.size());
+    for (auto const& section : elf_sections)
+        sorted_elf_sections.append(&section);
+    quick_sort(sorted_elf_sections, [](auto const* a, auto const* b) { return a->address() < b->address(); });
+
+    auto output_file = TRY(Core::File::open(pe_file_name, Core::File::OpenMode::Write));
+    auto output = TRY(Core::OutputBufferedFile::create(move(output_file)));
+
+    auto base_relocation_section_data = TRY(translate_relocations(elf_image, sorted_elf_sections, elf_data.bytes()));
+
+    auto coff_header = TRY(generate_coff_header(elf_image, sorted_elf_sections));
+
+    u32 size_of_headers = round_up_to_power_of_two(PE_MAGIC_OFFSET_OFFSET + sizeof(u32) + sizeof(PE_MAGIC) + sizeof(COFFHeader) + sizeof(OptionalHeader) + sizeof(SectionHeader) * coff_header.number_of_sections, PE_FILE_ALIGNMENT);
+
+    auto optional_header = TRY(generate_optional_header(elf_image, sorted_elf_sections, base_relocation_section_data, size_of_headers));
+
+    TRY(write_pe_headers(*output, coff_header, optional_header));
+    TRY(write_pe_sections(*output, sorted_elf_sections, base_relocation_section_data, coff_header, optional_header));
+
+    return 0;
+}

--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -300,10 +300,12 @@ typedef struct {
 #define SHT_SUNW_verneed 0x6ffffffe /* symbol versioning req */
 #define SHT_SUNW_versym 0x6fffffff  /* symbol versioning table */
 #define SHT_HIOS 0x6fffffff         /*  section header types */
-#define SHT_LOPROC 0x70000000       /* reserved range for processor */
-#define SHT_HIPROC 0x7fffffff       /*  specific section header types */
 #define SHT_LOUSER 0x80000000       /* reserved range for application */
 #define SHT_HIUSER 0xffffffff       /*  specific indices */
+
+#define SHT_LOPROC 0x70000000           /* start of reserved range for processor specific section header types */
+#define SHT_RISCV_ATTRIBUTES 0x70000003 /* RISC-V ELF attribute section */
+#define SHT_HIPROC 0x7fffffff           /* end of reserved range for processor specific section header types */
 
 #define SHT_GNU_HASH 0x6ffffff6 /* GNU-style hash table section */
 

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -248,20 +248,6 @@ Image::Relocation Image::RelocationSection::relocation(unsigned index) const
     return Relocation(m_image, *relocation_address, addend_used());
 }
 
-Optional<Image::RelocationSection> Image::Section::relocations() const
-{
-    StringBuilder builder;
-    builder.append(".rel"sv);
-    builder.append(name());
-
-    auto relocation_section = m_image.lookup_section(builder.string_view());
-    if (!relocation_section.has_value())
-        return {};
-
-    dbgln_if(ELF_IMAGE_DEBUG, "Found relocations for {} in {}", name(), relocation_section.value().name());
-    return static_cast<RelocationSection>(relocation_section.value());
-}
-
 Optional<Image::Section> Image::lookup_section(StringView name) const
 {
     VERIFY(m_valid);

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -243,8 +243,9 @@ Image::ProgramHeader Image::program_header(unsigned index) const
 Image::Relocation Image::RelocationSection::relocation(unsigned index) const
 {
     VERIFY(index < relocation_count());
-    auto* rels = reinterpret_cast<Elf_Rel const*>(m_image.raw_data(offset()));
-    return Relocation(m_image, rels[index]);
+    unsigned offset_in_section = index * entry_size();
+    auto relocation_address = bit_cast<Elf_Rela*>(m_image.raw_data(offset() + offset_in_section));
+    return Relocation(m_image, *relocation_address, addend_used());
 }
 
 Optional<Image::RelocationSection> Image::Section::relocations() const

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -221,8 +221,12 @@ public:
     bool is_dynamic() const { return header().e_type == ET_DYN; }
 
     VirtualAddress entry() const { return VirtualAddress(header().e_entry); }
+    Elf64_Quarter machine() const { return header().e_machine; }
     FlatPtr base_address() const { return (FlatPtr)m_buffer; }
     size_t size() const { return m_size; }
+
+    unsigned char elf_class() const { return header().e_ident[EI_CLASS]; }
+    unsigned char byte_order() const { return header().e_ident[EI_DATA]; }
 
     static Optional<StringView> object_file_type_to_string(Elf_Half type);
     static Optional<StringView> object_machine_type_to_string(Elf_Half type);

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -148,13 +148,16 @@ public:
 
         template<VoidFunction<Image::Relocation&> F>
         void for_each_relocation(F) const;
+
+        bool addend_used() const { return type() == SHT_RELA; }
     };
 
     class Relocation {
     public:
-        Relocation(Image const& image, Elf_Rel const& rel)
+        Relocation(Image const& image, Elf_Rela const& rel, bool addend_used)
             : m_image(image)
             , m_rel(rel)
+            , m_addend_used(addend_used)
         {
         }
 
@@ -171,9 +174,17 @@ public:
             return m_image.symbol(symbol_index());
         }
 
+        bool addend_used() const { return m_addend_used; }
+        unsigned addend() const
+        {
+            VERIFY(m_addend_used);
+            return m_rel.r_addend;
+        }
+
     private:
         Image const& m_image;
-        Elf_Rel const& m_rel;
+        Elf_Rela const& m_rel;
+        bool m_addend_used;
     };
 
     unsigned symbol_count() const;

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -125,7 +125,6 @@ public:
         FlatPtr address() const { return m_section_header.sh_addr; }
         char const* raw_data() const { return m_image.raw_data(m_section_header.sh_offset); }
         ReadonlyBytes bytes() const { return { raw_data(), size() }; }
-        Optional<RelocationSection> relocations() const;
         auto flags() const { return m_section_header.sh_flags; }
         bool is_writable() const { return flags() & SHF_WRITE; }
         bool is_executable() const { return flags() & PF_X; }


### PR DESCRIPTION
This EFI Prekernel will be used to boot the kernel on (U)EFI systems.
Currently, the Prekernel only actually runs the Kernel on RISC-V (as I still need to fix some bugs for x86 and aarch64 currently isn't bootable from arbitrary physical load addresses). The EFIPrekernel does boot on AArch64 and x86-64, it just panics before booting the kernel.

The EFIPrekernel doesn't pass the EFI cmdline to the kernel yet. The cmdline is hardcoded in the riscv64 kernel for now when booted via EFI.

Making it able to boot the riscv64 kernel currently requires this patch: https://gist.github.com/spholz/caee2a25ebab06e9b836b91748b717f8. I didn't add this patch to the PR, since it would break the current pre_init code and serenity.sh isn't able to use the efi prekernel yet.

~~This is currently a draft, as I still need to fix the cmake scripts.~~
~~Trying to do a clean build via `serenity.sh image` currently results in `error: unable to find library -lLibELF`.~~
~~The PrekernelPEImageGenerator also doesn't seem to get rerun when its code gets changed, but it seems to be rebuilt.~~