### PR TITLE
LibWeb: Set animation update flag from Animation::invalidate_effect()

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -1316,8 +1316,10 @@ JS::NonnullGCPtr<WebIDL::Promise> Animation::current_finished_promise() const
 void Animation::invalidate_effect()
 {
     if (m_effect) {
-        if (auto target = m_effect->target(); target && target->paintable())
+        if (auto target = m_effect->target(); target && target->paintable()) {
+            target->document().set_needs_animated_style_update();
             target->paintable()->set_needs_display();
+        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4064,8 +4064,6 @@ void Document::ensure_animation_timer()
                 for (auto& animation : timeline->associated_animations())
                     dispatch_events_for_animation_if_necessary(animation);
             }
-
-            m_needs_animated_style_update = true;
         }));
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -597,6 +597,7 @@ public:
     JS::GCPtr<Element const> scrolling_element() const;
 
     void set_needs_to_resolve_paint_only_properties() { m_needs_to_resolve_paint_only_properties = true; }
+    void set_needs_animated_style_update() { m_needs_animated_style_update = true; }
 
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual Vector<FlyString> supported_property_names() const override;


### PR DESCRIPTION
Fixes regressed animation tests.