### PR TITLE
LibWeb: Ensure enumerated attributes are always limited to known values

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/button-attributes.txt
+++ b/Tests/LibWeb/Text/expected/HTML/button-attributes.txt
@@ -1,3 +1,5 @@
 submit
 button
+button
+submit
 submit

--- a/Tests/LibWeb/Text/expected/HTML/crossOrigin-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/crossOrigin-attribute.txt
@@ -1,0 +1,21 @@
+audio crossOrigin initial value: null
+audio crossOrigin value after setting to "invalid": anonymous
+audio crossOrigin value after setting to "use-credentials": use-credentials
+audio crossOrigin value after setting to null: null
+audio crossOrigin value after setting to "USE-CREDENTIALS": use-credentials
+audio crossOrigin value after setting to "": anonymous
+audio crossOrigin value after calling removeAttribute: null
+script crossOrigin initial value: null
+script crossOrigin value after setting to "invalid": anonymous
+script crossOrigin value after setting to "use-credentials": use-credentials
+script crossOrigin value after setting to null: null
+script crossOrigin value after setting to "USE-CREDENTIALS": use-credentials
+script crossOrigin value after setting to "": anonymous
+script crossOrigin value after calling removeAttribute: null
+video crossOrigin initial value: null
+video crossOrigin value after setting to "invalid": anonymous
+video crossOrigin value after setting to "use-credentials": use-credentials
+video crossOrigin value after setting to null: null
+video crossOrigin value after setting to "USE-CREDENTIALS": use-credentials
+video crossOrigin value after setting to "": anonymous
+video crossOrigin value after calling removeAttribute: null

--- a/Tests/LibWeb/Text/input/HTML/button-attributes.html
+++ b/Tests/LibWeb/Text/input/HTML/button-attributes.html
@@ -5,6 +5,10 @@
         println(button.type);
         button.setAttribute("type", "button");
         println(button.type);
+        button.setAttribute("type", "BUTTON");
+        println(button.type);
+        button.setAttribute("type", "invalid");
+        println(button.type);
         button.removeAttribute("type");
         println(button.type);
     });

--- a/Tests/LibWeb/Text/input/HTML/crossOrigin-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/crossOrigin-attribute.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (let elementName of ["audio", "script", "video"]) {
+          const element = document.createElement(elementName);
+          println(`${elementName} crossOrigin initial value: ${element.crossOrigin}`);
+          element.crossOrigin = "invalid";
+          println(`${elementName} crossOrigin value after setting to "invalid": ${element.crossOrigin}`);
+          element.crossOrigin = "use-credentials";
+          println(`${elementName} crossOrigin value after setting to "use-credentials": ${element.crossOrigin}`);
+          element.crossOrigin = null;
+          println(`${elementName} crossOrigin value after setting to null: ${element.crossOrigin}`);
+          element.crossOrigin = "USE-CREDENTIALS";
+          println(`${elementName} crossOrigin value after setting to "USE-CREDENTIALS": ${element.crossOrigin}`);
+          element.crossOrigin = "";
+          println(`${elementName} crossOrigin value after setting to "": ${element.crossOrigin}`);
+          element.removeAttribute("crossOrigin");
+          println(`${elementName} crossOrigin value after calling removeAttribute: ${element.crossOrigin}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/CORSSettingAttribute.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CORSSettingAttribute.cpp
@@ -15,9 +15,6 @@ CORSSettingAttribute cors_setting_attribute_from_keyword(Optional<String> const&
         // its missing value default is the No CORS state
         return CORSSettingAttribute::NoCORS;
     }
-    if (keyword->is_empty() || keyword->bytes_as_string_view().equals_ignoring_ascii_case("anonymous"sv)) {
-        return CORSSettingAttribute::Anonymous;
-    }
     if (keyword->bytes_as_string_view().equals_ignoring_ascii_case("use-credentials"sv)) {
         return CORSSettingAttribute::UseCredentials;
     }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.idl
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.idl
@@ -1,7 +1,6 @@
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute
-[MissingValueDefault=, InvalidValueDefault=anonymous]
+[InvalidValueDefault=anonymous]
 enum CORSSettingsAttribute {
     "anonymous",
-    "",
     "use-credentials"
 };


### PR DESCRIPTION
Previously, the invalid value default wasn't taken into account when determining the value that should be returned from the getter of an enumerated attribute. This caused a crash when an enumerated attribute of type DOMString? was set to an invalid value.

I've also updated the values of `CrossOriginAttribute` to align it with the specification.