### PR TITLE
LibGfx/ISOBMFF: Support box header size 0 to mean "until end of data"

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.cpp
@@ -8,7 +8,7 @@
 
 namespace Gfx::ISOBMFF {
 
-ErrorOr<BoxHeader> read_box_header(Stream& stream)
+ErrorOr<BoxHeader> read_box_header(BoxStream& stream)
 {
     BoxHeader header;
     u64 total_size = TRY(stream.read_value<BigEndian<u32>>());
@@ -16,12 +16,16 @@ ErrorOr<BoxHeader> read_box_header(Stream& stream)
 
     u64 data_size_read = sizeof(u32) + sizeof(BoxType);
 
-    if (total_size == 1) {
-        total_size = TRY(stream.read_value<BigEndian<u64>>());
-        data_size_read += sizeof(u64);
-    }
+    if (total_size == 0) {
+        header.contents_size = stream.remaining();
+    } else {
+        if (total_size == 1) {
+            total_size = TRY(stream.read_value<BigEndian<u64>>());
+            data_size_read += sizeof(u64);
+        }
 
-    header.contents_size = total_size - data_size_read;
+        header.contents_size = total_size - data_size_read;
+    }
     return header;
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.h
@@ -26,7 +26,7 @@ struct BoxHeader {
     u64 contents_size { 0 };
 };
 
-ErrorOr<BoxHeader> read_box_header(Stream& stream);
+ErrorOr<BoxHeader> read_box_header(BoxStream& stream);
 
 struct Box {
     Box() = default;

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
@@ -10,7 +10,8 @@ namespace Gfx::ISOBMFF {
 
 ErrorOr<Reader> Reader::create(MaybeOwned<SeekableStream> stream)
 {
-    return Reader(move(stream));
+    size_t size = TRY(stream->size());
+    return Reader(move(stream), size);
 }
 
 ErrorOr<BoxList> Reader::read_entire_file()
@@ -18,8 +19,8 @@ ErrorOr<BoxList> Reader::read_entire_file()
     BoxList top_level_boxes;
 
     while (!m_stream->is_eof()) {
-        auto box_header = TRY(read_box_header(*m_stream));
-        BoxStream box_stream { *m_stream, static_cast<size_t>(box_header.contents_size) };
+        auto box_header = TRY(read_box_header(m_box_stream));
+        BoxStream box_stream { m_box_stream, static_cast<size_t>(box_header.contents_size) };
 
         switch (box_header.type) {
         case BoxType::FileTypeBox:

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.h
@@ -23,14 +23,16 @@ public:
     ErrorOr<Vector<BrandIdentifier>> get_minor_brands();
 
 private:
-    Reader(MaybeOwned<SeekableStream> stream)
+    Reader(MaybeOwned<SeekableStream> stream, size_t size)
         : m_stream(move(stream))
+        , m_box_stream(*m_stream, size)
     {
     }
 
     ErrorOr<void> parse_initial_data();
 
     MaybeOwned<SeekableStream> m_stream;
+    BoxStream m_box_stream;
 };
 
 }


### PR DESCRIPTION
JPEG2000 uses this, and as far as I can tell it's also part of
ISO/IEC 14496-12.

--

With this, `isobmff` can dump .jp2 files I have flying around.

@Zaggy1024 