### PR TITLE
LibWeb: Change Element::closest() to check if any of selector matches

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Element-closest.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-closest.txt
@@ -1,0 +1,1 @@
+  <DIV id="target" >

--- a/Tests/LibWeb/Text/input/DOM/Element-closest.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-closest.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div class="a" id="target"><div id="nested"></div></div>
+<script>    
+    test(() => {
+        const matchingElement = document.getElementById("nested").closest(".a, .b, .c");
+        printElement(matchingElement);     
+    });
+</script>
+</html>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -678,11 +678,11 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
         // 4. For each element in elements, if match a selector against an element, using s, element, and scoping root this, returns success, return element.
-        for (auto& selector : selector_list) {
-            if (!SelectorEngine::matches(selector, {}, *element, {}, this))
-                return false;
+        for (auto const& selector : selector_list) {
+            if (SelectorEngine::matches(selector, {}, *element, {}, this))
+                return true;
         }
-        return true;
+        return false;
     };
 
     auto const selector_list = maybe_selectors.release_value();


### PR DESCRIPTION
...instead of checking if all selectors match an element.

Fixes bug reduced from GitHub's "new issue" page.