### PR TITLE
LibWeb+LibWebView: Properly handle EOF in the middle of a comment

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -137,11 +137,17 @@ namespace Web::HTML {
         return m_queued_tokens.dequeue();               \
     } while (0)
 
-#define EMIT_CURRENT_TOKEN                              \
+#define EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF              \
     do {                                                \
         VERIFY(m_current_builder.is_empty());           \
         will_emit(m_current_token);                     \
         m_queued_tokens.enqueue(move(m_current_token)); \
+                                                        \
+        m_has_emitted_eof = true;                       \
+        create_new_token(HTMLToken::Type::EndOfFile);   \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+                                                        \
         return m_queued_tokens.dequeue();               \
     } while (0)
 
@@ -1428,7 +1434,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    EMIT_EOF;
+                    EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF;
                 }
                 ANYTHING_ELSE
                 {
@@ -1460,7 +1466,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.set_comment(consume_current_builder());
-                    EMIT_EOF;
+                    EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF;
                 }
                 ANYTHING_ELSE
                 {
@@ -1491,7 +1497,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.set_comment(consume_current_builder());
-                    EMIT_EOF;
+                    EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF;
                 }
                 ANYTHING_ELSE
                 {
@@ -1519,7 +1525,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.set_comment(consume_current_builder());
-                    EMIT_EOF;
+                    EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF;
                 }
                 ANYTHING_ELSE
                 {
@@ -1540,7 +1546,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.set_comment(consume_current_builder());
-                    EMIT_EOF;
+                    EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF;
                 }
                 ANYTHING_ELSE
                 {

--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -60,7 +60,7 @@ String highlight_source(URL::URL const& url, StringView source)
         previous_position = end_position;
     };
 
-    for (auto token = tokenizer.next_token(); token.has_value(); token = tokenizer.next_token()) {
+    for (auto token = tokenizer.next_token(); token.has_value() && !token->is_end_of_file(); token = tokenizer.next_token()) {
         if (token->is_comment()) {
             append_source(token->start_position().byte_offset);
             append_source(token->end_position().byte_offset, "comment"sv);


### PR DESCRIPTION
Fixes #23683

First commit fixes the crash, second commit is so we can actually see the source.

View-source after the first commit:
![before](https://github.com/SerenityOS/serenity/assets/5600524/da98c060-fe36-42fd-8483-dbba8940f7b0)

View-source after the second commit:
![after](https://github.com/SerenityOS/serenity/assets/5600524/e809f458-b3c6-4aff-a0e4-032201291172)
