### PR TITLE
LibWeb: Allow any FC type for replaced boxes in dimension_box_on_line()

### DIFF
--- a/Tests/LibWeb/Layout/expected/inline-flex-with-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/inline-flex-with-aspect-ratio.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from Box start: 0, length: 0, rect: [8,8 784x17] baseline: 13.296875
+      Box <div.inline-flex.aspect-ratio> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.img-wrapper> at (8,8) content-size 10x17 flex-item [BFC] children: inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,11 10x10] baseline: 10
+          ImageBox <img> at (8,11) content-size 10x10 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      PaintableBox (Box<DIV>.inline-flex.aspect-ratio) [8,8 784x17]
+        PaintableWithLines (BlockContainer<DIV>.img-wrapper) [8,8 10x17]
+          ImagePaintable (ImageBox<IMG>) [8,11 10x10]

--- a/Tests/LibWeb/Layout/input/inline-flex-with-aspect-ratio.html
+++ b/Tests/LibWeb/Layout/input/inline-flex-with-aspect-ratio.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><style>
+.inline-flex {
+    display: inline-flex
+}
+
+.aspect-ratio {
+    aspect-ratio: .975
+}
+</style><div class="inline-flex aspect-ratio"><div class="img-wrapper"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAADUlEQVR4nGNgGAWkAwABNgABVtF/yAAAAABJRU5ErkJggg==">

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -120,9 +120,9 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     if (box_is_sized_as_replaced_element(box)) {
         box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space));
         box_state.set_content_height(compute_height_for_replaced_element(box, *m_available_space));
-
-        if (is<SVGSVGBox>(box))
-            (void)layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
+        auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
+        if (independent_formatting_context)
+            independent_formatting_context->parent_context_did_dimension_child_root_box();
         return;
     }
 


### PR DESCRIPTION
If box is sized as replaced it still could be anything, not only SVG.

This fixes crashing on https://www.shopify.com/ that was caused by a missing paintable for a box that has a layout node. This occurred because the box was not laid out in dimension_box_on_line().