### PR TITLE
LibRegex: Account for extra explicit And/Or in class parser assertion

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -800,6 +800,7 @@ TEST_CASE(ECMA262_unicode_sets_parser_error)
 
     constexpr _test tests[] {
         { "[[]"sv, regex::Error::InvalidPattern },
+        { "[[x[]]]"sv, regex::Error::NoError }, // #23691, should not crash on empty charclass within AndOr.
     };
 
     for (auto test : tests) {

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -2386,7 +2386,12 @@ bool ECMA262Parser::parse_nested_class(Vector<regex::CompareTypeAndValuePair>& c
         if (match(TokenType::RightBracket)) {
             consume();
             // Should only have at most an 'Inverse' (after an 'Or')
-            VERIFY(compares.size() <= 2);
+            if (m_parser_state.regex_options.has_flag_set(regex::AllFlags::UnicodeSets)) {
+                // In unicode sets mode, we can have an additional 'And'/'Or' before the 'Inverse'.
+                VERIFY(compares.size() <= 3);
+            } else {
+                VERIFY(compares.size() <= 2);
+            }
             compares.append(CompareTypeAndValuePair { CharacterCompareType::EndAndOr, 0 });
             return true;
         }


### PR DESCRIPTION
Fixes #23691.