### PR TITLE
LibGfx/JBIG2: Implement refinement coding for text segments

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1608,9 +1608,13 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
 
     // 7.4.3.1.3 Text region refinement AT flags
     // "This field is only present if SBREFINE is 1 and SBRTEMPLATE is 0."
-    // FIXME: Support this eventually.
-    if (uses_refinement_coding && refinement_template == 0)
-        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode text region refinement AT flags yet");
+    Array<AdaptiveTemplatePixel, 2> adaptive_refinement_template {};
+    if (uses_refinement_coding && refinement_template == 0) {
+        for (size_t i = 0; i < adaptive_refinement_template.size(); ++i) {
+            adaptive_refinement_template[i].x = TRY(stream.read_value<i8>());
+            adaptive_refinement_template[i].y = TRY(stream.read_value<i8>());
+        }
+    }
 
     // 7.4.3.1.4 Number of symbol instances (SBNUMINSTANCES)
     u32 number_of_symbol_instances = TRY(stream.read_value<BigEndian<u32>>());
@@ -1656,7 +1660,7 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     inputs.symbols = move(symbols);
     // FIXME: Huffman tables.
     inputs.refinement_template = refinement_template;
-    // FIXME: inputs.refinement_adaptive_template_pixels;
+    inputs.refinement_adaptive_template_pixels = adaptive_refinement_template;
 
     auto result = TRY(text_region_decoding_procedure(inputs, data.slice(TRY(stream.tell()))));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -964,8 +964,23 @@ struct GenericRefinementRegionDecodingInputParameters {
 };
 
 // 6.3 Generic Refinement Region Decoding Procedure
-static ErrorOr<NonnullOwnPtr<BitBuffer>> generic_refinement_region_decoding_procedure(GenericRefinementRegionDecodingInputParameters&)
+static ErrorOr<NonnullOwnPtr<BitBuffer>> generic_refinement_region_decoding_procedure(GenericRefinementRegionDecodingInputParameters& inputs)
 {
+    VERIFY(inputs.gr_template == 0 || inputs.gr_template == 1);
+
+    if (inputs.is_typical_prediction_used)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode typical prediction in generic refinement regions yet");
+
+    if (inputs.gr_template == 0) {
+        if (inputs.adaptive_template_pixels[0].x != -1 || inputs.adaptive_template_pixels[0].y != -1
+            || inputs.adaptive_template_pixels[1].x != -1 || inputs.adaptive_template_pixels[1].y != -1)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot handle custom adaptive pixels in refinement regions yet");
+    }
+    // GRTEMPLATE 1 never uses adaptive pixels.
+
+    if (inputs.gr_template == 1)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode GRTEMPLATE 1 yet");
+
     return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode generic refinement regions yet");
 }
 


### PR DESCRIPTION
With this, we can decode all pages of `0000425.pdf`, `0000215.pdf`,
`0000882.pdf`, and `0000057.pdf`.

As part of this, implement basic support for the generic refinement decoding procedure.

For refinement coding, we get a symbol bitmap, and then decode a "refinement bitmap". This refinement bitmap can use pixels in the original bitmap as context, even to the right and bottom of the current pixel.

(Not yet supported: template 1, custom adaptive pixels, typical prediction for refinement coding. Template 1 is used by one PDF in my test set and will be in a future PR. I haven't seen the rest being used in practice yet.)

---

Overview articles of JBIG2 usually describe the symbol/text system and refinement. With this, we have all those parts (even if they're all technically incomplete), which is pretty cool :^)