### PR TITLE
LibWeb: Reschedule repaint for navigables with ongoing painting

### DIFF
--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -105,8 +105,11 @@ void PageClient::ready_to_paint()
 {
     auto old_paint_state = exchange(m_paint_state, PaintState::Ready);
 
-    if (old_paint_state == PaintState::PaintWhenReady)
-        schedule_repaint();
+    if (old_paint_state == PaintState::PaintWhenReady) {
+        // NOTE: Repainting always has to be scheduled from HTML event loop processing steps
+        //       to make sure style and layout are up-to-date.
+        page().top_level_traversable()->set_needs_display();
+    }
 }
 
 void PageClient::add_backing_store(i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap)


### PR DESCRIPTION
Fixes delayed repainting in the following case:
1. Style or layout invalidation triggers html event loop processing.
2. Event loop processing does nothing because there is no rendering opportunity.
3. Style or layout change won't be reflected until something else triggers event loop processing