### PR TITLE
LibDeviceTree+Firmware+riscv: Some steps toward a more general DeviceTree interface and RPi device trees

### DIFF
--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -14,12 +14,22 @@ Currently only UART output is supported, no display.
 
 Please follow [build instructions](BuildInstructions.md) to download and build Serenity. Make sure everything builds successfully for x86.
 
+It is also recommended to download an appropriate devicetree blob for your Raspberry Pi model.
+You can find them in the [Raspberry Pi firmware repository](https://github.com/raspberrypi/firmware/tree/master/boot),
+for example `bcm2710-rpi-3-b.dtb` for Raspberry Pi 3B.
+
 ### Step 2: Build and run in emulator
 
 Use the following command to build and run the AArch64 version of the system:
 
 ```console
 Meta/serenity.sh run aarch64
+```
+
+If you have a devicetree blob, you can pass it to QEMU using the `SERENITY_EXTRA_QEMU_ARGS` environment variable:
+
+```console
+SERENITY_EXTRA_QEMU_ARGS="-dtb PATH_TO_YOUR_DEVICETREE_BLOB" Meta/serenity.sh run aarch64
 ```
 
 It should build Serenity and open a QEMU window, similar to the x86 version. You should see some messages in the terminal.

--- a/Kernel/Arch/aarch64/CPU.h
+++ b/Kernel/Arch/aarch64/CPU.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Types.h>
+#include <Kernel/Memory/PhysicalAddress.h>
 
 namespace Kernel {
 
@@ -17,7 +18,7 @@ void dbgln_without_mmu(StringView);
 
 namespace Memory {
 
-void init_page_tables();
+void init_page_tables(PhysicalPtr fdt_ptr);
 void unmap_identity_map();
 
 }

--- a/Kernel/Arch/aarch64/pre_init.cpp
+++ b/Kernel/Arch/aarch64/pre_init.cpp
@@ -19,15 +19,17 @@ namespace Kernel {
 
 extern "C" [[noreturn]] void init();
 
-extern "C" [[noreturn]] void pre_init();
-extern "C" [[noreturn]] void pre_init()
+// https://github.com/raspberrypi/linux/blob/rpi-5.10.y/Documentation/arm/booting.rst#6-calling-the-kernel-image
+// FIXME: Depending on the machine type, the third argument might not a pointer to the flattened device tree
+extern "C" [[noreturn]] void pre_init(PhysicalPtr);
+extern "C" [[noreturn]] void pre_init(PhysicalPtr fdt_ptr)
 {
     // We want to drop to EL1 as soon as possible, because that is the
     // exception level the kernel should run at.
     initialize_exceptions();
 
     // Next step is to set up page tables and enable the MMU.
-    Memory::init_page_tables();
+    Memory::init_page_tables(fdt_ptr);
 
     // At this point the MMU is enabled, physical memory is identity mapped,
     // and the kernel is also mapped into higher virtual memory. However we are still executing

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -42,6 +42,7 @@
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Firmware/ACPI/Initialize.h>
 #include <Kernel/Firmware/ACPI/Parser.h>
+#include <Kernel/Firmware/Devicetree/Devicetree.h>
 #include <Kernel/Heap/kmalloc.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Library/Panic.h>

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -193,31 +193,41 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     multiboot_framebuffer_bpp = boot_info.multiboot_framebuffer_bpp;
     multiboot_framebuffer_type = boot_info.multiboot_framebuffer_type;
 #elif ARCH(AARCH64)
-    // FIXME: For the aarch64 platforms, we should get the information by parsing a device tree instead of using multiboot.
-    auto [ram_base, ram_size] = RPi::Mailbox::the().query_lower_arm_memory_range();
-    auto [vcmem_base, vcmem_size] = RPi::Mailbox::the().query_videocore_memory_range();
-    multiboot_memory_map_t mmap[] = {
-        {
-            sizeof(struct multiboot_mmap_entry) - sizeof(u32),
-            (u64)ram_base,
-            (u64)ram_size,
-            MULTIBOOT_MEMORY_AVAILABLE,
-        },
-        {
-            sizeof(struct multiboot_mmap_entry) - sizeof(u32),
-            (u64)vcmem_base,
-            (u64)vcmem_size,
-            MULTIBOOT_MEMORY_RESERVED,
-        },
-        // FIXME: VideoCore only reports the first 1GB of RAM, the rest only shows up in the device tree.
-    };
-    multiboot_memory_map = mmap;
-    multiboot_memory_map_count = 2;
+    // FIXME: Remove the later part of this if-statement once qemu generates its own FTD for aarch64
+    if (verify_fdt()) {
+        auto maybe_command_line = get_command_line_from_fdt();
+        if (maybe_command_line.is_error()) {
+            dmesgln("Failed to get command line from FDT: {}", maybe_command_line.error());
+            kernel_cmdline = "serial_debug dump_fdt"sv;
+        } else {
+            kernel_cmdline = maybe_command_line.value();
+        }
+    } else {
+        auto [ram_base, ram_size] = RPi::Mailbox::the().query_lower_arm_memory_range();
+        auto [vcmem_base, vcmem_size] = RPi::Mailbox::the().query_videocore_memory_range();
+        multiboot_memory_map_t mmap[] = {
+            {
+                sizeof(struct multiboot_mmap_entry) - sizeof(u32),
+                (u64)ram_base,
+                (u64)ram_size,
+                MULTIBOOT_MEMORY_AVAILABLE,
+            },
+            {
+                sizeof(struct multiboot_mmap_entry) - sizeof(u32),
+                (u64)vcmem_base,
+                (u64)vcmem_size,
+                MULTIBOOT_MEMORY_RESERVED,
+            },
+            // FIXME: VideoCore only reports the first 1GB of RAM, the rest only shows up in the device tree.
+        };
+        multiboot_memory_map = mmap;
+        multiboot_memory_map_count = 2;
 
-    multiboot_modules = nullptr;
-    multiboot_modules_count = 0;
-    // FIXME: Read the /chosen/bootargs property.
-    kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
+        multiboot_modules = nullptr;
+        multiboot_modules_count = 0;
+        // FIXME: Read the /chosen/bootargs property.
+        kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
+    }
 #elif ARCH(RISCV64)
     // FIXME: Technically we cant panic here, as serial debugging is not enabled yet,
     //        as that depends on the command line.

--- a/Kernel/Arch/riscv64/CPU.cpp
+++ b/Kernel/Arch/riscv64/CPU.cpp
@@ -4,45 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Singleton.h>
 #include <Kernel/Arch/riscv64/CPU.h>
-#include <Kernel/Memory/MemoryManager.h>
-#include <LibDeviceTree/DeviceTree.h>
-#include <Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h>
-#include <Userland/Libraries/LibDeviceTree/Validation.h>
-
-static Singleton<OwnPtr<DeviceTree::DeviceTree>> s_device_tree;
 
 namespace Kernel {
 
 BootInfo s_boot_info;
 
-alignas(PAGE_SIZE) __attribute__((section(".bss.fdt"))) u8 s_fdt_storage[fdt_storage_size];
-
-ErrorOr<void> unflatten_fdt()
-{
-    *s_device_tree = TRY(DeviceTree::DeviceTree::parse({ s_fdt_storage, fdt_storage_size }));
-    return {};
-}
-
-void dump_fdt()
-{
-    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
-    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
-    MUST(DeviceTree::dump(header, fdt));
-}
-
-ErrorOr<StringView> get_command_line_from_fdt()
-{
-    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
-    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
-    return TRY(DeviceTree::slow_get_property("/chosen/bootargs"sv, header, fdt)).as_string();
-}
-
-}
-
-DeviceTree::DeviceTree const& DeviceTree::get()
-{
-    VERIFY(*s_device_tree);
-    return **s_device_tree;
 }

--- a/Kernel/Arch/riscv64/CPU.h
+++ b/Kernel/Arch/riscv64/CPU.h
@@ -6,27 +6,13 @@
 
 #pragma once
 
-#include <Kernel/Memory/PhysicalAddress.h>
 #include <Kernel/Prekernel/Prekernel.h>
-#include <LibDeviceTree/DeviceTree.h>
 
 #include <AK/Platform.h>
 VALIDATE_IS_RISCV64()
 
 namespace Kernel {
 
-constexpr size_t fdt_storage_size = 2 * MiB;
-extern u8 s_fdt_storage[fdt_storage_size];
-
-// FIXME: These should move to an architecture independent location,
-//        once we need device tree parsing in other architectures, like aarch64
 extern BootInfo s_boot_info;
 
-ErrorOr<void> unflatten_fdt();
-void dump_fdt();
-ErrorOr<StringView> get_command_line_from_fdt();
-}
-
-namespace DeviceTree {
-DeviceTree const& get();
 }

--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -11,6 +11,7 @@
 #include <Kernel/Arch/riscv64/PageDirectory.h>
 #include <Kernel/Arch/riscv64/SBI.h>
 #include <Kernel/Arch/riscv64/pre_init.h>
+#include <Kernel/Firmware/Devicetree/Devicetree.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Sections.h>
 #include <LibDeviceTree/FlattenedDeviceTree.h>

--- a/Kernel/Arch/riscv64/PCI/Initializer.cpp
+++ b/Kernel/Arch/riscv64/PCI/Initializer.cpp
@@ -11,6 +11,7 @@
 #include <Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.h>
 #include <Kernel/Bus/PCI/Initializer.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h>
+#include <Kernel/Firmware/Devicetree/Devicetree.h>
 #include <Userland/Libraries/LibDeviceTree/DeviceTree.h>
 
 namespace Kernel::PCI {

--- a/Kernel/Arch/riscv64/Timer.cpp
+++ b/Kernel/Arch/riscv64/Timer.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/Arch/riscv64/CPU.h>
 #include <Kernel/Arch/riscv64/SBI.h>
 #include <Kernel/Arch/riscv64/Timer.h>
+#include <Kernel/Firmware/Devicetree/Devicetree.h>
 
 namespace Kernel::RISCV64 {
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -232,6 +232,7 @@ set(KERNEL_SOURCES
     Firmware/ACPI/Initialize.cpp
     Firmware/ACPI/Parser.cpp
     Firmware/ACPI/StaticParsing.cpp
+    Firmware/Devicetree/Devicetree.cpp
     Interrupts/GenericInterruptHandler.cpp
     Interrupts/IRQHandler.cpp
     Interrupts/PCIIRQHandler.cpp

--- a/Kernel/Firmware/Devicetree/Devicetree.cpp
+++ b/Kernel/Firmware/Devicetree/Devicetree.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Devicetree.h"
+#include <AK/Singleton.h>
+#include <Kernel/Memory/MemoryManager.h>
+#include <LibDeviceTree/DeviceTree.h>
+#include <Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h>
+#include <Userland/Libraries/LibDeviceTree/Validation.h>
+
+static Singleton<OwnPtr<DeviceTree::DeviceTree>> s_device_tree;
+
+namespace Kernel {
+
+alignas(PAGE_SIZE) __attribute__((section(".bss.fdt"))) u8 s_fdt_storage[fdt_storage_size];
+
+ErrorOr<void> unflatten_fdt()
+{
+    *s_device_tree = TRY(DeviceTree::DeviceTree::parse({ s_fdt_storage, fdt_storage_size }));
+    return {};
+}
+
+bool verify_fdt()
+{
+    static bool verified { false };
+    static bool verification_succeeded { false };
+
+    if (verified)
+        return verification_succeeded;
+
+    verified = true;
+    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
+    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
+
+    verification_succeeded = DeviceTree::validate_flattened_device_tree(header, fdt, DeviceTree::Verbose::Yes);
+
+    return verification_succeeded;
+}
+
+void dump_fdt()
+{
+    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
+    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
+    MUST(DeviceTree::dump(header, fdt));
+}
+
+ErrorOr<StringView> get_command_line_from_fdt()
+{
+    auto& header = *bit_cast<DeviceTree::FlattenedDeviceTreeHeader*>(&s_fdt_storage[0]);
+    auto fdt = ReadonlyBytes(s_fdt_storage, header.totalsize);
+    return TRY(DeviceTree::slow_get_property("/chosen/bootargs"sv, header, fdt)).as_string();
+}
+
+}
+
+DeviceTree::DeviceTree const& DeviceTree::get()
+{
+    VERIFY(*s_device_tree);
+    return **s_device_tree;
+}

--- a/Kernel/Firmware/Devicetree/Devicetree.h
+++ b/Kernel/Firmware/Devicetree/Devicetree.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Memory/PhysicalAddress.h>
+#include <LibDeviceTree/DeviceTree.h>
+
+namespace Kernel {
+constexpr size_t fdt_storage_size = 2 * MiB;
+extern u8 s_fdt_storage[fdt_storage_size];
+
+ErrorOr<void> unflatten_fdt();
+bool verify_fdt();
+void dump_fdt();
+ErrorOr<StringView> get_command_line_from_fdt();
+}
+
+namespace DeviceTree {
+DeviceTree const& get();
+}

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -470,6 +470,12 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_fdt(MemoryManager::GlobalD
                     break;
                 case State::InReservedMemoryChild:
                     // FIXME: Handle non static allocations,
+                    if (!state.start.has_value()) {
+                        VERIFY(state.size.has_value());
+                        dbgln("MM: Non static reserved memory range {} of size {:#x}, skipping for now", node_name, state.size.value());
+                        state.state = State::InReservedMemory;
+                        break;
+                    }
                     VERIFY(state.start.has_value() && state.size.has_value());
                     dbgln("MM: Reserved Range {}: address: {} size {:#x}", node_name, PhysicalAddress { state.start.value() }, state.size.value());
                     global_data.physical_memory_ranges.append(PhysicalMemoryRange { PhysicalMemoryRangeType::Reserved, PhysicalAddress { state.start.value() }, state.size.value() });

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -15,6 +15,7 @@
 #include <Kernel/Boot/BootInfo.h>
 #include <Kernel/Boot/Multiboot.h>
 #include <Kernel/FileSystem/Inode.h>
+#include <Kernel/Firmware/Devicetree/Devicetree.h>
 #include <Kernel/Heap/kmalloc.h>
 #include <Kernel/Interrupts/InterruptDisabler.h>
 #include <Kernel/KSyms.h>

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -387,6 +387,17 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_fdt(MemoryManager::GlobalD
     auto fdt_buffer = ReadonlyBytes(fdt_addr, fdt_header.totalsize);
 
     // FIXME: Parse the MemoryReservationBlock
+    auto const* mem_reserve_block = reinterpret_cast<DeviceTree::FlattenedDeviceTreeReserveEntry const*>(&fdt_buffer[fdt_header.off_mem_rsvmap]);
+
+    u64 next_block_offset = fdt_header.off_mem_rsvmap + sizeof(DeviceTree::FlattenedDeviceTreeReserveEntry);
+    while ((next_block_offset < fdt_header.off_dt_struct) && (*mem_reserve_block != DeviceTree::FlattenedDeviceTreeReserveEntry {})) {
+        dbgln("MM: Reserved Range /mem_reserve_block: address: {} size {:#x}", PhysicalAddress { mem_reserve_block->address }, mem_reserve_block->size);
+        global_data.physical_memory_ranges.append(PhysicalMemoryRange { PhysicalMemoryRangeType::Reserved, PhysicalAddress { mem_reserve_block->address }, mem_reserve_block->size });
+        // FIXME: Not all of these are "used", only those in "memory" are actually "used"
+        global_data.used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::BootModule, PhysicalAddress { mem_reserve_block->address }, PhysicalAddress { mem_reserve_block->address + mem_reserve_block->size } });
+        ++mem_reserve_block;
+        next_block_offset += sizeof(DeviceTree::FlattenedDeviceTreeReserveEntry);
+    }
 
     // Schema:
     // https://github.com/devicetree-org/dt-schema/blob/main/dtschema/schemas/root-node.yaml

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -689,7 +689,7 @@ hostfwd=tcp:{config.host_ip}:2222-10.0.2.15:22"
 
 def set_up_kernel(config: Configuration):
     if config.architecture == Arch.Aarch64:
-        config.kernel_and_initrd_arguments = ["-kernel", "Kernel/Kernel"]
+        config.kernel_and_initrd_arguments = ["-kernel", "Kernel/kernel8.img"]
     elif config.architecture == Arch.RISCV64:
         config.kernel_and_initrd_arguments = ["-kernel", "Kernel/Kernel.bin"]
     elif config.architecture == Arch.x86_64:

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from shutil import which
 from subprocess import run
 from typing import Any, Callable, Literal
+import shlex
 
 QEMU_MINIMUM_REQUIRED_MAJOR_VERSION = 6
 QEMU_MINIMUM_REQUIRED_MINOR_VERSION = 2
@@ -830,6 +831,8 @@ def assemble_arguments(config: Configuration) -> list[str | Path]:
         boch_src = Path(config.serenity_src or ".", "Meta/bochsrc")
         return [config.bochs_binary, "-q", "-f", boch_src]
 
+    passed_qemu_args = shlex.split(environ.get("SERENITY_EXTRA_QEMU_ARGS", ""))
+
     return [
         config.qemu_binary or "",
         # Deviate from standard order here:
@@ -855,6 +858,7 @@ def assemble_arguments(config: Configuration) -> list[str | Path]:
         *config.network_default_arguments,
         *config.boot_drive_arguments,
         *config.character_device_arguments,
+        *passed_qemu_args,
     ]
 
 

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.cpp
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.cpp
@@ -58,6 +58,17 @@ ErrorOr<NonnullOwnPtr<DeviceTree>> DeviceTree::parse(ReadonlyBytes flattened_dev
             },
         }));
 
+    // FIXME: While growing the a nodes children map, we might have reallocated it's storage
+    //        breaking the parent pointers of the children, so we need to fix them here
+    auto fix_parent = [](auto self, DeviceTreeNodeView& node) -> void {
+        for (auto& [name, child] : node.children()) {
+            child.m_parent = &node;
+            self(self, child);
+        }
+    };
+
+    fix_parent(fix_parent, *device_tree);
+
     return device_tree;
 }
 

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -19,6 +19,20 @@
 namespace DeviceTree {
 
 struct DeviceTreeProperty {
+    class ValueStream : public FixedMemoryStream {
+    public:
+        using AK::FixedMemoryStream::FixedMemoryStream;
+
+        ErrorOr<FlatPtr> read_cells(u32 cell_size)
+        {
+            // FIXME: There are rare cases of 3 cell size big values, even in addresses, especially in addresses
+            VERIFY(cell_size <= 2);
+            if (cell_size == 1)
+                return read_value<BigEndian<u32>>();
+            return read_value<BigEndian<u64>>();
+        }
+    };
+
     ReadonlyBytes raw_data;
 
     size_t size() const { return raw_data.size(); }
@@ -73,7 +87,7 @@ struct DeviceTreeProperty {
         return {};
     }
 
-    FixedMemoryStream as_stream() const { return FixedMemoryStream { raw_data }; }
+    ValueStream as_stream() const { return ValueStream { raw_data }; }
 };
 
 class DeviceTreeNodeView {


### PR DESCRIPTION
### LibDeviceTree: Add some helper functions for traversing the device tree


### Kernel/Firmware+riscv64: Move devicetree handling to Firmware directory

This also adds a `verify_fdt` method which will be used in later commits

### Kernel/MM: Parse /mem_reserve_block node in FDT memory map mode

These seem to be actually used in the RPi FTDs

### Kernel/MM: Skip non static reserved memory regions instead of crashing

Crashing seems a bit harsh, so let's just skip them instead, as they
actually show up in the device tree of RPis.

### Kernel/riscv64: Use new DT accessors for PCI controller enumeration


### Kernel/riscv64: Verify that the FDT is valid before using it

Also adjust the command line that is used when querying it from the FDT
fails.

### Kernel/aarch64: Safe the device tree, if we were passed one


### Kernel/aarch64: Use the FTD to get the device/boot info, if available

This brings it closer in line with the riscv paths, but is still
separated, as we are not always passed in a FDT, as qemu does not create
one for us, so we still need to support the old way of getting a memory
map and the kernel command line

### Meta/run.py: Bring back `SERENITY_EXTRA_QEMU_ARGS`


### Meta/aarch64: Use the `kernel8.img` for booting

This allows qemu to pass an fdt to the kernel.

### Documentation: Explain how to use devicetrees when booting on aarch64


### LibDeviceTree: Make DeviceTreeProperty::as_stream return a `ValueStream`

This new Stream class adds an interface to work in cell-sized chunks,
which is useful for parsing the data in a DeviceTreeProperty.

### LibDeviceTree: Fix up the parent chain in DeviceTree::parse

This is a bit of a hacky fix, but it works for now. We should probably
revisit this and come up with a better solution.

### LibDeviceTree: Add a address aware `reg()` API to DeviceTreeNodeView

This should also allow us to do handle more simple-bus devices in the
future, but the code for that was not added in this commit.

Also use it for the riscv PCI initialization code.