### PR TITLE
LibWeb: Remove cache for Paintable::is_visible()

### DIFF
--- a/Tests/LibWeb/Ref/change-opacity.html
+++ b/Tests/LibWeb/Ref/change-opacity.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/change-opacity-ref.html" />
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        background-color: greenyellow;
+        opacity: 0;
+    }
+</style>
+<div id="box"></div>
+<script>
+    document.getElementById("box").style.opacity = "1";
+</script>

--- a/Tests/LibWeb/Ref/reference/change-opacity-ref.html
+++ b/Tests/LibWeb/Ref/reference/change-opacity-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        background-color: greenyellow;
+    }
+</style>
+<div id="box"></div>

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -17,8 +17,6 @@ Paintable::Paintable(Layout::Node const& layout_node)
     , m_browsing_context(const_cast<HTML::BrowsingContext&>(layout_node.browsing_context()))
 {
     auto& computed_values = layout_node.computed_values();
-    m_visible = computed_values.visibility() == CSS::Visibility::Visible && computed_values.opacity() != 0;
-
     if (layout_node.is_grid_item() && computed_values.z_index().has_value()) {
         // https://www.w3.org/TR/css-grid-2/#z-order
         // grid items with z_index should behave as if position were "relative"
@@ -46,6 +44,12 @@ void Paintable::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_browsing_context);
     if (m_containing_block.has_value())
         visitor.visit(m_containing_block.value());
+}
+
+bool Paintable::is_visible() const
+{
+    auto const& computed_values = this->computed_values();
+    return computed_values.visibility() == CSS::Visibility::Visible && computed_values.opacity() != 0;
 }
 
 void Paintable::set_dom_node(JS::GCPtr<DOM::Node> dom_node)

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -56,7 +56,7 @@ class Paintable
 public:
     virtual ~Paintable();
 
-    [[nodiscard]] bool is_visible() const { return m_visible; }
+    [[nodiscard]] bool is_visible() const;
     [[nodiscard]] bool is_positioned() const { return m_positioned; }
     [[nodiscard]] bool is_fixed_position() const { return m_fixed_position; }
     [[nodiscard]] bool is_absolutely_positioned() const { return m_absolutely_positioned; }
@@ -233,7 +233,6 @@ private:
 
     SelectionState m_selection_state { SelectionState::None };
 
-    bool m_visible : 1 { false };
     bool m_positioned : 1 { false };
     bool m_fixed_position : 1 { false };
     bool m_absolutely_positioned : 1 { false };


### PR DESCRIPTION
...because it depends on computed values that could be changed without rebuilding paintable tree.