### PR TITLE
LibCore: Ignore timer events after stop() has been called

### DIFF
--- a/Userland/Libraries/LibCore/EventReceiver.cpp
+++ b/Userland/Libraries/LibCore/EventReceiver.cpp
@@ -41,6 +41,8 @@ void EventReceiver::event(Core::Event& event)
 {
     switch (event.type()) {
     case Core::Event::Timer:
+        if (!m_timer_id)
+            break; // Too late, the timer was already stopped.
         return timer_event(static_cast<TimerEvent&>(event));
     case Core::Event::ChildAdded:
     case Core::Event::ChildRemoved:


### PR DESCRIPTION
"Fixes" the RS crash with `!m_has_scheduled_finish`.