### PR TITLE
LibWeb: Fix endless spinning in apply_the_history_step()

### DIFF
--- a/Tests/LibWeb/Text/data/iframe-reload.html
+++ b/Tests/LibWeb/Text/data/iframe-reload.html
@@ -1,0 +1,12 @@
+<script>
+    window.addEventListener('message', event => {
+        if (event.data && event.data.action === 'reload') {
+            window.parent.postMessage({ action: 'acknowledge-asked-to-reload' });
+            location.reload();
+        }
+    });
+
+    window.addEventListener('load', () => {
+        window.parent.postMessage({ action: 'loaded' });
+    });
+</script>

--- a/Tests/LibWeb/Text/expected/navigation/location-reload-fetch.txt
+++ b/Tests/LibWeb/Text/expected/navigation/location-reload-fetch.txt
@@ -1,0 +1,3 @@
+iframe is loaded
+iframe is going to reload
+iframe is loaded

--- a/Tests/LibWeb/Text/expected/navigation/location-reload-srcdoc.txt
+++ b/Tests/LibWeb/Text/expected/navigation/location-reload-srcdoc.txt
@@ -1,0 +1,3 @@
+iframe is loaded
+iframe is going to reload
+iframe is loaded

--- a/Tests/LibWeb/Text/expected/navigation/remove-iframe-from-timeout-callback.txt
+++ b/Tests/LibWeb/Text/expected/navigation/remove-iframe-from-timeout-callback.txt
@@ -1,1 +1,1 @@
-  
+PASS: did not crash 

--- a/Tests/LibWeb/Text/input/navigation/location-reload-fetch.html
+++ b/Tests/LibWeb/Text/input/navigation/location-reload-fetch.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    let reloaded = false;
+    window.addEventListener('message', event => {
+        switch (event.data.action) {
+            case "loaded":
+                println("iframe is loaded");
+                if (!reloaded) {
+                    event.source.postMessage({ action: 'reload' });
+                    reloaded = true;
+                } else {
+                    internals.signalTextTestIsDone();
+                }
+                break;
+            case "acknowledge-asked-to-reload":
+                println("iframe is going to reload");
+                break;
+            default:
+                break;
+        }
+    });
+
+    document.addEventListener("DOMContentLoaded", () => {
+        const iframe = document.createElement('iframe');
+        iframe.src = "../../data/iframe-reload.html"
+        document.body.appendChild(iframe);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/location-reload-srcdoc.html
+++ b/Tests/LibWeb/Text/input/navigation/location-reload-srcdoc.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    let reloaded = false;
+    window.addEventListener('message', event => {
+        switch (event.data.action) {
+            case "loaded":
+                println("iframe is loaded");
+                if (!reloaded) {
+                    event.source.postMessage({ action: 'reload' });
+                    reloaded = true;
+                } else {
+                    internals.signalTextTestIsDone();
+                }
+                break;
+            case "acknowledge-asked-to-reload":
+                println("iframe is going to reload");
+                break;
+            default:
+                break;
+        }
+    });
+
+    const iframeScript = `
+        window.addEventListener('message', event => {
+            if (event.data && event.data.action === 'reload') {
+                window.parent.postMessage({ action: 'acknowledge-asked-to-reload' });
+                location.reload();
+            }
+        });
+
+        window.addEventListener('load', () => {
+            window.parent.postMessage({ action: 'loaded' });
+        });
+    `;
+    
+    document.addEventListener("DOMContentLoaded", () => {
+        const iframe = document.createElement('iframe');
+        iframe.srcdoc = "<script>" + iframeScript + "<\/script>";
+        document.body.appendChild(iframe);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/remove-iframe-from-timeout-callback.html
+++ b/Tests/LibWeb/Text/input/navigation/remove-iframe-from-timeout-callback.html
@@ -1,12 +1,16 @@
-<script src="../include.js"></script>
-<div id="foo">
-    <iframe></iframe>
-    <script>
-        setTimeout(function () {
-            foo.remove();
-            // Pass (didn't crash)
-            internals.signalTextTestIsDone();
+<script src="../include.js"></script><div id="foo"><iframe></iframe><script>
+    setTimeout(function () {
+        foo.remove();
+        window.done = true;
+    }, 0);
+</script></div><iframe></iframe><script>
+    asyncTest(function (done) {
+        let internalId;
+        internalId = setInterval(function () {
+            if (window.done) {
+                clearInterval(internalId);
+                done();
+            }
         }, 0);
-    </script>
-</div>
-<iframe></iframe>
+    });
+</script>PASS: did not crash

--- a/Userland/Libraries/LibWeb/HTML/DocumentState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DocumentState.cpp
@@ -27,4 +27,22 @@ void DocumentState::visit_edges(Cell::Visitor& visitor)
     }
 }
 
+JS::NonnullGCPtr<DocumentState> DocumentState::clone() const
+{
+    JS::NonnullGCPtr<DocumentState> cloned = *heap().allocate_without_realm<DocumentState>();
+    cloned->m_document = m_document;
+    cloned->m_history_policy_container = m_history_policy_container;
+    cloned->m_request_referrer = m_request_referrer;
+    cloned->m_request_referrer_policy = m_request_referrer_policy;
+    cloned->m_initiator_origin = m_initiator_origin;
+    cloned->m_origin = m_origin;
+    cloned->m_about_base_url = m_about_base_url;
+    cloned->m_nested_histories = m_nested_histories;
+    cloned->m_resource = m_resource;
+    cloned->m_reload_pending = m_reload_pending;
+    cloned->m_ever_populated = m_ever_populated;
+    cloned->m_navigable_target_name = m_navigable_target_name;
+    return cloned;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/DocumentState.h
+++ b/Userland/Libraries/LibWeb/HTML/DocumentState.h
@@ -31,6 +31,8 @@ public:
 
     virtual ~DocumentState();
 
+    JS::NonnullGCPtr<DocumentState> clone() const;
+
     enum class Client {
         Tag,
     };

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -28,6 +28,23 @@ SessionHistoryEntry::SessionHistoryEntry()
 {
 }
 
+JS::NonnullGCPtr<SessionHistoryEntry> SessionHistoryEntry::clone() const
+{
+    JS::NonnullGCPtr<SessionHistoryEntry> entry = *heap().allocate_without_realm<SessionHistoryEntry>();
+    entry->m_step = m_step;
+    entry->m_url = m_url;
+    entry->m_document_state = m_document_state->clone();
+    entry->m_classic_history_api_state = m_classic_history_api_state;
+    entry->m_navigation_api_state = m_navigation_api_state;
+    entry->m_navigation_api_key = m_navigation_api_key;
+    entry->m_navigation_api_id = m_navigation_api_id;
+    entry->m_scroll_restoration_mode = m_scroll_restoration_mode;
+    entry->m_policy_container = m_policy_container;
+    entry->m_browsing_context_name = m_browsing_context_name;
+    entry->m_original_source_browsing_context = m_original_source_browsing_context;
+    return entry;
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#she-document
 JS::GCPtr<DOM::Document> SessionHistoryEntry::document() const
 {

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -37,6 +37,8 @@ public:
 
     void visit_edges(Cell::Visitor&) override;
 
+    JS::NonnullGCPtr<SessionHistoryEntry> clone() const;
+
     JS::GCPtr<DOM::Document> document() const;
 
     enum class Pending {

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -683,6 +683,11 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
 
     // 18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
     for (auto& navigable : non_changing_navigables_that_still_need_updates) {
+        if (navigable->has_been_destroyed()) {
+            ++completed_non_changing_jobs;
+            continue;
+        }
+
         queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&] {
             // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
             if (navigable->has_been_destroyed()) {

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -572,7 +572,7 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
         // AD-HOC: Since currently populate_session_history_entry_document does not run in parallel
         //         we call spin_until to interrupt execution of this function and let document population
         //         to complete.
-        main_thread_event_loop().spin_processing_tasks_with_source_until(Task::Source::NavigationAndTraversal, [&] {
+        main_thread_event_loop().spin_until([&] {
             return !changing_navigable_continuations.is_empty() || completed_change_jobs == total_change_jobs;
         });
 


### PR DESCRIPTION
While waiting for a task that populates a session history entry, we can't limit the processing of the event loop to the `NavigationAndTraversal` task source. This is because fetching uses the `Networking` task source, which also needs to be processed.

Since making a fetch request might take some time, we want to process everything on the event loop while waiting, to avoid blocking user interactions.

It is still possible to use `spin_processing_tasks_with_source_until()` on subsequent steps of `apply_the_history_step()`.