### PR TITLE
LibWeb/Fetch: Replace usages of AbortSignal::follow() in Fetch::Request 

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -108,29 +108,6 @@ void AbortSignal::visit_edges(JS::Cell::Visitor& visitor)
         visitor.visit(dependent_signal);
 }
 
-// https://dom.spec.whatwg.org/#abortsignal-follow
-void AbortSignal::follow(JS::NonnullGCPtr<AbortSignal> parent_signal)
-{
-    // A followingSignal (an AbortSignal) is made to follow a parentSignal (an AbortSignal) by running these steps:
-
-    // 1. If followingSignal is aborted, then return.
-    if (aborted())
-        return;
-
-    // 2. If parentSignal is aborted, then signal abort on followingSignal with parentSignal’s abort reason.
-    if (parent_signal->aborted()) {
-        signal_abort(parent_signal->reason());
-        return;
-    }
-
-    // 3. Otherwise, add the following abort steps to parentSignal:
-    // NOTE: `this` and `parent_signal` are protected by AbortSignal using JS::SafeFunction.
-    parent_signal->add_abort_algorithm([this, parent_signal] {
-        // 1. Signal abort on followingSignal with parentSignal’s abort reason.
-        signal_abort(parent_signal->reason());
-    });
-}
-
 // https://dom.spec.whatwg.org/#dom-abortsignal-abort
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::abort(JS::VM& vm, JS::Value reason)
 {

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -49,13 +49,13 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> timeout(JS::VM&, Web::WebIDL::UnsignedLongLong milliseconds);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> any(JS::VM&, JS::Value signals);
 
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> create_dependent_abort_signal(JS::Realm&, Vector<JS::Handle<AbortSignal>> const&);
+
 private:
     explicit AbortSignal(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
-
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> create_dependent_abort_signal(JS::Realm&, Vector<JS::Handle<AbortSignal>> const&);
 
     bool dependent() const { return m_dependent; }
     void set_dependent(bool dependent) { m_dependent = dependent; }

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -43,8 +43,6 @@ public:
 
     JS::ThrowCompletionOr<void> throw_if_aborted() const;
 
-    void follow(JS::NonnullGCPtr<AbortSignal> parent_signal);
-
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> abort(JS::VM&, JS::Value reason);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> timeout(JS::VM&, Web::WebIDL::UnsignedLongLong milliseconds);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> any(JS::VM&, JS::Value signals);

--- a/Userland/Libraries/LibWeb/Fetch/Request.h
+++ b/Userland/Libraries/LibWeb/Fetch/Request.h
@@ -67,7 +67,7 @@ class Request final
     JS_DECLARE_ALLOCATOR(Request);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<Request> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Request>, Headers::Guard);
+    [[nodiscard]] static JS::NonnullGCPtr<Request> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Request>, Headers::Guard, JS::NonnullGCPtr<DOM::AbortSignal>);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> construct_impl(JS::Realm&, RequestInfo const& input, RequestInit const& init = {});
 
     virtual ~Request() override;


### PR DESCRIPTION
Since the introduction of `AbortSignal::any()`, the specification says `AbortSignal::create_dependent_abort_signal()` should be used where `AbortSignal::follow` was previously.

I made this change blindly assuming that it would fix a crash we're seeing in http://arstechnica.com.

It did not :sob: