### PR TITLE
LibGfx/ISOBMFFF: Add two more jpeg2000 boxes

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.cpp
@@ -120,4 +120,28 @@ void SuperBox::dump(String const& prepend) const
         child_box->dump(indented_prepend);
 }
 
+ErrorOr<void> UserExtensionBox::read_from_stream(BoxStream& stream)
+{
+    // unsigned int(8)[16] uuid;
+    TRY(stream.read_until_filled(uuid));
+    // unsigned int(8) data[];
+    data = TRY(ByteBuffer::create_uninitialized(stream.remaining()));
+    TRY(stream.read_until_filled(data));
+    return {};
+}
+
+void UserExtensionBox::dump(String const& prepend) const
+{
+    Box::dump(prepend);
+
+    auto indented_prepend = add_indent(prepend);
+
+    out("{}- uuid = ", prepend);
+    for (auto byte : uuid)
+        out("{:02x}"sv, byte);
+    outln();
+
+    outln("{}- data = [ {} bytes ]", prepend, data.size());
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Boxes.h
@@ -106,4 +106,11 @@ private:
     BoxList m_child_boxes;
 };
 
+struct UserExtensionBox final : public Box {
+    BOX_SUBTYPE(UserExtensionBox);
+
+    Array<u8, 16> uuid;
+    ByteBuffer data;
+};
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.cpp
@@ -130,6 +130,8 @@ ErrorOr<void> JPEG2000ResolutionBox::read_from_stream(BoxStream& stream)
         switch (type) {
         case BoxType::JPEG2000CaptureResolutionBox:
             return TRY(JPEG2000CaptureResolutionBox::create_from_stream(stream));
+        case BoxType::JPEG2000DefaultDisplayResolutionBox:
+            return TRY(JPEG2000DefaultDisplayResolutionBox::create_from_stream(stream));
         default:
             return OptionalNone {};
         }
@@ -168,6 +170,16 @@ ErrorOr<void> JPEG2000CaptureResolutionBox::read_from_stream(BoxStream& stream)
 }
 
 void JPEG2000CaptureResolutionBox::dump(String const& prepend) const
+{
+    JPEG2000ResolutionSubboxBase::dump(prepend);
+}
+
+ErrorOr<void> JPEG2000DefaultDisplayResolutionBox::read_from_stream(BoxStream& stream)
+{
+    return JPEG2000ResolutionSubboxBase::read_from_stream(stream);
+}
+
+void JPEG2000DefaultDisplayResolutionBox::dump(String const& prepend) const
 {
     JPEG2000ResolutionSubboxBase::dump(prepend);
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.cpp
@@ -144,7 +144,7 @@ void JPEG2000ResolutionBox::dump(String const& prepend) const
     SuperBox::dump(prepend);
 }
 
-ErrorOr<void> JPEG2000CaptureResolutionBox::read_from_stream(BoxStream& stream)
+ErrorOr<void> JPEG2000ResolutionSubboxBase::read_from_stream(BoxStream& stream)
 {
     vertical_capture_grid_resolution_numerator = TRY(stream.read_value<BigEndian<u16>>());
     vertical_capture_grid_resolution_denominator = TRY(stream.read_value<BigEndian<u16>>());
@@ -155,11 +155,21 @@ ErrorOr<void> JPEG2000CaptureResolutionBox::read_from_stream(BoxStream& stream)
     return {};
 }
 
-void JPEG2000CaptureResolutionBox::dump(String const& prepend) const
+void JPEG2000ResolutionSubboxBase::dump(String const& prepend) const
 {
     Box::dump(prepend);
     outln("{}- vertical_capture_grid_resolution = {}/{} * 10^{}", prepend, vertical_capture_grid_resolution_numerator, vertical_capture_grid_resolution_denominator, vertical_capture_grid_resolution_exponent);
     outln("{}- horizontal_capture_grid_resolution = {}/{} * 10^{}", prepend, horizontal_capture_grid_resolution_numerator, horizontal_capture_grid_resolution_denominator, horizontal_capture_grid_resolution_exponent);
+}
+
+ErrorOr<void> JPEG2000CaptureResolutionBox::read_from_stream(BoxStream& stream)
+{
+    return JPEG2000ResolutionSubboxBase::read_from_stream(stream);
+}
+
+void JPEG2000CaptureResolutionBox::dump(String const& prepend) const
+{
+    JPEG2000ResolutionSubboxBase::dump(prepend);
 }
 
 ErrorOr<void> JPEG2000ContiguousCodestreamBox::read_from_stream(BoxStream& stream)

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -72,6 +72,11 @@ struct JPEG2000CaptureResolutionBox final : public JPEG2000ResolutionSubboxBase 
     BOX_SUBTYPE(JPEG2000CaptureResolutionBox);
 };
 
+// I.5.3.7.2 Default Display Resolution box
+struct JPEG2000DefaultDisplayResolutionBox final : public JPEG2000ResolutionSubboxBase {
+    BOX_SUBTYPE(JPEG2000DefaultDisplayResolutionBox);
+};
+
 // I.5.4 Contiguous Codestream box
 struct JPEG2000ContiguousCodestreamBox final : public Box {
     BOX_SUBTYPE(JPEG2000ContiguousCodestreamBox);

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -55,9 +55,9 @@ struct JPEG2000ResolutionBox final : public SuperBox {
     BOX_SUBTYPE(JPEG2000ResolutionBox);
 };
 
-// I.5.3.7.1 Capture Resolution box
-struct JPEG2000CaptureResolutionBox final : public Box {
-    BOX_SUBTYPE(JPEG2000CaptureResolutionBox);
+struct JPEG2000ResolutionSubboxBase : public Box {
+    ErrorOr<void> read_from_stream(BoxStream&);
+    virtual void dump(String const& prepend) const override;
 
     u16 vertical_capture_grid_resolution_numerator { 0 };
     u16 vertical_capture_grid_resolution_denominator { 0 };
@@ -65,6 +65,11 @@ struct JPEG2000CaptureResolutionBox final : public Box {
     u16 horizontal_capture_grid_resolution_denominator { 0 };
     i8 vertical_capture_grid_resolution_exponent { 0 };
     i8 horizontal_capture_grid_resolution_exponent { 0 };
+};
+
+// I.5.3.7.1 Capture Resolution box
+struct JPEG2000CaptureResolutionBox final : public JPEG2000ResolutionSubboxBase {
+    BOX_SUBTYPE(JPEG2000CaptureResolutionBox);
 };
 
 // I.5.4 Contiguous Codestream box

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
@@ -35,6 +35,8 @@ ErrorOr<BoxList> Reader::read_entire_file()
             return TRY(JPEG2000SignatureBox::create_from_stream(stream));
         case BoxType::JPEG2000UUIDInfoBox:
             return TRY(JPEG2000UUIDInfoBox::create_from_stream(stream));
+        case BoxType::UserExtensionBox:
+            return TRY(UserExtensionBox::create_from_stream(stream));
         default:
             return OptionalNone {};
         }


### PR DESCRIPTION
No real behavior change. `isobmff` now prints some more output on jpeg2000 inputs.