### PR TITLE
LibGfx/JBIG2: Don't assert on unexpected OOB values in the bitstream

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1595,7 +1595,7 @@ static ErrorOr<Vector<NonnullRefPtr<Symbol>>> symbol_dictionary_decoding_procedu
         u32 code_length = ceil(log2(inputs.input_symbols.size() + inputs.number_of_new_symbols));
 
         // 6.5.8.2.2 Decoding a bitmap when REFAGGNINST = 1
-        // FIXME: This is missing some setps for the SDHUFF = 1 case.
+        // FIXME: This is missing some steps for the SDHUFF = 1 case.
         if (number_of_symbol_instances != 1)
             return Error::from_string_literal("JBIG2ImageDecoderPlugin: Unexpected number of symbol instances");
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1632,7 +1632,7 @@ static ErrorOr<Vector<NonnullRefPtr<Symbol>>> symbol_dictionary_decoding_procedu
 
     // 6.5.5 Decoding the symbol dictionary
     // "1) Create an array SDNEWSYMS of bitmaps, having SDNUMNEWSYMS entries."
-    // Done above read_bitmap().
+    // Done above read_symbol_bitmap's definition.
 
     // "2) If SDHUFF is 1 and SDREFAGG is 0, create an array SDNEWSYMWIDTHS of integers, having SDNUMNEWSYMS entries."
     // FIXME: Implement support for SDHUFF = 1.

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1690,11 +1690,11 @@ static ErrorOr<Vector<NonnullRefPtr<Symbol>>> symbol_dictionary_decoding_procedu
             //      NSYMSDECODED = NSYMSDECODED + 1"
             number_of_symbols_decoded++;
         }
-        //  d) If SDHUFF is 1 and SDREFAGG is 0, [...long text elided...]
+        // "d) If SDHUFF is 1 and SDREFAGG is 0, [...long text elided...]"
         // FIXME: Implement support for SDHUFF = 1.
     }
 
-    //  5) Determine which symbol bitmaps are exported from this symbol dictionary, as described in 6.5.10. These
+    // "5) Determine which symbol bitmaps are exported from this symbol dictionary, as described in 6.5.10. These
     //     bitmaps can be drawn from the symbols that are used as input to the symbol dictionary decoding
     //     procedure as well as the new symbols produced by the decoding procedure."
     JBIG2::ArithmeticIntegerDecoder export_integer_decoder(decoder);


### PR DESCRIPTION
This should only happen on either invalid inputs or if our code has
a bug (gasp!). Printing an error instead of asserting seems nicer.

---

Probably also good for the fuzzer.