### PR TITLE
LibWeb: Return the correct substring when parsing an HTTP quoted string

### DIFF
--- a/Meta/gn/secondary/Tests/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Tests/LibWeb/BUILD.gn
@@ -12,6 +12,12 @@ unittest("TestCSSPixels") {
   deps = [ "//Userland/Libraries/LibWeb" ]
 }
 
+unittest("TestFetchInfrastructure") {
+  include_dirs = [ "//Userland/Libraries" ]
+  sources = [ "TestFetchInfrastructure.cpp" ]
+  deps = [ "//Userland/Libraries/LibWeb" ]
+}
+
 unittest("TestFetchURL") {
   include_dirs = [ "//Userland/Libraries" ]
   sources = [ "TestFetchURL.cpp" ]
@@ -50,6 +56,7 @@ group("LibWeb") {
   deps = [
     ":TestCSSIDSpeed",
     ":TestCSSPixels",
+    ":TestFetchInfrastructure",
     ":TestFetchURL",
     ":TestHTMLTokenizer",
     ":TestMicrosyntax",

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestCSSIDSpeed.cpp
     TestCSSPixels.cpp
+    TestFetchInfrastructure.cpp
     TestFetchURL.cpp
     TestHTMLTokenizer.cpp
     TestMicrosyntax.cpp

--- a/Tests/LibWeb/TestFetchInfrastructure.cpp
+++ b/Tests/LibWeb/TestFetchInfrastructure.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/GenericLexer.h>
+#include <AK/String.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP.h>
+
+TEST_CASE(collect_an_http_quoted_string)
+{
+    {
+        auto test = "\"\""_string;
+        GenericLexer lexer { test };
+
+        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        EXPECT_EQ(result, "\"\""_string);
+    }
+    {
+        auto test = "\"abc\""_string;
+        GenericLexer lexer { test };
+
+        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        EXPECT_EQ(result, "\"abc\""_string);
+    }
+    {
+        auto test = "foo \"abc\""_string;
+
+        GenericLexer lexer { test };
+        lexer.ignore(4);
+
+        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        EXPECT_EQ(result, "\"abc\""_string);
+    }
+    {
+        auto test = "foo=\"abc\""_string;
+
+        GenericLexer lexer { test };
+        lexer.ignore(4);
+
+        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        EXPECT_EQ(result, "\"abc\""_string);
+    }
+    {
+        auto test = "foo=\"abc\" bar"_string;
+
+        GenericLexer lexer { test };
+        lexer.ignore(4);
+
+        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        EXPECT_EQ(result, "\"abc\""_string);
+    }
+    {
+        auto test = "\"abc\" bar"_string;
+        GenericLexer lexer { test };
+
+        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        EXPECT_EQ(result, "\"abc\""_string);
+    }
+}

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
@@ -72,10 +72,7 @@ ErrorOr<String> collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStr
         return value.to_string();
 
     // 7. Return the code points from positionStart to position, inclusive, within input.
-    auto position = lexer.tell();
-    auto number_of_characters_to_consume = position - position_start + 1;
-    lexer.retreat(number_of_characters_to_consume);
-    return String::from_utf8(lexer.consume(number_of_characters_to_consume));
+    return String::from_utf8(lexer.input().substring_view(position_start, lexer.tell() - position_start));
 }
 
 }


### PR DESCRIPTION
We were off-by-one when returning the result of parsing a quoted string in `Web::Fetch::Infrastructure::collect_an_http_quoted_string`. Instead of backtracking the lexer and consuming the backtracked string, do a simple substring operation.