### PR TITLE
LibWeb: Fix my flakey test case + another fix for animation-play-state

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -5,3 +5,4 @@ Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html
 Text/input/WebAnimations/animation-properties/playbackRate.html
 Text/input/WebAnimations/animation-properties/startTime.html
+Text/input/WebAnimations/misc/animation-single-iteration-no-repeat.html

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -107,6 +107,9 @@ public:
 
     virtual void update_style_properties() override;
 
+    Optional<CSS::AnimationPlayState> last_css_animation_play_state() const { return m_last_css_animation_play_state; }
+    void set_last_css_animation_play_state(CSS::AnimationPlayState state) { m_last_css_animation_play_state = state; }
+
 private:
     KeyframeEffect(JS::Realm&);
     virtual ~KeyframeEffect() override = default;
@@ -130,6 +133,8 @@ private:
     Vector<JS::Object*> m_keyframe_objects {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+
+    Optional<CSS::AnimationPlayState> m_last_css_animation_play_state;
 };
 
 }


### PR DESCRIPTION
This is like my third attempt to get animation-play-state working correctly, so let's hope it actually sticks this time. Note that the new way this test works also functions as a test for the new `animation-play-state` behavior, as the test does not pass without these changes.