### PR TITLE
Ladybird: Display an audio button on tabs that are playing audio

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -11,6 +11,7 @@
 #include <LibURL/Forward.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
 
 #import <System/Cocoa.h>
@@ -30,6 +31,7 @@
 
 - (void)onTitleChange:(ByteString const&)title;
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;
+- (void)onAudioPlayStateChange:(Web::HTML::AudioPlayState)play_state;
 
 - (void)onNavigateBack;
 - (void)onNavigateForward;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -809,6 +809,10 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         if (pasteboard_type)
             copy_data_to_clipboard(data, pasteboard_type);
     };
+
+    m_web_view_bridge->on_audio_play_state_changed = [self](auto play_state) {
+        [self.observer onAudioPlayStateChange:play_state];
+    };
 }
 
 - (void)selectDropdownAdd:(NSMenu*)menu item:(Web::HTML::SelectItem const&)item

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -275,6 +275,27 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     [self updateTabTitleAndFavicon];
 }
 
+- (void)onAudioPlayStateChange:(Web::HTML::AudioPlayState)play_state
+{
+    switch (play_state) {
+    case Web::HTML::AudioPlayState::Paused:
+        [[self tab] setAccessoryView:nil];
+        break;
+
+    case Web::HTML::AudioPlayState::Playing:
+        auto* icon = [NSImage imageNamed:NSImageNameTouchBarAudioOutputVolumeHighTemplate];
+        auto* button = [NSButton buttonWithImage:icon target:nil action:nil];
+
+        // FIXME: Add a click handler to mute the tab.
+        NSButtonCell* cell = [button cell];
+        [cell setImageDimsWhenDisabled:NO];
+        [button setEnabled:NO];
+
+        [[self tab] setAccessoryView:button];
+        break;
+    }
+}
+
 - (void)onNavigateBack
 {
     [[self tabController] navigateBack:nil];

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -534,7 +534,6 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
 
 void BrowserWindow::initialize_tab(Tab* tab)
 {
-
     QObject::connect(tab, &Tab::title_changed, this, &BrowserWindow::tab_title_changed);
     QObject::connect(tab, &Tab::favicon_changed, this, &BrowserWindow::tab_favicon_changed);
 
@@ -591,6 +590,8 @@ void BrowserWindow::initialize_tab(Tab* tab)
     tab->view().on_update_cookie = [this](auto const& cookie) {
         m_cookie_jar.update_cookie(cookie);
     };
+
+    m_tabs_container->setTabIcon(m_tabs_container->indexOf(tab), tab->favicon());
 
     tab->focus_location_editor();
 }

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -536,6 +536,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
 {
     QObject::connect(tab, &Tab::title_changed, this, &BrowserWindow::tab_title_changed);
     QObject::connect(tab, &Tab::favicon_changed, this, &BrowserWindow::tab_favicon_changed);
+    QObject::connect(tab, &Tab::audio_play_state_changed, this, &BrowserWindow::tab_audio_play_state_changed);
 
     QObject::connect(&tab->view(), &WebContentView::urls_dropped, this, [this](auto& urls) {
         VERIFY(urls.size());
@@ -644,6 +645,28 @@ void BrowserWindow::tab_title_changed(int index, QString const& title)
 void BrowserWindow::tab_favicon_changed(int index, QIcon const& icon)
 {
     m_tabs_container->setTabIcon(index, icon);
+}
+
+void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState play_state)
+{
+    switch (play_state) {
+    case Web::HTML::AudioPlayState::Paused:
+        m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, nullptr);
+        break;
+
+    case Web::HTML::AudioPlayState::Playing:
+        auto icon = style()->standardIcon(QStyle::SP_MediaVolume);
+
+        auto* button = new QPushButton(icon, {});
+        button->setFlat(true);
+        button->resize({ 20, 20 });
+
+        // FIXME: Add a click handler to mute the tab.
+        button->setEnabled(false);
+
+        m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, button);
+        break;
+    }
 }
 
 void BrowserWindow::open_next_tab()

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -11,6 +11,7 @@
 #include <Ladybird/Types.h>
 #include <LibCore/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
 #include <QIcon>
 #include <QLineEdit>
@@ -78,6 +79,7 @@ public slots:
     void device_pixel_ratio_changed(qreal dpi);
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
+    void tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState);
     Tab& new_tab_from_url(URL::URL const&, Web::HTML::ActivateTab);
     Tab& new_tab_from_content(StringView html, Web::HTML::ActivateTab);
     Tab& new_child_tab(Web::HTML::ActivateTab, Tab& parent, Web::HTML::WebViewHints, Optional<u64> page_index);

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -82,6 +82,8 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
 
     recreate_toolbar_icons();
 
+    m_favicon = load_icon_from_uri("resource://icons/16x16/app-browser.png"sv);
+
     m_toolbar->addAction(&m_window->go_back_action());
     m_toolbar->addAction(&m_window->go_forward_action());
     m_toolbar->addAction(&m_window->reload_action());
@@ -128,7 +130,12 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             m_history.replace_current(url, m_title.toUtf8().data());
         }
 
-        m_location_edit->setText(url.to_byte_string().characters());
+        auto url_serialized = qstring_from_ak_string(url.serialize());
+
+        m_title = url_serialized;
+        emit title_changed(tab_index(), url_serialized);
+
+        m_location_edit->setText(url_serialized);
         m_location_edit->setCursorPosition(0);
 
         // Don't add to history if back or forward is pressed
@@ -166,7 +173,9 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         auto qpixmap = QPixmap::fromImage(qimage);
         if (qpixmap.isNull())
             return;
-        emit favicon_changed(tab_index(), QIcon(qpixmap));
+
+        m_favicon = qpixmap;
+        emit favicon_changed(tab_index(), m_favicon);
     };
 
     view().on_request_alert = [this](auto const& message) {

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -389,6 +389,10 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         clipboard->setMimeData(mime_data);
     };
 
+    view().on_audio_play_state_changed = [this](auto play_state) {
+        emit audio_play_state_changed(tab_index(), play_state);
+    };
+
     auto* search_selected_text_action = new QAction("&Search for <query>", this);
     search_selected_text_action->setIcon(load_icon_from_uri("resource://icons/16x16/find.png"sv));
     QObject::connect(search_selected_text_action, &QAction::triggered, this, [this]() {

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -51,14 +51,16 @@ public:
     };
     void show_inspector_window(InspectorTarget = InspectorTarget::Document);
 
+    QIcon const& favicon() const { return m_favicon; }
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();
     void select_dropdown_action();
 
 signals:
-    void title_changed(int id, QString);
-    void favicon_changed(int id, QIcon);
+    void title_changed(int id, QString const&);
+    void favicon_changed(int id, QIcon const&);
 
 private:
     void select_dropdown_add_item(QMenu* menu, Web::HTML::SelectItem const& item);
@@ -85,6 +87,7 @@ private:
     WebView::History m_history;
     QString m_title;
     QLabel* m_hover_label { nullptr };
+    QIcon m_favicon;
 
     QMenu* m_page_context_menu { nullptr };
     Optional<String> m_page_context_menu_search_text;

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -9,6 +9,7 @@
 
 #include "LocationEdit.h"
 #include "WebContentView.h"
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/History.h>
 #include <QBoxLayout>
 #include <QLabel>
@@ -61,6 +62,7 @@ public slots:
 signals:
     void title_changed(int id, QString const&);
     void favicon_changed(int id, QIcon const&);
+    void audio_play_state_changed(int id, Web::HTML::AudioPlayState);
 
 private:
     void select_dropdown_add_item(QMenu* menu, Web::HTML::SelectItem const& item);

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -70,7 +70,7 @@ static bool is_primitive_type(ByteString const& type)
 static bool is_simple_type(ByteString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode", "Web::Cookie::Source", "Web::HTML::AllowMultipleFiles");
+    return type.is_one_of("Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode", "Web::Cookie::Source", "Web::HTML::AllowMultipleFiles", "Web::HTML::AudioPlayState");
 }
 
 static bool is_primitive_or_simple_type(ByteString const& type)

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -229,6 +229,7 @@ icons_16x16 = [
   "//Base/res/icons/16x16/layout.png",
   "//Base/res/icons/16x16/new-tab.png",
   "//Base/res/icons/16x16/open-parent-directory.png",
+  "//Base/res/icons/16x16/paste.png",
   "//Base/res/icons/16x16/pause.png",
   "//Base/res/icons/16x16/play.png",
   "//Base/res/icons/16x16/select-all.png",

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -546,6 +546,7 @@ Tab& BrowserWindow::create_new_tab(URL::URL const& url, Web::HTML::ActivateTab a
     auto& new_tab = m_tab_widget->add_tab<Browser::Tab>("New tab"_string, *this);
 
     m_tab_widget->set_bar_visible(!is_fullscreen() && m_tab_widget->children().size() > 1);
+    m_tab_widget->set_tab_icon(new_tab, new_tab.icon());
 
     new_tab.on_title_change = [this, &new_tab](auto& title) {
         m_tab_widget->set_tab_title(new_tab, String::from_byte_string(title).release_value_but_fixme_should_propagate_errors());

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -32,6 +32,7 @@
 #include <LibGUI/Widget.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWebView/CookieJar.h>
@@ -556,6 +557,18 @@ Tab& BrowserWindow::create_new_tab(URL::URL const& url, Web::HTML::ActivateTab a
 
     new_tab.on_favicon_change = [this, &new_tab](auto& bitmap) {
         m_tab_widget->set_tab_icon(new_tab, &bitmap);
+    };
+
+    new_tab.view().on_audio_play_state_changed = [this, &new_tab](auto play_state) {
+        switch (play_state) {
+        case Web::HTML::AudioPlayState::Paused:
+            m_tab_widget->set_tab_action_icon(new_tab, nullptr);
+            break;
+
+        case Web::HTML::AudioPlayState::Playing:
+            m_tab_widget->set_tab_action_icon(new_tab, g_icon_bag.unmute);
+            break;
+        }
     };
 
     new_tab.on_tab_open_request = [this](auto& url) {

--- a/Userland/Applications/Browser/IconBag.cpp
+++ b/Userland/Applications/Browser/IconBag.cpp
@@ -11,6 +11,7 @@ ErrorOr<IconBag> IconBag::try_create()
 {
     IconBag icon_bag;
 
+    icon_bag.default_favicon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-browser.png"sv));
     icon_bag.filetype_html = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-html.png"sv));
     icon_bag.filetype_text = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-text.png"sv));
     icon_bag.filetype_javascript = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-javascript.png"sv));

--- a/Userland/Applications/Browser/IconBag.h
+++ b/Userland/Applications/Browser/IconBag.h
@@ -13,6 +13,7 @@ namespace Browser {
 struct IconBag final {
     static ErrorOr<IconBag> try_create();
 
+    RefPtr<Gfx::Bitmap> default_favicon { nullptr };
     RefPtr<Gfx::Bitmap> filetype_html { nullptr };
     RefPtr<Gfx::Bitmap> filetype_text { nullptr };
     RefPtr<Gfx::Bitmap> filetype_javascript { nullptr };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -112,6 +112,8 @@ Tab::Tab(BrowserWindow& window)
 {
     load_from_gml(tab_gml).release_value_but_fixme_should_propagate_errors();
 
+    m_icon = g_icon_bag.default_favicon;
+
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
 
@@ -222,10 +224,16 @@ Tab::Tab(BrowserWindow& window)
             m_history.replace_current(url, title());
         }
 
+        auto url_serialized = url.serialize();
+
+        m_title = url_serialized;
+        if (on_title_change)
+            on_title_change(m_title);
+
         update_status();
 
         m_location_box->set_icon(nullptr);
-        m_location_box->set_text(url.to_byte_string());
+        m_location_box->set_text(url_serialized);
 
         // don't add to history if back or forward is pressed
         if (!m_is_history_navigation)
@@ -233,7 +241,7 @@ Tab::Tab(BrowserWindow& window)
         m_is_history_navigation = false;
 
         update_actions();
-        update_bookmark_button(url.to_byte_string());
+        update_bookmark_button(url_serialized);
 
         if (m_dom_inspector_widget)
             m_dom_inspector_widget->reset();

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -69,6 +69,7 @@ public:
 
     void set_tab_title(Widget& tab, String title);
     void set_tab_icon(Widget& tab, Gfx::Bitmap const*);
+    void set_tab_action_icon(Widget& tab, Gfx::Bitmap const*);
 
     bool is_tab_modified(Widget& tab);
     void set_tab_modified(Widget& tab, bool modified);
@@ -132,6 +133,7 @@ private:
     struct TabData {
         int width(Gfx::Font const&) const;
         String title;
+        RefPtr<Gfx::Bitmap const> action_icon;
         RefPtr<Gfx::Bitmap const> icon;
         Widget* widget { nullptr };
         bool modified { false };

--- a/Userland/Libraries/LibWeb/HTML/AudioPlayState.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioPlayState.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::HTML {
+
+enum class AudioPlayState {
+    Paused,
+    Playing,
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/AudioTrack.h>
 #include <LibWeb/HTML/AudioTrackList.h>
 #include <LibWeb/HTML/CORSSettingAttribute.h>
@@ -35,6 +36,7 @@
 #include <LibWeb/HTML/VideoTrackList.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/MimeSniff/MimeType.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -1602,6 +1604,9 @@ void HTMLMediaElement::set_paused(bool paused)
     if (auto* paintable = this->paintable())
         paintable->set_needs_display();
     set_needs_style_update(true);
+
+    if (m_audio_tracks->has_enabled_track())
+        document().page().client().page_did_change_audio_play_state(paused ? AudioPlayState::Paused : AudioPlayState::Playing);
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#blocked-media-element

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -285,11 +285,11 @@ public:
     virtual void request_file(FileRequest) = 0;
 
     // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
-    virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) {};
-    virtual void page_did_request_file_picker([[maybe_unused]] HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) {};
-    virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) {};
+    virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) { }
+    virtual void page_did_request_file_picker([[maybe_unused]] HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) { }
+    virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) { }
 
-    virtual void page_did_finish_text_test() {};
+    virtual void page_did_finish_text_test() { }
 
     virtual void page_did_change_theme_color(Gfx::Color) { }
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -30,6 +30,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -294,6 +295,8 @@ public:
     virtual void page_did_change_theme_color(Gfx::Color) { }
 
     virtual void page_did_insert_clipboard_entry([[maybe_unused]] String data, [[maybe_unused]] String presentation_style, [[maybe_unused]] String mime_type) { }
+
+    virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 
     virtual WebView::SocketPair request_worker_agent() { return { -1, -1 }; }
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -315,6 +315,14 @@ void ViewImplementation::toggle_media_controls_state()
     client().async_toggle_media_controls_state(page_id());
 }
 
+void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState play_state)
+{
+    m_audio_play_state = play_state;
+
+    if (on_audio_play_state_changed)
+        on_audio_play_state_changed(m_audio_play_state);
+}
+
 void ViewImplementation::handle_resize()
 {
     resize_backing_stores_if_needed(WindowResizeInProgress::Yes);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -17,6 +17,7 @@
 #include <LibGfx/StandardCursor.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -101,6 +102,9 @@ public:
     void toggle_media_loop_state();
     void toggle_media_controls_state();
 
+    void did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState);
+    Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
+
     enum class ScreenshotType {
         Visible,
         Full,
@@ -178,6 +182,7 @@ public:
     Function<void()> on_text_test_finish;
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;
+    Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
     Function<void()> on_inspector_loaded;
     Function<void(i32, Optional<Web::CSS::Selector::PseudoElement::Type> const&)> on_inspector_selected_dom_node;
     Function<void(i32, String const&)> on_inspector_set_dom_node_text;
@@ -252,6 +257,8 @@ protected:
     RefPtr<Core::Timer> m_repeated_crash_timer;
 
     RefPtr<Core::Promise<LexicalPath>> m_pending_screenshot;
+
+    Web::HTML::AudioPlayState m_audio_play_state { Web::HTML::AudioPlayState::Paused };
 };
 
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -870,6 +870,18 @@ void WebContentClient::did_insert_clipboard_entry(u64 page_id, String const& dat
         view.on_insert_clipboard_entry(data, presentation_style, mime_type);
 }
 
+void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state)
+{
+    auto maybe_view = m_views.get(page_id);
+    if (!maybe_view.has_value()) {
+        dbgln("Received insert clipboard entry for unknown page ID {}", page_id);
+        return;
+    }
+
+    auto& view = *maybe_view.value();
+    view.did_change_audio_play_state({}, play_state);
+}
+
 void WebContentClient::inspector_did_load(u64 page_id)
 {
     auto maybe_view = m_views.get(page_id);

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -96,6 +96,7 @@ private:
     virtual void did_finish_text_test(u64 page_id) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, String const& data, String const& presentation_style, String const& mime_type) override;
+    virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void inspector_did_load(u64 page_id) override;
     virtual void inspector_did_select_dom_node(u64 page_id, i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String const& text) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -577,6 +577,11 @@ void PageClient::page_did_insert_clipboard_entry(String data, String presentatio
     client().async_did_insert_clipboard_entry(m_id, move(data), move(presentation_style), move(mime_type));
 }
 
+void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play_state)
+{
+    client().async_did_change_audio_play_state(m_id, play_state);
+}
+
 WebView::SocketPair PageClient::request_worker_agent()
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::RequestWorkerAgent>(m_id);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -10,6 +10,7 @@
 
 #include <LibAccelGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
@@ -140,6 +141,7 @@ private:
     virtual void page_did_finish_text_test() override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type) override;
+    virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual WebView::SocketPair request_worker_agent() override;
     virtual void inspector_did_load() override;
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -6,6 +6,7 @@
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -77,6 +78,8 @@ endpoint WebContentClient
     did_finish_handling_input_event(u64 page_id, bool event_was_accepted) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|
     did_insert_clipboard_entry(u64 page_id, String data, String presentation_style, String mime_type) =|
+
+    did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|
 
     did_output_js_console_message(u64 page_id, i32 message_index) =|
     did_get_js_console_messages(u64 page_id, i32 start_index, Vector<ByteString> message_types, Vector<ByteString> messages) =|


### PR DESCRIPTION
Modern browsers display some indicator on tabs that are playing audio, which I've always found nice, so this adds the same feature to Ladybird. The indicator is added as a button, though currently disabled. In the future, this button can be used to e.g. mute the tab.

Serenity:

https://github.com/SerenityOS/serenity/assets/5600524/7605dcbe-7598-4552-a1d2-8de66609ce85

Qt:

https://github.com/SerenityOS/serenity/assets/5600524/d33ccec5-c860-4477-b8fe-59649002bccd

AppKit:

https://github.com/SerenityOS/serenity/assets/5600524/33f82c65-bc48-49cf-b443-2c9095dcae2b



