### PR TITLE
LibWeb: Layout fixes for flex layout, aspect ratio, floats, ...

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-aspect-ratio-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-aspect-ratio-2.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 100x100 flex-container(row) [FFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 9.46875x100 flex-item [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.46875x17] baseline: 13.296875
+            "b"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>) [8,8 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 9.46875x100]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x69.984375 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x51.984375 flex-container(row) [FFC] children: not-inline
-      ImageBox <img> at (11,11) content-size 66.65625x50 flex-item children: not-inline
+      ImageBox <img> at (11,10) content-size 66.65625x50 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.984375]
-    PaintableBox (Box<BODY>) [9,9 782x53.984375] overflow: [10,10 780x52]
-      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x52]
+    PaintableBox (Box<BODY>) [9,9 782x53.984375] overflow: [10,9 780x52.984375]
+      ImagePaintable (ImageBox<IMG>) [10,9 68.65625x52]

--- a/Tests/LibWeb/Layout/expected/inline-flex-with-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/inline-flex-with-aspect-ratio.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      frag 0 from Box start: 0, length: 0, rect: [8,8 784x17] baseline: 13.296875
-      Box <div.inline-flex.aspect-ratio> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
+      frag 0 from Box start: 0, length: 0, rect: [8,8 10x10.3125] baseline: 13.296875
+      Box <div.inline-flex.aspect-ratio> at (8,8) content-size 10x10.3125 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.img-wrapper> at (8,8) content-size 10x17 flex-item [BFC] children: inline
           frag 0 from ImageBox start: 0, length: 0, rect: [8,11 10x10] baseline: 10
           ImageBox <img> at (8,11) content-size 10x10 children: not-inline
@@ -10,6 +10,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableBox (Box<DIV>.inline-flex.aspect-ratio) [8,8 784x17]
+      PaintableBox (Box<DIV>.inline-flex.aspect-ratio) [8,8 10x10.3125] overflow: [8,8 10x17]
         PaintableWithLines (BlockContainer<DIV>.img-wrapper) [8,8 10x17]
           ImagePaintable (ImageBox<IMG>) [8,11 10x10]

--- a/Tests/LibWeb/Layout/expected/inline-flex-with-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/inline-flex-with-aspect-ratio.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      frag 0 from Box start: 0, length: 0, rect: [8,8 10x10.3125] baseline: 13.296875
-      Box <div.inline-flex.aspect-ratio> at (8,8) content-size 10x10.3125 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div.img-wrapper> at (8,8) content-size 10x17 flex-item [BFC] children: inline
-          frag 0 from ImageBox start: 0, length: 0, rect: [8,11 10x10] baseline: 10
-          ImageBox <img> at (8,11) content-size 10x10 children: not-inline
+      frag 0 from Box start: 0, length: 0, rect: [8,11 10x10.3125] baseline: 9.953125
+      Box <div.inline-flex.aspect-ratio> at (8,11) content-size 10x10.3125 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.img-wrapper> at (8,7.65625) content-size 10x17 flex-item [BFC] children: inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,10.65625 10x10] baseline: 10
+          ImageBox <img> at (8,10.65625) content-size 10x10 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableBox (Box<DIV>.inline-flex.aspect-ratio) [8,8 10x10.3125] overflow: [8,8 10x17]
-        PaintableWithLines (BlockContainer<DIV>.img-wrapper) [8,8 10x17]
-          ImagePaintable (ImageBox<IMG>) [8,11 10x10]
+      PaintableBox (Box<DIV>.inline-flex.aspect-ratio) [8,11 10x10.3125] overflow: [8,7.65625 10x17]
+        PaintableWithLines (BlockContainer<DIV>.img-wrapper) [8,7.65625 10x17]
+          ImagePaintable (ImageBox<IMG>) [8,10.65625 10x10]

--- a/Tests/LibWeb/Layout/input/block-and-inline/atomic-inline-with-aspect-ratio-2.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/atomic-inline-with-aspect-ratio-2.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><style>
+* {
+    outline: 1px solid black;
+}
+body {
+    aspect-ratio: 1;
+    width: 100px;
+    display: flex;
+}
+</style>b

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -914,6 +914,11 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     resolve_vertical_box_model_metrics(box);
 
     compute_width(box, available_space, layout_mode);
+
+    // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
+    if (box.is_replaced_box() || box.display().is_flex_inside())
+        compute_height(box, available_space);
+
     auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space));
     compute_height(box, available_space);
 

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -826,10 +826,9 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
         }
     };
 
-    // Flex-items don't float and also don't clear.
-    if ((computed_values.clear() == CSS::Clear::Left || computed_values.clear() == CSS::Clear::Both) && !child_box.is_flex_item())
+    if (computed_values.clear() == CSS::Clear::Left || computed_values.clear() == CSS::Clear::Both)
         clear_floating_boxes(m_left_floats);
-    if ((computed_values.clear() == CSS::Clear::Right || computed_values.clear() == CSS::Clear::Both) && !child_box.is_flex_item())
+    if (computed_values.clear() == CSS::Clear::Right || computed_values.clear() == CSS::Clear::Both)
         clear_floating_boxes(m_right_floats);
 
     return result;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -191,8 +191,6 @@ private:
 
     void align_all_flex_items_along_the_cross_axis();
 
-    void determine_flex_container_used_cross_size();
-
     void align_all_flex_lines();
 
     bool is_row_layout() const { return m_flex_direction == CSS::FlexDirection::Row || m_flex_direction == CSS::FlexDirection::RowReverse; }

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -466,7 +466,6 @@ void LayoutState::UsedValues::set_node(NodeWithStyle& node, UsedValues const* co
             }
             return false;
         }
-        // FIXME: Determine if calc() value is definite.
         return false;
     };
 


### PR DESCRIPTION
Visual progression on https://polar.sh/

Before:
![Screenshot at 2024-03-27 15-11-38](https://github.com/SerenityOS/serenity/assets/5954907/22fe6337-e06e-4353-b0e5-451e5d59ec26)

After:
![Screenshot at 2024-03-27 15-11-04](https://github.com/SerenityOS/serenity/assets/5954907/074fc7e7-f2f3-4ddb-b66b-c50f7ab3fd97)
