### PR TITLE
Ladybird: Add a simple process manager widget to track helper processes

### DIFF
--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -13,6 +13,7 @@
 #include <LibMain/Main.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/Database.h>
+#include <LibWebView/ProcessManager.h>
 #include <LibWebView/URL.h>
 
 #import <Application/Application.h>
@@ -80,6 +81,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .use_lagom_networking = Ladybird::UseLagomNetworking::Yes,
         .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,
     };
+
+    WebView::ProcessManager::initialize();
 
     auto* delegate = [[ApplicationDelegate alloc] init:move(initial_urls)
                                          newTabPageURL:move(new_tab_page_url)

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -124,6 +124,7 @@ if (ENABLE_QT)
         Qt/Settings.cpp
         Qt/SettingsDialog.cpp
         Qt/Tab.cpp
+        Qt/TaskManagerWindow.cpp
         Qt/TVGIconEngine.cpp
         Qt/StringUtils.cpp
         Qt/WebContentView.cpp

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -96,8 +96,6 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
         dbgln();
     }
 
-    WebView::ProcessManager::the().add_process(WebView::ProcessType::WebContent, child_pid);
-
     return new_client;
 }
 

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -12,6 +12,7 @@
 #include "Settings.h"
 #include "SettingsDialog.h"
 #include "StringUtils.h"
+#include "TaskManagerWindow.h"
 #include "WebContentView.h"
 #include <AK/TypeCasts.h>
 #include <Ladybird/Utilities.h>
@@ -21,6 +22,7 @@
 #include <LibWebView/UserAgent.h>
 #include <QAction>
 #include <QActionGroup>
+#include <QApplication>
 #include <QClipboard>
 #include <QGuiApplication>
 #include <QInputDialog>
@@ -211,6 +213,14 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
         if (m_current_tab) {
             m_current_tab->show_inspector_window();
         }
+    });
+
+    auto* task_manager_action = new QAction("Open Task &Manager", this);
+    task_manager_action->setIcon(load_icon_from_uri("resource://icons/16x16/app-system-monitor.png"sv));
+    task_manager_action->setShortcuts({ QKeySequence("Ctrl+Shift+M") });
+    inspect_menu->addAction(task_manager_action);
+    QObject::connect(task_manager_action, &QAction::triggered, this, [this] {
+        show_task_manager_window();
     });
 
     auto* debug_menu = menuBar()->addMenu("&Debug");
@@ -888,6 +898,22 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     Settings::the()->set_is_maximized(isMaximized());
 
     QMainWindow::closeEvent(event);
+}
+
+void BrowserWindow::show_task_manager_window()
+{
+    if (!m_task_manager_window) {
+        m_task_manager_window = new TaskManagerWindow(this);
+    }
+    m_task_manager_window->show();
+    m_task_manager_window->activateWindow();
+    m_task_manager_window->raise();
+}
+
+void BrowserWindow::close_task_manager_window()
+{
+    if (m_task_manager_window)
+        m_task_manager_window->close();
 }
 
 }

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -24,6 +24,7 @@ namespace Ladybird {
 
 class SettingsDialog;
 class WebContentView;
+class TaskManagerWindow;
 
 class BrowserWindow : public QMainWindow {
     Q_OBJECT
@@ -132,6 +133,9 @@ private:
     QString tool_tip_for_page_mute_state(Tab&) const;
     QTabBar::ButtonPosition audio_button_position_for_tab(int tab_index) const;
 
+    void show_task_manager_window();
+    void close_task_manager_window();
+
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
 
@@ -149,6 +153,9 @@ private:
     QAction* m_inspect_dom_node_action { nullptr };
 
     SettingsDialog* m_settings_dialog { nullptr };
+
+    // FIXME: This should be owned at a higher level in case we have multiple browser windows
+    TaskManagerWindow* m_task_manager_window { nullptr };
 
     WebView::CookieJar& m_cookie_jar;
 

--- a/Ladybird/Qt/TaskManagerWindow.cpp
+++ b/Ladybird/Qt/TaskManagerWindow.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TaskManagerWindow.h"
+#include <LibWebView/ProcessManager.h>
+#include <QVBoxLayout>
+
+namespace Ladybird {
+
+TaskManagerWindow::TaskManagerWindow(QWidget* parent)
+    : QWidget(parent, Qt::WindowFlags(Qt::WindowType::Window))
+    , m_web_view(new WebContentView(this, {}, {}))
+{
+    setLayout(new QVBoxLayout);
+    layout()->addWidget(m_web_view);
+
+    setWindowTitle("Task Manager");
+    resize(400, 300);
+
+    m_update_timer.setInterval(1000);
+
+    QObject::connect(&m_update_timer, &QTimer::timeout, [this] {
+        this->update_statistics();
+    });
+
+    update_statistics();
+}
+
+void TaskManagerWindow::showEvent(QShowEvent*)
+{
+    m_update_timer.start();
+}
+
+void TaskManagerWindow::hideEvent(QHideEvent*)
+{
+    m_update_timer.stop();
+}
+
+void TaskManagerWindow::update_statistics()
+{
+
+    WebView::ProcessManager::the().update_all_processes();
+    m_web_view->load_html(WebView::ProcessManager::the().generate_html());
+}
+
+}

--- a/Ladybird/Qt/TaskManagerWindow.h
+++ b/Ladybird/Qt/TaskManagerWindow.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "WebContentView.h"
+#include <QTimer>
+#include <QWidget>
+
+namespace Ladybird {
+
+class TaskManagerWindow : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TaskManagerWindow(QWidget* parent);
+
+private:
+    virtual void showEvent(QShowEvent*) override;
+    virtual void hideEvent(QHideEvent*) override;
+
+    void update_statistics();
+
+    WebContentView* m_web_view { nullptr };
+    QTimer m_update_timer;
+};
+
+}

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -18,6 +18,7 @@
 #include <LibMain/Main.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/Database.h>
+#include <LibWebView/ProcessManager.h>
 #include <LibWebView/URL.h>
 #include <QApplication>
 #include <QFileOpenEvent>
@@ -156,6 +157,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .use_lagom_networking = enable_qt_networking ? Ladybird::UseLagomNetworking::No : Ladybird::UseLagomNetworking::Yes,
         .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,
     };
+
+    WebView::ProcessManager::initialize();
 
     Ladybird::BrowserWindow window(initial_urls, cookie_jar, web_content_options, webdriver_content_ipc_path);
     window.setWindowTitle("Ladybird");

--- a/Ladybird/cmake/ResourceFiles.cmake
+++ b/Ladybird/cmake/ResourceFiles.cmake
@@ -18,6 +18,7 @@ list(TRANSFORM FONTS PREPEND "${SERENITY_SOURCE_DIR}/Base/res/fonts/")
 
 set(16x16_ICONS
     app-browser.png
+    app-system-monitor.png
     audio-volume-high.png
     audio-volume-muted.png
     close-tab.png
@@ -48,6 +49,7 @@ set(16x16_ICONS
 )
 set(32x32_ICONS
     app-browser.png
+    app-system-monitor.png
     filetype-folder.png
     filetype-unknown.png
     msgbox-warning.png

--- a/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
@@ -122,6 +122,7 @@ shared_library("LibWebView") {
     "Database.cpp",
     "History.cpp",
     "InspectorClient.cpp",
+    "ProcessManager.cpp",
     "RequestServerAdapter.cpp",
     "SearchEngine.cpp",
     "SocketPair.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
@@ -122,6 +122,7 @@ shared_library("LibWebView") {
     "Database.cpp",
     "History.cpp",
     "InspectorClient.cpp",
+    "ProcessHandle.cpp",
     "ProcessManager.cpp",
     "RequestServerAdapter.cpp",
     "SearchEngine.cpp",

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -65,6 +65,9 @@ private:
 
     void update_displayed_zoom_level();
 
+    void show_task_manager_window();
+    void close_task_manager_window();
+
     RefPtr<GUI::Action> m_go_back_action;
     RefPtr<GUI::Action> m_go_forward_action;
     RefPtr<GUI::Action> m_go_home_action;
@@ -75,6 +78,7 @@ private:
     RefPtr<GUI::Action> m_view_source_action;
     RefPtr<GUI::Action> m_inspect_dom_tree_action;
     RefPtr<GUI::Action> m_inspect_dom_node_action;
+    RefPtr<GUI::Action> m_task_manager_action;
 
     RefPtr<GUI::Menu> m_zoom_menu;
 
@@ -82,6 +86,9 @@ private:
     WindowActions m_window_actions;
     RefPtr<GUI::TabWidget> m_tab_widget;
     RefPtr<BookmarksBarWidget> m_bookmarks_bar;
+
+    // FIXME: This should be owned at a higher level in case we have multiple browser windows
+    RefPtr<GUI::Window> m_task_manager_window;
 
     GUI::ActionGroup m_user_agent_spoof_actions;
     GUI::ActionGroup m_search_engine_actions;

--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
     StorageModel.cpp
     StorageWidget.cpp
     Tab.cpp
+    TaskManagerWidget.cpp
     URLBox.cpp
     WindowActions.cpp
     main.cpp

--- a/Userland/Applications/Browser/IconBag.cpp
+++ b/Userland/Applications/Browser/IconBag.cpp
@@ -50,6 +50,7 @@ ErrorOr<IconBag> IconBag::try_create()
     icon_bag.mute = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/audio-volume-muted.png"sv));
     icon_bag.unmute = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/audio-volume-high.png"sv));
     icon_bag.search = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv));
+    icon_bag.task_manager = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-system-monitor.png"sv));
 
     return icon_bag;
 }

--- a/Userland/Applications/Browser/IconBag.h
+++ b/Userland/Applications/Browser/IconBag.h
@@ -52,5 +52,6 @@ struct IconBag final {
     RefPtr<Gfx::Bitmap> mute { nullptr };
     RefPtr<Gfx::Bitmap> unmute { nullptr };
     RefPtr<Gfx::Bitmap> search { nullptr };
+    RefPtr<Gfx::Bitmap> task_manager { nullptr };
 };
 }

--- a/Userland/Applications/Browser/TaskManagerWidget.cpp
+++ b/Userland/Applications/Browser/TaskManagerWidget.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TaskManagerWidget.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibWebView/OutOfProcessWebView.h>
+#include <LibWebView/ProcessManager.h>
+
+namespace Browser {
+
+TaskManagerWidget::~TaskManagerWidget() = default;
+
+TaskManagerWidget::TaskManagerWidget()
+{
+    m_update_timer = MUST(Core::Timer::create_repeating(1000, [this] {
+        this->update_statistics();
+    }));
+    m_update_timer->start();
+
+    m_web_view = add<WebView::OutOfProcessWebView>();
+
+    set_layout<GUI::VerticalBoxLayout>(4);
+    set_fill_with_background_color(true);
+
+    m_web_view->set_focus(true);
+
+    update_statistics();
+}
+
+void TaskManagerWidget::show_event(GUI::ShowEvent& event)
+{
+    m_update_timer->start();
+
+    GUI::Widget::show_event(event);
+}
+
+void TaskManagerWidget::hide_event(GUI::HideEvent& event)
+{
+    m_update_timer->stop();
+
+    GUI::Widget::hide_event(event);
+}
+
+void TaskManagerWidget::update_statistics()
+{
+    WebView::ProcessManager::the().update_all_processes();
+    m_web_view->load_html(WebView::ProcessManager::the().generate_html());
+}
+
+}

--- a/Userland/Applications/Browser/TaskManagerWidget.h
+++ b/Userland/Applications/Browser/TaskManagerWidget.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+#include <LibWeb/Forward.h>
+#include <LibWebView/Forward.h>
+
+namespace Browser {
+
+class TaskManagerWidget : public GUI::Widget {
+    C_OBJECT(TaskManagerWidget)
+
+public:
+    TaskManagerWidget();
+    ~TaskManagerWidget() override;
+
+private:
+    virtual void show_event(GUI::ShowEvent&) override;
+    virtual void hide_event(GUI::HideEvent&) override;
+
+    void update_statistics();
+
+    RefPtr<WebView::OutOfProcessWebView> m_web_view;
+    RefPtr<Core::Timer> m_update_timer;
+};
+
+}

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -26,6 +26,7 @@
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/Database.h>
 #include <LibWebView/OutOfProcessWebView.h>
+#include <LibWebView/ProcessManager.h>
 #include <LibWebView/RequestServerAdapter.h>
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/URL.h>
@@ -93,6 +94,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         warnln("Refusing to run as root");
         return 1;
     }
+
+    TRY(Core::System::pledge("sigaction stdio recvfd sendfd unix fattr cpath rpath wpath proc exec"));
+
+    WebView::ProcessManager::initialize();
 
     TRY(Core::System::pledge("stdio recvfd sendfd unix fattr cpath rpath wpath proc exec"));
 

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Database.cpp
     History.cpp
     InspectorClient.cpp
+    ProcessHandle.cpp
     ProcessManager.cpp
     RequestServerAdapter.cpp
     SearchEngine.cpp

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Database.cpp
     History.cpp
     InspectorClient.cpp
+    ProcessManager.cpp
     RequestServerAdapter.cpp
     SearchEngine.cpp
     SocketPair.cpp

--- a/Userland/Libraries/LibWebView/Forward.h
+++ b/Userland/Libraries/LibWebView/Forward.h
@@ -15,6 +15,7 @@ class Database;
 class History;
 class InspectorClient;
 class OutOfProcessWebView;
+class ProcessManager;
 class ViewImplementation;
 class WebContentClient;
 

--- a/Userland/Libraries/LibWebView/Forward.h
+++ b/Userland/Libraries/LibWebView/Forward.h
@@ -21,6 +21,7 @@ class WebContentClient;
 
 struct Attribute;
 struct CookieStorageKey;
+struct ProcessHandle;
 struct SearchEngine;
 struct SocketPair;
 

--- a/Userland/Libraries/LibWebView/ProcessHandle.cpp
+++ b/Userland/Libraries/LibWebView/ProcessHandle.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/ProcessHandle.h>
+
+template<>
+ErrorOr<void> IPC::encode(IPC::Encoder& encoder, WebView::ProcessHandle const& handle)
+{
+    TRY(encoder.encode(handle.pid));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::ProcessHandle> IPC::decode(IPC::Decoder& decoder)
+{
+    auto pid = TRY(decoder.decode<pid_t>());
+    return WebView::ProcessHandle { pid };
+}

--- a/Userland/Libraries/LibWebView/ProcessHandle.h
+++ b/Userland/Libraries/LibWebView/ProcessHandle.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <LibIPC/Forward.h>
+
+namespace WebView {
+
+struct ProcessHandle {
+    // FIXME: Use mach_port_t on macOS/Hurd and HANDLE on Windows.
+    pid_t pid;
+};
+
+}
+
+template<>
+ErrorOr<void> IPC::encode(IPC::Encoder&, WebView::ProcessHandle const&);
+
+template<>
+ErrorOr<WebView::ProcessHandle> IPC::decode(IPC::Decoder&);

--- a/Userland/Libraries/LibWebView/ProcessManager.cpp
+++ b/Userland/Libraries/LibWebView/ProcessManager.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/String.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
 #include <LibWebView/ProcessManager.h>
@@ -112,6 +113,72 @@ void ProcessManager::update_all_processes()
     }
 
     // FIXME: Actually gather stats in a platform-specific way
+}
+
+String ProcessManager::generate_html()
+{
+    StringBuilder builder;
+    auto processes = m_processes;
+
+    builder.append(R"(
+        <html>
+        <head>
+        <style>
+                table {
+                    width: 100%;
+                    border-collapse: collapse;
+                }
+                th {
+                    text-align: left;
+                    border-bottom: 1px solid #aaa;
+                }
+                td, th {
+                    padding: 4px;
+                    border: 1px solid #aaa;
+                }
+                tr:nth-child(odd) {
+                    background: #f7f7f7;
+                }
+        </style>
+        </head>
+        <body>
+        <table>
+                <thead>
+                <tr>
+                        <th>Type</th>
+                        <th>PID</th>
+                        <th>Memory Usage</th>
+                        <th>CPU %</th>
+                </tr>
+                </thead>
+                <tbody>
+    )"sv);
+
+    for (auto& process : processes) {
+        builder.append("<tr>"sv);
+        builder.append("<td>"sv);
+        builder.append(WebView::process_name_from_type(process.type));
+        builder.append("</td>"sv);
+        builder.append("<td>"sv);
+        builder.append(MUST(String::number(process.pid)));
+        builder.append("</td>"sv);
+        builder.append("<td>"sv);
+        builder.append(MUST(String::formatted("{} KB", process.memory_usage_kib)));
+        builder.append("</td>"sv);
+        builder.append("<td>"sv);
+        builder.append(MUST(String::formatted("{:.1f}", process.cpu_percent)));
+        builder.append("</td>"sv);
+        builder.append("</tr>"sv);
+    }
+
+    builder.append(R"(
+                </tbody>
+                </table>
+                </body>
+                </html>
+    )"sv);
+
+    return builder.to_string_without_validation();
 }
 
 }

--- a/Userland/Libraries/LibWebView/ProcessManager.cpp
+++ b/Userland/Libraries/LibWebView/ProcessManager.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibCore/System.h>
+#include <LibWebView/ProcessManager.h>
+
+namespace WebView {
+
+static sig_atomic_t s_received_sigchld = 0;
+
+ProcessType process_type_from_name(StringView name)
+{
+    if (name == "Chrome"sv)
+        return ProcessType::Chrome;
+    if (name == "WebContent"sv)
+        return ProcessType::WebContent;
+    if (name == "WebWorker"sv)
+        return ProcessType::WebWorker;
+    if (name == "SQLServer"sv)
+        return ProcessType::SQLServer;
+    if (name == "RequestServer"sv)
+        return ProcessType::RequestServer;
+    if (name == "ImageDecoder"sv)
+        return ProcessType::ImageDecoder;
+
+    dbgln("Unknown process type: '{}'", name);
+    VERIFY_NOT_REACHED();
+}
+
+StringView process_name_from_type(ProcessType type)
+{
+    switch (type) {
+    case ProcessType::Chrome:
+        return "Chrome"sv;
+    case ProcessType::WebContent:
+        return "WebContent"sv;
+    case ProcessType::WebWorker:
+        return "WebWorker"sv;
+    case ProcessType::SQLServer:
+        return "SQLServer"sv;
+    case ProcessType::RequestServer:
+        return "RequestServer"sv;
+    case ProcessType::ImageDecoder:
+        return "ImageDecoder"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+ProcessManager::ProcessManager()
+{
+}
+
+ProcessManager::~ProcessManager()
+{
+}
+
+ProcessManager& ProcessManager::the()
+{
+    static ProcessManager s_the;
+    return s_the;
+}
+
+void ProcessManager::initialize()
+{
+    // FIXME: Should we change this to call EventLoop::register_signal?
+    //        Note that only EventLoopImplementationUnix has a working register_signal
+
+    struct sigaction action { };
+    action.sa_flags = SA_RESTART;
+    action.sa_sigaction = [](int, auto*, auto) {
+        s_received_sigchld = 1;
+    };
+
+    MUST(Core::System::sigaction(SIGCHLD, &action, nullptr));
+
+    the().add_process(WebView::ProcessType::Chrome, getpid());
+}
+
+void ProcessManager::add_process(ProcessType type, pid_t pid)
+{
+    dbgln("ProcessManager::add_process({}, {})", process_name_from_type(type), pid);
+    m_processes.append({ type, pid, 0, 0 });
+}
+
+void ProcessManager::remove_process(pid_t pid)
+{
+    m_processes.remove_first_matching([&](auto& info) {
+        if (info.pid == pid) {
+            dbgln("ProcessManager: Remove process {} ({})", process_name_from_type(info.type), pid);
+            return true;
+        }
+        return false;
+    });
+}
+
+void ProcessManager::update_all_processes()
+{
+    if (s_received_sigchld) {
+        s_received_sigchld = 0;
+        auto result = Core::System::waitpid(-1, WNOHANG);
+        while (!result.is_error() && result.value().pid > 0) {
+            auto& [pid, status] = result.value();
+            if (WIFEXITED(status) || WIFSIGNALED(status)) {
+                remove_process(pid);
+            }
+            result = Core::System::waitpid(-1, WNOHANG);
+        }
+    }
+
+    // FIXME: Actually gather stats in a platform-specific way
+}
+
+}

--- a/Userland/Libraries/LibWebView/ProcessManager.h
+++ b/Userland/Libraries/LibWebView/ProcessManager.h
@@ -43,6 +43,8 @@ public:
     void update_all_processes();
     Vector<ProcessInfo> processes() const { return m_processes; }
 
+    String generate_html();
+
 private:
     ProcessManager();
     ~ProcessManager();

--- a/Userland/Libraries/LibWebView/ProcessManager.h
+++ b/Userland/Libraries/LibWebView/ProcessManager.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibCore/EventReceiver.h>
+#include <LibWebView/Forward.h>
+
+#pragma once
+
+namespace WebView {
+
+enum class ProcessType {
+    Chrome,
+    WebContent,
+    WebWorker,
+    SQLServer,
+    RequestServer,
+    ImageDecoder,
+};
+
+struct ProcessInfo {
+    ProcessType type;
+    pid_t pid;
+    u64 memory_usage_kib = 0;
+    float cpu_percent = 0.0f;
+};
+
+ProcessType process_type_from_name(StringView);
+StringView process_name_from_type(ProcessType type);
+
+class ProcessManager {
+public:
+    static ProcessManager& the();
+    static void initialize();
+
+    void add_process(WebView::ProcessType, pid_t);
+    void remove_process(pid_t);
+
+    void update_all_processes();
+    Vector<ProcessInfo> processes() const { return m_processes; }
+
+private:
+    ProcessManager();
+    ~ProcessManager();
+
+    Vector<ProcessInfo> m_processes;
+};
+
+}

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "WebContentClient.h"
+#include "ProcessManager.h"
 #include "ViewImplementation.h"
 #include <LibWeb/Cookie/ParsedCookie.h>
 
@@ -31,6 +32,12 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 void WebContentClient::unregister_view(u64 page_id)
 {
     m_views.remove(page_id);
+}
+
+void WebContentClient::notify_process_information(WebView::ProcessHandle const& handle)
+{
+    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::NotifyProcessInformation! pid={}", handle.pid);
+    ProcessManager::the().add_process(ProcessType::WebContent, handle.pid);
 }
 
 void WebContentClient::did_paint(u64 page_id, Gfx::IntRect const& rect, i32 bitmap_id)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -37,6 +37,7 @@ public:
 private:
     virtual void die() override;
 
+    virtual void notify_process_information(WebView::ProcessHandle const&) override;
     virtual void did_paint(u64 page_id, Gfx::IntRect const&, i32) override;
     virtual void did_finish_loading(u64 page_id, URL::URL const&) override;
     virtual void did_update_url(u64 page_id, URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -59,6 +59,7 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> sock
     , m_page_host(PageHost::create(*this))
 {
     m_input_event_queue_timer = Web::Platform::Timer::create_single_shot(0, [this] { process_next_input_event(); });
+    async_notify_process_information({ ::getpid() });
 }
 
 void ConnectionFromClient::die()

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -15,9 +15,12 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/SocketPair.h>
+#include <LibWebView/ProcessHandle.h>
 
 endpoint WebContentClient
 {
+    notify_process_information(WebView::ProcessHandle handle) =|
+
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
     did_update_url(u64 page_id, URL::URL url, Web::HTML::HistoryHandlingBehavior history_behavior) =|


### PR DESCRIPTION
This simplistic implementation is just the UI part: it doesn't do any grabbing of per-process information yet.

AppKit was left as an exercise for ~~the reader~~ Tim :)

The UI also splats the information into a simple WebView widget instead of creating a native Table view for each chrome. If the performance penalty from having a web UI for this becomes annoying, we can probably port it in a straightforward way to native widgets, assuming the models and views are not too complex.