### PR TITLE
Shell: Correctly auto format command lines consisting of only whitespace

### DIFF
--- a/Userland/Shell/Formatter.h
+++ b/Userland/Shell/Formatter.h
@@ -30,8 +30,11 @@ public:
             return;
 
         size_t offset = 0;
-        for (auto ptr = m_source.end() - 1; ptr >= m_source.begin() && isspace(*ptr); --ptr)
+        for (auto ptr = m_source.end() - 1; isspace(*ptr); --ptr) {
             ++offset;
+            if (ptr == m_source.begin())
+                break;
+        }
 
         m_trivia = m_source.substring_view(m_source.length() - offset, offset);
     }


### PR DESCRIPTION
```
When the command line consists of only whitespace characters, the auto
formatter basically tries to trim the trailing whitespace. But due to a
subtle bug of decrementing an iterator (which is an unsigned integer)
past 0 (or the start of the buffer), that operation resulted in an index
out of bounds error and a crash.
```

Why no reverse iterator for `StringView`?

This behaviour is unexpected if you want leading whitespace command lines to not get added to the history.
