### PR TITLE
headless-browser: Don't forget to load webpage before taking screenshot

### DIFF
--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -208,7 +208,7 @@ private:
     Vector<ByteString> m_certificates;
 };
 
-static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Core::EventLoop& event_loop, HeadlessWebContentView& view, int screenshot_timeout)
+static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Core::EventLoop& event_loop, HeadlessWebContentView& view, URL::URL url, int screenshot_timeout)
 {
     // FIXME: Allow passing the output path as an argument.
     static constexpr auto output_file_path = "output.png"sv;
@@ -234,6 +234,7 @@ static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Cor
             event_loop.quit(0);
         }));
 
+    view.load(url);
     timer->start();
     return timer;
 }
@@ -713,7 +714,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (web_driver_ipc_path.is_empty()) {
-        auto timer = TRY(load_page_for_screenshot_and_exit(event_loop, *view, screenshot_timeout));
+        auto timer = TRY(load_page_for_screenshot_and_exit(event_loop, *view, url.value(), screenshot_timeout));
         return event_loop.exec();
     }
 


### PR DESCRIPTION
```
For the normal non-test use case of headless-browser, the function 
`load_page_for_screenshot_and_exit()` didn't actually load the requested
webpage in the `WebView`, resulting in an all white pixels screenshot.
```

Next issue is that the screenshot produced isn't 800x600 size. The height is as big as the whole webpage.