### PR TITLE
LibWeb: Add basic "top layer" support

### DIFF
--- a/Tests/LibWeb/Layout/expected/top-layer.txt
+++ b/Tests/LibWeb/Layout/expected/top-layer.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      TextNode <#text>
+  BlockContainer <dialog#dialog> at (196.671875,35) content-size 406.65625x49 positioned [BFC] children: not-inline
+    BlockContainer <p> at (196.671875,51) content-size 406.65625x17 children: inline
+      frag 0 from TextNode start: 0, length: 50, rect: [196.671875,51 406.65625x17] baseline: 13.296875
+          "Dialog's layout node should be a child of viewport"
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+  PaintableWithLines (BlockContainer<DIALOG>#dialog) [177.671875,16 444.65625x87]
+    PaintableWithLines (BlockContainer<P>) [196.671875,51 406.65625x17]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/top-layer.html
+++ b/Tests/LibWeb/Layout/input/top-layer.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html><dialog id="dialog"><p>Dialog's layout node should be a child of viewport</p></dialog>
+<script>
+    dialog.showModal();
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -615,6 +615,13 @@ public:
     void unregister_shadow_root(Badge<DOM::ShadowRoot>, DOM::ShadowRoot&);
     void for_each_shadow_root(Function<void(DOM::ShadowRoot&)>&& callback);
 
+    void add_an_element_to_the_top_layer(JS::NonnullGCPtr<Element>);
+    void request_an_element_to_be_remove_from_the_top_layer(JS::NonnullGCPtr<Element>);
+    void remove_an_element_from_the_top_layer_immediately(JS::NonnullGCPtr<Element>);
+    void process_top_layer_removals();
+
+    OrderedHashTable<JS::NonnullGCPtr<Element>> const& top_layer_elements() const { return m_top_layer_elements; }
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -854,6 +861,13 @@ private:
     Vector<JS::NonnullGCPtr<DOM::ShadowRoot>> m_shadow_roots;
 
     u64 m_dom_tree_version { 0 };
+
+    // https://drafts.csswg.org/css-position-4/#document-top-layer
+    // Documents have a top layer, an ordered set containing elements from the document.
+    // Elements in the top layer do not lay out normally based on their position in the document;
+    // instead they generate boxes as if they were siblings of the root element.
+    OrderedHashTable<JS::NonnullGCPtr<Element>> m_top_layer_elements;
+    OrderedHashTable<JS::NonnullGCPtr<Element>> m_top_layer_pending_removals;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -361,6 +361,9 @@ public:
         return nullptr;
     }
 
+    void set_in_top_layer(bool in_top_layer) { m_in_top_layer = in_top_layer; }
+    bool in_top_layer() const { return m_in_top_layer; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -430,6 +433,8 @@ private:
     OwnPtr<Vector<IntersectionObserver::IntersectionObserverRegistration>> m_registered_intersection_observers;
 
     Array<CSSPixelPoint, 3> m_scroll_offset;
+
+    bool m_in_top_layer { false };
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -352,6 +352,11 @@ void EventLoop::process()
     // If there are eligible tasks in the queue, schedule a new round of processing. :^)
     if (m_task_queue.has_runnable_tasks() || (!m_microtask_queue.is_empty() && !m_performing_a_microtask_checkpoint))
         schedule();
+
+    // For each doc of docs, process top layer removals given doc.
+    for_each_fully_active_document_in_docs([&](DOM::Document& document) {
+        document.process_top_layer_removals();
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -18,11 +18,13 @@ class HTMLDialogElement final : public HTMLElement {
 public:
     virtual ~HTMLDialogElement() override;
 
+    virtual void removed_from(Node*) override;
+
     String return_value() const;
     void set_return_value(String);
 
     WebIDL::ExceptionOr<void> show();
-    void show_modal();
+    WebIDL::ExceptionOr<void> show_modal();
     void close(Optional<String> return_value);
 
     // https://www.w3.org/TR/html-aria/#el-dialog
@@ -38,6 +40,7 @@ private:
     void run_dialog_focusing_steps();
 
     String m_return_value;
+    bool m_is_modal { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -24,6 +24,7 @@ private:
     struct Context {
         bool has_svg_root = false;
         bool layout_svg_mask = false;
+        bool layout_top_layer = false;
     };
 
     i32 calculate_list_item_index(DOM::Node&);


### PR DESCRIPTION
Implements the "top layer" concept from "CSS Positioned Layout Module Level 4" specification.

- The tree builder is modified to ensure that layout nodes created by top layer elements are children of the viewport.
- Implements missing steps in `showModal()` to add an element top top layer.
- Implements missing steps in `close()` to remove an element from top layer.

Further steps could be:
- Add support for `::backdrop` pseudo-element.
- Implement the "inert" concept from HTML spec to block hit-testing when element from top layer is displayed.

With these changes we support displaying side panel on GitHub:
<img width="1220" alt="Screenshot 2024-03-28 at 19 31 09" src="https://github.com/SerenityOS/serenity/assets/45686940/107dde6c-ce3b-4029-b3c6-0ee19fbd470e">