### PR TITLE
Base+ImageViewer: Restore correct app icon

### DIFF
--- a/Base/usr/share/man/man1/Applications/ImageViewer.md
+++ b/Base/usr/share/man/man1/Applications/ImageViewer.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/filetype-image.png) Image Viewer - SerenityOS image viewer
+![Icon](/res/icons/16x16/app-image-viewer.png) Image Viewer - SerenityOS image viewer
 
 [Open](file:///bin/ImageViewer)
 
@@ -29,4 +29,3 @@ ImageViewer is even smart enough to detect other images and display them when cl
 ```sh
 $ ImageViewer /res/graphics/buggie.png
 ```
-

--- a/Userland/Applications/ImageViewer/CMakeLists.txt
+++ b/Userland/Applications/ImageViewer/CMakeLists.txt
@@ -11,5 +11,5 @@ set(SOURCES
         ViewWidget.cpp
 )
 
-serenity_app(ImageViewer ICON filetype-image)
+serenity_app(ImageViewer ICON app-image-viewer)
 target_link_libraries(ImageViewer PRIVATE LibCore LibDesktop LibFileSystemAccessClient LibGUI LibGfx LibConfig LibImageDecoderClient LibMain LibURL)


### PR DESCRIPTION
Restore ImageViewer's new application icon, which was accidentally changed back to using the filetype icon by e800605ad3e4e9dfdc320c137e1beef1a66d2eb0.

Additionally, use the correct icon in the ImageViewer manpage.