### PR TITLE
LibWeb/CSS: Don't sum up percentages with an indefinite basis

### DIFF
--- a/Tests/LibWeb/Layout/expected/relpos-indefinite-inset.txt
+++ b/Tests/LibWeb/Layout/expected/relpos-indefinite-inset.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x100 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 100x0 children: inline
+          TextNode <#text>
+        BlockContainer <div> at (8,8) content-size 100x100 positioned children: not-inline
+        BlockContainer <(anonymous)> at (8,108) content-size 100x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 100x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 100x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,108 100x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/input/relpos-indefinite-inset.html
+++ b/Tests/LibWeb/Layout/input/relpos-indefinite-inset.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<div style="width: 100px; background: red;">
+  <div style="width: 100px; height: 100px; background: green; top: calc(10px + 10%); position: relative;"></div>
+</div>


### PR DESCRIPTION
Instead, we can simply return a zero value with an appropriate type.
With this patch, the following WPT test now passes:
 - http://wpt.live/css/css-position/position-relative-007.html

Supersedes #23754.