### PR TITLE
LibJS: Include identifier information in nullish property access

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -489,16 +489,17 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> AssignmentExpressio
                     generator.emit_set_variable(identifier, rval);
                 } else if (is<MemberExpression>(*lhs)) {
                     auto& expression = static_cast<MemberExpression const&>(*lhs);
+                    auto base_identifier = generator.intern_identifier_for_expression(expression.object());
 
                     if (expression.is_computed()) {
                         if (!lhs_is_super_expression)
-                            generator.emit<Bytecode::Op::PutByValue>(*base, *computed_property, rval);
+                            generator.emit<Bytecode::Op::PutByValue>(*base, *computed_property, rval, Bytecode::Op::PropertyKind::KeyValue, move(base_identifier));
                         else
                             generator.emit<Bytecode::Op::PutByValueWithThis>(*base, *computed_property, *this_value, rval);
                     } else if (expression.property().is_identifier()) {
                         auto identifier_table_ref = generator.intern_identifier(verify_cast<Identifier>(expression.property()).string());
                         if (!lhs_is_super_expression)
-                            generator.emit<Bytecode::Op::PutById>(*base, identifier_table_ref, rval, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache());
+                            generator.emit<Bytecode::Op::PutById>(*base, identifier_table_ref, rval, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache(), move(base_identifier));
                         else
                             generator.emit<Bytecode::Op::PutByIdWithThis>(*base, *this_value, identifier_table_ref, rval, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache());
                     } else if (expression.property().is_private_identifier()) {

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1540,7 +1540,8 @@ static Bytecode::CodeGenerationErrorOr<BaseAndValue> get_base_and_value_from_mem
             base,
             generator.intern_identifier(verify_cast<PrivateIdentifier>(member_expression.property()).string()));
     } else {
-        generator.emit_get_by_id(value, base, generator.intern_identifier(verify_cast<Identifier>(member_expression.property()).string()));
+        auto base_identifier = generator.intern_identifier_for_expression(member_expression.object());
+        generator.emit_get_by_id(value, base, generator.intern_identifier(verify_cast<Identifier>(member_expression.property()).string()), move(base_identifier));
     }
 
     return BaseAndValue { base, value };

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -74,6 +74,13 @@ public:
     ByteString const& get_string(StringTableIndex index) const { return string_table->get(index); }
     DeprecatedFlyString const& get_identifier(IdentifierTableIndex index) const { return identifier_table->get(index); }
 
+    Optional<DeprecatedFlyString const&> get_identifier(Optional<IdentifierTableIndex> const& index) const
+    {
+        if (!index.has_value())
+            return {};
+        return get_identifier(*index);
+    }
+
     void dump() const;
 
 private:

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -183,6 +183,8 @@ public:
         return m_identifier_table->insert(move(string));
     }
 
+    Optional<IdentifierTableIndex> intern_identifier_for_expression(Expression const& expression);
+
     bool is_in_generator_or_async_function() const { return m_enclosing_function_kind == FunctionKind::Async || m_enclosing_function_kind == FunctionKind::Generator || m_enclosing_function_kind == FunctionKind::AsyncGenerator; }
     bool is_in_generator_function() const { return m_enclosing_function_kind == FunctionKind::Generator || m_enclosing_function_kind == FunctionKind::AsyncGenerator; }
     bool is_in_async_function() const { return m_enclosing_function_kind == FunctionKind::Async || m_enclosing_function_kind == FunctionKind::AsyncGenerator; }
@@ -247,7 +249,7 @@ public:
         m_boundaries.take_last();
     }
 
-    void emit_get_by_id(Operand dst, Operand base, IdentifierTableIndex);
+    void emit_get_by_id(Operand dst, Operand base, IdentifierTableIndex property_identifier, Optional<IdentifierTableIndex> base_identifier = {});
 
     void emit_get_by_id_with_this(Operand dst, Operand base, IdentifierTableIndex, Operand this_value);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1132,9 +1132,10 @@ ThrowCompletionOr<void> PutById::execute_impl(Bytecode::Interpreter& interpreter
     auto& vm = interpreter.vm();
     auto value = interpreter.get(m_src);
     auto base = interpreter.get(m_base);
+    auto base_identifier = interpreter.current_executable().get_identifier(m_base_identifier);
     PropertyKey name = interpreter.current_executable().get_identifier(m_property);
     auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
-    TRY(put_by_property_key(vm, base, base, value, name, m_kind, &cache));
+    TRY(put_by_property_key(vm, base, base, value, base_identifier, name, m_kind, &cache));
     return {};
 }
 
@@ -1145,7 +1146,7 @@ ThrowCompletionOr<void> PutByIdWithThis::execute_impl(Bytecode::Interpreter& int
     auto base = interpreter.get(m_base);
     PropertyKey name = interpreter.current_executable().get_identifier(m_property);
     auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
-    TRY(put_by_property_key(vm, base, interpreter.get(m_this_value), value, name, m_kind, &cache));
+    TRY(put_by_property_key(vm, base, interpreter.get(m_this_value), value, {}, name, m_kind, &cache));
     return {};
 }
 
@@ -1523,7 +1524,8 @@ ThrowCompletionOr<void> PutByValue::execute_impl(Bytecode::Interpreter& interpre
 {
     auto& vm = interpreter.vm();
     auto value = interpreter.get(m_src);
-    TRY(put_by_value(vm, interpreter.get(m_base), interpreter.get(m_property), value, m_kind));
+    auto base_identifier = interpreter.current_executable().get_identifier(m_base_identifier);
+    TRY(put_by_value(vm, interpreter.get(m_base), base_identifier, interpreter.get(m_property), value, m_kind));
     return {};
 }
 
@@ -1533,7 +1535,7 @@ ThrowCompletionOr<void> PutByValueWithThis::execute_impl(Bytecode::Interpreter& 
     auto value = interpreter.get(m_src);
     auto base = interpreter.get(m_base);
     auto property_key = m_kind != PropertyKind::Spread ? TRY(interpreter.get(m_property).to_property_key(vm)) : PropertyKey {};
-    TRY(put_by_property_key(vm, base, interpreter.get(m_this_value), value, property_key, m_kind));
+    TRY(put_by_property_key(vm, base, interpreter.get(m_this_value), value, {}, property_key, m_kind));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1083,9 +1083,13 @@ ThrowCompletionOr<void> SetLocal::execute_impl(Bytecode::Interpreter&) const
 
 ThrowCompletionOr<void> GetById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
+    auto base_identifier = interpreter.current_executable().get_identifier(m_base_identifier);
+    auto const& property_identifier = interpreter.current_executable().get_identifier(m_property);
+
     auto base_value = interpreter.get(base());
     auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
-    interpreter.set(dst(), TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, base_value, cache)));
+
+    interpreter.set(dst(), TRY(get_by_id(interpreter.vm(), base_identifier, property_identifier, base_value, base_value, cache)));
     return {};
 }
 
@@ -1094,7 +1098,7 @@ ThrowCompletionOr<void> GetByIdWithThis::execute_impl(Bytecode::Interpreter& int
     auto base_value = interpreter.get(m_base);
     auto this_value = interpreter.get(m_this_value);
     auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
-    interpreter.set(dst(), TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, this_value, cache)));
+    interpreter.set(dst(), TRY(get_by_id(interpreter.vm(), {}, interpreter.current_executable().get_identifier(m_property), base_value, this_value, cache)));
     return {};
 }
 
@@ -1499,7 +1503,9 @@ ThrowCompletionOr<void> Await::execute_impl(Bytecode::Interpreter& interpreter) 
 
 ThrowCompletionOr<void> GetByValue::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.set(dst(), TRY(get_by_value(interpreter.vm(), interpreter.get(m_base), interpreter.get(m_property))));
+    auto base_identifier = interpreter.current_executable().get_identifier(m_base_identifier);
+
+    interpreter.set(dst(), TRY(get_by_value(interpreter.vm(), base_identifier, interpreter.get(m_base), interpreter.get(m_property))));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -741,13 +741,14 @@ enum class PropertyKind {
 
 class PutById final : public Instruction {
 public:
-    explicit PutById(Operand base, IdentifierTableIndex property, Operand src, PropertyKind kind, u32 cache_index)
+    explicit PutById(Operand base, IdentifierTableIndex property, Operand src, PropertyKind kind, u32 cache_index, Optional<IdentifierTableIndex> base_identifier = {})
         : Instruction(Type::PutById, sizeof(*this))
         , m_base(base)
         , m_property(property)
         , m_src(src)
         , m_kind(kind)
         , m_cache_index(cache_index)
+        , m_base_identifier(move(base_identifier))
     {
     }
 
@@ -766,6 +767,7 @@ private:
     Operand m_src;
     PropertyKind m_kind;
     u32 m_cache_index { 0 };
+    Optional<IdentifierTableIndex> m_base_identifier {};
 };
 
 class PutByIdWithThis final : public Instruction {
@@ -929,12 +931,13 @@ private:
 
 class PutByValue final : public Instruction {
 public:
-    PutByValue(Operand base, Operand property, Operand src, PropertyKind kind = PropertyKind::KeyValue)
+    PutByValue(Operand base, Operand property, Operand src, PropertyKind kind = PropertyKind::KeyValue, Optional<IdentifierTableIndex> base_identifier = {})
         : Instruction(Type::PutByValue, sizeof(*this))
         , m_base(base)
         , m_property(property)
         , m_src(src)
         , m_kind(kind)
+        , m_base_identifier(move(base_identifier))
     {
     }
 
@@ -951,6 +954,7 @@ private:
     Operand m_property;
     Operand m_src;
     PropertyKind m_kind;
+    Optional<IdentifierTableIndex> m_base_identifier;
 };
 
 class PutByValueWithThis final : public Instruction {

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -629,11 +629,12 @@ private:
 
 class GetById final : public Instruction {
 public:
-    GetById(Operand dst, Operand base, IdentifierTableIndex property, u32 cache_index)
+    GetById(Operand dst, Operand base, IdentifierTableIndex property, Optional<IdentifierTableIndex> base_identifier, u32 cache_index)
         : Instruction(Type::GetById, sizeof(*this))
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
+        , m_base_identifier(move(base_identifier))
         , m_cache_index(cache_index)
     {
     }
@@ -650,6 +651,7 @@ private:
     Operand m_dst;
     Operand m_base;
     IdentifierTableIndex m_property;
+    Optional<IdentifierTableIndex> m_base_identifier;
     u32 m_cache_index { 0 };
 };
 
@@ -874,11 +876,12 @@ private:
 
 class GetByValue final : public Instruction {
 public:
-    explicit GetByValue(Operand dst, Operand base, Operand property)
+    GetByValue(Operand dst, Operand base, Operand property, Optional<IdentifierTableIndex> base_identifier = {})
         : Instruction(Type::GetByValue, sizeof(*this))
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
+        , m_base_identifier(move(base_identifier))
     {
     }
 
@@ -889,10 +892,13 @@ public:
     Operand base() const { return m_base; }
     Operand property() const { return m_property; }
 
+    Optional<DeprecatedFlyString const&> base_identifier(Bytecode::Interpreter const&) const;
+
 private:
     Operand m_dst;
     Operand m_base;
     Operand m_property;
+    Optional<IdentifierTableIndex> m_base_identifier;
 };
 
 class GetByValueWithThis final : public Instruction {

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -302,6 +302,9 @@
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \
     M(ThisIsAlreadyInitialized, "|this| is already initialized")                                                                        \
     M(ToObjectNullOrUndefined, "ToObject on null or undefined")                                                                         \
+    M(ToObjectNullOrUndefinedWithName, "\"{}\" is {}")                                                                                  \
+    M(ToObjectNullOrUndefinedWithProperty, "Cannot access property \"{}\" on {} object")                                                \
+    M(ToObjectNullOrUndefinedWithPropertyAndName, "Cannot access property \"{}\" on {} object \"{}\"")                                  \
     M(TopLevelVariableAlreadyDeclared, "Redeclaration of top level variable '{}'")                                                      \
     M(ToPrimitiveReturnedObject, "Can't convert {} to primitive with hint \"{}\", its @@toPrimitive method returned an object")         \
     M(TypedArrayContentTypeMismatch, "Can't create {} from {}")                                                                         \

--- a/Userland/Libraries/LibJS/Tests/null-or-undefined-access.js
+++ b/Userland/Libraries/LibJS/Tests/null-or-undefined-access.js
@@ -7,7 +7,15 @@ test("null/undefined object", () => {
         }).toThrowWithMessage(TypeError, `Cannot access property "bar" on ${value} object "foo"`);
 
         expect(() => {
+            foo.bar = 1;
+        }).toThrowWithMessage(TypeError, `Cannot access property "bar" on ${value} object "foo"`);
+
+        expect(() => {
             foo[0];
+        }).toThrowWithMessage(TypeError, `Cannot access property "0" on ${value} object "foo"`);
+
+        expect(() => {
+            foo[0] = 1;
         }).toThrowWithMessage(TypeError, `Cannot access property "0" on ${value} object "foo"`);
     });
 });
@@ -22,6 +30,13 @@ test("null/undefined object key", () => {
             TypeError,
             `Cannot access property "baz" on ${value} object "foo.bar"`
         );
+
+        expect(() => {
+            foo.bar.baz = 1;
+        }).toThrowWithMessage(
+            TypeError,
+            `Cannot access property "baz" on ${value} object "foo.bar"`
+        );
     });
 });
 
@@ -31,6 +46,10 @@ test("null/undefined array index", () => {
 
         expect(() => {
             foo[0].bar;
+        }).toThrowWithMessage(TypeError, `Cannot access property "bar" on ${value} object`);
+
+        expect(() => {
+            foo[0].bar = 1;
         }).toThrowWithMessage(TypeError, `Cannot access property "bar" on ${value} object`);
     });
 });

--- a/Userland/Libraries/LibJS/Tests/null-or-undefined-access.js
+++ b/Userland/Libraries/LibJS/Tests/null-or-undefined-access.js
@@ -1,0 +1,36 @@
+test("null/undefined object", () => {
+    [null, undefined].forEach(value => {
+        let foo = value;
+
+        expect(() => {
+            foo.bar;
+        }).toThrowWithMessage(TypeError, `Cannot access property "bar" on ${value} object "foo"`);
+
+        expect(() => {
+            foo[0];
+        }).toThrowWithMessage(TypeError, `Cannot access property "0" on ${value} object "foo"`);
+    });
+});
+
+test("null/undefined object key", () => {
+    [null, undefined].forEach(value => {
+        let foo = { bar: value };
+
+        expect(() => {
+            foo.bar.baz;
+        }).toThrowWithMessage(
+            TypeError,
+            `Cannot access property "baz" on ${value} object "foo.bar"`
+        );
+    });
+});
+
+test("null/undefined array index", () => {
+    [null, undefined].forEach(value => {
+        let foo = [value];
+
+        expect(() => {
+            foo[0].bar;
+        }).toThrowWithMessage(TypeError, `Cannot access property "bar" on ${value} object`);
+    });
+});


### PR DESCRIPTION
When a `GetById` / `GetByValue` / `PutById` / `PutByValue` bytecode operation results in accessing a nullish object, we now include the name of the property and the object being accessed in the exception message (if available). This should make
it easier to debug live websites.

For example, the following errors would all previously produce a generic error message of "ToObject on null or undefined":

```js
> foo = null

> foo.bar
Uncaught exception:
[TypeError] Cannot access property "bar" on null object "foo"
    at <unknown>

> foo.bar = 1
Uncaught exception:
[TypeError] Cannot access property "bar" on null object "foo"
    at <unknown>
```
```js
> foo = { bar: undefined }

> foo.bar.baz
Uncaught exception:
[TypeError] Cannot access property "baz" on undefined object "foo.bar"
    at <unknown>

> foo.bar.baz = 1
Uncaught exception:
[TypeError] Cannot access property "baz" on undefined object "foo.bar"
    at <unknown>
```

Note we certainly don't capture all possible nullish property accesses here. This just covers cases I've seen most on live websites; we can cover more cases as they arise.

And for a live example, we now get the following error on GitHub, which tells us we haven't implemented `PerformanceObserver.supportedEntryTypes`:
```
Unhandled JavaScript exception: [TypeError] Cannot access property "includes" on undefined object "PerformanceObserver.supportedEntryTypes"
    at E (https://github.githubassets.com/assets/vendors-node_modules_github_quote-selection_dist_index_js-node_modules_github_session-resume_-ff65ee-c202d20e2d3d.js:18:14553)
    at F (https://github.githubassets.com/assets/vendors-node_modules_github_quote-selection_dist_index_js-node_modules_github_session-resume_-ff65ee-c202d20e2d3d.js:18:14553)
    at https://github.githubassets.com/assets/behaviors-91d3668ba8db.js:33:72556
    at https://github.githubassets.com/assets/behaviors-91d3668ba8db.js:33:72556
```

Edit: Figured out a way to extract a bit more identifier information, so in the above example, we see `PerformanceObserver.supportedEntryTypes` in the error message instead of just `supportedEntryTypes`.