### PR TITLE
LibCore: Turn LibCoreMinimal into a normal shared library

### DIFF
--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -403,6 +403,7 @@ if (current_os != "mac") {
       "$root_out_dir/lib/liblagom-ak.dylib",
       "$root_out_dir/lib/liblagom-audio.dylib",
       "$root_out_dir/lib/liblagom-compress.dylib",
+      "$root_out_dir/lib/liblagom-core-minimal.dylib",
       "$root_out_dir/lib/liblagom-core.dylib",
       "$root_out_dir/lib/liblagom-crypto.dylib",
       "$root_out_dir/lib/liblagom-diff.dylib",

--- a/Meta/gn/secondary/Userland/Libraries/LibCore/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibCore/BUILD.gn
@@ -1,6 +1,8 @@
 # These are the minimal set of sources needed to build the code generators. We separate them to allow
 # LibCore to depend on generated sources.
-source_set("minimal") {
+shared_library("minimal") {
+  output_name = "core-minimal"
+
   include_dirs = [ "//Userland/Libraries" ]
 
   sources = [
@@ -14,9 +16,13 @@ source_set("minimal") {
     "Directory.h",
     "DirectoryEntry.cpp",
     "DirectoryEntry.h",
+    "Environment.cpp",
+    "Environment.h",
     "File.cpp",
     "File.h",
     "Forward.h",
+    "SessionManagement.cpp",
+    "SessionManagement.h",
     "StandardPaths.cpp",
     "StandardPaths.h",
     "System.cpp",
@@ -45,8 +51,6 @@ source_set("sources") {
     "DeferredInvocationContext.h",
     "ElapsedTimer.cpp",
     "ElapsedTimer.h",
-    "Environment.cpp",
-    "Environment.h",
     "Event.cpp",
     "Event.h",
     "EventLoop.cpp",
@@ -81,8 +85,6 @@ source_set("sources") {
     "SOCKSProxyClient.h",
     "SecretString.cpp",
     "SecretString.h",
-    "SessionManagement.cpp",
-    "SessionManagement.h",
     "SharedCircularQueue.h",
     "Socket.cpp",
     "Socket.h",
@@ -151,7 +153,6 @@ shared_library("LibCore") {
 
   deps = [
     ":filewatcher",
-    ":minimal",
     ":sources",
     "//Meta/gn/build/libs/crypt",
     "//Meta/gn/build/libs/pthread",
@@ -159,4 +160,6 @@ shared_library("LibCore") {
     "//Userland/Libraries/LibTimeZone",
     "//Userland/Libraries/LibURL",
   ]
+
+  public_deps = [ ":minimal" ]
 }

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -6,13 +6,15 @@ set(SOURCES
     Directory.cpp
     DirectoryEntry.cpp
     DirIterator.cpp
+    Environment.cpp
     File.cpp
+    SessionManagement.cpp
     StandardPaths.cpp
     System.cpp
     Version.cpp
 )
 
-serenity_lib(LibCoreMinimal coreminimal TYPE OBJECT)
+serenity_lib(LibCoreMinimal coreminimal)
 target_link_libraries(LibCoreMinimal PRIVATE LibSystem)
 
 set(SOURCES
@@ -20,7 +22,6 @@ set(SOURCES
     Command.cpp
     DateTime.cpp
     ElapsedTimer.cpp
-    Environment.cpp
     Event.cpp
     EventLoop.cpp
     EventLoopImplementation.cpp
@@ -37,7 +38,6 @@ set(SOURCES
     ResourceImplementation.cpp
     ResourceImplementationFile.cpp
     SecretString.cpp
-    SessionManagement.cpp
     Socket.cpp
     SOCKSProxyClient.cpp
     SystemServerTakeover.cpp
@@ -70,7 +70,8 @@ else()
 endif()
 
 serenity_lib(LibCore core)
-target_link_libraries(LibCore PRIVATE LibCoreMinimal LibCrypt LibSystem LibTimeZone LibURL)
+target_link_libraries(LibCore PRIVATE LibCrypt LibSystem LibTimeZone LibURL)
+target_link_libraries(LibCore PUBLIC LibCoreMinimal)
 
 if (APPLE)
     target_link_libraries(LibCore PUBLIC "-framework CoreFoundation")


### PR DESCRIPTION
We were able to keep LibCoreMinimal a bit smaller as an object library, but that is causing ODR violations in the fuzzer build (realistically, should be an issue in all builds, but only the fuzzer actively complains for some reason).

To make it a shared library, we have to add a couple more symbols to it, and make LibCore publicly depend on it.