### PR TITLE
LibWeb: Fix infinite loop in CSS::Parser::parse_transition_value()

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAnimations/transitions/parse-transition-property.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/transitions/parse-transition-property.txt
@@ -1,0 +1,1 @@
+   PASS! (Did not crash/timeout)

--- a/Tests/LibWeb/Text/input/WebAnimations/transitions/parse-transition-property.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/transitions/parse-transition-property.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    #foo {
+        transition: background-color 1s 2s linear,
+            opacity,
+            this is an invalid property value;
+    }
+</style>
+<div id="foo"></div>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        println("PASS! (Did not crash/timeout)");
+    });
+</script>


### PR DESCRIPTION
Accidentally added this in #23762