### PR TITLE
LibWeb: Don't attempt to notify chromes about audio playing until ready

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/StyleValues/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/StyleValues/BUILD.gn
@@ -32,6 +32,7 @@ source_set("StyleValues") {
     "ShorthandStyleValue.cpp",
     "StyleValueList.cpp",
     "TransformationStyleValue.cpp",
+    "TransitionStyleValue.cpp",
     "UnresolvedStyleValue.cpp",
   ]
 }

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/Layout/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/Layout/BUILD.gn
@@ -36,6 +36,7 @@ source_set("Layout") {
     "RadioButton.cpp",
     "ReplacedBox.cpp",
     "SVGBox.cpp",
+    "SVGClipBox.cpp",
     "SVGFormattingContext.cpp",
     "SVGGeometryBox.cpp",
     "SVGGraphicsBox.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/Painting/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/Painting/BUILD.gn
@@ -31,6 +31,7 @@ source_set("Painting") {
     "PaintableFragment.cpp",
     "RadioButtonPaintable.cpp",
     "RecordingPainter.cpp",
+    "SVGClipPaintable.cpp",
     "SVGGraphicsPaintable.cpp",
     "SVGMaskPaintable.cpp",
     "SVGPaintable.cpp",

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -1578,6 +1578,9 @@ void HTMLMediaElement::notify_about_playing()
     });
 
     on_playing();
+
+    if (m_audio_tracks->has_enabled_track())
+        document().page().client().page_did_change_audio_play_state(AudioPlayState::Playing);
 }
 
 void HTMLMediaElement::set_show_poster(bool show_poster)
@@ -1598,15 +1601,16 @@ void HTMLMediaElement::set_paused(bool paused)
 
     m_paused = paused;
 
-    if (m_paused)
+    if (m_paused) {
         on_paused();
+
+        if (m_audio_tracks->has_enabled_track())
+            document().page().client().page_did_change_audio_play_state(AudioPlayState::Paused);
+    }
 
     if (auto* paintable = this->paintable())
         paintable->set_needs_display();
     set_needs_style_update(true);
-
-    if (m_audio_tracks->has_enabled_track())
-        document().page().client().page_did_change_audio_play_state(paused ? AudioPlayState::Paused : AudioPlayState::Playing);
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#blocked-media-element


### PR DESCRIPTION
The current location of the IPC invocation is often too soon. We reach it before the audio file has completely finished downloading / loading, thus there isn't an `AudioTrack` object yet.

Instead, wait until we are actually playing the audio to invoke the IPC.

This is particularly frequent on bandcamp.