### PR TITLE
Ladybird+LibWeb: Support muting an entire page

### DIFF
--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -192,6 +192,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
     case Web::HTML::AudioPlayState::Playing:
         [button setImage:[self iconForPageMuteState]];
+        [button setToolTip:[self toolTipForPageMuteState]];
         break;
     }
 }
@@ -205,6 +206,20 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
         return [NSImage imageNamed:NSImageNameTouchBarAudioOutputVolumeOffTemplate];
     case Web::HTML::MuteState::Unmuted:
         return [NSImage imageNamed:NSImageNameTouchBarAudioOutputVolumeHighTemplate];
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+- (NSString*)toolTipForPageMuteState
+{
+    auto& view = [[self web_view] view];
+
+    switch (view.page_mute_state()) {
+    case Web::HTML::MuteState::Muted:
+        return @"Unmute tab";
+    case Web::HTML::MuteState::Unmuted:
+        return @"Mute tab";
     }
 
     VERIFY_NOT_REACHED();
@@ -321,6 +336,8 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
         auto* button = [NSButton buttonWithImage:[self iconForPageMuteState]
                                           target:self
                                           action:@selector(togglePageMuteState:)];
+        [button setToolTip:[self toolTipForPageMuteState]];
+
         [[self tab] setAccessoryView:button];
         break;
     }

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -657,6 +657,7 @@ void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlay
 
     case Web::HTML::AudioPlayState::Playing:
         auto* button = new QPushButton(icon_for_page_mute_state(), {});
+        button->setToolTip(tool_tip_for_page_mute_state());
         button->setFlat(true);
         button->resize({ 20, 20 });
 
@@ -670,6 +671,7 @@ void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlay
             case Web::HTML::AudioPlayState::Playing:
                 auto* button = m_tabs_container->tabBar()->tabButton(index, QTabBar::LeftSide);
                 verify_cast<QPushButton>(button)->setIcon(icon_for_page_mute_state());
+                button->setToolTip(tool_tip_for_page_mute_state());
                 break;
             }
         });
@@ -686,6 +688,18 @@ QIcon BrowserWindow::icon_for_page_mute_state() const
         return style()->standardIcon(QStyle::SP_MediaVolumeMuted);
     case Web::HTML::MuteState::Unmuted:
         return style()->standardIcon(QStyle::SP_MediaVolume);
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+QString BrowserWindow::tool_tip_for_page_mute_state() const
+{
+    switch (view().page_mute_state()) {
+    case Web::HTML::MuteState::Muted:
+        return "Unmute tab";
+    case Web::HTML::MuteState::Unmuted:
+        return "Mute tab";
     }
 
     VERIFY_NOT_REACHED();

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -129,6 +129,7 @@ private:
     }
 
     QIcon icon_for_page_mute_state() const;
+    QString tool_tip_for_page_mute_state() const;
 
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -128,6 +128,8 @@ private:
         }
     }
 
+    QIcon icon_for_page_mute_state() const;
+
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
 

--- a/Userland/Libraries/LibWeb/HTML/AudioPlayState.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioPlayState.h
@@ -6,11 +6,30 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
+
 namespace Web::HTML {
 
 enum class AudioPlayState {
     Paused,
     Playing,
 };
+
+enum class MuteState {
+    Muted,
+    Unmuted,
+};
+
+constexpr MuteState invert_mute_state(MuteState mute_state)
+{
+    switch (mute_state) {
+    case MuteState::Muted:
+        return MuteState::Unmuted;
+    case MuteState::Unmuted:
+        return MuteState::Muted;
+    }
+
+    VERIFY_NOT_REACHED();
+}
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -65,6 +65,13 @@ void HTMLMediaElement::initialize(JS::Realm& realm)
         // the document is active again.
         pause_element().release_value_but_fixme_should_propagate_errors();
     });
+
+    document().page().register_media_element({}, unique_id());
+}
+
+void HTMLMediaElement::finalize()
+{
+    document().page().unregister_media_element({}, unique_id());
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -438,11 +438,18 @@ void HTMLMediaElement::volume_or_muted_attribute_changed()
     on_volume_change();
 }
 
+void HTMLMediaElement::page_mute_state_changed(Badge<Page>)
+{
+    on_volume_change();
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#effective-media-volume
 double HTMLMediaElement::effective_media_volume() const
 {
-    // FIXME 1. If the user has indicated that the user agent is to override the volume of the element, then return the
-    //          volume desired by the user.
+    // 1. If the user has indicated that the user agent is to override the volume of the element, then return the
+    //    volume desired by the user.
+    if (document().page().page_mute_state() == MuteState::Muted)
+        return 0.0;
 
     // 2. If the element's audio output is muted, then return zero.
     if (m_muted)

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -132,6 +132,7 @@ protected:
     HTMLMediaElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void finalize() override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -98,6 +98,8 @@ public:
     bool muted() const { return m_muted; }
     void set_muted(bool);
 
+    void page_mute_state_changed(Badge<Page>);
+
     double effective_media_volume() const;
 
     JS::NonnullGCPtr<AudioTrackList> audio_tracks() const { return *m_audio_tracks; }

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -390,6 +390,18 @@ void Page::select_dropdown_closed(Optional<String> value)
     }
 }
 
+void Page::register_media_element(Badge<HTML::HTMLMediaElement>, int media_id)
+{
+    m_media_elements.append(media_id);
+}
+
+void Page::unregister_media_element(Badge<HTML::HTMLMediaElement>, int media_id)
+{
+    m_media_elements.remove_all_matching([&](auto candidate_id) {
+        return candidate_id == media_id;
+    });
+}
+
 void Page::did_request_media_context_menu(i32 media_id, CSSPixelPoint position, ByteString const& target, unsigned modifiers, MediaContextMenu menu)
 {
     m_media_context_menu_element_id = media_id;

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -470,6 +470,18 @@ WebIDL::ExceptionOr<void> Page::toggle_media_controls_state()
     return {};
 }
 
+void Page::toggle_page_mute_state()
+{
+    m_mute_state = HTML::invert_mute_state(m_mute_state);
+
+    for (auto media_id : m_media_elements) {
+        if (auto* node = DOM::Node::from_unique_id(media_id)) {
+            auto& media_element = verify_cast<HTML::HTMLMediaElement>(*node);
+            media_element.page_mute_state_changed({});
+        }
+    }
+}
+
 JS::GCPtr<HTML::HTMLMediaElement> Page::media_context_menu_element()
 {
     if (!m_media_context_menu_element_id.has_value())

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -150,6 +150,9 @@ public:
         Select,
     };
 
+    void register_media_element(Badge<HTML::HTMLMediaElement>, int media_id);
+    void unregister_media_element(Badge<HTML::HTMLMediaElement>, int media_id);
+
     struct MediaContextMenu {
         URL::URL media_url;
         bool is_video { false };
@@ -204,6 +207,7 @@ private:
     PendingNonBlockingDialog m_pending_non_blocking_dialog { PendingNonBlockingDialog::None };
     WeakPtr<HTML::HTMLElement> m_pending_non_blocking_dialog_target;
 
+    Vector<int> m_media_elements;
     Optional<int> m_media_context_menu_element_id;
 
     Optional<String> m_user_style_sheet_source;

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -167,6 +167,9 @@ public:
     WebIDL::ExceptionOr<void> toggle_media_loop_state();
     WebIDL::ExceptionOr<void> toggle_media_controls_state();
 
+    HTML::MuteState page_mute_state() const { return m_mute_state; }
+    void toggle_page_mute_state();
+
     Optional<String> const& user_style() const { return m_user_style_sheet_source; }
     void set_user_style(String source);
 
@@ -209,6 +212,8 @@ private:
 
     Vector<int> m_media_elements;
     Optional<int> m_media_context_menu_element_id;
+
+    Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
 
     Optional<String> m_user_style_sheet_source;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -317,9 +317,25 @@ void ViewImplementation::toggle_media_controls_state()
 
 void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState play_state)
 {
-    m_audio_play_state = play_state;
+    bool state_changed = false;
 
-    if (on_audio_play_state_changed)
+    switch (play_state) {
+    case Web::HTML::AudioPlayState::Paused:
+        if (--m_number_of_elements_playing_audio == 0) {
+            m_audio_play_state = play_state;
+            state_changed = true;
+        }
+        break;
+
+    case Web::HTML::AudioPlayState::Playing:
+        if (m_number_of_elements_playing_audio++ == 0) {
+            m_audio_play_state = play_state;
+            state_changed = true;
+        }
+        break;
+    }
+
+    if (state_changed && on_audio_play_state_changed)
         on_audio_play_state_changed(m_audio_play_state);
 }
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -315,6 +315,12 @@ void ViewImplementation::toggle_media_controls_state()
     client().async_toggle_media_controls_state(page_id());
 }
 
+void ViewImplementation::toggle_page_mute_state()
+{
+    m_mute_state = Web::HTML::invert_mute_state(m_mute_state);
+    client().async_toggle_page_mute_state(page_id());
+}
+
 void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState play_state)
 {
     bool state_changed = false;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -102,6 +102,9 @@ public:
     void toggle_media_loop_state();
     void toggle_media_controls_state();
 
+    Web::HTML::MuteState page_mute_state() const { return m_mute_state; }
+    void toggle_page_mute_state();
+
     void did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState);
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
@@ -261,6 +264,8 @@ protected:
 
     Web::HTML::AudioPlayState m_audio_play_state { Web::HTML::AudioPlayState::Paused };
     size_t m_number_of_elements_playing_audio { 0 };
+
+    Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
 };
 
 }

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -260,6 +260,7 @@ protected:
     RefPtr<Core::Promise<LexicalPath>> m_pending_screenshot;
 
     Web::HTML::AudioPlayState m_audio_play_state { Web::HTML::AudioPlayState::Paused };
+    size_t m_number_of_elements_playing_audio { 0 };
 };
 
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1072,6 +1072,12 @@ void ConnectionFromClient::toggle_media_controls_state(u64 page_id)
         page->page().toggle_media_controls_state().release_value_but_fixme_should_propagate_errors();
 }
 
+void ConnectionFromClient::toggle_page_mute_state(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().toggle_page_mute_state();
+}
+
 void ConnectionFromClient::set_user_style(u64 page_id, String const& source)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -111,6 +111,8 @@ private:
     virtual void toggle_media_loop_state(u64 page_id) override;
     virtual void toggle_media_controls_state(u64 page_id) override;
 
+    virtual void toggle_page_mute_state(u64 page_id) override;
+
     virtual void set_user_style(u64 page_id, String const&) override;
 
     virtual void enable_inspector_prototype(u64 page_id) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -98,6 +98,8 @@ endpoint WebContentServer
     toggle_media_loop_state(u64 page_id) =|
     toggle_media_controls_state(u64 page_id) =|
 
+    toggle_page_mute_state(u64 page_id) =|
+
     set_user_style(u64 page_id, String source) =|
 
     enable_inspector_prototype(u64 page_id) =|


### PR DESCRIPTION
We already display a speaker icon on tabs which are playing audio. This allows the user to click that icon to mute the tab, at which point the icon is replaced with a muted speaker icon.

We would previously hide the icon when audio stopped playing. We now do this only if the tab isn't muted. If it is muted, the muted speaker icon remains on the tab so that the page isn't stuck in a muted state.

Note: This is only supported in the Qt and AppKit chromes currently. The Serenity chrome will require more `GUI::TabWidget` work to make the speaker icon an actual button.

Qt (I couldn't get OBS to capture the tooltip on hover, but I promise it's there):

https://github.com/SerenityOS/serenity/assets/5600524/aa0e392c-bdeb-4049-9e12-fa56015eadce

AppKit (audio recorded on a microphone so it doesn't sound great):

https://github.com/SerenityOS/serenity/assets/5600524/775deddd-b94a-416f-9226-8570611a13f9

