### PR TITLE
LibWeb: Paint `SVGDecodedImageData` via `Navigable::paint()`

### DIFF
--- a/Tests/LibWeb/Ref/assets/nested-svg.svg
+++ b/Tests/LibWeb/Ref/assets/nested-svg.svg
@@ -1,0 +1,5 @@
+<svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" x="5" y="5">
+    <rect width="12" height="12" fill="red" />
+  </svg>
+</svg>

--- a/Tests/LibWeb/Ref/nested-svg-as-img.html
+++ b/Tests/LibWeb/Ref/nested-svg-as-img.html
@@ -1,0 +1,5 @@
+<style>
+  img { border: 1px solid black; }
+ </style>
+<img src="./assets/nested-svg.svg">
+<link rel="match" href="reference/nested-svg-as-img-ref.html" />

--- a/Tests/LibWeb/Ref/reference/nested-svg-as-img-ref.html
+++ b/Tests/LibWeb/Ref/reference/nested-svg-as-img-ref.html
@@ -1,0 +1,8 @@
+<svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="12" height="12" fill="red" />
+</svg>
+<style>
+  svg {
+    border: 1px solid black;
+  }
+</style>

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -133,11 +133,9 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
 
     Painting::CommandList painting_commands;
     Painting::RecordingPainter recording_painter(painting_commands);
-    PaintContext context(recording_painter, m_page_client->palette(), m_page_client->device_pixels_per_css_pixel());
-
-    m_document->paintable()->paint_all_phases(context);
-
     Painting::CommandExecutorCPU executor { *bitmap };
+
+    m_document->navigable()->paint(recording_painter, {});
     painting_commands.execute(executor);
 
     return bitmap;


### PR DESCRIPTION
Going via the `ViewportPaintable` missed some steps (in particular computing clip rects), which meant nested SVGs within SVGs-as-images were completely clipped.

This restores the rocket logo on the azure pipelines badge:

**Before:**
![image](https://github.com/SerenityOS/serenity/assets/11597044/45f170d5-0096-4d52-a6e2-0ef3b1e635b8)

**After:**
![image](https://github.com/SerenityOS/serenity/assets/11597044/5bf6c59b-2639-42b7-90fe-c6ec5945f0ad)
