### PR TITLE
Ports: Update ports that depend on LibCore to depend on LibCoreMinimal

### DIFF
--- a/Ports/OpenJDK/patches/0008-java.base-Enable-java.lang.Process-on-serenity.patch
+++ b/Ports/OpenJDK/patches/0008-java.base-Enable-java.lang.Process-on-serenity.patch
@@ -41,7 +41,7 @@ index e29f9d5ad78d6da367579dfda7b8e9c0d09be2c9..769c2fd8b5a7e0000c85d6d44ec30f64
      LIBS_unix := -ljvm, \
      LIBS_linux := $(LIBDL), \
      LIBS_aix := $(LIBDL) $(LIBM),\
-+    LIBS_serenity := $(LIBDL) -lcore, \
++    LIBS_serenity := $(LIBDL) -lcore -lcoreminimal, \
      LIBS_macosx := -framework CoreFoundation \
          -framework Foundation \
          -framework SystemConfiguration, \

--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -145,7 +145,7 @@ index c4aec174e35ee653c4c4e0449939054e0f68ad9d..2f88b7f8790df95838e7de7a45789804
 +    set(SDL_THREAD_PTHREAD_RECURSIVE_MUTEX 1)
 +    set(HAVE_VIDEO_OPENGL TRUE)
 +    set(SDL_VIDEO_OPENGL 1)
-+    list(APPEND EXTRA_LIBS ipc gui gfx gl core)
++    list(APPEND EXTRA_LIBS ipc gui gfx gl core coreminimal)
 +endmacro(CheckSerenity)
 +
  # Requires:

--- a/Ports/SDL2_image/package.sh
+++ b/Ports/SDL2_image/package.sh
@@ -19,7 +19,7 @@ configure() {
         --enable-webp-shared='false' \
         --disable-static \
         --enable-shared \
-        LDFLAGS='-lgui -lgfx -lipc -lcore -lm'
+        LDFLAGS='-lgui -lgfx -lipc -lcore -lcoreminimal -lm'
 }
 
 build() {

--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -22,7 +22,7 @@ configure() {
         --enable-music-opus-shared='false' \
         --disable-static \
         --enable-shared \
-        EXTRA_LDFLAGS='-lgui -lgfx -lipc -lcore -lcompression'
+        EXTRA_LDFLAGS='-lgui -lgfx -lipc -lcore -lcoreminimal -lcompression'
 }
 
 post_configure() {

--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -18,5 +18,5 @@ configure() {
         --disable-static \
         --enable-shared \
         FT2_CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/freetype2" \
-        LIBS='-lgui -lgfx -lipc -lcore -lcompress'
+        LIBS='-lgui -lgfx -lipc -lcore -lcoreminimal -lcompress'
 }

--- a/Ports/Super-Mario/patches/0003-Use-pkgconfig-instead-of-find_package-to-look-for-de.patch
+++ b/Ports/Super-Mario/patches/0003-Use-pkgconfig-instead-of-find_package-to-look-for-de.patch
@@ -35,6 +35,6 @@ index 616d876..d1aa020 100644
  add_executable (uMario ${uMario_SOURCES})
  
 -target_link_libraries(uMario ${SDL2_LIBRARY} ${SDL2_IMAGE_LIBRARY} ${SDL2_MIXER_LIBRARY})
-+target_link_libraries(uMario ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_MIXER_LIBRARIES}-lSDL2_mixer -lpthread -lm -lgfx -lgui -lipc -lcore)
++target_link_libraries(uMario ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_MIXER_LIBRARIES}-lSDL2_mixer -lpthread -lm -lgfx -lgui -lipc -lcore -lcoreminimal)
  
  install(TARGETS uMario RUNTIME DESTINATION ${BIN_DIR})

--- a/Ports/c-ray/patches/0004-Link-with-the-needed-serenity-libraries.patch
+++ b/Ports/c-ray/patches/0004-Link-with-the-needed-serenity-libraries.patch
@@ -18,7 +18,7 @@ index 20f8440..dc254b5 100644
  target_include_directories(c-ray PRIVATE ${c-ray_SOURCE_DIR}/tests)
  if (NOT MSVC)
 -	target_link_libraries(c-ray PRIVATE -lpthread -lm)
-+	target_link_libraries(c-ray PRIVATE -lSDL2 -lgui -lgfx -lipc -lcore -lpthread -lstdc++ -lm)
++	target_link_libraries(c-ray PRIVATE -lSDL2 -lgui -lgfx -lipc -lcore -lcoreminimal -lpthread -lstdc++ -lm)
  endif ()
  
  include(CheckIPOSupported)

--- a/Ports/nesalizer/patches/0001-Add-Serenity-to-Makefile.patch
+++ b/Ports/nesalizer/patches/0001-Add-Serenity-to-Makefile.patch
@@ -3,7 +3,7 @@ From: Dan MacDonald <allcoms@gmail.com>
 Date: Sun, 8 Dec 2019 17:30:52 +0000
 Subject: [PATCH] Add Serenity to Makefile
 
-- Add `-lSDL2 -lgui -lipc -lgfx -lcore -lpthread -lregex`
+- Add `-lSDL2 -lgui -lipc -lgfx -lcore -lcoreminimal -lpthread -lregex`
 - Disable RTTI
 - Add SDL2 include path to compile flags
 ---
@@ -19,7 +19,7 @@ index 527a3d08998163dadcd6a8d48c93a2906e19c31c..37fbb516e1c1f57daf911f373cb80158
  deps        = $(addprefix $(BUILD_DIR)/,$(c_sources:=.d) $(cpp_sources:=.d))
  
 -LDLIBS := $(shell sdl2-config --libs) -lrt
-+LDLIBS := -lSDL2 -lgui -lipc -lgfx -lcore -lpthread -lregex
++LDLIBS := -lSDL2 -lgui -lipc -lgfx -lcore -lcoreminimal -lpthread -lregex
  
  ifeq ($(INCLUDE_DEBUGGER),1)
      LDLIBS += -lreadline

--- a/Ports/nesalizer/patches/ReadMe.md
+++ b/Ports/nesalizer/patches/ReadMe.md
@@ -4,7 +4,7 @@
 
 Add Serenity to Makefile
 
-- Add `-lSDL2 -lgui -lipc -lgfx -lcore -lpthread -lregex`
+- Add `-lSDL2 -lgui -lipc -lgfx -lcore -lcoreminimal -lpthread -lregex`
 - Disable RTTI
 - Add SDL2 include path to compile flags
 

--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -10,7 +10,7 @@ useconfigure=true
 use_fresh_config_sub=true
 configopts=("--prefix=/usr/local" "--disable-utmp" "--disable-strip" "--sysconfdir=/etc/ssh" "--with-ssl-dir=${SERENITY_INSTALL_ROOT}/usr/local/lib")
 
-export LDFLAGS="-lcrypt -lcore"
+export LDFLAGS="-lcrypt -lcore -lcoreminimal"
 
 pre_configure() {
     run autoreconf

--- a/Ports/perl5/patches/0003-configure-Add-hint-for-serenity.patch
+++ b/Ports/perl5/patches/0003-configure-Add-hint-for-serenity.patch
@@ -14,7 +14,7 @@ index 0000000000000000000000000000000000000000..3e038d0ac1660d7ee485bc32ddaec5a1
 --- /dev/null
 +++ b/cnf/hints/serenity
 @@ -0,0 +1,24 @@
-+libs='-ldl -lm -lcrypt -lcore'
++libs='-ldl -lm -lcrypt -lcore -lcoreminimal'
 +
 +# Use OS's malloc() by default.
 +case "$usemymalloc" in

--- a/Ports/xmp-cli/patches/0001-Add-support-for-Serenity-LibAudio.patch
+++ b/Ports/xmp-cli/patches/0001-Add-support-for-Serenity-LibAudio.patch
@@ -30,7 +30,7 @@ index b65eb85244acec722b2f240976f184f06db11a27..840845dc1f5d7459bfbb339071b817ad
  endif
  
 +xmp_SOURCES += sound_serenity.cpp
-+xmp_LDADD   += -lcore -lipc -laudio -lstdc++
++xmp_LDADD   += -lcore -lcoreminimal -lipc -laudio -lstdc++
 +
  man_MANS = xmp.1
  


### PR DESCRIPTION
Looks like we need to be explicit for make-based ports.

I was not able to test the following ports as they depend on xz:
* OpenJDK
* SDL2_image
* Super-Mario

And xz is currently unavailable due to the backdoor mayhem.

```
=> Fetching xz...
[xz/fetch] Downloading URL: https://tukaani.org/xz/xz-5.4.4.tar.gz
[xz/fetch] /usr/bin/curl
[xz/fetch] + curl https://tukaani.org/xz/xz-5.4.4.tar.gz -L -o /home/flynn/workspace/serenity/Ports/xz/xz-5.4.4.tar.gz (nocd)
[xz/fetch]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[xz/fetch]                                  Dload  Upload   Total   Spent    Left  Speed
100   262  100   262    0     0    521      0 --:--:-- --:--:-- --:--:--   520
100  107k    0  107k    0     0   157k      0 --:--:-- --:--:-- --:--:--  157k
[xz/fetch] SHA256 checksum of downloaded file 'xz-5.4.4.tar.gz' does not match!
[xz/fetch] Expected: aae39544e254cfd27e942d35a048d592959bd7a79f9a624afb0498bb5613bdf8
[xz/fetch] Actual:   7be9663e81567bedcae523fd37cac5cae1a3114a0ed66ead6dfe2f05f144640c
[xz/fetch] Removed erroneous download.
[xz/fetch] Trying to download the file again.
[xz/fetch] Downloading URL: https://tukaani.org/xz/xz-5.4.4.tar.gz
[xz/fetch] /usr/bin/curl
[xz/fetch] + curl https://tukaani.org/xz/xz-5.4.4.tar.gz -L -o /home/flynn/workspace/serenity/Ports/xz/xz-5.4.4.tar.gz (nocd)
[xz/fetch]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[xz/fetch]                                  Dload  Upload   Total   Spent    Left  Speed
100   262  100   262    0     0      9      0  0:00:29  0:00:28  0:00:01    63
100  107k    0  107k    0     0   3849      0 --:--:--  0:00:28 --:--:--  3849
[xz/fetch] SHA256 checksum of downloaded file 'xz-5.4.4.tar.gz' does not match!
[xz/fetch] Expected: aae39544e254cfd27e942d35a048d592959bd7a79f9a624afb0498bb5613bdf8
[xz/fetch] Actual:   70602ecf282386b3506654cb7cf25b312a9bf31cabc07ceede24055cb3d4ab20
```