### PR TITLE
Ladybird/Qt: A couple of audio state button fixes specific to the Qt chrome

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -650,11 +650,12 @@ void BrowserWindow::tab_favicon_changed(int index, QIcon const& icon)
 void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState play_state)
 {
     auto* tab = verify_cast<Tab>(m_tabs_container->widget(index));
+    auto position = audio_button_position_for_tab(index);
 
     switch (play_state) {
     case Web::HTML::AudioPlayState::Paused:
         if (tab->view().page_mute_state() == Web::HTML::MuteState::Unmuted)
-            m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, nullptr);
+            m_tabs_container->tabBar()->setTabButton(index, position, nullptr);
         break;
 
     case Web::HTML::AudioPlayState::Playing:
@@ -663,23 +664,23 @@ void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlay
         button->setFlat(true);
         button->resize({ 20, 20 });
 
-        connect(button, &QPushButton::clicked, this, [this, tab]() {
+        connect(button, &QPushButton::clicked, this, [this, tab, position]() {
             tab->view().toggle_page_mute_state();
             auto index = tab_index(tab);
 
             switch (tab->view().audio_play_state()) {
             case Web::HTML::AudioPlayState::Paused:
-                m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, nullptr);
+                m_tabs_container->tabBar()->setTabButton(index, position, nullptr);
                 break;
             case Web::HTML::AudioPlayState::Playing:
-                auto* button = m_tabs_container->tabBar()->tabButton(index, QTabBar::LeftSide);
+                auto* button = m_tabs_container->tabBar()->tabButton(index, position);
                 verify_cast<QPushButton>(button)->setIcon(icon_for_page_mute_state(*tab));
                 button->setToolTip(tool_tip_for_page_mute_state(*tab));
                 break;
             }
         });
 
-        m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, button);
+        m_tabs_container->tabBar()->setTabButton(index, position, button);
         break;
     }
 }
@@ -706,6 +707,13 @@ QString BrowserWindow::tool_tip_for_page_mute_state(Tab& tab) const
     }
 
     VERIFY_NOT_REACHED();
+}
+
+QTabBar::ButtonPosition BrowserWindow::audio_button_position_for_tab(int tab_index) const
+{
+    if (m_tabs_container->tabBar()->tabButton(tab_index, QTabBar::LeftSide))
+        return QTabBar::RightSide;
+    return QTabBar::LeftSide;
 }
 
 void BrowserWindow::open_next_tab()

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -649,29 +649,32 @@ void BrowserWindow::tab_favicon_changed(int index, QIcon const& icon)
 
 void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState play_state)
 {
+    auto* tab = verify_cast<Tab>(m_tabs_container->widget(index));
+
     switch (play_state) {
     case Web::HTML::AudioPlayState::Paused:
-        if (view().page_mute_state() == Web::HTML::MuteState::Unmuted)
+        if (tab->view().page_mute_state() == Web::HTML::MuteState::Unmuted)
             m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, nullptr);
         break;
 
     case Web::HTML::AudioPlayState::Playing:
-        auto* button = new QPushButton(icon_for_page_mute_state(), {});
-        button->setToolTip(tool_tip_for_page_mute_state());
+        auto* button = new QPushButton(icon_for_page_mute_state(*tab), {});
+        button->setToolTip(tool_tip_for_page_mute_state(*tab));
         button->setFlat(true);
         button->resize({ 20, 20 });
 
-        connect(button, &QPushButton::clicked, this, [this, index]() {
-            view().toggle_page_mute_state();
+        connect(button, &QPushButton::clicked, this, [this, tab]() {
+            tab->view().toggle_page_mute_state();
+            auto index = tab_index(tab);
 
-            switch (view().audio_play_state()) {
+            switch (tab->view().audio_play_state()) {
             case Web::HTML::AudioPlayState::Paused:
                 m_tabs_container->tabBar()->setTabButton(index, QTabBar::LeftSide, nullptr);
                 break;
             case Web::HTML::AudioPlayState::Playing:
                 auto* button = m_tabs_container->tabBar()->tabButton(index, QTabBar::LeftSide);
-                verify_cast<QPushButton>(button)->setIcon(icon_for_page_mute_state());
-                button->setToolTip(tool_tip_for_page_mute_state());
+                verify_cast<QPushButton>(button)->setIcon(icon_for_page_mute_state(*tab));
+                button->setToolTip(tool_tip_for_page_mute_state(*tab));
                 break;
             }
         });
@@ -681,9 +684,9 @@ void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlay
     }
 }
 
-QIcon BrowserWindow::icon_for_page_mute_state() const
+QIcon BrowserWindow::icon_for_page_mute_state(Tab& tab) const
 {
-    switch (view().page_mute_state()) {
+    switch (tab.view().page_mute_state()) {
     case Web::HTML::MuteState::Muted:
         return style()->standardIcon(QStyle::SP_MediaVolumeMuted);
     case Web::HTML::MuteState::Unmuted:
@@ -693,9 +696,9 @@ QIcon BrowserWindow::icon_for_page_mute_state() const
     VERIFY_NOT_REACHED();
 }
 
-QString BrowserWindow::tool_tip_for_page_mute_state() const
+QString BrowserWindow::tool_tip_for_page_mute_state(Tab& tab) const
 {
-    switch (view().page_mute_state()) {
+    switch (tab.view().page_mute_state()) {
     case Web::HTML::MuteState::Muted:
         return "Unmute tab";
     case Web::HTML::MuteState::Unmuted:

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -130,6 +130,7 @@ private:
 
     QIcon icon_for_page_mute_state(Tab&) const;
     QString tool_tip_for_page_mute_state(Tab&) const;
+    QTabBar::ButtonPosition audio_button_position_for_tab(int tab_index) const;
 
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -128,8 +128,8 @@ private:
         }
     }
 
-    QIcon icon_for_page_mute_state() const;
-    QString tool_tip_for_page_mute_state() const;
+    QIcon icon_for_page_mute_state(Tab&) const;
+    QString tool_tip_for_page_mute_state(Tab&) const;
 
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };


### PR DESCRIPTION
This PR makes sure we interact with the correct tab when an audio play state changes and when clicking an audio icon on a tab. And makes sure we don't completely replace the "close tab" button on macOS.