### PR TITLE
LibWeb: Handle interpolation between percentages and dimension units

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -914,7 +914,7 @@ void KeyframeEffect::update_style_properties()
     auto animated_properties_before_update = style->animated_property_values();
 
     auto& document = target->document();
-    document.style_computer().collect_animation_into(*target, pseudo_element_type(), *this, *style, CSS::StyleComputer::AnimationRefresh::Yes);
+    document.style_computer().collect_animation_into(*target, pseudo_element_type(), *this, *style);
 
     // Traversal of the subtree is necessary to update the animated properties inherited from the target element.
     target->for_each_in_subtree_of_type<DOM::Element>([&](auto& element) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1377,7 +1377,7 @@ static ValueComparingRefPtr<StyleValue const> interpolate_property(DOM::Element&
     }
 }
 
-void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::Selector::PseudoElement::Type> pseudo_element, JS::NonnullGCPtr<Animations::KeyframeEffect> effect, StyleProperties& style_properties, AnimationRefresh refresh) const
+void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::Selector::PseudoElement::Type> pseudo_element, JS::NonnullGCPtr<Animations::KeyframeEffect> effect, StyleProperties& style_properties) const
 {
     auto animation = effect->associated_animation();
     if (!animation)
@@ -1430,9 +1430,9 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
         auto resolve_property = [&](auto& property) {
             return property.visit(
                 [&](Animations::KeyframeEffect::KeyFrameSet::UseInitial) -> RefPtr<StyleValue const> {
-                    if (refresh == AnimationRefresh::Yes)
-                        return {};
-                    return style_properties.maybe_null_property(it.key);
+                    // maybe_null_property() can return the result of the last animation effect stack, but we need the
+                    // element's underlying value here
+                    return style_properties.maybe_null_property_ignoring_animations(it.key);
                 },
                 [&](RefPtr<StyleValue const> value) -> RefPtr<StyleValue const> {
                     if (value->is_unresolved())

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -141,11 +141,7 @@ public:
 
     void set_viewport_rect(Badge<DOM::Document>, CSSPixelRect const& viewport_rect) { m_viewport_rect = viewport_rect; }
 
-    enum class AnimationRefresh {
-        No,
-        Yes,
-    };
-    void collect_animation_into(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, JS::NonnullGCPtr<Animations::KeyframeEffect> animation, StyleProperties& style_properties, AnimationRefresh = AnimationRefresh::No) const;
+    void collect_animation_into(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, JS::NonnullGCPtr<Animations::KeyframeEffect> animation, StyleProperties& style_properties) const;
 
 private:
     enum class ComputeStyleMode {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -75,6 +75,11 @@ RefPtr<StyleValue const> StyleProperties::maybe_null_property(CSS::PropertyID pr
     return m_property_values[to_underlying(property_id)].style;
 }
 
+RefPtr<StyleValue const> StyleProperties::maybe_null_property_ignoring_animations(CSS::PropertyID property_id) const
+{
+    return m_property_values[to_underlying(property_id)].style;
+}
+
 CSS::CSSStyleDeclaration const* StyleProperties::property_source_declaration(CSS::PropertyID property_id) const
 {
     return m_property_values[to_underlying(property_id)].declaration;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -63,6 +63,7 @@ public:
     void set_animated_property(CSS::PropertyID, NonnullRefPtr<StyleValue const> value);
     NonnullRefPtr<StyleValue const> property(CSS::PropertyID) const;
     RefPtr<StyleValue const> maybe_null_property(CSS::PropertyID) const;
+    RefPtr<StyleValue const> maybe_null_property_ignoring_animations(CSS::PropertyID) const;
     CSS::CSSStyleDeclaration const* property_source_declaration(CSS::PropertyID) const;
 
     CSS::Size size_value(CSS::PropertyID) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -196,6 +196,9 @@ public:
         Mod,
         Rem,
 
+        // Internal type used by StyleComputer
+        Interpolation,
+
         // This only exists during parsing.
         Unparsed,
     };
@@ -791,6 +794,31 @@ private:
     RemCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     NonnullOwnPtr<CalculationNode> m_x;
     NonnullOwnPtr<CalculationNode> m_y;
+};
+
+// This is an internal node used by StyleComputer that allows the interpolation of two unresolvable
+// StyleValues to be delayed until calculation resolution
+class InterpolationCalculationNode final : public CalculationNode {
+public:
+    static NonnullOwnPtr<InterpolationCalculationNode> create(NonnullOwnPtr<CalculationNode> from, NonnullOwnPtr<CalculationNode> to, float delta);
+    ~InterpolationCalculationNode();
+
+    virtual String to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
+    virtual bool contains_percentage() const override;
+    virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual void dump(StringBuilder&, int indent) const override;
+    virtual bool equals(CalculationNode const&) const override;
+
+private:
+    InterpolationCalculationNode(NonnullOwnPtr<CalculationNode> from, NonnullOwnPtr<CalculationNode> to, NonnullOwnPtr<CalculationNode> delta);
+
+    NonnullOwnPtr<CalculationNode> m_from;
+    NonnullOwnPtr<CalculationNode> m_to;
+    NonnullOwnPtr<CalculationNode> m_delta;
 };
 
 }


### PR DESCRIPTION
I've been thinking about how to do this for a while, and this is the simplest way I've found. Originally I wanted to add a new `StyleValue`, but whatever I do needs to be able to fit into a `LengthPercentage` unless I want to refactor a _lot_ of files. I'd like to get some feedback on this approach. I'm also having a very hard time writing tests for this, which is the main reason I've left this in draft.

Fixes the issue in #23543