### PR TITLE
LibPDF: Add a fastpath for 1bpp grayscale to load_image()

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1166,6 +1166,13 @@ PDFErrorOr<Renderer::LoadedImage> Renderer::load_image(NonnullRefPtr<StreamObjec
 
     int const n_components = color_space->number_of_components();
 
+    Vector<float> decode_array;
+    if (image_dict->contains(CommonNames::Decode)) {
+        decode_array = MUST(image_dict->get_array(m_document, CommonNames::Decode))->float_elements();
+    } else {
+        decode_array = color_space->default_decode();
+    }
+
     Vector<u8> resampled_storage;
     if (bits_per_component < 8) {
         UpsampleMode mode = color_space->family() == ColorSpaceFamily::Indexed ? UpsampleMode::StoreValuesUnchanged : UpsampleMode::UpsampleTo8Bit;
@@ -1187,12 +1194,6 @@ PDFErrorOr<Renderer::LoadedImage> Renderer::load_image(NonnullRefPtr<StreamObjec
         bits_per_component = 8;
     }
 
-    Vector<float> decode_array;
-    if (image_dict->contains(CommonNames::Decode)) {
-        decode_array = MUST(image_dict->get_array(m_document, CommonNames::Decode))->float_elements();
-    } else {
-        decode_array = color_space->default_decode();
-    }
     Vector<LinearInterpolation1D> component_value_decoders;
     component_value_decoders.ensure_capacity(decode_array.size());
     for (size_t i = 0; i < decode_array.size(); i += 2) {


### PR DESCRIPTION
We used to expand every bit in an 1bpp image to a 0 or 255 byte,
then map that to a float that's either 0.0f or 1.0f (or whatever's
in /DecodeArray), then multiply that by 255.0f to convert it to a
u8 and put that in the rgb channels of a Color.

Now we precompute the two possible outcomes (almost always Black
and White) and do a per-bit lookup.

Reduces time for

    Build/lagom/bin/pdf --render-bench --render-repeats 20 --page 36 \
        ~/Downloads/Flatland.pdf

(the "decoded data cached" case) from 3.3s to 1.1s on my system.

Reduces time for

    Build/lagom/bin/pdf --debugging-stats ~/Downloads/0000/0000231.pdf

(the "need to decode each page" case) from 52s to 43s on my machine.

Also makes paging through PDFs that contain a 1700x2200 pixel CCITT
or JBIG2 bitmap on each page noticeably snappier.