### PR TITLE
LibCpp: Add dereference unary operator and add test for unary

### DIFF
--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -382,6 +382,9 @@ void UnaryExpression::dump(FILE* output, size_t indent) const
     case UnaryOp::Address:
         op_string = "&";
         break;
+    case UnaryOp::Dereference:
+        op_string = "*";
+        break;
     default:
         op_string = "<invalid>";
     }

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -743,6 +743,7 @@ enum class UnaryOp {
     Minus,
     PlusPlus,
     Address,
+    Dereference,
 };
 
 class UnaryExpression : public Expression {

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -484,7 +484,8 @@ bool Parser::match_unary_expression()
         || type == Token::Type::Tilde
         || type == Token::Type::Plus
         || type == Token::Type::Minus
-        || type == Token::Type::And;
+        || type == Token::Type::And
+        || type == Token::Type::Asterisk;
 }
 
 NonnullRefPtr<UnaryExpression const> Parser::parse_unary_expression(ASTNode const& parent)
@@ -510,6 +511,9 @@ NonnullRefPtr<UnaryExpression const> Parser::parse_unary_expression(ASTNode cons
         break;
     case Token::Type::And:
         op = UnaryOp::Address;
+        break;
+    case Token::Type::Asterisk:
+        op = UnaryOp::Dereference;
         break;
     default:
         break;

--- a/Userland/Libraries/LibCpp/Tests/parser/unary-expression.ast
+++ b/Userland/Libraries/LibCpp/Tests/parser/unary-expression.ast
@@ -1,0 +1,18 @@
+TranslationUnit[0:0->4:0]
+  FunctionDeclaration[0:0->4:0]
+    NamedType[0:0->0:2]
+      int
+    foo
+    (
+    )
+    FunctionDefinition[1:0->4:0]
+    {
+      UnaryExpression[2:4->2:7]
+        &
+        Name[2:5->2:7]
+        bar
+      UnaryExpression[3:4->3:7]
+        *
+        Name[3:5->3:7]
+        bar
+    }

--- a/Userland/Libraries/LibCpp/Tests/parser/unary-expression.cpp
+++ b/Userland/Libraries/LibCpp/Tests/parser/unary-expression.cpp
@@ -1,0 +1,5 @@
+int foo()
+{
+    &bar;
+    *bar;
+}


### PR DESCRIPTION
expressions

The unary expressions test currently test the address-of('&) and dereference('*') operators.