### PR TITLE
LibWeb: Catch up with the spec on document destroy, abort and unload

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/WindowProxy-Get-after-detaching-from-browsing-context.txt
+++ b/Tests/LibWeb/Text/expected/HTML/WindowProxy-Get-after-detaching-from-browsing-context.txt
@@ -1,3 +1,3 @@
  
-null
+
 PASS (didn't crash)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -489,13 +489,20 @@ public:
     Vector<JS::Handle<HTML::Navigable>> inclusive_ancestor_navigables();
     Vector<JS::Handle<HTML::Navigable>> document_tree_child_navigables();
 
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document
     void destroy();
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document-and-its-descendants
+    void destroy_a_document_and_its_descendants(JS::SafeFunction<void()> after_all_destruction = {});
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#abort-a-document
     void abort();
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#abort-a-document-and-its-descendants
+    void abort_a_document_and_its_descendants();
 
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#unload-a-document
     void unload(JS::GCPtr<Document> new_document = nullptr);
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#unload-a-document-and-its-descendants
+    void unload_a_document_and_its_descendants(JS::GCPtr<Document> new_document, JS::SafeFunction<void()> after_all_unloads = {});
 
     // https://html.spec.whatwg.org/multipage/dom.html#active-parser
     JS::GCPtr<HTML::HTMLParser> active_parser();

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1371,10 +1371,10 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
             return;
         }
 
-        // 3. Queue a global task on the navigation and traversal task source given navigable's active window to abort navigable's active document.
+        // 3. Queue a global task on the navigation and traversal task source given navigable's active window to abort a document and its descendants given navigable's active document.
         queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), [this] {
             VERIFY(this->active_document());
-            this->active_document()->abort();
+            this->active_document()->abort_a_document_and_its_descendants();
         });
 
         // 4. Let documentState be a new document state with

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/Page/Page.h>
 
@@ -263,8 +264,12 @@ void NavigableContainer::destroy_the_child_navigable()
 
     // FIXME: 4. Inform the navigation API about child navigable destruction given navigable.
 
-    // 5. Destroy navigable's active document.
-    navigable->active_document()->destroy();
+    // 5. Destroy a document and its descendants given navigable's active document.
+    navigable->active_document()->destroy_a_document_and_its_descendants({});
+
+    // Not in the spec
+    navigable->set_has_been_destroyed();
+    HTML::all_navigables().remove(navigable);
 
     // 6. Let parentDocState be container's node navigable's active session history entry's document state.
     auto parent_doc_state = this->navigable()->active_session_history_entry()->document_state();
@@ -277,13 +282,9 @@ void NavigableContainer::destroy_the_child_navigable()
     // 8. Let traversable be container's node navigable's traversable navigable.
     auto traversable = this->navigable()->traversable_navigable();
 
-    // Not in the spec
-    navigable->set_has_been_destroyed();
-    HTML::all_navigables().remove(navigable);
-
     // 9. Append the following session history traversal steps to traversable:
     traversable->append_session_history_traversal_steps([traversable] {
-        // 1. Apply pending history changes to traversable.
+        // 1. Update for navigable creation/destruction given traversable.
         traversable->update_for_navigable_creation_or_destruction();
     });
 }


### PR DESCRIPTION
These changes do not solve hanging `location.reload()` and `location.go()` but only align implementation with the latest edits in the specification.

`WindowProxy-Get-after-detaching-from-browsing-context` test output is affected because `iframe.remove();` no longer synchronously does destruction of a document, but queues a task on event loop.