### PR TITLE
LibWeb: Avoid copying cached elements in HTMLCollection 

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -151,9 +151,6 @@ bool HTMLCollection::is_supported_property_index(u32 index) const
     // The object’s supported property indices are the numbers in the range zero to one less than the number of elements represented by the collection.
     // If there are no such elements, then there are no supported property indices.
     auto elements = collect_matching_elements();
-    if (elements.is_empty())
-        return false;
-
     return index < elements.size();
 }
 

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -150,8 +150,7 @@ bool HTMLCollection::is_supported_property_index(u32 index) const
 {
     // The object’s supported property indices are the numbers in the range zero to one less than the number of elements represented by the collection.
     // If there are no such elements, then there are no supported property indices.
-    auto elements = collect_matching_elements();
-    return index < elements.size();
+    return index < length();
 }
 
 WebIDL::ExceptionOr<JS::Value> HTMLCollection::item_value(size_t index) const

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -158,14 +158,14 @@ WebIDL::ExceptionOr<JS::Value> HTMLCollection::item_value(size_t index) const
     auto* element = item(index);
     if (!element)
         return JS::js_undefined();
-    return const_cast<Element*>(element);
+    return element;
 }
 
-WebIDL::ExceptionOr<JS::Value> HTMLCollection::named_item_value(FlyString const& index) const
+WebIDL::ExceptionOr<JS::Value> HTMLCollection::named_item_value(FlyString const& name) const
 {
-    auto* element = named_item(index);
+    auto* element = named_item(name);
     if (!element)
         return JS::js_undefined();
-    return const_cast<Element*>(element);
+    return element;
 }
 }

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -56,6 +56,8 @@ protected:
 private:
     virtual void visit_edges(Cell::Visitor&) override;
 
+    void update_cache_if_needed() const;
+
     mutable u64 m_cached_dom_tree_version { 0 };
     mutable Vector<JS::NonnullGCPtr<Element>> m_cached_elements;
 


### PR DESCRIPTION
Instead of a new copy each time. On a synthentic benchmark of a page with ~500 link elements, this results in a 45% percent speedup on my machine.

```html
<body>
    <ul>
        <li><a href="#">Link 1</a></li>
        ...
        <li><a href="#">Link N</a></li>
    </ul>

    <script>
        window.onload = function() {
            const startTime = performance.now();
            for (let i = 0; i < 1_000_000; ++i) {
                const numLinks = document.links.length;
            }
            const endTime = performance.now();
            const timeTaken = endTime - startTime;
            console.log(timeTaken);
        };
    </script>
</body>
</html>
```