### PR TITLE
LibWeb: Implement PerformanceObserver.supportedEntryTypes 

### DIFF
--- a/Tests/LibWeb/Text/expected/PerformanceObserver/PerformanceObserver-supportedEntryTypes.txt
+++ b/Tests/LibWeb/Text/expected/PerformanceObserver/PerformanceObserver-supportedEntryTypes.txt
@@ -1,0 +1,5 @@
+PerformanceObserver.supportedEntryTypes: mark,measure
+PerformanceObserver.supportedEntryTypes instanceof Array: true
+Object.isFrozen(PerformanceObserver.supportedEntryTypes): true
+PerformanceObserver.supportedEntryTypes === PerformanceObserver.supportedEntryTypes: true
+sorted alphabetically: true

--- a/Tests/LibWeb/Text/input/PerformanceObserver/PerformanceObserver-supportedEntryTypes.html
+++ b/Tests/LibWeb/Text/input/PerformanceObserver/PerformanceObserver-supportedEntryTypes.html
@@ -1,0 +1,21 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`PerformanceObserver.supportedEntryTypes: ${PerformanceObserver.supportedEntryTypes}`);
+        println(`PerformanceObserver.supportedEntryTypes instanceof Array: ${PerformanceObserver.supportedEntryTypes instanceof Array}`);
+        println(`Object.isFrozen(PerformanceObserver.supportedEntryTypes): ${Object.isFrozen(PerformanceObserver.supportedEntryTypes)}`);
+        println(`PerformanceObserver.supportedEntryTypes === PerformanceObserver.supportedEntryTypes: ${PerformanceObserver.supportedEntryTypes === PerformanceObserver.supportedEntryTypes}`);
+
+        const sorted = PerformanceObserver.supportedEntryTypes.toSorted((left, right) => {
+            if (left < right)
+                return -1;
+
+            if (left > right)
+                return 1;
+
+            return 0;
+        });
+
+        println(`sorted alphabetically: ${sorted.toString() === PerformanceObserver.supportedEntryTypes.toString()}`);
+    });
+</script>

--- a/Userland/Libraries/LibIDL/IDLParser.h
+++ b/Userland/Libraries/LibIDL/IDLParser.h
@@ -30,6 +30,11 @@ private:
         Yes,
     };
 
+    enum class IsStatic {
+        No,
+        Yes,
+    };
+
     Parser(Parser* parent, ByteString filename, StringView contents, ByteString import_base_path);
 
     void assert_specific(char ch);
@@ -38,7 +43,7 @@ private:
     Optional<Interface&> resolve_import(auto path);
 
     HashMap<ByteString, ByteString> parse_extended_attributes();
-    void parse_attribute(HashMap<ByteString, ByteString>& extended_attributes, Interface&);
+    void parse_attribute(HashMap<ByteString, ByteString>& extended_attributes, Interface&, IsStatic is_static = IsStatic::No);
     void parse_interface(Interface&);
     void parse_namespace(Interface&);
     void parse_non_interface_entities(bool allow_interface, Interface&);
@@ -53,7 +58,7 @@ private:
     void parse_deleter(HashMap<ByteString, ByteString>& extended_attributes, Interface&);
     void parse_stringifier(HashMap<ByteString, ByteString>& extended_attributes, Interface&);
     void parse_iterable(Interface&);
-    Function parse_function(HashMap<ByteString, ByteString>& extended_attributes, Interface&, IsSpecialOperation is_special_operation = IsSpecialOperation::No);
+    Function parse_function(HashMap<ByteString, ByteString>& extended_attributes, Interface&, IsStatic is_static = IsStatic::No, IsSpecialOperation is_special_operation = IsSpecialOperation::No);
     Vector<Parameter> parse_parameters();
     NonnullRefPtr<Type const> parse_type();
     void parse_constant(Interface&);

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -270,6 +270,7 @@ public:
     HashMap<ByteString, ByteString> extended_attributes;
 
     Vector<Attribute> attributes;
+    Vector<Attribute> static_attributes;
     Vector<Constant> constants;
     Vector<Constructor> constructors;
     Vector<Function> functions;

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -65,6 +65,8 @@ public:
 
     [[nodiscard]] JS::NonnullGCPtr<HighResolutionTime::Performance> performance();
 
+    JS::NonnullGCPtr<JS::Object> supported_entry_types() const;
+
 protected:
     void initialize(JS::Realm&);
     void visit_edges(JS::Cell::Visitor&);
@@ -95,6 +97,8 @@ private:
     OrderedHashMap<FlyString, PerformanceTimeline::PerformanceEntryTuple> m_performance_entry_buffer_map;
 
     JS::GCPtr<HighResolutionTime::Performance> m_performance;
+
+    mutable JS::GCPtr<JS::Object> m_supported_entry_types_array;
 };
 
 }

--- a/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
+++ b/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
@@ -218,6 +218,17 @@ Vector<JS::Handle<PerformanceTimeline::PerformanceEntry>> PerformanceObserver::t
     return records;
 }
 
+// https://w3c.github.io/performance-timeline/#dom-performanceobserver-supportedentrytypes
+JS::NonnullGCPtr<JS::Object> PerformanceObserver::supported_entry_types(JS::VM& vm)
+{
+    // 1. Let globalObject be the environment settings object's global object.
+    auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&vm.get_global_object());
+    VERIFY(window_or_worker);
+
+    // 2. Return globalObject's frozen array of supported entry types.
+    return window_or_worker->supported_entry_types();
+}
+
 void PerformanceObserver::unset_requires_dropped_entries(Badge<HTML::WindowOrWorkerGlobalScopeMixin>)
 {
     m_requires_dropped_entries = false;

--- a/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.h
+++ b/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.h
@@ -46,6 +46,8 @@ public:
 
     void append_to_observer_buffer(Badge<HTML::WindowOrWorkerGlobalScopeMixin>, JS::NonnullGCPtr<PerformanceTimeline::PerformanceEntry>);
 
+    static JS::NonnullGCPtr<JS::Object> supported_entry_types(JS::VM&);
+
 private:
     PerformanceObserver(JS::Realm&, JS::GCPtr<WebIDL::CallbackType>);
 

--- a/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.idl
+++ b/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.idl
@@ -21,5 +21,6 @@ interface PerformanceObserver {
     undefined observe(optional PerformanceObserverInit options = {});
     undefined disconnect();
     PerformanceEntryList takeRecords();
-    //[SameObject] static readonly attribute sequence<DOMString> supportedEntryTypes;
+    // FIXME: [SameObject] static readonly attribute FrozenArray<DOMString> supportedEntryTypes;
+    [SameObject] static readonly attribute any supportedEntryTypes;
 };


### PR DESCRIPTION
LibIDL+LibWeb: Add support for static readonly attributes

Support for settable attributes is a FIXME.

-----

LibWeb: Implement PerformanceObserver.supportedEntryTypes 