### PR TITLE
Meta/jbig2_to_pdf.py: Allow jbig2 files with random-access organization

### DIFF
--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -115,6 +115,10 @@ def main():
 
               ''')
 
+    operators = dedent(b'''\
+                  %d 0 0 %d 0 0 cm
+                  /Im Do''' % (width, height))
+
     objs = [dedent(b'''\
               1 0 obj
               <<
@@ -152,13 +156,14 @@ def main():
 
             dedent(b'''\
               4 0 obj
-              <</Length 25>>
+              <</Length %d>>
               stream
-              %d 0 0 %d 0 0 cm
-              /Im Do
+              ''' % len(operators)) +
+            operators +
+            dedent(b'''
               endstream
               endobj
-              ''' % (width, height)),
+              '''),
 
             dedent(b'''\
               5 0 obj


### PR DESCRIPTION
jbig2 data in PDFs is in the embedded organization, which is like the sequential organization with the file header removed.

That means jbig2 files using the random-access organization need to be transformed to be supported. A random-access jbig2 has all segment headers at the start, followed by the data of all segments. Decode all headers and rewrite them to the sequential organization, where each segment header is followed by that segment's data.

The motivation is that almost all of the jbig2 files in ghostpdl/test/jbig2 use the random-access organization.

And since we're now  parsing segment headers for random-access jbig2 inputs already, just always do that and get the image dimensions from the PageInformation segment data. Not all that much more code, and it makes this script much more pleasant to use.