### PR TITLE
LibJS: Mark GCPtr's operator bool as explicit

### DIFF
--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -177,7 +177,7 @@ public:
 
     T* ptr() const { return m_ptr; }
 
-    operator bool() const { return !!m_ptr; }
+    explicit operator bool() const { return !!m_ptr; }
     bool operator!() const { return !m_ptr; }
 
     operator T*() const { return m_ptr; }


### PR DESCRIPTION
This avoids the potential for unwanted implicit conversions to bool. It doesn't prevent if (m_ptr) checks though, as that invokes an explicit conversion to bool. This is how std::unique_ptr and std::optional work.