### PR TITLE
LibWeb: Fix spec bug in "destroy child navigable"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -107,7 +107,7 @@ void EventLoop::spin_processing_tasks_with_source_until(Task::Source source, JS:
             return true;
         if (m_task_queue.has_runnable_tasks()) {
             auto tasks = m_task_queue.take_tasks_matching([&](auto& task) {
-                return task.source() == source;
+                return task.source() == source && task.is_runnable();
             });
 
             for (auto& task : tasks.value()) {


### PR DESCRIPTION
See for more details whatwg/html#10242

Before this change it only worked because of another bug in
`EventLoop::spin_processing_tasks_with_source_until()`
where we execute tasks regardless of whether they are runnable or not.