### PR TITLE
Ladybird/Qt: Prevent adding multiple audio state buttons

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -671,6 +671,7 @@ void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlay
     case Web::HTML::AudioPlayState::Playing:
         auto* button = new QPushButton(icon_for_page_mute_state(*tab), {});
         button->setToolTip(tool_tip_for_page_mute_state(*tab));
+        button->setObjectName("LadybirdAudioState");
         button->setFlat(true);
         button->resize({ 20, 20 });
 
@@ -721,8 +722,11 @@ QString BrowserWindow::tool_tip_for_page_mute_state(Tab& tab) const
 
 QTabBar::ButtonPosition BrowserWindow::audio_button_position_for_tab(int tab_index) const
 {
-    if (m_tabs_container->tabBar()->tabButton(tab_index, QTabBar::LeftSide))
-        return QTabBar::RightSide;
+    if (auto* button = m_tabs_container->tabBar()->tabButton(tab_index, QTabBar::LeftSide)) {
+        if (button->objectName() != "LadybirdAudioState")
+            return QTabBar::RightSide;
+    }
+
     return QTabBar::LeftSide;
 }
 

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -20,6 +20,7 @@ moc_qt_objects("generate_moc") {
     "Qt/LocationEdit.h",
     "Qt/SettingsDialog.h",
     "Qt/Tab.h",
+    "Qt/TaskManagerWindow.h",
     "Qt/WebContentView.h",
   ]
 }
@@ -95,6 +96,7 @@ executable("ladybird_executable") {
       "Qt/StringUtils.cpp",
       "Qt/TVGIconEngine.cpp",
       "Qt/Tab.cpp",
+      "Qt/TaskManagerWindow.cpp",
       "Qt/WebContentView.cpp",
       "Qt/main.cpp",
     ]
@@ -212,6 +214,7 @@ fonts = [
 
 icons_16x16 = [
   "//Base/res/icons/16x16/app-browser.png",
+  "//Base/res/icons/16x16/app-system-monitor.png",
   "//Base/res/icons/16x16/audio-volume-high.png",
   "//Base/res/icons/16x16/audio-volume-muted.png",
   "//Base/res/icons/16x16/close-tab.png",
@@ -243,6 +246,7 @@ icons_16x16 = [
 
 icons_32x32 = [
   "//Base/res/icons/32x32/app-browser.png",
+  "//Base/res/icons/32x32/app-system-monitor.png",
   "//Base/res/icons/32x32/filetype-folder.png",
   "//Base/res/icons/32x32/filetype-unknown.png",
   "//Base/res/icons/32x32/msgbox-warning.png",


### PR DESCRIPTION
If the left-hand side of the tab is already occupied with an audio state button, we would add a second button to the right-hand side. Prevent that by checking if the occupant is our audio state button.