### PR TITLE
LibWeb: Don't use JS::SafeFunction for WebIDL promise reaction steps

### DIFF
--- a/Userland/Libraries/LibWeb/WebIDL/Promise.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.h
@@ -16,7 +16,8 @@
 
 namespace Web::WebIDL {
 
-using ReactionSteps = JS::SafeFunction<WebIDL::ExceptionOr<JS::Value>(JS::Value)>;
+// NOTE: This is Function, not SafeFunction, because they get stored in a NativeFunction anyway, which will protect captures.
+using ReactionSteps = Function<WebIDL::ExceptionOr<JS::Value>(JS::Value)>;
 
 // https://webidl.spec.whatwg.org/#es-promise
 using Promise = JS::PromiseCapability;


### PR DESCRIPTION
SafeFunction was causing massive GC reference cycles here and leaking entire realms as a result.

Since we end up storing these reaction steps in a JS::NativeFunction (which uses JS::HeapFunction internally) there should be no need to protect the captures with SafeFunction.

This dramatically shrinks our memory footprint while running tests.