### PR TITLE
Kernel+Userland: Change the behavior of loop devices

### DIFF
--- a/Base/usr/share/man/man1/losetup.md
+++ b/Base/usr/share/man/man1/losetup.md
@@ -1,0 +1,31 @@
+## Name
+
+losetup - manage loop devices
+
+## Synopsis
+
+```**sh
+$ losetup [options...] [path]
+```
+
+## Description
+
+losetup is a utility for managing loop devices. It can create new devices or delete
+existing ones.
+
+## Options
+
+* `-d`, `--delete`: Remove an existing loop device based on the `path` argument.
+* `-c`, `--create`: Create a new loop device based on the `path` argument.
+
+## Files
+
+* `/dev/devctl` - device control device inode, which allows creating and deleting loop devices.
+
+## Examples
+
+```sh
+$ losetup -c test.img
+Created new device at /dev/loop/0
+$ losetup -d /dev/loop/0
+```

--- a/Kernel/Devices/Loop/LoopDevice.cpp
+++ b/Kernel/Devices/Loop/LoopDevice.cpp
@@ -45,6 +45,8 @@ bool LoopDevice::unref() const
 
 ErrorOr<NonnullRefPtr<LoopDevice>> LoopDevice::create_with_file_description(OpenFileDescription& description)
 {
+    if (!(description.is_readable() && description.is_writable()))
+        return Error::from_errno(EPERM);
     auto custody = description.custody();
     if (!custody)
         return Error::from_errno(EINVAL);

--- a/Kernel/Devices/Loop/LoopDevice.h
+++ b/Kernel/Devices/Loop/LoopDevice.h
@@ -22,11 +22,12 @@ public:
     virtual bool unref() const override;
     virtual ~LoopDevice() = default;
 
-    void remove(Badge<DeviceControlDevice>);
+    ErrorOr<void> remove(Badge<DeviceControlDevice>);
     static ErrorOr<NonnullRefPtr<LoopDevice>> create_with_file_description(OpenFileDescription&);
 
     virtual StringView class_name() const override { return "LoopDevice"sv; }
 
+    virtual ErrorOr<NonnullRefPtr<OpenFileDescription>> open(int options) override;
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;
     virtual bool can_read(OpenFileDescription const&, u64) const override;
@@ -50,6 +51,8 @@ private:
 
     NonnullRefPtr<Custody> const m_backing_custody;
     unsigned const m_index { 0 };
+
+    SetOnce m_set_to_be_removed;
 
     mutable IntrusiveListNode<LoopDevice, NonnullRefPtr<LoopDevice>> m_list_node;
 

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -265,6 +265,17 @@ Inode& FATFS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> FATFS::prepare_to_clear_last_mount(Inode&)
+{
+    MutexLocker locker(m_lock);
+    m_root_inode = nullptr;
+    BlockBasedFileSystem::remove_disk_cache_before_last_unmount();
+
+    // FIXME: This is probably not correct to just return here once we have write support
+    // as we probably need to do more clean up procedures.
+    return {};
+}
+
 FatBlockSpan FATFS::first_block_of_cluster(u32 cluster) const
 {
     // For FAT12/16, we use a value of cluster 0 to indicate this is a cluster for the root directory.

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -69,9 +69,7 @@ public:
 private:
     virtual ErrorOr<void> initialize_while_locked() override;
     virtual bool is_initialized_while_locked() override;
-    // FIXME: This is not a proper way to clear last mount of a FAT filesystem,
-    // but for now we simply have no other way to properly do it.
-    virtual ErrorOr<void> prepare_to_clear_last_mount(Inode&) override { return {}; }
+    virtual ErrorOr<void> prepare_to_clear_last_mount(Inode&) override;
 
     FATFS(OpenFileDescription&);
 

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -42,12 +42,16 @@ ErrorOr<NonnullLockRefPtr<Memory::VMObject>> File::vmobject_for_mmap(Process&, M
 
 ErrorOr<void> File::attach(OpenFileDescription&)
 {
-    m_attach_count++;
+    m_attach_count.with([](auto& count) {
+        count++;
+    });
     return {};
 }
 
 void File::detach(OpenFileDescription&)
 {
-    m_attach_count--;
+    m_attach_count.with([](auto& count) {
+        count--;
+    });
 }
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -121,7 +121,7 @@ public:
 
     virtual FileBlockerSet& blocker_set() { return m_blocker_set; }
 
-    size_t attach_count() const { return m_attach_count; }
+    SpinlockProtected<size_t, LockRank::None> const& attach_count(Badge<OpenFileDescription>) const { return m_attach_count; }
 
 protected:
     File();
@@ -141,6 +141,8 @@ protected:
         }
     }
 
+    SpinlockProtected<size_t, LockRank::None> m_attach_count { 0 };
+
 private:
     ALWAYS_INLINE void do_evaluate_block_conditions()
     {
@@ -149,7 +151,6 @@ private:
     }
 
     FileBlockerSet m_blocker_set;
-    size_t m_attach_count { 0 };
 };
 
 }

--- a/Tests/Kernel/TestLoopDevice.cpp
+++ b/Tests/Kernel/TestLoopDevice.cpp
@@ -46,9 +46,9 @@ TEST_CASE(create_attach_and_destory_loop_device)
     auto loop_device_index = value;
     auto loop_device_fd_or_error = open_loop_device(loop_device_index);
     EXPECT(loop_device_fd_or_error >= 0);
-    auto cleanup_loop_device_fd_guard = ScopeGuard([&] {
-        close(loop_device_fd_or_error);
-    });
+
+    auto close_result = close(loop_device_fd_or_error);
+    EXPECT_EQ(close_result, 0);
 
     auto destroy_result = ioctl(devctl_fd, DEVCTL_DESTROY_LOOP_DEVICE, &loop_device_index);
     EXPECT_EQ(destroy_result, 0);

--- a/Userland/Utilities/losetup.cpp
+++ b/Userland/Utilities/losetup.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <AK/StringUtils.h>
+#include <AK/StringView.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    TRY(Core::System::pledge("stdio rpath wpath"));
+    StringView path;
+    bool flag_delete_device = false;
+    bool flag_add_new_device = false;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("Manage loop devices.");
+    args_parser.add_option(flag_delete_device, "Delete a loop device", "delete", 'd');
+    args_parser.add_option(flag_add_new_device, "Add new device", "create", 'c');
+    args_parser.add_positional_argument(path, "Path", "path", Core::ArgsParser::Required::No);
+    args_parser.parse(arguments);
+
+    if (!(flag_delete_device || flag_add_new_device))
+        return Error::from_string_literal("No specified option was requested.");
+
+    if (path.is_null())
+        return Error::from_string_literal("No specified path to handle.");
+
+    auto devctl_device = TRY(Core::File::open("/dev/devctl"sv, Core::File::OpenMode::Read));
+    if (flag_delete_device) {
+        constexpr StringView base_dev_loop_path = "/dev/loop/"sv;
+        if (!path.starts_with(base_dev_loop_path))
+            return Error::from_string_literal("Invalid loop device path.");
+        auto number = path.substring_view(base_dev_loop_path.length());
+        auto possible_number = number.to_number<u64>();
+        if (!possible_number.has_value())
+            return Error::from_string_literal("Invalid loop device number.");
+        auto loop_device_index = possible_number.release_value();
+        TRY(Core::System::ioctl(devctl_device->fd(), DEVCTL_DESTROY_LOOP_DEVICE, &loop_device_index));
+        return 0;
+    }
+
+    VERIFY(flag_add_new_device);
+    auto value = TRY(Core::System::open(path, O_RDWR));
+    TRY(Core::System::ioctl(devctl_device->fd(), DEVCTL_CREATE_LOOP_DEVICE, &value));
+    int loop_device_index = value;
+
+    auto loop_device_path = TRY(String::formatted("/dev/loop/{}", loop_device_index));
+    outln("Created new device at {}", loop_device_path);
+    return 0;
+}

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -213,7 +213,6 @@ static ErrorOr<void> mount_using_loop_device(int inode_fd, StringView mountpoint
     int loop_device_fd = TRY(Core::System::open(loop_device_path.bytes_as_string_view(), O_RDONLY));
 
     auto result = Core::System::mount(loop_device_fd, mountpoint, fs_type, flags);
-    TRY(Core::System::ioctl(devctl_fd, DEVCTL_DESTROY_LOOP_DEVICE, &loop_device_index));
     return result;
 }
 


### PR DESCRIPTION
This PR changes the way loop devices work (not a big change though).
It boils down to:
- You can't remove a loop device when it's in use. It doesn't make sense to allow this, and we should allow re-use of a loop device (for example, to re-mount it) if so desired.
- When doing a loop mount, the user is responsible for cleaning up the loop device if it's no longer in use
- A user can create a new loop device manually and mount it whenever it's needed.
- When creating a loop device, the open file description should be readable and writable, as the loop device does not check if the file is not writable later on and assume that it was writable when we created it.