### PR TITLE
LibWeb: Remove a bunch of calls to `to_byte_string`

### DIFF
--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -133,7 +133,7 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
             if (!hint.is_empty())
                 displayln("{}", hint);
 
-            auto error_string = TRY(error.to_string());
+            auto error_string = error.to_string();
             displayln("{}", error_string);
             result = g_vm->throw_completion<JS::SyntaxError>(move(error_string));
         } else {
@@ -149,7 +149,7 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
             if (!hint.is_empty())
                 displayln("{}", hint);
 
-            auto error_string = TRY(error.to_string());
+            auto error_string = error.to_string();
             displayln("{}", error_string);
             result = g_vm->throw_completion<JS::SyntaxError>(move(error_string));
         } else {

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -167,7 +167,7 @@ JS::ThrowCompletionOr<JS::Value> Sheet::evaluate(StringView source, Cell* on_beh
         name);
 
     if (script_or_error.is_error())
-        return vm().throw_completion<JS::SyntaxError>(TRY_OR_THROW_OOM(vm(), script_or_error.error().first().to_string()));
+        return vm().throw_completion<JS::SyntaxError>(script_or_error.error().first().to_string());
 
     return vm().bytecode_interpreter().run(script_or_error.value());
 }

--- a/Userland/Libraries/LibJS/Contrib/Test262/262Object.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/262Object.cpp
@@ -100,7 +100,7 @@ JS_DEFINE_NATIVE_FUNCTION($262Object::eval_script)
         auto& error = script_or_error.error()[0];
 
         // b. Return Completion { [[Type]]: throw, [[Value]]: error, [[Target]]: empty }.
-        return vm.throw_completion<SyntaxError>(TRY_OR_THROW_OOM(vm, error.to_string()));
+        return vm.throw_completion<SyntaxError>(error.to_string());
     }
 
     // 5. Let status be ScriptEvaluation(s).

--- a/Userland/Libraries/LibJS/ParserError.cpp
+++ b/Userland/Libraries/LibJS/ParserError.cpp
@@ -12,11 +12,11 @@
 
 namespace JS {
 
-ErrorOr<String> ParserError::to_string() const
+String ParserError::to_string() const
 {
     if (!position.has_value())
-        return String::from_byte_string(message);
-    return String::formatted("{} (line: {}, column: {})", message, position.value().line, position.value().column);
+        return MUST(String::from_byte_string(message));
+    return MUST(String::formatted("{} (line: {}, column: {})", message, position.value().line, position.value().column));
 }
 
 ByteString ParserError::to_byte_string() const

--- a/Userland/Libraries/LibJS/ParserError.h
+++ b/Userland/Libraries/LibJS/ParserError.h
@@ -19,7 +19,7 @@ struct ParserError {
     ByteString message;
     Optional<Position> position;
 
-    ErrorOr<String> to_string() const;
+    String to_string() const;
     ByteString to_byte_string() const;
     ByteString source_location_hint(StringView source, char const spacer = ' ', char const indicator = '^') const;
 };

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -586,7 +586,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
     //     b. If script is a List of errors, throw a SyntaxError exception.
     if (parser.has_errors()) {
         auto& error = parser.errors()[0];
-        return vm.throw_completion<SyntaxError>(TRY_OR_THROW_OOM(vm, error.to_string()));
+        return vm.throw_completion<SyntaxError>(error.to_string());
     }
 
     bool strict_eval = false;

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -178,7 +178,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     // 17. If parameters is a List of errors, throw a SyntaxError exception.
     if (parameters_parser.has_errors()) {
         auto error = parameters_parser.errors()[0];
-        return vm.throw_completion<SyntaxError>(TRY_OR_THROW_OOM(vm, error.to_string()));
+        return vm.throw_completion<SyntaxError>(error.to_string());
     }
 
     // 18. Let body be ParseText(StringToCodePoints(bodyString), bodySym).
@@ -188,7 +188,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     // 19. If body is a List of errors, throw a SyntaxError exception.
     if (body_parser.has_errors()) {
         auto error = body_parser.errors()[0];
-        return vm.throw_completion<SyntaxError>(TRY_OR_THROW_OOM(vm, error.to_string()));
+        return vm.throw_completion<SyntaxError>(error.to_string());
     }
 
     // 20. NOTE: The parameters and body are parsed separately to ensure that each is valid alone. For example, new Function("/*", "*/ ) {") is not legal.
@@ -202,7 +202,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     // 23. If expr is a List of errors, throw a SyntaxError exception.
     if (source_parser.has_errors()) {
         auto error = source_parser.errors()[0];
-        return vm.throw_completion<SyntaxError>(TRY_OR_THROW_OOM(vm, error.to_string()));
+        return vm.throw_completion<SyntaxError>(error.to_string());
     }
 
     // 24. Let proto be ? GetPrototypeFromConstructor(newTarget, fallbackProto).

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -110,7 +110,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
     // b. If script is a List of errors, throw a SyntaxError exception.
     if (parser.has_errors()) {
         auto& error = parser.errors()[0];
-        return vm.throw_completion<SyntaxError>(TRY_OR_THROW_OOM(vm, error.to_string()));
+        return vm.throw_completion<SyntaxError>(error.to_string());
     }
 
     // c. If script Contains ScriptBody is false, return undefined.

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3374,8 +3374,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> Document::create_attribute(String co
 
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
     // 3. Return a new attribute whose local name is localName and node document is this.
-    auto deprecated_local_name = local_name.to_byte_string();
-    return Attr::create(*this, MUST(FlyString::from_deprecated_fly_string(is_html_document() ? deprecated_local_name.to_lowercase() : deprecated_local_name)));
+    return Attr::create(*this, is_html_document() ? MUST(Infra::to_ascii_lowercase(local_name)) : local_name);
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createattributens

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1783,8 +1783,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         //   process its IDREFs in the order they occur:
         auto aria_labelled_by = element->aria_labelled_by();
         auto aria_described_by = element->aria_described_by();
-        if ((target == NameOrDescription::Name && aria_labelled_by.has_value() && Node::first_valid_id(aria_labelled_by->to_byte_string(), document).has_value())
-            || (target == NameOrDescription::Description && aria_described_by.has_value() && Node::first_valid_id(aria_described_by->to_byte_string(), document).has_value())) {
+        if ((target == NameOrDescription::Name && aria_labelled_by.has_value() && Node::first_valid_id(*aria_labelled_by, document).has_value())
+            || (target == NameOrDescription::Description && aria_described_by.has_value() && Node::first_valid_id(*aria_described_by, document).has_value())) {
 
             // i. Set the accumulated text to the empty string.
             total_accumulated_text.clear();

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -1218,7 +1218,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::create_contextual
     }
 
     // 3. Let fragment node be the result of invoking the fragment parsing algorithm with fragment as markup, and element as the context element.
-    auto fragment_node = TRY(DOMParsing::parse_fragment(fragment.to_byte_string(), *element));
+    auto fragment_node = TRY(DOMParsing::parse_fragment(fragment, *element));
 
     // 4. Unmark all scripts in fragment node as "already started" and as "parser-inserted".
     fragment_node->for_each_in_subtree_of_type<HTML::HTMLScriptElement>([&](HTML::HTMLScriptElement& script_element) {

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -58,7 +58,7 @@ public:
         {
             return m_fill_or_stroke_style.visit(
                 [&](Gfx::Color color) -> JsFillOrStrokeStyle {
-                    return MUST(String::from_byte_string(color.to_byte_string()));
+                    return color.to_string();
                 },
                 [&](auto handle) -> JsFillOrStrokeStyle {
                     return handle;

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -514,7 +514,7 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(By
     for (auto c : text) {
         builder.append(Infra::is_ascii_whitespace(c) ? ' ' : c);
     }
-    auto replaced_text = builder.to_byte_string();
+    auto replaced_text = builder.string_view();
 
     // 3. Let font be the current font of target, as given by that object's font attribute.
     auto font = current_font();

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -504,7 +504,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     if (!url.is_valid())
         return;
 
-    auto url_string = url.to_byte_string();
+    auto url_string = MUST(url.to_string());
 
     // 10. If hyperlinkSuffix is non-null, then append it to urlString.
     if (hyperlink_suffix.has_value()) {
@@ -512,7 +512,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
         url_builder.append(url_string);
         url_builder.append(*hyperlink_suffix);
 
-        url_string = url_builder.to_byte_string();
+        url_string = MUST(url_builder.to_string());
     }
 
     // FIXME: 11. Let referrerPolicy be the current state of subject's referrerpolicy content attribute.

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -372,7 +372,7 @@ ErrorOr<void> HTMLImageElement::update_the_image_data(bool restart_animations, b
         // 1. Parse selected source, relative to the element's node document.
         //    If that is not successful, then abort this inner set of steps.
         //    Otherwise, let urlString be the resulting URL string.
-        auto url_string = document().parse_url(selected_source.value().to_byte_string());
+        auto url_string = document().parse_url(selected_source.value());
         if (!url_string.is_valid())
             goto after_step_7;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -588,8 +588,6 @@ public:
 
     WebIDL::ExceptionOr<void> process_candidate()
     {
-        auto& vm = this->vm();
-
         // 2. ⌛ Process candidate: If candidate does not have a src attribute, or if its src attribute's value is the
         //    empty string, then end the synchronous section, and jump down to the failed with elements step below.
         String candiate_src;
@@ -605,7 +603,7 @@ public:
         //    would have resulted from parsing the URL specified by candidate's src attribute's value relative to the
         //    candidate's node document when the src attribute was last changed.
         auto url_record = m_candidate->document().parse_url(candiate_src);
-        auto url_string = TRY_OR_THROW_OOM(vm, String::from_byte_string(url_record.to_byte_string()));
+        auto url_string = MUST(url_record.to_string());
 
         // 4. ⌛ If urlString was not obtained successfully, then end the synchronous section, and jump down to the failed
         //    with elements step below.
@@ -853,7 +851,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::select_resource()
 
         // 3. ⌛ If urlString was obtained successfully, set the currentSrc attribute to urlString.
         if (url_record.is_valid())
-            m_current_src = TRY_OR_THROW_OOM(vm, String::from_byte_string(url_record.to_byte_string()));
+            m_current_src = MUST(url_record.to_string());
 
         // 4. End the synchronous section, continuing the remaining steps in parallel.
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -56,7 +56,7 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
     // 11. If result is a list of errors, then:
     if (result.is_error()) {
         auto& parse_error = result.error().first();
-        dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Failed to parse: {}", parse_error.to_byte_string());
+        dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Failed to parse: {}", parse_error.to_string());
 
         // 1. Set script's parse error and its error to rethrow to result[0].
         script->set_parse_error(JS::SyntaxError::create(environment_settings_object.realm(), parse_error.to_string()));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -59,7 +59,7 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
         dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Failed to parse: {}", parse_error.to_byte_string());
 
         // 1. Set script's parse error and its error to rethrow to result[0].
-        script->set_parse_error(JS::SyntaxError::create(environment_settings_object.realm(), parse_error.to_string().release_value_but_fixme_should_propagate_errors()));
+        script->set_parse_error(JS::SyntaxError::create(environment_settings_object.realm(), parse_error.to_string()));
         script->set_error_to_rethrow(script->parse_error());
 
         // 2. Return script.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -59,7 +59,7 @@ WebIDL::ExceptionOr<JS::GCPtr<JavaScriptModuleScript>> JavaScriptModuleScript::c
     // 8. If result is a list of errors, then:
     if (result.is_error()) {
         auto& parse_error = result.error().first();
-        dbgln("JavaScriptModuleScript: Failed to parse: {}", parse_error.to_byte_string());
+        dbgln("JavaScriptModuleScript: Failed to parse: {}", parse_error.to_string());
 
         // 1. Set script's parse error to result[0].
         script->set_parse_error(JS::SyntaxError::create(settings_object.realm(), parse_error.to_string()));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -62,7 +62,7 @@ WebIDL::ExceptionOr<JS::GCPtr<JavaScriptModuleScript>> JavaScriptModuleScript::c
         dbgln("JavaScriptModuleScript: Failed to parse: {}", parse_error.to_byte_string());
 
         // 1. Set script's parse error to result[0].
-        script->set_parse_error(JS::SyntaxError::create(settings_object.realm(), parse_error.to_string().release_value_but_fixme_should_propagate_errors()));
+        script->set_parse_error(JS::SyntaxError::create(settings_object.realm(), parse_error.to_string()));
 
         // 2. Return script.
         return script;

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -60,7 +60,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
     auto& outside_settings = current_settings_object();
 
     // 3. Parse the scriptURL argument relative to outside settings.
-    auto url = document.parse_url(script_url.to_byte_string());
+    auto url = document.parse_url(script_url);
 
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -887,7 +887,7 @@ bool Node::is_root_element() const
     return is<HTML::HTMLHtmlElement>(*dom_node());
 }
 
-ByteString Node::debug_description() const
+String Node::debug_description() const
 {
     StringBuilder builder;
     builder.append(class_name());
@@ -903,7 +903,7 @@ ByteString Node::debug_description() const
     } else {
         builder.append("(anonymous)"sv);
     }
-    return builder.to_byte_string();
+    return MUST(builder.to_string());
 }
 
 CSS::Display Node::display() const

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -84,7 +84,7 @@ public:
 
     bool is_root_element() const;
 
-    ByteString debug_description() const;
+    String debug_description() const;
 
     bool has_style() const { return m_has_style; }
     bool has_style_or_parent_with_style() const;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextAttributes.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextAttributes.cpp
@@ -99,7 +99,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     WebGLPowerPreference power_preference_value { WebGLPowerPreference::Default };
 
     if (!power_preference.is_undefined()) {
-        auto power_preference_string = TRY(power_preference.to_byte_string(vm));
+        auto power_preference_string = TRY(power_preference.to_string(vm));
 
         if (power_preference_string == "high-performance"sv)
             power_preference_value = WebGLPowerPreference::HighPerformance;

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -154,11 +154,8 @@ void XMLDocumentBuilder::text(StringView data)
         text_node.set_data(MUST(text_builder.to_string()));
         text_builder.clear();
     } else {
-        auto string = ByteString::empty();
-        if (!data.is_null())
-            string = data.to_byte_string();
-        if (!string.is_empty()) {
-            auto node = m_document->create_text_node(MUST(String::from_byte_string(string)));
+        if (!data.is_empty()) {
+            auto node = m_document->create_text_node(MUST(String::from_utf8(data)));
             MUST(m_current_node->append_child(node));
         }
     }
@@ -168,10 +165,7 @@ void XMLDocumentBuilder::comment(StringView data)
 {
     if (m_has_error)
         return;
-    auto string = ByteString::empty();
-    if (!data.is_null())
-        string = data.to_byte_string();
-    MUST(m_document->append_child(m_document->create_comment(MUST(String::from_byte_string(string)))));
+    MUST(m_document->append_child(m_document->create_comment(MUST(String::from_utf8(data)))));
 }
 
 void XMLDocumentBuilder::document_end()

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -222,7 +222,7 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
             if (!hint.is_empty())
                 outln("{}", hint);
 
-            auto error_string = TRY(error.to_string());
+            auto error_string = error.to_string();
             outln("{}", error_string);
             result = vm.throw_completion<JS::SyntaxError>(move(error_string));
         } else {
@@ -236,7 +236,7 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
             if (!hint.is_empty())
                 outln("{}", hint);
 
-            auto error_string = TRY(error.to_string());
+            auto error_string = error.to_string();
             outln("{}", error_string);
             result = vm.throw_completion<JS::SyntaxError>(move(error_string));
         } else {


### PR DESCRIPTION
A bunch of this is leftover from pre porting over to new AK::String. For example, for functions which previously took a ByteString const& now accepting a StringView.

Other places can have a relatively straightforward substituion of ByteString to String.