### PR TITLE
LibWeb: Stop leaking entire realms via Blob URLs

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2024, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021-2023, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
@@ -52,6 +52,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOM/TreeWalker.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/FileAPI/BlobURLStore.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
@@ -2988,6 +2989,8 @@ void Document::run_unloading_cleanup_steps()
         // 2. Clear window's map of active timers.
         window->clear_map_of_active_timers();
     }
+
+    FileAPI::run_unloading_cleanup_steps(*this);
 }
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document

--- a/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.h
+++ b/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.h
@@ -28,4 +28,6 @@ ErrorOr<String> generate_new_blob_url();
 ErrorOr<String> add_entry_to_blob_url_store(JS::NonnullGCPtr<Blob> object);
 ErrorOr<void> remove_entry_from_blob_url_store(StringView url);
 
+void run_unloading_cleanup_steps(JS::NonnullGCPtr<DOM::Document>);
+
 }


### PR DESCRIPTION
This patch implements the File API spec's supplemental steps for document's "unloading document cleanup steps" so that we now remove blob URLs associated with the document's relevant settings object when the document is being unloaded.

Fixes two realm leaks when running our test suite.