### PR TITLE
LibWeb: Remove WebContent include from SVGDecodedImageData

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -8,7 +8,6 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/DecodedImageData.h>
-#include <WebContent/PageClient.h>
 
 namespace Web::SVG {
 


### PR DESCRIPTION
This is a layering violation, and is not used. Caught by the gn build.