### PR TITLE
LibCore: Prevent SIGPIPE on Sockets by default

### DIFF
--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -133,7 +133,7 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalServer::accept()
     (void)fcntl(accepted_fd, F_SETFD, FD_CLOEXEC);
 #endif
 
-    return LocalSocket::adopt_fd(accepted_fd, Socket::PreventSIGPIPE::Yes);
+    return LocalSocket::adopt_fd(accepted_fd);
 }
 
 }

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -68,7 +68,7 @@ protected:
         Inet,
     };
 
-    Socket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::No)
+    explicit Socket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::Yes)
         : m_prevent_sigpipe(prevent_sigpipe == PreventSIGPIPE::Yes)
     {
     }
@@ -87,7 +87,7 @@ protected:
     }
 
 private:
-    bool m_prevent_sigpipe { false };
+    bool m_prevent_sigpipe { true };
 };
 
 /// A reusable socket maintains state about being connected in addition to
@@ -195,7 +195,7 @@ public:
     virtual ~TCPSocket() override { close(); }
 
 private:
-    TCPSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::No)
+    explicit TCPSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::Yes)
         : Socket(prevent_sigpipe)
     {
     }
@@ -269,7 +269,7 @@ public:
     virtual ~UDPSocket() override { close(); }
 
 private:
-    UDPSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::No)
+    explicit UDPSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::Yes)
         : Socket(prevent_sigpipe)
     {
     }
@@ -290,8 +290,8 @@ private:
 
 class LocalSocket final : public Socket {
 public:
-    static ErrorOr<NonnullOwnPtr<LocalSocket>> connect(ByteString const& path, PreventSIGPIPE = PreventSIGPIPE::No);
-    static ErrorOr<NonnullOwnPtr<LocalSocket>> adopt_fd(int fd, PreventSIGPIPE = PreventSIGPIPE::No);
+    static ErrorOr<NonnullOwnPtr<LocalSocket>> connect(ByteString const& path, PreventSIGPIPE = PreventSIGPIPE::Yes);
+    static ErrorOr<NonnullOwnPtr<LocalSocket>> adopt_fd(int fd, PreventSIGPIPE = PreventSIGPIPE::Yes);
 
     LocalSocket(LocalSocket&& other)
         : Socket(static_cast<Socket&&>(other))
@@ -343,7 +343,7 @@ public:
     virtual ~LocalSocket() { close(); }
 
 private:
-    LocalSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::No)
+    explicit LocalSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::Yes)
         : Socket(prevent_sigpipe)
     {
     }

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -107,12 +107,12 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(HTML::TransferDa
     auto fd_tag = data_holder.data.take_first();
     if (fd_tag == IPC_FILE_TAG) {
         auto fd = data_holder.fds.take_first();
-        m_socket = MUST(Core::LocalSocket::adopt_fd(fd.take_fd(), Core::LocalSocket::PreventSIGPIPE::Yes));
+        m_socket = MUST(Core::LocalSocket::adopt_fd(fd.take_fd()));
 
         fd_tag = data_holder.data.take_first();
         VERIFY(fd_tag == IPC_FILE_TAG);
         fd = data_holder.fds.take_first();
-        m_fd_passing_socket = MUST(Core::LocalSocket::adopt_fd(fd.take_fd(), Core::LocalSocket::PreventSIGPIPE::Yes));
+        m_fd_passing_socket = MUST(Core::LocalSocket::adopt_fd(fd.take_fd()));
 
         m_socket->on_ready_to_read = [strong_this = JS::make_handle(this)]() {
             strong_this->read_from_socket();
@@ -155,10 +155,10 @@ void MessagePort::entangle_with(MessagePort& remote_port)
     auto create_paired_sockets = []() -> Array<NonnullOwnPtr<Core::LocalSocket>, 2> {
         int fds[2] = {};
         MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
-        auto socket0 = MUST(Core::LocalSocket::adopt_fd(fds[0], Core::LocalSocket::PreventSIGPIPE::Yes));
+        auto socket0 = MUST(Core::LocalSocket::adopt_fd(fds[0]));
         MUST(socket0->set_blocking(false));
         MUST(socket0->set_close_on_exec(true));
-        auto socket1 = MUST(Core::LocalSocket::adopt_fd(fds[1], Core::LocalSocket::PreventSIGPIPE::Yes));
+        auto socket1 = MUST(Core::LocalSocket::adopt_fd(fds[1]));
         MUST(socket1->set_blocking(false));
         MUST(socket1->set_close_on_exec(true));
 


### PR DESCRIPTION
While this is the default for an underlying socket, it doesn't seem good
to have this as the default for our socket wrapper.

This fixes a crash in ladybird when connecting to the python HTTP server
with HTTPS.