### PR TITLE
LibWeb: Avoid UAF when encoding a fetch request body via URLSearchParams

### DIFF
--- a/Tests/LibWeb/Text/expected/fetch-request-url-search-params.txt
+++ b/Tests/LibWeb/Text/expected/fetch-request-url-search-params.txt
@@ -1,0 +1,1 @@
+username=buggie&password=hunter2

--- a/Tests/LibWeb/Text/input/fetch-request-url-search-params.html
+++ b/Tests/LibWeb/Text/input/fetch-request-url-search-params.html
@@ -1,0 +1,16 @@
+<script src="include.js"></script>
+<script type="text/javascript">
+    asyncTest(async done => {
+        const body = new URLSearchParams();
+        body.append("username", "buggie");
+        body.append("password", "hunter2");
+
+        const request = new Request("fetch-url-search-params.html", {
+            method: "POST",
+            body: body,
+        });
+
+        println(await request.text());
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -105,8 +105,8 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
         },
         [&](JS::Handle<DOMURL::URLSearchParams> const& url_search_params) -> WebIDL::ExceptionOr<void> {
             // Set source to the result of running the application/x-www-form-urlencoded serializer with object’s list.
-            auto search_params_bytes = TRY(url_search_params->to_string()).bytes();
-            source = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(search_params_bytes));
+            auto search_params_string = TRY(url_search_params->to_string());
+            source = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(search_params_string.bytes()));
             // Set type to `application/x-www-form-urlencoded;charset=UTF-8`.
             type = TRY_OR_THROW_OOM(vm, ByteBuffer::copy("application/x-www-form-urlencoded;charset=UTF-8"sv.bytes()));
             return {};


### PR DESCRIPTION
With this, we can log into spotify, but get the following exceptions when landing on the home page:

```
33840.190 WebContent(220180): Unhandled JavaScript exception (in promise): [undefined] undefined

33840.334 WebContent(220180): Unhandled JavaScript exception (in promise): [EMEError] Platform does not support navigator.requestMediaKeySystemAccess
33840.334 WebContent(220180):     at Error
    at v (https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:301915)
    at fatal (https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:302176)
    at https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:325898
    at Promise
    at create (https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:401088)
    at create (https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:401088)
    at https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:499685
    at Promise
    at Yt (https://open.spotifycdn.com/cdn/build/mobile-web-player/vendor~mobile-web-player.c7c1f610.js:1:497529)
    at https://open.spotifycdn.com/cdn/build/mobile-web-player/mobile-web-player.a76ebeae.js:1:522425
    at Te (https://open.spotifycdn.com/cdn/build/mobile-web-player/mobile-web-player.a76ebeae.js:1:523752)
    at Xe (https://open.spotifycdn.com/cdn/build/mobile-web-player/mobile-web-player.a76ebeae.js:1:565639)
    at https://open.spotifycdn.com/cdn/build/mobile-web-player/mobile-web-player.a76ebeae.js:1:597338
    at <unknown>

```