### PR TITLE
LibJSGCVerifier+LibJS: Fix false positives in HeapFunction::visit_edges

### DIFF
--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -90,8 +90,9 @@ std::vector<clang::QualType> get_all_qualified_types(clang::QualType const& type
         if (specialization_name == "JS::GCPtr" || specialization_name == "JS::NonnullGCPtr") {
             qualified_types.push_back(type);
         } else {
-            for (size_t i = 0; i < template_specialization->template_arguments().size(); i++) {
-                auto const& template_arg = template_specialization->template_arguments()[i];
+            auto const template_arguments = template_specialization->template_arguments();
+            for (size_t i = 0; i < template_arguments.size(); i++) {
+                auto const& template_arg = template_arguments[i];
                 if (template_arg.getKind() == clang::TemplateArgument::Type) {
                     auto template_qualified_types = get_all_qualified_types(template_arg.getAsType());
                     std::move(template_qualified_types.begin(), template_qualified_types.end(), std::back_inserter(qualified_types));
@@ -143,10 +144,11 @@ FieldValidationResult validate_field(clang::FieldDecl const* field_decl)
             if (template_type_name != "GCPtr" && template_type_name != "NonnullGCPtr")
                 return result;
 
-            if (specialization->template_arguments().size() != 1)
+            auto const template_args = specialization->template_arguments();
+            if (template_args.size() != 1)
                 return result; // Not really valid, but will produce a compilation error anyway
 
-            auto const& type_arg = specialization->template_arguments()[0];
+            auto const& type_arg = template_args[0];
             auto const* record_type = type_arg.getAsType()->getAs<clang::RecordType>();
             if (!record_type)
                 return result;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.cpp
@@ -47,6 +47,7 @@ FetchAlgorithms::FetchAlgorithms(
 
 void FetchAlgorithms::visit_edges(JS::Cell::Visitor& visitor)
 {
+    Base::visit_edges(visitor);
     visitor.visit(m_process_request_body_chunk_length);
     visitor.visit(m_process_request_end_of_body);
     visitor.visit(m_process_early_hints_response);

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -57,6 +57,7 @@ public:
 
     virtual void visit_edges(Cell::Visitor& visitor) override
     {
+        Base::visit_edges(visitor);
         visitor.visit(m_response);
     }
 


### PR DESCRIPTION
clang doesn't make all `Base::visit_edges()` calls `CXXMemberCallExprs`. This would lead to false positives like in HeapFunction, where the matcher would fail to match and report a warning.
Also previously the matcher would succeed if the visited class is missing the call to `Base::visit_edges()` but an included class has a correct method.

The new matcher checks the current class for declarations of `visit_edges`-methods and matches all `visit_edges`-memberExprs inside, checking for one starting with `Base::`.
This seems to get rid of the false positives and should be more correct detecting missing calls.

For consistency missing `Base::visit_edges()`-calls in `visit_edges` of FetchAlgorithms and Navitables were added too, although they are empty.

Should fix #23790 
