### PR TITLE
AK+Everywhere: Fix some UAF and prevent such instances from being able to compile

### DIFF
--- a/AK/ByteString.cpp
+++ b/AK/ByteString.cpp
@@ -81,14 +81,14 @@ ByteString ByteString::substring(size_t start) const
     return { characters() + start, length() - start };
 }
 
-StringView ByteString::substring_view(size_t start, size_t length) const
+StringView ByteString::substring_view(size_t start, size_t length) const&
 {
     VERIFY(!Checked<size_t>::addition_would_overflow(start, length));
     VERIFY(start + length <= m_impl->length());
     return { characters() + start, length };
 }
 
-StringView ByteString::substring_view(size_t start) const
+StringView ByteString::substring_view(size_t start) const&
 {
     VERIFY(start <= length());
     return { characters() + start, length() - start };
@@ -123,7 +123,7 @@ Vector<ByteString> ByteString::split_limit(char separator, size_t limit, SplitBe
     return v;
 }
 
-Vector<StringView> ByteString::split_view(Function<bool(char)> separator, SplitBehavior split_behavior) const
+Vector<StringView> ByteString::split_view(Function<bool(char)> separator, SplitBehavior split_behavior) const&
 {
     if (is_empty())
         return {};
@@ -147,7 +147,7 @@ Vector<StringView> ByteString::split_view(Function<bool(char)> separator, SplitB
     return v;
 }
 
-Vector<StringView> ByteString::split_view(char const separator, SplitBehavior split_behavior) const
+Vector<StringView> ByteString::split_view(char const separator, SplitBehavior split_behavior) const&
 {
     return split_view([separator](char ch) { return ch == separator; }, split_behavior);
 }

--- a/AK/ByteString.h
+++ b/AK/ByteString.h
@@ -166,8 +166,12 @@ public:
 
     [[nodiscard]] Vector<ByteString> split_limit(char separator, size_t limit, SplitBehavior = SplitBehavior::Nothing) const;
     [[nodiscard]] Vector<ByteString> split(char separator, SplitBehavior = SplitBehavior::Nothing) const;
-    [[nodiscard]] Vector<StringView> split_view(char separator, SplitBehavior = SplitBehavior::Nothing) const;
-    [[nodiscard]] Vector<StringView> split_view(Function<bool(char)> separator, SplitBehavior = SplitBehavior::Nothing) const;
+
+    [[nodiscard]] Vector<StringView> split_view(char separator, SplitBehavior = SplitBehavior::Nothing) const&;
+    [[nodiscard]] Vector<StringView> split_view(char separator, SplitBehavior = SplitBehavior::Nothing) const&& = delete;
+
+    [[nodiscard]] Vector<StringView> split_view(Function<bool(char)> separator, SplitBehavior = SplitBehavior::Nothing) const&;
+    [[nodiscard]] Vector<StringView> split_view(Function<bool(char)> separator, SplitBehavior = SplitBehavior::Nothing) const&& = delete;
 
     [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find(StringView needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
@@ -177,12 +181,17 @@ public:
     using SearchDirection = StringUtils::SearchDirection;
     [[nodiscard]] Optional<size_t> find_any_of(StringView needles, SearchDirection direction) const { return StringUtils::find_any_of(*this, needles, direction); }
 
-    [[nodiscard]] StringView find_last_split_view(char separator) const { return view().find_last_split_view(separator); }
+    [[nodiscard]] StringView find_last_split_view(char separator) const& { return view().find_last_split_view(separator); }
+    [[nodiscard]] StringView find_last_split_view(char separator) const&& = delete;
 
     [[nodiscard]] ByteString substring(size_t start, size_t length) const;
     [[nodiscard]] ByteString substring(size_t start) const;
-    [[nodiscard]] StringView substring_view(size_t start, size_t length) const;
-    [[nodiscard]] StringView substring_view(size_t start) const;
+
+    [[nodiscard]] StringView substring_view(size_t start, size_t length) const&;
+    [[nodiscard]] StringView substring_view(size_t start, size_t length) const&& = delete;
+
+    [[nodiscard]] StringView substring_view(size_t start) const&;
+    [[nodiscard]] StringView substring_view(size_t start) const&& = delete;
 
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return length() == 0; }
     [[nodiscard]] ALWAYS_INLINE size_t length() const { return m_impl->length(); }
@@ -191,10 +200,8 @@ public:
 
     [[nodiscard]] bool copy_characters_to_buffer(char* buffer, size_t buffer_size) const;
 
-    [[nodiscard]] ALWAYS_INLINE ReadonlyBytes bytes() const
-    {
-        return m_impl->bytes();
-    }
+    [[nodiscard]] ALWAYS_INLINE ReadonlyBytes bytes() const& { return m_impl->bytes(); }
+    [[nodiscard]] ALWAYS_INLINE ReadonlyBytes bytes() const&& = delete;
 
     [[nodiscard]] ALWAYS_INLINE char const& operator[](size_t i) const
     {
@@ -292,10 +299,8 @@ public:
         return formatted("{}", value);
     }
 
-    [[nodiscard]] StringView view() const
-    {
-        return { characters(), length() };
-    }
+    [[nodiscard]] StringView view() const& { return { characters(), length() }; }
+    [[nodiscard]] StringView view() const&& = delete;
 
     [[nodiscard]] ByteString replace(StringView needle, StringView replacement, ReplaceMode replace_mode = ReplaceMode::All) const { return StringUtils::replace(*this, needle, replacement, replace_mode); }
     [[nodiscard]] size_t count(StringView needle) const { return StringUtils::count(*this, needle); }

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -128,7 +128,7 @@ public:
         return m_value.get<bool>();
     }
 
-    ByteString as_string() const
+    ByteString const& as_string() const
     {
         return m_value.get<ByteString>();
     }

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
+#include <AK/StringView.h>
 #include <AK/Traits.h>
 
 namespace AK {
@@ -46,6 +48,12 @@ public:
     /// Same as write, but does not return until either the entire buffer
     /// contents are written or an error occurs.
     virtual ErrorOr<void> write_until_depleted(ReadonlyBytes);
+
+    template<Concepts::AnyString T>
+    ErrorOr<void> write_until_depleted(T const& buffer)
+    {
+        return write_until_depleted(StringView { buffer }.bytes());
+    }
 
     template<typename T>
     requires(requires(Stream& stream) { { T::read_from_stream(stream) } -> SameAs<ErrorOr<T>>; })

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -77,7 +77,7 @@ ErrorOr<String> String::repeated(u32 code_point, size_t count)
     return result;
 }
 
-StringView String::bytes_as_string_view() const
+StringView String::bytes_as_string_view() const&
 {
     return StringView(bytes());
 }
@@ -197,7 +197,7 @@ u32 String::ascii_case_insensitive_hash() const
     return case_insensitive_string_hash(reinterpret_cast<char const*>(bytes().data()), bytes().size());
 }
 
-Utf8View String::code_points() const
+Utf8View String::code_points() const&
 {
     return Utf8View(bytes_as_string_view());
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -107,13 +107,15 @@ public:
     ErrorOr<String> substring_from_byte_offset_with_shared_superstring(size_t start) const;
 
     // Returns an iterable view over the Unicode code points.
-    [[nodiscard]] Utf8View code_points() const;
+    [[nodiscard]] Utf8View code_points() const&;
+    [[nodiscard]] Utf8View code_points() const&& = delete;
 
     // Returns true if the String is zero-length.
     [[nodiscard]] bool is_empty() const;
 
     // Returns a StringView covering the full length of the string. Note that iterating this will go byte-at-a-time, not code-point-at-a-time.
-    [[nodiscard]] StringView bytes_as_string_view() const;
+    [[nodiscard]] StringView bytes_as_string_view() const&;
+    [[nodiscard]] StringView bytes_as_string_view() const&& = delete;
 
     [[nodiscard]] size_t count(StringView needle) const { return StringUtils::count(bytes_as_string_view(), needle); }
 

--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -101,15 +101,15 @@ ErrorOr<String> UUID::to_string() const
 {
     auto buffer_span = m_uuid_buffer.span();
     StringBuilder builder(36);
-    TRY(builder.try_append(encode_hex(buffer_span.trim(4)).view()));
+    TRY(builder.try_append(encode_hex(buffer_span.trim(4))));
     TRY(builder.try_append('-'));
-    TRY(builder.try_append(encode_hex(buffer_span.slice(4, 2)).view()));
+    TRY(builder.try_append(encode_hex(buffer_span.slice(4, 2))));
     TRY(builder.try_append('-'));
-    TRY(builder.try_append(encode_hex(buffer_span.slice(6, 2)).view()));
+    TRY(builder.try_append(encode_hex(buffer_span.slice(6, 2))));
     TRY(builder.try_append('-'));
-    TRY(builder.try_append(encode_hex(buffer_span.slice(8, 2)).view()));
+    TRY(builder.try_append(encode_hex(buffer_span.slice(8, 2))));
     TRY(builder.try_append('-'));
-    TRY(builder.try_append(encode_hex(buffer_span.slice(10, 6)).view()));
+    TRY(builder.try_append(encode_hex(buffer_span.slice(10, 6))));
     return builder.to_string();
 }
 #endif

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -261,12 +261,12 @@ static ErrorOr<void> generate_loader_for_object(GUI::GML::Object const& gml_obje
     generator.set("class_name", gml_object.name());
 
     auto append = [&]<size_t N>(auto& generator, char const(&text)[N]) -> ErrorOr<void> {
-        generator.append(TRY(String::repeated(' ', indentation * 4)).bytes_as_string_view());
+        generator.append(TRY(String::repeated(' ', indentation * 4)));
         generator.appendln(text);
         return {};
     };
 
-    generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)).bytes_as_string_view());
+    generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)));
     generator.appendln("{");
     if (use_object_constructor == UseObjectConstructor::Yes)
         TRY(append(generator, "@object_name@ = TRY(@class_name@::try_create());"));
@@ -336,7 +336,7 @@ static ErrorOr<void> generate_loader_for_object(GUI::GML::Object const& gml_obje
 
     TRY(append(generator, "TRY(::GUI::initialize(*@object_name@));"));
 
-    generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)).bytes_as_string_view());
+    generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)));
     generator.appendln("}");
 
     return {};
@@ -365,7 +365,7 @@ static ErrorOr<String> generate_cpp(NonnullRefPtr<GUI::GML::GMLFile> gml, Lexica
     };
     TRY(necessary_includes.try_set_from(always_necessary_includes));
     for (auto const& include : necessary_includes)
-        generator.appendln(TRY(String::formatted("#include {}", include)).bytes_as_string_view());
+        generator.appendln(TRY(String::formatted("#include {}", include)));
 
     // FIXME: Use a UTF-8 aware function once possible.
     generator.set("main_class_name", main_class.name());

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -370,7 +370,7 @@ static ErrorOr<void> parse_prop_list(Core::InputBufferedFile& file, PropList& pr
             properties = { segments[1].trim_whitespace() };
 
         for (auto& property : properties) {
-            auto& code_points = prop_list.ensure(sanitize_property ? sanitize_entry(property).trim_whitespace().view() : property.trim_whitespace());
+            auto& code_points = prop_list.ensure(sanitize_property ? sanitize_entry(property).trim_whitespace() : ByteString { property.trim_whitespace() });
             code_points.append(code_point_range);
         }
     }
@@ -490,11 +490,11 @@ static ErrorOr<void> parse_value_alias_list(Core::InputBufferedFile& file, Strin
         VERIFY((segments.size() == 3) || (segments.size() == 4));
         auto value = primary_value_is_first ? segments[1].trim_whitespace() : segments[2].trim_whitespace();
         auto alias = primary_value_is_first ? segments[2].trim_whitespace() : segments[1].trim_whitespace();
-        append_alias(sanitize_alias ? sanitize_entry(alias).view() : alias, value);
+        append_alias(sanitize_alias ? sanitize_entry(alias) : ByteString { alias }, value);
 
         if (segments.size() == 4) {
             alias = segments[3].trim_whitespace();
-            append_alias(sanitize_alias ? sanitize_entry(alias).view() : alias, value);
+            append_alias(sanitize_alias ? sanitize_entry(alias) : ByteString { alias }, value);
         }
     }
 

--- a/Tests/LibCrypto/TestChecksum.cpp
+++ b/Tests/LibCrypto/TestChecksum.cpp
@@ -16,11 +16,11 @@ TEST_CASE(test_adler32)
         EXPECT_EQ(digest, expected_result);
     };
 
-    do_test(ByteString("").bytes(), 0x1);
-    do_test(ByteString("a").bytes(), 0x00620062);
-    do_test(ByteString("abc").bytes(), 0x024d0127);
-    do_test(ByteString("message digest").bytes(), 0x29750586);
-    do_test(ByteString("abcdefghijklmnopqrstuvwxyz").bytes(), 0x90860b20);
+    do_test(""sv.bytes(), 0x1);
+    do_test("a"sv.bytes(), 0x00620062);
+    do_test("abc"sv.bytes(), 0x024d0127);
+    do_test("message digest"sv.bytes(), 0x29750586);
+    do_test("abcdefghijklmnopqrstuvwxyz"sv.bytes(), 0x90860b20);
 }
 
 TEST_CASE(test_cksum)
@@ -30,9 +30,9 @@ TEST_CASE(test_cksum)
         EXPECT_EQ(digest, expected_result);
     };
 
-    do_test(ByteString("").bytes(), 0xFFFFFFFF);
-    do_test(ByteString("The quick brown fox jumps over the lazy dog").bytes(), 0x7BAB9CE8);
-    do_test(ByteString("various CRC algorithms input data").bytes(), 0xEFB5CA4F);
+    do_test(""sv.bytes(), 0xFFFFFFFF);
+    do_test("The quick brown fox jumps over the lazy dog"sv.bytes(), 0x7BAB9CE8);
+    do_test("various CRC algorithms input data"sv.bytes(), 0xEFB5CA4F);
 }
 
 TEST_CASE(test_cksum_atomic_digest)
@@ -43,10 +43,10 @@ TEST_CASE(test_cksum_atomic_digest)
 
     Crypto::Checksum::cksum cksum;
 
-    cksum.update(ByteString("Well").bytes());
-    cksum.update(ByteString(" hello ").bytes());
+    cksum.update("Well"sv.bytes());
+    cksum.update(" hello "sv.bytes());
     cksum.digest();
-    cksum.update(ByteString("friends").bytes());
+    cksum.update("friends"sv.bytes());
     auto digest = cksum.digest();
 
     compare(digest, 0x2D65C7E0);
@@ -59,7 +59,7 @@ TEST_CASE(test_crc32)
         EXPECT_EQ(digest, expected_result);
     };
 
-    do_test(ByteString("").bytes(), 0x0);
-    do_test(ByteString("The quick brown fox jumps over the lazy dog").bytes(), 0x414FA339);
-    do_test(ByteString("various CRC algorithms input data").bytes(), 0x9BD366AE);
+    do_test(""sv.bytes(), 0x0);
+    do_test("The quick brown fox jumps over the lazy dog"sv.bytes(), 0x414FA339);
+    do_test("various CRC algorithms input data"sv.bytes(), 0x9BD366AE);
 }

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -320,7 +320,7 @@ void write_per_file(HashMap<size_t, TestResult> const& result_map, Vector<ByteSt
     complete_results.set("duration", time_taken_in_ms / 1000.);
     complete_results.set("results", result_object);
 
-    if (file->write_until_depleted(complete_results.to_byte_string().bytes()).is_error())
+    if (file->write_until_depleted(complete_results.to_byte_string()).is_error())
         warnln("Failed to write per-file");
     file->close();
 }

--- a/Userland/Applications/Calendar/EventManager.cpp
+++ b/Userland/Applications/Calendar/EventManager.cpp
@@ -42,8 +42,8 @@ ErrorOr<void> EventManager::save(FileSystemAccessClient::File& file)
     set_filename(file.filename());
 
     auto stream = file.release_stream();
-    auto json = TRY(serialize_events());
-    TRY(stream->write_some(json.to_byte_string().bytes()));
+    auto json = TRY(serialize_events()).to_byte_string();
+    TRY(stream->write_some(json.bytes()));
     stream->close();
 
     m_dirty = false;

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -87,8 +87,10 @@ ErrorOr<void> BackgroundSettingsWidget::create_frame()
     m_copy_action = GUI::CommonActions::make_copy_action(
         [this](auto&) {
             auto wallpaper = m_monitor_widget->wallpaper();
-            if (wallpaper.has_value())
-                GUI::Clipboard::the().set_data(URL::create_with_file_scheme(wallpaper.value().to_byte_string()).to_byte_string().bytes(), "text/uri-list");
+            if (wallpaper.has_value()) {
+                auto url = URL::create_with_file_scheme(wallpaper.value()).to_byte_string();
+                GUI::Clipboard::the().set_data(url.bytes(), "text/uri-list");
+            }
         },
         this);
     m_context_menu->add_action(*m_copy_action);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -171,7 +171,7 @@ void do_copy(Vector<ByteString> const& selected_file_paths, FileOperation file_o
         auto url = URL::create_with_file_scheme(path);
         copy_text.appendff("{}\n", url);
     }
-    GUI::Clipboard::the().set_data(copy_text.to_byte_string().bytes(), "text/uri-list");
+    GUI::Clipboard::the().set_data(copy_text.string_view().bytes(), "text/uri-list");
 }
 
 void do_paste(ByteString const& target_directory, GUI::Window* window)

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -237,7 +237,7 @@ void MapWidget::context_menu_event(GUI::ContextMenuEvent& event)
     m_context_menu = GUI::Menu::construct();
     m_context_menu->add_action(GUI::Action::create(
         "&Copy Coordinates to Clipboard", MUST(Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"sv)), [this](auto&) {
-            GUI::Clipboard::the().set_plain_text(MUST(String::formatted("{}, {}", m_context_menu_latlng.latitude, m_context_menu_latlng.longitude)).bytes_as_string_view());
+            GUI::Clipboard::the().set_plain_text(MUST(String::formatted("{}, {}", m_context_menu_latlng.latitude, m_context_menu_latlng.longitude)));
         }));
     m_context_menu->add_separator();
     if (!m_context_menu_actions.is_empty()) {

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -165,7 +165,7 @@ ErrorOr<void> NetworkSettingsWidget::apply_settings_impl()
         (void)TRY(Core::System::posix_spawn("/bin/Escalator"sv, &file_actions, nullptr, const_cast<char**>(argv), environ));
 
         auto outfile = TRY(Core::File::adopt_fd(pipefds[1], Core::File::OpenMode::Write, Core::File::ShouldCloseFileDescriptor::No));
-        TRY(outfile->write_until_depleted(json.serialized<StringBuilder>().bytes()));
+        TRY(outfile->write_until_depleted(json.serialized<StringBuilder>()));
     }
 
     return {};

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -249,7 +249,7 @@ ErrorOr<Vector<Color>> PaletteWidget::load_palette_path(ByteString const& file_p
 ErrorOr<void> PaletteWidget::save_palette_file(Vector<Color> palette, NonnullOwnPtr<Core::File> file)
 {
     for (auto& color : palette) {
-        TRY(file->write_until_depleted(color.to_byte_string_without_alpha().bytes()));
+        TRY(file->write_until_depleted(color.to_byte_string_without_alpha()));
         TRY(file->write_until_depleted({ "\n", 1 }));
     }
     return {};

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -188,7 +188,7 @@ ErrorOr<void> RunWindow::save_history()
 
     // Write the first 25 items of history
     for (int i = 0; i < min(static_cast<int>(m_path_history.size()), 25); i++)
-        TRY(file->write_until_depleted(ByteString::formatted("{}\n", m_path_history[i]).bytes()));
+        TRY(file->write_until_depleted(ByteString::formatted("{}\n", m_path_history[i])));
 
     return {};
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -128,7 +128,8 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
                 else
                     builder.appendff("  while evaluating builtin '{}'\n", frame.function_name);
             } else if (frame.source_range().filename().starts_with("cell "sv)) {
-                builder.appendff("  in cell '{}', at line {}, column {}\n", frame.source_range().filename().substring_view(5), frame.source_range().start.line, frame.source_range().start.column);
+                auto filename = frame.source_range().filename();
+                builder.appendff("  in cell '{}', at line {}, column {}\n", filename.substring_view(5), frame.source_range().start.line, frame.source_range().start.column);
             }
         }
         return builder.to_byte_string();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1699,7 +1699,7 @@ bool HackStudioWidget::any_document_is_dirty() const
 
 void HackStudioWidget::update_gml_preview()
 {
-    auto gml_content = current_editor_wrapper().filename().ends_with(".gml"sv) ? current_editor_wrapper().editor().text().view() : ""sv;
+    auto gml_content = current_editor_wrapper().filename().ends_with(".gml"sv) ? current_editor_wrapper().editor().text() : ByteString::empty();
     m_gml_preview_widget->load_gml(gml_content);
 }
 

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -135,7 +135,7 @@ ErrorOr<void> ProjectBuilder::initialize_build_directory()
         MUST(FileSystem::remove(cmake_file_path, FileSystem::RecursionMode::Disallowed));
 
     auto cmake_file = TRY(Core::File::open(cmake_file_path, Core::File::OpenMode::Write));
-    TRY(cmake_file->write_until_depleted(generate_cmake_file_content().bytes()));
+    TRY(cmake_file->write_until_depleted(generate_cmake_file_content()));
 
     TRY(m_terminal->run_command(ByteString::formatted("cmake -S {} -DHACKSTUDIO_BUILD=ON -DHACKSTUDIO_BUILD_CMAKE_FILE={}"
                                                       " -DENABLE_UNICODE_DATABASE_DOWNLOAD=OFF",

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -426,7 +426,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
             auto const filesystem_event_type = perf_event.get("fs_event_type"sv).value_or("").as_string();
             if (filesystem_event_type == "open"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);
-                auto const filename = profile_strings.get(string_index).value_or("").view();
+                auto const filename = profile_strings.get(string_index).value_or("");
                 fsdata.data = Event::OpenEventData {
                     .dirfd = perf_event.get_integer<int>("dirfd"sv).value_or(0),
                     .path = filename,
@@ -435,28 +435,28 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
                 };
             } else if (filesystem_event_type == "close"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);
-                auto const filename = profile_strings.get(string_index).value_or("").view();
+                auto const filename = profile_strings.get(string_index).value_or("");
                 fsdata.data = Event::CloseEventData {
                     .fd = perf_event.get_integer<int>("fd"sv).value_or(0),
                     .path = filename,
                 };
             } else if (filesystem_event_type == "readv"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);
-                auto const filename = profile_strings.get(string_index).value().view();
+                auto const filename = profile_strings.get(string_index).value();
                 fsdata.data = Event::ReadvEventData {
                     .fd = perf_event.get_integer<int>("fd"sv).value_or(0),
                     .path = filename,
                 };
             } else if (filesystem_event_type == "read"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);
-                auto const filename = profile_strings.get(string_index).value().view();
+                auto const filename = profile_strings.get(string_index).value();
                 fsdata.data = Event::ReadEventData {
                     .fd = perf_event.get_integer<int>("fd"sv).value_or(0),
                     .path = filename,
                 };
             } else if (filesystem_event_type == "pread"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);
-                auto const filename = profile_strings.get(string_index).value().view();
+                auto const filename = profile_strings.get(string_index).value();
                 fsdata.data = Event::PreadEventData {
                     .fd = perf_event.get_integer<int>("fd"sv).value_or(0),
                     .path = filename,

--- a/Userland/Libraries/LibArchive/Tar.cpp
+++ b/Userland/Libraries/LibArchive/Tar.cpp
@@ -27,8 +27,11 @@ unsigned TarFileHeader::expected_checksum() const
 ErrorOr<void> TarFileHeader::calculate_checksum()
 {
     memset(m_checksum, ' ', sizeof(m_checksum));
-    bool copy_successful = TRY(String::formatted("{:06o}", expected_checksum())).bytes_as_string_view().copy_characters_to_buffer(m_checksum, sizeof(m_checksum));
+
+    auto octal = TRY(String::formatted("{:06o}", expected_checksum()));
+    bool copy_successful = octal.bytes_as_string_view().copy_characters_to_buffer(m_checksum, sizeof(m_checksum));
     VERIFY(copy_successful);
+
     return {};
 }
 

--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -84,7 +84,8 @@ static void set_field(char (&field)[N], TSource&& source)
 template<class TSource, size_t N>
 static ErrorOr<void> set_octal_field(char (&field)[N], TSource&& source)
 {
-    set_field(field, TRY(String::formatted("{:o}", forward<TSource>(source))).bytes_as_string_view());
+    auto octal = TRY(String::formatted("{:o}", forward<TSource>(source)));
+    set_field(field, octal.bytes_as_string_view());
     return {};
 }
 

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -85,7 +85,7 @@ ErrorOr<void> Command::write_lines(Span<ByteString> lines)
     });
 
     for (ByteString const& line : lines)
-        TRY(m_stdin->write_until_depleted(ByteString::formatted("{}\n", line).bytes()));
+        TRY(m_stdin->write_until_depleted(ByteString::formatted("{}\n", line)));
 
     return {};
 }

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -178,10 +178,10 @@ ErrorOr<void> ConfigFile::sync()
     TRY(m_file->seek(0, SeekMode::SetPosition));
 
     for (auto& it : m_groups) {
-        TRY(m_file->write_until_depleted(ByteString::formatted("[{}]\n", it.key).bytes()));
+        TRY(m_file->write_until_depleted(ByteString::formatted("[{}]\n", it.key)));
         for (auto& jt : it.value)
-            TRY(m_file->write_until_depleted(ByteString::formatted("{}={}\n", jt.key, jt.value).bytes()));
-        TRY(m_file->write_until_depleted("\n"sv.bytes()));
+            TRY(m_file->write_until_depleted(ByteString::formatted("{}={}\n", jt.key, jt.value)));
+        TRY(m_file->write_until_depleted("\n"sv));
     }
 
     m_dirty = false;

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -186,7 +186,7 @@ struct AK::Formatter<DSP::ProcessorRangeParameter> : AK::StandardFormatter {
         m_width = m_width.value_or(0);
         m_precision = m_precision.value_or(NumericLimits<size_t>::max());
 
-        TRY(builder.put_literal(TRY(String::formatted("[{} - {}]: {}", value.min_value(), value.max_value(), value.value())).bytes_as_string_view()));
+        TRY(builder.put_literal(TRY(String::formatted("[{} - {}]: {}", value.min_value(), value.max_value(), value.value()))));
         return {};
     }
 };

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -188,19 +188,22 @@ bool AppFile::spawn_with_escalation(ReadonlySpan<StringView> user_arguments) con
 
     StringView exe;
     Vector<StringView, 2> args;
+
+    auto executable = AppFile::executable();
+
     // FIXME: These single quotes won't be enough for executables with single quotes in their name.
-    auto pls_with_executable = ByteString::formatted("/bin/pls '{}'", executable());
+    auto pls_with_executable = ByteString::formatted("/bin/pls '{}'", executable);
     if (run_in_terminal() && !requires_root()) {
         exe = "/bin/Terminal"sv;
-        args = { "-e"sv, executable().view() };
+        args = { "-e"sv, executable };
     } else if (!run_in_terminal() && requires_root()) {
         exe = "/bin/Escalator"sv;
-        args = { executable().view() };
+        args = { executable };
     } else if (run_in_terminal() && requires_root()) {
         exe = "/bin/Terminal"sv;
-        args = { "-e"sv, pls_with_executable.view() };
+        args = { "-e"sv, pls_with_executable };
     } else {
-        exe = executable().view();
+        exe = executable;
     }
     args.extend(Vector(user_arguments));
 

--- a/Userland/Libraries/LibGLSL/Preprocessor.cpp
+++ b/Userland/Libraries/LibGLSL/Preprocessor.cpp
@@ -366,7 +366,7 @@ ErrorOr<Optional<Preprocessor::Definition>> Preprocessor::create_definition(Stri
     }
 
     if (token_index < tokens.size())
-        definition.value = TRY(remove_escaped_newlines(line.substring_view(tokens[token_index].start().column))).bytes_as_string_view();
+        definition.value = TRY(remove_escaped_newlines(line.substring_view(tokens[token_index].start().column)));
 
     return definition;
 }

--- a/Userland/Libraries/LibGLSL/Preprocessor.h
+++ b/Userland/Libraries/LibGLSL/Preprocessor.h
@@ -28,7 +28,7 @@ public:
     struct Definition {
         StringView key;
         Vector<StringView> parameters;
-        StringView value;
+        String value;
         FlyString filename;
         size_t line { 0 };
         size_t column { 0 };

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1704,8 +1704,8 @@ ErrorOr<void> TextEditor::write_to_file(Core::File& file)
         // A size 0 file doesn't need a data copy.
     } else {
         for (size_t i = 0; i < line_count(); ++i) {
-            TRY(file.write_until_depleted(line(i).to_utf8().bytes()));
-            TRY(file.write_until_depleted("\n"sv.bytes()));
+            TRY(file.write_until_depleted(line(i).to_utf8()));
+            TRY(file.write_until_depleted("\n"sv));
         }
     }
     document().set_unmodified();

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -118,7 +118,8 @@ void FontDatabase::load_all_fonts_from_uri(StringView uri)
     auto root = root_or_error.release_value();
 
     root->for_each_descendant_file([this](Core::Resource const& resource) -> IterationDecision {
-        auto path = LexicalPath(resource.uri().bytes_as_string_view());
+        auto uri = resource.uri();
+        auto path = LexicalPath(uri.bytes_as_string_view());
         if (path.has_extension(".font"sv)) {
             if (auto font_or_error = Gfx::BitmapFont::try_load_from_resource(resource); !font_or_error.is_error()) {
                 auto font = font_or_error.release_value();

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -313,8 +313,11 @@ void Job::on_socket_connected()
                 // responds with nothing (content-length = 0 with normal encoding); if that's the case,
                 // quit early as we won't be reading anything anyway.
                 if (auto result = m_headers.get("Content-Length"sv).value_or(""sv).to_number<unsigned>(); result.has_value()) {
-                    if (result.value() == 0 && !m_headers.get("Transfer-Encoding"sv).value_or(""sv).view().trim_whitespace().equals_ignoring_ascii_case("chunked"sv))
-                        return finish_up();
+                    if (result.value() == 0) {
+                        auto transfer_encoding = m_headers.get("Transfer-Encoding"sv);
+                        if (!transfer_encoding.has_value() || !transfer_encoding->view().trim_whitespace().equals_ignoring_ascii_case("chunked"sv))
+                            return finish_up();
+                    }
                 }
                 // There's also the possibility that the server responds with 204 (No Content),
                 // and manages to set a Content-Length anyway, in such cases ignore Content-Length and quit early;

--- a/Userland/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Userland/Libraries/LibJS/MarkupGenerator.cpp
@@ -172,7 +172,7 @@ ErrorOr<void> MarkupGenerator::error_to_html(Error const& error, StringBuilder& 
     auto message_string = message.to_string_without_side_effects();
     auto uncaught_message = TRY(String::formatted("Uncaught {}[{}]: ", in_promise ? "(in promise) " : "", name_string));
 
-    TRY(html_output.try_append(TRY(wrap_string_in_style(uncaught_message, StyleType::Invalid)).bytes_as_string_view()));
+    TRY(html_output.try_append(TRY(wrap_string_in_style(uncaught_message, StyleType::Invalid))));
     TRY(html_output.try_appendff("{}<br>", message_string.is_empty() ? "\"\"" : escape_html_entities(message_string)));
 
     for (size_t i = 0; i < error.traceback().size() - min(error.traceback().size(), 3); i++) {

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1646,7 +1646,7 @@ ErrorOr<void> Editor::reposition_cursor(Stream& stream, bool to_end)
 
 ErrorOr<void> VT::move_absolute(u32 row, u32 col, Stream& stream)
 {
-    return stream.write_until_depleted(ByteString::formatted("\033[{};{}H", row, col).bytes());
+    return stream.write_until_depleted(ByteString::formatted("\033[{};{}H", row, col));
 }
 
 ErrorOr<void> VT::move_relative(int row, int col, Stream& stream)
@@ -1663,9 +1663,9 @@ ErrorOr<void> VT::move_relative(int row, int col, Stream& stream)
         col = -col;
 
     if (row > 0)
-        TRY(stream.write_until_depleted(ByteString::formatted("\033[{}{}", row, x_op).bytes()));
+        TRY(stream.write_until_depleted(ByteString::formatted("\033[{}{}", row, x_op)));
     if (col > 0)
-        TRY(stream.write_until_depleted(ByteString::formatted("\033[{}{}", col, y_op).bytes()));
+        TRY(stream.write_until_depleted(ByteString::formatted("\033[{}{}", col, y_op)));
 
     return {};
 }
@@ -1812,10 +1812,9 @@ ErrorOr<void> VT::apply_style(Style const& style, Stream& stream, bool is_starti
             style.italic() ? 3 : 23,
             style.background().to_vt_escape(),
             style.foreground().to_vt_escape(),
-            style.hyperlink().to_vt_escape(true))
-                                            .bytes()));
+            style.hyperlink().to_vt_escape(true))));
     } else {
-        TRY(stream.write_until_depleted(style.hyperlink().to_vt_escape(false).bytes()));
+        TRY(stream.write_until_depleted(style.hyperlink().to_vt_escape(false)));
     }
 
     return {};
@@ -1824,16 +1823,16 @@ ErrorOr<void> VT::apply_style(Style const& style, Stream& stream, bool is_starti
 ErrorOr<void> VT::clear_lines(size_t count_above, size_t count_below, Stream& stream)
 {
     if (count_below + count_above == 0) {
-        TRY(stream.write_until_depleted("\033[2K"sv.bytes()));
+        TRY(stream.write_until_depleted("\033[2K"sv));
     } else {
         // Go down count_below lines.
         if (count_below > 0)
-            TRY(stream.write_until_depleted(ByteString::formatted("\033[{}B", count_below).bytes()));
+            TRY(stream.write_until_depleted(ByteString::formatted("\033[{}B", count_below)));
         // Then clear lines going upwards.
         for (size_t i = count_below + count_above; i > 0; --i) {
-            TRY(stream.write_until_depleted("\033[2K"sv.bytes()));
+            TRY(stream.write_until_depleted("\033[2K"sv));
             if (i != 1)
-                TRY(stream.write_until_depleted("\033[A"sv.bytes()));
+                TRY(stream.write_until_depleted("\033[A"sv));
         }
     }
 
@@ -1842,17 +1841,17 @@ ErrorOr<void> VT::clear_lines(size_t count_above, size_t count_below, Stream& st
 
 ErrorOr<void> VT::save_cursor(Stream& stream)
 {
-    return stream.write_until_depleted("\033[s"sv.bytes());
+    return stream.write_until_depleted("\033[s"sv);
 }
 
 ErrorOr<void> VT::restore_cursor(Stream& stream)
 {
-    return stream.write_until_depleted("\033[u"sv.bytes());
+    return stream.write_until_depleted("\033[u"sv);
 }
 
 ErrorOr<void> VT::clear_to_end_of_line(Stream& stream)
 {
-    return stream.write_until_depleted("\033[K"sv.bytes());
+    return stream.write_until_depleted("\033[K"sv);
 }
 
 enum VTState {

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -119,7 +119,7 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
             TRY(stderr_stream->write_until_depleted(suggestion.display_trivia_string().bytes()));
         } else {
             auto field = ByteString::formatted("{: <{}}  {}", suggestion.text_string(), longest_suggestion_byte_length_without_trivia, suggestion.display_trivia_string());
-            TRY(stderr_stream->write_until_depleted(ByteString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2).bytes()));
+            TRY(stderr_stream->write_until_depleted(ByteString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2)));
             num_printed += longest_suggestion_length + 2;
         }
 

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -101,7 +101,7 @@ ErrorOr<NonnullRefPtr<Node const>> Node::try_find_from_help_url(URL::URL const& 
         child_node_found = false;
         auto children = TRY(current_node->children());
         for (auto const& child : children) {
-            if (TRY(child->name()) == url.path_segment_at_index(i).view()) {
+            if (auto path = url.path_segment_at_index(i); TRY(child->name()) == path.view()) {
                 child_node_found = true;
                 current_node = child;
                 break;

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -14,7 +14,7 @@ namespace Markdown {
 
 ByteString Heading::render_to_html(bool) const
 {
-    auto input = Unicode::normalize(m_text.render_for_raw_print().view(), Unicode::NormalizationForm::NFD);
+    auto input = Unicode::normalize(m_text.render_for_raw_print(), Unicode::NormalizationForm::NFD);
     auto slugified = MUST(AK::slugify(input));
     return ByteString::formatted("<h{} id='{}'><a href='#{}'>#</a> {}</h{}>\n", m_level, slugified, slugified, m_text.render_to_html(), m_level);
 }

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -75,7 +75,7 @@ static ErrorOr<void> launch_server(ByteString const& socket_path, ByteString con
 
         if (server_pid != 0) {
             auto server_pid_file = TRY(Core::File::open(pid_path, Core::File::OpenMode::Write));
-            TRY(server_pid_file->write_until_depleted(ByteString::number(server_pid).bytes()));
+            TRY(server_pid_file->write_until_depleted(ByteString::number(server_pid)));
 
             TRY(Core::System::kill(getpid(), SIGTERM));
         }

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -153,11 +153,11 @@ bool TLSv12::compute_master_secret_from_pre_master_secret(size_t length)
 
     if constexpr (TLS_SSL_KEYLOG_DEBUG) {
         auto file = MUST(Core::File::open("/home/anon/ssl_keylog"sv, Core::File::OpenMode::Append | Core::File::OpenMode::Write));
-        MUST(file->write_until_depleted("CLIENT_RANDOM "sv.bytes()));
-        MUST(file->write_until_depleted(encode_hex({ m_context.local_random, 32 }).bytes()));
-        MUST(file->write_until_depleted(" "sv.bytes()));
-        MUST(file->write_until_depleted(encode_hex(m_context.master_key).bytes()));
-        MUST(file->write_until_depleted("\n"sv.bytes()));
+        MUST(file->write_until_depleted("CLIENT_RANDOM "sv));
+        MUST(file->write_until_depleted(encode_hex({ m_context.local_random, 32 })));
+        MUST(file->write_until_depleted(" "sv));
+        MUST(file->write_until_depleted(encode_hex(m_context.master_key)));
+        MUST(file->write_until_depleted("\n"sv));
     }
 
     expand_key();

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1209,10 +1209,13 @@ void TerminalWidget::drop_event(GUI::DropEvent& event)
             if (!first)
                 send_non_user_input(" "sv.bytes());
 
-            if (url.scheme() == "file")
-                send_non_user_input(url.serialize_path().bytes());
-            else
-                send_non_user_input(url.to_byte_string().bytes());
+            if (url.scheme() == "file") {
+                auto path = url.serialize_path();
+                send_non_user_input(path.bytes());
+            } else {
+                auto url_string = url.to_byte_string();
+                send_non_user_input(url_string.bytes());
+            }
 
             first = false;
         }

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -468,11 +468,11 @@ static DecoderErrorOr<TrackEntry> parse_track_entry(Streamer& streamer)
             dbgln_if(MATROSKA_TRACE_DEBUG, "Read TrackType attribute: {}", to_underlying(track_entry.track_type()));
             break;
         case TRACK_LANGUAGE_ID:
-            track_entry.set_language(DECODER_TRY_ALLOC(FlyString::from_utf8(TRY_READ(streamer.read_string()).view())));
+            track_entry.set_language(DECODER_TRY_ALLOC(String::from_byte_string(TRY_READ(streamer.read_string()))));
             dbgln_if(MATROSKA_TRACE_DEBUG, "Read Track's Language attribute: {}", track_entry.language());
             break;
         case TRACK_CODEC_ID:
-            track_entry.set_codec_id(DECODER_TRY_ALLOC(FlyString::from_utf8(TRY_READ(streamer.read_string()).view())));
+            track_entry.set_codec_id(DECODER_TRY_ALLOC(String::from_byte_string(TRY_READ(streamer.read_string()))));
             dbgln_if(MATROSKA_TRACE_DEBUG, "Read Track's CodecID attribute: {}", track_entry.codec_id());
             break;
         case TRACK_TIMESTAMP_SCALE_ID:

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -77,7 +77,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_markdown_docume
             if (!markdown_document)
                 return;
 
-            auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(extra_head_contents), "utf-8");
+            auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(extra_head_contents), "utf-8"sv);
             parser->run(url);
         };
 

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1337,7 +1337,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
         // 11. If httpRequest’s referrer is a URL, then:
         if (http_request->referrer().has<URL::URL>()) {
             // 1. Let referrerValue be httpRequest’s referrer, serialized and isomorphic encoded.
-            auto referrer_value = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(http_request->referrer().get<URL::URL>().serialize().bytes()));
+            auto referrer_string = http_request->referrer().get<URL::URL>().serialize();
+            auto referrer_value = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(referrer_string.bytes()));
 
             // 2. Append (`Referer`, referrerValue) to httpRequest’s header list.
             auto header = Infrastructure::Header {

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -53,7 +53,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(StringView string, 
         // 2. Create an HTML parser parser, associated with document.
         // 3. Place string into the input stream for parser. The encoding confidence is irrelevant.
         // FIXME: We don't have the concept of encoding confidence yet.
-        auto parser = HTMLParser::create(*document, string, "UTF-8");
+        auto parser = HTMLParser::create(*document, string, "UTF-8"sv);
 
         // 4. Start parser and let it run until it has consumed all the characters just inserted into the input stream.
         // FIXME: This is to match the default URL. Instead, pass in this's relevant global object's associated Document's URL.

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -189,7 +189,9 @@ FileFilter HTMLInputElement::parse_accept_attribute() const
 
     // If specified, the attribute must consist of a set of comma-separated tokens, each of which must be an ASCII
     // case-insensitive match for one of the following:
-    get_attribute_value(HTML::AttributeNames::accept).bytes_as_string_view().for_each_split_view(',', SplitBehavior::Nothing, [&](StringView value) {
+    auto accept = get_attribute_value(HTML::AttributeNames::accept);
+
+    accept.bytes_as_string_view().for_each_split_view(',', SplitBehavior::Nothing, [&](StringView value) {
         // The string "audio/*"
         //     Indicates that sound files are accepted.
         if (value.equals_ignoring_ascii_case("audio/*"sv))

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1126,7 +1126,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
             // FIXME: Add error message to generated error page
             auto error_html = load_error_page(entry->url()).release_value_but_fixme_should_propagate_errors();
             entry->document_state()->set_document(create_document_for_inline_content(this, navigation_id, [error_html](auto& document) {
-                auto parser = HTML::HTMLParser::create(document, error_html, "utf-8");
+                auto parser = HTML::HTMLParser::create(document, error_html, "utf-8"sv);
                 document.set_url(URL::URL("about:error"));
                 parser->run();
             }));

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -132,7 +132,7 @@ static bool is_html_integration_point(DOM::Element const& element)
     return false;
 }
 
-HTMLParser::HTMLParser(DOM::Document& document, StringView input, ByteString const& encoding)
+HTMLParser::HTMLParser(DOM::Document& document, StringView input, StringView encoding)
     : m_tokenizer(input, encoding)
     , m_scripting_enabled(document.is_scripting_enabled())
     , m_document(JS::make_handle(document))
@@ -4144,7 +4144,7 @@ Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& cont
     temp_document->set_quirks_mode(context_element.document().mode());
 
     // 3. Create a new HTML parser, and associate it with the just created Document node.
-    auto parser = HTMLParser::create(*temp_document, markup, "utf-8");
+    auto parser = HTMLParser::create(*temp_document, markup, "utf-8"sv);
     parser->m_context_element = JS::make_handle(context_element);
     parser->m_parsing_fragment = true;
 
@@ -4239,7 +4239,7 @@ JS::NonnullGCPtr<HTMLParser> HTMLParser::create_with_uncertain_encoding(DOM::Doc
     return document.heap().allocate_without_realm<HTMLParser>(document, input, encoding);
 }
 
-JS::NonnullGCPtr<HTMLParser> HTMLParser::create(DOM::Document& document, StringView input, ByteString const& encoding)
+JS::NonnullGCPtr<HTMLParser> HTMLParser::create(DOM::Document& document, StringView input, StringView encoding)
 {
     return document.heap().allocate_without_realm<HTMLParser>(document, input, encoding);
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -51,7 +51,7 @@ public:
 
     static JS::NonnullGCPtr<HTMLParser> create_for_scripting(DOM::Document&);
     static JS::NonnullGCPtr<HTMLParser> create_with_uncertain_encoding(DOM::Document&, ByteBuffer const& input);
-    static JS::NonnullGCPtr<HTMLParser> create(DOM::Document&, StringView input, ByteString const& encoding);
+    static JS::NonnullGCPtr<HTMLParser> create(DOM::Document&, StringView input, StringView encoding);
 
     void run(HTMLTokenizer::StopAtInsertionPoint = HTMLTokenizer::StopAtInsertionPoint::No);
     void run(const URL::URL&, HTMLTokenizer::StopAtInsertionPoint = HTMLTokenizer::StopAtInsertionPoint::No);
@@ -84,7 +84,7 @@ public:
     size_t script_nesting_level() const { return m_script_nesting_level; }
 
 private:
-    HTMLParser(DOM::Document&, StringView input, ByteString const& encoding);
+    HTMLParser(DOM::Document&, StringView input, StringView encoding);
     HTMLParser(DOM::Document&);
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -117,7 +117,9 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
 
     // 6. If property is undefined and P is in W's document-tree child navigable target name property set, then:
     auto navigable_property_set = m_window->document_tree_child_navigable_target_name_property_set();
-    if (auto navigable = navigable_property_set.get(property_key.to_string().view()); navigable.has_value()) {
+    auto property_key_string = property_key.to_string();
+
+    if (auto navigable = navigable_property_set.get(property_key_string.view()); navigable.has_value()) {
         // 1. Let value be the active WindowProxy of the named object of W with the name P.
         auto value = navigable.value()->active_window_proxy();
 

--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -219,7 +219,7 @@ void WebSocket::send_client_handshake()
     builder.append("\r\n"sv);
 
     m_state = WebSocket::InternalState::WaitingForServerHandshake;
-    auto success = m_impl->send(builder.to_byte_string().bytes());
+    auto success = m_impl->send(builder.string_view().bytes());
     VERIFY(success);
 }
 

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -148,7 +148,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     if (line_index >= wanted_line_count)
                         line.append(ch);
                 }
-                out("{}", line.to_byte_string().substring_view(1, line.length() - 1));
+
+                auto line_string = line.to_byte_string();
+                out("{}", line_string.substring_view(1, line.length() - 1));
+
                 continue;
             }
 

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -18,9 +18,9 @@ static ErrorOr<void> write_line_content(StringView line, size_t count, bool dupl
         return {};
 
     if (print_count)
-        TRY(outfile.write_until_depleted(ByteString::formatted("{} {}\n", count, line).bytes()));
+        TRY(outfile.write_until_depleted(ByteString::formatted("{} {}\n", count, line)));
     else
-        TRY(outfile.write_until_depleted(ByteString::formatted("{}\n", line).bytes()));
+        TRY(outfile.write_until_depleted(ByteString::formatted("{}\n", line)));
     return {};
 }
 

--- a/Userland/Utilities/utmpupdate.cpp
+++ b/Userland/Utilities/utmpupdate.cpp
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(file->seek(0, SeekMode::SetPosition));
     TRY(file->truncate(0));
-    TRY(file->write_until_depleted(json.to_byte_string().bytes()));
+    TRY(file->write_until_depleted(json.to_byte_string()));
 
     return 0;
 }

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -247,12 +247,12 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
     if (always_print_stack)
         config.dump_stack();
     if (always_print_instruction) {
-        g_stdout->write_until_depleted(ByteString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
+        g_stdout->write_until_depleted(ByteString::formatted("{:0>4} ", ip.value())).release_value_but_fixme_should_propagate_errors();
         g_printer->print(instr);
     }
     if (g_continue)
         return true;
-    g_stdout->write_until_depleted(ByteString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
+    g_stdout->write_until_depleted(ByteString::formatted("{:0>4} ", ip.value())).release_value_but_fixme_should_propagate_errors();
     g_printer->print(instr);
     ByteString last_command = "";
     for (;;) {
@@ -732,15 +732,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto print_func = [&](auto const& address) {
             Wasm::FunctionInstance* fn = machine.store().get(address);
-            g_stdout->write_until_depleted(ByteString::formatted("- Function with address {}, ptr = {}\n", address.value(), fn).bytes()).release_value_but_fixme_should_propagate_errors();
+            g_stdout->write_until_depleted(ByteString::formatted("- Function with address {}, ptr = {}\n", address.value(), fn)).release_value_but_fixme_should_propagate_errors();
             if (fn) {
-                g_stdout->write_until_depleted(ByteString::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>()).bytes()).release_value_but_fixme_should_propagate_errors();
+                g_stdout->write_until_depleted(ByteString::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>())).release_value_but_fixme_should_propagate_errors();
                 fn->visit(
                     [&](Wasm::WasmFunction const& func) {
                         Wasm::Printer printer { *g_stdout, 3 };
-                        g_stdout->write_until_depleted("    type:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                        g_stdout->write_until_depleted("    type:\n"sv).release_value_but_fixme_should_propagate_errors();
                         printer.print(func.type());
-                        g_stdout->write_until_depleted("    code:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                        g_stdout->write_until_depleted("    code:\n"sv).release_value_but_fixme_should_propagate_errors();
                         printer.print(func.code());
                     },
                     [](Wasm::HostFunction const&) {});


### PR DESCRIPTION
The end goal is to prevent UAF such as:
```c++
StringView view = "foo"_string.bytes_as_string_view();
```

We do this by deleting functions such as `String::bytes_as_string_view()` for rvalue `String` instances. The first half of this PR is to handle compilation failures that result from such deletions.

The PR then fixes a handful of UAFs caught by this compile error. Note this also would have caught the UAF fixed in #23826.

Then the last 2 commits perform the rvalue method deletions on `String` and `ByteString`.

There's a bit of a tradeoff here - some code is slightly more annoying to write with these deleted. The `Userland: Avoid some conversions from rvalue strings to StringView` commit holds the bulk of changes that are ergonomically a bit worse. But writing one extra line to hold onto a temporary string in order to prevent these UAFs seems worthwhile IMO.