### PR TITLE
LibWeb: Exclude [Global] interfaces from legacy platform object method

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-iterate-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-iterate-properties.txt
@@ -1,0 +1,1 @@
+  PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/Window-iterate-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-iterate-properties.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="global-variable"></div>
+<script>
+    test(() => {
+        for (const property in window) {
+        }
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -414,7 +414,7 @@ JS::ThrowCompletionOr<bool> PlatformObject::internal_prevent_extensions()
 // https://webidl.spec.whatwg.org/#legacy-platform-object-ownpropertykeys
 JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> PlatformObject::internal_own_property_keys() const
 {
-    if (!m_legacy_platform_object_flags.has_value())
+    if (!m_legacy_platform_object_flags.has_value() || m_legacy_platform_object_flags->has_global_interface_extended_attribute)
         return Base::internal_own_property_keys();
 
     auto& vm = this->vm();


### PR DESCRIPTION
Previously, [Global] interfaces were not excluded from the `internal_own_property_keys()` call. This caused a crash when iterating over the properties of the Window object.

Fixes #22973 