### PR TITLE
LibWeb: Handle dynamic changes to HTMLInputElement's `type` attribute

### DIFF
--- a/Tests/LibWeb/Layout/expected/input-file.txt
+++ b/Tests/LibWeb/Layout/expected/input-file.txt
@@ -5,6 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 1 from TextNode start: 0, length: 1, rect: [245,8 8x17] baseline: 13.296875
           " "
       frag 2 from BlockContainer start: 0, length: 0, rect: [253,8 255.34375x21] baseline: 13.296875
+      frag 3 from TextNode start: 0, length: 1, rect: [508,8 8x17] baseline: 13.296875
+          " "
+      frag 4 from BlockContainer start: 0, length: 0, rect: [516,8 255.34375x21] baseline: 13.296875
       BlockContainer <input> at (8,8) content-size 236.65625x21 inline-block [BFC] children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 94.375x17] baseline: 13.296875
         frag 1 from Label start: 0, length: 0, rect: [116,8 128.28125x17] baseline: 13.296875
@@ -33,6 +36,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "No files selected."
           TextNode <#text>
       TextNode <#text>
+      BlockContainer <input#multiple> at (516,8) content-size 255.34375x21 inline-block [BFC] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [521,10 103.71875x17] baseline: 13.296875
+        frag 1 from Label start: 0, length: 0, rect: [634,8 137.625x17] baseline: 13.296875
+        BlockContainer <button> at (521,10) content-size 103.71875x17 inline-block [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (521,10) content-size 103.71875x17 flex-container(column) [FFC] children: not-inline
+            BlockContainer <(anonymous)> at (521,10) content-size 103.71875x17 flex-item [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 15, rect: [521,10 103.71875x17] baseline: 13.296875
+                  "Select files..."
+              TextNode <#text>
+        Label <label> at (634,8) content-size 137.625x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 18, rect: [634,8 137.625x17] baseline: 13.296875
+              "No files selected."
+          TextNode <#text>
+      TextNode <#text>
+      TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -51,4 +69,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableWithLines (BlockContainer(anonymous)) [258,10 103.71875x17]
               TextPaintable (TextNode<#text>)
         PaintableWithLines (Label<LABEL>) [367,8 141.625x17]
+          TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<INPUT>#multiple) [516,8 255.34375x21] overflow: [516,8 255.625x21]
+        PaintableWithLines (BlockContainer<BUTTON>) [516,8 113.71875x21]
+          PaintableWithLines (BlockContainer(anonymous)) [521,10 103.71875x17]
+            PaintableWithLines (BlockContainer(anonymous)) [521,10 103.71875x17]
+              TextPaintable (TextNode<#text>)
+        PaintableWithLines (Label<LABEL>) [630,8 141.625x17]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/input-image-to-text.txt
+++ b/Tests/LibWeb/Layout/expected/input-image-to-text.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 189.875x19] baseline: 13.296875
+      BlockContainer <input> at (9,9) content-size 189.875x19 inline-block [BFC] children: not-inline
+        Box <div> at (11,10) content-size 185.875x17 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (11,10) content-size 185.875x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 7, rect: [11,10 55.6875x17] baseline: 13.296875
+                "120.png"
+            TextNode <#text>
+      TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<INPUT>) [8,8 191.875x21]
+        PaintableBox (Box<DIV>) [9,9 189.875x19]
+          PaintableWithLines (BlockContainer<DIV>) [11,10 185.875x17]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/input-password-to-text.txt
+++ b/Tests/LibWeb/Layout/expected/input-password-to-text.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 189.875x19] baseline: 13.296875
+      BlockContainer <input> at (9,9) content-size 189.875x19 inline-block [BFC] children: not-inline
+        Box <div> at (11,10) content-size 185.875x17 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (11,10) content-size 185.875x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 7, rect: [11,10 61.890625x17] baseline: 13.296875
+                "hunter2"
+            TextNode <#text>
+      TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<INPUT>) [8,8 191.875x21]
+        PaintableBox (Box<DIV>) [9,9 189.875x19]
+          PaintableWithLines (BlockContainer<DIV>) [11,10 185.875x17]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/input-placeholder.txt
+++ b/Tests/LibWeb/Layout/expected/input-placeholder.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x42 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x26 children: inline
+  BlockContainer <html> at (0,0) content-size 800x68 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x52 children: inline
       frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 200x24] baseline: 17
       frag 1 from TextNode start: 0, length: 1, rect: [210,8 10x22] baseline: 17
           " "
@@ -8,6 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 3 from TextNode start: 0, length: 1, rect: [422,8 10x22] baseline: 17
           " "
       frag 4 from BlockContainer start: 0, length: 0, rect: [433,9 200x24] baseline: 17
+      frag 5 from BlockContainer start: 0, length: 0, rect: [9,35 200x24] baseline: 17
       BlockContainer <input> at (9,9) content-size 200x24 inline-block [BFC] children: not-inline
         Box <div> at (11,10) content-size 196x22 flex-container(row) [FFC] children: not-inline
           BlockContainer <div> at (11,10) content-size 196x22 flex-item [BFC] children: inline
@@ -31,10 +32,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 "text"
             TextNode <#text>
       TextNode <#text>
+      BlockContainer <input#placeholder> at (9,35) content-size 200x24 inline-block [BFC] children: not-inline
+        Box <div> at (11,36) content-size 196x22 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (11,36) content-size 196x22 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 16, rect: [11,36 166.75x22] baseline: 17
+                "This placeholder"
+            frag 1 from TextNode start: 17, length: 14, rect: [11,58 147.90625x22] baseline: 17
+                "should also be"
+            frag 2 from TextNode start: 32, length: 8, rect: [11,80 73.046875x22] baseline: 17
+                "visisble"
+            TextNode <#text>
+      TextNode <#text>
+      TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x26]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x68]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x52]
       PaintableWithLines (BlockContainer<INPUT>) [8,8 202x26]
         PaintableBox (Box<DIV>) [9,9 200x24]
           PaintableWithLines (BlockContainer<DIV>) [11,10 196x22]
@@ -48,4 +61,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<INPUT>) [432,8 202x26]
         PaintableBox (Box<DIV>) [433,9 200x24]
           PaintableWithLines (BlockContainer<DIV>) [435,10 196x22]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<INPUT>#placeholder) [8,34 202x26] overflow: [9,35 200x67]
+        PaintableBox (Box<DIV>) [9,35 200x24] overflow: [9,35 200x67]
+          PaintableWithLines (BlockContainer<DIV>) [11,36 196x22] overflow: [11,36 196x66]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/input-text-to-image.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-to-image.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x120 children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120] baseline: 120
+      ImageBox <input> at (8,8) content-size 120x120 inline-block children: not-inline
+      TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
+      ImagePaintable (ImageBox<INPUT>) [8,8 120x120]

--- a/Tests/LibWeb/Layout/expected/input-text-to-password.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-to-password.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 189.875x19] baseline: 13.296875
+      BlockContainer <input> at (9,9) content-size 189.875x19 inline-block [BFC] children: not-inline
+        Box <div> at (11,10) content-size 185.875x17 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (11,10) content-size 185.875x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 7, rect: [11,10 55.5625x17] baseline: 13.296875
+                "*******"
+            TextNode <#text>
+      TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<INPUT>) [8,8 191.875x21]
+        PaintableBox (Box<DIV>) [9,9 189.875x19]
+          PaintableWithLines (BlockContainer<DIV>) [11,10 185.875x17]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/input-file.html
+++ b/Tests/LibWeb/Layout/input/input-file.html
@@ -1,2 +1,9 @@
 <input type="file" />
 <input type="file" multiple />
+<input id="multiple" type="file" />
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", () => {
+        let input = document.querySelector("#multiple");
+        input.multiple = true;
+    });
+</script>

--- a/Tests/LibWeb/Layout/input/input-image-to-text.html
+++ b/Tests/LibWeb/Layout/input/input-image-to-text.html
@@ -1,0 +1,7 @@
+<input type="image" src="120.png" value="120.png" width="120" height="120" />
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", () => {
+        let input = document.querySelector("input");
+        input.type = "text";
+    });
+</script>

--- a/Tests/LibWeb/Layout/input/input-password-to-text.html
+++ b/Tests/LibWeb/Layout/input/input-password-to-text.html
@@ -1,0 +1,7 @@
+<input type="password" value="hunter2" />
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", () => {
+        let input = document.querySelector("input");
+        input.type = "text";
+    });
+</script>

--- a/Tests/LibWeb/Layout/input/input-placeholder.html
+++ b/Tests/LibWeb/Layout/input/input-placeholder.html
@@ -8,3 +8,10 @@ input {
 </style></head><body><input type="text" value="text" />
 <input type="text" placeholder="This placeholder should be visible" />
 <input type="text" value="text" placeholder="This placeholder should not be visible" />
+<input id="placeholder" type="text" />
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", () => {
+        let input = document.querySelector("#placeholder");
+        input.placeholder = "This placeholder should also be visisble";
+    });
+</script>

--- a/Tests/LibWeb/Layout/input/input-text-to-image.html
+++ b/Tests/LibWeb/Layout/input/input-text-to-image.html
@@ -1,0 +1,7 @@
+<input type="text" src="120.png" width="120" height="120" />
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", () => {
+        let input = document.querySelector("input");
+        input.type = "image";
+    });
+</script>

--- a/Tests/LibWeb/Layout/input/input-text-to-password.html
+++ b/Tests/LibWeb/Layout/input/input-text-to-password.html
@@ -1,0 +1,7 @@
+<input type="text" value="hunter2" />
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", () => {
+        let input = document.querySelector("input");
+        input.type = "password";
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1098,6 +1098,8 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
             did_update_alt_text(verify_cast<Layout::ImageBox>(*layout_node()));
     } else if (name == HTML::AttributeNames::maxlength) {
         handle_maxlength_attribute();
+    } else if (name == HTML::AttributeNames::multiple) {
+        update_shadow_tree();
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1085,8 +1085,10 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
             update_shadow_tree();
         }
     } else if (name == HTML::AttributeNames::placeholder) {
-        if (m_placeholder_text_node)
+        if (m_placeholder_text_node) {
             m_placeholder_text_node->set_data(placeholder());
+            update_placeholder_visibility();
+        }
     } else if (name == HTML::AttributeNames::readonly) {
         handle_readonly_attribute(value);
     } else if (name == HTML::AttributeNames::src) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -612,6 +612,14 @@ void HTMLInputElement::update_placeholder_visibility()
     }
 }
 
+void HTMLInputElement::update_text_input_shadow_tree()
+{
+    if (m_text_node) {
+        m_text_node->set_data(m_value);
+        update_placeholder_visibility();
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/input.html#the-input-element:attr-input-readonly-3
 static bool is_allowed_to_be_readonly(HTML::HTMLInputElement::TypeAttributeState state)
 {
@@ -746,6 +754,7 @@ void HTMLInputElement::update_shadow_tree()
         update_slider_thumb_element();
         break;
     default:
+        update_text_input_shadow_tree();
         break;
     }
 }
@@ -1073,6 +1082,9 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
         }
     } else if (name == HTML::AttributeNames::type) {
         m_type = parse_type_attribute(value.value_or(String {}));
+
+        set_shadow_root(nullptr);
+        create_shadow_tree_if_needed();
     } else if (name == HTML::AttributeNames::value) {
         if (!m_dirty_value) {
             if (!value.has_value()) {
@@ -1081,7 +1093,6 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
                 m_value = value_sanitization_algorithm(*value);
             }
 
-            update_placeholder_visibility();
             update_shadow_tree();
         }
     } else if (name == HTML::AttributeNames::placeholder) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -265,6 +265,7 @@ private:
     JS::GCPtr<DOM::Element> m_placeholder_element;
     JS::GCPtr<DOM::Text> m_placeholder_text_node;
 
+    void update_text_input_shadow_tree();
     JS::GCPtr<DOM::Element> m_inner_text_element;
     JS::GCPtr<DOM::Text> m_text_node;
     bool m_checked { false };

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -248,7 +248,7 @@ private:
 
     void handle_maxlength_attribute();
     void handle_readonly_attribute(Optional<String> const& value);
-    WebIDL::ExceptionOr<void> handle_src_attribute(StringView value);
+    WebIDL::ExceptionOr<void> handle_src_attribute(String const& value);
 
     // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm
     String value_sanitization_algorithm(String const&) const;
@@ -308,6 +308,8 @@ private:
 
     TypeAttributeState m_type { TypeAttributeState::Text };
     String m_value;
+
+    String m_last_src_value;
 
     bool m_has_uncommitted_changes { false };
 };


### PR DESCRIPTION
This makes us respond to the `type` attribute changing, and handles some fallout from the shadow tree now being more dynamic.

As seen on Spotify - the password field as a visibility toggle that flips the type between "password" and "text":


https://github.com/SerenityOS/serenity/assets/5600524/2be970af-45b7-4d03-ba8a-b1fdc13c78e9

