### PR TITLE
LibWeb: More work on GC leaks

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -86,6 +86,9 @@ ErrorOr<void> initialize_main_thread_vm()
     //       This avoids doing an exhaustive garbage collection on process exit.
     s_main_thread_vm->ref();
 
+    auto& custom_data = verify_cast<WebEngineCustomData>(*s_main_thread_vm->custom_data());
+    custom_data.event_loop = s_main_thread_vm->heap().allocate_without_realm<HTML::EventLoop>();
+
     // These strings could potentially live on the VM similar to CommonPropertyNames.
     DOM::MutationType::initialize_strings();
     HTML::AttributeNames::initialize_strings();
@@ -102,8 +105,6 @@ ErrorOr<void> initialize_main_thread_vm()
     WebGL::EventNames::initialize_strings();
     XHR::EventNames::initialize_strings();
     XLink::AttributeNames::initialize_strings();
-
-    static_cast<WebEngineCustomData*>(s_main_thread_vm->custom_data())->event_loop.set_vm(*s_main_thread_vm);
 
     // 8.1.5.1 HostEnsureCanAddPrivateElement(O), https://html.spec.whatwg.org/multipage/webappapis.html#the-hostensurecanaddprivateelement-implementation
     s_main_thread_vm->host_ensure_can_add_private_element = [](JS::Object const& object) -> JS::ThrowCompletionOr<void> {

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -40,7 +40,7 @@ struct WebEngineCustomData final : public JS::VM::CustomData {
 
     virtual void spin_event_loop_until(JS::SafeFunction<bool()> goal_condition) override;
 
-    HTML::EventLoop event_loop;
+    JS::Handle<HTML::EventLoop> event_loop;
 
     // FIXME: These should only be on similar-origin window agents, but we don't currently differentiate agent types.
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -178,7 +178,7 @@ RefPtr<Supports> Parser::parse_a_supports(TokenStream<T>& tokens)
     auto maybe_condition = parse_supports_condition(token_stream);
     token_stream.skip_whitespace();
     if (maybe_condition && !token_stream.has_next_token())
-        return Supports::create(maybe_condition.release_nonnull());
+        return Supports::create(m_context.realm(), maybe_condition.release_nonnull());
 
     return {};
 }
@@ -303,7 +303,7 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<Component
         if (auto declaration = consume_a_declaration(block_tokens); declaration.has_value()) {
             transaction.commit();
             return Supports::Feature {
-                Supports::Declaration { declaration->to_string(), JS::make_handle(m_context.realm()) }
+                Supports::Declaration { declaration->to_string() }
             };
         }
     }
@@ -316,7 +316,7 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<Component
             builder.append(item.to_string());
         transaction.commit();
         return Supports::Feature {
-            Supports::Selector { builder.to_string().release_value_but_fixme_should_propagate_errors(), JS::make_handle(m_context.realm()) }
+            Supports::Selector { builder.to_string().release_value_but_fixme_should_propagate_errors() }
         };
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Supports.cpp
@@ -10,26 +10,26 @@
 
 namespace Web::CSS {
 
-Supports::Supports(NonnullOwnPtr<Condition>&& condition)
+Supports::Supports(JS::Realm& realm, NonnullOwnPtr<Condition>&& condition)
     : m_condition(move(condition))
 {
-    m_matches = m_condition->evaluate();
+    m_matches = m_condition->evaluate(realm);
 }
 
-bool Supports::Condition::evaluate() const
+bool Supports::Condition::evaluate(JS::Realm& realm) const
 {
     switch (type) {
     case Type::Not:
-        return !children.first().evaluate();
+        return !children.first().evaluate(realm);
     case Type::And:
         for (auto& child : children) {
-            if (!child.evaluate())
+            if (!child.evaluate(realm))
                 return false;
         }
         return true;
     case Type::Or:
         for (auto& child : children) {
-            if (child.evaluate())
+            if (child.evaluate(realm))
                 return true;
         }
         return false;
@@ -37,40 +37,40 @@ bool Supports::Condition::evaluate() const
     VERIFY_NOT_REACHED();
 }
 
-bool Supports::InParens::evaluate() const
+bool Supports::InParens::evaluate(JS::Realm& realm) const
 {
     return value.visit(
         [&](NonnullOwnPtr<Condition> const& condition) {
-            return condition->evaluate();
+            return condition->evaluate(realm);
         },
         [&](Feature const& feature) {
-            return feature.evaluate();
+            return feature.evaluate(realm);
         },
         [&](GeneralEnclosed const&) {
             return false;
         });
 }
 
-bool Supports::Declaration::evaluate() const
+bool Supports::Declaration::evaluate(JS::Realm& realm) const
 {
-    auto style_property = parse_css_supports_condition(Parser::ParsingContext { *realm }, declaration);
+    auto style_property = parse_css_supports_condition(Parser::ParsingContext { realm }, declaration);
     return style_property.has_value();
 }
 
-bool Supports::Selector::evaluate() const
+bool Supports::Selector::evaluate(JS::Realm& realm) const
 {
-    auto style_property = parse_selector(Parser::ParsingContext { *realm }, selector);
+    auto style_property = parse_selector(Parser::ParsingContext { realm }, selector);
     return style_property.has_value();
 }
 
-bool Supports::Feature::evaluate() const
+bool Supports::Feature::evaluate(JS::Realm& realm) const
 {
     return value.visit(
         [&](Declaration const& declaration) {
-            return declaration.evaluate();
+            return declaration.evaluate(realm);
         },
         [&](Selector const& selector) {
-            return selector.evaluate();
+            return selector.evaluate(realm);
         });
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Supports.h
+++ b/Userland/Libraries/LibWeb/CSS/Supports.h
@@ -23,21 +23,19 @@ class Supports final : public RefCounted<Supports> {
 public:
     struct Declaration {
         String declaration;
-        JS::Handle<JS::Realm> realm;
-        bool evaluate() const;
+        [[nodiscard]] bool evaluate(JS::Realm&) const;
         String to_string() const;
     };
 
     struct Selector {
         String selector;
-        JS::Handle<JS::Realm> realm;
-        bool evaluate() const;
+        [[nodiscard]] bool evaluate(JS::Realm&) const;
         String to_string() const;
     };
 
     struct Feature {
         Variant<Declaration, Selector> value;
-        bool evaluate() const;
+        [[nodiscard]] bool evaluate(JS::Realm&) const;
         String to_string() const;
     };
 
@@ -45,7 +43,7 @@ public:
     struct InParens {
         Variant<NonnullOwnPtr<Condition>, Feature, GeneralEnclosed> value;
 
-        bool evaluate() const;
+        [[nodiscard]] bool evaluate(JS::Realm&) const;
         String to_string() const;
     };
 
@@ -58,20 +56,20 @@ public:
         Type type;
         Vector<InParens> children;
 
-        bool evaluate() const;
+        [[nodiscard]] bool evaluate(JS::Realm&) const;
         String to_string() const;
     };
 
-    static NonnullRefPtr<Supports> create(NonnullOwnPtr<Condition>&& condition)
+    static NonnullRefPtr<Supports> create(JS::Realm& realm, NonnullOwnPtr<Condition>&& condition)
     {
-        return adopt_ref(*new Supports(move(condition)));
+        return adopt_ref(*new Supports(realm, move(condition)));
     }
 
     bool matches() const { return m_matches; }
     String to_string() const;
 
 private:
-    Supports(NonnullOwnPtr<Condition>&&);
+    Supports(JS::Realm&, NonnullOwnPtr<Condition>&&);
 
     NonnullOwnPtr<Condition> m_condition;
     bool m_matches { false };

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3166,7 +3166,7 @@ void Document::unload(JS::GCPtr<Document>)
     auto intend_to_store_in_bfcache = false;
 
     // 6. Let eventLoop be oldDocument's relevant agent's event loop.
-    auto& event_loop = verify_cast<Bindings::WebEngineCustomData>(*vm.custom_data()).event_loop;
+    auto& event_loop = *verify_cast<Bindings::WebEngineCustomData>(*vm.custom_data()).event_loop;
 
     // 7. Increase eventLoop's termination nesting level by 1.
     event_loop.increment_termination_nesting_level();

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -785,9 +785,9 @@ void Element::make_html_uppercased_qualified_name()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task
-int Element::queue_an_element_task(HTML::Task::Source source, JS::SafeFunction<void()> steps)
+int Element::queue_an_element_task(HTML::Task::Source source, Function<void()> steps)
 {
-    auto task = HTML::Task::create(source, &document(), move(steps));
+    auto task = HTML::Task::create(vm(), source, &document(), JS::create_heap_function(heap(), move(steps)));
     auto id = task->id();
 
     HTML::main_thread_event_loop().task_queue().add(move(task));

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -190,7 +190,8 @@ public:
     void set_custom_properties(Optional<CSS::Selector::PseudoElement::Type>, HashMap<FlyString, CSS::StyleProperty> custom_properties);
     [[nodiscard]] HashMap<FlyString, CSS::StyleProperty> const& custom_properties(Optional<CSS::Selector::PseudoElement::Type>) const;
 
-    int queue_an_element_task(HTML::Task::Source, JS::SafeFunction<void()>);
+    // NOTE: The function is wrapped in a JS::HeapFunction immediately.
+    int queue_an_element_task(HTML::Task::Source, Function<void()>);
 
     bool is_void_element() const;
     bool serializes_as_void() const;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/Task.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/Task.cpp
@@ -11,7 +11,7 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#queue-a-fetch-task
-int queue_fetch_task(JS::Object& task_destination, JS::SafeFunction<void()> algorithm)
+int queue_fetch_task(JS::Object& task_destination, Function<void()> algorithm)
 {
     // FIXME: 1. If taskDestination is a parallel queue, then enqueue algorithm to taskDestination.
 
@@ -21,7 +21,7 @@ int queue_fetch_task(JS::Object& task_destination, JS::SafeFunction<void()> algo
 
 // AD-HOC: This overload allows tracking the queued task within the fetch controller so that we may cancel queued tasks
 //         when the spec indicates that we must stop an ongoing fetch.
-int queue_fetch_task(JS::NonnullGCPtr<FetchController> fetch_controller, JS::Object& task_destination, JS::SafeFunction<void()> algorithm)
+int queue_fetch_task(JS::NonnullGCPtr<FetchController> fetch_controller, JS::Object& task_destination, Function<void()> algorithm)
 {
     auto fetch_task_id = fetch_controller->next_fetch_task_id();
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/Task.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/Task.h
@@ -17,7 +17,7 @@ namespace Web::Fetch::Infrastructure {
 // FIXME: 'or a parallel queue'
 using TaskDestination = Variant<Empty, JS::NonnullGCPtr<JS::Object>>;
 
-int queue_fetch_task(JS::Object&, JS::SafeFunction<void()>);
-int queue_fetch_task(JS::NonnullGCPtr<FetchController>, JS::Object&, JS::SafeFunction<void()>);
+int queue_fetch_task(JS::Object&, Function<void()>);
+int queue_fetch_task(JS::NonnullGCPtr<FetchController>, JS::Object&, Function<void()>);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -74,7 +74,7 @@ void HTMLMediaElement::finalize()
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task
-void HTMLMediaElement::queue_a_media_element_task(JS::SafeFunction<void()> steps)
+void HTMLMediaElement::queue_a_media_element_task(Function<void()> steps)
 {
     // To queue a media element task with a media element element and a series of steps steps, queue an element task on the media element's
     // media element event task source given element and steps.
@@ -469,16 +469,14 @@ double HTMLMediaElement::effective_media_volume() const
 // https://html.spec.whatwg.org/multipage/media.html#media-element-load-algorithm
 WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
 {
-    auto& vm = this->vm();
-
     m_first_data_load_event_since_load_start = true;
 
     // FIXME: 1. Abort any already-running instance of the resource selection algorithm for this element.
 
     // 2. Let pending tasks be a list of all tasks from the media element's media element event task source in one of the task queues.
-    [[maybe_unused]] auto pending_tasks = TRY_OR_THROW_OOM(vm, HTML::main_thread_event_loop().task_queue().take_tasks_matching([&](auto& task) {
+    [[maybe_unused]] auto pending_tasks = HTML::main_thread_event_loop().task_queue().take_tasks_matching([&](auto& task) {
         return task.source() == media_element_event_task_source();
-    }));
+    });
 
     // FIXME: 3. For each task in pending tasks that would resolve pending play promises or reject pending play promises, immediately resolve or
     //           reject those promises in the order the corresponding tasks were queued.

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -40,7 +40,8 @@ public:
 
     virtual bool is_focusable() const override { return true; }
 
-    void queue_a_media_element_task(JS::SafeFunction<void()> steps);
+    // NOTE: The function is wrapped in a JS::HeapFunction immediately.
+    void queue_a_media_element_task(Function<void()>);
 
     JS::GCPtr<MediaError> error() const { return m_error; }
     WebIDL::ExceptionOr<void> set_decoder_error(String error_message);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -42,6 +42,7 @@ void EnvironmentSettingsObject::initialize(JS::Realm& realm)
 void EnvironmentSettingsObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_responsible_event_loop);
     visitor.visit(target_browsing_context);
     visitor.visit(m_module_map);
     visitor.ignore(m_outstanding_rejected_promises_weak_set);
@@ -84,8 +85,8 @@ EventLoop& EnvironmentSettingsObject::responsible_event_loop()
 
     auto& vm = global_object().vm();
     auto& event_loop = verify_cast<Bindings::WebEngineCustomData>(vm.custom_data())->event_loop;
-    m_responsible_event_loop = &event_loop;
-    return event_loop;
+    m_responsible_event_loop = event_loop;
+    return *event_loop;
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#check-if-we-can-run-script

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -122,7 +122,7 @@ private:
     NonnullOwnPtr<JS::ExecutionContext> m_realm_execution_context;
     JS::GCPtr<ModuleMap> m_module_map;
 
-    EventLoop* m_responsible_event_loop { nullptr };
+    JS::GCPtr<EventLoop> m_responsible_event_loop;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#outstanding-rejected-promises-weak-set
     // The outstanding rejected promises weak set must not create strong references to any of its members, and implementations are free to limit its size, e.g. by removing old entries from it when new ones are added.

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -289,9 +289,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
     return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
 }
 
-void AudioContext::queue_a_media_element_task(JS::SafeFunction<void()> steps)
+void AudioContext::queue_a_media_element_task(Function<void()> steps)
 {
-    auto task = HTML::Task::create(m_media_element_event_task_source.source, HTML::current_settings_object().responsible_document(), move(steps));
+    auto task = HTML::Task::create(vm(), m_media_element_event_task_source.source, HTML::current_settings_object().responsible_document(), JS::create_heap_function(heap(), move(steps)));
     HTML::main_thread_event_loop().task_queue().add(move(task));
 }
 

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.h
@@ -54,7 +54,7 @@ private:
     bool m_suspended_by_user = false;
     HTML::UniqueTaskSource m_media_element_event_task_source {};
 
-    void queue_a_media_element_task(JS::SafeFunction<void()> steps);
+    void queue_a_media_element_task(Function<void()> steps);
     bool start_rendering_audio_graph();
 };
 


### PR DESCRIPTION
- Make HTML's EventLoop, TaskQueue and Task all be GC-allocated
- Fix a GC realm leak in CSS `@supports` rules