### PR TITLE
RequestServer: Avoid race condition between timeout and socket creation

### DIFF
--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -56,6 +56,9 @@ void request_did_finish(URL::URL const& url, Core::Socket const* socket)
                 connection->job_data = {};
                 connection->removal_timer->on_timeout = [ptr = connection.ptr(), &cache_entry, key = move(key), &cache]() mutable {
                     Core::deferred_invoke([&, key = move(key), ptr] {
+                        if (ptr->has_started)
+                            return;
+
                         dbgln_if(REQUESTSERVER_DEBUG, "Removing no-longer-used connection {} (socket {})", ptr, ptr->socket);
                         auto did_remove = cache_entry.remove_first_matching([&](auto& entry) { return entry == ptr; });
                         VERIFY(did_remove);


### PR DESCRIPTION
Part of this issue was fixed in 89877b3f406aaf0290cc98e122cab285c1175df6 but that only addressed the first layer of deferred_invoke, ignoring the second one (which would cause a race if a request was sent to a host immediately following a timeout event from the same host). Fixes #23840.