### PR TITLE
Ladybird/AppKit: Add Default Check and Handler

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -558,66 +558,66 @@
 
     m_initial_urls.clear();
 
-    [self checkAndRegisterHandlers: tab];
+    [self checkAndRegisterHandlers:tab];
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification*)notification
 {
     [[NSAppleEventManager sharedAppleEventManager]
-    setEventHandler:self
-    andSelector:@selector(urlHandler:withReplyEvent:)
-    forEventClass:kInternetEventClass
-    andEventID:kAEGetURL];   
+        setEventHandler:self
+            andSelector:@selector(urlHandler:withReplyEvent:)
+          forEventClass:kInternetEventClass
+             andEventID:kAEGetURL];   
 }
 
 - (void)checkAndRegisterHandlers:(Tab*)tab
 {
     // Honour the user's wishes by suppressing the alert.
-    if ([[NSUserDefaults standardUserDefaults] boolForKey: @"suppressDefaultBrowserAlert"]) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"suppressDefaultBrowserAlert"]) {
         return;
     }
 
-    NSURL *url = [NSURL URLWithString: @"http://example.com/"];
-    NSURL *defaultBrowserURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL: url];
-    NSURL *appBundleURL = [[NSBundle mainBundle] bundleURL];
+    NSURL* url = [NSURL URLWithString:@"http://example.com/"];
+    NSURL* defaultBrowserURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:url];
+    NSURL* appBundleURL = [[NSBundle mainBundle] bundleURL];
 
     // Check if Ladybird isn't the default browser.
     if (![[appBundleURL absoluteString] isEqualToString:[defaultBrowserURL absoluteString]]) {
         NSLog(@"Ladybird is not the default browser!");
-        NSAlert *alert = [[NSAlert alloc] init];
+        NSAlert* alert = [[NSAlert alloc] init];
         [alert addButtonWithTitle:@"Yes"];
         [alert addButtonWithTitle:@"No"];
         [alert setMessageText:@"Set Ladybird as your default browser?"];
         [alert setShowsSuppressionButton:YES];
         [alert setAlertStyle:NSAlertStyleInformational];
         [alert beginSheetModalForWindow:tab
-            completionHandler:^(NSModalResponse response) {
-                if (response == NSAlertFirstButtonReturn) {
-                    [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
-                        toOpenURLsWithScheme:@"http"
-                        completionHandler:(void (^)(NSError *error)){}]; 
-                        [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
-                        toOpenURLsWithScheme:@"https"
-                        completionHandler:(void (^)(NSError *error)){}]; 
-                }
-                [[NSUserDefaults standardUserDefaults] setBool: [[alert suppressionButton] state] forKey: @"suppressDefaultBrowserAlert"];
-                [[NSUserDefaults standardUserDefaults] synchronize];
-        }];
+                      completionHandler:^(NSModalResponse response) {
+                          if (response == NSAlertFirstButtonReturn) {
+                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+                                                                   toOpenURLsWithScheme:@"http"
+                                                                      completionHandler:(void (^)(NSError *error)){}]; 
+                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+                                                                   toOpenURLsWithScheme:@"https"
+                                                                      completionHandler:(void (^)(NSError *error)){}]; 
+                          }
+                          [[NSUserDefaults standardUserDefaults] setBool: [[alert suppressionButton] state] forKey: @"suppressDefaultBrowserAlert"];
+                          [[NSUserDefaults standardUserDefaults] synchronize];
+                      }];
     }
 }
 
 - (void)urlHandler:(NSAppleEventDescriptor*)event
-        withReplyEvent:(NSAppleEventDescriptor*)replyEvent
+    withReplyEvent:(NSAppleEventDescriptor*)replyEvent
 {
-    NSString *url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+    NSString* url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
     auto* current_tab = [NSApp keyWindow];
     if (![current_tab isKindOfClass:[Tab class]]) {
         return;
     }
 
     [self createNewTab:URL::URL([url UTF8String])
-        fromTab:(Tab*)current_tab
-        activateTab:Web::HTML::ActivateTab::Yes];
+               fromTab:(Tab*)current_tab
+           activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)applicationWillTerminate:(NSNotification*)notification

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -567,7 +567,7 @@
         setEventHandler:self
             andSelector:@selector(urlHandler:withReplyEvent:)
           forEventClass:kInternetEventClass
-             andEventID:kAEGetURL];   
+             andEventID:kAEGetURL];
 }
 
 - (void)checkAndRegisterHandlers:(Tab*)tab
@@ -593,14 +593,14 @@
         [alert beginSheetModalForWindow:tab
                       completionHandler:^(NSModalResponse response) {
                           if (response == NSAlertFirstButtonReturn) {
-                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL
                                                                    toOpenURLsWithScheme:@"http"
-                                                                      completionHandler:(void (^)(NSError *error)){}]; 
-                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+                                                                      completionHandler:(void (^)(NSError* error)) {}];
+                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL
                                                                    toOpenURLsWithScheme:@"https"
-                                                                      completionHandler:(void (^)(NSError *error)){}]; 
+                                                                      completionHandler:(void (^)(NSError* error)) {}];
                           }
-                          [[NSUserDefaults standardUserDefaults] setBool: [[alert suppressionButton] state] forKey: @"suppressDefaultBrowserAlert"];
+                          [[NSUserDefaults standardUserDefaults] setBool:[[alert suppressionButton] state] forKey:@"suppressDefaultBrowserAlert"];
                           [[NSUserDefaults standardUserDefaults] synchronize];
                       }];
     }

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -557,67 +557,10 @@
     }
 
     m_initial_urls.clear();
-
-    [self checkAndRegisterHandlers:tab];
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification*)notification
 {
-    [[NSAppleEventManager sharedAppleEventManager]
-        setEventHandler:self
-            andSelector:@selector(urlHandler:withReplyEvent:)
-          forEventClass:kInternetEventClass
-             andEventID:kAEGetURL];
-}
-
-- (void)checkAndRegisterHandlers:(Tab*)tab
-{
-    // Honour the user's wishes by suppressing the alert.
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"suppressDefaultBrowserAlert"]) {
-        return;
-    }
-
-    NSURL* url = [NSURL URLWithString:@"http://example.com/"];
-    NSURL* defaultBrowserURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:url];
-    NSURL* appBundleURL = [[NSBundle mainBundle] bundleURL];
-
-    // Check if Ladybird isn't the default browser.
-    if (![[appBundleURL absoluteString] isEqualToString:[defaultBrowserURL absoluteString]]) {
-        NSLog(@"Ladybird is not the default browser!");
-        NSAlert* alert = [[NSAlert alloc] init];
-        [alert addButtonWithTitle:@"Yes"];
-        [alert addButtonWithTitle:@"No"];
-        [alert setMessageText:@"Set Ladybird as your default browser?"];
-        [alert setShowsSuppressionButton:YES];
-        [alert setAlertStyle:NSAlertStyleInformational];
-        [alert beginSheetModalForWindow:tab
-                      completionHandler:^(NSModalResponse response) {
-                          if (response == NSAlertFirstButtonReturn) {
-                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL
-                                                                   toOpenURLsWithScheme:@"http"
-                                                                      completionHandler:(void (^)(NSError* error)) {}];
-                              [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL
-                                                                   toOpenURLsWithScheme:@"https"
-                                                                      completionHandler:(void (^)(NSError* error)) {}];
-                          }
-                          [[NSUserDefaults standardUserDefaults] setBool:[[alert suppressionButton] state] forKey:@"suppressDefaultBrowserAlert"];
-                          [[NSUserDefaults standardUserDefaults] synchronize];
-                      }];
-    }
-}
-
-- (void)urlHandler:(NSAppleEventDescriptor*)event
-    withReplyEvent:(NSAppleEventDescriptor*)replyEvent
-{
-    NSString* url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-    auto* current_tab = [NSApp keyWindow];
-    if (![current_tab isKindOfClass:[Tab class]]) {
-        return;
-    }
-
-    [self createNewTab:URL::URL([url UTF8String])
-               fromTab:(Tab*)current_tab
-           activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)applicationWillTerminate:(NSNotification*)notification
@@ -645,6 +588,19 @@
     }
 
     return YES;
+}
+
+- (void)application:(NSApplication*)application
+           openURLs:(NSArray<NSURL*>*)urls
+{
+    auto* current_tab = [NSApp keyWindow];
+    if (![current_tab isKindOfClass:[Tab class]]) {
+        return;
+    }
+
+    [self createNewTab:URL::URL([[urls[0] absoluteString] UTF8String])
+               fromTab:(Tab*)current_tab
+           activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 @end

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -557,6 +557,63 @@
     }
 
     m_initial_urls.clear();
+
+    [self checkAndRegisterHandlers];
+}
+
+- (void)applicationWillFinishLaunching:(NSNotification*)notification
+{
+    [[NSAppleEventManager sharedAppleEventManager]
+    setEventHandler:self
+    andSelector:@selector(urlHandler:withReplyEvent:)
+    forEventClass:kInternetEventClass
+    andEventID:kAEGetURL];   
+}
+
+- (void)checkAndRegisterHandlers 
+{
+    // Honour the user's wishes by suppressing the alert.
+    if ([[NSUserDefaults standardUserDefaults] boolForKey: @"suppressDefaultBrowserAlert"]) {
+        return;
+    }
+
+    NSURL *url = [NSURL URLWithString: @"http://example.com/"];
+    NSURL *defaultBrowserURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL: url];
+    NSURL *appBundleURL = [[NSBundle mainBundle] bundleURL];
+
+    // Check if Ladybird isn't the default browser.
+    if (![[appBundleURL absoluteString] isEqualToString:[defaultBrowserURL absoluteString]]) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert addButtonWithTitle:@"Yes"];
+        [alert addButtonWithTitle:@"No"];
+        [alert setMessageText:@"Set Ladybird as your default browser?"];
+        [alert setShowsSuppressionButton:YES];
+        [alert setAlertStyle:NSAlertStyleInformational];
+        if ([alert runModal] == NSAlertFirstButtonReturn) {
+            [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+            toOpenURLsWithScheme:@"http"
+            completionHandler:(void (^)(NSError *error)){}]; 
+            [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+            toOpenURLsWithScheme:@"https"
+            completionHandler:(void (^)(NSError *error)){}]; 
+        }
+        [[NSUserDefaults standardUserDefaults] setBool: [[alert suppressionButton] state] forKey: @"suppressDefaultBrowserAlert"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+}
+
+- (void)urlHandler:(NSAppleEventDescriptor*)event
+        withReplyEvent:(NSAppleEventDescriptor*)replyEvent
+{
+    NSString *url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+    auto* current_tab = [NSApp keyWindow];
+    if (![current_tab isKindOfClass:[Tab class]]) {
+        return;
+    }
+
+    [self createNewTab:URL::URL([url UTF8String])
+        fromTab:(Tab*)current_tab
+        activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)applicationWillTerminate:(NSNotification*)notification

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -558,7 +558,7 @@
 
     m_initial_urls.clear();
 
-    [self checkAndRegisterHandlers];
+    [self checkAndRegisterHandlers: tab];
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification*)notification
@@ -570,7 +570,7 @@
     andEventID:kAEGetURL];   
 }
 
-- (void)checkAndRegisterHandlers 
+- (void)checkAndRegisterHandlers:(Tab*)tab
 {
     // Honour the user's wishes by suppressing the alert.
     if ([[NSUserDefaults standardUserDefaults] boolForKey: @"suppressDefaultBrowserAlert"]) {
@@ -583,22 +583,26 @@
 
     // Check if Ladybird isn't the default browser.
     if (![[appBundleURL absoluteString] isEqualToString:[defaultBrowserURL absoluteString]]) {
+        NSLog(@"Ladybird is not the default browser!");
         NSAlert *alert = [[NSAlert alloc] init];
         [alert addButtonWithTitle:@"Yes"];
         [alert addButtonWithTitle:@"No"];
         [alert setMessageText:@"Set Ladybird as your default browser?"];
         [alert setShowsSuppressionButton:YES];
         [alert setAlertStyle:NSAlertStyleInformational];
-        if ([alert runModal] == NSAlertFirstButtonReturn) {
-            [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
-            toOpenURLsWithScheme:@"http"
-            completionHandler:(void (^)(NSError *error)){}]; 
-            [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
-            toOpenURLsWithScheme:@"https"
-            completionHandler:(void (^)(NSError *error)){}]; 
-        }
-        [[NSUserDefaults standardUserDefaults] setBool: [[alert suppressionButton] state] forKey: @"suppressDefaultBrowserAlert"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
+        [alert beginSheetModalForWindow:tab
+            completionHandler:^(NSModalResponse response) {
+                if (response == NSAlertFirstButtonReturn) {
+                    [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+                        toOpenURLsWithScheme:@"http"
+                        completionHandler:(void (^)(NSError *error)){}]; 
+                        [[NSWorkspace sharedWorkspace] setDefaultApplicationAtURL:appBundleURL 
+                        toOpenURLsWithScheme:@"https"
+                        completionHandler:(void (^)(NSError *error)){}]; 
+                }
+                [[NSUserDefaults standardUserDefaults] setBool: [[alert suppressionButton] state] forKey: @"suppressDefaultBrowserAlert"];
+                [[NSUserDefaults standardUserDefaults] synchronize];
+        }];
     }
 }
 


### PR DESCRIPTION
Asks the user whether they want to set Ladybird as the default browser, and registers event handlers to make a new tab once a user clicks on a URL in another application

<img width="1440" alt="Screenshot 2024-04-05 at 7 30 08 pm" src="https://github.com/SerenityOS/serenity/assets/6598515/aab074f9-b60a-41cc-9c49-230382924f00">
