### PR TITLE
LibJSGCVerifier: Warn about missing visit_edges impls with GC members

### DIFF
--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -87,7 +87,7 @@ std::vector<clang::QualType> get_all_qualified_types(clang::QualType const& type
     if (auto const* template_specialization = type->getAs<clang::TemplateSpecializationType>()) {
         auto specialization_name = template_specialization->getTemplateName().getAsTemplateDecl()->getQualifiedNameAsString();
         // Do not unwrap GCPtr/NonnullGCPtr
-        if (specialization_name == "JS::GCPtr" || specialization_name == "JS::NonnullGCPtr") {
+        if (specialization_name == "JS::GCPtr" || specialization_name == "JS::NonnullGCPtr" || specialization_name == "JS::RawGCPtr") {
             qualified_types.push_back(type);
         } else {
             auto const template_arguments = template_specialization->template_arguments();
@@ -141,7 +141,7 @@ FieldValidationResult validate_field(clang::FieldDecl const* field_decl)
             }
         } else if (auto const* specialization = qualified_type->getAs<clang::TemplateSpecializationType>()) {
             auto template_type_name = specialization->getTemplateName().getAsTemplateDecl()->getName();
-            if (template_type_name != "GCPtr" && template_type_name != "NonnullGCPtr")
+            if (template_type_name != "GCPtr" && template_type_name != "NonnullGCPtr" && template_type_name != "RawGCPtr")
                 return result;
 
             auto const template_args = specialization->template_arguments();
@@ -159,7 +159,7 @@ FieldValidationResult validate_field(clang::FieldDecl const* field_decl)
 
             result.is_wrapped_in_gcptr = true;
             result.is_valid = record_inherits_from_cell(*record_decl);
-            result.needs_visiting = true;
+            result.needs_visiting = template_type_name != "RawGCPtr";
         }
     }
 

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -210,6 +210,12 @@ void CollectCellsHandler::run(clang::ast_matchers::MatchFinder::MatchResult cons
 
     clang::DeclarationName const name = &result.Context->Idents.get("visit_edges");
     auto const* visit_edges_method = record->lookup(name).find_first<clang::CXXMethodDecl>();
+    if (!visit_edges_method && !fields_that_need_visiting.empty()) {
+        auto diag_id = diag_engine.getCustomDiagID(clang::DiagnosticsEngine::Warning, "JS::Cell-inheriting class %0 contains a GC-allocated member %1 but has no visit_edges method");
+        auto builder = diag_engine.Report(record->getLocation(), diag_id);
+        builder << record->getName()
+                << fields_that_need_visiting[0];
+    }
     if (!visit_edges_method || !visit_edges_method->getBody())
         return;
 

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -86,8 +86,8 @@ std::vector<clang::QualType> get_all_qualified_types(clang::QualType const& type
 
     if (auto const* template_specialization = type->getAs<clang::TemplateSpecializationType>()) {
         auto specialization_name = template_specialization->getTemplateName().getAsTemplateDecl()->getQualifiedNameAsString();
-        // Do not unwrap GCPtr/NonnullGCPtr
-        if (specialization_name == "JS::GCPtr" || specialization_name == "JS::NonnullGCPtr" || specialization_name == "JS::RawGCPtr") {
+        // Do not unwrap GCPtr/NonnullGCPtr/MarkedVector
+        if (specialization_name == "JS::GCPtr" || specialization_name == "JS::NonnullGCPtr" || specialization_name == "JS::RawGCPtr" || specialization_name == "JS::MarkedVector") {
             qualified_types.push_back(type);
         } else {
             auto const template_arguments = template_specialization->template_arguments();

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -186,6 +186,10 @@ private:
     T* m_ptr { nullptr };
 };
 
+// Non-Owning GCPtr
+template<typename T>
+using RawGCPtr = GCPtr<T>;
+
 template<typename T, typename U>
 inline bool operator==(GCPtr<T> const& a, GCPtr<U> const& b)
 {

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -100,7 +100,7 @@ private:
     struct FreelistEntry final : public Cell {
         JS_CELL(FreelistEntry, Cell);
 
-        GCPtr<FreelistEntry> next;
+        RawGCPtr<FreelistEntry> next;
     };
 
     Cell* cell(size_t index)

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -228,4 +228,10 @@ ThrowCompletionOr<MarkedVector<Value>> ModuleNamespaceObject::internal_own_prope
     return exports;
 }
 
+void ModuleNamespaceObject::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_module);
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -35,7 +35,8 @@ public:
 private:
     ModuleNamespaceObject(Realm&, Module* module, Vector<DeprecatedFlyString> exports);
 
-    // FIXME: UHHH how do we want to store this to avoid cycles but be safe??
+    virtual void visit_edges(Visitor&) override;
+
     GCPtr<Module> m_module;                // [[Module]]
     Vector<DeprecatedFlyString> m_exports; // [[Exports]]
 };

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -304,6 +304,12 @@ ByteString RegExpObject::escape_regexp_pattern() const
     return builder.to_byte_string();
 }
 
+void RegExpObject::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_realm);
+}
+
 // 22.2.3.1 RegExpCreate ( P, F ), https://tc39.es/ecma262/#sec-regexpcreate
 ThrowCompletionOr<NonnullGCPtr<RegExpObject>> regexp_create(VM& vm, Value pattern, Value flags)
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -60,6 +60,8 @@ private:
     RegExpObject(Object& prototype);
     RegExpObject(Regex<ECMA262> regex, ByteString pattern, ByteString flags, Object& prototype);
 
+    virtual void visit_edges(Visitor&) override;
+
     ByteString m_pattern;
     ByteString m_flags;
     bool m_legacy_features_enabled { false }; // [[LegacyFeaturesEnabled]]

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -32,7 +32,7 @@ public:
 private:
     explicit WeakSet(Object& prototype);
 
-    HashTable<GCPtr<Cell>> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
+    HashTable<RawGCPtr<Cell>> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -608,4 +608,10 @@ void AnimationEffect::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(AnimationEffect);
 }
 
+void AnimationEffect::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_associated_animation);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -152,6 +152,8 @@ protected:
     AnimationEffect(JS::Realm&);
     virtual ~AnimationEffect() = default;
 
+    virtual void visit_edges(Visitor&) override;
+
     virtual void initialize(JS::Realm&) override;
 
     // https://www.w3.org/TR/web-animations-1/#start-delay

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.cpp
@@ -17,7 +17,6 @@ JS_DEFINE_ALLOCATOR(AudioTrackList);
 
 AudioTrackList::AudioTrackList(JS::Realm& realm)
     : DOM::EventTarget(realm, MayInterfereWithIndexedPropertyAccess::Yes)
-    , m_audio_tracks(realm.heap())
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.cpp
@@ -119,4 +119,11 @@ WebIDL::CallbackType* AudioTrackList::onremovetrack()
     return event_handler_attribute(HTML::EventNames::removetrack);
 }
 
+void AudioTrackList::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto const& track : m_audio_tracks)
+        visitor.visit(track);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
@@ -49,6 +49,8 @@ public:
 private:
     explicit AudioTrackList(JS::Realm&);
 
+    virtual void visit_edges(Visitor&) override;
+
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
@@ -52,7 +52,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 
-    JS::MarkedVector<JS::NonnullGCPtr<AudioTrack>> m_audio_tracks;
+    Vector<JS::NonnullGCPtr<AudioTrack>> m_audio_tracks;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.cpp
@@ -127,4 +127,11 @@ WebIDL::CallbackType* VideoTrackList::onremovetrack()
     return event_handler_attribute(HTML::EventNames::removetrack);
 }
 
+void VideoTrackList::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto const& track : m_video_tracks)
+        visitor.visit(track);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.cpp
@@ -17,7 +17,6 @@ JS_DEFINE_ALLOCATOR(VideoTrackList);
 
 VideoTrackList::VideoTrackList(JS::Realm& realm)
     : DOM::EventTarget(realm, MayInterfereWithIndexedPropertyAccess::Yes)
-    , m_video_tracks(realm.heap())
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
@@ -47,7 +47,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 
-    JS::MarkedVector<JS::NonnullGCPtr<VideoTrack>> m_video_tracks;
+    Vector<JS::NonnullGCPtr<VideoTrack>> m_video_tracks;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
@@ -42,6 +42,8 @@ public:
 private:
     explicit VideoTrackList(JS::Realm&);
 
+    virtual void visit_edges(Visitor&) override;
+
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -45,4 +45,10 @@ void MathMLElement::blur()
     dbgln("(STUBBED) MathMLElement::blur()");
 }
 
+void MathMLElement::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_dataset);
+}
+
 }

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.h
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.h
@@ -34,6 +34,8 @@ protected:
 private:
     MathMLElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual void visit_edges(Visitor&) override;
+
     virtual void initialize(JS::Realm&) override;
 
     JS::GCPtr<HTML::DOMStringMap> m_dataset;


### PR DESCRIPTION
Previously we would only warn about missing calls to visit inside visit_edges implementations, now we warn as well when there's no visit_edges implementation at all. (Resolves #23848)
Also fixes a couple of the new warnings that show up as a result.