### PR TITLE
Libweb: Add a couple of missing `visit_edges()` calls

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -608,4 +608,10 @@ void AnimationEffect::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(AnimationEffect);
 }
 
+void AnimationEffect::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_associated_animation);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -153,6 +153,7 @@ protected:
     virtual ~AnimationEffect() = default;
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
 
     // https://www.w3.org/TR/web-animations-1/#start-delay
     double m_start_delay { 0.0 };

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -27,6 +27,12 @@ void MathMLElement::initialize(JS::Realm& realm)
     m_dataset = HTML::DOMStringMap::create(*this);
 }
 
+void MathMLElement::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_dataset);
+}
+
 Optional<ARIA::Role> MathMLElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-math

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.h
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.h
@@ -35,6 +35,7 @@ private:
     MathMLElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
 
     JS::GCPtr<HTML::DOMStringMap> m_dataset;
 };


### PR DESCRIPTION
This change adds missing `visit_edges()` calls to `AnimationEffect` and `MathMLElement`.