### PR TITLE
Everywhere: Fix all (but 1) LibJSGCVerifier warning

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2814,7 +2814,7 @@ private:
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
 
-    JS::Realm& m_realm; // [[Realm]]
+    JS::NonnullGCPtr<JS::Realm> m_realm; // [[Realm]]
 };
 )~~~");
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2814,6 +2814,8 @@ private:
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
 
+    virtual void visit_edges(Visitor&) override;
+
     JS::NonnullGCPtr<JS::Realm> m_realm; // [[Realm]]
 };
 )~~~");
@@ -2952,6 +2954,12 @@ JS::ThrowCompletionOr<bool> @named_properties_class@::internal_prevent_extension
     // 1. Return false.
     // Note: this keeps named properties object extensible by making [[PreventExtensions]] fail.
     return false;
+}
+
+void @named_properties_class@::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_realm);
 }
 )~~~");
 }

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/main.py
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/main.py
@@ -63,6 +63,8 @@ def thread_execute(file_path):
         './build/LibJSGCVerifier',
         '--extra-arg',
         '-DUSING_AK_GLOBALLY=1',  # To avoid errors about USING_AK_GLOBALLY not being defined at all
+        '--extra-arg',
+        '-DNULL=0',  # To avoid errors about NULL not being defined at all
         '-p',
         compile_commands_path,
         file_path

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -474,11 +474,11 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executa
 {
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {:p}", &executable);
 
-    TemporaryChange restore_executable { m_current_executable, &executable };
+    TemporaryChange restore_executable { m_current_executable, GCPtr { executable } };
     TemporaryChange restore_saved_jump { m_scheduled_jump, static_cast<BasicBlock const*>(nullptr) };
-    TemporaryChange restore_realm { m_realm, vm().current_realm() };
-    TemporaryChange restore_global_object { m_global_object, &m_realm->global_object() };
-    TemporaryChange restore_global_declarative_environment { m_global_declarative_environment, &m_realm->global_environment().declarative_record() };
+    TemporaryChange restore_realm { m_realm, GCPtr { vm().current_realm() } };
+    TemporaryChange restore_global_object { m_global_object, GCPtr { m_realm->global_object() } };
+    TemporaryChange restore_global_declarative_environment { m_global_declarative_environment, GCPtr { m_realm->global_environment().declarative_record() } };
 
     VERIFY(!vm().execution_context_stack().is_empty());
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -125,11 +125,11 @@ private:
     Vector<Variant<NonnullOwnPtr<CallFrame>, CallFrame*>> m_call_frames;
     Span<Value> m_current_call_frame;
     BasicBlock const* m_scheduled_jump { nullptr };
-    Executable* m_current_executable { nullptr };
+    GCPtr<Executable> m_current_executable { nullptr };
     BasicBlock const* m_current_block { nullptr };
-    Realm* m_realm { nullptr };
-    Object* m_global_object { nullptr };
-    DeclarativeEnvironment* m_global_declarative_environment { nullptr };
+    GCPtr<Realm> m_realm { nullptr };
+    GCPtr<Object> m_global_object { nullptr };
+    GCPtr<DeclarativeEnvironment> m_global_declarative_environment { nullptr };
     Optional<InstructionStreamIterator&> m_pc {};
 };
 

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -186,8 +186,8 @@ public:
         while (!m_work_queue.is_empty()) {
             auto ptr = reinterpret_cast<FlatPtr>(&m_work_queue.last());
             m_node_being_visited = &m_graph.ensure(ptr);
-            m_node_being_visited->class_name = m_work_queue.last().class_name();
-            m_work_queue.take_last().visit_edges(*this);
+            m_node_being_visited->class_name = m_work_queue.last()->class_name();
+            m_work_queue.take_last()->visit_edges(*this);
             m_node_being_visited = nullptr;
         }
     }
@@ -244,7 +244,7 @@ private:
     };
 
     GraphNode* m_node_being_visited { nullptr };
-    Vector<Cell&> m_work_queue;
+    Vector<NonnullGCPtr<Cell>> m_work_queue;
     HashMap<FlatPtr, GraphNode> m_graph;
 
     Heap& m_heap;
@@ -438,13 +438,13 @@ public:
     void mark_all_live_cells()
     {
         while (!m_work_queue.is_empty()) {
-            m_work_queue.take_last().visit_edges(*this);
+            m_work_queue.take_last()->visit_edges(*this);
         }
     }
 
 private:
     Heap& m_heap;
-    Vector<Cell&> m_work_queue;
+    Vector<NonnullGCPtr<Cell>> m_work_queue;
     HashTable<HeapBlock*> m_all_live_heap_blocks;
     FlatPtr m_min_block_address;
     FlatPtr m_max_block_address;

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -183,7 +183,7 @@ struct ExecutionContextRootsCollector : public Cell::Visitor {
         VERIFY_NOT_REACHED();
     }
 
-    HashTable<Cell*> roots;
+    HashTable<GCPtr<Cell>> roots;
 };
 
 void VM::gather_roots(HashMap<Cell*, HeapRoot>& roots)
@@ -207,7 +207,7 @@ void VM::gather_roots(HashMap<Cell*, HeapRoot>& roots)
         for (auto const& execution_context : stack) {
             ExecutionContextRootsCollector visitor;
             execution_context->visit_edges(visitor);
-            for (auto* cell : visitor.roots)
+            for (auto cell : visitor.roots)
                 roots.set(cell, HeapRoot { .type = HeapRoot::Type::VM });
         }
     };

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -779,7 +779,7 @@ Optional<CSS::Selector::PseudoElement::Type> KeyframeEffect::pseudo_element_type
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-keyframeeffect-getkeyframes
-WebIDL::ExceptionOr<Vector<JS::Object*>> KeyframeEffect::get_keyframes()
+WebIDL::ExceptionOr<JS::MarkedVector<JS::Object*>> KeyframeEffect::get_keyframes()
 {
     if (m_keyframe_objects.size() != m_keyframes.size()) {
         auto& vm = this->vm();
@@ -814,7 +814,10 @@ WebIDL::ExceptionOr<Vector<JS::Object*>> KeyframeEffect::get_keyframes()
         }
     }
 
-    return m_keyframe_objects;
+    JS::MarkedVector<JS::Object*> keyframes { heap() };
+    for (auto const& keyframe : m_keyframe_objects)
+        keyframes.append(keyframe);
+    return keyframes;
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-keyframeeffect-setkeyframes

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -97,7 +97,7 @@ public:
     Bindings::CompositeOperation composite() const { return m_composite; }
     void set_composite(Bindings::CompositeOperation value) { m_composite = value; }
 
-    WebIDL::ExceptionOr<Vector<JS::Object*>> get_keyframes();
+    WebIDL::ExceptionOr<JS::MarkedVector<JS::Object*>> get_keyframes();
     WebIDL::ExceptionOr<void> set_keyframes(Optional<JS::Handle<JS::Object>> const&);
 
     KeyFrameSet const* key_frame_set() { return m_key_frame_set; }
@@ -130,7 +130,7 @@ private:
     Vector<BaseKeyframe> m_keyframes {};
 
     // A cached version of m_keyframes suitable for returning from get_keyframes()
-    Vector<JS::Object*> m_keyframe_objects {};
+    Vector<JS::NonnullGCPtr<JS::Object>> m_keyframe_objects {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
 

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -714,7 +714,7 @@ bool fast_matches(CSS::Selector const& selector, Optional<CSS::CSSStyleSheet con
     // NOTE: If we fail after following a child combinator, we may need to backtrack
     //       to the last matched descendant. We store the state here.
     struct {
-        DOM::Element const* element = nullptr;
+        JS::GCPtr<DOM::Element const> element;
         ssize_t compound_selector_index = 0;
     } backtrack_state;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -11,6 +11,7 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/PropertyID.h>
@@ -44,7 +45,7 @@ public:
 
     struct StyleAndSourceDeclaration {
         RefPtr<StyleValue const> style;
-        CSS::CSSStyleDeclaration const* declaration = nullptr;
+        JS::GCPtr<CSS::CSSStyleDeclaration const> declaration;
         Important important { Important::No };
         Inherited inherited { Inherited::No };
     };

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -384,7 +384,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcKeyGenParams::from_value
 // https://w3c.github.io/webcrypto/#rsa-oaep-operations
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> RSAOAEP::encrypt(AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, ByteBuffer const& plaintext)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto& vm = realm.vm();
     auto const& normalized_algorithm = static_cast<RsaOaepParams const&>(params);
 
@@ -412,7 +412,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> RSAOAEP::encrypt(Algorith
 // https://w3c.github.io/webcrypto/#rsa-oaep-operations
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> RSAOAEP::decrypt(AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, AK::ByteBuffer const& ciphertext)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto& vm = realm.vm();
     auto const& normalized_algorithm = static_cast<RsaOaepParams const&>(params);
 
@@ -508,7 +508,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
 // https://w3c.github.io/webcrypto/#rsa-oaep-operations
 WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto::AlgorithmParams const& params, Bindings::KeyFormat key_format, CryptoKey::InternalKeyData key_data, bool extractable, Vector<Bindings::KeyUsage> const& usages)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
 
     // 1. Let keyData be the key data to be imported.
 
@@ -678,7 +678,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
             // 2. If normalizedHash is not equal to the hash member of normalizedAlgorithm, throw a DataError.
             if (normalized_hash.parameter->name != TRY(normalized_algorithm.hash.visit([](String const& name) -> JS::ThrowCompletionOr<String> { return name; }, [&](JS::Handle<JS::Object> const& obj) -> JS::ThrowCompletionOr<String> {
                         auto name_property = TRY(obj->get("name"));
-                        return name_property.to_string(m_realm.vm()); })))
+                        return name_property.to_string(m_realm->vm()); })))
                 return WebIDL::DataError::create(m_realm, "Invalid hash"_fly_string);
         }
 
@@ -771,7 +771,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
 // https://w3c.github.io/webcrypto/#rsa-oaep-operations
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> RSAOAEP::export_key(Bindings::KeyFormat format, JS::NonnullGCPtr<CryptoKey> key)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto& vm = realm.vm();
 
     // 1. Let key be the key to be exported.
@@ -1104,7 +1104,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
 // https://w3c.github.io/webcrypto/#ecdsa-operations
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ECDSA::sign(AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, ByteBuffer const& message)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto& vm = realm.vm();
     auto const& normalized_algorithm = static_cast<EcdsaParams const&>(params);
 
@@ -1142,7 +1142,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ECDSA::sign(AlgorithmPara
 // https://w3c.github.io/webcrypto/#ecdsa-operations
 WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, ByteBuffer const& signature, ByteBuffer const& message)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto const& normalized_algorithm = static_cast<EcdsaParams const&>(params);
 
     // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
@@ -1154,7 +1154,7 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::
         [](String const& name) -> JS::ThrowCompletionOr<String> { return name; },
         [&](JS::Handle<JS::Object> const& obj) -> JS::ThrowCompletionOr<String> {
                         auto name_property = TRY(obj->get("name"));
-                        return name_property.to_string(m_realm.vm()); }));
+                        return name_property.to_string(m_realm->vm()); }));
 
     // 3. Let M be the result of performing the digest operation specified by hashAlgorithm using message.
     ::Crypto::Hash::HashKind hash_kind;
@@ -1314,7 +1314,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ED25519::sign([[maybe_unused]] AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, ByteBuffer const& message)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto& vm = realm.vm();
 
     // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
@@ -1348,7 +1348,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ED25519::sign([[maybe_unu
 
 WebIDL::ExceptionOr<JS::Value> ED25519::verify([[maybe_unused]] AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, ByteBuffer const& signature, ByteBuffer const& message)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
 
     // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Public)
@@ -1378,7 +1378,7 @@ WebIDL::ExceptionOr<JS::Value> ED25519::verify([[maybe_unused]] AlgorithmParams 
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> PBKDF2::derive_bits(AlgorithmParams const& params, JS::NonnullGCPtr<CryptoKey> key, Optional<u32> length_optional)
 {
-    auto& realm = m_realm;
+    auto& realm = *m_realm;
     auto const& normalized_algorithm = static_cast<PBKDF2Params const&>(params);
 
     // 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
@@ -1396,7 +1396,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> PBKDF2::derive_bits(Algor
         [](String const& name) -> JS::ThrowCompletionOr<String> { return name; },
         [&](JS::Handle<JS::Object> const& obj) -> JS::ThrowCompletionOr<String> {
                         auto name_property = TRY(obj->get("name"));
-                        return name_property.to_string(m_realm.vm()); }));
+                        return name_property.to_string(m_realm->vm()); }));
 
     // 4. Let result be the result of performing the PBKDF2 operation defined in Section 5.2 of [RFC8018]
     // using prf as the pseudo-random function, PRF,

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -210,7 +210,7 @@ protected:
     {
     }
 
-    JS::Realm& m_realm;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
 };
 
 class RSAOAEP : public AlgorithmMethods {

--- a/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
@@ -57,6 +57,12 @@ JS_DEFINE_NATIVE_FUNCTION(KeyAlgorithm::name_getter)
     return JS::PrimitiveString::create(vm, name);
 }
 
+void KeyAlgorithm::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_realm);
+}
+
 JS::NonnullGCPtr<RsaKeyAlgorithm> RsaKeyAlgorithm::create(JS::Realm& realm)
 {
     return realm.heap().allocate<RsaKeyAlgorithm>(realm, realm);
@@ -141,11 +147,6 @@ JS_DEFINE_NATIVE_FUNCTION(EcKeyAlgorithm::named_curve_getter)
 {
     auto* impl = TRY(impl_from<EcKeyAlgorithm>(vm, "EcKeyAlgorithm"sv));
     return JS::PrimitiveString::create(vm, impl->named_curve());
-}
-
-void EcKeyAlgorithm::visit_edges(Visitor& visitor)
-{
-    Base::visit_edges(visitor);
 }
 
 JS::NonnullGCPtr<RsaHashedKeyAlgorithm> RsaHashedKeyAlgorithm::create(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.h
@@ -17,7 +17,7 @@ namespace Web::Crypto {
 
 // https://w3c.github.io/webcrypto/#key-algorithm-dictionary
 class KeyAlgorithm : public JS::Object {
-    JS_OBJECT(KeyAlgorithm, Object);
+    JS_OBJECT(KeyAlgorithm, JS::Object);
     JS_DECLARE_ALLOCATOR(KeyAlgorithm);
 
 public:
@@ -33,6 +33,7 @@ protected:
     KeyAlgorithm(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(name_getter);
@@ -113,7 +114,6 @@ protected:
     EcKeyAlgorithm(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void visit_edges(Visitor&) override;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(named_curve_getter);

--- a/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Crypto/KeyAlgorithms.h
@@ -38,7 +38,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(name_getter);
 
     String m_name;
-    JS::Realm& m_realm;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
 };
 
 // https://w3c.github.io/webcrypto/#RsaKeyAlgorithm-dictionary

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -35,8 +35,7 @@ void Text::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     SlottableMixin::visit_edges(visitor);
-
-    visitor.visit(dynamic_cast<JS::Cell*>(m_owner.ptr()));
+    visitor.visit(m_owner);
 }
 
 // https://dom.spec.whatwg.org/#dom-text-text
@@ -45,6 +44,15 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& real
     // The new Text(data) constructor steps are to set this’s data to data and this’s node document to current global object’s associated Document.
     auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
     return realm.heap().allocate<Text>(realm, window.associated_document(), data);
+}
+
+EditableTextNodeOwner* Text::editable_text_node_owner()
+{
+    if (!m_owner)
+        return nullptr;
+    EditableTextNodeOwner* owner = dynamic_cast<EditableTextNodeOwner*>(m_owner.ptr());
+    VERIFY(owner);
+    return owner;
 }
 
 // https://dom.spec.whatwg.org/#dom-text-splittext

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -39,8 +39,8 @@ public:
     void set_max_length(Optional<size_t> max_length) { m_max_length = move(max_length); }
 
     template<DerivedFrom<EditableTextNodeOwner> T>
-    void set_editable_text_node_owner(Badge<T>, EditableTextNodeOwner& owner_element) { m_owner = &owner_element; }
-    EditableTextNodeOwner* editable_text_node_owner() { return m_owner.ptr(); }
+    void set_editable_text_node_owner(Badge<T>, Element& owner_element) { m_owner = &owner_element; }
+    EditableTextNodeOwner* editable_text_node_owner();
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> split_text(size_t offset);
 
@@ -55,7 +55,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    JS::GCPtr<EditableTextNodeOwner> m_owner;
+    JS::GCPtr<Element> m_owner;
 
     bool m_always_editable { false };
     Optional<size_t> m_max_length {};

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -328,7 +328,7 @@ void BrowsingContext::did_edit(Badge<EditEventHandler>)
 
     if (m_cursor_position && is<DOM::Text>(*m_cursor_position->node())) {
         auto& text_node = static_cast<DOM::Text&>(*m_cursor_position->node());
-        if (auto* text_node_owner = text_node.editable_text_node_owner())
+        if (auto text_node_owner = text_node.editable_text_node_owner())
             text_node_owner->did_edit_text_node({});
     }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -888,7 +888,7 @@ void HTMLFormElement::plan_to_navigate_to(URL::URL url, Variant<Empty, String, P
     // NOTE: `this`, `actual_resource` and `target_navigable` are protected by JS::SafeFunction.
     queue_an_element_task(Task::Source::DOMManipulation, [this, url, post_resource, target_navigable, history_handling, referrer_policy, user_involvement]() {
         // 1. Set the form's planned navigation to null.
-        m_planned_navigation = nullptr;
+        m_planned_navigation = {};
 
         // 2. Navigate targetNavigable to url using the form element's node document, with historyHandling set to historyHandling,
         //    referrerPolicy set to referrerPolicy, documentResource set to postResource, and cspNavigationType set to "form-submission".

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -61,6 +61,7 @@ void HTMLFormElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_elements);
     for (auto& element : m_associated_elements)
         visitor.visit(element);
+    visitor.visit(m_planned_navigation);
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -142,7 +142,7 @@ private:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#planned-navigation
     // Each form element has a planned navigation, which is either null or a task; when the form is first created,
     // its planned navigation must be set to null.
-    Task const* m_planned_navigation { nullptr };
+    JS::GCPtr<Task const> m_planned_navigation;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
@@ -13,16 +13,16 @@ TemporaryExecutionContext::TemporaryExecutionContext(EnvironmentSettingsObject& 
     : m_environment_settings(environment_settings)
     , m_callbacks_enabled(callbacks_enabled)
 {
-    m_environment_settings.prepare_to_run_script();
+    m_environment_settings->prepare_to_run_script();
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
-        m_environment_settings.prepare_to_run_callback();
+        m_environment_settings->prepare_to_run_callback();
 }
 
 TemporaryExecutionContext::~TemporaryExecutionContext()
 {
-    m_environment_settings.clean_up_after_running_script();
+    m_environment_settings->clean_up_after_running_script();
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
-        m_environment_settings.clean_up_after_running_callback();
+        m_environment_settings->clean_up_after_running_callback();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
@@ -24,7 +24,7 @@ public:
     ~TemporaryExecutionContext();
 
 private:
-    EnvironmentSettingsObject& m_environment_settings;
+    JS::NonnullGCPtr<EnvironmentSettingsObject> m_environment_settings;
     CallbacksEnabled m_callbacks_enabled { CallbacksEnabled::No };
 };
 

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -592,8 +592,9 @@ void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout,
 // https://w3c.github.io/hr-time/#dom-windoworworkerglobalscope-performance
 JS::NonnullGCPtr<HighResolutionTime::Performance> WindowOrWorkerGlobalScopeMixin::performance()
 {
+    auto& realm = this_impl().realm();
     if (!m_performance)
-        m_performance = this_impl().heap().allocate<HighResolutionTime::Performance>(this_impl().realm(), *this);
+        m_performance = this_impl().heap().allocate<HighResolutionTime::Performance>(realm, realm);
     return JS::NonnullGCPtr { *m_performance };
 }
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.h
@@ -37,7 +37,10 @@ public:
     WebIDL::ExceptionOr<Vector<JS::Handle<PerformanceTimeline::PerformanceEntry>>> get_entries_by_name(String const& name, Optional<String> type) const;
 
 private:
-    explicit Performance(HTML::WindowOrWorkerGlobalScopeMixin&);
+    explicit Performance(JS::Realm&);
+
+    HTML::WindowOrWorkerGlobalScopeMixin& window_or_worker();
+    HTML::WindowOrWorkerGlobalScopeMixin const& window_or_worker() const;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -45,7 +48,6 @@ private:
     WebIDL::ExceptionOr<HighResolutionTime::DOMHighResTimeStamp> convert_name_to_timestamp(JS::Realm& realm, String const& name);
     WebIDL::ExceptionOr<HighResolutionTime::DOMHighResTimeStamp> convert_mark_to_timestamp(JS::Realm& realm, Variant<String, HighResolutionTime::DOMHighResTimeStamp> mark);
 
-    JS::NonnullGCPtr<HTML::WindowOrWorkerGlobalScopeMixin> m_window_or_worker;
     JS::GCPtr<NavigationTiming::PerformanceTiming> m_timing;
 
     Core::ElapsedTimer m_timer;

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1128,7 +1128,7 @@ BlockFormattingContext::SpaceUsedAndContainingMarginForFloats BlockFormattingCon
                 + floating_box.used_values.content_width()
                 + floating_box.used_values.margin_box_right();
             space_and_containing_margin.left_total_containing_margin = offset_from_containing_block_chain_margins_between_here_and_root;
-            space_and_containing_margin.matching_left_float_box = floating_box.box.ptr();
+            space_and_containing_margin.matching_left_float_box = floating_box.box;
             break;
         }
     }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -128,7 +128,7 @@ protected:
         // Each block in the containing chain adds its own margin and we store the total here.
         CSSPixels left_total_containing_margin;
         CSSPixels right_total_containing_margin;
-        Box const* matching_left_float_box { nullptr };
+        JS::GCPtr<Box const> matching_left_float_box;
     };
 
     struct ShrinkToFitResult {

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -31,14 +31,14 @@ LayoutState::~LayoutState()
 
 LayoutState::UsedValues& LayoutState::get_mutable(NodeWithStyle const& node)
 {
-    if (auto* used_values = used_values_per_layout_node.get(&node).value_or(nullptr))
+    if (auto* used_values = used_values_per_layout_node.get(node).value_or(nullptr))
         return *used_values;
 
     for (auto const* ancestor = m_parent; ancestor; ancestor = ancestor->m_parent) {
-        if (auto* ancestor_used_values = ancestor->used_values_per_layout_node.get(&node).value_or(nullptr)) {
+        if (auto* ancestor_used_values = ancestor->used_values_per_layout_node.get(node).value_or(nullptr)) {
             auto cow_used_values = adopt_own(*new UsedValues(*ancestor_used_values));
             auto* cow_used_values_ptr = cow_used_values.ptr();
-            used_values_per_layout_node.set(&node, move(cow_used_values));
+            used_values_per_layout_node.set(node, move(cow_used_values));
             return *cow_used_values_ptr;
         }
     }
@@ -48,17 +48,17 @@ LayoutState::UsedValues& LayoutState::get_mutable(NodeWithStyle const& node)
     auto new_used_values = adopt_own(*new UsedValues);
     auto* new_used_values_ptr = new_used_values.ptr();
     new_used_values->set_node(const_cast<NodeWithStyle&>(node), containing_block_used_values);
-    used_values_per_layout_node.set(&node, move(new_used_values));
+    used_values_per_layout_node.set(node, move(new_used_values));
     return *new_used_values_ptr;
 }
 
 LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
 {
-    if (auto const* used_values = used_values_per_layout_node.get(&node).value_or(nullptr))
+    if (auto const* used_values = used_values_per_layout_node.get(node).value_or(nullptr))
         return *used_values;
 
     for (auto const* ancestor = m_parent; ancestor; ancestor = ancestor->m_parent) {
-        if (auto const* ancestor_used_values = ancestor->used_values_per_layout_node.get(&node).value_or(nullptr))
+        if (auto const* ancestor_used_values = ancestor->used_values_per_layout_node.get(node).value_or(nullptr))
             return *ancestor_used_values;
     }
 
@@ -67,7 +67,7 @@ LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
     auto new_used_values = adopt_own(*new UsedValues);
     auto* new_used_values_ptr = new_used_values.ptr();
     new_used_values->set_node(const_cast<NodeWithStyle&>(node), containing_block_used_values);
-    const_cast<LayoutState*>(this)->used_values_per_layout_node.set(&node, move(new_used_values));
+    const_cast<LayoutState*>(this)->used_values_per_layout_node.set(node, move(new_used_values));
     return *new_used_values_ptr;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -176,7 +176,7 @@ struct LayoutState {
     // NOTE: get() will not CoW the UsedValues.
     UsedValues const& get(NodeWithStyle const&) const;
 
-    HashMap<Layout::Node const*, NonnullOwnPtr<UsedValues>> used_values_per_layout_node;
+    HashMap<JS::NonnullGCPtr<Layout::Node const>, NonnullOwnPtr<UsedValues>> used_values_per_layout_node;
 
     // We cache intrinsic sizes once determined, as they will not change over the course of a full layout.
     // This avoids computing them several times while performing flex layout.

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -138,7 +138,7 @@ private:
     };
 
     struct ConflictingEdge {
-        Node const* element;
+        JS::GCPtr<Node const> element;
         Painting::PaintableBox::ConflictingElementKind element_kind;
         ConflictingSide side;
         Optional<size_t> row;
@@ -166,12 +166,12 @@ private:
         void collect_table_box_conflicting_edges(Vector<ConflictingEdge>&, Cell const&, ConflictingSide) const;
 
         struct RowGroupInfo {
-            Node const* row_group;
+            JS::GCPtr<Node const> row_group;
             size_t start_index;
             size_t row_count;
         };
 
-        Vector<Node const*> m_col_elements_by_index;
+        Vector<JS::GCPtr<Node const>> m_col_elements_by_index;
         Vector<Optional<RowGroupInfo>> m_row_group_elements_by_index;
         TableFormattingContext const* m_context;
     };

--- a/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
+++ b/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
@@ -10,9 +10,8 @@ namespace Web::NavigationTiming {
 
 JS_DEFINE_ALLOCATOR(PerformanceTiming);
 
-PerformanceTiming::PerformanceTiming(HTML::WindowOrWorkerGlobalScopeMixin& window_or_worker)
-    : PlatformObject(window_or_worker.this_impl().realm())
-    , m_window_or_worker(window_or_worker)
+PerformanceTiming::PerformanceTiming(JS::Realm& realm)
+    : PlatformObject(realm)
 {
 }
 
@@ -22,13 +21,6 @@ void PerformanceTiming::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(PerformanceTiming);
-}
-
-void PerformanceTiming::visit_edges(Cell::Visitor& visitor)
-{
-    Base::visit_edges(visitor);
-    if (m_window_or_worker)
-        visitor.visit(m_window_or_worker->this_impl());
 }
 
 }

--- a/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.h
+++ b/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.h
@@ -42,12 +42,9 @@ public:
     u64 load_event_end() { return 0; }
 
 private:
-    explicit PerformanceTiming(HTML::WindowOrWorkerGlobalScopeMixin&);
+    explicit PerformanceTiming(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void visit_edges(Cell::Visitor&) override;
-
-    JS::GCPtr<HTML::WindowOrWorkerGlobalScopeMixin> m_window_or_worker;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -207,15 +207,15 @@ void StackingContext::paint_internal(PaintContext& context) const
     // Draw positioned descendants with z-index `0` or `auto` in tree order. (step 8)
     // FIXME: There's more to this step that we have yet to understand and implement.
     for (auto const& paintable : m_positioned_descendants_with_stack_level_0_and_stacking_contexts) {
-        if (!paintable.is_positioned())
+        if (!paintable->is_positioned())
             continue;
 
         // At this point, `paintable_box` is a positioned descendant with z-index: auto.
         // FIXME: This is basically duplicating logic found elsewhere in this same function. Find a way to make this more elegant.
-        auto* parent_paintable = paintable.parent();
+        auto* parent_paintable = paintable->parent();
         if (parent_paintable)
             parent_paintable->before_children_paint(context, PaintPhase::Foreground);
-        if (auto* child = paintable.stacking_context()) {
+        if (auto* child = paintable->stacking_context()) {
             paint_child(context, *child);
         } else {
             paint_node_as_stacking_context(paintable, context);
@@ -354,11 +354,11 @@ TraversalDecision StackingContext::hit_test(CSSPixelPoint position, HitTestType 
 
     // 6. the child stacking contexts with stack level 0 and the positioned descendants with stack level 0.
     for (auto const& paintable : m_positioned_descendants_with_stack_level_0_and_stacking_contexts.in_reverse()) {
-        if (paintable.stacking_context()) {
-            if (paintable.stacking_context()->hit_test(transformed_position, type, callback) == TraversalDecision::Break)
+        if (paintable->stacking_context()) {
+            if (paintable->stacking_context()->hit_test(transformed_position, type, callback) == TraversalDecision::Break)
                 return TraversalDecision::Break;
         } else {
-            if (paintable.hit_test(transformed_position, type, callback) == TraversalDecision::Break)
+            if (paintable->hit_test(transformed_position, type, callback) == TraversalDecision::Break)
                 return TraversalDecision::Break;
         }
     }
@@ -375,7 +375,7 @@ TraversalDecision StackingContext::hit_test(CSSPixelPoint position, HitTestType 
 
     // 4. the non-positioned floats.
     for (auto const& paintable : m_non_positioned_floating_descendants.in_reverse()) {
-        if (paintable.hit_test(transformed_position, type, callback) == TraversalDecision::Break)
+        if (paintable->hit_test(transformed_position, type, callback) == TraversalDecision::Break)
             return TraversalDecision::Break;
     }
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -52,8 +52,8 @@ private:
     Vector<StackingContext*> m_children;
     size_t m_index_in_tree_order { 0 };
 
-    Vector<Paintable const&> m_positioned_descendants_with_stack_level_0_and_stacking_contexts;
-    Vector<Paintable const&> m_non_positioned_floating_descendants;
+    Vector<JS::NonnullGCPtr<Paintable const>> m_positioned_descendants_with_stack_level_0_and_stacking_contexts;
+    Vector<JS::NonnullGCPtr<Paintable const>> m_non_positioned_floating_descendants;
 
     static void paint_child(PaintContext&, StackingContext const&);
     void paint_internal(PaintContext&) const;

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -72,7 +72,7 @@ void ViewportPaintable::assign_scroll_frames()
         if (paintable_box.has_scrollable_overflow()) {
             auto scroll_frame = adopt_ref(*new ScrollFrame());
             scroll_frame->id = next_id++;
-            scroll_state.set(&paintable_box, move(scroll_frame));
+            scroll_state.set(paintable_box, move(scroll_frame));
         }
         return TraversalDecision::Continue;
     });
@@ -102,7 +102,7 @@ void ViewportPaintable::assign_clip_frames()
         auto has_hidden_overflow = overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible;
         if (has_hidden_overflow || paintable_box.get_clip_rect().has_value()) {
             auto clip_frame = adopt_ref(*new ClipFrame());
-            clip_state.set(&paintable_box, move(clip_frame));
+            clip_state.set(paintable_box, move(clip_frame));
         }
         return TraversalDecision::Continue;
     });

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -513,4 +513,13 @@ void ViewportPaintable::recompute_selection_states()
     }
 }
 
+void ViewportPaintable::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto it : scroll_state)
+        visitor.visit(it.key);
+    for (auto it : clip_state)
+        visitor.visit(it.key);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -20,11 +20,11 @@ public:
     void paint_all_phases(PaintContext&);
     void build_stacking_context_tree_if_needed();
 
-    HashMap<PaintableBox const*, RefPtr<ScrollFrame>> scroll_state;
+    HashMap<JS::GCPtr<PaintableBox const>, RefPtr<ScrollFrame>> scroll_state;
     void assign_scroll_frames();
     void refresh_scroll_state();
 
-    HashMap<PaintableBox const*, RefPtr<ClipFrame>> clip_state;
+    HashMap<JS::GCPtr<PaintableBox const>, RefPtr<ClipFrame>> clip_state;
     void assign_clip_frames();
     void refresh_clip_state();
 

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -37,6 +37,8 @@ private:
     void build_stacking_context_tree();
 
     explicit ViewportPaintable(Layout::Viewport const&);
+
+    virtual void visit_edges(Visitor&) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -167,4 +167,11 @@ Optional<CSSPixelFraction> SVGDecodedImageData::intrinsic_aspect_ratio() const
     return {};
 }
 
+void SVGDecodedImageData::SVGPageClient::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_host_page);
+    visitor.visit(m_svg_page);
+}
+
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -61,16 +61,16 @@ public:
 
     virtual ~SVGPageClient() override = default;
 
-    Page& m_host_page;
-    Page* m_svg_page { nullptr };
+    JS::NonnullGCPtr<Page> m_host_page;
+    JS::GCPtr<Page> m_svg_page;
 
     virtual Page& page() override { return *m_svg_page; }
     virtual Page const& page() const override { return *m_svg_page; }
     virtual bool is_connection_open() const override { return false; }
-    virtual Gfx::Palette palette() const override { return m_host_page.client().palette(); }
+    virtual Gfx::Palette palette() const override { return m_host_page->client().palette(); }
     virtual DevicePixelRect screen_rect() const override { return {}; }
     virtual double device_pixels_per_css_pixel() const override { return 1.0; }
-    virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page.client().preferred_color_scheme(); }
+    virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page->client().preferred_color_scheme(); }
     virtual void request_file(FileRequest) override { }
     virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override { }
     virtual void schedule_repaint() override { }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -81,6 +81,8 @@ private:
         : m_host_page(host_page)
     {
     }
+
+    virtual void visit_edges(Visitor&) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -100,7 +100,7 @@ private:
     }
 
     JS::NonnullGCPtr<JS::Realm> m_realm;
-    WebIDL::Promise& m_promise;
+    JS::NonnullGCPtr<WebIDL::Promise> m_promise;
 };
 
 // https://streams.spec.whatwg.org/#byob-reader-read

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -148,7 +148,7 @@ private:
     }
 
     JS::NonnullGCPtr<JS::Realm> m_realm;
-    WebIDL::Promise& m_promise;
+    JS::NonnullGCPtr<WebIDL::Promise> m_promise;
 };
 
 // https://streams.spec.whatwg.org/#default-reader-read

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -678,12 +678,12 @@ void PageClient::initialize_js_console(Web::DOM::Document& document)
         m_top_level_document_console_client = console_client->make_weak_ptr();
     }
 
-    m_console_clients.set(&document, move(console_client));
+    m_console_clients.set(document, move(console_client));
 }
 
 void PageClient::destroy_js_console(Web::DOM::Document& document)
 {
-    m_console_clients.remove(&document);
+    m_console_clients.remove(document);
 }
 
 void PageClient::js_console_input(ByteString const& js_source)

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -124,6 +124,8 @@ void PageClient::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_page);
+    for (auto document : m_console_clients.keys())
+        visitor.visit(document);
 }
 
 ConnectionFromClient& PageClient::client() const

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -192,7 +192,7 @@ private:
     };
     BackingStores m_backing_stores;
 
-    HashMap<Web::DOM::Document*, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
+    HashMap<JS::NonnullGCPtr<Web::DOM::Document>, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
     WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
 
     JS::Handle<JS::GlobalObject> m_console_global_object;

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -59,25 +59,25 @@ void WebContentConsoleClient::report_exception(JS::Error const& exception, bool 
 void WebContentConsoleClient::print_html(ByteString const& line)
 {
     m_message_log.append({ .type = ConsoleOutput::Type::HTML, .data = line });
-    m_client.did_output_js_console_message(m_message_log.size() - 1);
+    m_client->did_output_js_console_message(m_message_log.size() - 1);
 }
 
 void WebContentConsoleClient::clear_output()
 {
     m_message_log.append({ .type = ConsoleOutput::Type::Clear, .data = "" });
-    m_client.did_output_js_console_message(m_message_log.size() - 1);
+    m_client->did_output_js_console_message(m_message_log.size() - 1);
 }
 
 void WebContentConsoleClient::begin_group(ByteString const& label, bool start_expanded)
 {
     m_message_log.append({ .type = start_expanded ? ConsoleOutput::Type::BeginGroup : ConsoleOutput::Type::BeginGroupCollapsed, .data = label });
-    m_client.did_output_js_console_message(m_message_log.size() - 1);
+    m_client->did_output_js_console_message(m_message_log.size() - 1);
 }
 
 void WebContentConsoleClient::end_group()
 {
     m_message_log.append({ .type = ConsoleOutput::Type::EndGroup, .data = "" });
-    m_client.did_output_js_console_message(m_message_log.size() - 1);
+    m_client->did_output_js_console_message(m_message_log.size() - 1);
 }
 
 void WebContentConsoleClient::send_messages(i32 start_index)
@@ -89,7 +89,7 @@ void WebContentConsoleClient::send_messages(i32 start_index)
         // then, by requesting with start_index=0. If we don't have any messages at all, that
         // is still a valid request, and we can just ignore it.
         if (start_index != 0)
-            m_client.console_peer_did_misbehave("Requested non-existent console message index.");
+            m_client->console_peer_did_misbehave("Requested non-existent console message index.");
         return;
     }
 
@@ -122,7 +122,7 @@ void WebContentConsoleClient::send_messages(i32 start_index)
         messages.append(message.data);
     }
 
-    m_client.did_get_js_console_messages(start_index, message_types, messages);
+    m_client->did_get_js_console_messages(start_index, message_types, messages);
 }
 
 void WebContentConsoleClient::clear()

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -37,7 +37,7 @@ private:
         m_current_message_style.append(';');
     }
 
-    PageClient& m_client;
+    JS::NonnullGCPtr<PageClient> m_client;
     JS::Handle<ConsoleGlobalEnvironmentExtensions> m_console_global_environment_extensions;
 
     void clear_output();

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -117,7 +117,7 @@ private:
     ErrorOr<ScriptArguments, Web::WebDriver::Error> extract_the_script_arguments_from_a_request(JsonValue const& payload);
     void delete_cookies(Optional<StringView> const& name = {});
 
-    Web::PageClient& m_page_client;
+    JS::NonnullGCPtr<Web::PageClient> m_page_client;
 
     // https://w3c.github.io/webdriver/#dfn-page-load-strategy
     Web::WebDriver::PageLoadStrategy m_page_load_strategy { Web::WebDriver::PageLoadStrategy::Normal };


### PR DESCRIPTION
The one warning is clang failing to resolve `#include <GL/gl.h>` somewhere, so not really something I care about. But all of the other relevant warnings have been fixed. I don't _think_ this will conflict with #23854, but best to merge that one first just to be safe. 