### PR TITLE
LibGfx/JBIG2: Add support for pattern and halftone segments

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -555,6 +555,9 @@ enum class CombinationOperator {
 
 static void composite_bitbuffer(BitBuffer& out, BitBuffer const& bitmap, Gfx::IntPoint position, CombinationOperator operator_)
 {
+    if (!IntRect { position, { bitmap.width(), bitmap.height() } }.intersects(IntRect { { 0, 0 }, { out.width(), out.height() } }))
+        return;
+
     size_t start_x = 0, end_x = bitmap.width();
     size_t start_y = 0, end_y = bitmap.height();
     if (position.x() < 0) {

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -2090,9 +2090,11 @@ static ErrorOr<void> decode_immediate_generic_region(JBIG2LoadingContext& contex
     // 7.4.6.4 Decoding a generic region segment
     // "1) Interpret its header, as described in 7.4.6.1"
     // Done above.
+
     // "2) As described in E.3.7, reset all the arithmetic coding statistics to zero."
     Vector<JBIG2::ArithmeticDecoder::Context> contexts;
-    contexts.resize(1 << number_of_context_bits_for_template(arithmetic_coding_template));
+    if (!uses_mmr)
+        contexts.resize(1 << number_of_context_bits_for_template(arithmetic_coding_template));
 
     // "3) Invoke the generic region decoding procedure described in 6.2, with the parameters to the generic region decoding procedure set as shown in Table 37."
     GenericRegionDecodingInputParameters inputs;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1759,6 +1759,22 @@ static ErrorOr<Vector<NonnullRefPtr<Symbol>>> symbol_dictionary_decoding_procedu
     return exported_symbols;
 }
 
+// 6.7.2 Input parameters
+// Table 24 – Parameters for the pattern dictionary decoding procedure
+struct PatternDictionaryDecodingInputParameters {
+    bool uses_mmr { false }; // "HDMMR" in spec.
+    u32 width { 0 };         // "HDPW" in spec.
+    u32 height { 0 };        // "HDPH" in spec.
+    u32 gray_max { 0 };      // "GRAYMAX" in spec.
+    u8 hd_template { 0 };    // "HDTEMPLATE" in spec.
+};
+
+// 6.7 Pattern Dictionary Decoding Procedure
+static ErrorOr<void> pattern_dictionary_decoding_procedure(PatternDictionaryDecodingInputParameters const&, ReadonlyBytes)
+{
+    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode pattern dictionary yet");
+}
+
 static ErrorOr<void> decode_symbol_dictionary(JBIG2LoadingContext& context, SegmentData& segment)
 {
     // 7.4.2 Symbol dictionary segment syntax
@@ -2019,9 +2035,52 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     return {};
 }
 
-static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData const&)
+static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData const& segment)
 {
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode pattern dictionary yet");
+    // 7.4.4 Pattern dictionary segment syntax
+    FixedMemoryStream stream(segment.data);
+
+    // 7.4.4.1.1 Pattern dictionary flags
+    u8 flags = TRY(stream.read_value<u8>());
+    bool uses_mmr = flags & 1;
+    u8 hd_template = (flags >> 1) & 3;
+    if (uses_mmr && hd_template != 0)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid hd_template");
+    if (flags & 0b1111'1000)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid flags");
+
+    // 7.4.4.1.2 Width of the patterns in the pattern dictionary (HDPW)
+    u8 width = TRY(stream.read_value<u8>());
+    if (width == 0)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid width");
+
+    // 7.4.4.1.3 Height of the patterns in the pattern dictionary (HDPH)
+    u8 height = TRY(stream.read_value<u8>());
+    if (height == 0)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid height");
+
+    // 7.4.4.1.4 Largest gray-scale value (GRAYMAX)
+    u32 gray_max = TRY(stream.read_value<BigEndian<u32>>());
+
+    // 7.4.4.2 Decoding a pattern dictionary segment
+    dbgln_if(JBIG2_DEBUG, "Pattern dictionary: uses_mmr={}, hd_template={}, width={}, height={}, gray_max={}", uses_mmr, hd_template, width, height, gray_max);
+
+    // "1) Interpret its header, as described in 7.4.4.1."
+    // Done!
+
+    // "2) As described in E.3.7, reset all the arithmetic coding statistics to zero."
+    // FIXME
+
+    // "3) Invoke the pattern dictionary decoding procedure described in 6.7, with the parameters to the pattern
+    //     dictionary decoding procedure set as shown in Table 35."
+    PatternDictionaryDecodingInputParameters inputs;
+    inputs.uses_mmr = uses_mmr;
+    inputs.width = width;
+    inputs.height = height;
+    inputs.gray_max = gray_max;
+    inputs.hd_template = hd_template;
+    TRY(pattern_dictionary_decoding_procedure(inputs, segment.data.slice(TRY(stream.tell()))));
+    return {};
 }
 
 static ErrorOr<void> decode_intermediate_halftone_region(JBIG2LoadingContext&, SegmentData const&)

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1781,6 +1781,32 @@ static ErrorOr<Vector<NonnullRefPtr<Symbol>>> symbol_dictionary_decoding_procedu
     return exported_symbols;
 }
 
+// 6.6.2 Input parameters
+struct HalftoneRegionDecodingInputParameters {
+    u32 region_width { 0 };                                               // "HBW" in spec.
+    u32 region_height { 0 };                                              // "HBH" in spec.
+    bool uses_mmr { false };                                              // "HMMR" in spec.
+    u8 halftone_template { 0 };                                           // "HTEMPLATE" in spec.
+    Vector<NonnullRefPtr<Symbol>> patterns;                               // "HNUMPATS" / "HPATS" in spec.
+    bool default_pixel_value { false };                                   // "HDEFPIXEL" in spec.
+    CombinationOperator combination_operator { CombinationOperator::Or }; // "HCOMBOP" in spec.
+    bool enable_skip { false };                                           // "HENABLESKIP" in spec.
+    u32 grayscale_width { 0 };                                            // "HGW" in spec.
+    u32 grayscale_height { 0 };                                           // "HGH" in spec.
+    i32 grid_origin_x_offset { 0 };                                       // "HGX" in spec.
+    i32 grid_origin_y_offset { 0 };                                       // "HGY" in spec.
+    u16 grid_vector_x { 0 };                                              // "HRY" in spec.
+    u16 grid_vector_y { 0 };                                              // "HRX" in spec.
+    u8 pattern_width { 0 };                                               // "HPW" in spec.
+    u8 pattern_height { 0 };                                              // "HPH" in spec.
+};
+
+// 6.6 Halftone Region Decoding Procedure
+static ErrorOr<NonnullOwnPtr<BitBuffer>> halftone_region_decoding_procedure(HalftoneRegionDecodingInputParameters const&, ReadonlyBytes)
+{
+    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone region decoding not implemented yet");
+}
+
 // 6.7.2 Input parameters
 // Table 24 – Parameters for the pattern dictionary decoding procedure
 struct PatternDictionaryDecodingInputParameters {
@@ -2151,9 +2177,99 @@ static ErrorOr<void> decode_intermediate_halftone_region(JBIG2LoadingContext&, S
     return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode intermediate halftone region yet");
 }
 
-static ErrorOr<void> decode_immediate_halftone_region(JBIG2LoadingContext&, SegmentData const&)
+static ErrorOr<void> decode_immediate_halftone_region(JBIG2LoadingContext& context, SegmentData const& segment)
 {
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode immediate halftone region yet");
+    // 7.4.5 Halftone region segment syntax
+    auto data = segment.data;
+    auto information_field = TRY(decode_region_segment_information_field(data));
+    data = data.slice(sizeof(information_field));
+
+    dbgln_if(JBIG2_DEBUG, "Halftone region: width={}, height={}, x={}, y={}, flags={:#x}", information_field.width, information_field.height, information_field.x_location, information_field.y_location, information_field.flags);
+
+    FixedMemoryStream stream(data);
+
+    // 7.4.5.1.1 Halftone region segment flags
+    u8 flags = TRY(stream.read_value<u8>());
+    bool uses_mmr = flags & 1;           // "HMMR" in spec.
+    u8 template_used = (flags >> 1) & 3; // "HTTEMPLATE" in spec.
+    if (uses_mmr && template_used != 0)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid template_used");
+    bool enable_skip = (flags >> 3) & 1;        // "HENABLESKIP" in spec.
+    u8 combination_operator = (flags >> 4) & 7; // "HCOMBOP" in spec.
+    if (combination_operator > 4)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid combination_operator");
+    bool default_pixel_value = (flags >> 7) & 1; // "HDEFPIXEL" in spec.
+
+    dbgln_if(JBIG2_DEBUG, "Halftone region: uses_mmr={}, template_used={}, enable_skip={}, combination_operator={}, default_pixel_value={}", uses_mmr, template_used, enable_skip, combination_operator, default_pixel_value);
+
+    // 7.4.5.1.2 Halftone grid position and size
+    // 7.4.5.1.2.1 Width of the gray-scale image (HGW)
+    u32 gray_width = TRY(stream.read_value<BigEndian<u32>>());
+
+    // 7.4.5.1.2.2 Height of the gray-scale image (HGH)
+    u32 gray_height = TRY(stream.read_value<BigEndian<u32>>());
+
+    // 7.4.5.1.2.3 Horizontal offset of the grid (HGX)
+    i32 grid_x = TRY(stream.read_value<BigEndian<i32>>());
+
+    // 7.4.5.1.2.4 Vertical offset of the grid (HGY)
+    i32 grid_y = TRY(stream.read_value<BigEndian<i32>>());
+
+    // 7.4.5.1.3 Halftone grid vector
+    // 7.4.5.1.3.1 Horizontal coordinate of the halftone grid vector (HRX)
+    u16 grid_vector_x = TRY(stream.read_value<BigEndian<u16>>());
+
+    // 7.4.5.1.3.2 Vertical coordinate of the halftone grid vector (HRY)
+    u16 grid_vector_y = TRY(stream.read_value<BigEndian<u16>>());
+
+    dbgln_if(JBIG2_DEBUG, "Halftone region: gray_width={}, gray_height={}, grid_x={}, grid_y={}, grid_vector_x={}, grid_vector_y={}", gray_width, gray_height, grid_x, grid_y, grid_vector_x, grid_vector_y);
+
+    // 7.4.5.2 Decoding a halftone region segment
+    // "1) Interpret its header, as described in 7.4.5.1."
+    // Done!
+
+    // "2) Decode (or retrieve the results of decoding) the referred-to pattern dictionary segment."
+    if (segment.header.referred_to_segment_numbers.size() != 1)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone segment refers to wrong number of segments");
+    auto opt_referred_to_segment = context.segments_by_number.get(segment.header.referred_to_segment_numbers[0]);
+    if (!opt_referred_to_segment.has_value())
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone segment refers to non-existent segment");
+    dbgln_if(JBIG2_DEBUG, "Halftone segment refers to segment id {} index {}", segment.header.referred_to_segment_numbers[0], opt_referred_to_segment.value());
+    auto const& referred_to_segment = context.segments[opt_referred_to_segment.value()];
+    if (!referred_to_segment.patterns.has_value())
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone segment referred-to segment without patterns");
+    Vector<NonnullRefPtr<Symbol>> patterns = referred_to_segment.patterns.value();
+    if (patterns.is_empty())
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone segment without patterns");
+
+    // "3) As described in E.3.7, reset all the arithmetic coding statistics to zero."
+    // FIXME
+
+    // "4) Invoke the halftone region decoding procedure described in 6.6, with the parameters to the halftone
+    //     region decoding procedure set as shown in Table 36."
+    data = data.slice(TRY(stream.tell()));
+    HalftoneRegionDecodingInputParameters inputs;
+    inputs.region_width = information_field.width;
+    inputs.region_height = information_field.height;
+    inputs.uses_mmr = uses_mmr;
+    inputs.halftone_template = template_used;
+    inputs.enable_skip = enable_skip;
+    inputs.combination_operator = static_cast<CombinationOperator>(combination_operator);
+    inputs.default_pixel_value = default_pixel_value;
+    inputs.grayscale_width = gray_width;
+    inputs.grayscale_height = gray_height;
+    inputs.grid_origin_x_offset = grid_x;
+    inputs.grid_origin_y_offset = grid_y;
+    inputs.grid_vector_x = grid_vector_x;
+    inputs.grid_vector_y = grid_vector_y;
+    inputs.patterns = move(patterns);
+    inputs.pattern_width = inputs.patterns[0]->bitmap().width();
+    inputs.pattern_height = inputs.patterns[0]->bitmap().height();
+    auto result = TRY(halftone_region_decoding_procedure(inputs, data));
+
+    composite_bitbuffer(*context.page.bits, *result, { information_field.x_location, information_field.y_location }, information_field.external_combination_operator());
+
+    return {};
 }
 
 static ErrorOr<void> decode_immediate_lossless_halftone_region(JBIG2LoadingContext&, SegmentData const&)

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -416,6 +416,8 @@ public:
     void set_bit(size_t x, size_t y, bool b);
     void fill(bool b);
 
+    ErrorOr<NonnullOwnPtr<BitBuffer>> subbitmap(Gfx::IntRect const& rect) const;
+
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_gfx_bitmap() const;
     ErrorOr<ByteBuffer> to_byte_buffer() const;
 
@@ -471,6 +473,23 @@ void BitBuffer::fill(bool b)
         byte = fill_byte;
 }
 
+ErrorOr<NonnullOwnPtr<BitBuffer>> BitBuffer::subbitmap(Gfx::IntRect const& rect) const
+{
+    VERIFY(rect.x() >= 0);
+    VERIFY(rect.width() >= 0);
+    VERIFY(static_cast<size_t>(rect.right()) <= width());
+
+    VERIFY(rect.y() >= 0);
+    VERIFY(rect.height() >= 0);
+    VERIFY(static_cast<size_t>(rect.bottom()) <= height());
+
+    auto subbitmap = TRY(create(rect.width(), rect.height()));
+    for (int y = 0; y < rect.height(); ++y)
+        for (int x = 0; x < rect.width(); ++x)
+            subbitmap->set_bit(x, y, get_bit(rect.x() + x, rect.y() + y));
+    return subbitmap;
+}
+
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> BitBuffer::to_gfx_bitmap() const
 {
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { m_width, m_height }));
@@ -520,6 +539,9 @@ struct SegmentData {
 
     // Set on dictionary segments after they've been decoded.
     Optional<Vector<NonnullRefPtr<Symbol>>> symbols;
+
+    // Set on pattern segments after they've been decoded.
+    Optional<Vector<NonnullRefPtr<Symbol>>> patterns;
 };
 
 // 7.4.8.5 Page segment flags
@@ -777,7 +799,7 @@ static ErrorOr<void> decode_segment_headers(JBIG2LoadingContext& context, Readon
     if (segment_headers.size() != segment_datas.size())
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Segment headers and segment datas have different sizes");
     for (size_t i = 0; i < segment_headers.size(); ++i) {
-        context.segments.append({ segment_headers[i], segment_datas[i], {} });
+        context.segments.append({ segment_headers[i], segment_datas[i], {}, {} });
         context.segments_by_number.set(segment_headers[i].segment_number, context.segments.size() - 1);
     }
 
@@ -1770,9 +1792,44 @@ struct PatternDictionaryDecodingInputParameters {
 };
 
 // 6.7 Pattern Dictionary Decoding Procedure
-static ErrorOr<void> pattern_dictionary_decoding_procedure(PatternDictionaryDecodingInputParameters const&, ReadonlyBytes)
+static ErrorOr<Vector<NonnullRefPtr<Symbol>>> pattern_dictionary_decoding_procedure(PatternDictionaryDecodingInputParameters const& inputs, ReadonlyBytes data, Vector<JBIG2::ArithmeticDecoder::Context>& contexts)
 {
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode pattern dictionary yet");
+    // Table 27 – Parameters used to decode a pattern dictionary's collective bitmap
+    GenericRegionDecodingInputParameters generic_inputs;
+    generic_inputs.is_modified_modified_read = inputs.uses_mmr;
+    generic_inputs.region_width = (inputs.gray_max + 1) * inputs.width;
+    generic_inputs.region_height = inputs.height;
+    generic_inputs.gb_template = inputs.hd_template;
+    generic_inputs.is_typical_prediction_used = false;
+    generic_inputs.is_extended_reference_template_used = false; // Missing from spec in table 27.
+    generic_inputs.skip_pattern = OptionalNone {};
+    generic_inputs.adaptive_template_pixels[0].x = -inputs.width;
+    generic_inputs.adaptive_template_pixels[0].y = 0;
+    generic_inputs.adaptive_template_pixels[1].x = -3;
+    generic_inputs.adaptive_template_pixels[1].y = -1;
+    generic_inputs.adaptive_template_pixels[2].x = 2;
+    generic_inputs.adaptive_template_pixels[2].y = -2;
+    generic_inputs.adaptive_template_pixels[3].x = -2;
+    generic_inputs.adaptive_template_pixels[3].y = -2;
+
+    Optional<JBIG2::ArithmeticDecoder> decoder;
+    if (!inputs.uses_mmr) {
+        decoder = TRY(JBIG2::ArithmeticDecoder::initialize(data));
+        generic_inputs.arithmetic_decoder = &decoder.value();
+    }
+
+    auto bitmap = TRY(generic_region_decoding_procedure(generic_inputs, data, contexts));
+
+    Vector<NonnullRefPtr<Symbol>> patterns;
+    for (u32 gray = 0; gray <= inputs.gray_max; ++gray) {
+        int x = gray * inputs.width;
+        auto pattern = TRY(bitmap->subbitmap({ x, 0, static_cast<int>(inputs.width), static_cast<int>(inputs.height) }));
+        patterns.append(Symbol::create(move(pattern)));
+    }
+
+    dbgln_if(JBIG2_DEBUG, "Pattern dictionary: {} patterns", patterns.size());
+
+    return patterns;
 }
 
 static ErrorOr<void> decode_symbol_dictionary(JBIG2LoadingContext& context, SegmentData& segment)
@@ -2035,7 +2092,7 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     return {};
 }
 
-static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData const& segment)
+static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData& segment)
 {
     // 7.4.4 Pattern dictionary segment syntax
     FixedMemoryStream stream(segment.data);
@@ -2064,12 +2121,15 @@ static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData
 
     // 7.4.4.2 Decoding a pattern dictionary segment
     dbgln_if(JBIG2_DEBUG, "Pattern dictionary: uses_mmr={}, hd_template={}, width={}, height={}, gray_max={}", uses_mmr, hd_template, width, height, gray_max);
+    auto data = segment.data.slice(TRY(stream.tell()));
 
     // "1) Interpret its header, as described in 7.4.4.1."
     // Done!
 
     // "2) As described in E.3.7, reset all the arithmetic coding statistics to zero."
-    // FIXME
+    Vector<JBIG2::ArithmeticDecoder::Context> contexts;
+    if (!uses_mmr)
+        contexts.resize(1 << number_of_context_bits_for_template(hd_template));
 
     // "3) Invoke the pattern dictionary decoding procedure described in 6.7, with the parameters to the pattern
     //     dictionary decoding procedure set as shown in Table 35."
@@ -2079,7 +2139,10 @@ static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData
     inputs.height = height;
     inputs.gray_max = gray_max;
     inputs.hd_template = hd_template;
-    TRY(pattern_dictionary_decoding_procedure(inputs, segment.data.slice(TRY(stream.tell()))));
+    auto result = TRY(pattern_dictionary_decoding_procedure(inputs, data, contexts));
+
+    segment.patterns = move(result);
+
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -931,7 +931,7 @@ struct GenericRegionDecodingInputParameters {
     u8 gb_template { 0 };
     bool is_typical_prediction_used { false };          // "TPGDON" in spec.
     bool is_extended_reference_template_used { false }; // "EXTTEMPLATE" in spec.
-    Optional<NonnullOwnPtr<BitBuffer>> skip_pattern;    // "USESKIP", "SKIP" in spec.
+    Optional<BitBuffer const&> skip_pattern;            // "USESKIP", "SKIP" in spec.
 
     Array<AdaptiveTemplatePixel, 12> adaptive_template_pixels; // "GBATX" / "GBATY" in spec.
     // FIXME: GBCOLS, GBCOMBOP, COLEXTFLAG
@@ -1781,7 +1781,102 @@ static ErrorOr<Vector<NonnullRefPtr<Symbol>>> symbol_dictionary_decoding_procedu
     return exported_symbols;
 }
 
+// Annex C Gray-scale image decoding procedure
+
+// C.2 Input parameters
+// Table C.1 – Parameters for the gray-scale image decoding procedure
+struct GrayscaleInputParameters {
+    bool uses_mmr { false }; // "GSMMR" in spec.
+
+    Optional<BitBuffer const&> skip_pattern; // "GSUSESKIP" / "GSKIP" in spec.
+
+    u8 bpp { 0 };         // "GSBPP" in spec.
+    u32 width { 0 };      // "GSW" in spec.
+    u32 height { 0 };     // "GSH" in spec.
+    u8 template_id { 0 }; // "GSTEMPLATE" in spec.
+
+    // If uses_mmr is false, grayscale_image_decoding_procedure() reads data off this decoder.
+    JBIG2::ArithmeticDecoder* arithmetic_decoder { nullptr };
+};
+
+static ErrorOr<Vector<u8>> grayscale_image_decoding_procedure(GrayscaleInputParameters const& inputs, ReadonlyBytes data, Vector<JBIG2::ArithmeticDecoder::Context>& contexts)
+{
+    // FIXME: Support this. generic_region_decoding_procedure() currently doesn't tell us how much data it
+    //        reads for MMR bitmaps, so we can't currently read more than one MMR bitplane here.
+    if (inputs.uses_mmr)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode MMR grayscale images yet");
+
+    // Table C.4 – Parameters used to decode a bitplane of the gray-scale image
+    GenericRegionDecodingInputParameters generic_inputs;
+    generic_inputs.is_modified_modified_read = inputs.uses_mmr;
+    generic_inputs.region_width = inputs.width;
+    generic_inputs.region_height = inputs.height;
+    generic_inputs.gb_template = inputs.template_id;
+    generic_inputs.is_typical_prediction_used = false;
+    generic_inputs.is_extended_reference_template_used = false; // Missing from spec.
+    generic_inputs.skip_pattern = inputs.skip_pattern;
+    generic_inputs.adaptive_template_pixels[0].x = inputs.template_id <= 1 ? 3 : 2;
+    generic_inputs.adaptive_template_pixels[0].y = -1;
+    generic_inputs.adaptive_template_pixels[1].x = -3;
+    generic_inputs.adaptive_template_pixels[1].y = -1;
+    generic_inputs.adaptive_template_pixels[2].x = 2;
+    generic_inputs.adaptive_template_pixels[2].y = -2;
+    generic_inputs.adaptive_template_pixels[3].x = -2;
+    generic_inputs.adaptive_template_pixels[3].y = -2;
+    generic_inputs.arithmetic_decoder = inputs.arithmetic_decoder;
+
+    // C.5 Decoding the gray-scale image
+    // "The gray-scale image is obtained by decoding GSBPP bitplanes. These bitplanes are denoted (from least significant to
+    //  most significant) GSPLANES[0], GSPLANES[1], . . . , GSPLANES[GSBPP – 1]. The bitplanes are Gray-coded, so
+    //  that each bitplane's true value is equal to its coded value XORed with the next-more-significant bitplane."
+    Vector<OwnPtr<BitBuffer>> bitplanes;
+    bitplanes.resize(inputs.bpp);
+
+    // "1) Decode GSPLANES[GSBPP – 1] using the generic region decoding procedure. The parameters to the
+    //     generic region decoding procedure are as shown in Table C.4."
+    bitplanes[inputs.bpp - 1] = TRY(generic_region_decoding_procedure(generic_inputs, data, contexts));
+
+    // "2) Set J = GSBPP – 2."
+    int j = inputs.bpp - 2;
+
+    // "3) While J >= 0, perform the following steps:"
+    while (j >= 0) {
+        // "a) Decode GSPLANES[J] using the generic region decoding procedure. The parameters to the generic
+        //     region decoding procedure are as shown in Table C.4."
+        bitplanes[j] = TRY(generic_region_decoding_procedure(generic_inputs, data, contexts));
+
+        // "b) For each pixel (x, y) in GSPLANES[J], set:
+        //     GSPLANES[J][x, y] = GSPLANES[J + 1][x, y] XOR GSPLANES[J][x, y]"
+        for (u32 y = 0; y < inputs.height; ++y) {
+            for (u32 x = 0; x < inputs.width; ++x) {
+                bool bit = bitplanes[j + 1]->get_bit(x, y) ^ bitplanes[j]->get_bit(x, y);
+                bitplanes[j]->set_bit(x, y, bit);
+            }
+        }
+
+        // "c) Set J = J – 1."
+        j = j - 1;
+    }
+
+    // "4) For each (x, y), set:
+    //     GSVALS [x, y] = sum_{J = 0}^{GSBPP - 1} GSPLANES[J][x,y] × 2**J)"
+    Vector<u8> result;
+    result.resize(inputs.width * inputs.height);
+    for (u32 y = 0; y < inputs.height; ++y) {
+        for (u32 x = 0; x < inputs.width; ++x) {
+            u8 value = 0;
+            for (int j = 0; j < inputs.bpp; ++j) {
+                if (bitplanes[j]->get_bit(x, y))
+                    value |= 1 << j;
+            }
+            result[y * inputs.width + x] = value;
+        }
+    }
+    return result;
+}
+
 // 6.6.2 Input parameters
+// Table 20 – Parameters for the halftone region decoding procedure
 struct HalftoneRegionDecodingInputParameters {
     u32 region_width { 0 };                                               // "HBW" in spec.
     u32 region_height { 0 };                                              // "HBH" in spec.
@@ -1802,9 +1897,105 @@ struct HalftoneRegionDecodingInputParameters {
 };
 
 // 6.6 Halftone Region Decoding Procedure
-static ErrorOr<NonnullOwnPtr<BitBuffer>> halftone_region_decoding_procedure(HalftoneRegionDecodingInputParameters const&, ReadonlyBytes)
+static ErrorOr<NonnullOwnPtr<BitBuffer>> halftone_region_decoding_procedure(HalftoneRegionDecodingInputParameters const& inputs, ReadonlyBytes data, Vector<JBIG2::ArithmeticDecoder::Context>& contexts)
 {
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone region decoding not implemented yet");
+    // 6.6.5 Decoding the halftone region
+    // "1) Fill a bitmap HTREG, of the size given by HBW and HBH, with the HDEFPIXEL value."
+    auto result = TRY(BitBuffer::create(inputs.region_width, inputs.region_height));
+    result->fill(inputs.default_pixel_value);
+
+    // "2) If HENABLESKIP equals 1, compute a bitmap HSKIP as shown in 6.6.5.1."
+    Optional<BitBuffer const&> skip_pattern;
+    OwnPtr<BitBuffer> skip_pattern_storage;
+    if (inputs.enable_skip) {
+        // FIXME: This is untested; I haven't found a sample that uses HENABLESKIP yet.
+        //        But generic_region_decoding_procedure() currently doesn't implement skip_pattern anyways
+        //        and errors out on it, so we'll notice when this gets hit.
+        skip_pattern_storage = TRY(BitBuffer::create(inputs.pattern_width, inputs.pattern_height));
+        skip_pattern = *skip_pattern_storage;
+
+        // 6.6.5.1 Computing HSKIP
+        // "1) For each value of mg between 0 and HGH – 1, beginning from 0, perform the following steps:"
+        for (int m_g = 0; m_g < (int)inputs.grayscale_height; ++m_g) {
+            // "a) For each value of ng between 0 and HGW – 1, beginning from 0, perform the following steps:"
+            for (int n_g = 0; n_g < (int)inputs.grayscale_width; ++n_g) {
+                // "i) Set:
+                //      x = (HGX + m_g × HRY + n_g × HRX) >> 8
+                //      y = (HGY + m_g × HRX – n_g × HRY) >> 8"
+                auto x = (inputs.grid_origin_x_offset + m_g * inputs.grid_vector_y + n_g * inputs.grid_vector_x) >> 8;
+                auto y = (inputs.grid_origin_y_offset + m_g * inputs.grid_vector_x - n_g * inputs.grid_vector_y) >> 8;
+
+                // "ii) If ((x + HPW <= 0) OR (x >= HBW) OR (y + HPH <= 0) OR (y >= HBH)) then set:
+                //          HSKIP[n_g, m_g] = 1
+                //      Otherwise, set:
+                //          HSKIP[n_g, m_g] = 0"
+                if (x + inputs.pattern_width <= 0 || x >= (int)inputs.region_width || y + inputs.pattern_height <= 0 || y >= (int)inputs.region_height)
+                    skip_pattern_storage->set_bit(n_g, m_g, true);
+                else
+                    skip_pattern_storage->set_bit(n_g, m_g, false);
+            }
+        }
+    }
+
+    // "3) Set HBPP to ⌈log2 (HNUMPATS)⌉."
+    u8 bits_per_pattern = ceil(log2(inputs.patterns.size()));
+
+    // "4) Decode an image GI of size HGW by HGH with HBPP bits per pixel using the gray-scale image decoding
+    //     procedure as described in Annex C. Set the parameters to this decoding procedure as shown in Table 23.
+    //     Let GI be the results of invoking this decoding procedure."
+    GrayscaleInputParameters grayscale_inputs;
+    grayscale_inputs.uses_mmr = inputs.uses_mmr;
+    grayscale_inputs.width = inputs.grayscale_width;
+    grayscale_inputs.height = inputs.grayscale_height;
+    grayscale_inputs.bpp = bits_per_pattern;
+    grayscale_inputs.skip_pattern = skip_pattern;
+    grayscale_inputs.template_id = inputs.halftone_template;
+
+    Optional<JBIG2::ArithmeticDecoder> decoder;
+    if (!inputs.uses_mmr) {
+        decoder = TRY(JBIG2::ArithmeticDecoder::initialize(data));
+        grayscale_inputs.arithmetic_decoder = &decoder.value();
+    }
+
+    auto grayscale_image = TRY(grayscale_image_decoding_procedure(grayscale_inputs, data, contexts));
+
+    // "5) Place sequentially the patterns corresponding to the values in GI into HTREG by the procedure described in 6.6.5.2.
+    //     The rendering procedure is illustrated in Figure 26. The outline of two patterns are marked by dotted boxes."
+    {
+        // 6.6.5.2 Rendering the patterns
+        // "Draw the patterns into HTREG using the following procedure:
+        //  1) For each value of m_g between 0 and HGH – 1, beginning from 0, perform the following steps."
+        for (int m_g = 0; m_g < (int)inputs.grayscale_height; ++m_g) {
+            // "a) For each value of n_g between 0 and HGW – 1, beginning from 0, perform the following steps."
+            for (int n_g = 0; n_g < (int)inputs.grayscale_width; ++n_g) {
+                // "i) Set:
+                //      x = (HGX + m_g × HRY + n_g × HRX) >> 8
+                //      y = (HGY + m_g × HRX – n_g × HRY) >> 8"
+                auto x = (inputs.grid_origin_x_offset + m_g * inputs.grid_vector_y + n_g * inputs.grid_vector_x) >> 8;
+                auto y = (inputs.grid_origin_y_offset + m_g * inputs.grid_vector_x - n_g * inputs.grid_vector_y) >> 8;
+
+                // "ii) Draw the pattern HPATS[GI[n_g, m_g]] into HTREG such that its upper left pixel is at location (x, y) in HTREG.
+                //
+                //      A pattern is drawn into HTREG as follows. Each pixel of the pattern shall be combined with
+                //      the current value of the corresponding pixel in the halftone-coded bitmap, using the
+                //      combination operator specified by HCOMBOP. The results of each combination shall be
+                //      written into that pixel in the halftone-coded bitmap.
+                //
+                //      If any part of a decoded pattern, when placed at location (x, y) lies outside the actual halftone-
+                //      coded bitmap, then this part of the pattern shall be ignored in the process of combining the
+                //      pattern with the bitmap."
+                u8 grayscale_value = grayscale_image[n_g + m_g * inputs.grayscale_width];
+                if (grayscale_value >= inputs.patterns.size())
+                    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Grayscale value out of range");
+                auto const& pattern = inputs.patterns[grayscale_value];
+                composite_bitbuffer(*result, pattern->bitmap(), { x, y }, inputs.combination_operator);
+            }
+        }
+    }
+
+    // "6) After all the patterns have been placed on the bitmap, the current contents of the halftone-coded bitmap are
+    //     the results that shall be obtained by every decoder, whether it performs this exact sequence of steps or not."
+    return result;
 }
 
 // 6.7.2 Input parameters
@@ -2243,7 +2434,9 @@ static ErrorOr<void> decode_immediate_halftone_region(JBIG2LoadingContext& conte
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Halftone segment without patterns");
 
     // "3) As described in E.3.7, reset all the arithmetic coding statistics to zero."
-    // FIXME
+    Vector<JBIG2::ArithmeticDecoder::Context> contexts;
+    if (!uses_mmr)
+        contexts.resize(1 << number_of_context_bits_for_template(template_used));
 
     // "4) Invoke the halftone region decoding procedure described in 6.6, with the parameters to the halftone
     //     region decoding procedure set as shown in Table 36."
@@ -2265,7 +2458,7 @@ static ErrorOr<void> decode_immediate_halftone_region(JBIG2LoadingContext& conte
     inputs.patterns = move(patterns);
     inputs.pattern_width = inputs.patterns[0]->bitmap().width();
     inputs.pattern_height = inputs.patterns[0]->bitmap().height();
-    auto result = TRY(halftone_region_decoding_procedure(inputs, data));
+    auto result = TRY(halftone_region_decoding_procedure(inputs, data, contexts));
 
     composite_bitbuffer(*context.page.bits, *result, { information_field.x_location, information_field.y_location }, information_field.external_combination_operator());
 


### PR DESCRIPTION
A pattern dictionary stores n bitmaps with the same dimensions w x h.
They're stored in a single bitmap of width `n * w` that's then cut
into n stripes.

A halftone region stores a grayscale bitmap and a linear coordinate
system the grayscale bitmap is in.  The grayscale bitmap is overlaid
the halftone region using the coordinate system, and each sample in
the grayscale bitmap is used as an index into a pattern dictionary
and the bitmap at that index is drawn at the current location.
This allows for efficient compression of ordered dithering
(but not error-diffusion dithering).

This does not yet implement halftone region decoding for MMR bitmaps.

The halftone region decoding procedure is the only way to call the
generic region decoding procedure with a skip pattern. This does
include code to compute the skip pattern, but support for that
is not yet implemented in the generic region decoding procedure,
so it'll error out when encountered. (I haven't yet found a file
using this feature, not a way to create such a file yet.)

---

Pattern/halftone are the two big remaining segments from the original JBIG2 spec, so this is a good step towards complete JBIG2 support.

No test yet, since I haven't found a way to make one yet. Hopefully I'll make a test input later.

Part of the motivation is to implement all generic region decoding procedure inputs (see skip pattern remark above) before I try to optimize that.

For amb_1.jb2 from https://git.ghostscript.com/?p=tests.git;a=tree;f=jbig2;h=8a7abaf842435e204c1ff1dbeed10826bf24afe6;hb=refs/heads/master , this is the pattern dictionary (this is 16 4x4 bitmaps):

![pattern-0_skip_not pdf](https://github.com/SerenityOS/serenity/assets/3487/aa752af3-ed35-43f1-b9a8-4b857b878414)

This is the 4bpp grayscale image:

![image_skip_not pdf](https://github.com/SerenityOS/serenity/assets/3487/806e8fdb-a7dd-400c-bf23-2053814c6f37)

The halftone grid in that file is aligned with the page grid, resulting in this decoded image:

![image_skip_not pdf](https://github.com/SerenityOS/serenity/assets/3487/36e2694f-4ab0-4c7c-8172-f3b1c27c35bd)

While this is rarely used, it _is_ sometimes hit in practice. For https://fraser.stlouisfed.org/files/docs/publications/employment/1970s/1970-1974/empl_081971.pdf here's a before/after:

<img width="881" alt="empl_081971.pdf_p6_before" src="https://github.com/SerenityOS/serenity/assets/3487/a424d329-7620-4249-954c-2fbbc9bc5e1d">

<img width="881" alt="empl_081971.pdf_p6_after" src="https://github.com/SerenityOS/serenity/assets/3487/816f0225-a446-4148-9f8f-ada8983dfe3c">

<img width="881" alt="empl_081971.pdf_p10_before" src="https://github.com/SerenityOS/serenity/assets/3487/a8f32790-8d76-46a3-9871-c61ac99a46bb">

<img width="881" alt="empl_081971.pdf_p10_after" src="https://github.com/SerenityOS/serenity/assets/3487/8230b2f6-3384-4f69-8804-d1c6a2a8cef4">

