### PR TITLE
AK: Simplify and optimize ASCIICaseInsensitiveFlyStringTraits::equals

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -97,7 +97,7 @@ struct Formatter<FlyString> : Formatter<StringView> {
 
 struct ASCIICaseInsensitiveFlyStringTraits : public Traits<String> {
     static unsigned hash(FlyString const& s) { return s.ascii_case_insensitive_hash(); }
-    static bool equals(FlyString const& a, FlyString const& b) { return a.bytes().data() == b.bytes().data() || a.bytes_as_string_view().equals_ignoring_ascii_case(b.bytes_as_string_view()); }
+    static bool equals(FlyString const& a, FlyString const& b) { return a.equals_ignoring_ascii_case(b); }
 };
 
 }


### PR DESCRIPTION
The member function `equals_ignoring_ascii_case` has a fast path which will return early if it is the same FlyString instance.