### PR TITLE
LibWeb: Fix crash for calculated transition duration/delays

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAnimations/transitions/parse-transition-calc-duration-delay.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/transitions/parse-transition-calc-duration-delay.txt
@@ -1,0 +1,1 @@
+   PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/WebAnimations/transitions/parse-transition-calc-duration-delay.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/transitions/parse-transition-calc-duration-delay.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<style>
+    #foo {
+        transition:
+            color 0.6s cubic-bezier(0.19, 1, 0.22, 1),
+            background-size calc(0.3s) cubic-bezier(0.19, 1, 0.22, 1);
+    }
+</style>
+<div id="foo"></div>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        println("PASS! (Didn't crash)");
+        // FIXME: It would be good if this test case could verify the serialized CSS - but that isn't correct right now.
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5354,10 +5354,10 @@ RefPtr<StyleValue> Parser::parse_transition_value(TokenStream<ComponentValue>& t
             if (auto time = parse_time(tokens); time.has_value()) {
                 switch (time_value_count) {
                 case 0:
-                    transition.duration = time.release_value().value();
+                    transition.duration = time.release_value();
                     break;
                 case 1:
-                    transition.delay = time.release_value().value();
+                    transition.delay = time.release_value();
                     break;
                 default:
                     dbgln_if(CSS_PARSER_DEBUG, "Transition property has more than two time values");

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -696,8 +696,8 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
         Array<Vector<ValueComparingNonnullRefPtr<StyleValue const>>, 4> transition_values;
         for (auto const& transition : transitions) {
             transition_values[0].append(*transition.property_name);
-            transition_values[1].append(TimeStyleValue::create(transition.duration));
-            transition_values[2].append(TimeStyleValue::create(transition.delay));
+            transition_values[1].append(transition.duration.as_style_value());
+            transition_values[2].append(transition.delay.as_style_value());
             if (transition.easing)
                 transition_values[3].append(*transition.easing);
         }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/TransitionStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/TransitionStyleValue.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/CSS/CalculatedOr.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
@@ -17,8 +18,8 @@ class TransitionStyleValue final : public StyleValueWithDefaultOperators<Transit
 public:
     struct Transition {
         ValueComparingRefPtr<CustomIdentStyleValue> property_name;
-        CSS::Time duration { CSS::Time::make_seconds(0.0) };
-        CSS::Time delay { CSS::Time::make_seconds(0.0) };
+        TimeOrCalculated duration { CSS::Time::make_seconds(0.0) };
+        TimeOrCalculated delay { CSS::Time::make_seconds(0.0) };
         ValueComparingRefPtr<EasingStyleValue> easing;
 
         bool operator==(Transition const&) const = default;


### PR DESCRIPTION
As the parser was trying to directly unwrap an unresolved duration. Currently we are outputting the wrong results for the serialized duration, but this is still a step forwards.

Fixes a crash seen on: https://evaparish.com/blog/how-i-edit