### PR TITLE
LibUnicode: Optimize the canonical composition algorithm implementation

### DIFF
--- a/Userland/Libraries/LibUnicode/Normalize.h
+++ b/Userland/Libraries/LibUnicode/Normalize.h
@@ -17,7 +17,7 @@
 namespace Unicode {
 
 Optional<CodePointDecomposition const> code_point_decomposition(u32 code_point);
-Optional<CodePointDecomposition const> code_point_decomposition_by_index(size_t index);
+Optional<u32> code_point_composition(u32 first_code_point, u32 second_code_point);
 
 enum class NormalizationForm {
     NFD,


### PR DESCRIPTION
These 2 changes bring the runtime of Tim's test case from 70 seconds to 80 milliseconds on my machine.
Resolves #23863.