### PR TITLE
LibWeb: Implement ReadableStream.pipeTo()

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo-cannot-pipe-locked-stream.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo-cannot-pipe-locked-stream.txt
@@ -1,0 +1,1 @@
+TypeError: Failed to execute 'pipeTo' on 'ReadableStream': Cannot pipe a locked stream

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo-cannot-pipe-to-locked-stream.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo-cannot-pipe-to-locked-stream.txt
@@ -1,0 +1,1 @@
+TypeError: Failed to execute 'pipeTo' on 'ReadableStream':  Cannot pipe to a locked stream

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo.txt
@@ -1,0 +1,3 @@
+abcdefghijklmnopqrstuvwxyz
+ABCDEFGHIJKLMNOPQRSTUVWXYZ
+0123456789!@#$%^&*()-=_+,<

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo-cannot-pipe-locked-stream.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo-cannot-pipe-locked-stream.html
@@ -1,0 +1,22 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const writableStream = new WritableStream(
+            {
+                write(chunk) {}
+            }
+        );
+        const stream = new ReadableStream({
+            start(controller) {},
+            pull(controller) {},
+            cancel() {},
+        });
+
+        stream.getReader();
+        stream.pipeTo(writableStream)
+            .catch(reason => {
+                println(reason);
+                done();
+            });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo-cannot-pipe-to-locked-stream.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo-cannot-pipe-to-locked-stream.html
@@ -1,0 +1,22 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const writableStream = new WritableStream(
+            {
+                write(chunk) {}
+            }
+        );
+        const stream = new ReadableStream({
+            start(controller) {},
+            pull(controller) {},
+            cancel() {},
+        });
+
+        writableStream.getWriter();
+        stream.pipeTo(writableStream)
+            .catch(reason => {
+                println(reason);
+                done();
+            });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo.html
@@ -1,0 +1,47 @@
+<script src="../include.js"></script>
+<script>
+    const CHUNK1 =  "abcdefghijklmnopqrstuvwxyz";
+    const CHUNK2 =  "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const CHUNK3 =  "0123456789!@#$%^&*()-=_+,<";
+
+    asyncTest(done => {
+        const writableStream = new WritableStream(
+            {
+                write(chunk) {
+                    return new Promise((resolve) => {
+                        const textDecoder = new TextDecoder("utf-8");
+                        println(textDecoder.decode(new Uint8Array(chunk)));
+                        resolve();
+                    });
+                }
+            }
+        );
+        const stream = new ReadableStream({
+            start(controller) {
+                pullCount = 0;
+            },
+
+            pull(controller) {
+                const textEncoder = new TextEncoder();
+
+                ++pullCount;
+
+                if (pullCount == 1) {
+                    controller.enqueue(textEncoder.encode(CHUNK1));
+                } else if (pullCount == 2) {
+                     controller.enqueue(textEncoder.encode(CHUNK2));
+                } else if (pullCount == 3) {
+                     controller.enqueue(textEncoder.encode(CHUNK3));
+                } else {
+                    controller.close();
+                }
+            },
+
+            cancel() {},
+        });
+
+        stream.pipeTo(writableStream).then(() => {
+            done();
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
  * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
- * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2023-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -46,6 +46,8 @@ size_t readable_stream_get_num_read_into_requests(ReadableStream const&);
 size_t readable_stream_get_num_read_requests(ReadableStream const&);
 bool readable_stream_has_byob_reader(ReadableStream const&);
 bool readable_stream_has_default_reader(ReadableStream const&);
+
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> readable_stream_pipe_to(ReadableStream& source, WritableStream& dest, bool prevent_close, bool prevent_abort, bool prevent_cancel, Optional<JS::Value> signal);
 
 WebIDL::ExceptionOr<ReadableStreamPair> readable_stream_tee(JS::Realm&, ReadableStream&, bool clone_for_branch2);
 WebIDL::ExceptionOr<ReadableStreamPair> readable_stream_default_tee(JS::Realm& realm, ReadableStream& stream, bool clone_for_branch2);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +25,13 @@ using ReadableStreamController = Variant<JS::NonnullGCPtr<ReadableStreamDefaultC
 // https://streams.spec.whatwg.org/#dictdef-readablestreamgetreaderoptions
 struct ReadableStreamGetReaderOptions {
     Optional<Bindings::ReadableStreamReaderMode> mode;
+};
+
+struct StreamPipeOptions {
+    bool prevent_close { false };
+    bool prevent_abort { false };
+    bool prevent_cancel { false };
+    Optional<JS::NonnullGCPtr<DOM::AbortSignal>> signal;
 };
 
 struct ReadableStreamPair {
@@ -62,6 +70,7 @@ public:
     bool locked() const;
     WebIDL::ExceptionOr<JS::GCPtr<JS::Object>> cancel(JS::Value reason);
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader(ReadableStreamGetReaderOptions const& = {});
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> pipe_to(WritableStream& destination, StreamPipeOptions const& = {});
     WebIDL::ExceptionOr<ReadableStreamPair> tee();
 
     Optional<ReadableStreamController>& controller() { return m_controller; }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.idl
@@ -1,6 +1,15 @@
+#import <DOM/AbortSignal.idl>
 #import <Streams/QueuingStrategy.idl>
 #import <Streams/ReadableStreamBYOBReader.idl>
 #import <Streams/ReadableStreamDefaultReader.idl>
+#import <Streams/WritableStream.idl>
+
+dictionary StreamPipeOptions {
+    boolean preventClose = false;
+    boolean preventAbort = false;
+    boolean preventCancel = false;
+    AbortSignal signal;
+};
 
 // https://streams.spec.whatwg.org/#enumdef-readablestreamreadermode
 enum ReadableStreamReaderMode { "byob" };
@@ -22,7 +31,7 @@ interface ReadableStream {
     Promise<undefined> cancel(optional any reason);
     ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
     // FIXME: ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
-    // FIXME: Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
+    Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
     sequence<ReadableStream> tee();
 
     // FIXME: async iterable<any>(optional ReadableStreamIteratorOptions options = {});

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -36,7 +36,7 @@ class ReadLoopReadRequest final : public ReadRequest {
 
 public:
     // successSteps, which is an algorithm accepting a byte sequence
-    using SuccessSteps = JS::SafeFunction<void(ByteBuffer)>;
+    using SuccessSteps = JS::SafeFunction<void(Vector<ByteBuffer> const&)>;
 
     // failureSteps, which is an algorithm accepting a JavaScript value
     using FailureSteps = JS::SafeFunction<void(JS::Value error)>;
@@ -55,7 +55,7 @@ private:
     JS::VM& m_vm;
     JS::NonnullGCPtr<JS::Realm> m_realm;
     JS::NonnullGCPtr<ReadableStreamDefaultReader> m_reader;
-    ByteBuffer m_bytes;
+    Vector<ByteBuffer> m_byte_chunks;
     SuccessSteps m_success_steps;
     FailureSteps m_failure_steps;
 };


### PR DESCRIPTION
Currently the implementation of AO `readable_stream_pipe_to()` is quite naive compared to the guidelines in the spec and will a need a few iterations before it's up to par with the spec.

Also worth a note, to be able to write the chunks to `WritableableStream` in the same order they are read from `ReadableStream`, the `ByteBuffer` in `ReadLoopReadRequest` is now a `Vector<ByteBuffer>`. With that change we reflect the behavior of other browsers.