### PR TITLE
IPCCompiler: Improve parsing of parameter types

### DIFF
--- a/Userland/Services/Clipboard/ClipboardServer.ipc
+++ b/Userland/Services/Clipboard/ClipboardServer.ipc
@@ -2,6 +2,6 @@
 
 endpoint ClipboardServer
 {
-    get_clipboard_data() => (Core::AnonymousBuffer data, [UTF8] ByteString mime_type, HashMap<ByteString,ByteString> metadata)
-    set_clipboard_data(Core::AnonymousBuffer data, [UTF8] ByteString mime_type, HashMap<ByteString,ByteString> metadata) =|
+    get_clipboard_data() => (Core::AnonymousBuffer data, [UTF8] ByteString mime_type, HashMap<ByteString, ByteString> metadata)
+    set_clipboard_data(Core::AnonymousBuffer data, [UTF8] ByteString mime_type, HashMap<ByteString, ByteString> metadata) =|
 }

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -5,7 +5,7 @@ endpoint RequestClient
     request_started(i32 request_id, IPC::File fd) =|
     request_progress(i32 request_id, Optional<u64> total_size, u64 downloaded_size) =|
     request_finished(i32 request_id, bool success, u64 total_size) =|
-    headers_became_available(i32 request_id, HashMap<ByteString,ByteString,CaseInsensitiveStringTraits> response_headers, Optional<u32> status_code) =|
+    headers_became_available(i32 request_id, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> response_headers, Optional<u32> status_code) =|
 
     // Websocket API
     // FIXME: See if this can be merged with the regular APIs

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -6,14 +6,14 @@ endpoint RequestServer
     // Test if a specific protocol is supported, e.g "http"
     is_supported_protocol(ByteString protocol) => (bool supported)
 
-    start_request(i32 request_id, ByteString method, URL::URL url, HashMap<ByteString,ByteString> request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) =|
+    start_request(i32 request_id, ByteString method, URL::URL url, HashMap<ByteString, ByteString> request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) =|
     stop_request(i32 request_id) => (bool success)
     set_certificate(i32 request_id, ByteString certificate, ByteString key) => (bool success)
 
     ensure_connection(URL::URL url, ::RequestServer::CacheLevel cache_level) =|
 
     // Websocket Connection API
-    websocket_connect(URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, HashMap<ByteString,ByteString> additional_request_headers) => (i32 connection_id)
+    websocket_connect(URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, HashMap<ByteString, ByteString> additional_request_headers) => (i32 connection_id)
     websocket_ready_state(i32 connection_id) => (u32 ready_state)
     websocket_subprotocol_in_use(i32 connection_id) => (ByteString subprotocol_in_use)
     websocket_send(i32 connection_id, bool is_text, ByteBuffer data) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -70,7 +70,7 @@ endpoint WebContentServer
     set_content_filters(u64 page_id, Vector<String> filters) =|
     set_autoplay_allowed_on_all_websites(u64 page_id) =|
     set_autoplay_allowlist(u64 page_id, Vector<String> allowlist) =|
-    set_proxy_mappings(u64 page_id, Vector<ByteString> proxies, HashMap<ByteString,size_t> mappings) =|
+    set_proxy_mappings(u64 page_id, Vector<ByteString> proxies, HashMap<ByteString, size_t> mappings) =|
     set_preferred_color_scheme(u64 page_id, Web::CSS::PreferredColorScheme color_scheme) =|
     set_has_focus(u64 page_id, bool has_focus) =|
     set_is_scripting_enabled(u64 page_id, bool is_scripting_enabled) =|
@@ -79,8 +79,8 @@ endpoint WebContentServer
     set_window_position(u64 page_id, Web::DevicePixelPoint position) =|
     set_window_size(u64 page_id, Web::DevicePixelSize size) =|
 
-    get_local_storage_entries(u64 page_id) => (OrderedHashMap<String,String> entries)
-    get_session_storage_entries(u64 page_id) => (OrderedHashMap<String,String> entries)
+    get_local_storage_entries(u64 page_id) => (OrderedHashMap<String, String> entries)
+    get_session_storage_entries(u64 page_id) => (OrderedHashMap<String, String> entries)
 
     handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) =|
 

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -36,7 +36,7 @@ endpoint WindowClient
     drag_accepted() =|
     drag_cancelled() =|
 
-    drag_dropped(i32 window_id, Gfx::IntPoint mouse_position, [UTF8] ByteString text, HashMap<String,ByteBuffer> mime_data) =|
+    drag_dropped(i32 window_id, Gfx::IntPoint mouse_position, [UTF8] ByteString text, HashMap<String, ByteBuffer> mime_data) =|
 
     update_system_theme(Core::AnonymousBuffer theme_buffer) =|
     update_system_fonts(ByteString default_font_query, ByteString fixed_width_font_query, ByteString window_title_font_query) =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -130,7 +130,7 @@ endpoint WindowServer
     set_window_cursor(i32 window_id, i32 cursor_type) =|
     set_window_custom_cursor(i32 window_id, Gfx::ShareableBitmap cursor) =|
 
-    start_drag([UTF8] ByteString text, HashMap<String,ByteBuffer> mime_data, Gfx::ShareableBitmap drag_bitmap) => (bool started)
+    start_drag([UTF8] ByteString text, HashMap<String, ByteBuffer> mime_data, Gfx::ShareableBitmap drag_bitmap) => (bool started)
     set_accepts_drag(bool accepts) =|
 
     set_system_theme(ByteString theme_path, [UTF8] ByteString theme_name, bool keep_desktop_background, Optional<ByteString> color_scheme_path) => (bool success)


### PR DESCRIPTION
This PR includes a couple of changes to `IPCCompiler` that improve parameter type parsing:

* Parameter types can now contain spaces (like `HashMap<String, String>`, for example).
* An error is now shown if a parameter is given without a name.

Fixes #23744