### PR TITLE
LibJSGCVerifier: Warn on missing visit of JS::Value members

### DIFF
--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -160,6 +160,10 @@ FieldValidationResult validate_field(clang::FieldDecl const* field_decl)
             result.is_wrapped_in_gcptr = true;
             result.is_valid = record_inherits_from_cell(*record_decl);
             result.needs_visiting = template_type_name != "RawGCPtr";
+        } else if (auto const* record = qualified_type->getAsCXXRecordDecl()) {
+            if (record->getQualifiedNameAsString() == "JS::Value") {
+                result.needs_visiting = true;
+            }
         }
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Map.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Map.cpp
@@ -86,6 +86,8 @@ void Map::visit_edges(Cell::Visitor& visitor)
         visitor.visit(value.key);
         visitor.visit(value.value);
     }
+    // NOTE: The entries in m_keys are already visited by the walk over m_entries above.
+    visitor.ignore(m_keys);
 }
 
 }

--- a/Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
+++ b/Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
@@ -35,6 +35,7 @@ void ConsoleGlobalEnvironmentExtensions::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_window_object);
+    visitor.visit(m_most_recent_result);
 }
 
 static JS::ThrowCompletionOr<ConsoleGlobalEnvironmentExtensions*> get_console(JS::VM& vm)


### PR DESCRIPTION
A JS::Value can refer to a GC-allocated object, so let's ensure they are visited when necessary.

Also fix two issues found by adding this check.