### PR TITLE
LibWeb: Implement ReadableStream.pipeThrough()

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeThrough-cannot-pipe-locked-stream.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeThrough-cannot-pipe-locked-stream.txt
@@ -1,0 +1,1 @@
+TypeError: Failed to execute 'pipeThrough' on 'ReadableStream': Cannot pipe a locked stream

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeThrough-cannot-pipe-to-locked-stream.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeThrough-cannot-pipe-to-locked-stream.txt
@@ -1,0 +1,1 @@
+TypeError: Failed to execute 'pipeThrough' on 'ReadableStream': parameter 1's 'writable' is locked

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeThrough.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeThrough.txt
@@ -1,0 +1,3 @@
+WELL,
+HELLO
+FRIENDS!

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-locked-stream.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-locked-stream.html
@@ -1,0 +1,17 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const transformStream = new TransformStream();
+
+        const stream = new ReadableStream();
+
+        stream.getReader();
+        try {
+            stream.pipeThrough(transformStream);
+        }
+        catch (e) {
+            println(e);
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-to-locked-stream.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-to-locked-stream.html
@@ -1,0 +1,17 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const transformStream = new TransformStream();
+
+        const stream = new ReadableStream();
+
+        transformStream.writable.getWriter();
+        try {
+            stream.pipeThrough(transformStream);
+        }
+        catch (e) {
+            println(e);
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough.html
@@ -1,0 +1,57 @@
+<script src="../include.js"></script>
+<script>
+    const CHUNK1 =  "well,";
+    const CHUNK2 =  "hello";
+    const CHUNK3 =  "friends!";
+
+    asyncTest((done) => {
+        const transformStream = new TransformStream({
+            transform(chunk, controller) {
+                controller.enqueue(
+                    new TextDecoder("utf-8")
+                        .decode(chunk)
+                        .toUpperCase()
+                );
+            }
+        });
+
+        const stream = new ReadableStream({
+            start(controller) {
+                pullCount = 0;
+            },
+
+            pull(controller) {
+                const textEncoder = new TextEncoder();
+
+                ++pullCount;
+
+                if (pullCount == 1) {
+                    controller.enqueue(textEncoder.encode(CHUNK1));
+                } else if (pullCount == 2) {
+                    controller.enqueue(textEncoder.encode(CHUNK2));
+                } else if (pullCount == 3) {
+                    controller.enqueue(textEncoder.encode(CHUNK3));
+                } else {
+                    controller.close();
+                }
+            },
+
+            cancel() {},
+        });
+
+
+        const reader = transformStream.readable.getReader();
+        reader.read().then(function processText({done, value}) {
+            if (done)
+                return;
+
+            println(value);
+            reader.read().then(processText);
+        }).then(() => {
+            done();
+        });
+
+        stream.pipeThrough(transformStream);
+
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -27,6 +27,11 @@ struct ReadableStreamGetReaderOptions {
     Optional<Bindings::ReadableStreamReaderMode> mode;
 };
 
+struct ReadableWritablePair {
+    JS::GCPtr<ReadableStream> readable;
+    JS::GCPtr<WritableStream> writable;
+};
+
 struct StreamPipeOptions {
     bool prevent_close { false };
     bool prevent_abort { false };
@@ -70,6 +75,7 @@ public:
     bool locked() const;
     WebIDL::ExceptionOr<JS::GCPtr<JS::Object>> cancel(JS::Value reason);
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader(ReadableStreamGetReaderOptions const& = {});
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> pipe_through(ReadableWritablePair transform, StreamPipeOptions const& = {});
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> pipe_to(WritableStream& destination, StreamPipeOptions const& = {});
     WebIDL::ExceptionOr<ReadableStreamPair> tee();
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.idl
@@ -4,6 +4,11 @@
 #import <Streams/ReadableStreamDefaultReader.idl>
 #import <Streams/WritableStream.idl>
 
+dictionary ReadableWritablePair {
+  required ReadableStream readable;
+  required WritableStream writable;
+};
+
 dictionary StreamPipeOptions {
     boolean preventClose = false;
     boolean preventAbort = false;
@@ -30,7 +35,7 @@ interface ReadableStream {
 
     Promise<undefined> cancel(optional any reason);
     ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
-    // FIXME: ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
+    ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
     Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
     sequence<ReadableStream> tee();
 


### PR DESCRIPTION
This implements `ReadableStream.pipeThrough()` and adds test to prove we can successfully pipe through a transform stream.