### PR TITLE
HexEditor: Make offsets column configurable to be hex, decimal, or hidden entirely

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -421,6 +421,60 @@ void HexEditor::scroll_position_into_view(size_t position)
     scroll_into_view(rect, true, true);
 }
 
+size_t HexEditor::total_rows() const
+{
+    return ceil_div(m_content_length, bytes_per_row());
+}
+
+size_t HexEditor::line_height() const
+{
+    return font().pixel_size_rounded_up() + m_line_spacing;
+}
+
+size_t HexEditor::character_width() const
+{
+    return font().glyph_fixed_width();
+}
+
+size_t HexEditor::cell_gap() const
+{
+    return character_width() / 2;
+}
+
+size_t HexEditor::cell_width() const
+{
+    return character_width() * 2 + cell_gap();
+}
+
+size_t HexEditor::group_gap() const
+{
+    return character_width() * 1.5;
+}
+
+size_t HexEditor::group_width() const
+{
+    return (character_width() * 2 * bytes_per_group())
+        + (cell_gap() * (bytes_per_group() - 1))
+        + group_gap();
+}
+
+int HexEditor::offset_area_width() const
+{
+    return m_padding + font().width_rounded_up("0X12345678"sv) + m_padding;
+}
+
+int HexEditor::hex_area_width() const
+{
+    return m_padding
+        + groups_per_row() * group_width() - group_gap()
+        + m_padding;
+}
+
+int HexEditor::text_area_width() const
+{
+    return m_padding + bytes_per_row() * character_width() + m_padding;
+}
+
 void HexEditor::keydown_event(GUI::KeyEvent& event)
 {
     dbgln_if(HEX_DEBUG, "Editor::keydown_event key={}", static_cast<u8>(event.key()));

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -113,27 +113,16 @@ private:
 
     void scroll_position_into_view(size_t position);
 
-    size_t total_rows() const { return ceil_div(m_content_length, bytes_per_row()); }
-    size_t line_height() const { return font().pixel_size_rounded_up() + m_line_spacing; }
-    size_t character_width() const { return font().glyph_fixed_width(); }
-    size_t cell_gap() const { return character_width() / 2; }
-    size_t cell_width() const { return character_width() * 2 + cell_gap(); }
-    size_t group_gap() const { return character_width() * 1.5; }
-    size_t group_width() const
-    {
-        return (character_width() * 2 * bytes_per_group())
-            + (cell_gap() * (bytes_per_group() - 1))
-            + group_gap();
-    }
-
-    int offset_area_width() const { return m_padding + font().width_rounded_up("0X12345678"sv) + m_padding; }
-    int hex_area_width() const
-    {
-        return m_padding
-            + groups_per_row() * group_width() - group_gap()
-            + m_padding;
-    }
-    int text_area_width() const { return m_padding + bytes_per_row() * character_width() + m_padding; }
+    size_t total_rows() const;
+    size_t line_height() const;
+    size_t character_width() const;
+    size_t cell_gap() const;
+    size_t cell_width() const;
+    size_t group_gap() const;
+    size_t group_width() const;
+    int offset_area_width() const;
+    int hex_area_width() const;
+    int text_area_width() const;
 
     struct OffsetData {
         size_t offset;

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -55,6 +55,8 @@ public:
     bool copy_selected_hex_to_clipboard();
     bool copy_selected_hex_to_clipboard_as_c_code();
 
+    void set_show_offsets_column(bool);
+
     size_t bytes_per_group() const { return m_bytes_per_group; }
     void set_bytes_per_group(size_t);
     size_t groups_per_row() const { return m_groups_per_row; }
@@ -95,6 +97,7 @@ private:
     size_t m_content_length { 0 };
     size_t m_bytes_per_group { 4 };
     size_t m_groups_per_row { 4 };
+    bool m_show_offsets_column { true };
     bool m_in_drag_select { false };
     Selection m_selection;
     size_t m_position { 0 };

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -32,6 +32,12 @@ public:
         Text
     };
 
+    enum class OffsetFormat {
+        Decimal,
+        Hexadecimal,
+    };
+    static OffsetFormat offset_format_from_string(StringView);
+
     virtual ~HexEditor() override = default;
 
     size_t buffer_size() const { return m_document->size(); }
@@ -56,6 +62,7 @@ public:
     bool copy_selected_hex_to_clipboard_as_c_code();
 
     void set_show_offsets_column(bool);
+    void set_offset_format(OffsetFormat);
 
     size_t bytes_per_group() const { return m_bytes_per_group; }
     void set_bytes_per_group(size_t);
@@ -98,6 +105,7 @@ private:
     size_t m_bytes_per_group { 4 };
     size_t m_groups_per_row { 4 };
     bool m_show_offsets_column { true };
+    OffsetFormat m_offset_format { OffsetFormat::Hexadecimal };
     bool m_in_drag_select { false };
     Selection m_selection;
     size_t m_position { 0 };

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -326,6 +326,11 @@ ErrorOr<void> HexEditorWidget::setup()
         Config::write_bool("HexEditor"sv, "Layout"sv, "ShowSearchResults"sv, action.is_checked());
     });
 
+    m_show_offsets_column_action = GUI::Action::create_checkable("Show &Offsets Column", [&](auto& action) {
+        m_editor->set_show_offsets_column(action.is_checked());
+        Config::write_bool("HexEditor"sv, "Layout"sv, "ShowOffsetsColumn"sv, action.is_checked());
+    });
+
     m_copy_hex_action = GUI::Action::create("Copy &Hex", { Mod_Ctrl, Key_C }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/hex.png"sv)), [&](const GUI::Action&) {
         m_editor->copy_selected_hex_to_clipboard();
     });
@@ -623,6 +628,12 @@ ErrorOr<void> HexEditorWidget::initialize_menubar(GUI::Window& window)
     view_menu->add_action(*m_layout_annotations_action);
     view_menu->add_action(*m_layout_search_results_action);
     view_menu->add_action(*m_layout_value_inspector_action);
+    view_menu->add_separator();
+
+    auto show_offsets_column = Config::read_bool("HexEditor"sv, "Layout"sv, "ShowOffsetsColumn"sv, true);
+    m_show_offsets_column_action->set_checked(show_offsets_column);
+    m_editor->set_show_offsets_column(show_offsets_column);
+    view_menu->add_action(*m_show_offsets_column_action);
     view_menu->add_separator();
 
     auto bytes_per_row = Config::read_i32("HexEditor"sv, "Layout"sv, "BytesPerRow"sv, 16);

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -634,6 +634,31 @@ ErrorOr<void> HexEditorWidget::initialize_menubar(GUI::Window& window)
     m_show_offsets_column_action->set_checked(show_offsets_column);
     m_editor->set_show_offsets_column(show_offsets_column);
     view_menu->add_action(*m_show_offsets_column_action);
+
+    auto offset_format = HexEditor::offset_format_from_string(Config::read_string("HexEditor"sv, "Layout"sv, "OffsetFormat"sv));
+    m_editor->set_offset_format(offset_format);
+    m_offset_format_actions.set_exclusive(true);
+    auto offset_format_menu = view_menu->add_submenu("Offset Format"_string);
+    auto offset_format_decimal_action = GUI::Action::create_checkable("&Decimal", [this](auto&) {
+        m_editor->set_offset_format(HexEditor::OffsetFormat::Decimal);
+        Config::write_string("HexEditor"sv, "Layout"sv, "OffsetFormat"sv, "decimal"sv);
+    });
+    auto offset_format_hexadecimal_action = GUI::Action::create_checkable("&Hexadecimal", [this](auto&) {
+        m_editor->set_offset_format(HexEditor::OffsetFormat::Hexadecimal);
+        Config::write_string("HexEditor"sv, "Layout"sv, "OffsetFormat"sv, "hexadecimal"sv);
+    });
+    switch (offset_format) {
+    case HexEditor::OffsetFormat::Decimal:
+        offset_format_decimal_action->set_checked(true);
+        break;
+    case HexEditor::OffsetFormat::Hexadecimal:
+        offset_format_hexadecimal_action->set_checked(true);
+        break;
+    }
+    m_offset_format_actions.add_action(offset_format_decimal_action);
+    m_offset_format_actions.add_action(offset_format_hexadecimal_action);
+    offset_format_menu->add_action(offset_format_decimal_action);
+    offset_format_menu->add_action(offset_format_hexadecimal_action);
     view_menu->add_separator();
 
     auto bytes_per_row = Config::read_i32("HexEditor"sv, "Layout"sv, "BytesPerRow"sv, 16);

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -87,6 +87,8 @@ private:
     RefPtr<GUI::Action> m_copy_as_c_code_action;
     RefPtr<GUI::Action> m_fill_selection_action;
 
+    RefPtr<GUI::Action> m_show_offsets_column_action;
+
     GUI::ActionGroup m_bytes_per_row_actions;
     GUI::ActionGroup m_value_inspector_mode_actions;
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -88,6 +88,7 @@ private:
     RefPtr<GUI::Action> m_fill_selection_action;
 
     RefPtr<GUI::Action> m_show_offsets_column_action;
+    GUI::ActionGroup m_offset_format_actions;
 
     GUI::ActionGroup m_bytes_per_row_actions;
     GUI::ActionGroup m_value_inspector_mode_actions;


### PR DESCRIPTION
Adds two options to the View menu:

![image](https://github.com/SerenityOS/serenity/assets/222642/1ac07132-e846-47d6-9455-0a1724fbdcbc)

- "Show Offsets Column" lets you hide the byte offset shown to the left of each row of data.
- "Offset Format" lets you pick between showing those values in decimal (which is new) or hexadecimal.