### PR TITLE
LibJSGCVerifier: Detect missing calls to JS_{DECLARE,DEFINE}_ALLOCATOR()

### DIFF
--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -14,6 +14,7 @@
 #include <clang/Frontend/CompilerInstance.h>
 #include <filesystem>
 #include <llvm/Support/Casting.h>
+#include <llvm/Support/JSON.h>
 #include <llvm/Support/raw_ostream.h>
 #include <unordered_set>
 #include <vector>
@@ -152,6 +153,33 @@ FieldValidationResult validate_field(clang::FieldDecl const* field_decl)
     return result;
 }
 
+void emit_record_json_data(clang::CXXRecordDecl const& record)
+{
+    llvm::json::Object obj;
+    obj.insert({ "name", record.getQualifiedNameAsString() });
+
+    std::vector<std::string> bases;
+    record.forallBases([&](clang::CXXRecordDecl const* base) {
+        bases.push_back(base->getQualifiedNameAsString());
+        return true;
+    });
+    obj.insert({ "parents", bases });
+
+    bool has_cell_allocator = false;
+    bool has_js_constructor = false;
+    for (auto const& decl : record.decls()) {
+        if (auto* var_decl = llvm::dyn_cast<clang::VarDecl>(decl); var_decl && var_decl->getQualifiedNameAsString().ends_with("::cell_allocator")) {
+            has_cell_allocator = true;
+        } else if (auto* fn_decl = llvm::dyn_cast<clang::CXXMethodDecl>(decl); fn_decl && fn_decl->getQualifiedNameAsString().ends_with("::construct_impl")) {
+            has_js_constructor = true;
+        }
+    }
+    obj.insert({ "has_cell_allocator", has_cell_allocator });
+    obj.insert({ "has_js_constructor", has_js_constructor });
+
+    llvm::outs() << std::move(obj) << "\n";
+}
+
 void CollectCellsHandler::run(clang::ast_matchers::MatchFinder::MatchResult const& result)
 {
     using namespace clang::ast_matchers;
@@ -193,6 +221,8 @@ void CollectCellsHandler::run(clang::ast_matchers::MatchFinder::MatchResult cons
 
     if (!record_inherits_from_cell(*record))
         return;
+
+    emit_record_json_data(*record);
 
     clang::DeclarationName const name = &result.Context->Idents.get("visit_edges");
     auto const* visit_edges_method = record->lookup(name).find_first<clang::CXXMethodDecl>();

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -224,6 +224,20 @@ void CollectCellsHandler::run(clang::ast_matchers::MatchFinder::MatchResult cons
 
     emit_record_json_data(*record);
 
+    bool has_base = false;
+    for (auto const& decl : record->decls()) {
+        if (auto* alias_decl = llvm::dyn_cast<clang::TypeAliasDecl>(decl); alias_decl && alias_decl->getQualifiedNameAsString().ends_with("::Base")) {
+            has_base = true;
+            break;
+        }
+    }
+
+    if (!has_base) {
+        auto diag_id = diag_engine.getCustomDiagID(clang::DiagnosticsEngine::Warning, "JS::Cell-inheriting class %0 is missing a JS_CELL() call in its header file");
+        auto builder = diag_engine.Report(record->getLocation(), diag_id);
+        builder << record->getName();
+    }
+
     clang::DeclarationName const name = &result.Context->Idents.get("visit_edges");
     auto const* visit_edges_method = record->lookup(name).find_first<clang::CXXMethodDecl>();
     if (!visit_edges_method && !fields_that_need_visiting.empty()) {

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -50,20 +50,6 @@ CollectCellsHandler::CollectCellsHandler()
         this);
 }
 
-bool CollectCellsHandler::handleBeginSource(clang::CompilerInstance& ci)
-{
-    auto const& source_manager = ci.getSourceManager();
-    auto file_id = source_manager.getMainFileID();
-    auto const* file_entry = source_manager.getFileEntryForID(file_id);
-    if (!file_entry)
-        return false;
-
-    auto current_filepath = std::filesystem::canonical(file_entry->getName().str());
-    llvm::outs() << "Processing " << current_filepath.string() << "\n";
-
-    return true;
-}
-
 bool record_inherits_from_cell(clang::CXXRecordDecl const& record)
 {
     if (!record.isCompleteDefinition())

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.h
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.h
@@ -18,8 +18,6 @@ public:
     CollectCellsHandler();
     virtual ~CollectCellsHandler() override = default;
 
-    virtual bool handleBeginSource(clang::CompilerInstance&) override;
-
     virtual void run(clang::ast_matchers::MatchFinder::MatchResult const& result) override;
 
     clang::ast_matchers::MatchFinder& finder() { return m_finder; }

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -16,6 +16,9 @@
 
 namespace Spreadsheet {
 
+JS_DEFINE_ALLOCATOR(SheetGlobalObject);
+JS_DEFINE_ALLOCATOR(WorkbookObject);
+
 Optional<FunctionAndArgumentIndex> get_function_and_argument_index(StringView source)
 {
     JS::Lexer lexer { source };

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -21,6 +21,7 @@ Optional<FunctionAndArgumentIndex> get_function_and_argument_index(StringView so
 
 class SheetGlobalObject final : public JS::GlobalObject {
     JS_OBJECT(SheetGlobalObject, JS::GlobalObject);
+    JS_DECLARE_ALLOCATOR(SheetGlobalObject);
 
 public:
     SheetGlobalObject(JS::Realm&, Sheet&);
@@ -47,6 +48,7 @@ private:
 
 class WorkbookObject final : public JS::Object {
     JS_OBJECT(WorkbookObject, JS::Object);
+    JS_DECLARE_ALLOCATOR(WorkbookObject);
 
 public:
     WorkbookObject(JS::Realm&, Workbook&);

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -14,10 +14,10 @@
 #include <LibJS/Heap/HeapBlock.h>
 
 #define JS_DECLARE_ALLOCATOR(ClassName) \
-    static JS::TypeIsolatingCellAllocator<ClassName> cell_allocator;
+    static JS::TypeIsolatingCellAllocator<ClassName> cell_allocator
 
 #define JS_DEFINE_ALLOCATOR(ClassName) \
-    JS::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator { #ClassName };
+    JS::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator { #ClassName }
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Module.cpp
+++ b/Userland/Libraries/LibJS/Module.cpp
@@ -16,6 +16,7 @@
 namespace JS {
 
 JS_DEFINE_ALLOCATOR(Module);
+JS_DEFINE_ALLOCATOR(GraphLoadingState);
 
 Module::Module(Realm& realm, ByteString filename, Script::HostDefined* host_defined)
     : m_realm(realm)

--- a/Userland/Libraries/LibJS/Module.h
+++ b/Userland/Libraries/LibJS/Module.h
@@ -59,6 +59,7 @@ struct ResolvedBinding {
 // https://tc39.es/ecma262/#graphloadingstate-record
 struct GraphLoadingState : public Cell {
     JS_CELL(GraphLoadingState, Cell);
+    JS_DECLARE_ALLOCATOR(GraphLoadingState);
 
 public:
     struct HostDefined : Cell {

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -125,6 +125,8 @@ JS_DEFINE_NATIVE_FUNCTION(ErrorPrototype::stack_setter)
 }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)               \
+    JS_DEFINE_ALLOCATOR(PrototypeName);                                                                \
+                                                                                                       \
     PrototypeName::PrototypeName(Realm& realm)                                                         \
         : PrototypeObject(realm.intrinsics().error_prototype())                                        \
     {                                                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
@@ -31,6 +31,7 @@ private:
 #define DECLARE_NATIVE_ERROR_PROTOTYPE(ClassName, snake_name, PrototypeName, ConstructorName) \
     class PrototypeName final : public PrototypeObject<PrototypeName, ClassName> {            \
         JS_PROTOTYPE_OBJECT(PrototypeName, ClassName, ClassName);                             \
+        JS_DECLARE_ALLOCATOR(PrototypeName);                                                  \
                                                                                               \
     public:                                                                                   \
         virtual void initialize(Realm&) override;                                             \

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -17,6 +17,7 @@ JS_DEFINE_ALLOCATOR(RemainingElements);
 JS_DEFINE_ALLOCATOR(PromiseValueList);
 JS_DEFINE_ALLOCATOR(PromiseResolvingElementFunction);
 JS_DEFINE_ALLOCATOR(PromiseAllResolveElementFunction);
+JS_DEFINE_ALLOCATOR(PromiseAllSettledResolveElementFunction);
 JS_DEFINE_ALLOCATOR(PromiseAllSettledRejectElementFunction);
 JS_DEFINE_ALLOCATOR(PromiseAnyRejectElementFunction);
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -88,6 +88,7 @@ private:
 // 27.2.4.2.2 Promise.allSettled Resolve Element Functions, https://tc39.es/ecma262/#sec-promise.allsettled-resolve-element-functions
 class PromiseAllSettledResolveElementFunction final : public PromiseResolvingElementFunction {
     JS_OBJECT(PromiseResolvingFunction, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PromiseAllSettledResolveElementFunction);
 
 public:
     static NonnullGCPtr<PromiseAllSettledResolveElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SetPrototype);
+
 SetPrototype::SetPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class SetPrototype final : public PrototypeObject<SetPrototype, Set> {
     JS_PROTOTYPE_OBJECT(SetPrototype, Set, Set);
+    JS_DECLARE_ALLOCATOR(SetPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WrapForValidIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WrapForValidIteratorPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WrapForValidIteratorPrototype);
+
 // 3.1.1.2.2.1 The %WrapForValidIteratorPrototype% Object, https://tc39.es/proposal-iterator-helpers/#sec-wrapforvaliditeratorprototype-object
 WrapForValidIteratorPrototype::WrapForValidIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())

--- a/Userland/Libraries/LibJS/Runtime/WrapForValidIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WrapForValidIteratorPrototype.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class WrapForValidIteratorPrototype final : public PrototypeObject<WrapForValidIteratorPrototype, Iterator> {
     JS_PROTOTYPE_OBJECT(WrapForValidIteratorPrototype, Iterator, Iterator);
+    JS_DECLARE_ALLOCATOR(WrapForValidIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace Web::Bindings {
 
+JS_DEFINE_ALLOCATOR(AudioConstructor);
+
 AudioConstructor::AudioConstructor(JS::Realm& realm)
     : NativeFunction(realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.h
@@ -12,6 +12,9 @@
 namespace Web::Bindings {
 
 class AudioConstructor final : public JS::NativeFunction {
+    JS_OBJECT(AudioConstructor, JS::NativeFunction);
+    JS_DECLARE_ALLOCATOR(AudioConstructor);
+
 public:
     explicit AudioConstructor(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
@@ -22,7 +25,6 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
-    virtual StringView class_name() const override { return "AudioConstructor"sv; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace Web::Bindings {
 
+JS_DEFINE_ALLOCATOR(ImageConstructor);
+
 ImageConstructor::ImageConstructor(JS::Realm& realm)
     : NativeFunction(realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.h
@@ -12,6 +12,9 @@
 namespace Web::Bindings {
 
 class ImageConstructor final : public JS::NativeFunction {
+    JS_OBJECT(ImageConstructor, JS::NativeFunction);
+    JS_DECLARE_ALLOCATOR(ImageConstructor);
+
 public:
     explicit ImageConstructor(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
@@ -22,7 +25,6 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
-    virtual StringView class_name() const override { return "ImageConstructor"sv; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -17,6 +17,8 @@
 
 namespace Web::Bindings {
 
+JS_DEFINE_ALLOCATOR(OptionConstructor);
+
 OptionConstructor::OptionConstructor(JS::Realm& realm)
     : NativeFunction(realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.h
@@ -12,6 +12,9 @@
 namespace Web::Bindings {
 
 class OptionConstructor final : public JS::NativeFunction {
+    JS_OBJECT(OptionConstructor, JS::NativeFunction);
+    JS_DECLARE_ALLOCATOR(OptionConstructor);
+
 public:
     explicit OptionConstructor(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
@@ -22,7 +25,6 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
-    virtual StringView class_name() const override { return "OptionConstructor"sv; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/AnimationEvent.cpp
+++ b/Userland/Libraries/LibWeb/CSS/AnimationEvent.cpp
@@ -9,6 +9,8 @@
 
 namespace Web::CSS {
 
+JS_DEFINE_ALLOCATOR(AnimationEvent);
+
 JS::NonnullGCPtr<AnimationEvent> AnimationEvent::create(JS::Realm& realm, FlyString const& type, AnimationEventInit const& event_init)
 {
     return realm.heap().allocate<AnimationEvent>(realm, realm, type, event_init);

--- a/Userland/Libraries/LibWeb/CSS/AnimationEvent.h
+++ b/Userland/Libraries/LibWeb/CSS/AnimationEvent.h
@@ -21,6 +21,7 @@ struct AnimationEventInit : public DOM::EventInit {
 // https://www.w3.org/TR/css-animations-1/#animationevent
 class AnimationEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(AnimationEvent, DOM::Event);
+    JS_DECLARE_ALLOCATOR(AnimationEvent);
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<AnimationEvent> create(JS::Realm&, FlyString const& type, AnimationEventInit const& event_init = {});

--- a/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::CSS {
 
+JS_DEFINE_ALLOCATOR(CSSAnimation);
+
 JS::NonnullGCPtr<CSSAnimation> CSSAnimation::create(JS::Realm& realm)
 {
     return realm.heap().allocate<CSSAnimation>(realm, realm);

--- a/Userland/Libraries/LibWeb/CSS/CSSAnimation.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSAnimation.h
@@ -15,6 +15,7 @@ namespace Web::CSS {
 // https://www.w3.org/TR/css-animations-2/#cssanimation
 class CSSAnimation : public Animations::Animation {
     WEB_PLATFORM_OBJECT(CSSAnimation, Animations::Animation);
+    JS_DECLARE_ALLOCATOR(CSSAnimation);
 
 public:
     static JS::NonnullGCPtr<CSSAnimation> create(JS::Realm&);

--- a/Userland/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::CSS {
 
+JS_DEFINE_ALLOCATOR(CSSTransition);
+
 JS::NonnullGCPtr<CSSTransition> CSSTransition::create(JS::Realm& realm, PropertyID property_id, size_t transition_generation)
 {
     return realm.heap().allocate<CSSTransition>(realm, realm, property_id, transition_generation);

--- a/Userland/Libraries/LibWeb/CSS/CSSTransition.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSTransition.h
@@ -16,6 +16,7 @@ namespace Web::CSS {
 
 class CSSTransition : public Animations::Animation {
     WEB_PLATFORM_OBJECT(CSSTransition, Animations::Animation);
+    JS_DECLARE_ALLOCATOR(CSSTransition);
 
 public:
     static JS::NonnullGCPtr<CSSTransition> create(JS::Realm&, PropertyID, size_t transition_generation);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -38,6 +38,8 @@
 
 namespace Web::DOM {
 
+JS_DEFINE_ALLOCATOR(EventTarget);
+
 EventTarget::EventTarget(JS::Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
     : PlatformObject(realm, may_interfere_with_indexed_property_access)
 {

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -19,6 +19,7 @@ namespace Web::DOM {
 
 class EventTarget : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(EventTarget, Bindings::PlatformObject);
+    JS_DECLARE_ALLOCATOR(EventTarget);
 
 public:
     virtual ~EventTarget() override;

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::DOM {
 
+JS_DEFINE_ALLOCATOR(IDLEventListener);
+
 JS::NonnullGCPtr<IDLEventListener> IDLEventListener::create(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)
 {
     return realm.heap().allocate<IDLEventListener>(realm, realm, move(callback));

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.h
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.h
@@ -26,6 +26,7 @@ struct AddEventListenerOptions : public EventListenerOptions {
 
 class IDLEventListener final : public JS::Object {
     JS_OBJECT(IDLEventListener, JS::Object);
+    JS_DECLARE_ALLOCATOR(IDLEventListener);
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<IDLEventListener> create(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -12,6 +12,7 @@
 namespace Web::DOM {
 
 JS_DEFINE_ALLOCATOR(MutationObserver);
+JS_DEFINE_ALLOCATOR(TransientRegisteredObserver);
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationObserver>> MutationObserver::construct_impl(JS::Realm& realm, JS::GCPtr<WebIDL::CallbackType> callback)
 {

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.h
@@ -93,6 +93,7 @@ private:
 // https://dom.spec.whatwg.org/#transient-registered-observer
 class TransientRegisteredObserver final : public RegisteredObserver {
     JS_CELL(TransientRegisteredObserver, RegisteredObserver);
+    JS_DECLARE_ALLOCATOR(TransientRegisteredObserver);
 
 public:
     static JS::NonnullGCPtr<TransientRegisteredObserver> create(MutationObserver&, MutationObserverInit const&, RegisteredObserver& source);

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -19,6 +19,8 @@
 
 namespace Web::DOM {
 
+JS_DEFINE_ALLOCATOR(ParentNode);
+
 // https://dom.spec.whatwg.org/#dom-parentnode-queryselector
 WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView selector_text)
 {

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -12,6 +12,7 @@ namespace Web::DOM {
 
 class ParentNode : public Node {
     WEB_PLATFORM_OBJECT(ParentNode, Node);
+    JS_DECLARE_ALLOCATOR(ParentNode);
 
 public:
     template<typename F>

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Fetch::Infrastructure {
 
+JS_DEFINE_ALLOCATOR(FetchTimingInfo);
+
 FetchTimingInfo::FetchTimingInfo() = default;
 
 JS::NonnullGCPtr<FetchTimingInfo> FetchTimingInfo::create(JS::VM& vm)

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.h
@@ -19,6 +19,7 @@ namespace Web::Fetch::Infrastructure {
 // https://fetch.spec.whatwg.org/#fetch-timing-info
 class FetchTimingInfo : public JS::Cell {
     JS_CELL(FetchTimingInfo, JS::Cell);
+    JS_DECLARE_ALLOCATOR(FetchTimingInfo);
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<FetchTimingInfo> create(JS::VM&);

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -25,6 +25,8 @@
 
 namespace Web::Fetch::Infrastructure {
 
+JS_DEFINE_ALLOCATOR(HeaderList);
+
 template<typename T>
 requires(IsSameIgnoringCV<T, u8>) struct CaseInsensitiveBytesTraits : public Traits<Span<T>> {
     static constexpr bool equals(Span<T> const& a, Span<T> const& b)

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -14,8 +14,8 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
-#include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Heap/Heap.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 
 namespace Web::Fetch::Infrastructure {
@@ -35,6 +35,7 @@ class HeaderList final
     : public JS::Cell
     , Vector<Header> {
     JS_CELL(HeaderList, JS::Cell);
+    JS_DECLARE_ALLOCATOR(HeaderList);
 
 public:
     using Vector::begin;

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -20,6 +20,8 @@
 
 namespace Web::Geometry {
 
+JS_DEFINE_ALLOCATOR(DOMMatrixReadOnly);
+
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-dommatrixreadonly
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMMatrixReadOnly>> DOMMatrixReadOnly::construct_impl(JS::Realm& realm, Optional<Variant<String, Vector<double>>> const& init)
 {

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
@@ -52,6 +52,7 @@ class DOMMatrixReadOnly
     : public Bindings::PlatformObject
     , public Bindings::Serializable {
     WEB_PLATFORM_OBJECT(DOMMatrixReadOnly, Bindings::PlatformObject);
+    JS_DECLARE_ALLOCATOR(DOMMatrixReadOnly);
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMMatrixReadOnly>> construct_impl(JS::Realm&, Optional<Variant<String, Vector<double>>> const& init);

--- a/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -15,6 +15,8 @@ namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/images.html#img-req-data
 class DecodedImageData : public JS::Cell {
+    JS_CELL(DecodedImageData, JS::Cell);
+
 public:
     virtual ~DecodedImageData();
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -21,6 +21,8 @@
 
 namespace Web::HTML {
 
+JS_DEFINE_ALLOCATOR(EventLoop);
+
 EventLoop::EventLoop()
 {
     m_task_queue = heap().allocate_without_realm<TaskQueue>(*this);

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -17,6 +17,7 @@ namespace Web::HTML {
 
 class EventLoop : public JS::Cell {
     JS_CELL(EventLoop, Cell);
+    JS_DECLARE_ALLOCATOR(EventLoop);
 
 public:
     enum class Type {

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::HTML {
 
+JS_DEFINE_ALLOCATOR(TaskQueue);
+
 TaskQueue::TaskQueue(HTML::EventLoop& event_loop)
     : m_event_loop(event_loop)
 {

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.h
@@ -14,6 +14,7 @@ namespace Web::HTML {
 
 class TaskQueue : public JS::Cell {
     JS_CELL(TaskQueue, Cell);
+    JS_DECLARE_ALLOCATOR(TaskQueue);
 
 public:
     explicit TaskQueue(HTML::EventLoop&);

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -31,6 +31,7 @@
 namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(Navigation);
+JS_DEFINE_ALLOCATOR(NavigationAPIMethodTracker);
 
 static NavigationResult navigation_api_method_tracker_derived_result(JS::NonnullGCPtr<NavigationAPIMethodTracker> api_method_tracker);
 

--- a/Userland/Libraries/LibWeb/HTML/Navigation.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.h
@@ -47,6 +47,7 @@ struct NavigationResult {
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker
 struct NavigationAPIMethodTracker final : public JS::Cell {
     JS_CELL(NavigationAPIMethodTracker, JS::Cell);
+    JS_DECLARE_ALLOCATOR(NavigationAPIMethodTracker);
 
     NavigationAPIMethodTracker(JS::NonnullGCPtr<Navigation> navigation,
         Optional<String> key,

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -28,6 +28,8 @@
 
 namespace Web::HTML {
 
+JS_DEFINE_ALLOCATOR(FetchContext);
+
 OnFetchScriptComplete create_on_fetch_script_complete(JS::Heap& heap, Function<void(JS::GCPtr<Script>)> function)
 {
     return JS::create_heap_function(heap, move(function));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -56,6 +56,7 @@ ScriptFetchOptions default_classic_script_fetch_options();
 
 class FetchContext : public JS::GraphLoadingState::HostDefined {
     JS_CELL(FetchContext, JS::GraphLoadingState::HostDefined);
+    JS_DECLARE_ALLOCATOR(FetchContext);
 
 public:
     JS::Value parse_error;                                    // [[ParseError]]

--- a/Userland/Libraries/LibWeb/Layout/AudioBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/AudioBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(AudioBox);
+
 AudioBox::AudioBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
     : ReplacedBox(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/AudioBox.h
+++ b/Userland/Libraries/LibWeb/Layout/AudioBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class AudioBox final : public ReplacedBox {
     JS_CELL(AudioBox, ReplacedBox);
+    JS_DECLARE_ALLOCATOR(AudioBox);
 
 public:
     HTML::HTMLAudioElement& dom_node();

--- a/Userland/Libraries/LibWeb/Layout/BreakNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(BreakNode);
+
 BreakNode::BreakNode(DOM::Document& document, HTML::HTMLBRElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : Layout::NodeWithStyleAndBoxModelMetrics(document, &element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/BreakNode.h
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class BreakNode final : public NodeWithStyleAndBoxModelMetrics {
     JS_CELL(BreakNode, NodeWithStyleAndBoxModelMetrics);
+    JS_DECLARE_ALLOCATOR(BreakNode);
 
 public:
     BreakNode(DOM::Document&, HTML::HTMLBRElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/ButtonBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ButtonBox.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(ButtonBox);
+
 ButtonBox::ButtonBox(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/ButtonBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ButtonBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class ButtonBox final : public FormAssociatedLabelableNode {
     JS_CELL(ButtonBox, FormAssociatedLabelableNode);
+    JS_DECLARE_ALLOCATOR(ButtonBox);
 
 public:
     ButtonBox(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
@@ -9,6 +9,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(CanvasBox);
+
 CanvasBox::CanvasBox(DOM::Document& document, HTML::HTMLCanvasElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : ReplacedBox(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/CanvasBox.h
+++ b/Userland/Libraries/LibWeb/Layout/CanvasBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class CanvasBox final : public ReplacedBox {
     JS_CELL(CanvasBox, ReplacedBox);
+    JS_DECLARE_ALLOCATOR(CanvasBox);
 
 public:
     CanvasBox(DOM::Document&, HTML::HTMLCanvasElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -13,6 +13,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(CheckBox);
+
 CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.h
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class CheckBox final : public FormAssociatedLabelableNode {
     JS_CELL(CheckBox, FormAssociatedLabelableNode);
+    JS_DECLARE_ALLOCATOR(CheckBox);
 
 public:
     CheckBox(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(FrameBox);
+
 FrameBox::FrameBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
     : ReplacedBox(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.h
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class FrameBox final : public ReplacedBox {
     JS_CELL(FrameBox, ReplacedBox);
+    JS_DECLARE_ALLOCATOR(FrameBox);
 
 public:
     FrameBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -14,6 +14,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(ImageBox);
+
 ImageBox::ImageBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style, ImageProvider const& image_provider)
     : ReplacedBox(document, element, move(style))
     , m_image_provider(image_provider)

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class ImageBox final : public ReplacedBox {
     JS_CELL(ImageBox, ReplacedBox);
+    JS_DECLARE_ALLOCATOR(ImageBox);
 
 public:
     ImageBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>, ImageProvider const&);

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -14,6 +14,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(InlineNode);
+
 InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
     : Layout::NodeWithStyleAndBoxModelMetrics(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.h
@@ -12,6 +12,7 @@ namespace Web::Layout {
 
 class InlineNode final : public NodeWithStyleAndBoxModelMetrics {
     JS_CELL(InlineNode, NodeWithStyleAndBoxModelMetrics);
+    JS_DECLARE_ALLOCATOR(InlineNode);
 
 public:
     InlineNode(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -15,6 +15,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(Label);
+
 Label::Label(DOM::Document& document, HTML::HTMLLabelElement* element, NonnullRefPtr<CSS::StyleProperties> style)
     : BlockContainer(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/Label.h
+++ b/Userland/Libraries/LibWeb/Layout/Label.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class Label final : public BlockContainer {
     JS_CELL(Label, BlockContainer);
+    JS_DECLARE_ALLOCATOR(Label);
 
 public:
     Label(DOM::Document&, HTML::HTMLLabelElement*, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(ListItemBox);
+
 ListItemBox::ListItemBox(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
     : Layout::BlockContainer(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class ListItemBox final : public BlockContainer {
     JS_CELL(ListItemBox, BlockContainer);
+    JS_DECLARE_ALLOCATOR(ListItemBox);
 
 public:
     ListItemBox(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(ListItemMarkerBox);
+
 ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, CSS::ListStylePosition style_position, size_t index, NonnullRefPtr<CSS::StyleProperties> style)
     : Box(document, nullptr, move(style))
     , m_list_style_type(style_type)

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class ListItemMarkerBox final : public Box {
     JS_CELL(ListItemMarkerBox, Box);
+    JS_DECLARE_ALLOCATOR(ListItemMarkerBox);
 
 public:
     explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, size_t index, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(RadioButton);
+
 RadioButton::RadioButton(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.h
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class RadioButton final : public FormAssociatedLabelableNode {
     JS_CELL(RadioButton, FormAssociatedLabelableNode);
+    JS_DECLARE_ALLOCATOR(RadioButton);
 
 public:
     RadioButton(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/SVGClipBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGClipBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(SVGClipBox);
+
 SVGClipBox::SVGClipBox(DOM::Document& document, SVG::SVGClipPathElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : SVGBox(document, element, properties)
 {

--- a/Userland/Libraries/LibWeb/Layout/SVGClipBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGClipBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class SVGClipBox : public SVGBox {
     JS_CELL(SVGClipBox, SVGBox);
+    JS_DECLARE_ALLOCATOR(SVGClipBox);
 
 public:
     SVGClipBox(DOM::Document&, SVG::SVGClipPathElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -12,6 +12,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(SVGGeometryBox);
+
 SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : SVGGraphicsBox(document, element, properties)
 {

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class SVGGeometryBox final : public SVGGraphicsBox {
     JS_CELL(SVGGeometryBox, SVGGraphicsBox);
+    JS_DECLARE_ALLOCATOR(SVGGeometryBox);
 
 public:
     SVGGeometryBox(DOM::Document&, SVG::SVGGeometryElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/SVGMaskBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGMaskBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(SVGMaskBox);
+
 SVGMaskBox::SVGMaskBox(DOM::Document& document, SVG::SVGMaskElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : SVGGraphicsBox(document, element, properties)
 {

--- a/Userland/Libraries/LibWeb/Layout/SVGMaskBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGMaskBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class SVGMaskBox : public SVGGraphicsBox {
     JS_CELL(SVGMaskBox, SVGBox);
+    JS_DECLARE_ALLOCATOR(SVGMaskBox);
 
 public:
     SVGMaskBox(DOM::Document&, SVG::SVGMaskElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -12,6 +12,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(SVGSVGBox);
+
 SVGSVGBox::SVGSVGBox(DOM::Document& document, SVG::SVGSVGElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : ReplacedBox(document, element, move(properties))
 {

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class SVGSVGBox final : public ReplacedBox {
     JS_CELL(SVGSVGBox, ReplacedBox);
+    JS_DECLARE_ALLOCATOR(SVGSVGBox);
 
 public:
     SVGSVGBox(DOM::Document&, SVG::SVGSVGElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(SVGTextBox);
+
 SVGTextBox::SVGTextBox(DOM::Document& document, SVG::SVGTextPositioningElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : SVGGraphicsBox(document, element, properties)
 {

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class SVGTextBox final : public SVGGraphicsBox {
     JS_CELL(SVGTextBox, SVGGraphicsBox);
+    JS_DECLARE_ALLOCATOR(SVGTextBox);
 
 public:
     SVGTextBox(DOM::Document&, SVG::SVGTextPositioningElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.cpp
@@ -9,6 +9,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(SVGTextPathBox);
+
 SVGTextPathBox::SVGTextPathBox(DOM::Document& document, SVG::SVGTextPathElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : SVGGraphicsBox(document, element, properties)
 {

--- a/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class SVGTextPathBox final : public SVGGraphicsBox {
     JS_CELL(SVGTextPathBox, SVGGraphicsBox);
+    JS_DECLARE_ALLOCATOR(SVGTextPathBox);
 
 public:
     SVGTextPathBox(DOM::Document&, SVG::SVGTextPathElement&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/TableWrapper.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableWrapper.cpp
@@ -8,6 +8,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(TableWrapper);
+
 TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
     : BlockContainer(document, node, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/TableWrapper.h
+++ b/Userland/Libraries/LibWeb/Layout/TableWrapper.h
@@ -12,6 +12,7 @@ namespace Web::Layout {
 
 class TableWrapper : public BlockContainer {
     JS_CELL(TableWrapper, BlockContainer);
+    JS_DECLARE_ALLOCATOR(TableWrapper);
 
 public:
     TableWrapper(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -16,6 +16,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(TextNode);
+
 TextNode::TextNode(DOM::Document& document, DOM::Text& text)
     : Node(document, &text)
 {

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -16,6 +16,7 @@ class LineBoxFragment;
 
 class TextNode final : public Node {
     JS_CELL(TextNode, Node);
+    JS_DECLARE_ALLOCATOR(TextNode);
 
 public:
     TextNode(DOM::Document&, DOM::Text&);

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(VideoBox);
+
 VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
     : ReplacedBox(document, element, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.h
@@ -16,6 +16,7 @@ class VideoBox final
     : public ReplacedBox
     , public DOM::Document::ViewportClient {
     JS_CELL(VideoBox, ReplacedBox);
+    JS_DECLARE_ALLOCATOR(VideoBox);
 
 public:
     virtual void prepare_for_replaced_layout() override;

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -13,6 +13,8 @@
 
 namespace Web::Layout {
 
+JS_DEFINE_ALLOCATOR(Viewport);
+
 Viewport::Viewport(DOM::Document& document, NonnullRefPtr<CSS::StyleProperties> style)
     : BlockContainer(document, &document, move(style))
 {

--- a/Userland/Libraries/LibWeb/Layout/Viewport.h
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.h
@@ -13,6 +13,7 @@ namespace Web::Layout {
 
 class Viewport final : public BlockContainer {
     JS_CELL(Viewport, BlockContainer);
+    JS_DECLARE_ALLOCATOR(Viewport);
 
 public:
     explicit Viewport(DOM::Document&, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -25,6 +25,8 @@
 
 namespace Web {
 
+JS_DEFINE_ALLOCATOR(Page);
+
 JS::NonnullGCPtr<Page> Page::create(JS::VM& vm, JS::NonnullGCPtr<PageClient> page_client)
 {
     return vm.heap().allocate_without_realm<Page>(page_client);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -22,8 +22,8 @@
 #include <LibGfx/Size.h>
 #include <LibGfx/StandardCursor.h>
 #include <LibIPC/Forward.h>
-#include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/Handle.h>
+#include <LibJS/Heap/Heap.h>
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/Selector.h>
@@ -47,6 +47,7 @@ class PageClient;
 
 class Page final : public JS::Cell {
     JS_CELL(Page, JS::Cell);
+    JS_DECLARE_ALLOCATOR(Page);
 
 public:
     static JS::NonnullGCPtr<Page> create(JS::VM&, JS::NonnullGCPtr<PageClient>);

--- a/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
@@ -18,6 +18,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(AudioPaintable);
+
 JS::NonnullGCPtr<AudioPaintable> AudioPaintable::create(Layout::AudioBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<AudioPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/AudioPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/AudioPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class AudioPaintable final : public MediaPaintable {
     JS_CELL(AudioPaintable, MediaPaintable);
+    JS_DECLARE_ALLOCATOR(AudioPaintable);
 
 public:
     static JS::NonnullGCPtr<AudioPaintable> create(Layout::AudioBox const&);

--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
@@ -13,6 +13,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(ButtonPaintable);
+
 JS::NonnullGCPtr<ButtonPaintable> ButtonPaintable::create(Layout::ButtonBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<ButtonPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class ButtonPaintable final : public LabelablePaintable {
     JS_CELL(ButtonPaintable, LabelablePaintable);
+    JS_DECLARE_ALLOCATOR(ButtonPaintable);
 
 public:
     static JS::NonnullGCPtr<ButtonPaintable> create(Layout::ButtonBox const&);

--- a/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -8,6 +8,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(CanvasPaintable);
+
 JS::NonnullGCPtr<CanvasPaintable> CanvasPaintable::create(Layout::CanvasBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<CanvasPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/CanvasPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/CanvasPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class CanvasPaintable final : public PaintableBox {
     JS_CELL(CanvasPaintable, PaintableBox);
+    JS_DECLARE_ALLOCATOR(CanvasPaintable);
 
 public:
     static JS::NonnullGCPtr<CanvasPaintable> create(Layout::CanvasBox const&);

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -18,6 +18,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(CheckBoxPaintable);
+
 // A 16x16 signed distance field for the checkbox's tick (slightly rounded):
 static constexpr Array<u8, 16 * 16> s_check_mark_sdf {
     254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 251, 254, 254, 254,

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class CheckBoxPaintable final : public LabelablePaintable {
     JS_CELL(CheckBoxPaintable, LabelablePaintable);
+    JS_DECLARE_ALLOCATOR(CheckBoxPaintable);
 
 public:
     static JS::NonnullGCPtr<CheckBoxPaintable> create(Layout::CheckBox const&);

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -18,6 +18,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(ImagePaintable);
+
 JS::NonnullGCPtr<ImagePaintable> ImagePaintable::create(Layout::ImageBox const& layout_box)
 {
     auto alt = layout_box.dom_node().get_attribute_value(HTML::AttributeNames::alt);

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
@@ -15,6 +15,7 @@ class ImagePaintable final
     : public PaintableBox
     , public DOM::Document::ViewportClient {
     JS_CELL(ImagePaintable, PaintableBox);
+    JS_DECLARE_ALLOCATOR(ImagePaintable);
 
 public:
     static JS::NonnullGCPtr<ImagePaintable> create(Layout::ImageBox const&);

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -13,6 +13,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(InlinePaintable);
+
 JS::NonnullGCPtr<InlinePaintable> InlinePaintable::create(Layout::InlineNode const& layout_node)
 {
     return layout_node.heap().allocate_without_realm<InlinePaintable>(layout_node);

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -14,6 +14,7 @@ namespace Web::Painting {
 
 class InlinePaintable final : public Paintable {
     JS_CELL(InlinePaintable, Paintable);
+    JS_DECLARE_ALLOCATOR(InlinePaintable);
 
 public:
     static JS::NonnullGCPtr<InlinePaintable> create(Layout::InlineNode const&);

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -12,6 +12,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(MarkerPaintable);
+
 JS::NonnullGCPtr<MarkerPaintable> MarkerPaintable::create(Layout::ListItemMarkerBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<MarkerPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class MarkerPaintable final : public PaintableBox {
     JS_CELL(MarkerPaintable, PaintableBox);
+    JS_DECLARE_ALLOCATOR(MarkerPaintable);
 
 public:
     static JS::NonnullGCPtr<MarkerPaintable> create(Layout::ListItemMarkerBox const&);

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -14,6 +14,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(NestedBrowsingContextPaintable);
+
 JS::NonnullGCPtr<NestedBrowsingContextPaintable> NestedBrowsingContextPaintable::create(Layout::FrameBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<NestedBrowsingContextPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class NestedBrowsingContextPaintable final : public PaintableBox {
     JS_CELL(NestedBrowsingContextPaintable, PaintableBox);
+    JS_DECLARE_ALLOCATOR(NestedBrowsingContextPaintable);
 
 public:
     static JS::NonnullGCPtr<NestedBrowsingContextPaintable> create(Layout::FrameBox const&);

--- a/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
@@ -17,6 +17,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(RadioButtonPaintable);
+
 JS::NonnullGCPtr<RadioButtonPaintable> RadioButtonPaintable::create(Layout::RadioButton const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<RadioButtonPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class RadioButtonPaintable final : public LabelablePaintable {
     JS_CELL(RadioButtonPaintable, LabelablePaintable);
+    JS_DECLARE_ALLOCATOR(RadioButtonPaintable);
 
 public:
     static JS::NonnullGCPtr<RadioButtonPaintable> create(Layout::RadioButton const&);

--- a/Userland/Libraries/LibWeb/Painting/SVGClipPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGClipPaintable.cpp
@@ -8,6 +8,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(SVGClipPaintable);
+
 JS::NonnullGCPtr<SVGClipPaintable> SVGClipPaintable::create(Layout::SVGClipBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<SVGClipPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/SVGClipPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGClipPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class SVGClipPaintable : public SVGPaintable {
     JS_CELL(SVGClipPaintable, SVGPaintable);
+    JS_DECLARE_ALLOCATOR(SVGClipPaintable);
 
 public:
     static JS::NonnullGCPtr<SVGClipPaintable> create(Layout::SVGClipBox const&);

--- a/Userland/Libraries/LibWeb/Painting/SVGMaskPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGMaskPaintable.cpp
@@ -8,6 +8,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(SVGMaskPaintable);
+
 JS::NonnullGCPtr<SVGMaskPaintable> SVGMaskPaintable::create(Layout::SVGMaskBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<SVGMaskPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/SVGMaskPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGMaskPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class SVGMaskPaintable : public SVGGraphicsPaintable {
     JS_CELL(SVGMaskPaintable, SVGGraphicsPaintable);
+    JS_DECLARE_ALLOCATOR(SVGMaskPaintable);
 
 public:
     static JS::NonnullGCPtr<SVGMaskPaintable> create(Layout::SVGMaskBox const&);

--- a/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(SVGPathPaintable);
+
 JS::NonnullGCPtr<SVGPathPaintable> SVGPathPaintable::create(Layout::SVGGraphicsBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<SVGPathPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class SVGPathPaintable final : public SVGGraphicsPaintable {
     JS_CELL(SVGPathPaintable, SVGGraphicsPaintable);
+    JS_DECLARE_ALLOCATOR(SVGPathPaintable);
 
 public:
     static JS::NonnullGCPtr<SVGPathPaintable> create(Layout::SVGGraphicsBox const&);

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -9,6 +9,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(SVGSVGPaintable);
+
 JS::NonnullGCPtr<SVGSVGPaintable> SVGSVGPaintable::create(Layout::SVGSVGBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<SVGSVGPaintable>(layout_box);

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class SVGSVGPaintable final : public PaintableBox {
     JS_CELL(SVGSVGPaintable, PaintableBox);
+    JS_DECLARE_ALLOCATOR(SVGSVGPaintable);
 
 public:
     static JS::NonnullGCPtr<SVGSVGPaintable> create(Layout::SVGSVGBox const&);

--- a/Userland/Libraries/LibWeb/Painting/TextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/TextPaintable.cpp
@@ -12,6 +12,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(TextPaintable);
+
 JS::NonnullGCPtr<TextPaintable> TextPaintable::create(Layout::TextNode const& layout_node, String const& text_for_rendering)
 {
     return layout_node.heap().allocate_without_realm<TextPaintable>(layout_node, text_for_rendering);

--- a/Userland/Libraries/LibWeb/Painting/TextPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/TextPaintable.h
@@ -12,6 +12,7 @@ namespace Web::Painting {
 
 class TextPaintable final : public Paintable {
     JS_CELL(TextPaintable, Paintable);
+    JS_DECLARE_ALLOCATOR(TextPaintable);
 
 public:
     static JS::NonnullGCPtr<TextPaintable> create(Layout::TextNode const&, String const& text_for_rendering);

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -20,6 +20,8 @@ namespace Web::Painting {
 static constexpr auto control_box_color = Gfx::Color::from_rgb(0x26'26'26);
 static constexpr auto control_highlight_color = Gfx::Color::from_rgb(0x1d'99'f3);
 
+JS_DEFINE_ALLOCATOR(VideoPaintable);
+
 static constexpr Gfx::Color control_button_color(bool is_hovered)
 {
     if (!is_hovered)

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 
 class VideoPaintable final : public MediaPaintable {
     JS_CELL(VideoPaintable, MediaPaintable);
+    JS_DECLARE_ALLOCATOR(VideoPaintable);
 
 public:
     static JS::NonnullGCPtr<VideoPaintable> create(Layout::VideoBox const&);

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -14,6 +14,8 @@
 
 namespace Web::Painting {
 
+JS_DEFINE_ALLOCATOR(ViewportPaintable);
+
 JS::NonnullGCPtr<ViewportPaintable> ViewportPaintable::create(Layout::Viewport const& layout_viewport)
 {
     return layout_viewport.heap().allocate_without_realm<ViewportPaintable>(layout_viewport);

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -12,6 +12,7 @@ namespace Web::Painting {
 
 class ViewportPaintable final : public PaintableWithLines {
     JS_CELL(ViewportPaintable, PaintableWithLines);
+    JS_DECLARE_ALLOCATOR(ViewportPaintable);
 
 public:
     static JS::NonnullGCPtr<ViewportPaintable> create(Layout::Viewport const&);

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -24,6 +24,7 @@
 namespace Web::SVG {
 
 JS_DEFINE_ALLOCATOR(SVGDecodedImageData);
+JS_DEFINE_ALLOCATOR(SVGDecodedImageData::SVGPageClient);
 
 ErrorOr<JS::NonnullGCPtr<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& realm, JS::NonnullGCPtr<Page> host_page, URL::URL const& url, ByteBuffer data)
 {

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -52,6 +52,7 @@ private:
 
 class SVGDecodedImageData::SVGPageClient final : public PageClient {
     JS_CELL(SVGDecodedImageData::SVGPageClient, PageClient);
+    JS_DECLARE_ALLOCATOR(SVGDecodedImageData::SVGPageClient);
 
 public:
     static JS::NonnullGCPtr<SVGPageClient> create(JS::VM& vm, Page& page)

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -62,6 +62,7 @@ void ReadableStreamBYOBReader::visit_edges(Cell::Visitor& visitor)
 
 class BYOBReaderReadIntoRequest : public ReadIntoRequest {
     JS_CELL(BYOBReaderReadIntoRequest, ReadIntoRequest);
+    JS_DECLARE_ALLOCATOR(BYOBReaderReadIntoRequest);
 
 public:
     BYOBReaderReadIntoRequest(JS::Realm& realm, WebIDL::Promise& promise)
@@ -102,6 +103,8 @@ private:
     JS::NonnullGCPtr<JS::Realm> m_realm;
     JS::NonnullGCPtr<WebIDL::Promise> m_promise;
 };
+
+JS_DEFINE_ALLOCATOR(BYOBReaderReadIntoRequest);
 
 // https://streams.spec.whatwg.org/#byob-reader-read
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> ReadableStreamBYOBReader::read(JS::Handle<WebIDL::ArrayBufferView>& view)

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -24,6 +24,7 @@
 namespace Web::Streams {
 
 JS_DEFINE_ALLOCATOR(ReadableStreamDefaultReader);
+JS_DEFINE_ALLOCATOR(ReadLoopReadRequest);
 
 void ReadLoopReadRequest::visit_edges(Visitor& visitor)
 {
@@ -116,6 +117,7 @@ void ReadLoopReadRequest::on_error(JS::Value error)
 
 class DefaultReaderReadRequest final : public ReadRequest {
     JS_CELL(DefaultReaderReadRequest, Cell);
+    JS_DECLARE_ALLOCATOR(DefaultReaderReadRequest);
 
 public:
     DefaultReaderReadRequest(JS::Realm& realm, WebIDL::Promise& promise)
@@ -150,6 +152,8 @@ private:
     JS::NonnullGCPtr<JS::Realm> m_realm;
     JS::NonnullGCPtr<WebIDL::Promise> m_promise;
 };
+
+JS_DEFINE_ALLOCATOR(DefaultReaderReadRequest);
 
 // https://streams.spec.whatwg.org/#default-reader-read
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> ReadableStreamDefaultReader::read()

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -33,6 +33,7 @@ public:
 
 class ReadLoopReadRequest final : public ReadRequest {
     JS_CELL(ReadLoopReadRequest, JS::Cell);
+    JS_DECLARE_ALLOCATOR(ReadLoopReadRequest);
 
 public:
     // successSteps, which is an algorithm accepting a byte sequence

--- a/Userland/Libraries/LibWeb/WebIDL/Buffers.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/Buffers.cpp
@@ -11,6 +11,10 @@
 
 namespace Web::WebIDL {
 
+JS_DEFINE_ALLOCATOR(BufferableObjectBase);
+JS_DEFINE_ALLOCATOR(ArrayBufferView);
+JS_DEFINE_ALLOCATOR(BufferSource);
+
 u32 BufferableObjectBase::byte_length() const
 {
     return m_bufferable_object.visit(

--- a/Userland/Libraries/LibWeb/WebIDL/Buffers.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Buffers.h
@@ -20,6 +20,7 @@ using BufferableObject = Variant<
 
 class BufferableObjectBase : public JS::Cell {
     JS_CELL(BufferableObjectBase, JS::Cell);
+    JS_DECLARE_ALLOCATOR(BufferableObjectBase);
 
 public:
     virtual ~BufferableObjectBase() override = default;
@@ -54,6 +55,7 @@ protected:
 //          Float32Array or Float64Array or DataView) ArrayBufferView;
 class ArrayBufferView : public BufferableObjectBase {
     JS_CELL(ArrayBufferView, BufferableObjectBase);
+    JS_DECLARE_ALLOCATOR(ArrayBufferView);
 
 public:
     using BufferableObjectBase::BufferableObjectBase;
@@ -71,6 +73,7 @@ public:
 // typedef (ArrayBufferView or ArrayBuffer) BufferSource;
 class BufferSource : public BufferableObjectBase {
     JS_CELL(BufferSource, BufferableObjectBase);
+    JS_DECLARE_ALLOCATOR(BufferSource);
 
 public:
     using BufferableObjectBase::BufferableObjectBase;

--- a/Userland/Libraries/LibWeb/WebIDL/ObservableArray.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/ObservableArray.cpp
@@ -9,6 +9,8 @@
 
 namespace Web::WebIDL {
 
+JS_DEFINE_ALLOCATOR(ObservableArray);
+
 JS::NonnullGCPtr<ObservableArray> ObservableArray::create(JS::Realm& realm)
 {
     auto prototype = realm.intrinsics().array_prototype();

--- a/Userland/Libraries/LibWeb/WebIDL/ObservableArray.h
+++ b/Userland/Libraries/LibWeb/WebIDL/ObservableArray.h
@@ -13,6 +13,9 @@ namespace Web::WebIDL {
 
 // https://webidl.spec.whatwg.org/#idl-observable-array
 class ObservableArray final : public JS::Array {
+    JS_OBJECT(ObservableArray, JS::Array);
+    JS_DECLARE_ALLOCATOR(ObservableArray);
+
 public:
     static JS::NonnullGCPtr<ObservableArray> create(JS::Realm& realm);
 

--- a/Userland/Libraries/LibWeb/WebIDL/Promise.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.cpp
@@ -176,6 +176,7 @@ void mark_promise_as_handled(Promise const& promise)
 
 struct WaitForAllResults : JS::Cell {
     JS_CELL(WaitForAllResults, JS::Cell);
+    JS_DECLARE_ALLOCATOR(WaitForAllResults);
 
     WaitForAllResults(JS::NonnullGCPtr<JS::HeapFunction<void(Vector<JS::Value> const&)>> s, size_t t)
         : success_steps(s)
@@ -201,6 +202,8 @@ struct WaitForAllResults : JS::Cell {
     size_t total = 0;
     size_t fulfilled_count = 0;
 };
+
+JS_DEFINE_ALLOCATOR(WaitForAllResults);
 
 // https://webidl.spec.whatwg.org/#wait-for-all
 void wait_for_all(JS::Realm& realm, Vector<JS::NonnullGCPtr<Promise>> const& promises, Function<void(Vector<JS::Value> const&)> success_steps, Function<void(JS::Value)> failure_steps)

--- a/Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
+++ b/Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
@@ -15,6 +15,8 @@
 
 namespace WebContent {
 
+JS_DEFINE_ALLOCATOR(ConsoleGlobalEnvironmentExtensions);
+
 ConsoleGlobalEnvironmentExtensions::ConsoleGlobalEnvironmentExtensions(JS::Realm& realm, Web::HTML::Window& window)
     : Object(realm, nullptr)
     , m_window_object(window)

--- a/Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.h
+++ b/Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.h
@@ -15,6 +15,7 @@ namespace WebContent {
 
 class ConsoleGlobalEnvironmentExtensions final : public JS::Object {
     JS_OBJECT(ConsoleGlobalEnvironmentExtensions, JS::Object);
+    JS_DECLARE_ALLOCATOR(ConsoleGlobalEnvironmentExtensions);
 
 public:
     ConsoleGlobalEnvironmentExtensions(JS::Realm&, Web::HTML::Window&);

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -39,6 +39,8 @@ namespace WebContent {
 
 static bool s_use_gpu_painter = false;
 
+JS_DEFINE_ALLOCATOR(PageClient);
+
 void PageClient::set_use_gpu_painter()
 {
     s_use_gpu_painter = true;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -24,6 +24,7 @@ namespace WebContent {
 
 class PageClient final : public Web::PageClient {
     JS_CELL(PageClient, Web::PageClient);
+    JS_DECLARE_ALLOCATOR(PageClient);
 
 public:
     static JS::NonnullGCPtr<PageClient> create(JS::VM& vm, PageHost& page_host, u64 id);

--- a/Userland/Services/WebWorker/PageHost.cpp
+++ b/Userland/Services/WebWorker/PageHost.cpp
@@ -11,6 +11,8 @@
 
 namespace WebWorker {
 
+JS_DEFINE_ALLOCATOR(PageHost);
+
 JS::NonnullGCPtr<PageHost> PageHost::create(JS::VM& vm, ConnectionFromClient& client)
 {
     return vm.heap().allocate_without_realm<PageHost>(client);

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -15,6 +15,7 @@ namespace WebWorker {
 
 class PageHost final : public Web::PageClient {
     JS_CELL(PageHost, Web::PageClient);
+    JS_DECLARE_ALLOCATOR(PageHost);
 
 public:
     static JS::NonnullGCPtr<PageHost> create(JS::VM& vm, ConnectionFromClient& client);


### PR DESCRIPTION
Closes #23805, with a bonus feature in the last commit since I noticed it while adding the allocator calls and it was a pretty easy fix. 