### PR TITLE
LibCrypto: Remove simple-template-id from constructors

### DIFF
--- a/Userland/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Cipher.h
@@ -96,7 +96,7 @@ public:
     using KeyType = KeyT;
     using BlockType = BlockT;
 
-    explicit Cipher<KeyT, BlockT>(PaddingMode mode)
+    explicit Cipher(PaddingMode mode)
         : m_padding_mode(mode)
     {
     }

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
@@ -30,7 +30,7 @@ public:
     virtual ~GCM() = default;
 
     template<typename... Args>
-    explicit constexpr GCM<T>(Args... args)
+    explicit constexpr GCM(Args... args)
         : CTR<T>(args...)
     {
         static_assert(T::BlockSizeInBits == 128u, "GCM Mode is only available for 128-bit Ciphers");


### PR DESCRIPTION
This is disallowed as from C++20. GCC 14 gives an error for these two.

See:
https://cplusplus.github.io/CWG/issues/2237.html
https://stackoverflow.com/questions/71978335/class-templates-constructor-declaration-doesnt-compile-for-c20-but-compiles