### PR TITLE
LibWeb: Split `SVGFormattingContext` up into functions

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 2 from BlockContainer start: 0, length: 0, rect: [319,51 0x108] baseline: 110
         SVGSVGBox <svg> at (9,9) content-size 300x150 [SVG] children: inline
           InlineNode <a>
-            SVGTextBox <text> at (29,25.015625) content-size 193.59375x67.578125 children: inline
+            SVGTextBox <text> (not painted) children: inline
               TextNode <#text>
         TextNode <#text>
         BlockContainer <math> at (319,51) content-size 0x108 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-inside-g.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-inside-g.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGraphicsBox <g> at (58,58) content-size 10x10 children: inline
+          TextNode <#text>
+          SVGGraphicsBox <g> at (58,58) content-size 10x10 children: inline
+            TextNode <#text>
+            SVGGeometryBox <rect> at (58,58) content-size 10x10 children: not-inline
+            TextNode <#text>
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [58,58 10x10]
+          SVGGraphicsPaintable (SVGGraphicsBox<g>) [58,58 10x10]
+            SVGPathPaintable (SVGGeometryBox<rect>) [58,58 10x10]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
           TextNode <#text>
           SVGGraphicsBox <use> at (8,8) content-size 300x150 children: not-inline
-            SVGGraphicsBox <symbol#braces> at (92.375,26.75) content-size 131.25x112.15625 [BFC] children: inline
+            SVGGraphicsBox <symbol#braces> at (8,8) content-size 300x150 [BFC] children: inline
               TextNode <#text>
               SVGGeometryBox <path> at (92.375,26.75) content-size 131.25x112.15625 children: inline
                 TextNode <#text>
@@ -25,5 +25,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x150]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
           SVGGraphicsPaintable (SVGGraphicsBox<use>) [8,8 300x150]
-            SVGGraphicsPaintable (SVGGraphicsBox<symbol>#braces) [92.375,26.75 131.25x112.15625]
+            SVGGraphicsPaintable (SVGGraphicsBox<symbol>#braces) [8,8 300x150]
               SVGPathPaintable (SVGGeometryBox<path>) [92.375,26.75 131.25x112.15625]

--- a/Tests/LibWeb/Layout/expected/svg/use-honor-outer-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/use-honor-outer-viewBox.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100] baseline: 102
       SVGSVGBox <svg#outer> at (9,9) content-size 100x100 [SVG] children: inline
         TextNode <#text>
-        SVGGraphicsBox <use> at (9,9) content-size 50x50 children: inline
+        SVGGraphicsBox <use> at (9,9) content-size 100x100 children: inline
           SVGSVGBox <svg#whee> at (9,9) content-size 100x100 [SVG] children: inline
             TextNode <#text>
             SVGGeometryBox <rect> at (9,9) content-size 50x50 children: inline
@@ -16,6 +16,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
       SVGSVGPaintable (SVGSVGBox<svg>#outer) [8,8 102x102]
-        SVGGraphicsPaintable (SVGGraphicsBox<use>) [9,9 50x50]
+        SVGGraphicsPaintable (SVGGraphicsBox<use>) [9,9 100x100]
           SVGSVGPaintable (SVGSVGBox<svg>#whee) [9,9 100x100]
             SVGPathPaintable (SVGGeometryBox<rect>) [9,9 50x50]

--- a/Tests/LibWeb/Layout/input/svg/svg-g-inside-g.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-g-inside-g.html
@@ -1,0 +1,8 @@
+<svg width="100" height="100">
+  <!-- Both <g> elements should have the same size -->
+  <g>
+    <g>
+      <rect x="50" y="50" height="10" width="10" />
+    </g>
+  </g>
+</svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -6,8 +6,12 @@
 
 #pragma once
 
+#include <LibGfx/Path.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/FormattingContext.h>
+#include <LibWeb/Layout/SVGSVGBox.h>
+#include <LibWeb/Layout/SVGTextBox.h>
+#include <LibWeb/Layout/SVGTextPathBox.h>
 
 namespace Web::Layout {
 
@@ -21,7 +25,22 @@ public:
     virtual CSSPixels automatic_content_height() const override;
 
 private:
+    void layout_svg_element(Box const&);
+    void layout_nested_viewport(Box const&);
+    void layout_container_element(SVGBox const&);
+    void layout_graphics_element(SVGGraphicsBox const&);
+    void layout_path_like_element(SVGGraphicsBox const&);
+    void layout_mask_or_clip(SVGBox const&);
+
+    Gfx::Path compute_path_for_text(SVGTextBox const&);
+    Gfx::Path compute_path_for_text_path(SVGTextPathBox const&);
+
     Gfx::AffineTransform m_parent_viewbox_transform {};
+
+    Optional<AvailableSpace> m_available_space {};
+    Gfx::AffineTransform m_current_viewbox_transform {};
+    CSSPixelSize m_viewport_size {};
+    CSSPixelPoint m_svg_offset {};
 };
 
 }


### PR DESCRIPTION
Doing multiple `for_each_in_subtree()` passes was kind of a hack. We can resolve everything in a single pass with a little more control over the layout process. This also fixes a few minor issues like the sizing of nested `<g>` elements.

More work is needed here though as this is still fairly ad-hoc.

Note: This does regress `css-namespace-tag-name-selector.html`, previously SVG text within `<a>` elements would appear. However, this was only because `for_each_in_subtree()` would blindly look through the InlineNodes from the unimplemented `SVGAElement`s.