### PR TITLE
LibWeb: Wait for initial navigation to complete before modifying iframe

### DIFF
--- a/Tests/LibWeb/Text/expected/navigation/populate-iframe-using-document-write.txt
+++ b/Tests/LibWeb/Text/expected/navigation/populate-iframe-using-document-write.txt
@@ -1,0 +1,1 @@
+  PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/navigation/populate-iframe-using-document-write.html
+++ b/Tests/LibWeb/Text/input/navigation/populate-iframe-using-document-write.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body></body>
+<script>
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument;
+
+    iframeDocument.open();
+    iframeDocument.write(
+        "<!DOCTYPE html><html><head><title>Iframe Content</title></head><body>"
+    );
+    iframeDocument.write("<h1>Hello</h1>");
+    iframeDocument.write("<p>from iframe</p>");
+    iframeDocument.write("</body></html>");
+    iframeDocument.close();
+
+    test(() => {
+        println("PASS (didn't crash)");
+    })
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -76,6 +76,12 @@ void HTMLIFrameElement::process_the_iframe_attributes(bool initial_insertion)
     if (!content_navigable())
         return;
 
+    // Make sure applying of history step caused by potential sync navigation to "about:blank"
+    // is finished. Otherwise, it might interrupt navigation caused by changing src or srcdoc.
+    if (!initial_insertion && !content_navigable_initialized()) {
+        main_thread_event_loop().spin_processing_tasks_with_source_until(Task::Source::NavigationAndTraversal, [this] { return content_navigable_initialized(); });
+    }
+
     // 1. If element's srcdoc attribute is specified, then:
     if (has_attribute(HTML::AttributeNames::srcdoc)) {
         // 1. Set element's current navigation was lazy loaded boolean to false.

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.h
@@ -51,6 +51,8 @@ public:
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#potentially-delays-the-load-event
     bool currently_delays_the_load_event() const;
 
+    bool content_navigable_initialized() const { return m_content_navigable_initialized; }
+
 protected:
     NavigableContainer(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
If initial src of an iframe is "about:blank", it does synchronous navigation that is not supposed to be interleaved by other navigation or usage of Document.open().

Fixes crashing in navigation on https://twinings.co.uk/