### PR TITLE
LibGfx/JPEG2000: Decode SIZ, COD, QCD, QCC, COM marker segments

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -555,11 +555,14 @@ static ErrorOr<void> parse_codestream_main_header(JPEG2000LoadingContext& contex
         }
         case J2K_SOT: {
             // SOT terminates the main header.
+            // A.4.2: "There shall be at least one SOT in a codestream."
             if (!saw_COD_marker)
                 return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Required COD marker not present in main header");
             if (!saw_QCD_marker)
                 return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Required QCD marker not present in main header");
 
+            // A.6.4: "there is not necessarily a correspondence with the number of sub-bands present because the sub-bands
+            //         can be truncated with no requirement to correct [the QCD] marker segment."
             size_t step_sizes_count = context.qcd.step_sizes.visit(
                 [](Empty) -> size_t { VERIFY_NOT_REACHED(); },
                 [](Vector<QuantizationDefault::ReversibleStepSize> const& step_sizes) { return step_sizes.size(); },

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -549,6 +549,7 @@ static ErrorOr<void> parse_codestream_main_header(JPEG2000LoadingContext& contex
             } else {
                 // FIXME: These are valid main header markers. Parse contents.
                 dbgln("JPEG2000ImageDecoderPlugin: marker {:#04x} not yet implemented", marker.marker);
+                return Error::from_string_literal("JPEG2000ImageDecoderPlugin: marker not yet implemented");
             }
             break;
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -249,6 +249,8 @@ static ErrorOr<void> parse_codestream_tile_header(JPEG2000LoadingContext& contex
         tile_bitstream_length = context.codestream_data.size() - context.codestream_cursor - 2;
     } else {
         u32 tile_header_length = context.codestream_cursor - tile_start;
+        if (start_of_tile.tile_part_length < tile_header_length)
+            return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Invalid tile part length");
         tile_bitstream_length = start_of_tile.tile_part_length - tile_header_length;
     }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -673,6 +673,7 @@ static ErrorOr<void> parse_codestream_tile_header(JPEG2000LoadingContext& contex
             } else {
                 // FIXME: These are valid main header markers. Parse contents.
                 dbgln("JPEG2000ImageDecoderPlugin: marker {:#04x} not yet implemented in tile header", marker.marker);
+                return Error::from_string_literal("JPEG2000ImageDecoderPlugin: marker not yet implemented in tile header");
             }
             break;
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -597,12 +597,14 @@ static ErrorOr<void> parse_codestream_tile_header(JPEG2000LoadingContext& contex
             context.codestream_cursor += 2;
             found_start_of_data = true;
             break;
-        // FIXME: COD, COC, QCD, QCC are only valid on the first tile part header, reject them in non-first tile part headers.
         case J2K_COD:
         case J2K_COC:
         case J2K_QCD:
         case J2K_QCC:
         case J2K_RGN:
+            if (start_of_tile.tile_part_index != 0)
+                return Error::from_string_literal("JPEG2000ImageDecoderPlugin: COD, COC, QCD, QCC, RGN markers are only valid in the first tile-part header");
+            [[fallthrough]];
         case J2K_POC:
         case J2K_PPT:
         case J2K_PLT:

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -440,6 +440,7 @@ static ErrorOr<Comment> read_comment(ReadonlyBytes data)
 
 struct TilePartData {
     StartOfTilePart sot;
+    Vector<Comment> coms;
     ReadonlyBytes data;
 };
 
@@ -631,9 +632,13 @@ static ErrorOr<void> parse_codestream_tile_header(JPEG2000LoadingContext& contex
         case J2K_PPT:
         case J2K_PLT:
         case J2K_COM: {
-            // FIXME: These are valid tile part header markers. Parse contents.
             auto marker = TRY(read_marker_at_cursor(context));
-            dbgln("JPEG2000ImageDecoderPlugin: marker {:#04x} not yet implemented in tile header", marker.marker);
+            if (marker.marker == J2K_COM) {
+                tile_part.coms.append(TRY(read_comment(marker.data.value())));
+            } else {
+                // FIXME: These are valid main header markers. Parse contents.
+                dbgln("JPEG2000ImageDecoderPlugin: marker {:#04x} not yet implemented in tile header", marker.marker);
+            }
             break;
         }
         default:


### PR DESCRIPTION
With this, we can decode all required marker segments, and also some that are very common in practice.

Still doesn't do anything except log data if JPEG2000_DEBUG is 1. If we dig through enough layers there's gotta be image data eventually I'm sure! But not yet.

(QCC is neither required nor super duper common, but it's used by `Tests/LibGfx/test-inputs/jpeg2000/buggie-gray.jpf`.)