### PR TITLE
Kernel: Add FATFS write support

### DIFF
--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -237,7 +237,7 @@ ErrorOr<void> FATFS::initialize_while_locked()
     }
 
     root_entry.attributes = FATAttributes::Directory;
-    m_root_inode = TRY(FATInode::create(*this, root_entry));
+    m_root_inode = TRY(FATInode::create(*this, root_entry, { 0, 1 }));
 
     return {};
 }

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -354,6 +354,23 @@ u32 FATFS::cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u
     return cluster;
 }
 
+u32 FATFS::end_of_chain_marker() const
+{
+    // Returns the end of chain entry for the given file system.
+    // Any FAT entry of this value or greater signifies the end
+    // of the chain has been reached for a given entry.
+    switch (m_fat_version) {
+    case FATVersion::FAT12:
+        return 0xFF8;
+    case FATVersion::FAT16:
+        return 0xFFF8;
+    case FATVersion::FAT32:
+        return 0x0FFFFFF8;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 ErrorOr<u32> FATFS::fat_read(u32 cluster)
 {
     dbgln_if(FAT_DEBUG, "FATFS: Reading FAT entry for cluster {}", cluster);

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -122,11 +122,11 @@ ErrorOr<void> FATFS::initialize_while_locked()
 
     if constexpr (FAT_DEBUG) {
         dbgln("FATFS: oem_identifier: {}", block->oem_identifier);
-        dbgln("FATFS: bytes_per_sector: {}", block->bytes_per_sector);
+        dbgln("FATFS: bytes_per_sector: {}", static_cast<u16>(block->bytes_per_sector));
         dbgln("FATFS: sectors_per_cluster: {}", block->sectors_per_cluster);
         dbgln("FATFS: reserved_sector_count: {}", block->reserved_sector_count);
         dbgln("FATFS: fat_count: {}", block->fat_count);
-        dbgln("FATFS: root_directory_entry_count: {}", block->root_directory_entry_count);
+        dbgln("FATFS: root_directory_entry_count: {}", static_cast<u16>(block->root_directory_entry_count));
         dbgln("FATFS: media_descriptor_type: {}", block->media_descriptor_type);
         dbgln("FATFS: sectors_per_track: {}", block->sectors_per_track);
         dbgln("FATFS: head_count: {}", block->head_count);
@@ -144,7 +144,7 @@ ErrorOr<void> FATFS::initialize_while_locked()
             dbgln("FATFS: fs_info_sector: {}", dos7_boot_record->fs_info_sector);
             dbgln("FATFS: backup_boot_sector: {}", dos7_boot_record->backup_boot_sector);
             dbgln("FATFS: drive_number: {}", dos7_boot_record->drive_number);
-            dbgln("FATFS: volume_id: {}", dos7_boot_record->volume_id);
+            dbgln("FATFS: volume_id: {}", static_cast<u32>(dos7_boot_record->volume_id));
         } else if (ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_3 || ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_4) {
             DOS4BIOSParameterBlock const* dos4_boot_record = ebpb.dos4_bpb();
             if (ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_3) {
@@ -154,7 +154,7 @@ ErrorOr<void> FATFS::initialize_while_locked()
             }
             dbgln("FATFS: drive_number: {}", dos4_boot_record->drive_number);
             dbgln("FATFS: flags: {}", dos4_boot_record->flags);
-            dbgln("FATFS: volume_id: {}", dos4_boot_record->volume_id);
+            dbgln("FATFS: volume_id: {}", static_cast<u32>(dos4_boot_record->volume_id));
 
             // volume_label_string and file_system_type are only valid when
             // ebpb_version == DOSBIOSParameterBlockVersion::DOS4.

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -239,6 +239,24 @@ ErrorOr<void> FATFS::initialize_while_locked()
     root_entry.attributes = FATAttributes::Directory;
     m_root_inode = TRY(FATInode::create(*this, root_entry, { 0, 1 }));
 
+    if (m_fat_version == FATVersion::FAT32) {
+        auto fs_info_buffer = UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&m_fs_info));
+        // We know that there is a DOS7 BPB, because if it wasn't present
+        // we would have returned EINVAL above.
+        TRY(read_block(ebpb.dos7_bpb()->fs_info_sector, &fs_info_buffer, sizeof(m_fs_info)));
+
+        if (m_fs_info.lead_signature != fs_info_signature_1 || m_fs_info.struct_signature != fs_info_signature_2 || m_fs_info.trailing_signature != fs_info_signature_3) {
+            dbgln("FATFS: Invalid FSInfo struct signature");
+            dbgln_if(FAT_DEBUG, "FATFS: FSInfo signature1: {:#x}, expected: {:#x}", m_fs_info.lead_signature, fs_info_signature_1);
+            dbgln_if(FAT_DEBUG, "FATFS: FSInfo signature2: {:#x}, expected: {:#x}", m_fs_info.struct_signature, fs_info_signature_2);
+            dbgln_if(FAT_DEBUG, "FATFS: FSInfo signature3: {:#x}, expected: {:#x}", m_fs_info.trailing_signature, fs_info_signature_3);
+            return Error::from_errno(EINVAL);
+        }
+
+        dbgln_if(FAT_DEBUG, "FATFS: fs_info.last_known_free_cluster_count: {}", m_fs_info.last_known_free_cluster_count);
+        dbgln_if(FAT_DEBUG, "FATFS: fs_info.next_free_cluster_hint: {}", m_fs_info.next_free_cluster_hint);
+    }
+
     return {};
 }
 

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -371,6 +371,36 @@ u32 FATFS::end_of_chain_marker() const
     }
 }
 
+ErrorOr<u32> FATFS::allocate_cluster()
+{
+    u32 start_cluster;
+    if (m_fat_version == FATVersion::FAT32) {
+        // If we have a hint, start there.
+        if (m_fs_info.next_free_cluster_hint != fs_info_data_unknown) {
+            start_cluster = m_fs_info.next_free_cluster_hint;
+        } else {
+            // Otherwise, start at the beginning of the data area.
+            start_cluster = first_data_cluster;
+        }
+    } else {
+        // For FAT12/16, start at the beginning of the data area, as there is no
+        // FSInfo struct to store the hint.
+        start_cluster = first_data_cluster;
+    }
+
+    MutexLocker locker(m_lock);
+
+    for (u32 i = start_cluster; i < m_parameter_block->sector_count() / m_parameter_block->common_bpb()->sectors_per_cluster; i++) {
+        if (TRY(fat_read(i)) == 0) {
+            dbgln_if(FAT_DEBUG, "FATFS: Allocating cluster {}", i);
+            TRY(fat_write(i, end_of_chain_marker()));
+            return i;
+        }
+    }
+
+    return Error::from_errno(ENOSPC);
+}
+
 ErrorOr<u32> FATFS::fat_read(u32 cluster)
 {
     dbgln_if(FAT_DEBUG, "FATFS: Reading FAT entry for cluster {}", cluster);

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -82,9 +82,12 @@ private:
     static constexpr u32 fs_info_signature_2 = 0x61417272;
     static constexpr u32 fs_info_signature_3 = 0xAA550000;
 
+    static constexpr u32 fs_info_data_unknown = 0xFFFFFFFF;
+
     static constexpr u32 first_data_cluster = 2;
 
     FatBlockSpan first_block_of_cluster(u32 cluster) const;
+    ErrorOr<u32> allocate_cluster();
 
     size_t fat_offset_for_cluster(u32 cluster) const;
 

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -78,6 +78,10 @@ private:
     static constexpr u8 signature_1 = 0x28;
     static constexpr u8 signature_2 = 0x29;
 
+    static constexpr u32 fs_info_signature_1 = 0x41615252;
+    static constexpr u32 fs_info_signature_2 = 0x61417272;
+    static constexpr u32 fs_info_signature_3 = 0xAA550000;
+
     static constexpr u32 first_data_cluster = 2;
 
     FatBlockSpan first_block_of_cluster(u32 cluster) const;
@@ -91,6 +95,7 @@ private:
     ErrorOr<void> fat_write(u32 cluster, u32 value);
 
     OwnPtr<KBuffer> m_boot_record;
+    FAT32FSInfo m_fs_info;
     OwnPtr<DOSBIOSParameterBlock> m_parameter_block;
     RefPtr<FATInode> m_root_inode;
     u32 m_first_data_sector { 0 };

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -91,6 +91,11 @@ private:
     // Reads the cluster number located at the offset within the table.
     u32 cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u32 entry_offset) const;
 
+    // Returns cluster number value that indicates the end of the chain
+    // has been reached. Any cluster value >= this value indicates this
+    // is the last cluster.
+    u32 end_of_chain_marker() const;
+
     ErrorOr<u32> fat_read(u32 cluster);
     ErrorOr<void> fat_write(u32 cluster, u32 value);
 

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Undefine <undefine@undefine.pl>
+ * Copyright (c) 2022-2024, Undefine <undefine@undefine.pl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -81,6 +81,13 @@ private:
     static constexpr u32 first_data_cluster = 2;
 
     FatBlockSpan first_block_of_cluster(u32 cluster) const;
+
+    size_t fat_offset_for_cluster(u32 cluster) const;
+
+    // Reads the cluster number located at the offset within the table.
+    u32 cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u32 entry_offset) const;
+
+    ErrorOr<u32> fat_read(u32 cluster);
 
     OwnPtr<KBuffer> m_boot_record;
     OwnPtr<DOSBIOSParameterBlock> m_parameter_block;

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -88,6 +88,7 @@ private:
     u32 cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u32 entry_offset) const;
 
     ErrorOr<u32> fat_read(u32 cluster);
+    ErrorOr<void> fat_write(u32 cluster, u32 value);
 
     OwnPtr<KBuffer> m_boot_record;
     OwnPtr<DOSBIOSParameterBlock> m_parameter_block;

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -87,7 +87,10 @@ private:
     static constexpr u32 first_data_cluster = 2;
 
     FatBlockSpan first_block_of_cluster(u32 cluster) const;
+
+    ErrorOr<void> set_free_cluster_count(u32);
     ErrorOr<u32> allocate_cluster();
+    ErrorOr<void> notify_cluster_freed();
 
     size_t fat_offset_for_cluster(u32 cluster) const;
 

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -57,7 +57,7 @@ ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::compute_block_list()
 
         auto first_block_and_length = fs().first_block_of_cluster(cluster);
         for (u8 i = 0; i < first_block_and_length.number_of_sectors; i++)
-            block_list.append(BlockBasedFileSystem::BlockIndex { first_block_and_length.start_block.value() + i });
+            TRY(block_list.try_append(BlockBasedFileSystem::BlockIndex { first_block_and_length.start_block.value() + i }));
 
         // Clusters 0 and 1 are reserved in the FAT, and their entries in the FAT will
         // not point to another valid cluster in the chain (Cluster 0 typically holds
@@ -176,28 +176,28 @@ ErrorOr<NonnullOwnPtr<KString>> FATInode::compute_filename(FATEntry& entry, Vect
 {
     if (lfn_entries.is_empty()) {
         StringBuilder filename;
-        filename.append(byte_terminated_string(StringView(entry.filename, normal_filename_length), ' '));
+        TRY(filename.try_append(byte_terminated_string(StringView(entry.filename, normal_filename_length), ' ')));
         if (entry.extension[0] != ' ') {
-            filename.append('.');
-            filename.append(byte_terminated_string(StringView(entry.extension, normal_extension_length), ' '));
+            TRY(filename.try_append('.'));
+            TRY(filename.try_append(byte_terminated_string(StringView(entry.extension, normal_extension_length), ' ')));
         }
         return TRY(KString::try_create(filename.string_view()));
     } else {
         StringBuilder filename;
         for (auto& lfn_entry : lfn_entries) {
-            filename.append(lfn_entry.characters1[0]);
-            filename.append(lfn_entry.characters1[1]);
-            filename.append(lfn_entry.characters1[2]);
-            filename.append(lfn_entry.characters1[3]);
-            filename.append(lfn_entry.characters1[4]);
-            filename.append(lfn_entry.characters2[0]);
-            filename.append(lfn_entry.characters2[1]);
-            filename.append(lfn_entry.characters2[2]);
-            filename.append(lfn_entry.characters2[3]);
-            filename.append(lfn_entry.characters2[4]);
-            filename.append(lfn_entry.characters2[5]);
-            filename.append(lfn_entry.characters3[0]);
-            filename.append(lfn_entry.characters3[1]);
+            TRY(filename.try_append(lfn_entry.characters1[0]));
+            TRY(filename.try_append(lfn_entry.characters1[1]));
+            TRY(filename.try_append(lfn_entry.characters1[2]));
+            TRY(filename.try_append(lfn_entry.characters1[3]));
+            TRY(filename.try_append(lfn_entry.characters1[4]));
+            TRY(filename.try_append(lfn_entry.characters2[0]));
+            TRY(filename.try_append(lfn_entry.characters2[1]));
+            TRY(filename.try_append(lfn_entry.characters2[2]));
+            TRY(filename.try_append(lfn_entry.characters2[3]));
+            TRY(filename.try_append(lfn_entry.characters2[4]));
+            TRY(filename.try_append(lfn_entry.characters2[5]));
+            TRY(filename.try_append(lfn_entry.characters3[0]));
+            TRY(filename.try_append(lfn_entry.characters3[1]));
         }
 
         // Long Filenames have two terminators:

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -11,15 +11,16 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<FATInode>> FATInode::create(FATFS& fs, FATEntry entry, Vector<FATLongFileNameEntry> const& lfn_entries)
+ErrorOr<NonnullRefPtr<FATInode>> FATInode::create(FATFS& fs, FATEntry entry, FATEntryLocation inode_metadata_location, Vector<FATLongFileNameEntry> const& lfn_entries)
 {
     auto filename = TRY(compute_filename(entry, lfn_entries));
-    return adopt_nonnull_ref_or_enomem(new (nothrow) FATInode(fs, entry, move(filename)));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) FATInode(fs, entry, inode_metadata_location, move(filename)));
 }
 
-FATInode::FATInode(FATFS& fs, FATEntry entry, NonnullOwnPtr<KString> filename)
+FATInode::FATInode(FATFS& fs, FATEntry entry, FATEntryLocation inode_metadata_location, NonnullOwnPtr<KString> filename)
     : Inode(fs, first_cluster(fs.m_fat_version))
     , m_entry(entry)
+    , m_inode_metadata_location(inode_metadata_location)
     , m_filename(move(filename))
 {
     dbgln_if(FAT_DEBUG, "FATFS: Creating inode {} with filename \"{}\"", index(), m_filename);
@@ -160,9 +161,15 @@ ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATIn
             dbgln_if(FAT_DEBUG, "FATFS: Invalid cluster for entry");
             return EINVAL;
         } else {
-            dbgln_if(FAT_DEBUG, "FATFS: Found 8.3 entry");
+            auto entry_number_bytes = i * sizeof(FATEntry);
+            auto block = m_block_list[entry_number_bytes / fs().m_device_block_size];
+
+            auto entries_per_sector = fs().m_device_block_size / sizeof(FATEntry);
+            u32 block_entry = i % entries_per_sector;
+
+            dbgln_if(FAT_DEBUG, "FATFS: Found 8.3 entry at block {}, entry {}", block, block_entry);
             lfn_entries.reverse();
-            auto inode = TRY(FATInode::create(fs(), *entry, lfn_entries));
+            auto inode = TRY(FATInode::create(fs(), *entry, { block, block_entry }, lfn_entries));
             if (TRY(callback(inode)))
                 return inode;
             lfn_entries.clear();

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -180,10 +180,12 @@ ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()
     return blocks.release_nonnull();
 }
 
-ErrorOr<void> FATInode::replace_child(StringView, Inode&)
+ErrorOr<void> FATInode::replace_child(StringView name, Inode& inode)
 {
-    // TODO: Implement this once we have write support.
-    return Error::from_errno(EROFS);
+    // FIXME: Implement this properly
+    TRY(remove_child(name));
+    TRY(add_child(inode, name, inode.mode()));
+    return {};
 }
 
 ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATInode>)> callback)

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -43,22 +43,20 @@ FATInode::FATInode(FATFS& fs, FATEntry entry, FATEntryLocation inode_metadata_lo
     };
 }
 
-ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::compute_block_list()
+ErrorOr<Vector<u32>> FATInode::compute_cluster_list()
 {
     VERIFY(m_inode_lock.is_locked());
 
-    dbgln_if(FAT_DEBUG, "FATFS: computing block list for inode {}", index());
+    dbgln_if(FAT_DEBUG, "FATFS: computing cluster list for inode {}", index());
 
     u32 cluster = first_cluster();
 
-    Vector<BlockBasedFileSystem::BlockIndex> block_list;
+    Vector<u32> cluster_list;
 
     while (cluster < end_of_chain_marker()) {
         dbgln_if(FAT_DEBUG, "FATFS: Appending cluster {} to inode {}'s cluster chain", cluster, index());
 
-        auto first_block_and_length = fs().first_block_of_cluster(cluster);
-        for (u8 i = 0; i < first_block_and_length.number_of_sectors; i++)
-            TRY(block_list.try_append(BlockBasedFileSystem::BlockIndex { first_block_and_length.start_block.value() + i }));
+        TRY(cluster_list.try_append(cluster));
 
         // Clusters 0 and 1 are reserved in the FAT, and their entries in the FAT will
         // not point to another valid cluster in the chain (Cluster 0 typically holds
@@ -78,6 +76,28 @@ ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::compute_block_list()
 
         // Look up the next cluster to read, or read End of Chain marker from table.
         cluster = TRY(fs().fat_read(cluster));
+    }
+
+    return cluster_list;
+}
+
+ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::get_block_list()
+{
+    VERIFY(m_inode_lock.is_locked());
+
+    dbgln_if(FAT_DEBUG, "FATFS: getting block list for inode {}", index());
+
+    Vector<BlockBasedFileSystem::BlockIndex> block_list;
+
+    if (m_cluster_list.is_empty())
+        m_cluster_list = TRY(compute_cluster_list());
+
+    for (auto cluster : m_cluster_list) {
+        auto span = fs().first_block_of_cluster(cluster);
+        for (size_t i = 0; i < span.number_of_sectors; i++) {
+            dbgln_if(FAT_DEBUG, "FATFS: Appending block {} to inode {}'s block list", BlockBasedFileSystem::BlockIndex { span.start_block.value() + i }, index());
+            TRY(block_list.try_append(BlockBasedFileSystem::BlockIndex { span.start_block.value() + i }));
+        }
     }
 
     return block_list;
@@ -104,10 +124,9 @@ ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()
 {
     VERIFY(m_inode_lock.is_locked());
 
-    dbgln_if(FAT_DEBUG, "FATFS: reading block list for inode {} ({} blocks)", index(), m_block_list.size());
+    auto block_list = TRY(get_block_list());
 
-    if (m_block_list.is_empty())
-        m_block_list = TRY(compute_block_list());
+    dbgln_if(FAT_DEBUG, "FATFS: reading block list for inode {} ({} blocks)", index(), block_list.size());
 
     auto builder = TRY(KBufferBuilder::try_create());
 
@@ -115,7 +134,7 @@ ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()
     VERIFY(fs().m_device_block_size <= sizeof(buffer));
     auto buf = UserOrKernelBuffer::for_kernel_buffer(buffer);
 
-    for (BlockBasedFileSystem::BlockIndex block : m_block_list) {
+    for (BlockBasedFileSystem::BlockIndex block : block_list) {
         dbgln_if(FAT_DEBUG, "FATFS: reading block: {}", block);
         TRY(fs().read_block(block, &buf, sizeof(buffer)));
         TRY(builder.append((char const*)buffer, fs().m_device_block_size));
@@ -140,6 +159,8 @@ ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATIn
     Vector<FATLongFileNameEntry> lfn_entries;
     auto blocks = TRY(read_block_list());
 
+    u32 bytes_per_cluster = fs().m_device_block_size * fs().m_parameter_block->common_bpb()->sectors_per_cluster;
+
     for (u32 i = 0; i < blocks->size() / sizeof(FATEntry); i++) {
         auto* entry = reinterpret_cast<FATEntry*>(blocks->data() + i * sizeof(FATEntry));
         if (entry->filename[0] == end_entry_byte) {
@@ -162,7 +183,8 @@ ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATIn
             return EINVAL;
         } else {
             auto entry_number_bytes = i * sizeof(FATEntry);
-            auto block = m_block_list[entry_number_bytes / fs().m_device_block_size];
+            auto cluster = m_cluster_list[entry_number_bytes / bytes_per_cluster];
+            auto block = BlockBasedFileSystem::BlockIndex { fs().first_block_of_cluster(cluster).start_block.value() + (entry_number_bytes % bytes_per_cluster) / fs().m_device_block_size };
 
             auto entries_per_sector = fs().m_device_block_size / sizeof(FATEntry);
             u32 block_entry = i % entries_per_sector;
@@ -265,7 +287,7 @@ ErrorOr<size_t> FATInode::read_bytes_locked(off_t offset, size_t size, UserOrKer
     //   3. The number of blocks returned for reading.
     size_t read_size = min(
         min(size, m_metadata.size - offset),
-        (m_block_list.size() * fs().m_device_block_size) - offset);
+        (m_cluster_list.size() * fs().m_device_block_size * fs().m_parameter_block->common_bpb()->sectors_per_cluster) - offset);
     TRY(buffer.write(blocks->data() + offset, read_size));
 
     return read_size;

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -1,11 +1,9 @@
 /*
- * Copyright (c) 2022, Undefine <undefine@undefine.pl>
+ * Copyright (c) 2022-2024, Undefine <undefine@undefine.pl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteReader.h>
-#include <AK/Endian.h>
 #include <AK/Time.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/FATFS/Inode.h>
@@ -54,9 +52,6 @@ ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::compute_block_list()
 
     Vector<BlockBasedFileSystem::BlockIndex> block_list;
 
-    auto fat_sector = TRY(KBuffer::try_create_with_size("FATFS: FAT read buffer"sv, fs().m_device_block_size));
-    auto fat_sector_buffer = UserOrKernelBuffer::for_kernel_buffer(fat_sector->data());
-
     while (cluster < end_of_chain_marker()) {
         dbgln_if(FAT_DEBUG, "FATFS: Appending cluster {} to inode {}'s cluster chain", cluster, index());
 
@@ -80,14 +75,8 @@ ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::compute_block_list()
             break;
         }
 
-        u32 fat_offset = fat_offset_for_cluster(cluster);
-        u32 fat_sector_index = fs().m_parameter_block->common_bpb()->reserved_sector_count + (fat_offset / fs().m_device_block_size);
-        u32 entry_offset = fat_offset % fs().m_device_block_size;
-
-        TRY(fs().read_block(fat_sector_index, &fat_sector_buffer, m_device_block_size));
-
         // Look up the next cluster to read, or read End of Chain marker from table.
-        cluster = cluster_number(*fat_sector, cluster, entry_offset);
+        cluster = TRY(fs().fat_read(cluster));
     }
 
     return block_list;
@@ -108,70 +97,6 @@ u32 FATInode::end_of_chain_marker() const
     default:
         VERIFY_NOT_REACHED();
     }
-}
-
-size_t FATInode::fat_offset_for_cluster(u32 cluster) const
-{
-    switch (fs().m_fat_version) {
-    case FATVersion::FAT12: {
-        // In FAT12, a cluster entry is stored in a byte, plus
-        // the low/high nybble of an adjacent byte.
-        //
-        // CLSTR:   0 1      2 3      4 5
-        // INDEX: [0 1 2], [3 4 5], [6 7 8]
-
-        // Every 2 clusters are represented using 3 bytes.
-        return (cluster * 3) / 2;
-    } break;
-    case FATVersion::FAT16:
-        return cluster * 2; // Each cluster is stored in 2 bytes.
-    case FATVersion::FAT32:
-        return cluster * 4; // Each cluster is stored in 4 bytes.
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-u32 FATInode::cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u32 entry_offset) const
-{
-    u32 cluster = 0;
-    switch (fs().m_fat_version) {
-    case FATVersion::FAT12: {
-        u16 fat12_bytes_le = 0;
-        // Two FAT12 entries get stored in a total of 3 bytes, as follows:
-        // AB CD EF are grouped as [D AB] and [E FC] (little-endian).
-        // For a given cluster, we interpret the associated 2 bytes as a little-endian
-        // 16-bit value ({CD AB} or {EF CD}), and then shift/mask the extra high or low nybble.
-        ByteReader::load<u16>(fat_sector.bytes().offset(entry_offset), fat12_bytes_le);
-        cluster = LittleEndian { fat12_bytes_le };
-        if (entry_cluster_number % 2 == 0) {
-            // CD AB -> D AB
-            cluster &= 0x0FFF;
-        } else {
-            // EF CD -> E FC.
-            cluster = cluster >> 4;
-        }
-        break;
-    }
-    case FATVersion::FAT16: {
-        u16 cluster_u16_le = 0;
-        ByteReader::load<u16>(fat_sector.bytes().offset(entry_offset), cluster_u16_le);
-        cluster = LittleEndian { cluster_u16_le };
-        break;
-    }
-    case FATVersion::FAT32: {
-        u32 cluster_u32_le = 0;
-        ByteReader::load<u32>(fat_sector.bytes().offset(entry_offset), cluster_u32_le);
-        cluster = LittleEndian { cluster_u32_le };
-        // FAT32 entries use 28-bits to represent the cluster number. The top 4 bits
-        // may contain flags or other data and must be masked off.
-        cluster &= 0x0FFFFFFF;
-        break;
-    }
-    default:
-        VERIFY_NOT_REACHED();
-    }
-    return cluster;
 }
 
 ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/Time.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/FATFS/Inode.h>
@@ -68,6 +69,70 @@ ErrorOr<Vector<u32>> FATInode::compute_cluster_list(FATFS& fs, u32 first_cluster
     }
 
     return cluster_list;
+}
+
+u8 FATInode::lfn_entry_checksum(FATEntry const& entry)
+{
+    u8 checksum = entry.filename[0];
+    for (size_t i = 1; i < normal_filename_length; i++)
+        checksum = (checksum << 7) + (checksum >> 1) + entry.filename[i];
+    for (size_t i = 0; i < normal_extension_length; i++)
+        checksum = (checksum << 7) + (checksum >> 1) + entry.extension[i];
+    return checksum;
+}
+
+void FATInode::create_83_filename_for(FATEntry& entry, StringView name)
+{
+    // FIXME: Implement the correct algorithm based on 3.2.4 from http://www.osdever.net/documents/LongFileName.pdf
+    for (size_t i = 0; i < min(name.length(), normal_filename_length); i++)
+        entry.filename[i] = to_ascii_uppercase(name[i]);
+}
+
+ErrorOr<Vector<FATLongFileNameEntry>> FATInode::create_lfn_entries(StringView name, u8 checksum)
+{
+    u32 lfn_entry_count = ceil_div(name.length(), characters_per_lfn_entry);
+
+    Vector<FATLongFileNameEntry> lfn_entries;
+    TRY(lfn_entries.try_ensure_capacity(lfn_entry_count));
+
+    auto characters_left = name.length();
+
+    for (u32 i = 0; i < lfn_entry_count; i++) {
+        FATLongFileNameEntry lfn_entry {};
+
+        size_t characters_in_part = min(characters_left, lfn_entry_characters_part_1_length);
+
+        for (size_t j = 0; j < characters_in_part; j++) {
+            lfn_entry.characters1[j] = name[name.length() - characters_left];
+            characters_left--;
+        }
+
+        if (characters_left > 0) {
+            characters_in_part = min(characters_left, lfn_entry_characters_part_2_length);
+
+            for (size_t j = 0; j < characters_in_part; j++) {
+                lfn_entry.characters2[j] = name[name.length() - characters_left];
+                characters_left--;
+            }
+        }
+
+        if (characters_left > 0) {
+            characters_in_part = min(characters_left, lfn_entry_characters_part_3_length);
+
+            for (size_t j = 0; j < characters_in_part; j++) {
+                lfn_entry.characters3[j] = name[name.length() - characters_left];
+                characters_left--;
+            }
+        }
+
+        lfn_entry.entry_index = (i + 1) | (i + 1 == lfn_entry_count ? last_lfn_entry_mask : 0);
+        lfn_entry.checksum = checksum;
+        lfn_entry.attributes = FATAttributes::LongFileName;
+
+        lfn_entries.unchecked_append(lfn_entry);
+    }
+
+    return lfn_entries;
 }
 
 ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::get_block_list()
@@ -301,6 +366,64 @@ ErrorOr<void> FATInode::remove_last_cluster_from_chain()
     return {};
 }
 
+ErrorOr<Vector<FATEntryLocation>> FATInode::allocate_entries(u32 count)
+{
+    // FIXME: This function ignores unused entries, we should make use of them
+    // FIXME: If we fail anywhere here, we should make sure the end entry is at the correct location
+
+    auto blocks = TRY(read_block_list());
+    auto entries = bit_cast<FATEntry*>(blocks->data());
+
+    auto const entries_per_block = fs().logical_block_size() / sizeof(FATEntry);
+
+    auto block_list = TRY(get_block_list());
+
+    Vector<FATEntryLocation> locations;
+    TRY(locations.try_ensure_capacity(count));
+
+    for (u32 current_entry_index = 0; current_entry_index < blocks->size() / sizeof(FATEntry); current_entry_index++) {
+        auto& entry = entries[current_entry_index];
+        if (entry.filename[0] != end_entry_byte)
+            continue;
+
+        while (current_entry_index < blocks->size() / sizeof(FATEntry) && locations.size() < count) {
+            u32 chosen_block_index = current_entry_index / entries_per_block;
+            u32 chosen_entry_index = current_entry_index % entries_per_block;
+            locations.unchecked_append({ block_list[chosen_block_index], chosen_entry_index });
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::allocate_entries(): allocated new entry at block {}, offset {}", identifier(), block_list[chosen_block_index], chosen_entry_index);
+            current_entry_index++;
+        }
+        if (locations.size() == count) {
+            u32 block_index = current_entry_index / entries_per_block;
+            u32 entry_index = current_entry_index % entries_per_block;
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::allocate_entries(): putting new end entry at block {}, offset {}", identifier(), block_list[block_index], entry_index);
+
+            FATEntry end_entry {};
+            end_entry.filename[0] = end_entry_byte;
+            TRY(fs().write_block(block_list[block_index], UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&end_entry)), sizeof(FATEntry), entry_index * sizeof(FATEntry)));
+            break;
+        }
+    }
+
+    if (locations.size() < count) {
+        TRY(allocate_and_add_cluster_to_chain());
+        u32 new_block_index = block_list.size() - fs().m_parameter_block->common_bpb()->sectors_per_cluster - 1;
+        u32 entry_index;
+        for (entry_index = 0; entry_index < count - locations.size(); entry_index++) {
+            locations.unchecked_append({ block_list[new_block_index], entry_index });
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::allocate_entries(): allocated new entry at block {}, offset {}", identifier(), block_list[new_block_index], entry_index);
+        }
+
+        dbgln_if(FAT_DEBUG, "FATInode[{}]::allocate_entries(): putting new end entry at block {}, offset {}", identifier(), block_list[new_block_index], entry_index);
+
+        FATEntry end_entry {};
+        end_entry.filename[0] = end_entry_byte;
+        TRY(fs().write_block(block_list[new_block_index], UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&end_entry)), sizeof(FATEntry), entry_index * sizeof(FATEntry)));
+    }
+
+    return locations;
+}
+
 ErrorOr<size_t> FATInode::read_bytes_locked(off_t offset, size_t size, UserOrKernelBuffer& buffer, OpenFileDescription*) const
 {
     dbgln_if(FAT_DEBUG, "FATInode[{}]::read_bytes_locked(): Reading {} bytes at offset {}", identifier(), size, offset);
@@ -407,9 +530,42 @@ ErrorOr<size_t> FATInode::write_bytes_locked(off_t offset, size_t size, UserOrKe
     return size;
 }
 
-ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView, mode_t, dev_t, UserID, GroupID)
+ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView name, mode_t mode, dev_t, UserID, GroupID)
 {
-    return EROFS;
+    VERIFY(has_flag(m_entry.attributes, FATAttributes::Directory));
+
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::create_child(): creating inode \"{}\"", identifier(), name);
+
+    FATEntry entry {};
+    create_83_filename_for(entry, name);
+
+    // TODO: We should set the hidden attribute if the file starts with a dot or read only (the same way Linux does this).
+    if (mode & S_IFDIR)
+        entry.attributes |= FATAttributes::Directory;
+
+    // FIXME: Set the dates
+
+    // FIXME: For some filenames lfn entries are not necessary
+    auto lfn_entries = TRY(create_lfn_entries(name, lfn_entry_checksum(entry)));
+
+    MutexLocker locker(m_inode_lock);
+
+    auto entries = TRY(allocate_entries(lfn_entries.size() + 1));
+    u32 allocated_cluster = TRY(fs().allocate_cluster());
+    if (fs().m_fat_version == FATVersion::FAT32)
+        entry.first_cluster_high = allocated_cluster >> 16;
+
+    entry.first_cluster_low = allocated_cluster & 0xFFFF;
+
+    // FIXME: If we fail here we should clean up the entries we wrote
+    TRY(fs().write_block(entries[lfn_entries.size()].block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&entry)), sizeof(FATEntry), entries[lfn_entries.size()].entry * sizeof(FATEntry)));
+
+    for (u32 i = 0; i < lfn_entries.size(); i++) {
+        auto location = entries[lfn_entries.size() - i - 1];
+        TRY(fs().write_block(location.block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&lfn_entries[i])), sizeof(FATLongFileNameEntry), location.entry * sizeof(FATLongFileNameEntry)));
+    }
+
+    return TRY(FATInode::create(fs(), entry, entries[lfn_entries.size()], lfn_entries));
 }
 
 ErrorOr<void> FATInode::add_child(Inode&, StringView, mode_t)

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -84,7 +84,7 @@ ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::compute_block_list()
         u32 fat_sector_index = fs().m_parameter_block->common_bpb()->reserved_sector_count + (fat_offset / fs().m_device_block_size);
         u32 entry_offset = fat_offset % fs().m_device_block_size;
 
-        TRY(fs().raw_read(fat_sector_index, fat_sector_buffer));
+        TRY(fs().read_block(fat_sector_index, &fat_sector_buffer, m_device_block_size));
 
         // Look up the next cluster to read, or read End of Chain marker from table.
         cluster = cluster_number(*fat_sector, cluster, entry_offset);
@@ -191,7 +191,7 @@ ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()
 
     for (BlockBasedFileSystem::BlockIndex block : m_block_list) {
         dbgln_if(FAT_DEBUG, "FATFS: reading block: {}", block);
-        TRY(fs().raw_read(block, buf));
+        TRY(fs().read_block(block, &buf, sizeof(buffer)));
         TRY(builder.append((char const*)buffer, fs().m_device_block_size));
     }
 

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -29,21 +29,21 @@ FATInode::FATInode(FATFS& fs, FATEntry entry, FATEntryLocation inode_metadata_lo
     , m_inode_metadata_location(inode_metadata_location)
     , m_filename(move(filename))
 {
-    dbgln_if(FAT_DEBUG, "FATFS: Creating inode {} with filename \"{}\"", index(), m_filename);
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::FATInode(): Creating inode with filename \"{}\"", identifier(), m_filename);
 }
 
 ErrorOr<Vector<u32>> FATInode::compute_cluster_list(FATFS& fs, u32 first_cluster)
 {
     VERIFY(m_inode_lock.is_locked());
 
-    dbgln_if(FAT_DEBUG, "FATFS: computing block list starting with cluster {}", first_cluster);
+    dbgln_if(FAT_DEBUG, "FATInode::compute_cluster_list(): computing block list starting with cluster {}", first_cluster);
 
     u32 cluster = first_cluster;
 
     Vector<u32> cluster_list;
 
     while (cluster < fs.end_of_chain_marker()) {
-        dbgln_if(FAT_DEBUG, "FATFS: Appending cluster {} to cluster chain starting with {}", cluster, first_cluster);
+        dbgln_if(FAT_DEBUG, "FATInode::compute_cluster_list(): Appending cluster {} to cluster chain starting with {}", cluster, first_cluster);
 
         TRY(cluster_list.try_append(cluster));
 
@@ -74,14 +74,14 @@ ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> FATInode::get_block_list()
 {
     VERIFY(m_inode_lock.is_locked());
 
-    dbgln_if(FAT_DEBUG, "FATFS: getting block list for inode {}", index());
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::get_block_list(): getting block list", identifier());
 
     Vector<BlockBasedFileSystem::BlockIndex> block_list;
 
     for (auto cluster : m_cluster_list) {
         auto span = fs().first_block_of_cluster(cluster);
         for (size_t i = 0; i < span.number_of_sectors; i++) {
-            dbgln_if(FAT_DEBUG, "FATFS: Appending block {} to inode {}'s block list", BlockBasedFileSystem::BlockIndex { span.start_block.value() + i }, index());
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::get_block_list(): Appending block {} to  block list", identifier(), BlockBasedFileSystem::BlockIndex { span.start_block.value() + i });
             TRY(block_list.try_append(BlockBasedFileSystem::BlockIndex { span.start_block.value() + i }));
         }
     }
@@ -95,7 +95,7 @@ ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()
 
     auto block_list = TRY(get_block_list());
 
-    dbgln_if(FAT_DEBUG, "FATFS: reading block list for inode {} ({} blocks)", index(), block_list.size());
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::read_block_list(): reading block list ({} blocks)", identifier(), block_list.size());
 
     auto builder = TRY(KBufferBuilder::try_create());
 
@@ -104,7 +104,7 @@ ErrorOr<NonnullOwnPtr<KBuffer>> FATInode::read_block_list()
     auto buf = UserOrKernelBuffer::for_kernel_buffer(buffer);
 
     for (BlockBasedFileSystem::BlockIndex block : block_list) {
-        dbgln_if(FAT_DEBUG, "FATFS: reading block: {}", block);
+        dbgln_if(FAT_DEBUG, "FATInode[{}]::read_block_list(): reading block: {}", identifier(), block);
         TRY(fs().read_block(block, &buf, sizeof(buffer)));
         TRY(builder.append((char const*)buffer, fs().m_device_block_size));
     }
@@ -133,13 +133,13 @@ ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATIn
     for (u32 i = 0; i < blocks->size() / sizeof(FATEntry); i++) {
         auto* entry = reinterpret_cast<FATEntry*>(blocks->data() + i * sizeof(FATEntry));
         if (entry->filename[0] == end_entry_byte) {
-            dbgln_if(FAT_DEBUG, "FATFS: Found end entry");
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::traverse(): Found end entry", identifier());
             return nullptr;
         } else if (static_cast<u8>(entry->filename[0]) == unused_entry_byte) {
-            dbgln_if(FAT_DEBUG, "FATFS: Found unused entry");
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::traverse(): Found unused entry", identifier());
             lfn_entries.clear();
         } else if (entry->attributes == FATAttributes::LongFileName) {
-            dbgln_if(FAT_DEBUG, "FATFS: Found LFN entry");
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::traverse(): Found LFN entry", identifier());
             TRY(lfn_entries.try_append(*reinterpret_cast<FATLongFileNameEntry*>(entry)));
         } else if ((entry->first_cluster_high << 16 | entry->first_cluster_low) <= 1 && entry->file_size > 0) {
             // Because clusters 0 and 1 are reserved, only empty files (size == 0 files)
@@ -148,7 +148,7 @@ ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATIn
             // on FAT12/16 file systems (a signal to look in the root directory region),
             // so we ensure that no entries read off the file system have a cluster number
             // that would also point to this region.
-            dbgln_if(FAT_DEBUG, "FATFS: Invalid cluster for entry");
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::traverse(): Invalid cluster for entry", identifier());
             return EINVAL;
         } else {
             auto entry_number_bytes = i * sizeof(FATEntry);
@@ -158,7 +158,7 @@ ErrorOr<RefPtr<FATInode>> FATInode::traverse(Function<ErrorOr<bool>(RefPtr<FATIn
             auto entries_per_sector = fs().m_device_block_size / sizeof(FATEntry);
             u32 block_entry = i % entries_per_sector;
 
-            dbgln_if(FAT_DEBUG, "FATFS: Found 8.3 entry at block {}, entry {}", block, block_entry);
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::traverse(): Found 8.3 entry at block {}, entry {}", identifier(), block, block_entry);
             lfn_entries.reverse();
             auto inode = TRY(FATInode::create(fs(), *entry, { block, block_entry }, lfn_entries));
             if (TRY(callback(inode)))
@@ -242,7 +242,7 @@ u32 FATInode::first_cluster(FATVersion const version) const
 
 ErrorOr<size_t> FATInode::read_bytes_locked(off_t offset, size_t size, UserOrKernelBuffer& buffer, OpenFileDescription*) const
 {
-    dbgln_if(FAT_DEBUG, "FATFS: Reading inode {}: size: {} offset: {}", identifier().index(), size, offset);
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::read_bytes_locked(): Reading {} bytes at offset {}", identifier(), size, offset);
     VERIFY(offset >= 0);
     if (offset >= m_entry.file_size)
         return 0;

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -604,9 +604,64 @@ ErrorOr<void> FATInode::add_child(Inode& inode, StringView name, mode_t mode)
     return {};
 }
 
-ErrorOr<void> FATInode::remove_child(StringView)
+ErrorOr<void> FATInode::remove_child(StringView name)
 {
-    return EROFS;
+    MutexLocker locker(m_inode_lock);
+
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::remove_child(): removing inode \"{}\"", identifier(), name);
+
+    VERIFY(has_flag(m_entry.attributes, FATAttributes::Directory));
+
+    Vector<FATLongFileNameEntry> lfn_entries;
+    TRY(lfn_entries.try_ensure_capacity(ceil_div(max_filename_length, characters_per_lfn_entry)));
+
+    Vector<FATEntryLocation> lfn_entry_locations;
+    TRY(lfn_entry_locations.try_ensure_capacity(ceil_div(max_filename_length, characters_per_lfn_entry)));
+
+    auto block_list = TRY(get_block_list());
+    auto block_buffer = TRY(read_block_list());
+
+    for (u32 i = 0; i < block_buffer->size() / sizeof(FATEntry); i++) {
+        auto* entry = bit_cast<FATEntry*>(block_buffer->data() + i * sizeof(FATEntry));
+
+        auto entry_number_bytes = i * sizeof(FATEntry);
+        auto block = block_list[entry_number_bytes / fs().logical_block_size()];
+
+        auto entries_per_sector = fs().logical_block_size() / sizeof(FATEntry);
+        u32 block_entry = i % entries_per_sector;
+
+        if (entry->filename[0] == end_entry_byte) {
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::remove_child(): Found end entry", identifier());
+            return ENOENT;
+        } else if (static_cast<u8>(entry->filename[0]) == unused_entry_byte) {
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::remove_child(): Found unused entry", identifier());
+            lfn_entries.clear_with_capacity();
+            lfn_entry_locations.clear_with_capacity();
+        } else if (entry->attributes == FATAttributes::LongFileName) {
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::remove_child(): Found LFN entry", identifier());
+            lfn_entries.unchecked_append(*bit_cast<FATLongFileNameEntry*>(entry));
+            lfn_entry_locations.unchecked_append({ block, block_entry });
+        } else {
+            dbgln_if(FAT_DEBUG, "FATInode[{}]::remove_child(): Found 8.3 entry at block {}, entry {}", identifier(), block, block_entry);
+            lfn_entries.reverse();
+            auto filename = TRY(compute_filename(*entry, lfn_entries));
+            if (filename->view() == name) {
+                // FIXME: If it's the last entry move the end entry instead of unused entries
+                FATEntry unused_entry {};
+                unused_entry.filename[0] = unused_entry_byte;
+                TRY(fs().write_block(block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&unused_entry)), sizeof(FATEntry), block_entry * sizeof(FATEntry)));
+
+                for (auto const& lfn_entry_location : lfn_entry_locations)
+                    TRY(fs().write_block(lfn_entry_location.block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&unused_entry)), sizeof(FATEntry), lfn_entry_location.entry * sizeof(FATEntry)));
+
+                return {};
+            }
+            lfn_entries.clear_with_capacity();
+            lfn_entry_locations.clear_with_capacity();
+        }
+    }
+
+    return EINVAL;
 }
 
 ErrorOr<void> FATInode::chmod(mode_t)

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -568,9 +568,40 @@ ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView name, mode_t mod
     return TRY(FATInode::create(fs(), entry, entries[lfn_entries.size()], lfn_entries));
 }
 
-ErrorOr<void> FATInode::add_child(Inode&, StringView, mode_t)
+ErrorOr<void> FATInode::add_child(Inode& inode, StringView name, mode_t mode)
 {
-    return EROFS;
+    VERIFY(has_flag(m_entry.attributes, FATAttributes::Directory));
+    VERIFY(inode.fsid() == fsid());
+
+    // FIXME: There's a lot of similar code between this function and create_child, we should try to factor out some of the common code.
+
+    dbgln_if(FAT_DEBUG, "FATInode[{}]::add_child(): appending inode {} as \"{}\"", identifier(), inode.identifier(), name);
+
+    auto entry = bit_cast<FATInode*>(&inode)->m_entry;
+    create_83_filename_for(entry, name);
+
+    // TODO: We should set the hidden attribute if the file starts with a dot or read only (the same way Linux does this).
+    if (mode & S_IFDIR)
+        entry.attributes |= FATAttributes::Directory;
+
+    // FIXME: Set the dates
+
+    // FIXME: For some filenames lfn entries are not necessary
+    auto lfn_entries = TRY(create_lfn_entries(name, lfn_entry_checksum(entry)));
+
+    MutexLocker locker(m_inode_lock);
+
+    auto entries = TRY(allocate_entries(lfn_entries.size() + 1));
+
+    // FIXME: If we fail here we should clean up the entries we wrote
+    TRY(fs().write_block(entries[lfn_entries.size()].block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&entry)), sizeof(FATEntry), entries[lfn_entries.size()].entry * sizeof(FATEntry)));
+
+    for (u32 i = 0; i < lfn_entries.size(); i++) {
+        auto location = entries[lfn_entries.size() - i - 1];
+        TRY(fs().write_block(location.block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&lfn_entries[i])), sizeof(FATLongFileNameEntry), location.entry * sizeof(FATLongFileNameEntry)));
+    }
+
+    return {};
 }
 
 ErrorOr<void> FATInode::remove_child(StringView)

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -329,12 +329,13 @@ ErrorOr<void> FATInode::remove_child(StringView)
 
 ErrorOr<void> FATInode::chmod(mode_t)
 {
-    return EROFS;
+    // TODO: Linux actually does do some stuff here, like setting the hidden attribute if the file starts with a dot.
+    return Error::from_errno(ENOTSUP);
 }
 
 ErrorOr<void> FATInode::chown(UserID, GroupID)
 {
-    return EROFS;
+    return Error::from_errno(ENOTSUP);
 }
 
 ErrorOr<void> FATInode::flush_metadata()

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -476,8 +476,6 @@ ErrorOr<void> FATInode::traverse_as_directory(Function<ErrorOr<void>(FileSystem:
     VERIFY(has_flag(m_entry.attributes, FATAttributes::Directory));
 
     [[maybe_unused]] auto inode = TRY(const_cast<FATInode&>(*this).traverse([&callback](auto inode) -> ErrorOr<bool> {
-        if (inode->m_filename->view() == "" || inode->m_filename->view() == "." || inode->m_filename->view() == "..")
-            return false;
         TRY(callback({ inode->m_filename->view(), inode->identifier(), static_cast<u8>(inode->m_entry.attributes) }));
         return false;
     }));

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -346,6 +346,7 @@ ErrorOr<void> FATInode::remove_last_cluster_from_chain()
 
     dbgln_if(FAT_DEBUG, "FATInode[{}]::remove_last_cluster_from_chain(): freeing cluster {}", identifier(), last_cluster);
 
+    TRY(fs().notify_cluster_freed());
     m_cluster_list.remove(m_cluster_list.size() - 1);
 
     if (m_cluster_list.is_empty() || (m_cluster_list.size() == 1 && first_cluster() <= 1)) {

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -52,7 +52,8 @@ private:
     static ErrorOr<NonnullOwnPtr<KString>> compute_filename(FATEntry&, Vector<FATLongFileNameEntry> const& = {});
     static StringView byte_terminated_string(StringView, u8);
 
-    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> compute_block_list();
+    ErrorOr<Vector<u32>> compute_cluster_list();
+    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_block_list();
     ErrorOr<NonnullOwnPtr<KBuffer>> read_block_list();
     ErrorOr<RefPtr<FATInode>> traverse(Function<ErrorOr<bool>(RefPtr<FATInode>)> callback);
     u32 first_cluster() const;
@@ -76,7 +77,7 @@ private:
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> flush_metadata() override;
 
-    Vector<BlockBasedFileSystem::BlockIndex> m_block_list;
+    Vector<u32> m_cluster_list;
     FATEntry m_entry;
     FATEntryLocation m_inode_metadata_location;
     NonnullOwnPtr<KString> m_filename;

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Undefine <undefine@undefine.pl>
+ * Copyright (c) 2022-2024, Undefine <undefine@undefine.pl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,15 +30,10 @@ public:
 private:
     FATInode(FATFS&, FATEntry, NonnullOwnPtr<KString> filename);
 
-    size_t fat_offset_for_cluster(u32 cluster) const;
-
     // Returns cluster number value that indicates the end of the chain
     // has been reached. Any cluster value >= this value indicates this
     // is the last cluster.
     u32 end_of_chain_marker() const;
-
-    // Reads the cluster number located at the offset within the table.
-    u32 cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u32 entry_offset) const;
 
     static constexpr u8 end_entry_byte = 0x00;
     static constexpr u8 unused_entry_byte = 0xE5;

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -16,19 +16,24 @@
 
 namespace Kernel {
 
+struct FATEntryLocation {
+    BlockBasedFileSystem::BlockIndex block;
+    u32 entry;
+};
+
 class FATInode final : public Inode {
     friend FATFS;
 
 public:
     virtual ~FATInode() override = default;
 
-    static ErrorOr<NonnullRefPtr<FATInode>> create(FATFS&, FATEntry, Vector<FATLongFileNameEntry> const& = {});
+    static ErrorOr<NonnullRefPtr<FATInode>> create(FATFS&, FATEntry, FATEntryLocation inode_metadata_location, Vector<FATLongFileNameEntry> const& = {});
 
     FATFS& fs() { return static_cast<FATFS&>(Inode::fs()); }
     FATFS const& fs() const { return static_cast<FATFS const&>(Inode::fs()); }
 
 private:
-    FATInode(FATFS&, FATEntry, NonnullOwnPtr<KString> filename);
+    FATInode(FATFS&, FATEntry, FATEntryLocation inode_metadata_location, NonnullOwnPtr<KString> filename);
 
     // Returns cluster number value that indicates the end of the chain
     // has been reached. Any cluster value >= this value indicates this
@@ -73,6 +78,7 @@ private:
 
     Vector<BlockBasedFileSystem::BlockIndex> m_block_list;
     FATEntry m_entry;
+    FATEntryLocation m_inode_metadata_location;
     NonnullOwnPtr<KString> m_filename;
     InodeMetadata m_metadata;
 };

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -44,8 +44,18 @@ private:
     static constexpr u8 normal_filename_length = 8;
     static constexpr u8 normal_extension_length = 3;
 
+    static constexpr size_t lfn_entry_characters_part_1_length = 5;
+    static constexpr size_t lfn_entry_characters_part_2_length = 6;
+    static constexpr size_t lfn_entry_characters_part_3_length = 2;
+
+    static constexpr size_t characters_per_lfn_entry = lfn_entry_characters_part_1_length + lfn_entry_characters_part_2_length + lfn_entry_characters_part_3_length;
+    static constexpr u8 last_lfn_entry_mask = 0x40;
+
     static ErrorOr<NonnullOwnPtr<KString>> compute_filename(FATEntry&, Vector<FATLongFileNameEntry> const& = {});
     static StringView byte_terminated_string(StringView, u8);
+    static u8 lfn_entry_checksum(FATEntry const& entry);
+    static void create_83_filename_for(FATEntry& entry, StringView name);
+    static ErrorOr<Vector<FATLongFileNameEntry>> create_lfn_entries(StringView name, u8 checksum);
 
     ErrorOr<Vector<u32>> compute_cluster_list(FATFS&, u32 first_cluster);
     ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_block_list();
@@ -58,6 +68,7 @@ private:
     u32 first_cluster(FATVersion const version) const;
     ErrorOr<void> allocate_and_add_cluster_to_chain();
     ErrorOr<void> remove_last_cluster_from_chain();
+    ErrorOr<Vector<FATEntryLocation>> allocate_entries(u32 count);
 
     ErrorOr<void> resize(u64 size);
 

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -35,11 +35,6 @@ public:
 private:
     FATInode(FATFS&, FATEntry, FATEntryLocation inode_metadata_location, NonnullOwnPtr<KString> filename);
 
-    // Returns cluster number value that indicates the end of the chain
-    // has been reached. Any cluster value >= this value indicates this
-    // is the last cluster.
-    u32 end_of_chain_marker() const;
-
     static constexpr u8 end_entry_byte = 0x00;
     static constexpr u8 unused_entry_byte = 0xE5;
 
@@ -52,7 +47,7 @@ private:
     static ErrorOr<NonnullOwnPtr<KString>> compute_filename(FATEntry&, Vector<FATLongFileNameEntry> const& = {});
     static StringView byte_terminated_string(StringView, u8);
 
-    ErrorOr<Vector<u32>> compute_cluster_list();
+    ErrorOr<Vector<u32>> compute_cluster_list(FATFS&, u32 first_cluster);
     ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_block_list();
     ErrorOr<NonnullOwnPtr<KBuffer>> read_block_list();
     ErrorOr<RefPtr<FATInode>> traverse(Function<ErrorOr<bool>(RefPtr<FATInode>)> callback);
@@ -81,7 +76,6 @@ private:
     FATEntry m_entry;
     FATEntryLocation m_inode_metadata_location;
     NonnullOwnPtr<KString> m_filename;
-    InodeMetadata m_metadata;
 };
 
 }

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -51,6 +51,8 @@ private:
     static constexpr size_t characters_per_lfn_entry = lfn_entry_characters_part_1_length + lfn_entry_characters_part_2_length + lfn_entry_characters_part_3_length;
     static constexpr u8 last_lfn_entry_mask = 0x40;
 
+    static constexpr size_t max_filename_length = 255;
+
     static ErrorOr<NonnullOwnPtr<KString>> compute_filename(FATEntry&, Vector<FATLongFileNameEntry> const& = {});
     static StringView byte_terminated_string(StringView, u8);
     static u8 lfn_entry_checksum(FATEntry const& entry);

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -56,6 +56,10 @@ private:
     // already being created to determine the FAT version. It is used
     // during FATInode creation (create()).
     u32 first_cluster(FATVersion const version) const;
+    ErrorOr<void> allocate_and_add_cluster_to_chain();
+    ErrorOr<void> remove_last_cluster_from_chain();
+
+    ErrorOr<void> resize(u64 size);
 
     // ^Inode
     virtual ErrorOr<size_t> write_bytes_locked(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*) override;
@@ -70,7 +74,9 @@ private:
     virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
+    virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<void> flush_metadata() override;
+    virtual ErrorOr<void> update_timestamps(Optional<UnixDateTime> atime, Optional<UnixDateTime> ctime, Optional<UnixDateTime> mtime) override;
 
     Vector<u32> m_cluster_list;
     FATEntry m_entry;

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -223,10 +223,14 @@ ErrorOr<void> copy_file(StringView destination_path, StringView source_path, str
     if (!has_flag(preserve_mode, PreserveMode::Permissions))
         my_umask |= 06000;
 
-    TRY(Core::System::fchmod(destination->fd(), source_stat.st_mode & ~my_umask));
+    if (auto result = Core::System::fchmod(destination->fd(), source_stat.st_mode & ~my_umask); result.is_error())
+        if (result.error().is_errno() && result.error().code() != ENOTSUP)
+            return result.release_error();
 
     if (has_flag(preserve_mode, PreserveMode::Ownership))
-        TRY(Core::System::fchown(destination->fd(), source_stat.st_uid, source_stat.st_gid));
+        if (auto result = Core::System::fchown(destination->fd(), source_stat.st_uid, source_stat.st_gid); result.is_error())
+            if (result.error().is_errno() && result.error().code() != ENOTSUP)
+                return result.release_error();
 
     if (has_flag(preserve_mode, PreserveMode::Timestamps)) {
         struct timespec times[2] = {


### PR DESCRIPTION
This continues where #22852 left off, so the majority of the commits here are based on those in that PR. I've tested the write support on all the FAT variants we support, and `fsck_msdos` on macOS comes up with no errors when checking a filesystem that has been modified by this driver.