### PR TITLE
Ladybird/AppKit: Implement a simple TaskManager window

### DIFF
--- a/Ladybird/AppKit/UI/TaskManager.h
+++ b/Ladybird/AppKit/UI/TaskManager.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <System/Cocoa.h>
+
+@class LadybirdWebView;
+
+@interface TaskManager : NSWindow
+
+- (instancetype)init;
+
+@property (nonatomic, strong) LadybirdWebView* web_view;
+
+@end

--- a/Ladybird/AppKit/UI/TaskManager.mm
+++ b/Ladybird/AppKit/UI/TaskManager.mm
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <LibCore/Timer.h>
+#include <LibWebView/ProcessManager.h>
+
+#import <UI/LadybirdWebView.h>
+#import <UI/TaskManager.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+static constexpr CGFloat const WINDOW_WIDTH = 400;
+static constexpr CGFloat const WINDOW_HEIGHT = 300;
+
+@interface TaskManager ()
+{
+    RefPtr<Core::Timer> m_update_timer;
+}
+
+@end
+
+@implementation TaskManager
+
+- (instancetype)init
+{
+    auto tab_rect = [[NSApp keyWindow] frame];
+    auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
+    auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
+
+    auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
+    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+
+    self = [super initWithContentRect:window_rect
+                            styleMask:style_mask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        self.web_view = [[LadybirdWebView alloc] init:nil];
+        [self.web_view setPostsBoundsChangedNotifications:YES];
+
+        auto* scroll_view = [[NSScrollView alloc] init];
+        [scroll_view setHasVerticalScroller:YES];
+        [scroll_view setHasHorizontalScroller:YES];
+        [scroll_view setLineScroll:24];
+
+        [scroll_view setContentView:self.web_view];
+        [scroll_view setDocumentView:[[NSView alloc] init]];
+
+        __weak TaskManager* weak_self = self;
+
+        m_update_timer = MUST(Core::Timer::create_repeating(1000, [weak_self] {
+            TaskManager* strong_self = weak_self;
+            if (strong_self == nil) {
+                return;
+            }
+
+            [strong_self updateStatistics];
+        }));
+
+        [self setContentView:scroll_view];
+        [self setTitle:@"Task Manager"];
+        [self setIsVisible:YES];
+
+        [self updateStatistics];
+        m_update_timer->start();
+    }
+
+    return self;
+}
+
+- (void)updateStatistics
+{
+    WebView::ProcessManager::the().update_all_processes();
+    [self.web_view loadHTML:WebView::ProcessManager::the().generate_html()];
+}
+
+@end

--- a/Ladybird/AppKit/UI/TaskManagerController.h
+++ b/Ladybird/AppKit/UI/TaskManagerController.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <System/Cocoa.h>
+
+@protocol TaskManagerDelegate <NSObject>
+
+- (void)onTaskManagerClosed;
+
+@end
+
+@interface TaskManagerController : NSWindowController
+
+- (instancetype)init:(id<TaskManagerDelegate>)delegate;
+
+@end

--- a/Ladybird/AppKit/UI/TaskManagerController.mm
+++ b/Ladybird/AppKit/UI/TaskManagerController.mm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <UI/LadybirdWebView.h>
+#import <UI/TaskManager.h>
+#import <UI/TaskManagerController.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+@interface TaskManagerController () <NSWindowDelegate>
+
+@property (nonatomic, weak) id<TaskManagerDelegate> delegate;
+
+@end
+
+@implementation TaskManagerController
+
+- (instancetype)init:(id<TaskManagerDelegate>)delegate
+{
+    if (self = [super init]) {
+        self.delegate = delegate;
+    }
+
+    return self;
+}
+
+#pragma mark - Private methods
+
+- (TaskManager*)taskManager
+{
+    return (TaskManager*)[self window];
+}
+
+#pragma mark - NSWindowController
+
+- (IBAction)showWindow:(id)sender
+{
+    self.window = [[TaskManager alloc] init];
+    [self.window setDelegate:self];
+    [self.window makeKeyAndOrderFront:sender];
+}
+
+#pragma mark - NSWindowDelegate
+
+- (void)windowWillClose:(NSNotification*)notification
+{
+    [self.delegate onTaskManagerClosed];
+}
+
+- (void)windowDidResize:(NSNotification*)notification
+{
+    if (![[self window] inLiveResize]) {
+        [[[self taskManager] web_view] handleResize];
+    }
+}
+
+- (void)windowDidChangeBackingProperties:(NSNotification*)notification
+{
+    [[[self taskManager] web_view] handleDevicePixelRatioChange];
+}
+
+@end

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -148,6 +148,8 @@ elseif (APPLE)
         AppKit/UI/Palette.mm
         AppKit/UI/Tab.mm
         AppKit/UI/TabController.mm
+        AppKit/UI/TaskManager.mm
+        AppKit/UI/TaskManagerController.mm
         AppKit/Utilities/Conversions.mm
     )
     target_include_directories(ladybird PRIVATE AppKit)

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -123,6 +123,8 @@ executable("ladybird_executable") {
       "AppKit/UI/Palette.mm",
       "AppKit/UI/Tab.mm",
       "AppKit/UI/TabController.mm",
+      "AppKit/UI/TaskManager.mm",
+      "AppKit/UI/TaskManagerController.mm",
       "AppKit/Utilities/Conversions.mm",
       "AppKit/main.mm",
     ]


### PR DESCRIPTION
Unlike the Inspector window, this is owned by the ApplicationDelegate as there should be only a single task manager for the entire application.

<img width="1142" alt="Screenshot 2024-04-09 at 10 34 03 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/29e3fad7-35ec-4b38-a922-53b11bb2a757">
