### PR TITLE
LibWeb: Process all task source while waiting for document population 

### DIFF
--- a/Tests/LibWeb/Text/expected/navigation/history-replace-push-state-race-3.txt
+++ b/Tests/LibWeb/Text/expected/navigation/history-replace-push-state-race-3.txt
@@ -1,0 +1,1 @@
+test done!

--- a/Tests/LibWeb/Text/input/navigation/history-replace-push-state-race-3.html
+++ b/Tests/LibWeb/Text/input/navigation/history-replace-push-state-race-3.html
@@ -1,0 +1,22 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let counter = 0;
+        setTimeout(() => {
+            history.replaceState({}, "test", "history-replace-push-state-race-3.html");
+            counter++;
+            if (counter === 2) {
+                println("test done!");
+                done();
+            }
+        }, 0);
+        setTimeout(() => {
+            history.replaceState({}, "test", "history-replace-push-state-race-3.html");
+            counter++;
+            if (counter === 2) {
+                println("test done!");
+                done();
+            }
+        }, 0);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -89,7 +89,8 @@ WebIDL::ExceptionOr<void> History::go(WebIDL::Long delta = 0)
     VERIFY(m_associated_document->navigable());
 
     // 3. If delta is 0, then reload document's node navigable.
-    m_associated_document->navigable()->reload();
+    if (delta == 0)
+        m_associated_document->navigable()->reload();
 
     // 4. Traverse the history by a delta given document's node navigable's traversable navigable, delta, and with sourceDocument set to document.
     auto traversable = m_associated_document->navigable()->traversable_navigable();


### PR DESCRIPTION
"apply the history step" initiated by reloading or back/forward
navigation might require doing fetching while populating a document,
so it is not possible to restrict spin_until() to process only
NavigationAndTraversal task source.

"apply the history step" initiated by synchronous navigation keeps
processing only NavigationAndTraversal task source because it will
never have to populate a document. Another reason to keep synchronous
navigation blocking other task sources is that we crash if active SHE
changes in the middle of "apply the history step" initiated by sync
navigation. The new test is added to makes sure we don't regress that.