### PR TITLE
LibJS: Propagate finalizers into nested try-catch blocks without them

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2461,8 +2461,10 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> TryStatement::gener
         auto caught_value = Bytecode::Operand { generator.allocate_register() };
         generator.emit<Bytecode::Op::Catch>(caught_value);
 
-        if (!m_finalizer)
+        if (!m_finalizer) {
             generator.emit<Bytecode::Op::LeaveUnwindContext>();
+            generator.emit<Bytecode::Op::RestoreScheduledJump>();
+        }
 
         // OPTIMIZATION: We avoid creating a lexical environment if the catch clause has no parameter.
         bool did_create_variable_scope_for_catch_clause = false;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2443,7 +2443,11 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> TryStatement::gener
         auto& finalizer_block = generator.make_block();
         generator.switch_to_basic_block(finalizer_block);
         generator.emit<Bytecode::Op::LeaveUnwindContext>();
+
+        generator.start_boundary(Bytecode::Generator::BlockBoundaryType::LeaveFinally);
         (void)TRY(m_finalizer->generate_bytecode(generator));
+        generator.end_boundary(Bytecode::Generator::BlockBoundaryType::LeaveFinally);
+
         if (!generator.is_current_block_terminated()) {
             next_block = &generator.make_block();
             auto next_target = Bytecode::Label { *next_block };

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2510,8 +2510,13 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> TryStatement::gener
     if (m_finalizer)
         generator.end_boundary(Bytecode::Generator::BlockBoundaryType::ReturnToFinally);
     if (m_handler) {
-        if (!m_finalizer)
-            unwind_context.emplace(generator, OptionalNone());
+        if (!m_finalizer) {
+            auto const* parent_unwind_context = generator.current_unwind_context();
+            if (parent_unwind_context)
+                unwind_context.emplace(generator, parent_unwind_context->finalizer());
+            else
+                unwind_context.emplace(generator, OptionalNone());
+        }
         unwind_context->set_handler(handler_target.value());
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -532,7 +532,10 @@ void Generator::generate_scoped_jump(JumpType type)
             switch_to_basic_block(block);
             last_was_finally = true;
             break;
-        };
+        }
+        case LeaveFinally:
+            emit<Op::LeaveFinally>();
+            break;
         }
     }
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -209,6 +209,7 @@ public:
         Continue,
         Unwind,
         ReturnToFinally,
+        LeaveFinally,
         LeaveLexicalEnvironment,
     };
     template<typename OpType>
@@ -232,6 +233,9 @@ public:
                 break;
             case ReturnToFinally:
                 return;
+            case LeaveFinally:
+                emit<Bytecode::Op::LeaveFinally>();
+                break;
             };
         }
     }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -276,6 +276,8 @@ public:
         return Operand(Operand::Type::Constant, m_constants.size() - 1);
     }
 
+    UnwindContext const* current_unwind_context() const { return m_current_unwind_context; }
+
 private:
     VM& m_vm;
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -98,6 +98,7 @@
     O(PutPrivateById)                  \
     O(ResolveThisBinding)              \
     O(ResolveSuperBase)                \
+    O(RestoreScheduledJump)            \
     O(Return)                          \
     O(RightShift)                      \
     O(ScheduleJump)                    \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -39,8 +39,8 @@
     O(Div)                             \
     O(Dump)                            \
     O(End)                             \
-    O(EnterUnwindContext)              \
     O(EnterObjectEnvironment)          \
+    O(EnterUnwindContext)              \
     O(Exp)                             \
     O(GetById)                         \
     O(GetByIdWithThis)                 \
@@ -48,10 +48,10 @@
     O(GetByValueWithThis)              \
     O(GetCalleeAndThisFromEnvironment) \
     O(GetIterator)                     \
-    O(GetObjectFromIteratorRecord)     \
     O(GetMethod)                       \
     O(GetNewTarget)                    \
     O(GetNextMethodFromIteratorRecord) \
+    O(GetObjectFromIteratorRecord)     \
     O(GetImportMeta)                   \
     O(GetObjectPropertyIterator)       \
     O(GetPrivateById)                  \
@@ -71,6 +71,7 @@
     O(JumpIf)                          \
     O(JumpNullish)                     \
     O(JumpUndefined)                   \
+    O(LeaveFinally)                    \
     O(LeaveLexicalEnvironment)         \
     O(LeaveUnwindContext)              \
     O(LeftShift)                       \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -386,9 +386,6 @@ void Interpreter::run_bytecode()
                 }
                 auto const* old_scheduled_jump = call_frame().previously_scheduled_jumps.take_last();
                 if (m_scheduled_jump) {
-                    // FIXME: If we `break` or `continue` in the finally, we need to clear
-                    //        this field
-                    //        Same goes for popping an old_scheduled_jump form the stack
                     m_current_block = exchange(m_scheduled_jump, nullptr);
                 } else {
                     m_current_block = &static_cast<Op::ContinuePendingUnwind const&>(instruction).resume_target().block();
@@ -558,6 +555,12 @@ void Interpreter::catch_exception(Operand dst)
 
 void Interpreter::restore_scheduled_jump()
 {
+    m_scheduled_jump = call_frame().previously_scheduled_jumps.take_last();
+}
+
+void Interpreter::leave_finally()
+{
+    reg(Register::exception()) = {};
     m_scheduled_jump = call_frame().previously_scheduled_jumps.take_last();
 }
 
@@ -1053,6 +1056,12 @@ ThrowCompletionOr<void> EnterObjectEnvironment::execute_impl(Bytecode::Interpret
 ThrowCompletionOr<void> Catch::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     interpreter.catch_exception(dst());
+    return {};
+}
+
+ThrowCompletionOr<void> LeaveFinally::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.leave_finally();
     return {};
 }
 
@@ -2269,6 +2278,11 @@ ByteString Catch::to_byte_string_impl(Bytecode::Executable const& executable) co
 {
     return ByteString::formatted("Catch {}",
         format_operand("dst"sv, m_dst, executable));
+}
+
+ByteString LeaveFinally::to_byte_string_impl(Bytecode::Executable const&) const
+{
+    return ByteString::formatted("LeaveFinally");
 }
 
 ByteString RestoreScheduledJump::to_byte_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -561,6 +561,11 @@ void Interpreter::catch_exception(Operand dst)
     vm().running_execution_context().lexical_environment = context.lexical_environment;
 }
 
+void Interpreter::restore_scheduled_jump()
+{
+    m_scheduled_jump = call_frame().previously_scheduled_jumps.take_last();
+}
+
 void Interpreter::enter_object_environment(Object& object)
 {
     auto& old_environment = vm().running_execution_context().lexical_environment;
@@ -1053,6 +1058,12 @@ ThrowCompletionOr<void> EnterObjectEnvironment::execute_impl(Bytecode::Interpret
 ThrowCompletionOr<void> Catch::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     interpreter.catch_exception(dst());
+    return {};
+}
+
+ThrowCompletionOr<void> RestoreScheduledJump::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.restore_scheduled_jump();
     return {};
 }
 
@@ -2263,6 +2274,11 @@ ByteString Catch::to_byte_string_impl(Bytecode::Executable const& executable) co
 {
     return ByteString::formatted("Catch {}",
         format_operand("dst"sv, m_dst, executable));
+}
+
+ByteString RestoreScheduledJump::to_byte_string_impl(Bytecode::Executable const&) const
+{
+    return ByteString::formatted("RestoreScheduledJump");
 }
 
 ByteString GetObjectFromIteratorRecord::to_byte_string_impl(Bytecode::Executable const& executable) const

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -427,11 +427,6 @@ void Interpreter::run_bytecode()
                 }
                 if (finalizer) {
                     m_current_block = finalizer;
-                    // If an exception was thrown inside the corresponding `catch` block, we need to rethrow it
-                    // from the `finally` block. But if the exception is from the `try` block, and has already been
-                    // handled by `catch`, we swallow it.
-                    if (!unwind_context.handler_called)
-                        reg(Register::exception()) = {};
                     goto start;
                 }
                 // An unwind context with no handler or finalizer? We have nowhere to jump, and continuing on will make us crash on the next `Call` to a non-native function if there's an exception! So let's crash here instead.

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -90,6 +90,7 @@ public:
     void enter_unwind_context();
     void leave_unwind_context();
     void catch_exception(Operand dst);
+    void restore_scheduled_jump();
 
     void enter_object_environment(Object&);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -91,6 +91,7 @@ public:
     void leave_unwind_context();
     void catch_exception(Operand dst);
     void restore_scheduled_jump();
+    void leave_finally();
 
     void enter_object_environment(Object&);
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -452,6 +452,17 @@ private:
     Operand m_dst;
 };
 
+class LeaveFinally final : public Instruction {
+public:
+    explicit LeaveFinally()
+        : Instruction(Type::LeaveFinally, sizeof(*this))
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+};
+
 class RestoreScheduledJump final : public Instruction {
 public:
     explicit RestoreScheduledJump()

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -452,6 +452,17 @@ private:
     Operand m_dst;
 };
 
+class RestoreScheduledJump final : public Instruction {
+public:
+    explicit RestoreScheduledJump()
+        : Instruction(Type::RestoreScheduledJump, sizeof(*this))
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+};
+
 class CreateVariable final : public Instruction {
 public:
     explicit CreateVariable(IdentifierTableIndex identifier, EnvironmentMode mode, bool is_immutable, bool is_global = false, bool is_strict = false)

--- a/Userland/Libraries/LibJS/Tests/try-catch-finally-nested.js
+++ b/Userland/Libraries/LibJS/Tests/try-catch-finally-nested.js
@@ -103,3 +103,18 @@ test("Deeply nested try/catch/finally with return in inner context", () => {
     })();
     expect(success).toBe(7);
 });
+
+test("Nested try/finally/catch with exception in inner context ", () => {
+    success = 0;
+    try {
+        try {
+            throw Error("Error in inner try");
+        } finally {
+            success += 1;
+        }
+        expect.fail();
+    } catch (e) {
+        success += 1;
+    }
+    expect(success).toBe(2);
+});

--- a/Userland/Libraries/LibJS/Tests/try-catch-finally-nested.js
+++ b/Userland/Libraries/LibJS/Tests/try-catch-finally-nested.js
@@ -118,3 +118,24 @@ test("Nested try/finally/catch with exception in inner context ", () => {
     }
     expect(success).toBe(2);
 });
+
+test("Nested try/catch/finally with exception in inner most finally inside loop", () => {
+    success = 0;
+    try {
+        try {
+            do {
+                try {
+                    throw 1;
+                } finally {
+                    break;
+                }
+                expect.fail();
+            } while (expect.fail());
+        } catch (e) {
+            expect.fail();
+        }
+    } finally {
+        success = 1;
+    }
+    expect(success).toBe(1);
+});

--- a/Userland/Libraries/LibJS/Tests/try-catch-finally-nested.js
+++ b/Userland/Libraries/LibJS/Tests/try-catch-finally-nested.js
@@ -53,3 +53,53 @@ test("Nested try/catch/finally with exceptions", () => {
     expect(level3CatchHasBeenExecuted).toBeTrue();
     expect(level3FinallyHasBeenExecuted).toBeTrue();
 });
+
+test("Nested try/catch/finally with return in inner context", () => {
+    success = false;
+    (() => {
+        try {
+            try {
+                return;
+            } catch (e) {
+                expect().fail();
+            }
+        } finally {
+            success = true;
+        }
+        expect().fail();
+    })();
+    expect(success).toBeTrue();
+});
+
+test("Deeply nested try/catch/finally with return in inner context", () => {
+    success = 0;
+    (() => {
+        try {
+            try {
+                try {
+                    try {
+                        try {
+                            return;
+                        } catch (e) {
+                            expect().fail();
+                        } finally {
+                            success += 4;
+                        }
+                    } catch (e) {
+                        expect().fail();
+                    }
+                } catch (e) {
+                    expect().fail();
+                } finally {
+                    success += 2;
+                }
+            } catch (e) {
+                expect().fail();
+            }
+        } finally {
+            success += 1;
+        }
+        expect().fail();
+    })();
+    expect(success).toBe(7);
+});

--- a/Userland/Libraries/LibJS/Tests/try-finally-break.js
+++ b/Userland/Libraries/LibJS/Tests/try-finally-break.js
@@ -342,19 +342,23 @@ test("labelled break in finally overrides labelled break in try", () => {
 
 test("Throw while breaking", () => {
     const executionOrder = [];
-    try {
-        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
-            try {
-                executionOrder.push(1);
-                break;
-            } finally {
-                executionOrder.push(2);
-                throw 1;
+    expect(() => {
+        try {
+            for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+                try {
+                    executionOrder.push(1);
+                    break;
+                } finally {
+                    executionOrder.push(2);
+                    throw Error(1);
+                }
             }
+        } finally {
+            executionOrder.push(3);
         }
-    } finally {
-        executionOrder.push(3);
-    }
+        expect().fail("Running code after for loop");
+    }).toThrowWithMessage(Error, 1);
+
     expect(() => {
         i;
     }).toThrowWithMessage(ReferenceError, "'i' is not defined");


### PR DESCRIPTION
CC: @ADKaster 