### PR TITLE
LibWeb: Mark initial about:blank as ready to run scripts after creation 

### DIFF
--- a/Tests/LibWeb/Text/expected/navigation/run-script-before-iframe-initial-navigation.txt
+++ b/Tests/LibWeb/Text/expected/navigation/run-script-before-iframe-initial-navigation.txt
@@ -1,0 +1,1 @@
+    message from test iframe

--- a/Tests/LibWeb/Text/input/navigation/run-script-before-iframe-initial-navigation.html
+++ b/Tests/LibWeb/Text/input/navigation/run-script-before-iframe-initial-navigation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+    <!-- Other browsers seem to display the message below regardless of what src is (valid or not) -->
+    <iframe id="target" srcdoc="iframe content"></iframe>
+    <script>
+        asyncTest((done) => {
+            const script = target.contentDocument.createElement("script");
+            script.innerHTML = `parent.postMessage("message from test iframe", "*");`;
+            target.contentDocument.body.appendChild(script);
+            window.addEventListener("message", event => {
+                println(event.data);
+                done();
+            });
+        });
+    </script>
+</body>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -378,6 +378,8 @@ void Document::initialize(JS::Realm& realm)
     m_selection = heap().allocate<Selection::Selection>(realm, realm, *this);
 
     m_list_of_available_images = heap().allocate<HTML::ListOfAvailableImages>(realm);
+
+    page().client().page_did_create_new_document(*this);
 }
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#populate-with-html/head/body
@@ -3407,6 +3409,10 @@ void Document::make_active()
 
     // 2. Set document's browsing context's WindowProxy's [[Window]] internal slot value to window.
     m_browsing_context->window_proxy()->set_window(window);
+
+    if (m_browsing_context->is_top_level()) {
+        page().client().page_did_change_active_document_in_top_level_browsing_context(*this);
+    }
 
     // 3. Set document's visibility state to document's node navigable's traversable navigable's system visibility state.
     if (navigable()) {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -227,6 +227,8 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
 
     // is initial about:blank: true
     document->set_is_initial_about_blank(true);
+    // Spec issue: https://github.com/whatwg/html/issues/10261
+    document->set_ready_to_run_scripts();
 
     // about base URL: creatorBaseURL
     document->set_about_base_url(creator_base_url);

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -197,10 +197,6 @@ void Navigable::activate_history_entry(JS::GCPtr<SessionHistoryEntry> entry)
 
     // 5. Make active newDocument.
     new_document->make_active();
-
-    // Not in the spec:
-    VERIFY(active_browsing_context());
-    active_browsing_context()->page().client().page_did_create_new_document(*new_document);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -220,11 +220,7 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
     // 4. If url matches about:blank and initialInsertion is true, then perform the URL and history update steps given element's content navigable's active document and url.
     if (url_matches_about_blank(url) && initial_insertion) {
         auto& document = *m_content_navigable->active_document();
-
         perform_url_and_history_update_steps(document, url);
-
-        // Spec issue: https://github.com/whatwg/html/issues/10261
-        document.set_ready_to_run_scripts();
     }
 
     // 5. Return url.

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -258,6 +258,7 @@ public:
     virtual Gfx::IntRect page_did_request_fullscreen_window() { return {}; }
     virtual void page_did_start_loading(URL::URL const&, bool is_redirect) { (void)is_redirect; }
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
+    virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) { }
     virtual void page_did_destroy_document(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(URL::URL const&) { }
     virtual void page_did_update_url(URL::URL const&, Web::HTML::HistoryHandlingBehavior) { }

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -355,6 +355,12 @@ void PageClient::page_did_create_new_document(Web::DOM::Document& document)
     initialize_js_console(document);
 }
 
+void PageClient::page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document& document)
+{
+    VERIFY(m_console_clients.contains(document));
+    m_top_level_document_console_client = *m_console_clients.get(document).value();
+}
+
 void PageClient::page_did_destroy_document(Web::DOM::Document& document)
 {
     destroy_js_console(document);
@@ -674,11 +680,6 @@ void PageClient::initialize_js_console(Web::DOM::Document& document)
     auto console_object = realm.intrinsics().console_object();
     auto console_client = make<WebContentConsoleClient>(console_object->console(), document.realm(), *this);
     console_object->console().set_client(*console_client);
-
-    VERIFY(document.browsing_context());
-    if (document.browsing_context()->is_top_level()) {
-        m_top_level_document_console_client = console_client->make_weak_ptr();
-    }
 
     m_console_clients.set(document, move(console_client));
 }

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -117,6 +117,7 @@ private:
     virtual void page_did_request_media_context_menu(Web::CSSPixelPoint, ByteString const& target, unsigned modifiers, Web::Page::MediaContextMenu) override;
     virtual void page_did_start_loading(URL::URL const&, bool) override;
     virtual void page_did_create_new_document(Web::DOM::Document&) override;
+    virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
     virtual void page_did_destroy_document(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(URL::URL const&) override;
     virtual void page_did_update_url(URL::URL const&, Web::HTML::HistoryHandlingBehavior) override;


### PR DESCRIPTION
Fixes https://github.com/SerenityOS/serenity/issues/23892