### PR TITLE
LibWeb: Use static position for abspos box axes with auto insets

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-with-static-position-in-one-axis.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-with-static-position-in-one-axis.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 13, rect: [8,8 100.203125x17] baseline: 13.296875
+            "hello friends"
+        TextNode <#text>
+      ImageBox <img> at (50,25) content-size 100x100 positioned children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33] overflow: [0,0 800x125]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784x117]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+        TextPaintable (TextNode<#text>)
+      ImagePaintable (ImageBox<IMG>) [50,25 100x100]

--- a/Tests/LibWeb/Layout/input/abspos-with-static-position-in-one-axis.html
+++ b/Tests/LibWeb/Layout/input/abspos-with-static-position-in-one-axis.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+* { outline: 1px solid black; }
+img {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: green;
+    left: 50px;
+}
+</style><div>hello friends</div><img>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -126,6 +126,11 @@ Box const* Node::containing_block() const
     return nearest_ancestor_capable_of_forming_a_containing_block(*this);
 }
 
+Box const* Node::static_position_containing_block() const
+{
+    return nearest_ancestor_capable_of_forming_a_containing_block(*this);
+}
+
 Box const* Node::non_anonymous_containing_block() const
 {
     auto nearest_ancestor_box = containing_block();

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -132,6 +132,9 @@ public:
     Box const* containing_block() const;
     Box* containing_block() { return const_cast<Box*>(const_cast<Node const*>(this)->containing_block()); }
 
+    [[nodiscard]] Box const* static_position_containing_block() const;
+    [[nodiscard]] Box* static_position_containing_block() { return const_cast<Box*>(const_cast<Node const*>(this)->static_position_containing_block()); }
+
     // Closest non-anonymous ancestor box, to be used when resolving percentage values.
     // Anonymous block boxes are ignored when resolving percentage values that would refer to it:
     // the closest non-anonymous ancestor box is used instead.


### PR DESCRIPTION
When both insets in a given axis are auto, we should use the static position for absolutely positioned elements.

By doing this correctly, we exposed a bunch of other small bugs which had to be fixed to compensate for new test failures. Those fixes are included here as well:
- Don't apply margins twice.
- Compute the static position containing block chain correctly.

This makes https://brave.com/ look much better. :^)

Before:
![Screenshot from 2024-04-11 22-06-09](https://github.com/SerenityOS/serenity/assets/5954907/3e7ae146-3428-4a62-aed6-5b56c615cbac)

After:
![Screenshot from 2024-04-11 22-03-09](https://github.com/SerenityOS/serenity/assets/5954907/ce7a4e99-8dfa-42c4-85d5-553a4388386a)
