### PR TITLE
LibWeb: Stub out Navigator.maxTouchPoints, set event timestamps

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1661,9 +1661,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(StringView i
     // NOTE: These are done in the if-chain above
     // 5. Let event be the result of creating an event given constructor.
     // 6. Initialize event’s type attribute to the empty string.
+    // 7. Initialize event’s timeStamp attribute to the result of calling current high resolution time with this’s relevant global object.
     // NOTE: This is handled by each constructor.
-
-    // FIXME: 7. Initialize event’s timeStamp attribute to the result of calling current high resolution time with this’s relevant global object.
 
     // 8. Initialize event’s isTrusted attribute to false.
     event->set_is_trusted(false);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2148,7 +2148,7 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
     // 3. If document is associated with an HTML parser, then:
     if (m_parser) {
         // 1. Let now be the current high resolution time given document's relevant global object.
-        auto now = HighResolutionTime::unsafe_shared_current_time();
+        auto now = HighResolutionTime::current_high_resolution_time(relevant_global_object(*this));
 
         // 2. If readinessValue is "complete", and document's load timing info's DOM complete time is 0,
         //    then set document's load timing info's DOM complete time to now.

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/HighResolutionTime/TimeOrigin.h>
 
 namespace Web::DOM {
 
@@ -26,13 +27,16 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::construct_impl(JS::Realm& re
     return create(realm, event_name, event_init);
 }
 
+// https://dom.spec.whatwg.org/#inner-event-creation-steps
 Event::Event(JS::Realm& realm, FlyString const& type)
     : PlatformObject(realm)
     , m_type(type)
     , m_initialized(true)
+    , m_time_stamp(HighResolutionTime::current_high_resolution_time(HTML::relevant_global_object(*this)))
 {
 }
 
+// https://dom.spec.whatwg.org/#inner-event-creation-steps
 Event::Event(JS::Realm& realm, FlyString const& type, EventInit const& event_init)
     : PlatformObject(realm)
     , m_type(type)
@@ -40,6 +44,7 @@ Event::Event(JS::Realm& realm, FlyString const& type, EventInit const& event_ini
     , m_cancelable(event_init.cancelable)
     , m_composed(event_init.composed)
     , m_initialized(true)
+    , m_time_stamp(HighResolutionTime::current_high_resolution_time(HTML::relevant_global_object(*this)))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -179,10 +179,7 @@ void EventLoop::process()
     // 1. Let oldestTask be null.
     JS::GCPtr<Task> oldest_task;
 
-    // 2. Let taskStartTime be the current high resolution time.
-    // FIXME: 'current high resolution time' in hr-time-3 takes a global object,
-    //        the HTML spec has not been updated to reflect this, let's use the shared timer.
-    //        - https://github.com/whatwg/html/issues/7776
+    // 2. Set taskStartTime to the unsafe shared current time.
     double task_start_time = HighResolutionTime::unsafe_shared_current_time();
 
     // 3. Let taskQueue be one of the event loop's task queues, chosen in an implementation-defined manner,
@@ -377,7 +374,7 @@ void EventLoop::process()
     // - hasARenderingOpportunity is false
     // FIXME: has_a_rendering_opportunity is always true
     if (m_type == Type::Window && !task_queue.has_runnable_tasks() && m_microtask_queue->is_empty() /*&& !has_a_rendering_opportunity*/) {
-        // 1. Set this event loop's last idle period start time to the current high resolution time.
+        // 1. Set this event loop's last idle period start time to the unsafe shared current time.
         m_last_idle_period_start_time = HighResolutionTime::unsafe_shared_current_time();
 
         // 2. Let computeDeadline be the following steps:

--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -84,4 +84,11 @@ JS::NonnullGCPtr<Clipboard::Clipboard> Navigator::clipboard()
     return *m_clipboard;
 }
 
+// https://w3c.github.io/pointerevents/#dom-navigator-maxtouchpoints
+WebIDL::Long Navigator::max_touch_points()
+{
+    dbgln("FIXME: Unimplemented Navigator.maxTouchPoints");
+    return 0;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigator.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.h
@@ -48,6 +48,8 @@ public:
     [[nodiscard]] JS::NonnullGCPtr<PluginArray> plugins();
     [[nodiscard]] JS::NonnullGCPtr<Clipboard::Clipboard> clipboard();
 
+    static WebIDL::Long max_touch_points();
+
     virtual ~Navigator() override;
 
 protected:

--- a/Userland/Libraries/LibWeb/HTML/Navigator.idl
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.idl
@@ -14,6 +14,9 @@ interface Navigator {
 
     // https://w3c.github.io/clipboard-apis/#navigator-interface
     [SecureContext, SameObject] readonly attribute Clipboard clipboard;
+
+    // https://w3c.github.io/pointerevents/#extensions-to-the-navigator-interface
+    readonly attribute long maxTouchPoints;
 };
 
 // NOTE: As NavigatorContentUtils, NavigatorCookies, NavigatorPlugins, and NavigatorAutomationInformation

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -293,7 +293,7 @@ void HTMLParser::the_end(JS::NonnullGCPtr<DOM::Document> document, JS::GCPtr<HTM
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
     queue_global_task(HTML::Task::Source::DOMManipulation, *document, [document = document] {
         // 1. Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
-        document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
         // 2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
         auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
@@ -301,7 +301,7 @@ void HTMLParser::the_end(JS::NonnullGCPtr<DOM::Document> document, JS::GCPtr<HTM
         document->dispatch_event(content_loaded_event);
 
         // 3. Set the Document's load timing info's DOM content loaded event end time to the current high resolution time given the Document's relevant global object.
-        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
         // FIXME: 4. Enable the client message queue of the ServiceWorkerContainer object whose associated service worker client is the Document object's relevant settings object.
 
@@ -331,7 +331,7 @@ void HTMLParser::the_end(JS::NonnullGCPtr<DOM::Document> document, JS::GCPtr<HTM
         auto& window = verify_cast<Window>(relevant_global_object(*document));
 
         // 4. Set the Document's load timing info's load event start time to the current high resolution time given window.
-        document->load_timing_info().load_event_start_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().load_event_start_time = HighResolutionTime::current_high_resolution_time(window);
 
         // 5. Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
@@ -343,7 +343,7 @@ void HTMLParser::the_end(JS::NonnullGCPtr<DOM::Document> document, JS::GCPtr<HTM
         // FIXME: 7. Set the Document object's navigation id to null.
 
         // 8. Set the Document's load timing info's load event end time to the current high resolution time given window.
-        document->load_timing_info().load_event_end_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().load_event_end_time = HighResolutionTime::current_high_resolution_time(window);
 
         // 9. Assert: Document's page showing is false.
         VERIFY(!document->page_showing());

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -604,8 +604,7 @@ bool Window::has_transient_activation() const
     static constexpr HighResolutionTime::DOMHighResTimeStamp transient_activation_duration_ms = 5000;
 
     // When the current high resolution time given W
-    auto unsafe_shared_time = HighResolutionTime::unsafe_shared_current_time();
-    auto current_time = HighResolutionTime::relative_high_resolution_time(unsafe_shared_time, realm().global_object());
+    auto current_time = HighResolutionTime::current_high_resolution_time(*this);
 
     // is greater than or equal to the last activation timestamp in W
     if (current_time >= m_last_activation_timestamp) {

--- a/Userland/Libraries/LibWeb/HighResolutionTime/TimeOrigin.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/TimeOrigin.cpp
@@ -27,6 +27,14 @@ DOMHighResTimeStamp coarsen_time(DOMHighResTimeStamp timestamp, bool cross_origi
     return timestamp;
 }
 
+// https://w3c.github.io/hr-time/#dfn-current-high-resolution-time
+DOMHighResTimeStamp current_high_resolution_time(JS::Object const& global)
+{
+    // The current high resolution time given a global object current global must return the result
+    // of relative high resolution time given unsafe shared current time and current global.
+    return HighResolutionTime::relative_high_resolution_time(HighResolutionTime::unsafe_shared_current_time(), global);
+}
+
 // https://w3c.github.io/hr-time/#dfn-relative-high-resolution-time
 DOMHighResTimeStamp relative_high_resolution_time(DOMHighResTimeStamp time, JS::Object const& global)
 {

--- a/Userland/Libraries/LibWeb/HighResolutionTime/TimeOrigin.h
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/TimeOrigin.h
@@ -14,6 +14,7 @@ namespace Web::HighResolutionTime {
 
 DOMHighResTimeStamp get_time_origin_timestamp(JS::Object const&);
 DOMHighResTimeStamp coarsen_time(DOMHighResTimeStamp timestamp, bool cross_origin_isolated_capability = false);
+DOMHighResTimeStamp current_high_resolution_time(JS::Object const&);
 DOMHighResTimeStamp relative_high_resolution_time(DOMHighResTimeStamp, JS::Object const&);
 DOMHighResTimeStamp relative_high_resolution_coarsen_time(DOMHighResTimeStamp, JS::Object const&);
 DOMHighResTimeStamp coarsened_shared_current_time(bool cross_origin_isolated_capability = false);

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
@@ -38,7 +38,7 @@ double IdleDeadline::time_remaining() const
 {
     auto const& event_loop = HTML::main_thread_event_loop();
     // 1. Let now be a DOMHighResTimeStamp representing current high resolution time in milliseconds.
-    auto now = HighResolutionTime::unsafe_shared_current_time();
+    auto now = HighResolutionTime::current_high_resolution_time(global_object());
     // 2. Let deadline be the result of calling IdleDeadline's get deadline time algorithm.
     auto deadline = event_loop.compute_deadline();
     // 3. Let timeRemaining be deadline - now.

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -201,7 +201,7 @@ void XMLDocumentBuilder::document_end()
     // Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
     queue_global_task(HTML::Task::Source::DOMManipulation, m_document, [document = m_document] {
         // Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
-        document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
         // Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
         auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
@@ -209,7 +209,7 @@ void XMLDocumentBuilder::document_end()
         document->dispatch_event(content_loaded_event);
 
         // Set the Document's load timing info's DOM content loaded event end time to the current high resolution time given the Document's relevant global object.
-        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
         // FIXME: Enable the client message queue of the ServiceWorkerContainer object whose associated service worker client is the Document object's relevant settings object.
 
@@ -239,7 +239,7 @@ void XMLDocumentBuilder::document_end()
         JS::NonnullGCPtr<HTML::Window> window = verify_cast<HTML::Window>(relevant_global_object(*document));
 
         // Set the Document's load timing info's load event start time to the current high resolution time given window.
-        document->load_timing_info().load_event_start_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().load_event_start_time = HighResolutionTime::current_high_resolution_time(window);
 
         // Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
@@ -251,7 +251,7 @@ void XMLDocumentBuilder::document_end()
         // FIXME: Set the Document object's navigation id to null.
 
         // Set the Document's load timing info's load event end time to the current high resolution time given window.
-        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::unsafe_shared_current_time();
+        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::current_high_resolution_time(window);
 
         // Assert: Document's page showing is false.
         VERIFY(!document->page_showing());


### PR DESCRIPTION
Further very minor steps towards: https://github.com/SerenityOS/serenity/issues/23632

Note that the actual timestamps are not correct as get_time_origin_timestamp and coarsen_time are not yet implemented / stubbed out.