### PR TITLE
LibWeb: Set decoder error when decoding fails

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -37,6 +37,10 @@ AudioTrack::AudioTrack(JS::Realm& realm, JS::NonnullGCPtr<HTMLMediaElement> medi
         auto playback_position = static_cast<double>(position.to_milliseconds()) / 1000.0;
         m_media_element->set_current_playback_position(playback_position);
     };
+
+    m_audio_plugin->on_decoder_error = [this](String error_message) {
+        m_media_element->set_decoder_error(error_message).release_value_but_fixme_should_propagate_errors();
+    };
 }
 
 AudioTrack::~AudioTrack()

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
@@ -35,6 +35,7 @@ public:
     virtual Duration duration() = 0;
 
     Function<void(Duration)> on_playback_position_updated;
+    Function<void(String)> on_decoder_error;
 
 protected:
     AudioCodecPlugin();


### PR DESCRIPTION
When trying to load ogg/vorbis files the MP3 Loader is used, what is resulting in decoding errors. To stop crashing the whole browser i added error handling with the on_decoder_error function.
@trflynn89 and @Zaggy1024 helped me.

The ogg/vorbis audios are "garbage" now but this will be fixed in the future when ogg/vorbis streams are implemented.
Also notable is that the stream won't stop playing on a decode error.