### PR TITLE
LibWeb: Fix always hanging Navigable::reload()

### DIFF
--- a/Tests/LibWeb/Text/data/iframe-reload.html
+++ b/Tests/LibWeb/Text/data/iframe-reload.html
@@ -1,0 +1,12 @@
+<script>
+    window.addEventListener('message', event => {
+        if (event.data && event.data.action === 'reload') {
+            window.parent.postMessage({ action: 'acknowledge-asked-to-reload' });
+            location.reload();
+        }
+    });
+
+    window.addEventListener('load', () => {
+        window.parent.postMessage({ action: 'loaded' });
+    });
+</script>

--- a/Tests/LibWeb/Text/expected/navigation/location-reload-fetch.txt
+++ b/Tests/LibWeb/Text/expected/navigation/location-reload-fetch.txt
@@ -1,0 +1,3 @@
+iframe is loaded
+iframe is going to reload
+iframe is loaded

--- a/Tests/LibWeb/Text/expected/navigation/location-reload-srcdoc.txt
+++ b/Tests/LibWeb/Text/expected/navigation/location-reload-srcdoc.txt
@@ -1,0 +1,3 @@
+iframe is loaded
+iframe is going to reload
+iframe is loaded

--- a/Tests/LibWeb/Text/input/navigation/location-reload-fetch.html
+++ b/Tests/LibWeb/Text/input/navigation/location-reload-fetch.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    let reloaded = false;
+    window.addEventListener('message', event => {
+        switch (event.data.action) {
+            case "loaded":
+                println("iframe is loaded");
+                if (!reloaded) {
+                    event.source.postMessage({ action: 'reload' });
+                    reloaded = true;
+                } else {
+                    internals.signalTextTestIsDone();
+                }
+                break;
+            case "acknowledge-asked-to-reload":
+                println("iframe is going to reload");
+                break;
+            default:
+                break;
+        }
+    });
+
+    document.addEventListener("DOMContentLoaded", () => {
+        const iframe = document.createElement('iframe');
+        iframe.src = "../../data/iframe-reload.html"
+        document.body.appendChild(iframe);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/location-reload-srcdoc.html
+++ b/Tests/LibWeb/Text/input/navigation/location-reload-srcdoc.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    let reloaded = false;
+    window.addEventListener('message', event => {
+        switch (event.data.action) {
+            case "loaded":
+                println("iframe is loaded");
+                if (!reloaded) {
+                    event.source.postMessage({ action: 'reload' });
+                    reloaded = true;
+                } else {
+                    internals.signalTextTestIsDone();
+                }
+                break;
+            case "acknowledge-asked-to-reload":
+                println("iframe is going to reload");
+                break;
+            default:
+                break;
+        }
+    });
+
+    const iframeScript = `
+        window.addEventListener('message', event => {
+            if (event.data && event.data.action === 'reload') {
+                window.parent.postMessage({ action: 'acknowledge-asked-to-reload' });
+                location.reload();
+            }
+        });
+        window.addEventListener('load', () => {
+            window.parent.postMessage({ action: 'loaded' });
+        });
+    `;
+
+    document.addEventListener("DOMContentLoaded", () => {
+        const iframe = document.createElement('iframe');
+        iframe.srcdoc = "<script>" + iframeScript + "<\/script>";
+        document.body.appendChild(iframe);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/DocumentState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DocumentState.cpp
@@ -16,6 +16,24 @@ DocumentState::DocumentState() = default;
 
 DocumentState::~DocumentState() = default;
 
+JS::NonnullGCPtr<DocumentState> DocumentState::clone() const
+{
+    JS::NonnullGCPtr<DocumentState> cloned = *heap().allocate_without_realm<DocumentState>();
+    cloned->m_document = m_document;
+    cloned->m_history_policy_container = m_history_policy_container;
+    cloned->m_request_referrer = m_request_referrer;
+    cloned->m_request_referrer_policy = m_request_referrer_policy;
+    cloned->m_initiator_origin = m_initiator_origin;
+    cloned->m_origin = m_origin;
+    cloned->m_about_base_url = m_about_base_url;
+    cloned->m_nested_histories = m_nested_histories;
+    cloned->m_resource = m_resource;
+    cloned->m_reload_pending = m_reload_pending;
+    cloned->m_ever_populated = m_ever_populated;
+    cloned->m_navigable_target_name = m_navigable_target_name;
+    return cloned;
+}
+
 void DocumentState::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibWeb/HTML/DocumentState.h
+++ b/Userland/Libraries/LibWeb/HTML/DocumentState.h
@@ -31,6 +31,8 @@ public:
 
     virtual ~DocumentState();
 
+    JS::NonnullGCPtr<DocumentState> clone() const;
+
     enum class Client {
         Tag,
     };

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -28,6 +28,23 @@ SessionHistoryEntry::SessionHistoryEntry()
 {
 }
 
+JS::NonnullGCPtr<SessionHistoryEntry> SessionHistoryEntry::clone() const
+{
+    JS::NonnullGCPtr<SessionHistoryEntry> entry = *heap().allocate_without_realm<SessionHistoryEntry>();
+    entry->m_step = m_step;
+    entry->m_url = m_url;
+    entry->m_document_state = m_document_state->clone();
+    entry->m_classic_history_api_state = m_classic_history_api_state;
+    entry->m_navigation_api_state = m_navigation_api_state;
+    entry->m_navigation_api_key = m_navigation_api_key;
+    entry->m_navigation_api_id = m_navigation_api_id;
+    entry->m_scroll_restoration_mode = m_scroll_restoration_mode;
+    entry->m_policy_container = m_policy_container;
+    entry->m_browsing_context_name = m_browsing_context_name;
+    entry->m_original_source_browsing_context = m_original_source_browsing_context;
+    return entry;
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#she-document
 JS::GCPtr<DOM::Document> SessionHistoryEntry::document() const
 {

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -35,6 +35,8 @@ class SessionHistoryEntry final : public JS::Cell {
 public:
     SessionHistoryEntry();
 
+    JS::NonnullGCPtr<SessionHistoryEntry> clone() const;
+
     void visit_edges(Cell::Visitor&) override;
 
     JS::GCPtr<DOM::Document> document() const;


### PR DESCRIPTION
See spec issue https://github.com/whatwg/html/issues/9869

Previous attempt on fixing reload had to be reverted because it broke Soundcloud and GitHub, but this change does not seem to introduce new crashes.