### PR TITLE
Revert "LibWeb: Forbid interleaving execution of HTML tasks with same…

### DIFF
--- a/Tests/LibWeb/Text/expected/parse-document-from-string-in-fetch-callback.txt
+++ b/Tests/LibWeb/Text/expected/parse-document-from-string-in-fetch-callback.txt
@@ -1,0 +1,1 @@
+hello! hello!

--- a/Tests/LibWeb/Text/input/parse-document-from-string-in-fetch-callback.html
+++ b/Tests/LibWeb/Text/input/parse-document-from-string-in-fetch-callback.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<head>
+    <script src="include.js"></script>
+    <link href="file://does-not-exists.css" rel="stylesheet" />
+</head>
+<script>
+    asyncTest(done => {
+        fetch("parse-document-from-string-in-fetch-callback.html")
+            .then(response => {
+                return response.text()
+            })
+            .then(text => {
+                const parser = new DOMParser();
+                const newDoc = parser.parseFromString(text, 'text/html');
+                println(newDoc.body.innerHTML);
+                done();
+            });
+    });
+</script>
+<body>hello!</body>

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -39,10 +39,6 @@ public:
     TaskQueue& microtask_queue() { return *m_microtask_queue; }
     TaskQueue const& microtask_queue() const { return *m_microtask_queue; }
 
-    bool is_task_source_blocked(Task::Source source) const;
-    void block_task_source(Task::Source source);
-    void unblock_task_source(Task::Source source);
-
     void spin_until(NOESCAPE JS::SafeFunction<bool()> goal_condition);
     void spin_processing_tasks_with_source_until(Task::Source, NOESCAPE JS::SafeFunction<bool()> goal_condition);
     void process();
@@ -117,8 +113,6 @@ private:
     bool m_execution_paused { false };
 
     bool m_skip_event_loop_processing_steps { false };
-
-    Array<bool, to_underlying(Task::Source::UniqueTaskSourceStart)> m_blocked_task_sources;
 };
 
 EventLoop& main_thread_event_loop();

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
@@ -39,10 +39,7 @@ JS::GCPtr<Task> TaskQueue::take_first_runnable()
         return nullptr;
 
     for (size_t i = 0; i < m_tasks.size(); ++i) {
-        auto const& task = m_tasks[i];
-        if (m_event_loop->is_task_source_blocked(task->source()))
-            continue;
-        if (task->is_runnable())
+        if (m_tasks[i]->is_runnable())
             return m_tasks.take(i);
     }
     return nullptr;
@@ -54,8 +51,6 @@ bool TaskQueue::has_runnable_tasks() const
         return false;
 
     for (auto& task : m_tasks) {
-        if (m_event_loop->is_task_source_blocked(task->source()))
-            continue;
         if (task->is_runnable())
             return true;
     }


### PR DESCRIPTION
… source"

This reverts commit 664611bae41a20d3bf740da12fdf19322f6574f1.

It seems like the HTML spec has been misinterpreted and this text: "... Note that in this setup, the processing model still enforces that the user agent would never process events from any one task source out of order."

does not mean we can't interrupt execution of task by a task with the same task source. It just says they should be processed in the order they were added.

This commit adds a test that was broken by original change. It does fetching and uses parseFromString() DOMParser API in the fetch callback. Following steps end up hanging:
1. Do fetching initiated by fetch() js call.
2. Invoke fetch callback on networking task source
3. Fetch callback does parseFromString()
4. parseFromString() invoked HTMLParser
5. HTMLLinkElement from parsed document is inserted into DOM and initiates fetching
6. Fetching callback cannot run because networking source was blocked on step 2.
7. HTMLParser::the_end() spinning waiting for HTMLLinkElement to unblock load event, which will never happen because fetching callback cannot proceed.

Fixes hanging while navigating from PR list to PR page on GitHub.