### PR TITLE
Utilities/w: Work around Clang 18 bug with templated lambda + Variant

### DIFF
--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     if (!hide_header)
         outln("\033[1m{:10} {:12} {:16} {:6} {}\033[0m", "USER", "TTY", "LOGIN@", "IDLE", "WHAT");
 
-    TRY(json.as_object().try_for_each_member([&](auto& tty, auto& value) -> ErrorOr<void> {
+    TRY(json.as_object().try_for_each_member([&](ByteString const& tty, auto& value) -> ErrorOr<void> {
         const JsonObject& entry = value.as_object();
         auto uid = entry.get_u32("uid"sv).value_or(0);
         [[maybe_unused]] auto pid = entry.get_i32("pid"sv).value_or(0);


### PR DESCRIPTION
This was missed in 6f972c1 since this file is not compiled as a part of  a Lagom build.

While we can successfully build Serenity using clang trunk with this patch (and one from Daniel regarding `IPC::encode`, and three first commits from #21182), newly compiled kernel unfortunately crashes just after it initializes memory manager.