### PR TITLE
LibWeb: Don't limit available space during early height for inline-flex

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/inline-flex-early-resolution-of-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-flex-early-resolution-of-percentage-height.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: inline
+    frag 0 from Box start: 0, length: 0, rect: [8,8 200x200] baseline: 13.296875
+    Box <body> at (8,8) content-size 200x200 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 200x200 flex-item [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableBox (Box<BODY>) [8,8 200x200]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 200x200]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/flex/inline-flex-early-resolution-of-percentage-height.html
+++ b/Tests/LibWeb/Layout/input/flex/inline-flex-early-resolution-of-percentage-height.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+* { outline: 1px solid black; }
+html { background: white; }
+body {
+    display: inline-flex;
+    background: orange;
+    height: 100%;
+}
+div {
+    background: magenta;
+    height: 200px;
+    width: 200px;
+}
+</style><body><div>hello

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -178,7 +178,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
     if (box_state.has_definite_height() || box.display().is_flex_inside())
-        parent().compute_height(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_definite(m_containing_block_used_values.content_height())));
+        parent().compute_height(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()));
 
     auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
 


### PR DESCRIPTION
There was no need to set an available height constraint when doing early height calculation for inline-flex boxes. It created a situation where the flex containers could wrongly get zero height early, and then resolve percentages against zero instead of the real intrinsic size.

Fixes #23942