### PR TITLE
LibWeb: Let queue_a_microtask() take a JS::HeapFunction

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1840,7 +1840,7 @@ void Element::enqueue_an_element_on_the_appropriate_element_queue()
 
         // 4. Queue a microtask to perform the following steps:
         // NOTE: `this` is protected by JS::SafeFunction
-        HTML::queue_a_microtask(&document(), [this]() {
+        HTML::queue_a_microtask(&document(), JS::create_heap_function(relevant_agent.heap(), [this]() {
             auto& relevant_agent = HTML::relevant_agent(*this);
             auto* custom_data = verify_cast<Bindings::WebEngineCustomData>(relevant_agent.custom_data());
             auto& reactions_stack = custom_data->custom_element_reactions_stack;
@@ -1850,7 +1850,7 @@ void Element::enqueue_an_element_on_the_appropriate_element_queue()
 
             // 2. Unset reactionsStack's processing the backup element queue flag.
             reactions_stack.processing_the_backup_element_queue = false;
-        });
+        }));
 
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -393,7 +393,7 @@ int queue_global_task(HTML::Task::Source source, JS::Object& global_object, Func
 }
 
 // https://html.spec.whatwg.org/#queue-a-microtask
-void queue_a_microtask(DOM::Document const* document, Function<void()> steps)
+void queue_a_microtask(DOM::Document const* document, JS::NonnullGCPtr<JS::HeapFunction<void()>> steps)
 {
     // 1. If event loop was not given, set event loop to the implied event loop.
     auto& event_loop = HTML::main_thread_event_loop();
@@ -405,7 +405,7 @@ void queue_a_microtask(DOM::Document const* document, Function<void()> steps)
     // 5. Set microtask's source to the microtask task source.
     // 6. Set microtask's document to document.
     auto& vm = event_loop.vm();
-    auto microtask = HTML::Task::create(vm, HTML::Task::Source::Microtask, document, JS::create_heap_function(vm.heap(), move(steps)));
+    auto microtask = HTML::Task::create(vm, HTML::Task::Source::Microtask, document, steps);
 
     // FIXME: 7. Set microtask's script evaluation environment settings object set to an empty set.
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -117,7 +117,7 @@ private:
 
 EventLoop& main_thread_event_loop();
 int queue_global_task(HTML::Task::Source, JS::Object&, Function<void()> steps);
-void queue_a_microtask(DOM::Document const*, Function<void()> steps);
+void queue_a_microtask(DOM::Document const*, JS::NonnullGCPtr<JS::HeapFunction<void()>> steps);
 void perform_a_microtask_checkpoint();
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -422,7 +422,7 @@ ErrorOr<void> HTMLImageElement::update_the_image_data(bool restart_animations, b
     }
 after_step_7:
     // 8. Queue a microtask to perform the rest of this algorithm, allowing the task that invoked this algorithm to continue.
-    queue_a_microtask(&document(), [this, restart_animations, maybe_omit_events, previous_url]() mutable {
+    queue_a_microtask(&document(), JS::create_heap_function(this->heap(), [this, restart_animations, maybe_omit_events, previous_url]() mutable {
         // FIXME: 9. If another instance of this algorithm for this img element was started after this instance
         //           (even if it aborted and is no longer running), then return.
 
@@ -572,7 +572,7 @@ after_step_7:
         }
 
         image_request->fetch_image(realm(), request);
-    });
+    }));
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -152,11 +152,11 @@ void WindowOrWorkerGlobalScopeMixin::queue_microtask(WebIDL::CallbackType& callb
         document = &static_cast<Window&>(this_impl()).associated_document();
 
     // The queueMicrotask(callback) method must queue a microtask to invoke callback, and if callback throws an exception, report the exception.
-    HTML::queue_a_microtask(document, [&callback, &realm] {
+    HTML::queue_a_microtask(document, JS::create_heap_function(realm.heap(), [&callback, &realm] {
         auto result = WebIDL::invoke_callback(callback, {});
         if (result.is_error())
             HTML::report_exception(result, realm);
-    });
+    }));
 }
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -391,7 +391,7 @@ public:
     virtual void on_chunk(JS::Value chunk) override
     {
         // 1. Queue a microtask to perform the following steps:
-        HTML::queue_a_microtask(nullptr, [this, chunk]() {
+        HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk]() {
             HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm) };
 
             auto controller1 = m_params->branch1->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>();
@@ -450,7 +450,7 @@ public:
             if (m_params->read_again) {
                 MUST(m_params->pull_algorithm->function()());
             }
-        });
+        }));
 
         // NOTE: The microtask delay here is necessary because it takes at least a microtask to detect errors, when we
         //       use reader.[[closedPromise]] below. We want errors in stream to error both branches immediately, so we
@@ -700,7 +700,7 @@ public:
     virtual void on_chunk(JS::Value chunk) override
     {
         // 1. Queue a microtask to perform the following steps:
-        HTML::queue_a_microtask(nullptr, [this, chunk]() mutable {
+        HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk]() mutable {
             HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm) };
 
             auto controller1 = m_params->branch1->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>();
@@ -767,7 +767,7 @@ public:
             else if (m_params->read_again_for_branch2) {
                 MUST(m_params->pull2_algorithm->function()());
             }
-        });
+        }));
 
         // NOTE: The microtask delay here is necessary because it takes at least a microtask to detect errors, when we
         //       use reader.[[closedPromise]] below. We want errors in stream to error both branches immediately, so we
@@ -864,7 +864,7 @@ public:
         auto chunk_view = m_realm->vm().heap().allocate<WebIDL::ArrayBufferView>(m_realm, chunk.as_object());
 
         // 1. Queue a microtask to perform the following steps:
-        HTML::queue_a_microtask(nullptr, [this, chunk = chunk_view]() {
+        HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk = chunk_view]() {
             HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm) };
 
             auto byob_controller = m_byob_branch->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>();
@@ -934,7 +934,7 @@ public:
             else if (m_params->read_again_for_branch2) {
                 MUST(m_params->pull2_algorithm->function()());
             }
-        });
+        }));
 
         // NOTE: The microtask delay here is necessary because it takes at least a microtask to detect errors, when we
         //       use reader.[[closedPromise]] below. We want errors in stream to error both branches immediately, so we

--- a/Userland/Libraries/LibWeb/WebIDL/Promise.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.cpp
@@ -239,9 +239,9 @@ void wait_for_all(JS::Realm& realm, Vector<JS::NonnullGCPtr<Promise>> const& pro
     // 6. If total is 0, then:
     if (total == 0) {
         // 1. Queue a microtask to perform successSteps given « ».
-        HTML::queue_a_microtask(nullptr, [success_steps = JS::create_heap_function(realm.heap(), move(success_steps))] {
+        HTML::queue_a_microtask(nullptr, JS::create_heap_function(realm.heap(), [success_steps = JS::create_heap_function(realm.heap(), move(success_steps))] {
             success_steps->function()({});
-        });
+        }));
 
         // 2. Return.
         return;


### PR DESCRIPTION
This changes the signature of `queue_a_microtask()` from `AK:Function` to `JS::HeapFunction` to be more clear to the user of the functions that this is what it uses internally.