### PR TITLE
LibJIT: Fix minor typo

### DIFF
--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -815,8 +815,6 @@ struct X86_64Assembler {
 
     void push_callee_saved_registers()
     {
-        // FIXME: Don't push RBX twice :^)
-        push(Operand::Register(Reg::RBX));
         push(Operand::Register(Reg::RBX));
         push(Operand::Register(Reg::R12));
         push(Operand::Register(Reg::R13));
@@ -831,8 +829,6 @@ struct X86_64Assembler {
         pop(Operand::Register(Reg::R13));
         pop(Operand::Register(Reg::R12));
 
-        // FIXME: Don't pop RBX twice :^)
-        pop(Operand::Register(Reg::RBX));
         pop(Operand::Register(Reg::RBX));
     }
 


### PR DESCRIPTION
This fixes a simple typo. Sorry if I was missing something.

Quick question:
Are there any plans of adding new features to the x86 assembler? Or is it good mature enough for now?
I see that memory addressing modes requiring a SIB byte are not supported. Is there no use-case for it in the JIT compiler? Or is it simply not implemented yet? 