### PR TITLE
Ladybird/Qt: Stop using history to drive navigation 

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -282,7 +282,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [self.observer onLoadFinish:url];
     };
 
-    m_web_view_bridge->on_url_updated = [self](auto const& url, auto history_behavior) {
+    m_web_view_bridge->on_history_api_push_or_replace = [self](auto const& url, auto history_behavior) {
         [self.observer onURLUpdated:url historyBehavior:history_behavior];
     };
 

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -220,6 +220,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     auto* debug_menu = menuBar()->addMenu("&Debug");
 
     auto* dump_session_history_tree_action = new QAction("Dump Session History Tree", this);
+    dump_session_history_tree_action->setIcon(load_icon_from_uri("resource://icons/16x16/history.png"sv));
     debug_menu->addAction(dump_session_history_tree_action);
     QObject::connect(dump_session_history_tree_action, &QAction::triggered, this, [this] {
         debug_request("dump-session-history");

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -86,6 +86,7 @@ public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
     void tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState);
+    void tab_navigation_buttons_state_changed(int index);
     Tab& new_tab_from_url(URL::URL const&, Web::HTML::ActivateTab);
     Tab& new_tab_from_content(StringView html, Web::HTML::ActivateTab);
     Tab& new_child_tab(Web::HTML::ActivateTab, Tab& parent, Web::HTML::WebViewHints, Optional<u64> page_index);

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -150,7 +150,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             m_inspector_widget->inspect();
     };
 
-    view().on_url_updated = [this](auto const& url, auto history_behavior) {
+    view().on_history_api_push_or_replace = [this](auto const& url, auto history_behavior) {
         switch (history_behavior) {
         case Web::HTML::HistoryHandlingBehavior::Push:
             m_history.push(url, m_title.toUtf8().data());

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -786,11 +786,7 @@ void Tab::forward()
 
 void Tab::reload()
 {
-    if (m_history.is_empty())
-        return;
-
-    m_is_history_navigation = true;
-    view().load(m_history.current().url.to_byte_string());
+    view().reload();
 }
 
 void Tab::open_link(URL::URL const& url)

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -54,6 +54,8 @@ public:
 
     QIcon const& favicon() const { return m_favicon; }
 
+    void update_navigation_buttons_state();
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();
@@ -63,6 +65,7 @@ signals:
     void title_changed(int id, QString const&);
     void favicon_changed(int id, QIcon const&);
     void audio_play_state_changed(int id, Web::HTML::AudioPlayState);
+    void navigation_buttons_state_changed(int id);
 
 private:
     virtual void resizeEvent(QResizeEvent*) override;
@@ -70,7 +73,6 @@ private:
 
     void recreate_toolbar_icons();
     void update_hover_label();
-    void update_navigation_button_states();
 
     void open_link(URL::URL const&);
     void open_link_in_new_tab(URL::URL const&);
@@ -85,7 +87,6 @@ private:
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     BrowserWindow* m_window { nullptr };
-    WebView::History m_history;
     QString m_title;
     QLabel* m_hover_label { nullptr };
     QIcon m_favicon;
@@ -117,11 +118,12 @@ private:
 
     int tab_index();
 
-    bool m_is_history_navigation { false };
-
     Ladybird::InspectorWidget* m_inspector_widget { nullptr };
 
     QPointer<QDialog> m_dialog;
+
+    bool m_can_navigate_back { false };
+    bool m_can_navigate_forward { false };
 };
 
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -262,7 +262,7 @@ Tab::Tab(BrowserWindow& window)
             m_dom_inspector_widget->inspect();
     };
 
-    view().on_url_updated = [this](auto const& url, auto history_behavior) {
+    view().on_history_api_push_or_replace = [this](auto const& url, auto history_behavior) {
         switch (history_behavior) {
         case Web::HTML::HistoryHandlingBehavior::Push:
             m_history.push(url, m_title);

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -215,7 +215,7 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value d
 
     auto navigable = document->navigable();
     if (navigable->is_top_level_traversable()) {
-        navigable->active_browsing_context()->page().client().page_did_update_url(new_url, history_handling);
+        navigable->active_browsing_context()->page().client().page_did_history_api_push_or_replace(new_url, history_handling);
     }
 
     // 10. Run the URL and history update steps given document and newURL, with serializedData set to

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -788,6 +788,8 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     auto forward_enabled = m_current_session_history_step < static_cast<int>(m_session_history_entries.size()) - 1;
     page().client().page_did_update_navigation_buttons_state(back_enabled, forward_enabled);
 
+    page().client().page_did_change_url(current_session_history_entry()->url());
+
     // 21. Return "applied".
     return HistoryStepResult::Applied;
 }

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -782,6 +782,12 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     // 20. Set traversable's current session history step to targetStep.
     m_current_session_history_step = target_step;
 
+    // Not in the spec:
+    auto back_enabled = m_current_session_history_step > 0;
+    VERIFY(m_session_history_entries.size() > 0);
+    auto forward_enabled = m_current_session_history_step < static_cast<int>(m_session_history_entries.size()) - 1;
+    page().client().page_did_update_navigation_buttons_state(back_enabled, forward_enabled);
+
     // 21. Return "applied".
     return HistoryStepResult::Applied;
 }

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -79,6 +79,11 @@ void Page::reload()
     top_level_traversable()->reload();
 }
 
+void Page::traverse_the_history_by_delta(int delta)
+{
+    top_level_traversable()->traverse_the_history_by_delta(delta);
+}
+
 Gfx::Palette Page::palette() const
 {
     return m_client->palette();

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -74,6 +74,11 @@ void Page::load_html(StringView html)
         .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
 }
 
+void Page::reload()
+{
+    top_level_traversable()->reload();
+}
+
 Gfx::Palette Page::palette() const
 {
     return m_client->palette();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -76,6 +76,8 @@ public:
 
     void load_html(StringView);
 
+    void reload();
+
     CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
     DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
     DevicePixelRect css_to_device_rect(CSSPixelRect) const;

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -251,6 +251,7 @@ public:
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
     virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, PaintOptions = {}) = 0;
     virtual void page_did_change_title(ByteString const&) { }
+    virtual void page_did_change_url(URL::URL const&) { }
     virtual void page_did_request_navigate_back() { }
     virtual void page_did_request_navigate_forward() { }
     virtual void page_did_request_refresh() { }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -299,6 +299,7 @@ public:
     virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints, HTML::TokenizedFeature::NoOpener) { return {}; }
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
+    virtual void page_did_update_navigation_buttons_state([[maybe_unused]] bool back_enabled, [[maybe_unused]] bool forward_enabled) { }
 
     virtual void request_file(FileRequest) = 0;
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -265,7 +265,7 @@ public:
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) { }
     virtual void page_did_destroy_document(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(URL::URL const&) { }
-    virtual void page_did_update_url(URL::URL const&, Web::HTML::HistoryHandlingBehavior) { }
+    virtual void page_did_history_api_push_or_replace(URL::URL const&, Web::HTML::HistoryHandlingBehavior) { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }
     virtual void page_did_request_context_menu(CSSPixelPoint) { }
     virtual void page_did_request_link_context_menu(CSSPixelPoint, URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -78,6 +78,8 @@ public:
 
     void reload();
 
+    void traverse_the_history_by_delta(int delta);
+
     CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
     DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
     DevicePixelRect css_to_device_rect(CSSPixelRect) const;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -90,6 +90,11 @@ void ViewImplementation::load_empty_document()
     load_html(""sv);
 }
 
+void ViewImplementation::reload()
+{
+    client().async_reload(page_id());
+}
+
 void ViewImplementation::zoom_in()
 {
     if (m_zoom_level >= ZOOM_MAX_LEVEL)

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -355,6 +355,12 @@ void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, We
         on_audio_play_state_changed(m_audio_play_state);
 }
 
+void ViewImplementation::did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const
+{
+    if (on_navigation_buttons_state_changed)
+        on_navigation_buttons_state_changed(back_enabled, forward_enabled);
+}
+
 void ViewImplementation::handle_resize()
 {
     resize_backing_stores_if_needed(WindowResizeInProgress::Yes);

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -95,6 +95,11 @@ void ViewImplementation::reload()
     client().async_reload(page_id());
 }
 
+void ViewImplementation::traverse_the_history_by_delta(int delta)
+{
+    client().async_traverse_the_history_by_delta(page_id(), delta);
+}
+
 void ViewImplementation::zoom_in()
 {
     if (m_zoom_level >= ZOOM_MAX_LEVEL)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -145,7 +145,7 @@ public:
     Function<void(ByteString const&)> on_title_change;
     Function<void(URL::URL const&, bool)> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
-    Function<void(URL::URL const&, Web::HTML::HistoryHandlingBehavior)> on_url_updated;
+    Function<void(URL::URL const&, Web::HTML::HistoryHandlingBehavior)> on_history_api_push_or_replace;
     Function<void(ByteString const& path, i32)> on_request_file;
     Function<void()> on_navigate_back;
     Function<void()> on_navigate_forward;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -50,6 +50,7 @@ public:
     void load_html(StringView);
     void load_empty_document();
     void reload();
+    void traverse_the_history_by_delta(int delta);
 
     void zoom_in();
     void zoom_out();

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -143,6 +143,7 @@ public:
     Function<void(URL::URL const&, ByteString const& target, unsigned modifiers)> on_link_click;
     Function<void(URL::URL const&, ByteString const& target, unsigned modifiers)> on_link_middle_click;
     Function<void(ByteString const&)> on_title_change;
+    Function<void(URL::URL const&)> on_url_change;
     Function<void(URL::URL const&, bool)> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
     Function<void(URL::URL const&, Web::HTML::HistoryHandlingBehavior)> on_history_api_push_or_replace;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -49,6 +49,7 @@ public:
     void load(URL::URL const&);
     void load_html(StringView);
     void load_empty_document();
+    void reload();
 
     void zoom_in();
     void zoom_out();

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -110,6 +110,8 @@ public:
     void did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState);
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
+    void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
+
     enum class ScreenshotType {
         Visible,
         Full,
@@ -189,6 +191,7 @@ public:
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
+    Function<void(bool, bool)> on_navigation_buttons_state_changed;
     Function<void()> on_inspector_loaded;
     Function<void(i32, Optional<Web::CSS::Selector::PseudoElement::Type> const&)> on_inspector_selected_dom_node;
     Function<void(i32, String const&)> on_inspector_set_dom_node_text;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -142,6 +142,14 @@ void WebContentClient::did_change_title(u64 page_id, ByteString const& title)
     }
 }
 
+void WebContentClient::did_change_url(u64 page_id, URL::URL const& url)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_url_change)
+            view->on_url_change(url);
+    }
+}
+
 void WebContentClient::did_request_scroll(u64 page_id, i32 x_delta, i32 y_delta)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -588,6 +588,12 @@ void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::Audio
         view->did_change_audio_play_state({}, play_state);
 }
 
+void WebContentClient::did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_update_navigation_buttons_state({}, back_enabled, forward_enabled);
+}
+
 void WebContentClient::inspector_did_load(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -66,13 +66,13 @@ void WebContentClient::did_finish_loading(u64 page_id, URL::URL const& url)
     }
 }
 
-void WebContentClient::did_update_url(u64 page_id, URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior)
+void WebContentClient::did_history_api_push_or_replace(u64 page_id, URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         view->set_url({}, url);
 
-        if (view->on_url_updated)
-            view->on_url_updated(url, history_behavior);
+        if (view->on_history_api_push_or_replace)
+            view->on_history_api_push_or_replace(url, history_behavior);
     }
 }
 

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -101,6 +101,7 @@ private:
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, String const& data, String const& presentation_style, String const& mime_type) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
+    virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual void inspector_did_load(u64 page_id) override;
     virtual void inspector_did_select_dom_node(u64 page_id, i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String const& text) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -40,7 +40,7 @@ private:
     virtual void notify_process_information(WebView::ProcessHandle const&) override;
     virtual void did_paint(u64 page_id, Gfx::IntRect const&, i32) override;
     virtual void did_finish_loading(u64 page_id, URL::URL const&) override;
-    virtual void did_update_url(u64 page_id, URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior) override;
+    virtual void did_history_api_push_or_replace(u64 page_id, URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior) override;
     virtual void did_request_navigate_back(u64 page_id) override;
     virtual void did_request_navigate_forward(u64 page_id) override;
     virtual void did_request_refresh(u64 page_id) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -47,6 +47,7 @@ private:
     virtual void did_request_cursor_change(u64 page_id, i32) override;
     virtual void did_layout(u64 page_id, Gfx::IntSize) override;
     virtual void did_change_title(u64 page_id, ByteString const&) override;
+    virtual void did_change_url(u64 page_id, URL::URL const&) override;
     virtual void did_request_scroll(u64 page_id, i32, i32) override;
     virtual void did_request_scroll_to(u64 page_id, Gfx::IntPoint) override;
     virtual void did_enter_tooltip_area(u64 page_id, Gfx::IntPoint, ByteString const&) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -162,6 +162,12 @@ void ConnectionFromClient::reload(u64 page_id)
         page->page().reload();
 }
 
+void ConnectionFromClient::traverse_the_history_by_delta(u64 page_id, i32 delta)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().traverse_the_history_by_delta(delta);
+}
+
 void ConnectionFromClient::set_viewport_rect(u64 page_id, Web::DevicePixelRect const& rect)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -156,6 +156,12 @@ void ConnectionFromClient::load_html(u64 page_id, ByteString const& html)
         page->page().load_html(html);
 }
 
+void ConnectionFromClient::reload(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().reload();
+}
+
 void ConnectionFromClient::set_viewport_rect(u64 page_id, Web::DevicePixelRect const& rect)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -57,6 +57,7 @@ private:
     virtual void update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> const&, u32) override;
     virtual void load_url(u64 page_id, URL::URL const&) override;
     virtual void load_html(u64 page_id, ByteString const&) override;
+    virtual void reload(u64 page_id) override;
     virtual void set_viewport_rect(u64 page_id, Web::DevicePixelRect const&) override;
     virtual void key_event(u64 page_id, Web::KeyEvent const&) override;
     virtual void mouse_event(u64 page_id, Web::MouseEvent const&) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -58,6 +58,7 @@ private:
     virtual void load_url(u64 page_id, URL::URL const&) override;
     virtual void load_html(u64 page_id, ByteString const&) override;
     virtual void reload(u64 page_id) override;
+    virtual void traverse_the_history_by_delta(u64 page_id, i32 delta) override;
     virtual void set_viewport_rect(u64 page_id, Web::DevicePixelRect const&) override;
     virtual void key_event(u64 page_id, Web::KeyEvent const&) override;
     virtual void mouse_event(u64 page_id, Web::MouseEvent const&) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -257,6 +257,11 @@ void PageClient::page_did_change_title(ByteString const& title)
     client().async_did_change_title(m_id, title);
 }
 
+void PageClient::page_did_change_url(URL::URL const& url)
+{
+    client().async_did_change_url(m_id, url);
+}
+
 void PageClient::page_did_request_navigate_back()
 {
     client().async_did_request_navigate_back(m_id);

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -371,9 +371,9 @@ void PageClient::page_did_finish_loading(URL::URL const& url)
     client().async_did_finish_loading(m_id, url);
 }
 
-void PageClient::page_did_update_url(URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior)
+void PageClient::page_did_history_api_push_or_replace(URL::URL const& url, Web::HTML::HistoryHandlingBehavior history_behavior)
 {
-    client().async_did_update_url(m_id, url, history_behavior);
+    client().async_did_history_api_push_or_replace(m_id, url, history_behavior);
 }
 
 void PageClient::page_did_finish_text_test()

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -562,6 +562,11 @@ void PageClient::page_did_close_top_level_traversable()
     m_owner.remove_page({}, m_id);
 }
 
+void PageClient::page_did_update_navigation_buttons_state(bool back_enabled, bool forward_enabled)
+{
+    client().async_did_update_navigation_buttons_state(m_id, back_enabled, forward_enabled);
+}
+
 void PageClient::request_file(Web::FileRequest file_request)
 {
     client().request_file(m_id, move(file_request));

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -95,6 +95,7 @@ private:
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;
     virtual void page_did_layout() override;
     virtual void page_did_change_title(ByteString const&) override;
+    virtual void page_did_change_url(URL::URL const&) override;
     virtual void page_did_request_navigate_back() override;
     virtual void page_did_request_navigate_forward() override;
     virtual void page_did_request_refresh() override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -137,6 +137,7 @@ private:
     virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_top_level_traversable() override;
+    virtual void page_did_update_navigation_buttons_state(bool back_enabled, bool forward_enabled) override;
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;
     virtual void page_did_request_file_picker(Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -120,7 +120,7 @@ private:
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
     virtual void page_did_destroy_document(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(URL::URL const&) override;
-    virtual void page_did_update_url(URL::URL const&, Web::HTML::HistoryHandlingBehavior) override;
+    virtual void page_did_history_api_push_or_replace(URL::URL const&, Web::HTML::HistoryHandlingBehavior) override;
     virtual void page_did_request_alert(String const&) override;
     virtual void page_did_request_confirm(String const&) override;
     virtual void page_did_request_prompt(String const&, String const&) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -31,6 +31,7 @@ endpoint WebContentClient
     did_request_cursor_change(u64 page_id, i32 cursor_type) =|
     did_layout(u64 page_id, Gfx::IntSize content_size) =|
     did_change_title(u64 page_id, ByteString title) =|
+    did_change_url(u64 page_id, URL::URL url) =|
     did_request_scroll(u64 page_id, i32 x_delta, i32 y_delta) =|
     did_request_scroll_to(u64 page_id, Gfx::IntPoint scroll_position) =|
     did_enter_tooltip_area(u64 page_id, Gfx::IntPoint content_position, ByteString title) =|

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -83,6 +83,7 @@ endpoint WebContentClient
     did_finish_handling_input_event(u64 page_id, bool event_was_accepted) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|
     did_insert_clipboard_entry(u64 page_id, String data, String presentation_style, String mime_type) =|
+    did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
 
     did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -23,7 +23,7 @@ endpoint WebContentClient
 
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
-    did_update_url(u64 page_id, URL::URL url, Web::HTML::HistoryHandlingBehavior history_behavior) =|
+    did_history_api_push_or_replace(u64 page_id, URL::URL url, Web::HTML::HistoryHandlingBehavior history_behavior) =|
     did_request_navigate_back(u64 page_id) =|
     did_request_navigate_forward(u64 page_id) =|
     did_request_refresh(u64 page_id) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -25,6 +25,7 @@ endpoint WebContentServer
     load_url(u64 page_id, URL::URL url) =|
     load_html(u64 page_id, ByteString html) =|
     reload(u64 page_id) =|
+    traverse_the_history_by_delta(u64 page_id, i32 delta) =|
 
     add_backing_store(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
     ready_to_paint(u64 page_id) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -24,6 +24,7 @@ endpoint WebContentServer
 
     load_url(u64 page_id, URL::URL url) =|
     load_html(u64 page_id, ByteString html) =|
+    reload(u64 page_id) =|
 
     add_backing_store(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
     ready_to_paint(u64 page_id) =|


### PR DESCRIPTION
Before this change we had to keep session history on browser side to
calculate a url for back/forward/reload action.
Now, with a mature enough implementation of navigation algorithms from
the specification, there is no need to use
history on the browser side to calculate navigation URLs because:
- Traversable navigable owns session history that is aware of all
  navigations, including those initiated by History API and Navigation
  API
- TraversableNavigable::traverse_the_history_by_delta() uses
  traversable's history to calculate the next URL based on delta, so
  there is no need for UI to keep sesion history.

In the future, we will likely want to add a way to pull session history
from WebContent to make it browsable from the UI.