### PR TITLE
LibPDF: Make CFF.cpp use Stream instead of Reader

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -138,7 +138,7 @@ public:
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
     static PDFErrorOr<Vector<SID>> parse_charset(Reader&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_fdselect(Reader&&, size_t);
-    static PDFErrorOr<Vector<u8>> parse_encoding(Reader&&, HashMap<Card8, SID>& supplemental);
+    static PDFErrorOr<Vector<u8>> parse_encoding(Stream&&, HashMap<Card8, SID>& supplemental);
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -137,7 +137,7 @@ public:
 
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
     static PDFErrorOr<Vector<SID>> parse_charset(Reader&&, size_t);
-    static PDFErrorOr<Vector<u8>> parse_fdselect(Reader&&, size_t);
+    static PDFErrorOr<Vector<u8>> parse_fdselect(Stream&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_encoding(Stream&&, HashMap<Card8, SID>& supplemental);
 };
 

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -99,9 +99,9 @@ public:
         return operand.get<float>();
     }
 
-    static int load_int_dict_operand(u8 b0, Reader&);
-    static float load_float_dict_operand(Reader&);
-    static PDFErrorOr<DictOperand> load_dict_operand(u8, Reader&);
+    static ErrorOr<int> load_int_dict_operand(u8 b0, Stream&);
+    static ErrorOr<float> load_float_dict_operand(Stream&);
+    static PDFErrorOr<DictOperand> load_dict_operand(u8, Stream&);
 
     using IndexDataHandler = Function<PDFErrorOr<void>(ReadonlyBytes const&)>;
     static PDFErrorOr<void> parse_index(Reader& reader, IndexDataHandler&&);
@@ -112,10 +112,10 @@ public:
     using DictEntryHandler = Function<PDFErrorOr<void>(OperatorT, Vector<DictOperand> const&)>;
 
     template<typename OperatorT>
-    static PDFErrorOr<void> parse_dict(Reader& reader, DictEntryHandler<OperatorT>&& handler);
+    static PDFErrorOr<void> parse_dict(Stream&, DictEntryHandler<OperatorT>&& handler);
 
     template<typename OperatorT>
-    static PDFErrorOr<OperatorT> parse_dict_operator(u8, Reader&);
+    static PDFErrorOr<OperatorT> parse_dict_operator(u8, Stream&);
 
     // CFF spec, "8 Top DICT INDEX"
     struct TopDict {

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -12,8 +12,6 @@
 
 namespace PDF {
 
-class Reader;
-
 // CFF spec: https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf
 
 class CFF : public Type1FontProgram {
@@ -104,9 +102,9 @@ public:
     static PDFErrorOr<DictOperand> load_dict_operand(u8, Stream&);
 
     using IndexDataHandler = Function<PDFErrorOr<void>(ReadonlyBytes const&)>;
-    static PDFErrorOr<void> parse_index(Reader& reader, IndexDataHandler&&);
+    static PDFErrorOr<void> parse_index(FixedMemoryStream&, IndexDataHandler&&);
 
-    static PDFErrorOr<void> parse_index_data(OffSize offset_size, Card16 count, Reader& reader, IndexDataHandler&);
+    static PDFErrorOr<void> parse_index_data(OffSize offset_size, Card16 count, FixedMemoryStream&, IndexDataHandler&);
 
     template<typename OperatorT>
     using DictEntryHandler = Function<PDFErrorOr<void>(OperatorT, Vector<DictOperand> const&)>;
@@ -129,11 +127,11 @@ public:
         int fdselect_offset = 0;
         int fdarray_offset = 0;
     };
-    static PDFErrorOr<Vector<TopDict>> parse_top_dicts(Reader&, ReadonlyBytes const& cff_bytes);
+    static PDFErrorOr<Vector<TopDict>> parse_top_dicts(FixedMemoryStream&, ReadonlyBytes const& cff_bytes);
 
-    static PDFErrorOr<Vector<StringView>> parse_strings(Reader&);
+    static PDFErrorOr<Vector<StringView>> parse_strings(FixedMemoryStream&);
 
-    static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
+    static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(FixedMemoryStream&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
 
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
     static PDFErrorOr<Vector<SID>> parse_charset(Stream&&, size_t);

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -136,7 +136,7 @@ public:
     static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
 
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
-    static PDFErrorOr<Vector<SID>> parse_charset(Reader&&, size_t);
+    static PDFErrorOr<Vector<SID>> parse_charset(Stream&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_fdselect(Stream&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_encoding(Stream&&, HashMap<Card8, SID>& supplemental);
 };


### PR DESCRIPTION
No behavior change.

Part of #20744.