### PR TITLE
LibWeb: Add methods to Window and Document that must do nothing

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Document-methods-that-must-do-nothing.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-methods-that-must-do-nothing.txt
@@ -1,0 +1,3 @@
+document.clear() returns undefined: true
+document.captureEvents() returns undefined: true
+document.releaseEvents() returns undefined: true

--- a/Tests/LibWeb/Text/expected/DOM/Window-methods-that-must-do-nothing.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Window-methods-that-must-do-nothing.txt
@@ -1,0 +1,2 @@
+window.captureEvents() returns undefined: true
+window.releaseEvents() returns undefined: true

--- a/Tests/LibWeb/Text/input/DOM/Document-methods-that-must-do-nothing.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-methods-that-must-do-nothing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`document.clear() returns undefined: ${document.clear() === undefined}`);
+        println(`document.captureEvents() returns undefined: ${document.captureEvents() === undefined}`);
+        println(`document.releaseEvents() returns undefined: ${document.releaseEvents() === undefined}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/Window-methods-that-must-do-nothing.html
+++ b/Tests/LibWeb/Text/input/DOM/Window-methods-that-must-do-nothing.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`window.captureEvents() returns undefined: ${window.captureEvents() === undefined}`);
+        println(`window.releaseEvents() returns undefined: ${window.releaseEvents() === undefined}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1472,6 +1472,24 @@ JS::NonnullGCPtr<HTML::HTMLAllCollection> Document::all()
     return *m_all;
 }
 
+// https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-clear
+void Document::clear()
+{
+    // Do nothing
+}
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-captureevents
+void Document::capture_events()
+{
+    // Do nothing
+}
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-releaseevents
+void Document::release_events()
+{
+    // Do nothing
+}
+
 Color Document::link_color() const
 {
     if (m_link_color.has_value())

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -243,6 +243,10 @@ public:
     JS::NonnullGCPtr<HTMLCollection> scripts();
     JS::NonnullGCPtr<HTML::HTMLAllCollection> all();
 
+    void clear();
+    void capture_events();
+    void release_events();
+
     String const& source() const { return m_source; }
     void set_source(String source) { m_source = move(source); }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -78,6 +78,10 @@ interface Document : Node {
 
     readonly attribute HTMLAllCollection all;
 
+    undefined clear();
+    undefined captureEvents();
+    undefined releaseEvents();
+
     [CEReactions, NewObject] Element createElement(DOMString tagName, optional (DOMString or ElementCreationOptions) options = {});
     [CEReactions, NewObject] Element createElementNS([FlyString] DOMString? namespace, DOMString qualifiedName, optional (DOMString or ElementCreationOptions) options = {});
     DocumentFragment createDocumentFragment();

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1600,6 +1600,18 @@ JS::NonnullGCPtr<Crypto::Crypto> Window::crypto()
     return JS::NonnullGCPtr { *m_crypto };
 }
 
+// https://html.spec.whatwg.org/multipage/obsolete.html#dom-window-captureevents
+void Window::capture_events()
+{
+    // Do nothing.
+}
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-releaseevents
+void Window::release_events()
+{
+    // Do nothing.
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation
 JS::NonnullGCPtr<Navigation> Window::navigation()
 {

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -202,6 +202,9 @@ public:
 
     [[nodiscard]] JS::NonnullGCPtr<Crypto::Crypto> crypto();
 
+    void capture_events();
+    void release_events();
+
     [[nodiscard]] JS::NonnullGCPtr<CustomElementRegistry> custom_elements();
 
     HighResolutionTime::DOMHighResTimeStamp get_last_activation_timestamp() const { return m_last_activation_timestamp; }

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -110,6 +110,9 @@ interface Window : EventTarget {
 
     // https://w3c.github.io/webcrypto/#crypto-interface
     [SameObject] readonly attribute Crypto crypto;
+
+    undefined captureEvents();
+    undefined releaseEvents();
 };
 Window includes AnimationFrameProvider;
 Window includes GlobalEventHandlers;


### PR DESCRIPTION
This PR adds the following methods to Window and Document:
* `document.clear()`
* `document.captureEvents()`
* `document.releaseEvents()`
* `window.captureEvents()`
* `window.releaseEvents()`

These are obsolete, but the HTML specification says they must do nothing.

With this change we now pass this WPT test: http://wpt.live/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/nothing.html