### PR TITLE
LibPDF: Move Type1FontProgram and CFF to use AK::Error

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -1144,4 +1144,20 @@ PDFErrorOr<CFF::DictOperand> CFF::load_dict_operand(u8 b0, Stream& reader)
     return Error { Error::Type::MalformedPDF, ByteString::formatted("Unknown CFF dict element prefix: {}", b0) };
 }
 
+
+Error CFF::error(
+    ByteString const& message
+#ifdef PDF_DEBUG
+    ,
+    SourceLocation loc
+#endif
+)
+{
+#ifdef PDF_DEBUG
+    dbgln("\033[31m{} Type 1 font error: {}\033[0m", loc, message);
+#endif
+
+    return Error { Error::Type::MalformedPDF, message };
+}
+
 }

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -80,7 +80,7 @@ private:
     };
 
 public:
-    static PDFErrorOr<NonnullRefPtr<CFF>> create(ReadonlyBytes const&, RefPtr<Encoding> encoding);
+    static ErrorOr<NonnullRefPtr<CFF>> create(ReadonlyBytes const&, RefPtr<Encoding> encoding);
 
     // to private
     using Card8 = u8;
@@ -99,21 +99,21 @@ public:
 
     static ErrorOr<int> load_int_dict_operand(u8 b0, Stream&);
     static ErrorOr<float> load_float_dict_operand(Stream&);
-    static PDFErrorOr<DictOperand> load_dict_operand(u8, Stream&);
+    static ErrorOr<DictOperand> load_dict_operand(u8, Stream&);
 
-    using IndexDataHandler = Function<PDFErrorOr<void>(ReadonlyBytes const&)>;
-    static PDFErrorOr<void> parse_index(FixedMemoryStream&, IndexDataHandler&&);
+    using IndexDataHandler = Function<ErrorOr<void>(ReadonlyBytes const&)>;
+    static ErrorOr<void> parse_index(FixedMemoryStream&, IndexDataHandler&&);
 
-    static PDFErrorOr<void> parse_index_data(OffSize offset_size, Card16 count, FixedMemoryStream&, IndexDataHandler&);
-
-    template<typename OperatorT>
-    using DictEntryHandler = Function<PDFErrorOr<void>(OperatorT, Vector<DictOperand> const&)>;
+    static ErrorOr<void> parse_index_data(OffSize offset_size, Card16 count, FixedMemoryStream&, IndexDataHandler&);
 
     template<typename OperatorT>
-    static PDFErrorOr<void> parse_dict(Stream&, DictEntryHandler<OperatorT>&& handler);
+    using DictEntryHandler = Function<ErrorOr<void>(OperatorT, Vector<DictOperand> const&)>;
 
     template<typename OperatorT>
-    static PDFErrorOr<OperatorT> parse_dict_operator(u8, Stream&);
+    static ErrorOr<void> parse_dict(Stream&, DictEntryHandler<OperatorT>&& handler);
+
+    template<typename OperatorT>
+    static ErrorOr<OperatorT> parse_dict_operator(u8, Stream&);
 
     // CFF spec, "8 Top DICT INDEX"
     struct TopDict {
@@ -127,24 +127,16 @@ public:
         int fdselect_offset = 0;
         int fdarray_offset = 0;
     };
-    static PDFErrorOr<Vector<TopDict>> parse_top_dicts(FixedMemoryStream&, ReadonlyBytes const& cff_bytes);
+    static ErrorOr<Vector<TopDict>> parse_top_dicts(FixedMemoryStream&, ReadonlyBytes const& cff_bytes);
 
-    static PDFErrorOr<Vector<StringView>> parse_strings(FixedMemoryStream&);
+    static ErrorOr<Vector<StringView>> parse_strings(FixedMemoryStream&);
 
-    static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(FixedMemoryStream&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
+    static ErrorOr<Vector<CFF::Glyph>> parse_charstrings(FixedMemoryStream&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
 
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
-    static PDFErrorOr<Vector<SID>> parse_charset(Stream&&, size_t);
-    static PDFErrorOr<Vector<u8>> parse_fdselect(Stream&&, size_t);
-    static PDFErrorOr<Vector<u8>> parse_encoding(Stream&&, HashMap<Card8, SID>& supplemental);
-
-    static Error error(
-        ByteString const& message
-#ifdef PDF_DEBUG
-        ,
-        SourceLocation loc = SourceLocation::current()
-#endif
-    );
+    static ErrorOr<Vector<SID>> parse_charset(Stream&&, size_t);
+    static ErrorOr<Vector<u8>> parse_fdselect(Stream&&, size_t);
+    static ErrorOr<Vector<u8>> parse_encoding(Stream&&, HashMap<Card8, SID>& supplemental);
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -137,6 +137,14 @@ public:
     static PDFErrorOr<Vector<SID>> parse_charset(Stream&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_fdselect(Stream&&, size_t);
     static PDFErrorOr<Vector<u8>> parse_encoding(Stream&&, HashMap<Card8, SID>& supplemental);
+
+    static Error error(
+        ByteString const& message
+#ifdef PDF_DEBUG
+        ,
+        SourceLocation loc = SourceLocation::current()
+#endif
+    );
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -237,4 +237,19 @@ bool PS1FontProgram::seek_name(Reader& reader, ByteString const& name)
     return false;
 }
 
+Error PS1FontProgram::error(
+    ByteString const& message
+#ifdef PDF_DEBUG
+    ,
+    SourceLocation loc
+#endif
+)
+{
+#ifdef PDF_DEBUG
+    dbgln("\033[31m{} Type 1 font error: {}\033[0m", loc, message);
+#endif
+
+    return Error { Error::Type::MalformedPDF, message };
+}
+
 }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.h
@@ -23,6 +23,14 @@ public:
     static PDFErrorOr<NonnullRefPtr<Type1FontProgram>> create(ReadonlyBytes const&, RefPtr<Encoding>, size_t cleartext_length, size_t encrypted_length);
 
 private:
+    static Error error(
+        ByteString const& message
+#ifdef PDF_DEBUG
+        ,
+        SourceLocation loc = SourceLocation::current()
+#endif
+    );
+
     PDFErrorOr<void> parse_encrypted_portion(ByteBuffer const&);
     PDFErrorOr<Vector<ByteBuffer>> parse_subroutines(Reader&) const;
     static PDFErrorOr<Vector<float>> parse_number_array(Reader&, size_t length);

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -11,7 +11,6 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Path.h>
 #include <LibPDF/Encoding.h>
-#include <LibPDF/Error.h>
 
 namespace PDF {
 
@@ -90,15 +89,7 @@ protected:
         bool is_first_command { true };
     };
 
-    static PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines, GlyphParserState&, bool is_type2);
-
-    static Error error(
-        ByteString const& message
-#ifdef PDF_DEBUG
-        ,
-        SourceLocation loc = SourceLocation::current()
-#endif
-    );
+    static ErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines, GlyphParserState&, bool is_type2);
 
     void set_encoding(RefPtr<Encoding>&& encoding)
     {
@@ -110,7 +101,7 @@ protected:
         m_font_matrix = move(font_matrix);
     }
 
-    PDFErrorOr<void> add_glyph(DeprecatedFlyString name, Glyph&& glyph)
+    ErrorOr<void> add_glyph(DeprecatedFlyString name, Glyph&& glyph)
     {
         TRY(m_glyph_map.try_set(move(name), move(glyph)));
         return {};


### PR DESCRIPTION
No behavior change.

Part of #20744.