### PR TITLE
LibWeb: Invalidate style when CSSStyleRule selectorText changes

### DIFF
--- a/Tests/LibWeb/Text/expected/css/CSSStyleRule-set-selectorText.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleRule-set-selectorText.txt
@@ -1,0 +1,10 @@
+  Testing window.document:
+selectorText initial value: .green-background
+container element backgroundColor initial value: rgb(255, 0, 0)
+selectorText after setting selectorText value to #container: #container
+container element backgroundColor after setting selectorText value to #container: rgb(0, 255, 0)
+Testing iframe.contentDocument:
+selectorText initial value: .green-background
+container element backgroundColor initial value: rgb(255, 0, 0)
+selectorText after setting selectorText value to #container: #container
+container element backgroundColor after setting selectorText value to #container: rgb(0, 255, 0)

--- a/Tests/LibWeb/Text/input/css/CSSStyleRule-set-selectorText.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleRule-set-selectorText.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style id="styleElement">
+    .green-background { background-color: rgb(0, 255, 0) !important; }
+    .red-background { background-color: rgb(255, 0, 0); }
+</style>
+<script src="../include.js"></script>
+<iframe id="iframe"></iframe>
+<script>
+
+    function testSetSelectorText(doc) {
+        const divElement = doc.createElement("div");
+        divElement.classList.add("red-background");
+        divElement.id = "container";
+        divElement.innerHTML = "This shouldn't be visible";
+        doc.body.appendChild(divElement);
+        const divStyle = getComputedStyle(divElement);
+        const greenBackgroundRule = doc.styleSheets[0].cssRules[0];
+        println(`selectorText initial value: ${greenBackgroundRule.selectorText}`);
+        println(`container element backgroundColor initial value: ${divStyle.backgroundColor}`);
+        greenBackgroundRule.selectorText = "#container";
+        println(`selectorText after setting selectorText value to #container: ${greenBackgroundRule.selectorText}`);
+        println(`container element backgroundColor after setting selectorText value to #container: ${divStyle.backgroundColor}`);
+        doc.body.removeChild(divElement);        
+    }
+
+    test(() => {
+        const frameDocument = document.getElementById("iframe").contentDocument;
+        frameDocument.body.appendChild(document.getElementById("styleElement").cloneNode(true));
+
+        println("Testing window.document:");
+        testSetSelectorText(document);
+        
+        println("Testing iframe.contentDocument:");
+        testSetSelectorText(frameDocument);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -62,6 +62,7 @@ public:
     bool evaluate_media_queries(HTML::Window const&);
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
 
+    JS::GCPtr<StyleSheetList> style_sheet_list() const { return m_style_sheet_list; }
     void set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList*);
 
     Optional<FlyString> default_namespace() const;


### PR DESCRIPTION
Previously, any change to the selectorText of a CSSStyleRule was not reflected in the document style.

Relevant WPT test: https://wpt.live/css/cssom/CSSStyleRule-set-selectorText.html 
(there are still some subtests that fail when matching `lang` attributes, but that's a separate issue).
