### PR TITLE
LibWeb: Don't invalidate style & layout in disconnected subtrees

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -699,12 +699,18 @@ void Document::set_origin(HTML::Origin const& origin)
 
 void Document::schedule_style_update()
 {
+    if (!browsing_context())
+        return;
+
     // NOTE: Update of the style is a step in HTML event loop processing.
     HTML::main_thread_event_loop().schedule();
 }
 
 void Document::schedule_layout_update()
 {
+    if (!browsing_context())
+        return;
+
     // NOTE: Update of the layout is a step in HTML event loop processing.
     HTML::main_thread_event_loop().schedule();
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1007,12 +1007,6 @@ void Document::set_needs_layout()
     schedule_layout_update();
 }
 
-void Document::force_layout()
-{
-    tear_down_layout_tree();
-    update_layout();
-}
-
 void Document::invalidate_layout()
 {
     tear_down_layout_tree();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -207,8 +207,6 @@ public:
     Color visited_link_color() const;
     void set_visited_link_color(Color);
 
-    void force_layout();
-
     void update_style();
     void update_layout();
     void update_paint_and_hit_testing_properties_if_needed();

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
@@ -52,9 +52,10 @@ WebIDL::ExceptionOr<void> inner_html_setter(JS::NonnullGCPtr<DOM::Node> context_
     if (!is<HTML::HTMLTemplateElement>(*context_object)) {
         context_object->set_needs_style_update(true);
 
-        // NOTE: Since the DOM has changed, we have to rebuild the layout tree.
-        context_object->document().invalidate_layout();
-        context_object->document().set_needs_layout();
+        if (context_object->is_connected()) {
+            // NOTE: Since the DOM has changed, we have to rebuild the layout tree.
+            context_object->document().invalidate_layout();
+        }
     }
 
     return {};

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -743,11 +743,6 @@ void ConnectionFromClient::remove_dom_node(u64 page_id, i32 node_id)
 
     dom_node->remove();
 
-    // FIXME: When nodes are removed from the DOM, the associated layout nodes become stale and still
-    //        remain in the layout tree. This has to be fixed, this just causes everything to be recomputed
-    //        which really hurts performance.
-    active_document->force_layout();
-
     async_did_finish_editing_dom_node(page_id, previous_dom_node->unique_id());
 }
 


### PR DESCRIPTION
Disconnected subtrees in the DOM don't need style or layout, so let's not invalidate the whole document they belong to when mutation happens inside them.