### PR TITLE
LibWeb: Look into nested session histories to find max history step

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -102,6 +102,8 @@ private:
 
     Vector<JS::NonnullGCPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(JS::NonnullGCPtr<Navigable>, int);
 
+    [[nodiscard]] bool can_go_forward() const;
+
     // https://html.spec.whatwg.org/multipage/document-sequences.html#tn-current-session-history-step
     int m_current_session_history_step { 0 };
 


### PR DESCRIPTION
Fixes bug when "navigate forward" button in UI is disabled after performing following steps:
1. Load page with an iframe (top step = 0, iframe step = 0)
2. Navigate iframe to different document (top step = 0, iframe step = 1)
3. Navigate back from browser UI (top step = 0, iframe step = 0)

No test because change is only observable from browser UI.