### PR TITLE
LibWeb: Default to an empty string when a string attr substitution fails

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-attr-typed-fallback.txt
+++ b/Tests/LibWeb/Layout/expected/css-attr-typed-fallback.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x126 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x110 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x148 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x132 children: not-inline
       BlockContainer <div.string> at (9,9) content-size 100x20 children: inline
         InlineNode <(anonymous)>
           frag 0 from TextNode start: 0, length: 4, rect: [9,9 41.53125x17] baseline: 13.296875
@@ -8,31 +8,39 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,30) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div.length> at (9,31) content-size 200x20 children: not-inline
+      BlockContainer <div.string-no-fallback> at (9,31) content-size 100x20 children: inline
+        InlineNode <(anonymous)>
+          TextNode <#text>
       BlockContainer <(anonymous)> at (8,52) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div.px> at (9,53) content-size 200x20 children: not-inline
+      BlockContainer <div.length> at (9,53) content-size 200x20 children: not-inline
       BlockContainer <(anonymous)> at (8,74) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div.color> at (9,75) content-size 100x20 children: not-inline
+      BlockContainer <div.px> at (9,75) content-size 200x20 children: not-inline
       BlockContainer <(anonymous)> at (8,96) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.color> at (9,97) content-size 100x20 children: not-inline
       BlockContainer <(anonymous)> at (8,118) content-size 784x0 children: inline
         TextNode <#text>
+      BlockContainer <div.color> at (9,119) content-size 100x20 children: not-inline
+      BlockContainer <(anonymous)> at (8,140) content-size 784x0 children: inline
+        TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x110]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x148]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x132]
       PaintableWithLines (BlockContainer<DIV>.string) [8,8 102x22]
         InlinePaintable (InlineNode(anonymous))
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,30 784x0]
-      PaintableWithLines (BlockContainer<DIV>.length) [8,30 202x22]
+      PaintableWithLines (BlockContainer<DIV>.string-no-fallback) [8,30 102x22]
+        InlinePaintable (InlineNode(anonymous))
       PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]
-      PaintableWithLines (BlockContainer<DIV>.px) [8,52 202x22]
+      PaintableWithLines (BlockContainer<DIV>.length) [8,52 202x22]
       PaintableWithLines (BlockContainer(anonymous)) [8,74 784x0]
-      PaintableWithLines (BlockContainer<DIV>.color) [8,74 102x22]
+      PaintableWithLines (BlockContainer<DIV>.px) [8,74 202x22]
       PaintableWithLines (BlockContainer(anonymous)) [8,96 784x0]
       PaintableWithLines (BlockContainer<DIV>.color) [8,96 102x22]
       PaintableWithLines (BlockContainer(anonymous)) [8,118 784x0]
+      PaintableWithLines (BlockContainer<DIV>.color) [8,118 102x22]
+      PaintableWithLines (BlockContainer(anonymous)) [8,140 784x0]

--- a/Tests/LibWeb/Layout/expected/css-attr-typed-fallback.txt
+++ b/Tests/LibWeb/Layout/expected/css-attr-typed-fallback.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x126 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x110 children: not-inline
+      BlockContainer <div.string> at (9,9) content-size 100x20 children: inline
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 4, rect: [9,9 41.53125x17] baseline: 13.296875
+              "WHF!"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,30) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.length> at (9,31) content-size 200x20 children: not-inline
+      BlockContainer <(anonymous)> at (8,52) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.px> at (9,53) content-size 200x20 children: not-inline
+      BlockContainer <(anonymous)> at (8,74) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.color> at (9,75) content-size 100x20 children: not-inline
+      BlockContainer <(anonymous)> at (8,96) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.color> at (9,97) content-size 100x20 children: not-inline
+      BlockContainer <(anonymous)> at (8,118) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x110]
+      PaintableWithLines (BlockContainer<DIV>.string) [8,8 102x22]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,30 784x0]
+      PaintableWithLines (BlockContainer<DIV>.length) [8,30 202x22]
+      PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]
+      PaintableWithLines (BlockContainer<DIV>.px) [8,52 202x22]
+      PaintableWithLines (BlockContainer(anonymous)) [8,74 784x0]
+      PaintableWithLines (BlockContainer<DIV>.color) [8,74 102x22]
+      PaintableWithLines (BlockContainer(anonymous)) [8,96 784x0]
+      PaintableWithLines (BlockContainer<DIV>.color) [8,96 102x22]
+      PaintableWithLines (BlockContainer(anonymous)) [8,118 784x0]

--- a/Tests/LibWeb/Layout/input/css-attr-typed-fallback.html
+++ b/Tests/LibWeb/Layout/input/css-attr-typed-fallback.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<link rel="match" href="reference/css-attr-typed-ref.html" />
+<style>
+    div {
+        width: 100px;
+        height: 20px;
+        border: 1px solid black;
+    }
+    .string::before {
+        content: attr(foo string, "WHF!");
+    }
+    .length {
+        width: attr(foo length, 200px);
+    }
+    .px {
+        width: attr(foo px, 200px);
+    }
+    .color {
+        background-color: attr(foo color, lime);
+    }
+</style>
+<div class="string"></div>
+<div class="length" foo="90pizzas"></div>
+<div class="px" foo="twohundred"></div>
+<div class="color" foo="grunge"></div>
+<div class="color" foo="rgb(0,0,0)"></div>

--- a/Tests/LibWeb/Layout/input/css-attr-typed-fallback.html
+++ b/Tests/LibWeb/Layout/input/css-attr-typed-fallback.html
@@ -9,6 +9,9 @@
     .string::before {
         content: attr(foo string, "WHF!");
     }
+    .string-no-fallback::before {
+        content: attr(foo string);
+    }
     .length {
         width: attr(foo length, 200px);
     }
@@ -20,6 +23,7 @@
     }
 </style>
 <div class="string"></div>
+<div class="string-no-fallback"></div>
 <div class="length" foo="90pizzas"></div>
 <div class="px" foo="twohundred"></div>
 <div class="color" foo="grunge"></div>

--- a/Tests/LibWeb/Ref/css-attr-typed-fallback.html
+++ b/Tests/LibWeb/Ref/css-attr-typed-fallback.html
@@ -9,6 +9,9 @@
     .string::before {
         content: attr(foo string, "WHF!");
     }
+    .string-no-fallback::before {
+        content: attr(foo string);
+    }
     .length {
         width: attr(foo length, 200px);
     }
@@ -20,6 +23,7 @@
     }
 </style>
 <div class="string"></div>
+<div class="string-no-fallback"></div>
 <div class="length" foo="90pizzas"></div>
 <div class="px" foo="twohundred"></div>
 <div class="color" foo="grunge"></div>

--- a/Tests/LibWeb/Ref/css-attr-typed.html
+++ b/Tests/LibWeb/Ref/css-attr-typed.html
@@ -20,6 +20,7 @@
     }
 </style>
 <div class="string" foo="WHF!"></div>
+<div class="string" foo=""></div>
 <div class="length" foo="200px"></div>
 <div class="px" foo="200"></div>
 <div class="color" foo="lime"></div>

--- a/Tests/LibWeb/Ref/reference/css-attr-typed-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-attr-typed-ref.html
@@ -16,6 +16,7 @@
     }
 </style>
 <div>WHF!</div>
+<div></div>
 <div class="length"></div>
 <div class="px"></div>
 <div class="color" foo="green"></div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7450,6 +7450,12 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
     if (has_fallback_values)
         return expand_unresolved_values(element, property_name, attr_contents, dest);
 
+    if (attribute_type.equals_ignoring_ascii_case("string"_fly_string)) {
+        // If the <attr-type> argument is string, defaults to the empty string if omitted
+        dest.empend(Token::create_string({}));
+        return true;
+    }
+
     // 3. Otherwise, the property containing the attr() function is invalid at computed-value time.
     return false;
 }


### PR DESCRIPTION
When a string-type `attr()` substitution produces no value and no fallback
had been specified, the spec mandates we default to the empty string.

Fixes #23939

![Screenshot_20240416_124617](https://github.com/SerenityOS/serenity/assets/5600524/aca265ce-c876-4f56-96dc-84c667f0c00d)
