### PR TITLE
LibWeb: Make document.createEvent("hashchangeevent") produce right type

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/createEvent-hashchangeevent.txt
+++ b/Tests/LibWeb/Text/expected/DOM/createEvent-hashchangeevent.txt
@@ -1,0 +1,1 @@
+[object HashChangeEvent]

--- a/Tests/LibWeb/Text/input/DOM/createEvent-hashchangeevent.html
+++ b/Tests/LibWeb/Text/input/DOM/createEvent-hashchangeevent.html
@@ -1,0 +1,7 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let e = document.createEvent("hashchangeevent");
+        println(e);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1624,7 +1624,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(StringView i
     } else if (Infra::is_ascii_case_insensitive_match(interface, "focusevent"sv)) {
         event = UIEvents::FocusEvent::create(realm, FlyString {});
     } else if (Infra::is_ascii_case_insensitive_match(interface, "hashchangeevent"sv)) {
-        event = Event::create(realm, FlyString {}); // FIXME: Create HashChangeEvent
+        event = HTML::HashChangeEvent::create(realm, FlyString {}, {});
     } else if (Infra::is_ascii_case_insensitive_match(interface, "htmlevents"sv)) {
         event = Event::create(realm, FlyString {});
     } else if (Infra::is_ascii_case_insensitive_match(interface, "keyboardevent"sv)) {


### PR DESCRIPTION
This is supposed to return a HashChangeEvent, and now it does.