### PR TITLE
LibWeb: Stop leaking socket fds when sending them over IPC

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -64,7 +64,7 @@ void LanguageClient::open_file(ByteString const& path, int fd)
 {
     if (!m_connection_wrapper.connection())
         return;
-    m_connection_wrapper.connection()->async_file_opened(path, fd);
+    m_connection_wrapper.connection()->async_file_opened(path, MUST(IPC::File::clone_fd(fd)));
 }
 
 void LanguageClient::set_file_content(ByteString const& path, ByteString const& content)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -983,7 +983,7 @@ void Window::set_current_backing_store(WindowBackingStore& backing_store, bool f
         m_window_id,
         32,
         bitmap.pitch(),
-        bitmap.anonymous_buffer().fd(),
+        MUST(IPC::File::clone_fd(bitmap.anonymous_buffer().fd())),
         backing_store.serial(),
         bitmap.has_alpha_channel(),
         bitmap.size(),

--- a/Userland/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.cpp
@@ -30,7 +30,7 @@ ErrorOr<void> encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bit
         return {};
 
     auto& bitmap = *shareable_bitmap.bitmap();
-    TRY(encoder.encode(IPC::File(bitmap.anonymous_buffer().fd())));
+    TRY(encoder.encode(TRY(IPC::File::clone_fd(bitmap.anonymous_buffer().fd()))));
     TRY(encoder.encode(bitmap.size()));
     TRY(encoder.encode(static_cast<u32>(bitmap.scale())));
     TRY(encoder.encode(static_cast<u32>(bitmap.format())));

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -91,7 +91,7 @@ template<>
 ErrorOr<File> decode(Decoder& decoder)
 {
     int fd = TRY(decoder.socket().receive_fd(O_CLOEXEC));
-    return File { fd, File::ConstructWithReceivedFileDescriptor };
+    return File::adopt_fd(fd);
 }
 
 template<>

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -105,10 +105,7 @@ ErrorOr<void> encode(Encoder& encoder, URL::URL const& value)
 template<>
 ErrorOr<void> encode(Encoder& encoder, File const& file)
 {
-    int fd = file.fd();
-
-    if (fd != -1)
-        fd = TRY(Core::System::dup(fd));
+    int fd = file.take_fd();
 
     TRY(encoder.append_file_descriptor(fd));
     return {};
@@ -127,7 +124,7 @@ ErrorOr<void> encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
 
     if (buffer.is_valid()) {
         TRY(encoder.encode_size(buffer.size()));
-        TRY(encoder.encode(IPC::File { buffer.fd() }));
+        TRY(encoder.encode(TRY(IPC::File::clone_fd(buffer.fd()))));
     }
 
     return {};

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -13,6 +13,7 @@
 #include <AK/Variant.h>
 #include <LibCore/SharedCircularQueue.h>
 #include <LibIPC/Concepts.h>
+#include <LibIPC/File.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
 #include <LibURL/Forward.h>
@@ -148,7 +149,8 @@ ErrorOr<void> encode(Encoder& encoder, T const& hashmap)
 template<Concepts::SharedSingleProducerCircularQueue T>
 ErrorOr<void> encode(Encoder& encoder, T const& queue)
 {
-    return encoder.encode(IPC::File { queue.fd() });
+    TRY(encoder.encode(TRY(IPC::File::clone_fd(queue.fd()))));
+    return {};
 }
 
 template<Concepts::Optional T>

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -80,12 +80,12 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_steps(HTML::TransferDataHolder& 
         // 2. Set dataHolder.[[RemotePort]] to remotePort.
         auto fd = MUST(m_socket->release_fd());
         m_socket = nullptr;
-        data_holder.fds.append(fd);
+        data_holder.fds.append(IPC::File(fd, IPC::File::CloseAfterSending));
         data_holder.data.append(IPC_FILE_TAG);
 
         auto fd_passing_socket = MUST(m_fd_passing_socket->release_fd());
         m_fd_passing_socket = nullptr;
-        data_holder.fds.append(fd_passing_socket);
+        data_holder.fds.append(IPC::File(fd_passing_socket, IPC::File::CloseAfterSending));
         data_holder.data.append(IPC_FILE_TAG);
     }
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -80,12 +80,12 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_steps(HTML::TransferDataHolder& 
         // 2. Set dataHolder.[[RemotePort]] to remotePort.
         auto fd = MUST(m_socket->release_fd());
         m_socket = nullptr;
-        data_holder.fds.append(IPC::File(fd, IPC::File::CloseAfterSending));
+        data_holder.fds.append(IPC::File::adopt_fd(fd));
         data_holder.data.append(IPC_FILE_TAG);
 
         auto fd_passing_socket = MUST(m_fd_passing_socket->release_fd());
         m_fd_passing_socket = nullptr;
-        data_holder.fds.append(IPC::File(fd_passing_socket, IPC::File::CloseAfterSending));
+        data_holder.fds.append(IPC::File::adopt_fd(fd_passing_socket));
         data_holder.data.append(IPC_FILE_TAG);
     }
 

--- a/Userland/Libraries/LibWeb/HTML/SelectedFile.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SelectedFile.cpp
@@ -20,7 +20,7 @@ ErrorOr<SelectedFile> SelectedFile::from_file_path(ByteString const& file_path)
     auto name = LexicalPath::basename(file_path);
 
     auto file = TRY(Core::File::open(file_path, Core::File::OpenMode::Read));
-    return SelectedFile { move(name), IPC::File { *file } };
+    return SelectedFile { move(name), IPC::File::adopt_file(move(file)) };
 }
 
 SelectedFile::SelectedFile(ByteString name, ByteBuffer contents)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -315,7 +315,7 @@ public:
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 
-    virtual WebView::SocketPair request_worker_agent() { return { -1, -1 }; }
+    virtual WebView::SocketPair request_worker_agent() { return { IPC::File {}, IPC::File {} }; }
 
     virtual void inspector_did_load() { }
     virtual void inspector_did_select_dom_node([[maybe_unused]] i32 node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement::Type> const& pseudo_element) { }

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -22,8 +22,8 @@ WebWorkerClient::WebWorkerClient(NonnullOwnPtr<Core::LocalSocket> socket)
 WebView::SocketPair WebWorkerClient::dup_sockets()
 {
     WebView::SocketPair pair;
-    pair.socket = IPC::File(MUST(Core::System::dup(socket().fd().value())), IPC::File::CloseAfterSending);
-    pair.fd_passing_socket = IPC::File(MUST(Core::System::dup(fd_passing_socket().fd().value())), IPC::File::CloseAfterSending);
+    pair.socket = MUST(IPC::File::clone_fd(socket().fd().value()));
+    pair.fd_passing_socket = MUST(IPC::File::clone_fd(fd_passing_socket().fd().value()));
     return pair;
 }
 

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -22,8 +22,8 @@ WebWorkerClient::WebWorkerClient(NonnullOwnPtr<Core::LocalSocket> socket)
 WebView::SocketPair WebWorkerClient::dup_sockets()
 {
     WebView::SocketPair pair;
-    pair.socket = MUST(Core::System::dup(socket().fd().value()));
-    pair.fd_passing_socket = MUST(Core::System::dup(fd_passing_socket().fd().value()));
+    pair.socket = IPC::File(MUST(Core::System::dup(socket().fd().value())), IPC::File::CloseAfterSending);
+    pair.fd_passing_socket = IPC::File(MUST(Core::System::dup(fd_passing_socket().fd().value())), IPC::File::CloseAfterSending);
     return pair;
 }
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -44,7 +44,7 @@ OutOfProcessWebView::OutOfProcessWebView()
         if (file.is_error())
             client().async_handle_file_return(m_client_state.page_index, file.error().code(), {}, request_id);
         else
-            client().async_handle_file_return(m_client_state.page_index, 0, IPC::File(file.value().stream()), request_id);
+            client().async_handle_file_return(m_client_state.page_index, 0, IPC::File::adopt_file(file.release_value().release_stream()), request_id);
     };
 
     on_scroll_by_delta = [this](auto x_delta, auto y_delta) {

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -32,7 +32,7 @@ ViewImplementation::ViewImplementation()
         if (file.is_error())
             client().async_handle_file_return(page_id(), file.error().code(), {}, request_id);
         else
-            client().async_handle_file_return(page_id(), 0, IPC::File(*file.value()), request_id);
+            client().async_handle_file_return(page_id(), 0, IPC::File::adopt_file(file.release_value()), request_id);
     };
 }
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -665,7 +665,7 @@ Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request
             return view->on_request_worker_agent();
     }
 
-    return WebView::SocketPair { -1, -1 };
+    return WebView::SocketPair { IPC::File {}, IPC::File {} };
 }
 
 Optional<ViewImplementation&> WebContentClient::view_for_page_id(u64 page_id, SourceLocation location)

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -81,7 +81,7 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
             dbgln("FileSystemAccessServer: Couldn't open {}, error {}", path, file.error());
             async_handle_prompt_end(request_id, file.error().code(), Optional<IPC::File> {}, path);
         } else {
-            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value()), path);
+            async_handle_prompt_end(request_id, 0, IPC::File::adopt_file(file.release_value()), path);
         }
     } else {
         async_handle_prompt_end(request_id, EPERM, Optional<IPC::File> {}, path);
@@ -138,7 +138,7 @@ void ConnectionFromClient::prompt_helper(i32 request_id, Optional<ByteString> co
 
             m_approved_files.set(user_picked_file.value(), new_permissions);
 
-            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value()), user_picked_file);
+            async_handle_prompt_end(request_id, 0, IPC::File::adopt_file(file.release_value()), user_picked_file);
         }
     } else {
         async_handle_prompt_end(request_id, ECANCELED, Optional<IPC::File> {}, Optional<ByteString> {});

--- a/Userland/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Userland/Services/WebWorker/ConnectionFromClient.cpp
@@ -31,7 +31,7 @@ void ConnectionFromClient::request_file(Web::FileRequest request)
     if (file.is_error())
         handle_file_return(file.error().code(), {}, request_id);
     else
-        handle_file_return(0, IPC::File(*file.value()), request_id);
+        handle_file_return(0, IPC::File::adopt_file(file.release_value()), request_id);
 }
 
 ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> socket)


### PR DESCRIPTION
The implicit constructor for IPC::File does not take ownership of the file, which is surprising.