### PR TITLE
LibWeb: Fix get_client_rects() on elements that are not paintable

### DIFF
--- a/Tests/LibWeb/Text/expected/get-bounding-client-rect-display-none.txt
+++ b/Tests/LibWeb/Text/expected/get-bounding-client-rect-display-none.txt
@@ -1,1 +1,3 @@
+ 
    {"x":0,"y":0,"width":0,"height":0,"top":0,"right":0,"bottom":0,"left":0}
+{"x":0,"y":0,"width":0,"height":0,"top":0,"right":0,"bottom":0,"left":0}

--- a/Tests/LibWeb/Text/input/get-bounding-client-rect-display-none.html
+++ b/Tests/LibWeb/Text/input/get-bounding-client-rect-display-none.html
@@ -3,10 +3,14 @@
     #box { display: none; }
 </style>
 <div id="box"></div>
+<br id="br"/>
 <script src="include.js"></script>
 <script>
     test(() => {
         const rect = document.getElementById("box").getBoundingClientRect();
         println(JSON.stringify(rect));
+
+        const br_rect = document.getElementById("br").getBoundingClientRect();
+        println(JSON.stringify(br_rect));
     });
 </script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -880,16 +880,16 @@ JS::NonnullGCPtr<Geometry::DOMRectList> Element::get_client_rects() const
     const_cast<Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     Gfx::AffineTransform transform;
-    if (auto const* paintable_box = this->paintable_box())
-        transform = Gfx::extract_2d_affine_transform(paintable_box->transform());
     CSSPixelPoint scroll_offset;
-    for (auto const* containing_block = paintable()->containing_block(); containing_block; containing_block = containing_block->containing_block()) {
-        transform = Gfx::extract_2d_affine_transform(containing_block->transform()).multiply(transform);
-        scroll_offset.translate_by(containing_block->scroll_offset());
-    }
-
     auto const* paintable = this->paintable();
+
     if (auto const* paintable_box = this->paintable_box()) {
+        transform = Gfx::extract_2d_affine_transform(paintable_box->transform());
+        for (auto const* containing_block = paintable->containing_block(); containing_block; containing_block = containing_block->containing_block()) {
+            transform = Gfx::extract_2d_affine_transform(containing_block->transform()).multiply(transform);
+            scroll_offset.translate_by(containing_block->scroll_offset());
+        }
+
         auto absolute_rect = paintable_box->absolute_border_box_rect();
         auto transformed_rect = transform.map(absolute_rect.translated(-paintable_box->transform_origin()).to_type<float>())
                                     .to_type<CSSPixels>()


### PR DESCRIPTION
This small patch should fix #23829 where we try to get a paintable for elements that don't have one. 

Not 100% sure if this is actually correct as I've slightly changed the checks for the `containing_block` call