### PR TITLE
LibWeb: Support loading alternative style sheets

### DIFF
--- a/Tests/LibWeb/Ref/alternative-style-sheets.html
+++ b/Tests/LibWeb/Ref/alternative-style-sheets.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/alternative-style-sheets-ref.html" />
+<link title="preferred" rel="stylesheet" href="data:text/css,html { background: green }">
+<!-- These alternative style sheets shouldn't be applied -->
+<link title="alternative" rel="alternate stylesheet" href="data:text/css,html { background: red !important }">
+<link id="no-title" rel="alternate stylesheet" href="data:text/css,html { background: blue !important }">

--- a/Tests/LibWeb/Ref/reference/alternative-style-sheets-ref.html
+++ b/Tests/LibWeb/Ref/reference/alternative-style-sheets-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    html {
+        background-color: green;
+    }
+</style>

--- a/Tests/LibWeb/Text/expected/HTMLLinkElement-explicitly-enabled-alternative-stylesheets.txt
+++ b/Tests/LibWeb/Text/expected/HTMLLinkElement-explicitly-enabled-alternative-stylesheets.txt
@@ -1,0 +1,3 @@
+background color initial value: rgba(0, 0, 0, 0)
+background color after preferred style sheet enabled: rgb(255, 0, 0)
+background color after alternate style sheet enabled: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/HTMLLinkElement-explicitly-enabled-alternative-stylesheets.html
+++ b/Tests/LibWeb/Text/input/HTMLLinkElement-explicitly-enabled-alternative-stylesheets.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<link title="preferred" disabled rel="stylesheet" href="data:text/css,html { background: rgb(255, 0, 0) }">
+<link title="alternative" disabled rel="alternate stylesheet" href="data:text/css,html { background: rgb(0, 128, 0) !important }">
+<script>
+    asyncTest(done => {
+        const documentStyle = getComputedStyle(document.documentElement);    
+        println(`background color initial value: ${documentStyle.backgroundColor}`);
+        const primaryLink = document.querySelector("link[title=preferred]");
+        const alternativeLink = document.querySelector("link[title=alternative]");
+        primaryLink.onload = () => {
+            println(`background color after preferred style sheet enabled: ${documentStyle.backgroundColor}`);
+            alternativeLink.disabled = false;
+        };
+        alternativeLink.onload = () => {
+            println(`background color after alternate style sheet enabled: ${documentStyle.backgroundColor}`);
+            done();
+        };
+        primaryLink.disabled = false;
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.h
@@ -54,6 +54,11 @@ private:
 
     JS::NonnullGCPtr<DOM::Document> m_document;
     Vector<JS::NonnullGCPtr<CSSStyleSheet>> m_sheets;
+
+    // https://www.w3.org/TR/cssom/#preferred-css-style-sheet-set-name
+    String m_preferred_css_style_sheet_set_name;
+    // https://www.w3.org/TR/cssom/#last-css-style-sheet-set-name
+    Optional<String> m_last_css_style_sheet_set_name;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4806,12 +4806,15 @@ WebIDL::ExceptionOr<void> Document::set_adopted_style_sheets(JS::Value new_value
 
 void Document::for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const
 {
-    for (auto& style_sheet : m_style_sheets->sheets())
-        callback(*style_sheet);
+    for (auto& style_sheet : m_style_sheets->sheets()) {
+        if (!(style_sheet->is_alternate() && style_sheet->disabled()))
+            callback(*style_sheet);
+    }
 
     if (m_adopted_style_sheets) {
         m_adopted_style_sheets->for_each<CSS::CSSStyleSheet>([&](auto& style_sheet) {
-            callback(style_sheet);
+            if (!(style_sheet.is_alternate() && style_sheet.disabled()))
+                callback(style_sheet);
         });
     }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -133,6 +133,8 @@ private:
 
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
     unsigned m_relationship { 0 };
+    // https://html.spec.whatwg.org/multipage/semantics.html#explicitly-enabled
+    bool m_explicitly_enabled { false };
 };
 
 }


### PR DESCRIPTION
Alternative style sheets are now fetched and are applied to the document if they are explicitly enabled by removing the disabled attribute.

With this change we now pass the following WPT tests (and stops timeouts on some others):
* http://wpt.live/css/cssom/HTMLLinkElement-disabled-002.html
* http://wpt.live/css/cssom/HTMLLinkElement-disabled-003.html
* http://wpt.live/css/cssom/HTMLLinkElement-disabled-005.html
* http://wpt.live/css/cssom/HTMLLinkElement-disabled-006.html
* http://wpt.live/css/cssom/HTMLLinkElement-disabled-007.html