### PR TITLE
LibWeb: Fix two problems where media queries didn't invalidate properly

### DIFF
--- a/Tests/LibWeb/Text/expected/css/text-transform-invalidation-on-media-query-change.txt
+++ b/Tests/LibWeb/Text/expected/css/text-transform-invalidation-on-media-query-change.txt
@@ -1,0 +1,2 @@
+  TRANSFORMED TEXT
+transformed text

--- a/Tests/LibWeb/Text/input/css/text-transform-invalidation-on-media-query-change.html
+++ b/Tests/LibWeb/Text/input/css/text-transform-invalidation-on-media-query-change.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<style>
+iframe {
+    width: 0;
+    height: 0;
+    border: 1px solid black;
+}
+</style>
+<script src="../include.js"></script>
+<body><iframe id="i1"></iframe>
+<script>
+    asyncTest((done) => {
+        i1.srcdoc = `
+<style>
+@media all and (min-height: 1px) { #y1 { text-transform: uppercase; } }
+</style><div id=y1>transformed text</div><script>document.body.offsetWidth</` + `script>`;
+        i1.onload = function() {
+            i1.setAttribute("style", "height: 100px; width: 100px");
+            println(i1.contentDocument.body.innerText);
+            i1.removeAttribute("style");
+            println(i1.contentDocument.body.innerText);
+            done();
+        };
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2503,6 +2503,7 @@ void Document::evaluate_media_rules()
     if (any_media_queries_changed_match_state) {
         style_computer().invalidate_rule_cache();
         invalidate_style();
+        invalidate_layout();
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -475,7 +475,7 @@ void Element::attribute_changed(FlyString const& name, Optional<String> const& v
             m_class_list->associated_attribute_changed(value_or_empty);
     } else if (name == HTML::AttributeNames::style) {
         if (!value.has_value()) {
-            if (!m_inline_style) {
+            if (m_inline_style) {
                 m_inline_style = nullptr;
                 set_needs_style_update(true);
             }


### PR DESCRIPTION
There were two things going wrong here:

- Transformed text (via CSS text-transform) was not invalidated after a `@media` rule changed state.

- Removing the `style` attribute from an element didn't trigger a style update.

This fixes the regression in subtest 46 of Acid3.

Fixes #21777