### PR TITLE
LibWeb: Add name validation and document check to setAttribute.

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Element-setAttribute-capitalization.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-setAttribute-capitalization.txt
@@ -1,0 +1,1 @@
+<root><div xmlns="http://www.w3.org/1999/xhtml" FoO="bar"></div></root>

--- a/Tests/LibWeb/Text/expected/DOM/Element-setAttribute-name-validation.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-setAttribute-name-validation.txt
@@ -1,0 +1,4 @@
+OK: InvalidCharacterError: Attribute name must not be empty or contain invalid characters
+OK: InvalidCharacterError: Attribute name must not be empty or contain invalid characters
+OK: InvalidCharacterError: Attribute name must not be empty or contain invalid characters
+OK: InvalidCharacterError: Attribute name must not be empty or contain invalid characters

--- a/Tests/LibWeb/Text/input/DOM/Element-setAttribute-capitalization.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-setAttribute-capitalization.html
@@ -1,0 +1,12 @@
+<script src="../include.js"></script>
+<script>
+  test(() => {
+    var xmlDocument = document.implementation.createDocument(null, "root", null);
+    var divElement = xmlDocument.createElementNS("http://www.w3.org/1999/xhtml", "div");
+    divElement.setAttribute("FoO", "bar");
+
+    xmlDocument.documentElement.appendChild(divElement);
+
+    println(new XMLSerializer().serializeToString(xmlDocument));
+  });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/Element-setAttribute-name-validation.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-setAttribute-name-validation.html
@@ -1,0 +1,21 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let e = document.createElement('div');
+        function testInvalidQualifiedName(name) {
+            try {
+                e.setAttribute(name, 'bar');
+                println('FAIL')
+            } catch (e) {
+                println('OK: ' + e);
+            }
+        }
+
+        invalidNames =
+            ['',  '1foo', 'f@oo', 'foo!']
+
+        for (let i = 0; i < invalidNames.length; i++) {
+            testInvalidQualifiedName(invalidNames[i])
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2563,12 +2563,13 @@ static inline bool is_valid_name_character(u32 code_point)
         || (code_point >= 0x203f && code_point <= 0x2040);
 }
 
+// https://www.w3.org/TR/xml/#NT-Name
 bool Document::is_valid_name(String const& name)
 {
-    auto code_points = Utf8View { name };
-    auto it = code_points.begin();
-    if (code_points.is_empty())
+    if (name.is_empty())
         return false;
+    auto code_points = name.code_points();
+    auto it = code_points.begin();
 
     if (!is_valid_name_start_character(*it))
         return false;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -167,13 +167,11 @@ JS::GCPtr<Attr> Element::get_attribute_node_ns(Optional<FlyString> const& namesp
 WebIDL::ExceptionOr<void> Element::set_attribute(FlyString const& name, String const& value)
 {
     // 1. If qualifiedName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
-    // FIXME: Proper name validation
-    if (name.is_empty())
-        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty"_fly_string);
+    if (!Document::is_valid_name(name.to_string()))
+        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty or contain invalid characters"_fly_string);
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
-    // FIXME: Handle the second condition, assume it is an HTML document for now.
-    bool insert_as_lowercase = namespace_uri() == Namespace::HTML;
+    bool insert_as_lowercase = namespace_uri() == Namespace::HTML && document().document_type() == Document::Type::HTML;
 
     // 3. Let attribute be the first attribute in this’s attribute list whose qualified name is qualifiedName, and null otherwise.
     auto* attribute = m_attributes->get_attribute(name);


### PR DESCRIPTION
Hello, we are students at the University of Utah working on fixing a bug for Professor Panchekha's Web Browser class. We have implemented the FIXME's previously described in the setAttributes method.