### PR TITLE
PixelPaint: Avoid infinite loop when updating zoom level ComboBox text

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1423,7 +1423,7 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
     };
 
     image_editor.on_scale_change = Core::debounce(100, [this](float scale) {
-        m_zoom_combobox->set_text(ByteString::formatted("{}%", roundf(scale * 100)));
+        m_zoom_combobox->set_text(ByteString::formatted("{}%", roundf(scale * 100)), GUI::AllowCallback::No);
         current_image_editor()->update_tool_cursor();
     });
 


### PR DESCRIPTION
After 8b4e2e20 `Combobox::set_text()` invokes the `on_change` event by default. This led to an infinite loop at program startup which caused a crash.

Fixes #23998