### PR TITLE
PixelPaint: Prevent on_scale_change callback from triggering itself

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1423,7 +1423,7 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
     };
 
     image_editor.on_scale_change = Core::debounce(100, [this](float scale) {
-        m_zoom_combobox->set_text(ByteString::formatted("{}%", roundf(scale * 100)));
+        m_zoom_combobox->set_text(ByteString::formatted("{}%", roundf(scale * 100)), GUI::AllowCallback::No);
         current_image_editor()->update_tool_cursor();
     });
 


### PR DESCRIPTION
This caused a crash on startup

Fixes #23998