### PR TITLE
Kernel+LibC+LibELF: Move TLS handling to userspace and add support for Variant I of the ELF TLS data structures

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -49,7 +49,6 @@ enum class NeedsBigProcessLock {
     S(accept4, NeedsBigProcessLock::No)                    \
     S(adjtime, NeedsBigProcessLock::No)                    \
     S(alarm, NeedsBigProcessLock::No)                      \
-    S(allocate_tls, NeedsBigProcessLock::No)               \
     S(archctl, NeedsBigProcessLock::No)                    \
     S(anon_create, NeedsBigProcessLock::No)                \
     S(annotate_mapping, NeedsBigProcessLock::No)           \
@@ -375,6 +374,7 @@ struct SC_create_thread_params {
     void* stack_location;                      // nullptr means any, o.w. process virtual address
     void* (*entry)(void*);
     void* entry_argument;
+    void* tls_pointer;
 };
 
 struct SC_realpath_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -50,6 +50,7 @@ enum class NeedsBigProcessLock {
     S(adjtime, NeedsBigProcessLock::No)                    \
     S(alarm, NeedsBigProcessLock::No)                      \
     S(allocate_tls, NeedsBigProcessLock::No)               \
+    S(archctl, NeedsBigProcessLock::No)                    \
     S(anon_create, NeedsBigProcessLock::No)                \
     S(annotate_mapping, NeedsBigProcessLock::No)           \
     S(bind, NeedsBigProcessLock::No)                       \

--- a/Kernel/API/archctl_numbers.h
+++ b/Kernel/API/archctl_numbers.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once

--- a/Kernel/API/archctl_numbers.h
+++ b/Kernel/API/archctl_numbers.h
@@ -5,3 +5,5 @@
  */
 
 #pragma once
+
+#define ARCHCTL_X86_64_SET_FS_BASE_FOR_CURRENT_THREAD 1

--- a/Kernel/Arch/ArchSpecificThreadData.h
+++ b/Kernel/Arch/ArchSpecificThreadData.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if ARCH(X86_64)
+#    include <Kernel/Arch/x86_64/ArchSpecificThreadData.h>
+#elif ARCH(AARCH64)
+#    include <Kernel/Arch/aarch64/ArchSpecificThreadData.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/ArchSpecificThreadData.h>
+#else
+#    error Unknown architecture
+#endif

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -165,8 +165,6 @@ public:
 
     static void deferred_call_queue(Function<void()> callback);
 
-    static void set_thread_specific_data(VirtualAddress thread_specific_data);
-
     [[noreturn]] void initialize_context_switching(Thread& initial_thread);
     NEVER_INLINE void switch_context(Thread*& from_thread, Thread*& to_thread);
     [[noreturn]] static void assume_context(Thread& thread, InterruptsState new_interrupts_state);

--- a/Kernel/Arch/ProcessorFunctions.include
+++ b/Kernel/Arch/ProcessorFunctions.include
@@ -26,7 +26,6 @@ template bool ProcessorBase<Processor>::are_interrupts_enabled();
 template void ProcessorBase<Processor>::wait_for_interrupt() const;
 template Processor& ProcessorBase<Processor>::by_id(u32 id);
 template StringView ProcessorBase<Processor>::platform_string();
-template void ProcessorBase<Processor>::set_thread_specific_data(VirtualAddress thread_specific_data);
 template void ProcessorBase<Processor>::initialize_context_switching(Thread& initial_thread);
 template void ProcessorBase<Processor>::switch_context(Thread*& from_thread, Thread*& to_thread);
 template void ProcessorBase<Processor>::assume_context(Thread& thread, InterruptsState new_interrupts_state);

--- a/Kernel/Arch/aarch64/ArchSpecificThreadData.h
+++ b/Kernel/Arch/aarch64/ArchSpecificThreadData.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+
+struct ArchSpecificThreadData {
+};
+
+}

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -43,6 +43,7 @@ void dump_registers(RegisterState const& regs)
     dbgln("Saved Program Status: (NZCV({:#b}) DAIF({:#b}) M({:#b})) / {:#x}", ((regs.spsr_el1 >> 28) & 0b1111), ((regs.spsr_el1 >> 6) & 0b1111), regs.spsr_el1 & 0b1111, regs.spsr_el1);
     dbgln("Exception Link Register: {:#x}", regs.elr_el1);
     dbgln("Stack Pointer (EL0): {:#x}", regs.sp_el0);
+    dbgln("Software Thread ID Register (EL0): {:#x}", regs.tpidr_el0);
 
     dbgln(" x0={:p}  x1={:p}  x2={:p}  x3={:p}  x4={:p}", regs.x[0], regs.x[1], regs.x[2], regs.x[3], regs.x[4]);
     dbgln(" x5={:p}  x6={:p}  x7={:p}  x8={:p}  x9={:p}", regs.x[5], regs.x[6], regs.x[7], regs.x[8], regs.x[9]);

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -337,6 +337,7 @@ FlatPtr ProcessorBase<T>::init_context(Thread& thread, bool leave_crit)
     }
     eretframe.elr_el1 = thread_regs.elr_el1;
     eretframe.sp_el0 = thread_regs.sp_el0;
+    eretframe.tpidr_el0 = thread_regs.tpidr_el0;
     eretframe.spsr_el1 = thread_regs.spsr_el1;
 
     // Push a TrapFrame onto the stack
@@ -472,8 +473,6 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
 
     to_thread->set_cpu(Processor::current().id());
 
-    Processor::set_thread_specific_data(to_thread->thread_specific_data());
-
     auto in_critical = to_thread->saved_critical();
     VERIFY(in_critical > 0);
     Processor::restore_critical(in_critical);
@@ -485,12 +484,6 @@ template<typename T>
 StringView ProcessorBase<T>::platform_string()
 {
     return "aarch64"sv;
-}
-
-template<typename T>
-void ProcessorBase<T>::set_thread_specific_data(VirtualAddress thread_specific_data)
-{
-    Aarch64::Asm::set_tpidr_el0(thread_specific_data.get());
 }
 
 template<typename T>

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -17,11 +17,12 @@ VALIDATE_IS_AARCH64()
 
 namespace Kernel {
 
-struct RegisterState {
-    u64 x[31];    // Saved general purpose registers
-    u64 spsr_el1; // Save Processor Status Register, EL1
-    u64 elr_el1;  // Exception Link Register, EL1
-    u64 sp_el0;   // EL0 stack pointer
+struct alignas(16) RegisterState {
+    u64 x[31];     // Saved general purpose registers
+    u64 spsr_el1;  // Save Processor Status Register, EL1
+    u64 elr_el1;   // Exception Link Register, EL1
+    u64 sp_el0;    // EL0 stack pointer
+    u64 tpidr_el0; // EL0 Software Thread ID Register
 
     FlatPtr userspace_sp() const { return sp_el0; }
     void set_userspace_sp(FlatPtr value)
@@ -51,7 +52,7 @@ struct RegisterState {
     }
 };
 
-#define REGISTER_STATE_SIZE (34 * 8)
+#define REGISTER_STATE_SIZE (36 * 8)
 static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
 
 inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, RegisterState const& kernel_regs)

--- a/Kernel/Arch/aarch64/ThreadRegisters.h
+++ b/Kernel/Arch/aarch64/ThreadRegisters.h
@@ -17,6 +17,7 @@ struct ThreadRegisters {
     u64 spsr_el1;
     u64 elr_el1;
     u64 sp_el0;
+    u64 tpidr_el0;
     u64 ttbr0_el1;
 
     FlatPtr ip() const { return elr_el1; }

--- a/Kernel/Arch/aarch64/archctl.cpp
+++ b/Kernel/Arch/aarch64/archctl.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::sys$archctl(int option, FlatPtr arg1)
+{
+    (void)option;
+    (void)arg1;
+
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
+    return ENOSYS;
+}
+
+}

--- a/Kernel/Arch/aarch64/vector_table.S
+++ b/Kernel/Arch/aarch64/vector_table.S
@@ -8,7 +8,7 @@
 
 // NOTE: This size must be a multiple of 16 bytes, to ensure that the stack pointer
 //       stays 16 byte aligned.
-#define REGISTER_STATE_SIZE 272
+#define REGISTER_STATE_SIZE (36 * 8)
 #if REGISTER_STATE_SIZE % 16 != 0
 #    error "REGISTER_STATE_SIZE is not a multiple of 16 bytes!"
 #endif
@@ -16,6 +16,7 @@
 #define SPSR_EL1_SLOT       (31 * 8)
 #define ELR_EL1_SLOT        (32 * 8)
 #define SP_EL0_SLOT         (33 * 8)
+#define TPIDR_EL0_SLOT      (34 * 8)
 
 // Vector Table Entry macro. Each entry is aligned at 128 bytes, meaning we have
 // at most that many instructions.
@@ -65,6 +66,8 @@
     str x0, [sp, #ELR_EL1_SLOT]
     mrs x0, sp_el0
     str x0, [sp, #SP_EL0_SLOT]
+    mrs x0, tpidr_el0
+    str x0, [sp, #TPIDR_EL0_SLOT]
 
     // Set up TrapFrame struct on the stack
     mov x0, sp
@@ -88,6 +91,8 @@
     msr elr_el1, x0
     ldr x0, [sp, #SP_EL0_SLOT]
     msr sp_el0, x0
+    ldr x0, [sp, #TPIDR_EL0_SLOT]
+    msr tpidr_el0, x0
 
     ldp x0, x1,     [sp, #(0 * 0)]
     ldp x2, x3,     [sp, #(2 * 8)]

--- a/Kernel/Arch/riscv64/ArchSpecificThreadData.h
+++ b/Kernel/Arch/riscv64/ArchSpecificThreadData.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+
+struct ArchSpecificThreadData {
+};
+
+}

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -499,8 +499,6 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
 
     to_thread->set_cpu(Processor::current().id());
 
-    Processor::set_thread_specific_data(to_thread->thread_specific_data());
-
     auto in_critical = to_thread->saved_critical();
     VERIFY(in_critical > 0);
     Processor::restore_critical(in_critical);
@@ -544,12 +542,6 @@ template<typename T>
 StringView ProcessorBase<T>::platform_string()
 {
     return "riscv64"sv;
-}
-
-template<typename T>
-void ProcessorBase<T>::set_thread_specific_data(VirtualAddress)
-{
-    // FIXME: Add support for thread-local storage on RISC-V
 }
 
 template<typename T>

--- a/Kernel/Arch/riscv64/archctl.cpp
+++ b/Kernel/Arch/riscv64/archctl.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::sys$archctl(int option, FlatPtr arg1)
+{
+    (void)option;
+    (void)arg1;
+
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
+    return ENOSYS;
+}
+
+}

--- a/Kernel/Arch/x86_64/ArchSpecificThreadData.h
+++ b/Kernel/Arch/x86_64/ArchSpecificThreadData.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+
+struct ArchSpecificThreadData {
+};
+
+}

--- a/Kernel/Arch/x86_64/ArchSpecificThreadData.h
+++ b/Kernel/Arch/x86_64/ArchSpecificThreadData.h
@@ -11,6 +11,7 @@
 namespace Kernel {
 
 struct ArchSpecificThreadData {
+    FlatPtr fs_base { 0 };
 };
 
 }

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -1390,7 +1390,7 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
     }
 
     auto& processor = Processor::current();
-    Processor::set_thread_specific_data(to_thread->thread_specific_data());
+    Processor::set_fs_base(to_thread->arch_specific_data().fs_base);
 
     if (from_regs.cr3 != to_regs.cr3)
         write_cr3(to_regs.cr3);
@@ -1717,11 +1717,10 @@ UNMAP_AFTER_INIT void ProcessorBase<T>::initialize_context_switching(Thread& ini
     VERIFY_NOT_REACHED();
 }
 
-template<typename T>
-void ProcessorBase<T>::set_thread_specific_data(VirtualAddress thread_specific_data)
+void Processor::set_fs_base(FlatPtr fs_base)
 {
     MSR fs_base_msr(MSR_FS_BASE);
-    fs_base_msr.set(thread_specific_data.get());
+    fs_base_msr.set(fs_base);
 }
 
 template<typename T>

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -153,6 +153,8 @@ public:
 
     static void smp_unicast(u32 cpu, Function<void()>, bool async);
     static void smp_broadcast_flush_tlb(Memory::PageDirectory const*, VirtualAddress, size_t);
+
+    static void set_fs_base(FlatPtr);
 };
 
 template<typename T>

--- a/Kernel/Arch/x86_64/archctl.cpp
+++ b/Kernel/Arch/x86_64/archctl.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::sys$archctl(int option, FlatPtr arg1)
+{
+    (void)option;
+    (void)arg1;
+
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
+    return ENOSYS;
+}
+
+}

--- a/Kernel/Arch/x86_64/archctl.cpp
+++ b/Kernel/Arch/x86_64/archctl.cpp
@@ -4,17 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/API/archctl_numbers.h>
 #include <Kernel/Tasks/Process.h>
 
 namespace Kernel {
 
 ErrorOr<FlatPtr> Process::sys$archctl(int option, FlatPtr arg1)
 {
-    (void)option;
-    (void)arg1;
-
     VERIFY_NO_PROCESS_BIG_LOCK(this);
-    return ENOSYS;
+    switch (option) {
+    case ARCHCTL_X86_64_SET_FS_BASE_FOR_CURRENT_THREAD: {
+        Thread::current()->arch_specific_data().fs_base = arg1;
+        Processor::set_fs_base(arg1);
+        return 0;
+    }
+
+    default:
+        return EINVAL;
+    }
 }
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -386,6 +386,8 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(KERNEL_SOURCES
         ${KERNEL_SOURCES}
 
+        Arch/x86_64/archctl.cpp
+
         Arch/x86_64/CMOS.cpp
         Arch/x86_64/DebugOutput.cpp
         Arch/x86_64/Delay.cpp
@@ -485,6 +487,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
 
         Arch/aarch64/Firmware/ACPI/StaticParsing.cpp
 
+        Arch/aarch64/archctl.cpp
         Arch/aarch64/boot.S
         Arch/aarch64/BootPPMParser.cpp
         Arch/aarch64/CPUID.cpp
@@ -528,6 +531,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
 
         Arch/riscv64/Firmware/ACPI/StaticParsing.cpp
 
+        Arch/riscv64/archctl.cpp
         Arch/riscv64/boot.S
         Arch/riscv64/CPU.cpp
         Arch/riscv64/CurrentTime.cpp

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -482,6 +482,7 @@ public:
     ErrorOr<FlatPtr> sys$get_root_session_id(pid_t force_sid);
     ErrorOr<FlatPtr> sys$remount(Userspace<Syscall::SC_remount_params const*> user_params);
     ErrorOr<FlatPtr> sys$bindmount(Userspace<Syscall::SC_bindmount_params const*> user_params);
+    ErrorOr<FlatPtr> sys$archctl(int option, FlatPtr arg1);
 
     enum SockOrPeerName {
         SockName,

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -471,7 +471,6 @@ public:
     ErrorOr<FlatPtr> sys$recvfd(int sockfd, int options);
     ErrorOr<FlatPtr> sys$sysconf(int name);
     ErrorOr<FlatPtr> sys$disown(ProcessID);
-    ErrorOr<FlatPtr> sys$allocate_tls(Userspace<char const*> initial_data, size_t);
     ErrorOr<FlatPtr> sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, FlatPtr arg3);
     ErrorOr<FlatPtr> sys$anon_create(size_t, int options);
     ErrorOr<FlatPtr> sys$statvfs(Userspace<Syscall::SC_statvfs_params const*> user_params);
@@ -954,13 +953,6 @@ public:
 private:
     SpinlockProtected<RefPtr<ProcessList>, LockRank::None> m_jail_process_list;
     SpinlockProtected<RefPtr<Jail>, LockRank::Process> m_attached_jail {};
-
-    struct MasterThreadLocalStorage {
-        LockWeakPtr<Memory::Region> region;
-        size_t size { 0 };
-        size_t alignment { 0 };
-    };
-    SpinlockProtected<MasterThreadLocalStorage, LockRank::None> m_master_tls;
 
     Mutex m_big_lock { "Process"sv, Mutex::MutexBehavior::BigLock };
     Mutex m_ptrace_lock { "ptrace"sv };

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -1210,6 +1210,7 @@ ErrorOr<NonnullRefPtr<Thread>> Thread::clone(NonnullRefPtr<Process> process)
     clone->m_signal_mask = m_signal_mask;
     clone->m_fpu_state = m_fpu_state;
     clone->m_thread_specific_data = m_thread_specific_data;
+    clone->m_arch_specific_data = m_arch_specific_data;
     return clone;
 }
 

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -790,7 +790,6 @@ public:
     State state() const { return m_state; }
     StringView state_string() const;
 
-    VirtualAddress thread_specific_data() const { return m_thread_specific_data; }
     ArchSpecificThreadData& arch_specific_data() { return m_arch_specific_data; }
     ArchSpecificThreadData const& arch_specific_data() const { return m_arch_specific_data; }
 
@@ -891,8 +890,6 @@ public:
     [[nodiscard]] bool is_in_alternative_signal_stack() const;
 
     FPUState& fpu_state() { return m_fpu_state; }
-
-    ErrorOr<void> make_thread_specific_region(Badge<Process>);
 
     unsigned syscall_count() const { return m_syscall_count; }
     void did_syscall() { ++m_syscall_count; }
@@ -1186,8 +1183,6 @@ private:
     FlatPtr m_kernel_stack_base { 0 };
     FlatPtr m_kernel_stack_top { 0 };
     NonnullOwnPtr<Memory::Region> m_kernel_stack_region;
-    VirtualAddress m_thread_specific_data;
-    Optional<Memory::VirtualRange> m_thread_specific_range;
     Array<Optional<u32>, NSIG> m_signal_action_masks;
     Array<ProcessID, NSIG> m_signal_senders;
     Blocker* m_blocker { nullptr };

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -20,6 +20,7 @@
 #include <Kernel/API/POSIX/sched.h>
 #include <Kernel/API/POSIX/select.h>
 #include <Kernel/API/POSIX/signal_numbers.h>
+#include <Kernel/Arch/ArchSpecificThreadData.h>
 #include <Kernel/Arch/RegisterState.h>
 #include <Kernel/Arch/ThreadRegisters.h>
 #include <Kernel/Debug.h>
@@ -790,6 +791,8 @@ public:
     StringView state_string() const;
 
     VirtualAddress thread_specific_data() const { return m_thread_specific_data; }
+    ArchSpecificThreadData& arch_specific_data() { return m_arch_specific_data; }
+    ArchSpecificThreadData const& arch_specific_data() const { return m_arch_specific_data; }
 
     ALWAYS_INLINE void yield_if_should_be_stopped()
     {
@@ -1193,6 +1196,7 @@ private:
     IntrusiveListNode<Thread> m_blocked_threads_list_node;
     LockRank m_lock_rank_mask {};
     bool m_allocation_enabled { true };
+    ArchSpecificThreadData m_arch_specific_data;
 
     // FIXME: remove this after annihilating Process::m_big_lock
     IntrusiveListNode<Thread> m_big_lock_blocked_threads_list_node;

--- a/Tests/LibELF/TestTLS.cpp
+++ b/Tests/LibELF/TestTLS.cpp
@@ -14,3 +14,26 @@ TEST_CASE(basic)
 {
     run_test();
 }
+
+TEST_CASE(local_exec)
+{
+    [[gnu::tls_model("local-exec")]] static volatile __thread char test1[PAGE_SIZE * 4 + 10];
+
+    for (size_t i = 0; i < sizeof(test1); i++) {
+        test1[i] = static_cast<char>(i);
+        AK::taint_for_optimizer(test1[i]);
+    }
+
+    for (size_t i = 0; i < sizeof(test1); i++) {
+        AK::taint_for_optimizer(test1[i]);
+        EXPECT_EQ(test1[i], static_cast<char>(i));
+    }
+
+    [[gnu::tls_model("local-exec")]] static volatile __thread u16 test2[] = { 0x1234, 0x5678, 0xabcd };
+    AK::taint_for_optimizer(test2[0]);
+    EXPECT_EQ(test2[0], 0x1234);
+    AK::taint_for_optimizer(test2[1]);
+    EXPECT_EQ(test2[1], 0x5678);
+    AK::taint_for_optimizer(test2[2]);
+    EXPECT_EQ(test2[2], 0xabcd);
+}

--- a/Userland/DynamicLoader/CMakeLists.txt
+++ b/Userland/DynamicLoader/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB LIBC_SOURCES2 "../Libraries/LibC/*/*.cpp")
 set(ARCH_FOLDER "${SERENITY_ARCH}")
 
 file(GLOB LIBC_SOURCES3 "../Libraries/LibC/arch/${ARCH_FOLDER}/*.S")
-set(ELF_SOURCES ${ELF_SOURCES} "../Libraries/LibELF/Arch/${ARCH_FOLDER}/entry.S" "../Libraries/LibELF/Arch/${ARCH_FOLDER}/plt_trampoline.S")
+set(ELF_SOURCES ${ELF_SOURCES} "../Libraries/LibELF/Arch/${ARCH_FOLDER}/entry.S" "../Libraries/LibELF/Arch/${ARCH_FOLDER}/plt_trampoline.S" "../Libraries/LibELF/Arch/${ARCH_FOLDER}/tls.cpp")
 set(LIBC_SOURCES3 ${LIBC_SOURCES3} "../Libraries/LibC/arch/${ARCH_FOLDER}/fenv.cpp")
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(LIBC_SOURCES3 ${LIBC_SOURCES3} "../Libraries/LibC/arch/x86_64/memset.cpp")

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -52,6 +52,7 @@ set(LIBC_SOURCES
     string.cpp
     strings.cpp
     stubs.cpp
+    sys/archctl.cpp
     sys/auxv.cpp
     sys/file.cpp
     sys/mman.cpp

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -97,7 +97,7 @@ foreach(RELATIVE_HEADER_PATH IN LISTS LIBC_HEADERS)
     )
 endforeach()
 
-file(GLOB ELF_SOURCES CONFIGURE_DEPENDS "../LibELF/*.cpp")
+file(GLOB ELF_SOURCES CONFIGURE_DEPENDS "../LibELF/*.cpp" "../LibELF/Arch/${SERENITY_ARCH}/*.cpp")
 
 if ("${SERENITY_ARCH}" STREQUAL "aarch64")
     set(LIBC_SOURCES ${LIBC_SOURCES} "arch/aarch64/fenv.cpp")

--- a/Userland/Libraries/LibC/sys/archctl.cpp
+++ b/Userland/Libraries/LibC/sys/archctl.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <errno.h>
+#include <stdarg.h>
+#include <sys/archctl.h>
+#include <syscall.h>
+
+extern "C" {
+
+int archctl(int option, ...)
+{
+    va_list args;
+    va_start(args, option);
+
+    uintptr_t arg1 = va_arg(args, uintptr_t);
+
+    va_end(args);
+
+    int rc = syscall(SC_archctl, option, arg1);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+}

--- a/Userland/Libraries/LibC/sys/archctl.h
+++ b/Userland/Libraries/LibC/sys/archctl.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/API/archctl_numbers.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+__BEGIN_DECLS
+
+int archctl(int option, ...);
+
+__END_DECLS

--- a/Userland/Libraries/LibC/sys/mman.cpp
+++ b/Userland/Libraries/LibC/sys/mman.cpp
@@ -84,16 +84,6 @@ int posix_madvise(void* address, size_t len, int advice)
     return madvise(address, len, advice);
 }
 
-void* allocate_tls(char const* initial_data, size_t size)
-{
-    ptrdiff_t rc = syscall(SC_allocate_tls, initial_data, size);
-    if (rc < 0 && rc > -EMAXERRNO) {
-        errno = -rc;
-        return MAP_FAILED;
-    }
-    return (void*)rc;
-}
-
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/mlock.html
 int mlock(void const*, size_t)
 {

--- a/Userland/Libraries/LibC/sys/mman.h
+++ b/Userland/Libraries/LibC/sys/mman.h
@@ -20,7 +20,6 @@ int mprotect(void*, size_t, int prot);
 int set_mmap_name(void*, size_t, char const*);
 int madvise(void*, size_t, int advice);
 int posix_madvise(void*, size_t, int advice);
-void* allocate_tls(char const* initial_data, size_t);
 int mlock(void const*, size_t);
 int munlock(void const*, size_t);
 int msync(void*, size_t, int flags);

--- a/Userland/Libraries/LibC/tls.cpp
+++ b/Userland/Libraries/LibC/tls.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Types.h>
+#include <LibELF/Arch/tls.h>
 #include <sys/internals.h>
 
 extern "C" {
@@ -21,6 +22,6 @@ extern "C" {
 // changed if we support dynamically allocated TLS blocks.
 void* __tls_get_addr(__tls_index* index)
 {
-    return reinterpret_cast<void*>(reinterpret_cast<FlatPtr>(__builtin_thread_pointer()) + index->ti_module + index->ti_offset);
+    return reinterpret_cast<void*>(reinterpret_cast<FlatPtr>(__builtin_thread_pointer()) + index->ti_module + index->ti_offset + ELF::TLS_DTV_OFFSET);
 }
 }

--- a/Userland/Libraries/LibELF/Arch/aarch64/tls.S
+++ b/Userland/Libraries/LibELF/Arch/aarch64/tls.S
@@ -24,7 +24,7 @@
 // };
 //
 // The resolver takes a pointer to the descriptor as an argument and returns
-// the symbol's offset to the thread pointer (tpidr_el1). The second field of
+// the symbol's offset to the thread pointer (tpidr_el0). The second field of
 // the descriptor is an implementation-defined value which the resolver uses to
 // identify the symbol.
 //

--- a/Userland/Libraries/LibELF/Arch/aarch64/tls.S
+++ b/Userland/Libraries/LibELF/Arch/aarch64/tls.S
@@ -60,4 +60,6 @@
 .type __tlsdesc_static,@function
 __tlsdesc_static:
     ldr x0, [x0, #8]
+    // The first static TLS block is 16 bytes after the thread pointer on AArch64.
+    add x0, x0, 16
     ret

--- a/Userland/Libraries/LibELF/Arch/aarch64/tls.cpp
+++ b/Userland/Libraries/LibELF/Arch/aarch64/tls.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibELF/Arch/tls.h>
+
+namespace ELF {
+
+void set_thread_pointer_register(FlatPtr value)
+{
+    asm volatile("msr tpidr_el0, %0" ::"r"(value));
+}
+
+}

--- a/Userland/Libraries/LibELF/Arch/aarch64/tls.h
+++ b/Userland/Libraries/LibELF/Arch/aarch64/tls.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BitCast.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Types.h>
+
+namespace ELF {
+
+struct ThreadControlBlock {
+    // Variant I of the ELF TLS data structures requires that the TCB has to contain a pointer to the dtv at offset 0.
+    // This member is unused, as we currently only support static TLS blocks.
+    void* dynamic_thread_vector;
+
+    FlatPtr padding;
+};
+
+// The TCB needs to have a size of 2 * sizeof(FlatPtr) on AArch64.
+static_assert(AssertSize<ThreadControlBlock, 2 * sizeof(FlatPtr)>());
+
+static constexpr size_t TLS_VARIANT = 1;
+static constexpr size_t TLS_DTV_OFFSET = 0;
+static constexpr size_t TLS_TP_STATIC_TLS_BLOCK_OFFSET = sizeof(ThreadControlBlock);
+
+// AArch64 ELF TLS Layout
+//
+// [TCB][static TLS.....]
+//  ^tp (tpidr_el0)
+
+inline size_t calculate_static_tls_region_size(size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_alignment;
+    return sizeof(ThreadControlBlock) + tls_template_size;
+}
+
+inline FlatPtr calculate_tp_value_from_static_tls_region_address(FlatPtr static_tls_region_address, size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_template_size;
+    (void)tls_alignment;
+    return static_tls_region_address;
+}
+
+inline ThreadControlBlock* get_tcb_pointer_from_thread_pointer(FlatPtr thread_pointer)
+{
+    return bit_cast<ThreadControlBlock*>(thread_pointer);
+}
+
+inline void* get_pointer_to_first_static_tls_block_from_thread_pointer(FlatPtr thread_pointer, size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_template_size;
+    (void)tls_alignment;
+    return bit_cast<void*>(thread_pointer + sizeof(ThreadControlBlock));
+}
+
+inline void* get_pointer_to_static_tls_region_from_thread_pointer(FlatPtr thread_pointer, size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_template_size;
+    (void)tls_alignment;
+    return bit_cast<void*>(thread_pointer);
+}
+
+}

--- a/Userland/Libraries/LibELF/Arch/riscv64/tls.cpp
+++ b/Userland/Libraries/LibELF/Arch/riscv64/tls.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibELF/Arch/tls.h>
+
+namespace ELF {
+
+void set_thread_pointer_register(FlatPtr value)
+{
+    asm volatile("mv tp, %0" ::"r"(value));
+}
+
+}

--- a/Userland/Libraries/LibELF/Arch/riscv64/tls.h
+++ b/Userland/Libraries/LibELF/Arch/riscv64/tls.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BitCast.h>
+#include <AK/Types.h>
+
+namespace ELF {
+
+struct ThreadControlBlock {
+    // NOTE: "ELF Handling For Thread-Local Storage" says that when using variant I of the data structures (which RISC-V does),
+    //       the TCB has to have a pointer to the dtv at offset 0.
+    //       However, that document also says that the thread pointer has to point to the TCB.
+    //       It's probably still a good idea to put the dtv pointer at offset 0.
+    // This member is unused, as we currently only support static TLS blocks.
+    void* dynamic_thread_vector;
+};
+
+static constexpr size_t TLS_VARIANT = 1;
+static constexpr size_t TLS_DTV_OFFSET = 0x800;
+static constexpr size_t TLS_TP_STATIC_TLS_BLOCK_OFFSET = 0;
+
+// RISC-V ELF TLS Layout
+// The padding is needed so tp is correctly aligned.
+//
+// [..padding..][TCB][static TLS.....]
+//                    ^tp
+
+inline size_t calculate_static_tls_region_size(size_t tls_template_size, size_t tls_alignment)
+{
+    return align_up_to(sizeof(ThreadControlBlock), tls_alignment) + tls_template_size;
+}
+
+inline FlatPtr calculate_tp_value_from_static_tls_region_address(FlatPtr static_tls_region_address, size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_template_size;
+    return static_tls_region_address + align_up_to(sizeof(ThreadControlBlock), tls_alignment);
+}
+
+inline ThreadControlBlock* get_tcb_pointer_from_thread_pointer(FlatPtr thread_pointer)
+{
+    return bit_cast<ThreadControlBlock*>(thread_pointer - sizeof(ThreadControlBlock));
+}
+
+inline void* get_pointer_to_first_static_tls_block_from_thread_pointer(FlatPtr thread_pointer, size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_template_size;
+    (void)tls_alignment;
+    return bit_cast<void*>(thread_pointer);
+}
+
+inline void* get_pointer_to_static_tls_region_from_thread_pointer(FlatPtr thread_pointer, size_t tls_template_size, size_t tls_alignment)
+{
+    (void)tls_template_size;
+    return bit_cast<void*>(thread_pointer - align_up_to(sizeof(ThreadControlBlock), tls_alignment));
+}
+
+}

--- a/Userland/Libraries/LibELF/Arch/tls.h
+++ b/Userland/Libraries/LibELF/Arch/tls.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace ELF {
+
+void set_thread_pointer_register(FlatPtr);
+
+}

--- a/Userland/Libraries/LibELF/Arch/tls.h
+++ b/Userland/Libraries/LibELF/Arch/tls.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Platform.h>
 #include <AK/Types.h>
 
 namespace ELF {
@@ -13,3 +14,13 @@ namespace ELF {
 void set_thread_pointer_register(FlatPtr);
 
 }
+
+#if ARCH(AARCH64)
+#    include <LibELF/Arch/aarch64/tls.h>
+#elif ARCH(RISCV64)
+#    include <LibELF/Arch/riscv64/tls.h>
+#elif ARCH(X86_64)
+#    include <LibELF/Arch/x86_64/tls.h>
+#else
+#    error Unknown architecture
+#endif

--- a/Userland/Libraries/LibELF/Arch/x86_64/tls.cpp
+++ b/Userland/Libraries/LibELF/Arch/x86_64/tls.cpp
@@ -10,9 +10,10 @@
 
 namespace ELF {
 
-void set_thread_pointer_register(FlatPtr)
+void set_thread_pointer_register(FlatPtr value)
 {
-    TODO();
+    // TODO: Consider if we want to support the FSGSBASE extension: https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/best-practices/guidance-enabling-fsgsbase.html
+    VERIFY(archctl(ARCHCTL_X86_64_SET_FS_BASE_FOR_CURRENT_THREAD, value) == 0);
 }
 
 }

--- a/Userland/Libraries/LibELF/Arch/x86_64/tls.cpp
+++ b/Userland/Libraries/LibELF/Arch/x86_64/tls.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <LibELF/Arch/tls.h>
+#include <sys/archctl.h>
+
+namespace ELF {
+
+void set_thread_pointer_register(FlatPtr)
+{
+    TODO();
+}
+
+}

--- a/Userland/Libraries/LibELF/Arch/x86_64/tls.h
+++ b/Userland/Libraries/LibELF/Arch/x86_64/tls.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BitCast.h>
+#include <AK/Types.h>
+
+namespace ELF {
+
+struct ThreadControlBlock {
+    // The %fs segment register is the thread pointer register on x86-64.
+    // x86-64 uses variant II of the TLS data structures described in "ELF Handling For Thread-Local Storage",
+    // which requires the thread pointer to point to the TCB.
+    // That document also requires that the pointer shall be accessible with "movq %fs:0, %<reg>",
+    // so the first member in the TCB has to be a copy of the thread pointer.
+    void* thread_pointer;
+
+    // Variant II requires that the TCB has to contain a pointer to the dtv at an unspecified offset.
+    // This member is unused, as we currently only support static TLS blocks.
+    void* dynamic_thread_vector;
+};
+
+static constexpr size_t TLS_VARIANT = 2;
+static constexpr size_t TLS_DTV_OFFSET = 0;
+static constexpr size_t TLS_TP_STATIC_TLS_BLOCK_OFFSET = 0;
+
+// x86-64 ELF TLS Layout
+// The padding is needed so tp (fs_base) is correctly aligned.
+//
+// [.....static TLS][..padding..][TCB]
+//                                ^tp (fs_base)
+
+inline size_t calculate_static_tls_region_size(size_t tls_template_size, size_t tls_alignment)
+{
+    return align_up_to(tls_template_size, tls_alignment) + sizeof(ThreadControlBlock);
+}
+
+inline FlatPtr calculate_tp_value_from_static_tls_region_address(FlatPtr static_tls_region_address, size_t tls_template_size, size_t tls_alignment)
+{
+    return static_tls_region_address + align_up_to(tls_template_size, tls_alignment);
+}
+
+inline ThreadControlBlock* get_tcb_pointer_from_thread_pointer(FlatPtr thread_pointer)
+{
+    return bit_cast<ThreadControlBlock*>(thread_pointer);
+}
+
+inline void* get_pointer_to_first_static_tls_block_from_thread_pointer(FlatPtr thread_pointer, size_t tls_template_size, size_t tls_alignment)
+{
+    return bit_cast<void*>(thread_pointer - align_up_to(tls_template_size, tls_alignment));
+}
+
+inline void* get_pointer_to_static_tls_region_from_thread_pointer(FlatPtr thread_pointer, size_t tls_template_size, size_t tls_alignment)
+{
+    return bit_cast<void*>(thread_pointer - align_up_to(tls_template_size, tls_alignment));
+}
+
+}

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -755,7 +755,7 @@ void DynamicLoader::do_relr_relocations()
     });
 }
 
-void DynamicLoader::copy_initial_tls_data_into(ByteBuffer& buffer) const
+void DynamicLoader::copy_initial_tls_data_into(Bytes buffer) const
 {
     image().for_each_program_header([this, &buffer](ELF::Image::ProgramHeader program_header) {
         if (program_header.type() != PT_TLS)

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -12,6 +12,7 @@
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <LibELF/Arch/GenericDynamicRelocationType.h>
+#include <LibELF/Arch/tls.h>
 #include <LibELF/DynamicLinker.h>
 #include <LibELF/DynamicLoader.h>
 #include <LibELF/Hashes.h>
@@ -654,10 +655,16 @@ DynamicLoader::RelocationResult DynamicLoader::do_direct_relocation(DynamicObjec
         auto [dynamic_object_of_symbol, symbol_value] = maybe_resolution.value();
 
         size_t addend = relocation.addend_used() ? relocation.addend() : *patch_ptr;
-        *patch_ptr = addend + dynamic_object_of_symbol.tls_offset().value() + symbol_value;
+        *patch_ptr = addend + dynamic_object_of_symbol.tls_offset().value() + symbol_value + TLS_TP_STATIC_TLS_BLOCK_OFFSET;
 
-        // At offset 0 there's the thread's ThreadSpecificData structure, we don't want to collide with it.
-        VERIFY(static_cast<ssize_t>(*patch_ptr) < 0);
+        if constexpr (TLS_VARIANT == 1) {
+            // Until offset TLS_TP_STATIC_TLS_BLOCK_OFFSET there's the thread's ThreadControlBlock, we don't want to collide with it.
+            VERIFY(static_cast<ssize_t>(*patch_ptr) >= static_cast<ssize_t>(TLS_TP_STATIC_TLS_BLOCK_OFFSET));
+        } else if constexpr (TLS_VARIANT == 2) {
+            // At offset 0 there's the thread's ThreadControlBlock, we don't want to collide with it.
+            VERIFY(static_cast<ssize_t>(*patch_ptr) < 0);
+        }
+
         break;
     }
     case TLS_DTPMOD: {
@@ -676,7 +683,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_direct_relocation(DynamicObjec
             break;
 
         size_t addend = relocation.addend_used() ? relocation.addend() : *patch_ptr;
-        *patch_ptr = addend + maybe_resolution->value;
+        *patch_ptr = addend + maybe_resolution->value - TLS_DTV_OFFSET + TLS_TP_STATIC_TLS_BLOCK_OFFSET;
         break;
     }
 #ifdef HAS_TLSDESC_SUPPORT
@@ -765,14 +772,21 @@ void DynamicLoader::copy_initial_tls_data_into(Bytes buffer) const
         // only included in the "size in memory" metric, and is expected to not be touched or read from, as
         // it is not present in the image and zeroed out in-memory. We will still check that the buffer has
         // space for both the initialized and the uninitialized data.
-        // Note: The m_tls_offset here is (of course) negative.
         // TODO: Is the initialized data always in the beginning of the TLS segment, or should we walk the
         // sections to figure that out?
-        size_t tls_start_in_buffer = buffer.size() + m_tls_offset;
+
         VERIFY(program_header.size_in_image() <= program_header.size_in_memory());
         VERIFY(program_header.size_in_memory() <= m_tls_size_of_current_object);
-        VERIFY(tls_start_in_buffer + program_header.size_in_memory() <= buffer.size());
-        memcpy(buffer.data() + tls_start_in_buffer, static_cast<u8 const*>(m_file_data) + program_header.offset(), program_header.size_in_image());
+
+        if constexpr (TLS_VARIANT == 1) {
+            size_t tls_start_in_buffer = m_tls_offset;
+            VERIFY(tls_start_in_buffer + program_header.size_in_memory() <= buffer.size());
+            memcpy(buffer.data() + tls_start_in_buffer, static_cast<u8 const*>(m_file_data) + program_header.offset(), program_header.size_in_image());
+        } else if constexpr (TLS_VARIANT == 2) {
+            size_t tls_start_in_buffer = buffer.size() + m_tls_offset;
+            VERIFY(tls_start_in_buffer + program_header.size_in_memory() <= buffer.size());
+            memcpy(buffer.data() + tls_start_in_buffer, static_cast<u8 const*>(m_file_data) + program_header.offset(), program_header.size_in_image());
+        }
 
         return IterationDecision::Break;
     });

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -86,7 +86,7 @@ public:
     bool is_dynamic() const { return image().is_dynamic(); }
 
     static Optional<DynamicObject::SymbolLookupResult> lookup_symbol(const ELF::DynamicObject::Symbol&);
-    void copy_initial_tls_data_into(ByteBuffer& buffer) const;
+    void copy_initial_tls_data_into(Bytes buffer) const;
 
     DynamicObject const& dynamic_object() const;
 


### PR DESCRIPTION
This PR moves TLS handing to userspace so we can add support for TLS on RISC-V without weird hacks, such as leaving the userspace thread pointer register value (which is a GPR on RISC-V) in the kernel.
Moving TLS handling to userspace required adding a new syscall "archctl" with an option to set the fs segment register on x86-64.

This also adds support for Variant I of the ELF TLS data structures as described in ["ELF Handling For Thread-Local Storage"](https://akkadia.org/drepper/tls.pdf). This is needed for accesses to TLS variables using the local-exec model to work, as that model directly uses TLS offsets. Variant II uses negative offsets to the static TLS blocks while Variant I uses positive offsets, so code using local-exec would break.

Some details "ELF Handling For Thread-Local Storage" is describing (like the TCB contents) seem quite implementation-specific. I don't think compilers make use of all of those details. But I still followed the layout described in that document as much as I can, just to be safe.