### PR TITLE
IDLGenerators: Set namespace object prototype to Object.prototype

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3738,6 +3738,7 @@ void generate_namespace_implementation(IDL::Interface const& interface, StringBu
 
     generator.set("name", interface.name);
     generator.set("namespace_class", interface.namespace_class);
+    generator.set("interface_name", interface.name);
 
     generator.append(R"~~~(
 #include <AK/Function.h>
@@ -3795,7 +3796,7 @@ namespace Web::Bindings {
 JS_DEFINE_ALLOCATOR(@namespace_class@);
 
 @namespace_class@::@namespace_class@(JS::Realm& realm)
-    : Object(ConstructWithoutPrototypeTag::Tag, realm)
+    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {
 }
 
@@ -3809,6 +3810,8 @@ void @namespace_class@::initialize(JS::Realm& realm)
     [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable;
 
     Base::initialize(realm);
+
+    define_direct_property(vm.well_known_symbol_to_string_tag(), JS::PrimitiveString::create(vm, "@interface_name@"_string), JS::Attribute::Configurable);
 
 )~~~");
 

--- a/Tests/LibWeb/Text/expected/namespace-object-prototype.txt
+++ b/Tests/LibWeb/Text/expected/namespace-object-prototype.txt
@@ -1,0 +1,6 @@
+Prototype of CSS is Object.prototype: true
+CSS.toString(): [object CSS]
+Object.prototype.toString.call(CSS): [object CSS]
+Prototype of WebAssembly is Object.prototype: true
+WebAssembly.toString(): [object WebAssembly]
+Object.prototype.toString.call(WebAssembly): [object WebAssembly]

--- a/Tests/LibWeb/Text/input/namespace-object-prototype.html
+++ b/Tests/LibWeb/Text/input/namespace-object-prototype.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    function testNamespace(testCase) {
+        println(`Prototype of ${testCase.name} is Object.prototype: ${Object.getPrototypeOf(testCase.namespace) === Object.prototype}`); 
+        println(`${testCase.name}.toString(): ${testCase.namespace.toString()}`);
+        println(`Object.prototype.toString.call(${testCase.name}): ${Object.prototype.toString.call(testCase.namespace)}`);
+    }
+
+    test(() => {
+        const testCases = [
+            { namespace: CSS, name: "CSS" },
+            { namespace: WebAssembly, name: "WebAssembly" },
+        ];
+
+        for (const testCase of testCases) {
+            testNamespace(testCase);
+        }
+    });
+</script>


### PR DESCRIPTION
Previously, namespace objects were constructed with no prototype, so calling methods like `toString()` on them would unexpectedly throw an exception.

After this change we now pass this test: http://wpt.live/css/cssom/CSS-namespace-object-class-string.html