### PR TITLE
nix-shell: Disable gcc hardening to be able to build toolchain

### DIFF
--- a/Toolchain/default.nix
+++ b/Toolchain/default.nix
@@ -27,4 +27,5 @@ mkShell.override { stdenv = gcc13Stdenv; } {
     qemu
     python3
   ];
+  hardeningDisable = [ "format" ];
 }


### PR DESCRIPTION
Currently, if building under `nix-shell Toolchain`, serenityOS'
gcc won't build because of hardening options added in nix,
more specifically the breaking format-security.
