### PR TITLE
LibWeb: Ignore mousewheel events in ViewportPaintable

### DIFF
--- a/Tests/LibWeb/Text/expected/scroll-window-using-wheel-event.txt
+++ b/Tests/LibWeb/Text/expected/scroll-window-using-wheel-event.txt
@@ -1,0 +1,1 @@
+              new scrollY: 100

--- a/Tests/LibWeb/Text/input/scroll-window-using-wheel-event.html
+++ b/Tests/LibWeb/Text/input/scroll-window-using-wheel-event.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<style>
+    body {
+        overflow: scroll;
+    }
+
+    .box {
+        height: 300px;
+        width: 200px;
+    }
+
+    .red {
+        background-color: red;
+    }
+
+    .green {
+        background-color: green;
+    }
+
+    .cyan {
+        background-color: cyan;
+    }
+
+    .pink {
+        background-color: pink;
+    }
+
+    .blue {
+        background-color: blue;
+    }
+</style>
+<div class="container">
+    <div class="box red"></div>
+    <div class="box green"></div>
+    <div class="box blue"></div>
+    <div class="box pink"></div>
+    <div class="box cyan"></div>
+    <div class="box red"></div>
+    <div class="box green"></div>
+    <div class="box blue"></div>
+    <div class="box pink"></div>
+    <div class="box cyan"></div>
+</div>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        const container = document.querySelector(".container");
+        window.onscroll = () => {
+            println(`new scrollY: ${window.scrollY}`);
+            done();
+        };
+        internals.wheel(50, 50, 0, 100);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -343,7 +343,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
     }
 
     auto scrollbar_width = computed_values().scrollbar_width();
-    if (phase == PaintPhase::Overlay && scrollbar_width != CSS::ScrollbarWidth::None) {
+    if (!layout_box().is_viewport() && phase == PaintPhase::Overlay && scrollbar_width != CSS::ScrollbarWidth::None) {
         auto color = Color(Color::NamedColor::DarkGray).with_alpha(128);
         int thumb_corner_radius = static_cast<int>(context.rounded_device_pixels(scrollbar_thumb_thickness / 2));
         if (auto thumb_rect = scroll_thumb_rect(ScrollDirection::Horizontal); thumb_rect.has_value()) {

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -515,6 +515,11 @@ void ViewportPaintable::recompute_selection_states()
     }
 }
 
+bool ViewportPaintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int, int)
+{
+    return false;
+}
+
 void ViewportPaintable::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -34,6 +34,8 @@ public:
     JS::GCPtr<Selection::Selection> selection() const;
     void recompute_selection_states();
 
+    bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y) override;
+
 private:
     void build_stacking_context_tree();
 


### PR DESCRIPTION
That allow EventHandler process wheel event on corresponding navigable.
For top-level navigable that means IPC call to let chrome know about
scrollbar position update.

Fixes https://github.com/SerenityOS/serenity/issues/23599
Fixes https://github.com/SerenityOS/serenity/issues/23493
Fixes https://github.com/SerenityOS/serenity/issues/23966