### PR TITLE
LibJS: throw RangeError in `StringPrototype::repeat` if OOM

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -308,13 +308,14 @@ bool String::equals_ignoring_ascii_case(StringView other) const
     return StringUtils::equals_ignoring_ascii_case(bytes_as_string_view(), other);
 }
 
-String String::repeated(String const& input, size_t count)
+ErrorOr<String> String::repeated(String const& input, size_t count)
 {
-    VERIFY(!Checked<size_t>::multiplication_would_overflow(count, input.bytes().size()));
+    if (Checked<size_t>::multiplication_would_overflow(count, input.bytes().size()))
+        return Error::from_errno(EOVERFLOW);
 
     String result;
     size_t input_size = input.bytes().size();
-    MUST(result.replace_with_new_string(count * input_size, [&](Bytes buffer) {
+    TRY(result.replace_with_new_string(count * input_size, [&](Bytes buffer) {
         if (input_size == 1) {
             buffer.fill(input.bytes().first());
         } else {
@@ -323,6 +324,7 @@ String String::repeated(String const& input, size_t count)
         }
         return ErrorOr<void> {};
     }));
+
     return result;
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -79,7 +79,7 @@ public:
     static ErrorOr<String> repeated(u32 code_point, size_t count);
 
     // Creates a new String from another string, repeated N times.
-    static String repeated(String const&, size_t count);
+    static ErrorOr<String> repeated(String const&, size_t count);
 
     // Creates a new String by case-transforming this String. Using these methods require linking LibUnicode into your application.
     ErrorOr<String> to_lowercase(Optional<StringView> const& locale = {}) const;

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -156,7 +156,7 @@ jobs:
         env:
           SERENITY_SOURCE_DIR: '$(Build.SourcesDirectory)'
           CTEST_OUTPUT_ON_FAILURE: 1
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1'
+          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
           TESTS_ONLY: 1
 
@@ -209,7 +209,7 @@ jobs:
           MARKDOWN_CHECK_BINARY: ./Meta/Lagom/Build/bin/markdown-check
           GML_FORMAT: ./Meta/Lagom/Build/bin/gml-format
           # FIXME: enable detect_stack_use_after_return=1 #7420
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0'
+          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0:allocator_may_return_null=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
 
     - script: |

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -230,6 +230,7 @@
     M(StringNonGlobalRegExp, "RegExp argument is non-global")                                                                           \
     M(StringRawCannotConvert, "Cannot convert property 'raw' to object from {}")                                                        \
     M(StringRepeatCountMustBe, "repeat count must be a {} number")                                                                      \
+    M(StringRepeatCountMustNotOverflow, "repeat count must not overflow")                                                               \
     M(TemporalAmbiguousMonthOfPlainMonthDay, "Accessing month of PlainMonthDay is ambiguous, use monthCode instead")                    \
     M(TemporalDifferentCalendars, "Cannot compare dates from two different calendars")                                                  \
     M(TemporalDifferentTimeZones, "Cannot compare dates from two different time zones")                                                 \

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -776,8 +776,12 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::repeat)
     if (string.is_empty())
         return PrimitiveString::create(vm, String {});
 
+    auto repeated = String::repeated(string, n);
+    if (repeated.is_error())
+        return vm.throw_completion<RangeError>(ErrorType::StringRepeatCountMustNotOverflow);
+
     // 6. Return the String value that is made from n copies of S appended together.
-    return PrimitiveString::create(vm, String::repeated(string, n));
+    return PrimitiveString::create(vm, repeated.release_value());
 }
 
 // 22.1.3.19 String.prototype.replace ( searchValue, replaceValue ), https://tc39.es/ecma262/#sec-string.prototype.replace

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.repeat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.repeat.js
@@ -22,6 +22,10 @@ test("throws correct range errors", () => {
     expect(() => {
         "foo".repeat(Infinity);
     }).toThrowWithMessage(RangeError, "repeat count must be a finite number");
+
+    expect(() => {
+        "foo".repeat(0xffffffffff);
+    }).toThrowWithMessage(RangeError, "repeat count must not overflow");
 });
 
 test("UTF-16", () => {


### PR DESCRIPTION
Currently crashes with an assertion failure in `String::repeated` if malloc can't serve a `count * input_size` sized request, so propagate the error then thow a `RangeError`.

This can happen when
```js
"A".repeat(0xffffffffff);
```
```
VERIFICATION FAILED: !_temporary_result.is_error() at /home/jess/code/serenity/AK/String.cpp:313
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-ak.so.0(ak_verification_failed+0x86) [0x7ffff7767f2f]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-ak.so.0 AK::String::repeated(AK::String const&, unsigned long) 0x5e) [0x7ffff77983ba]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::StringPrototype::repeat(JS::VM&) 0x3bf) [0x7ffff7b9f3bb]
Build/lagom/bin/js() [0x40e707]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0(+0x335291) [0x7ffff7b35291]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::NativeFunction::call() 0x3d) [0x7ffff7b3471d]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::NativeFunction::internal_call(JS::Value, AK::Span<JS::Value const>) 0x1be) [0x7ffff7b34c24]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::call_impl(JS::VM&, JS::FunctionObject&, JS::Value, AK::Span<JS::Value const>) 0x30) [0x7ffff7a20827]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0(+0x18e2d1) [0x7ffff798e2d1]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::Bytecode::Op::Call::execute_impl(JS::Bytecode::Interpreter&) const 0x4c6) [0x7ffff7981ec8]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::Bytecode::Interpreter::run_bytecode() 0x997) [0x7ffff7987209]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::Bytecode::Interpreter::run_and_return_frame(JS::Bytecode::Executable&, JS::Bytecode::BasicBlock const*, JS::Bytecode::CallFrame*) 0x198) [0x7ffff7987d06]
/home/jess/code/serenity/Build/lagom/bin/../lib64/liblagom-js.so.0 JS::Bytecode::Interpreter::run(JS::Script&, JS::GCPtr<JS::Environment>) 0x3be) [0x7ffff79884da]
...
```
Its not [spec'ed](https://tc39.es/ecma262/#sec-string.prototype.repeat), but V8 and SpiderMonkey both do somthing similar with a max string length, I think its better than crashing, maybe a fixed max string length is better?
They also both throw `RangeError`'s
