### PR TITLE
LibWeb: Marker Position and sizing #23941

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1096,7 +1096,7 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     marker_state.set_content_height(max(image_height, marker.first_available_font().pixel_size_rounded_up() + 1));
 
-    auto final_marker_width = marker_state.content_width() + default_marker_width;
+    auto final_marker_width = default_marker_width;
 
     if (marker.list_style_position() == CSS::ListStylePosition::Inside) {
         list_item_state.set_content_offset({ final_marker_width, list_item_state.offset.y() });

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -41,7 +41,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
     CSSPixelRect enclosing = absolute_rect().to_rounded<CSSPixels>();
     auto device_enclosing = context.enclosing_device_rect(enclosing);
 
-    CSSPixels marker_width = enclosing.height() / 2;
+    CSSPixels marker_width = enclosing.height() / 4;
 
     if (auto const* list_style_image = layout_box().list_style_image()) {
         CSSPixelRect image_rect {


### PR DESCRIPTION
Student Project.

Made changes to both BlockFormattingContext and MarkerPaintable to adjust the size and positioning of bullet points. 

BlockFormattingContext:
Removed the marker_state.content_width() from the final marker width. This made the markers width adjust to the font size more naturally and have spacing similar to other browsers. 

MarkerPaintable:
Made the marker height scaled down by a factor of 4 instead of 2. This made bullet size more similar to Chrome and Firefox. 


