### PR TITLE
Everywhere: Partially reformat code using clang-format 18

### DIFF
--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -28,7 +28,7 @@ struct Array {
     constexpr static size_t size() { return Size; }
     constexpr T const& operator[](size_t index) const { return __data[index]; }
     constexpr T& operator[](size_t index) { return __data[index]; }
-    using ConstIterator = SimpleIterator<const Array, T const>;
+    using ConstIterator = SimpleIterator<Array const, T const>;
     using Iterator = SimpleIterator<Array, T>;
 
     constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -80,7 +80,7 @@ public:
 
     private:
         friend class CircularQueue;
-        ConstIterator(CircularQueue const& queue, const size_t index)
+        ConstIterator(CircularQueue const& queue, size_t const index)
             : m_queue(queue)
             , m_index(index)
         {

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -105,7 +105,7 @@ public:
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T> operator*=(Complex<U> const& x)
     {
-        const T real = m_real;
+        T const real = m_real;
         m_real = real * x.real() - m_imag * x.imag();
         m_imag = real * x.imag() + m_imag * x.real();
         return *this;
@@ -122,8 +122,8 @@ public:
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T> operator/=(Complex<U> const& x)
     {
-        const T real = m_real;
-        const T divisor = x.real() * x.real() + x.imag() * x.imag();
+        T const real = m_real;
+        T const divisor = x.real() * x.real() + x.imag() * x.imag();
         m_real = (real * x.real() + m_imag * x.imag()) / divisor;
         m_imag = (m_imag * x.real() - x.real() * x.imag()) / divisor;
         return *this;

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -158,7 +158,7 @@ public:
     Iterator begin() { return Iterator(m_head); }
     Iterator end() { return Iterator::universal_end(); }
 
-    using ConstIterator = DoublyLinkedListIterator<const DoublyLinkedList, T const>;
+    using ConstIterator = DoublyLinkedListIterator<DoublyLinkedList const, T const>;
     friend ConstIterator;
     ConstIterator begin() const { return ConstIterator(m_head); }
     ConstIterator end() const { return ConstIterator::universal_end(); }

--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -95,9 +95,9 @@ static_assert(AssertSize<FloatExtractor<f32>, sizeof(f32)>());
 template<size_t S, size_t E, size_t M>
 requires(S <= 1 && E >= 1 && M >= 1 && (S + E + M) <= 64) class FloatingPointBits final {
 public:
-    static const size_t signbit = S;
-    static const size_t exponentbits = E;
-    static const size_t mantissabits = M;
+    static size_t const signbit = S;
+    static size_t const exponentbits = E;
+    static size_t const mantissabits = M;
 
     template<typename T>
     requires(IsIntegral<T> && IsUnsigned<T> && sizeof(T) <= 8) constexpr FloatingPointBits(T bits)

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -280,8 +280,8 @@ public:
     }
 
     using ConstIterator = Conditional<IsOrdered,
-        OrderedHashTableIterator<const HashTable, const T, BucketType const>,
-        HashTableIterator<const HashTable, const T, BucketType const>>;
+        OrderedHashTableIterator<HashTable const, T const, BucketType const>,
+        HashTableIterator<HashTable const, T const, BucketType const>>;
 
     [[nodiscard]] ConstIterator begin() const
     {

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -35,7 +35,7 @@ ErrorOr<ByteBuffer> decode_hex(StringView input)
 }
 
 #ifdef KERNEL
-ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(const ReadonlyBytes input)
+ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(ReadonlyBytes const input)
 {
     StringBuilder output(input.size() * 2);
 
@@ -45,7 +45,7 @@ ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(const ReadonlyBytes input)
     return Kernel::KString::try_create(output.string_view());
 }
 #else
-ByteString encode_hex(const ReadonlyBytes input)
+ByteString encode_hex(ReadonlyBytes const input)
 {
     StringBuilder output(input.size() * 2);
 

--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -41,7 +41,7 @@ public:
         m_data = (d << 24) | (c << 16) | (b << 8) | a;
     }
 
-    constexpr IPv4Address(const u8 data[4])
+    constexpr IPv4Address(u8 const data[4])
     {
         m_data = (u32(data[3]) << 24) | (u32(data[2]) << 16) | (u32(data[1]) << 8) | u32(data[0]);
     }
@@ -149,7 +149,7 @@ public:
     }
 
 private:
-    constexpr u32 octet(const SubnetClass subnet) const
+    constexpr u32 octet(SubnetClass const subnet) const
     {
         constexpr auto bits_per_byte = 8;
         auto const bits_to_shift = bits_per_byte * int(subnet);

--- a/AK/Random.cpp
+++ b/AK/Random.cpp
@@ -17,7 +17,7 @@ u32 get_random_uniform(u32 max_bounds)
     // `arc4random() % max_bounds` would be insufficient. Here we compute the last number of the
     // last "full group". Note that if max_bounds is a divisor of UINT32_MAX,
     // then we end up with UINT32_MAX:
-    const u32 max_usable = UINT32_MAX - (static_cast<u64>(UINT32_MAX) + 1) % max_bounds;
+    u32 const max_usable = UINT32_MAX - (static_cast<u64>(UINT32_MAX) + 1) % max_bounds;
     auto random_value = get_random<u32>();
     for (int i = 0; i < 20 && random_value > max_usable; ++i) {
         // By chance we picked a value from the incomplete group. Note that this group has size at
@@ -34,7 +34,7 @@ u64 get_random_uniform_64(u64 max_bounds)
 {
     // Uses the same algorithm as `get_random_uniform`,
     // by replacing u64 with u128 and u32 with u64.
-    const u64 max_usable = UINT64_MAX - static_cast<u64>((static_cast<u128>(UINT64_MAX) + 1) % max_bounds);
+    u64 const max_usable = UINT64_MAX - static_cast<u64>((static_cast<u128>(UINT64_MAX) + 1) % max_bounds);
     auto random_value = get_random<u64>();
     for (int i = 0; i < 20 && random_value > max_usable; ++i) {
         random_value = get_random<u64>();

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -505,7 +505,7 @@ public:
     Iterator end() { return {}; }
     Iterator begin_from(K key) { return Iterator(static_cast<Node*>(BaseTree::find(this->m_root, key))); }
 
-    using ConstIterator = RedBlackTreeIterator<const RedBlackTree, V const>;
+    using ConstIterator = RedBlackTreeIterator<RedBlackTree const, V const>;
     friend ConstIterator;
     ConstIterator begin() const { return ConstIterator(static_cast<Node*>(this->m_minimum)); }
     ConstIterator end() const { return {}; }

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -205,7 +205,7 @@ public:
     Iterator begin() { return Iterator(m_head); }
     Iterator end() { return {}; }
 
-    using ConstIterator = SinglyLinkedListIterator<const SinglyLinkedList, T const>;
+    using ConstIterator = SinglyLinkedListIterator<SinglyLinkedList const, T const>;
     friend ConstIterator;
     ConstIterator begin() const { return ConstIterator(m_head); }
     ConstIterator end() const { return {}; }

--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -183,13 +183,13 @@ public:
         TRY(state.try_empend(false, m_children.begin(), m_children.end()));
 
         auto invoke = [&](auto& current_node) -> ErrorOr<IterationDecision> {
-            if constexpr (VoidFunction<Fn, const BaseType&>) {
-                callback(static_cast<const BaseType&>(current_node));
+            if constexpr (VoidFunction<Fn, BaseType const&>) {
+                callback(static_cast<BaseType const&>(current_node));
                 return IterationDecision::Continue;
-            } else if constexpr (IsSpecializationOf<decltype(callback(declval<const BaseType&>())), ErrorOr>) {
-                return callback(static_cast<const BaseType&>(current_node));
-            } else if constexpr (IteratorFunction<Fn, const BaseType&>) {
-                return callback(static_cast<const BaseType&>(current_node));
+            } else if constexpr (IsSpecializationOf<decltype(callback(declval<BaseType const&>())), ErrorOr>) {
+                return callback(static_cast<BaseType const&>(current_node));
+            } else if constexpr (IteratorFunction<Fn, BaseType const&>) {
+                return callback(static_cast<BaseType const&>(current_node));
             } else {
                 static_assert(DependentFalse<Fn>, "Invalid iterator function type signature");
             }

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -180,12 +180,12 @@ static_assert(explode_byte(0x80) == static_cast<FlatPtr>(0x8080808080808080ull))
 static_assert(explode_byte(0x7f) == static_cast<FlatPtr>(0x7f7f7f7f7f7f7f7full));
 static_assert(explode_byte(0) == 0);
 
-constexpr size_t align_up_to(const size_t value, const size_t alignment)
+constexpr size_t align_up_to(size_t const value, size_t const alignment)
 {
     return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
-constexpr size_t align_down_to(const size_t value, const size_t alignment)
+constexpr size_t align_down_to(size_t const value, size_t const alignment)
 {
     return value & ~(alignment - 1);
 }

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -108,7 +108,7 @@ public:
     }
 
     template<UFixedInt T, size_t n>
-    requires((assumed_bit_size<T> * n) <= bit_size) constexpr UFixedBigInt(const T (&value)[n])
+    requires((assumed_bit_size<T> * n) <= bit_size) constexpr UFixedBigInt(T const (&value)[n])
     {
         size_t offset = 0;
 

--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -63,7 +63,7 @@ void operator delete[](void* ptr, size_t) noexcept
 // This is usually provided by libstdc++ in most cases, and the kernel has its own definition in
 // Kernel/Heap/kmalloc.cpp. If neither of those apply, the following should suffice to not fail during linking.
 namespace AK_REPLACED_STD_NAMESPACE {
-const nothrow_t nothrow;
+nothrow_t const nothrow;
 }
 
 #endif

--- a/Kernel/API/TimePage.h
+++ b/Kernel/API/TimePage.h
@@ -22,9 +22,9 @@ inline bool time_page_supports(clockid_t clock_id)
 }
 
 struct TimePage {
-    volatile u32 update1;
+    u32 volatile update1;
     struct timespec clocks[CLOCK_ID_COUNT];
-    volatile u32 update2;
+    u32 volatile update2;
 };
 
 }

--- a/Kernel/API/kcov.h
+++ b/Kernel/API/kcov.h
@@ -8,5 +8,5 @@
 
 #include <AK/Types.h>
 
-typedef volatile u64 kcov_pc_t;
+typedef u64 volatile kcov_pc_t;
 #define KCOV_ENTRY_SIZE sizeof(kcov_pc_t)

--- a/Kernel/API/ttydefaultschars.h
+++ b/Kernel/API/ttydefaultschars.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-static const cc_t ttydefchars[NCCS] = {
+static cc_t const ttydefchars[NCCS] = {
     [VINTR] = CINTR,
     [VQUIT] = CQUIT,
     [VERASE] = CERASE,

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -192,7 +192,7 @@ private:
     // FIXME: On aarch64, once there is code in place to differentiate IRQs from synchronous exceptions (syscalls),
     //        this member should be incremented. Also this member shouldn't be a FlatPtr.
     FlatPtr m_in_irq { 0 };
-    volatile u32 m_in_critical;
+    u32 volatile m_in_critical;
     // NOTE: Since these variables are accessed with atomic magic on x86 (through GP with a single load instruction),
     //       they need to be FlatPtrs or everything becomes highly unsound and breaks. They are actually just booleans.
     FlatPtr m_in_scheduler;

--- a/Kernel/Arch/SmapDisabler.h
+++ b/Kernel/Arch/SmapDisabler.h
@@ -16,7 +16,7 @@ public:
     ~SmapDisabler();
 
 private:
-    const FlatPtr m_flags;
+    FlatPtr const m_flags;
 };
 
 }

--- a/Kernel/Arch/aarch64/RPi/Mailbox.cpp
+++ b/Kernel/Arch/aarch64/RPi/Mailbox.cpp
@@ -76,7 +76,7 @@ static void wait_for_reply(MMIO& mmio)
 bool Mailbox::send_queue(void* queue, u32 queue_size) const
 {
     // According to Raspberry Pi specs this is the only channel implemented.
-    const u32 channel = ARM_TO_VIDEOCORE_CHANNEL;
+    u32 const channel = ARM_TO_VIDEOCORE_CHANNEL;
 
     auto message_header = reinterpret_cast<MessageHeader*>(queue);
     message_header->set_queue_size(queue_size);

--- a/Kernel/Arch/aarch64/RPi/MiniUART.cpp
+++ b/Kernel/Arch/aarch64/RPi/MiniUART.cpp
@@ -105,7 +105,7 @@ ErrorOr<size_t> MiniUART::write(Kernel::OpenFileDescription& description, u64, K
         return EAGAIN;
 
     return buffer.read_buffered<128>(size, [&](ReadonlyBytes bytes) {
-        for (const auto& byte : bytes)
+        for (auto const& byte : bytes)
             put_char(byte);
         return bytes.size();
     });

--- a/Kernel/Arch/x86_64/InterruptManagement.h
+++ b/Kernel/Arch/x86_64/InterruptManagement.h
@@ -34,10 +34,10 @@ public:
     u16 flags() const { return m_flags; }
 
 private:
-    const u8 m_bus;
-    const u8 m_source;
-    const u32 m_global_system_interrupt;
-    const u16 m_flags;
+    u8 const m_bus;
+    u8 const m_source;
+    u32 const m_global_system_interrupt;
+    u16 const m_flags;
 };
 
 class InterruptManagement {

--- a/Kernel/Arch/x86_64/Interrupts/IOAPIC.h
+++ b/Kernel/Arch/x86_64/Interrupts/IOAPIC.h
@@ -11,9 +11,9 @@
 
 namespace Kernel {
 struct [[gnu::packed]] ioapic_mmio_regs {
-    volatile u32 select;
+    u32 volatile select;
     u32 reserved[3];
-    volatile u32 window;
+    u32 volatile window;
 };
 
 class PCIInterruptOverrideMetadata {
@@ -28,13 +28,13 @@ public:
     u16 ioapic_interrupt_pin() const { return m_ioapic_interrupt_pin; }
 
 private:
-    const u8 m_bus_id;
-    const u8 m_polarity;
-    const u8 m_trigger_mode;
-    const u8 m_pci_interrupt_pin;
-    const u8 m_pci_device_number;
-    const u32 m_ioapic_id;
-    const u16 m_ioapic_interrupt_pin;
+    u8 const m_bus_id;
+    u8 const m_polarity;
+    u8 const m_trigger_mode;
+    u8 const m_pci_interrupt_pin;
+    u8 const m_pci_device_number;
+    u32 const m_ioapic_id;
+    u16 const m_ioapic_interrupt_pin;
 };
 
 class IOAPIC final : public IRQController {

--- a/Kernel/Arch/x86_64/Time/APICTimer.cpp
+++ b/Kernel/Arch/x86_64/Time/APICTimer.cpp
@@ -44,10 +44,10 @@ UNMAP_AFTER_INIT bool APICTimer::calibrate(HardwareTimerBase& calibration_source
         size_t ticks_in_100ms { 0 };
         Atomic<size_t, AK::memory_order_relaxed> calibration_ticks { 0 };
 #ifdef APIC_TIMER_MEASURE_CPU_CLOCK
-        volatile u64 start_tsc { 0 }, end_tsc { 0 };
+        u64 volatile start_tsc { 0 }, end_tsc { 0 };
 #endif
-        volatile u64 start_reference { 0 }, end_reference { 0 };
-        volatile u32 start_apic_count { 0 }, end_apic_count { 0 };
+        u64 volatile start_reference { 0 }, end_reference { 0 };
+        u32 volatile start_apic_count { 0 }, end_apic_count { 0 };
         bool query_reference { false };
     } state;
 

--- a/Kernel/Arch/x86_64/Time/HPET.cpp
+++ b/Kernel/Arch/x86_64/Time/HPET.cpp
@@ -46,26 +46,26 @@ enum class TimerConfiguration : u32 {
 
 struct [[gnu::packed]] HPETRegister {
     union {
-        volatile u64 full;
+        u64 volatile full;
         struct {
-            volatile u32 low;
-            volatile u32 high;
+            u32 volatile low;
+            u32 volatile high;
         };
     };
 };
 
 struct [[gnu::packed]] TimerStructure {
-    volatile u32 capabilities;
-    volatile u32 interrupt_routing;
+    u32 volatile capabilities;
+    u32 volatile interrupt_routing;
     HPETRegister comparator_value;
-    volatile u64 fsb_interrupt_route;
+    u64 volatile fsb_interrupt_route;
     u64 reserved;
 };
 
 struct [[gnu::packed]] HPETCapabilityRegister {
     // Note: We must do a 32 bit access to offsets 0x0, or 0x4 only, according to HPET spec.
-    volatile u32 attributes;
-    volatile u32 main_counter_tick_period;
+    u32 volatile attributes;
+    u32 volatile main_counter_tick_period;
     u64 reserved;
 };
 

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -337,9 +337,9 @@ public:
     void write32(size_t offset, u32 value) const;
 
 private:
-    const Address m_address;
-    const CapabilityID m_id;
-    const u8 m_ptr;
+    Address const m_address;
+    CapabilityID const m_id;
+    u8 const m_ptr;
 };
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u8, ClassCode);

--- a/Kernel/Bus/USB/EHCI/Registers.h
+++ b/Kernel/Bus/USB/EHCI/Registers.h
@@ -202,21 +202,21 @@ struct OperationalRegisters {
     // 2.3.4 FRINDEX - Frame Index Register
     // Note: We use `volatile` to ensure 32 bit writes
     // Note: Only up to 14 bits are actually used, and the last 3 bits must never be `000` or `111`
-    volatile u32 frame_index;
+    u32 volatile frame_index;
 
     // 2.3.5 CTRLDSSEGMENT - Control Data Structure Segment Register
     // Note: We use `volatile` to ensure 32 bit writes
     // Note: Upper 32 bits of periodic-frame- and asynchronous-list pointers
-    volatile u32 segment_selector;
+    u32 volatile segment_selector;
 
     // 2.3.6 PERIODICLISTBASE - Periodic Frame List Base Address Register
     // Note: We use `volatile` to ensure 32 bit writes
     // Note: Page-aligned addresses only
-    volatile u32 frame_list_base_address;
+    u32 volatile frame_list_base_address;
     // 2.3.7 ASYNCLISTADDR - Current Asynchronous List Address Register
     // Note: We use `volatile` to ensure 32 bit writes
     // Note: 32 byte (cache-line) aligned addresses only
-    volatile u32 next_asynchronous_list_address;
+    u32 volatile next_asynchronous_list_address;
 
     u32 _padding[9];
 

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
@@ -241,7 +241,7 @@ struct alignas(16) TransferDescriptor final {
 
 private:
     u32 m_link_ptr;                // Points to another Queue Head or Transfer Descriptor
-    volatile u32 m_control_status; // Control and status field
+    u32 volatile m_control_status; // Control and status field
     u32 m_token;                   // Contains all information required to fill in a USB Start Token
     u32 m_buffer_ptr;              // Points to a data buffer for this transaction (i.e what we want to send or recv)
 
@@ -367,7 +367,7 @@ struct alignas(16) QueueHead {
 
 private:
     u32 m_link_ptr { 0 };                  // Pointer to the next horizontal object that the controller will execute after this one
-    volatile u32 m_element_link_ptr { 0 }; // Pointer to the first data object in the queue (can be modified by hw)
+    u32 volatile m_element_link_ptr { 0 }; // Pointer to the first data object in the queue (can be modified by hw)
 
     // This structure pointer will be ignored by the controller, but we can use it for configuration and bookkeeping
     QueueHeadBookkeeping* m_bookkeeping { nullptr };

--- a/Kernel/Bus/VirtIO/Queue.h
+++ b/Kernel/Bus/VirtIO/Queue.h
@@ -87,8 +87,8 @@ private:
         QueueDeviceItem rings[];
     };
 
-    const u16 m_queue_size;
-    const u16 m_notify_offset;
+    u16 const m_queue_size;
+    u16 const m_notify_offset;
     u16 m_free_buffers;
     u16 m_free_head { 0 };
     u16 m_used_tail { 0 };

--- a/Kernel/Devices/Audio/Channel.h
+++ b/Kernel/Devices/Audio/Channel.h
@@ -34,6 +34,6 @@ private:
     virtual StringView class_name() const override { return "AudioChannel"sv; }
 
     LockWeakPtr<AudioController> m_controller;
-    const size_t m_channel_index;
+    size_t const m_channel_index;
 };
 }

--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -85,11 +85,11 @@ public:
 
 private:
     BlockDevice& m_block_device;
-    const RequestType m_request_type;
-    const u64 m_block_index;
-    const u32 m_block_count;
+    RequestType const m_request_type;
+    u64 const m_block_index;
+    u32 const m_block_count;
     UserOrKernelBuffer m_buffer;
-    const size_t m_buffer_size;
+    size_t const m_buffer_size;
 };
 
 }

--- a/Kernel/Devices/GPU/Intel/DisplayConnectorGroup.h
+++ b/Kernel/Devices/GPU/Intel/DisplayConnectorGroup.h
@@ -86,11 +86,11 @@ private:
     Array<OwnPtr<IntelDisplayTranscoder>, 5> m_transcoders;
     Array<OwnPtr<IntelDisplayPlane>, 3> m_planes;
 
-    const MMIORegion m_mmio_first_region;
-    const MMIORegion m_mmio_second_region;
+    MMIORegion const m_mmio_first_region;
+    MMIORegion const m_mmio_second_region;
     MMIORegion const& m_assigned_mmio_registers_region;
 
-    const IntelGraphics::Generation m_generation;
+    IntelGraphics::Generation const m_generation;
     NonnullOwnPtr<Memory::Region> m_registers_region;
     NonnullOwnPtr<GMBusConnector> m_gmbus_connector;
 };

--- a/Kernel/Devices/GPU/Intel/Plane/G33DisplayPlane.h
+++ b/Kernel/Devices/GPU/Intel/Plane/G33DisplayPlane.h
@@ -21,6 +21,6 @@ public:
     virtual ErrorOr<void> enable(Badge<IntelDisplayConnectorGroup>) override;
 
 private:
-    explicit IntelG33DisplayPlane(Memory::TypedMapping<volatile IntelDisplayPlane::PlaneRegisters> plane_registers_mapping);
+    explicit IntelG33DisplayPlane(Memory::TypedMapping<IntelDisplayPlane::PlaneRegisters volatile> plane_registers_mapping);
 };
 }

--- a/Kernel/Devices/GPU/VirtIO/GraphicsAdapter.cpp
+++ b/Kernel/Devices/GPU/VirtIO/GraphicsAdapter.cpp
@@ -305,7 +305,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::ensure_backing_storage(Graphics::VirtIOGPU:
 
     auto writer = create_scratchspace_writer();
     auto& request = writer.append_structure<Graphics::VirtIOGPU::Protocol::ResourceAttachBacking>();
-    const size_t header_block_size = sizeof(request) + num_mem_regions * sizeof(Graphics::VirtIOGPU::Protocol::MemoryEntry);
+    size_t const header_block_size = sizeof(request) + num_mem_regions * sizeof(Graphics::VirtIOGPU::Protocol::MemoryEntry);
 
     populate_virtio_gpu_request_header(request.header, Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_CMD_RESOURCE_ATTACH_BACKING, 0);
     request.resource_id = resource_id.value();

--- a/Kernel/Devices/Generic/ConsoleDevice.cpp
+++ b/Kernel/Devices/Generic/ConsoleDevice.cpp
@@ -50,7 +50,7 @@ ErrorOr<size_t> ConsoleDevice::write(OpenFileDescription&, u64, Kernel::UserOrKe
         return 0;
 
     return data.read_buffered<256>(size, [&](ReadonlyBytes readonly_bytes) {
-        for (const auto& byte : readonly_bytes)
+        for (auto const& byte : readonly_bytes)
             put_char(byte);
         return readonly_bytes.size();
     });

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -57,7 +57,7 @@ ErrorOr<size_t> SerialDevice::write(OpenFileDescription& description, u64, UserO
         return EAGAIN;
 
     return buffer.read_buffered<128>(size, [&](ReadonlyBytes bytes) {
-        for (const auto& byte : bytes)
+        for (auto const& byte : bytes)
             put_char(byte);
         return bytes.size();
     });

--- a/Kernel/Devices/Storage/ATA/AHCI/Definitions.h
+++ b/Kernel/Devices/Storage/ATA/AHCI/Definitions.h
@@ -197,7 +197,7 @@ public:
 
 private:
     u32 volatile& m_bitfield;
-    const u32 m_bit_mask;
+    u32 const m_bit_mask;
 };
 
 enum Limits : u16 {

--- a/Kernel/Devices/Storage/ATA/ATADevice.h
+++ b/Kernel/Devices/Storage/ATA/ATADevice.h
@@ -39,8 +39,8 @@ protected:
     ATADevice(ATAController const&, Address, u16, u16, u64);
 
     LockWeakPtr<ATAController> m_controller;
-    const Address m_ata_address;
-    const u16 m_capabilities;
+    Address const m_ata_address;
+    u16 const m_capabilities;
 };
 
 }

--- a/Kernel/Devices/Storage/ATA/ATAPort.h
+++ b/Kernel/Devices/Storage/ATA/ATAPort.h
@@ -148,7 +148,7 @@ protected:
     RefPtr<Memory::PhysicalPage> m_prdt_page;
     RefPtr<Memory::PhysicalPage> m_dma_buffer_page;
 
-    const u8 m_port_index;
+    u8 const m_port_index;
     Vector<NonnullLockRefPtr<ATADevice>> m_ata_devices;
     NonnullOwnPtr<KBuffer> m_ata_identify_data_buffer;
     NonnullLockRefPtr<ATAController> m_parent_ata_controller;

--- a/Kernel/Devices/Storage/SD/SDHostController.cpp
+++ b/Kernel/Devices/Storage/SD/SDHostController.cpp
@@ -157,7 +157,7 @@ ErrorOr<NonnullLockRefPtr<SDMemoryCard>> SDHostController::try_initialize_insert
     // 2. Send CMD8 (SEND_IF_COND) to the card
     // SD interface condition: 7:0 = check pattern, 11:8 = supply voltage
     //      0x1aa: check pattern = 10101010, supply voltage = 1 => 2.7-3.6V
-    const u32 voltage_window = 0x1aa;
+    u32 const voltage_window = 0x1aa;
     TRY(issue_command(SD::Commands::send_if_cond, voltage_window));
     auto interface_condition_response = wait_for_response();
 
@@ -456,14 +456,14 @@ ErrorOr<void> SDHostController::sd_clock_supply(u32 frequency)
     VERIFY((m_registers->host_configuration_1 & sd_clock_enable) == 0);
 
     // 1. Find out the divisor to determine the SD Clock Frequency
-    const u32 sd_clock_frequency = TRY(retrieve_sd_clock_frequency());
+    u32 const sd_clock_frequency = TRY(retrieve_sd_clock_frequency());
     u32 divisor = TRY(calculate_sd_clock_divisor(sd_clock_frequency, frequency));
 
     // 2. Set Internal Clock Enable and SDCLK Frequency Select in the Clock Control register
-    const u32 eight_lower_bits_of_sdclk_frequency_select = (divisor & 0xff) << 8;
+    u32 const eight_lower_bits_of_sdclk_frequency_select = (divisor & 0xff) << 8;
     u32 sdclk_frequency_select = eight_lower_bits_of_sdclk_frequency_select;
     if (host_version() == SD::HostVersion::Version3) {
-        const u32 two_upper_bits_of_sdclk_frequency_select = (divisor >> 8 & 0x3) << 6;
+        u32 const two_upper_bits_of_sdclk_frequency_select = (divisor >> 8 & 0x3) << 6;
         sdclk_frequency_select |= two_upper_bits_of_sdclk_frequency_select;
     }
     m_registers->host_configuration_1 = (m_registers->host_configuration_1 & ~sd_clock_divisor_mask) | internal_clock_enable | sdclk_frequency_select;
@@ -958,7 +958,7 @@ ErrorOr<u32> SDHostController::retrieve_sd_clock_frequency()
         // If these bits are all 0, the Host System has to get information via another method
         TODO();
     }
-    const i64 one_mhz = 1'000'000;
+    i64 const one_mhz = 1'000'000;
     return { m_registers->capabilities.base_clock_frequency * one_mhz };
 }
 

--- a/Kernel/Devices/TTY/SlavePTY.cpp
+++ b/Kernel/Devices/TTY/SlavePTY.cpp
@@ -67,7 +67,7 @@ void SlavePTY::echo(u8 ch)
 void SlavePTY::on_master_write(UserOrKernelBuffer const& buffer, size_t size)
 {
     auto result = buffer.read_buffered<128>(size, [&](ReadonlyBytes data) {
-        for (const auto& byte : data)
+        for (auto const& byte : data)
             emit(byte, false);
         return data.size();
     });

--- a/Kernel/Devices/TTY/TTY.cpp
+++ b/Kernel/Devices/TTY/TTY.cpp
@@ -89,7 +89,7 @@ ErrorOr<size_t> TTY::write(OpenFileDescription&, u64, UserOrKernelBuffer const& 
     return buffer.read_buffered<num_chars>(size, [&](ReadonlyBytes bytes) -> ErrorOr<size_t> {
         u8 modified_data[num_chars * 2];
         size_t modified_data_size = 0;
-        for (const auto& byte : bytes) {
+        for (auto const& byte : bytes) {
             process_output(byte, [&modified_data, &modified_data_size](u8 out_ch) {
                 modified_data[modified_data_size++] = out_ch;
             });

--- a/Kernel/Devices/TTY/VirtualConsole.cpp
+++ b/Kernel/Devices/TTY/VirtualConsole.cpp
@@ -285,7 +285,7 @@ ErrorOr<size_t> VirtualConsole::on_tty_write(UserOrKernelBuffer const& data, siz
 {
     SpinlockLocker global_lock(ConsoleManagement::the().tty_write_lock());
     auto result = data.read_buffered<512>(size, [&](ReadonlyBytes buffer) {
-        for (const auto& byte : buffer)
+        for (auto const& byte : buffer)
             m_console_impl.on_input(byte);
         return buffer.size();
     });

--- a/Kernel/FileSystem/MountFile.cpp
+++ b/Kernel/FileSystem/MountFile.cpp
@@ -54,7 +54,7 @@ ErrorOr<void> MountFile::ioctl(OpenFileDescription&, unsigned request, Userspace
             if ((mount_specific_data.value_type == MountSpecificFlag::ValueType::SignedInteger || mount_specific_data.value_type == MountSpecificFlag::ValueType::UnsignedInteger) && mount_specific_data.value_length != 8)
                 return EDOM;
 
-            Syscall::StringArgument user_key_string { reinterpret_cast<const char*>(mount_specific_data.key_string_addr), static_cast<size_t>(mount_specific_data.key_string_length) };
+            Syscall::StringArgument user_key_string { reinterpret_cast<char const*>(mount_specific_data.key_string_addr), static_cast<size_t>(mount_specific_data.key_string_length) };
             auto key_string = TRY(Process::get_syscall_name_string_fixed_buffer<MOUNT_SPECIFIC_FLAG_KEY_STRING_MAX_LENGTH>(user_key_string));
 
             if (mount_specific_data.value_type != MountSpecificFlag::ValueType::Boolean && mount_specific_data.value_length == 0)

--- a/Kernel/FileSystem/Plan9FS/FileSystem.h
+++ b/Kernel/FileSystem/Plan9FS/FileSystem.h
@@ -69,7 +69,7 @@ private:
     struct ReceiveCompletion final : public AtomicRefCounted<ReceiveCompletion> {
         mutable Spinlock<LockRank::None> lock {};
         bool completed { false };
-        const u16 tag;
+        u16 const tag;
         OwnPtr<Plan9FSMessage> message;
         ErrorOr<void> result;
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.cpp
@@ -45,13 +45,13 @@ ErrorOr<void> SysFSDiskUsage::try_generate(KBufferBuilder& builder)
             TRY(fs_object.add("source"sv, "unknown"));
         } else {
             if (fs.is_file_backed()) {
-                auto& file = static_cast<const FileBackedFileSystem&>(fs).file();
+                auto& file = static_cast<FileBackedFileSystem const&>(fs).file();
                 if (file.is_loop_device()) {
                     auto& device = static_cast<LoopDevice const&>(file);
                     auto path = TRY(device.custody().try_serialize_absolute_path());
                     TRY(fs_object.add("source"sv, path->view()));
                 } else {
-                    auto pseudo_path = TRY(static_cast<const FileBackedFileSystem&>(fs).file_description().pseudo_path());
+                    auto pseudo_path = TRY(static_cast<FileBackedFileSystem const&>(fs).file_description().pseudo_path());
                     TRY(fs_object.add("source"sv, pseudo_path->view()));
                 }
             } else {

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
@@ -114,7 +114,7 @@ ErrorOr<void> SysFSOverallProcesses::try_generate(KBufferBuilder& builder)
         TRY(process_object.add("dumpable"sv, process.is_dumpable()));
         TRY(process_object.add("kernel"sv, process.is_kernel_process()));
         auto thread_array = TRY(process_object.add_array("threads"sv));
-        TRY(process.try_for_each_thread([&](const Thread& thread) -> ErrorOr<void> {
+        TRY(process.try_for_each_thread([&](Thread const& thread) -> ErrorOr<void> {
             SpinlockLocker locker(thread.get_lock());
             auto thread_object = TRY(thread_array.add_object());
 #if LOCK_DEBUG

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -33,7 +33,7 @@ static constexpr size_t KMALLOC_DEFAULT_ALIGNMENT = 16;
 __attribute__((section(".heap"))) static u8 initial_kmalloc_memory[INITIAL_KMALLOC_MEMORY_SIZE];
 
 namespace std {
-const nothrow_t nothrow;
+nothrow_t const nothrow;
 }
 
 // FIXME: Figure out whether this can be MemoryManager.

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -38,7 +38,7 @@ struct nothrow_t {
     explicit nothrow_t() = default;
 };
 
-extern const nothrow_t nothrow;
+extern nothrow_t const nothrow;
 
 enum class align_val_t : size_t {};
 };

--- a/Kernel/Library/StdLib.cpp
+++ b/Kernel/Library/StdLib.cpp
@@ -213,7 +213,7 @@ ErrorOr<void> memset_user(void* dest_ptr, int c, size_t n)
 // See https://bugs.llvm.org/show_bug.cgi?id=39634
 FlatPtr missing_got_workaround()
 {
-    extern volatile FlatPtr _GLOBAL_OFFSET_TABLE_;
+    extern FlatPtr volatile _GLOBAL_OFFSET_TABLE_;
     return _GLOBAL_OFFSET_TABLE_;
 }
 #endif

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -624,7 +624,7 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
         rtentry route;
         TRY(copy_from_user(&route, user_route));
 
-        Userspace<const char*> user_rt_dev((FlatPtr)route.rt_dev);
+        Userspace<char const*> user_rt_dev((FlatPtr)route.rt_dev);
         auto ifname = TRY(Process::get_syscall_name_string_fixed_buffer<IFNAMSIZ>(user_rt_dev));
         auto adapter = NetworkingManagement::the().lookup_by_name(ifname.representable_view());
         if (!adapter)

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -51,22 +51,22 @@ protected:
     virtual StringView class_name() const override { return "E1000NetworkAdapter"sv; }
 
     struct [[gnu::packed]] e1000_rx_desc {
-        volatile uint64_t addr { 0 };
-        volatile uint16_t length { 0 };
-        volatile uint16_t checksum { 0 };
-        volatile uint8_t status { 0 };
-        volatile uint8_t errors { 0 };
-        volatile uint16_t special { 0 };
+        uint64_t volatile addr { 0 };
+        uint16_t volatile length { 0 };
+        uint16_t volatile checksum { 0 };
+        uint8_t volatile status { 0 };
+        uint8_t volatile errors { 0 };
+        uint16_t volatile special { 0 };
     };
 
     struct [[gnu::packed]] e1000_tx_desc {
-        volatile uint64_t addr { 0 };
-        volatile uint16_t length { 0 };
-        volatile uint8_t cso { 0 };
-        volatile uint8_t cmd { 0 };
-        volatile uint8_t status { 0 };
-        volatile uint8_t css { 0 };
-        volatile uint16_t special { 0 };
+        uint64_t volatile addr { 0 };
+        uint16_t volatile length { 0 };
+        uint8_t volatile cso { 0 };
+        uint8_t volatile cmd { 0 };
+        uint8_t volatile status { 0 };
+        uint8_t volatile css { 0 };
+        uint16_t volatile special { 0 };
     };
 
     virtual void detect_eeprom();

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -340,9 +340,9 @@ void send_tcp_rst(IPv4Packet const& ipv4_packet, TCPPacket const& tcp_packet, Re
 
     auto ipv4_payload_offset = routing_decision.adapter->ipv4_payload_offset();
 
-    const size_t options_size = 0;
-    const size_t tcp_header_size = sizeof(TCPPacket) + options_size;
-    const size_t buffer_size = ipv4_payload_offset + tcp_header_size;
+    size_t const options_size = 0;
+    size_t const tcp_header_size = sizeof(TCPPacket) + options_size;
+    size_t const buffer_size = ipv4_payload_offset + tcp_header_size;
 
     auto packet = routing_decision.adapter->acquire_packet_buffer(buffer_size);
     if (!packet)

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -50,12 +50,12 @@ private:
     bool determine_supported_version() const;
 
     struct [[gnu::packed]] TXDescriptor {
-        volatile u16 frame_length; // top 2 bits are reserved
-        volatile u16 flags;
-        volatile u16 vlan_tag;
-        volatile u16 vlan_flags;
-        volatile u32 buffer_address_low;
-        volatile u32 buffer_address_high;
+        u16 volatile frame_length; // top 2 bits are reserved
+        u16 volatile flags;
+        u16 volatile vlan_tag;
+        u16 volatile vlan_flags;
+        u32 volatile buffer_address_low;
+        u32 volatile buffer_address_high;
 
         // flags bit field
         static constexpr u16 Ownership = 0x8000u;
@@ -68,12 +68,12 @@ private:
     static_assert(AssertSize<TXDescriptor, 16u>());
 
     struct [[gnu::packed]] RXDescriptor {
-        volatile u16 buffer_size; // top 2 bits are reserved
-        volatile u16 flags;
-        volatile u16 vlan_tag;
-        volatile u16 vlan_flags;
-        volatile u32 buffer_address_low;
-        volatile u32 buffer_address_high;
+        u16 volatile buffer_size; // top 2 bits are reserved
+        u16 volatile flags;
+        u16 volatile vlan_tag;
+        u16 volatile vlan_flags;
+        u32 volatile buffer_address_low;
+        u32 volatile buffer_address_high;
 
         // flags bit field
         static constexpr u16 Ownership = 0x8000u;

--- a/Kernel/Net/Routing.h
+++ b/Kernel/Net/Routing.h
@@ -34,10 +34,10 @@ struct Route final : public AtomicRefCounted<Route> {
         return destination == other.destination && (gateway == other.gateway || other.gateway.is_zero()) && netmask == other.netmask && flags == other.flags && adapter.ptr() == other.adapter.ptr();
     }
 
-    const IPv4Address destination;
-    const IPv4Address gateway;
-    const IPv4Address netmask;
-    const u16 flags;
+    IPv4Address const destination;
+    IPv4Address const gateway;
+    IPv4Address const netmask;
+    u16 const flags;
     NonnullRefPtr<NetworkAdapter> const adapter;
 
     IntrusiveListNode<Route, RefPtr<Route>> route_list_node {};

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -733,7 +733,7 @@ void TCPSocket::retransmit_packets()
             packet.tx_counter++;
 
             if constexpr (TCP_SOCKET_DEBUG) {
-                auto& tcp_packet = *(const TCPPacket*)(packet.buffer->buffer->data() + packet.ipv4_payload_offset);
+                auto& tcp_packet = *(TCPPacket const*)(packet.buffer->buffer->data() + packet.ipv4_payload_offset);
                 dbgln("Sending TCP packet from {}:{} to {}:{} with ({}{}{}{}) seq_no={}, ack_no={}, tx_counter={}",
                     local_address(), local_port(),
                     peer_address(), peer_port(),

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -91,7 +91,7 @@ ErrorOr<size_t> UDPSocket::protocol_send(UserOrKernelBuffer const& data, size_t 
         return set_so_error(EHOSTUNREACH);
     auto ipv4_payload_offset = routing_decision.adapter->ipv4_payload_offset();
     data_length = min(data_length, routing_decision.adapter->mtu() - ipv4_payload_offset - sizeof(UDPPacket));
-    const size_t udp_buffer_size = sizeof(UDPPacket) + data_length;
+    size_t const udp_buffer_size = sizeof(UDPPacket) + data_length;
     auto packet = routing_decision.adapter->acquire_packet_buffer(ipv4_payload_offset + udp_buffer_size);
     if (!packet)
         return set_so_error(ENOMEM);

--- a/Kernel/Prekernel/UBSanitizer.cpp
+++ b/Kernel/Prekernel/UBSanitizer.cpp
@@ -130,8 +130,8 @@ void __ubsan_handle_implicit_conversion(ImplicitConversionData const& data, Valu
     print_location(data.location);
 }
 
-void __ubsan_handle_invalid_builtin(const InvalidBuiltinData) __attribute__((used));
-void __ubsan_handle_invalid_builtin(const InvalidBuiltinData data)
+void __ubsan_handle_invalid_builtin(InvalidBuiltinData const) __attribute__((used));
+void __ubsan_handle_invalid_builtin(InvalidBuiltinData const data)
 {
     print_location(data.location);
 }

--- a/Kernel/Security/UBSanitizer.cpp
+++ b/Kernel/Security/UBSanitizer.cpp
@@ -188,8 +188,8 @@ void __ubsan_handle_implicit_conversion(ImplicitConversionData const& data, Valu
     print_location(data.location);
 }
 
-void __ubsan_handle_invalid_builtin(const InvalidBuiltinData) __attribute__((used));
-void __ubsan_handle_invalid_builtin(const InvalidBuiltinData data)
+void __ubsan_handle_invalid_builtin(InvalidBuiltinData const) __attribute__((used));
+void __ubsan_handle_invalid_builtin(InvalidBuiltinData const data)
 {
     critical_dmesgln("KUBSAN: passing invalid argument");
     print_location(data.location);

--- a/Kernel/Syscalls/SyscallHandler.cpp
+++ b/Kernel/Syscalls/SyscallHandler.cpp
@@ -31,7 +31,7 @@ struct HandlerMetadata {
 };
 
 #define __ENUMERATE_SYSCALL(sys_call, needs_lock) { bit_cast<Handler>(&Process::sys$##sys_call), needs_lock },
-static const HandlerMetadata s_syscall_table[] = {
+static HandlerMetadata const s_syscall_table[] = {
     ENUMERATE_SYSCALLS(__ENUMERATE_SYSCALL)
 };
 #undef __ENUMERATE_SYSCALL

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -526,7 +526,7 @@ public:
 
     private:
         NonnullRefPtr<OpenFileDescription> m_blocked_description;
-        const BlockFlags m_flags;
+        BlockFlags const m_flags;
         BlockFlags& m_unblocked_flags;
         bool m_did_unblock { false };
     };

--- a/Userland/Applications/3DFileViewer/Mesh.cpp
+++ b/Userland/Applications/3DFileViewer/Mesh.cpp
@@ -13,7 +13,7 @@
 
 #include "Mesh.h"
 
-const Color colors[] {
+Color const colors[] {
     Color::Red,
     Color::Green,
     Color::Blue,
@@ -36,17 +36,17 @@ void Mesh::draw(float uv_scale)
     for (u32 i = 0; i < m_triangle_list.size(); i++) {
         auto const& triangle = m_triangle_list[i];
 
-        const FloatVector3 vertex_a(
+        FloatVector3 const vertex_a(
             m_vertex_list.at(triangle.a).x,
             m_vertex_list.at(triangle.a).y,
             m_vertex_list.at(triangle.a).z);
 
-        const FloatVector3 vertex_b(
+        FloatVector3 const vertex_b(
             m_vertex_list.at(triangle.b).x,
             m_vertex_list.at(triangle.b).y,
             m_vertex_list.at(triangle.b).z);
 
-        const FloatVector3 vertex_c(
+        FloatVector3 const vertex_c(
             m_vertex_list.at(triangle.c).x,
             m_vertex_list.at(triangle.c).y,
             m_vertex_list.at(triangle.c).z);
@@ -70,8 +70,8 @@ void Mesh::draw(float uv_scale)
 
         } else {
             // Compute the triangle normal
-            const FloatVector3 vec_ab = vertex_b - vertex_a;
-            const FloatVector3 vec_ac = vertex_c - vertex_a;
+            FloatVector3 const vec_ab = vertex_b - vertex_a;
+            FloatVector3 const vec_ac = vertex_c - vertex_a;
             normal_a = vec_ab.cross(vec_ac).normalized();
             normal_b = normal_a;
             normal_c = normal_a;

--- a/Userland/Applications/Calendar/CalendarWidget.cpp
+++ b/Userland/Applications/Calendar/CalendarWidget.cpp
@@ -299,7 +299,7 @@ ErrorOr<NonnullRefPtr<GUI::Action>> CalendarWidget::create_open_settings_action(
 void CalendarWidget::create_on_tile_doubleclick()
 {
     m_event_calendar->on_tile_doubleclick = [&] {
-        for (const auto& event : m_event_calendar->event_manager().events()) {
+        for (auto const& event : m_event_calendar->event_manager().events()) {
             auto start = event.start;
             auto selected_date = m_event_calendar->selected_date();
 

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -248,14 +248,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         VERIFY(optional_regs.has_value());
-        const PtraceRegisters& regs = optional_regs.value();
+        PtraceRegisters const& regs = optional_regs.value();
 #if ARCH(X86_64)
-        const FlatPtr ip = regs.rip;
+        FlatPtr const ip = regs.rip;
 #elif ARCH(AARCH64)
-        const FlatPtr ip = 0; // FIXME
+        FlatPtr const ip = 0; // FIXME
         TODO_AARCH64();
 #elif ARCH(RISCV64)
-        const FlatPtr ip = 0; // FIXME
+        FlatPtr const ip = 0; // FIXME
         TODO_RISCV64();
 #else
 #    error Unknown architecture

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -97,7 +97,7 @@ void KeyboardMapperWidget::create_frame()
     bottom_widget.add_spacer();
 }
 
-void KeyboardMapperWidget::add_map_radio_button(const StringView map_name, String button_text)
+void KeyboardMapperWidget::add_map_radio_button(StringView const map_name, String button_text)
 {
     auto& map_radio_button = m_map_group->add<GUI::RadioButton>(button_text);
     map_radio_button.set_name(map_name);
@@ -106,7 +106,7 @@ void KeyboardMapperWidget::add_map_radio_button(const StringView map_name, Strin
     };
 }
 
-u32* KeyboardMapperWidget::map_from_name(const StringView map_name)
+u32* KeyboardMapperWidget::map_from_name(StringView const map_name)
 {
     u32* map;
     if (map_name == "map"sv) {
@@ -234,7 +234,7 @@ void KeyboardMapperWidget::keyup_event(GUI::KeyEvent& event)
     }
 }
 
-void KeyboardMapperWidget::set_current_map(const ByteString current_map)
+void KeyboardMapperWidget::set_current_map(ByteString const current_map)
 {
     m_current_map_name = current_map;
     u32* map = map_from_name(m_current_map_name);

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
@@ -31,7 +31,7 @@ protected:
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void keyup_event(GUI::KeyEvent&) override;
 
-    void set_current_map(const ByteString);
+    void set_current_map(ByteString const);
     void update_window_title();
 
 private:
@@ -39,8 +39,8 @@ private:
 
     Vector<KeyButton*> m_keys;
     RefPtr<GUI::Widget> m_map_group;
-    void add_map_radio_button(const StringView map_name, String button_text);
-    u32* map_from_name(const StringView map_name);
+    void add_map_radio_button(StringView const map_name, String button_text);
+    u32* map_from_name(StringView const map_name);
     void update_modifier_radio_buttons(GUI::KeyEvent&);
 
     ByteString m_filename;

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -475,7 +475,7 @@ void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
 
     auto& body_data = fetch_response_data.body_data();
     auto body_text_part_iterator = body_data.find_if([](Tuple<IMAP::FetchCommand::DataItem, ByteString>& data) {
-        const auto data_item = data.get<0>();
+        auto const data_item = data.get<0>();
         return data_item.section.has_value() && data_item.section->type == IMAP::FetchCommand::DataItem::SectionType::Parts;
     });
     VERIFY(body_text_part_iterator != body_data.end());

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -51,10 +51,10 @@ constexpr KeyColor key_pattern[] = {
     White,
 };
 
-const Color note_pressed_color(64, 64, 255);
-const Color column_playing_color(128, 128, 255);
+Color const note_pressed_color(64, 64, 255);
+Color const column_playing_color(128, 128, 255);
 
-const Color left_wave_colors[] = {
+Color const left_wave_colors[] = {
     // Sine
     {
         255,
@@ -96,7 +96,7 @@ const Color left_wave_colors[] = {
 // HACK: make the display code shut up for now
 constexpr int RecordedSample = 5;
 
-const Color right_wave_colors[] = {
+Color const right_wave_colors[] = {
     // Sine
     {
         255,

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -237,8 +237,8 @@ void RollWidget::mousemove_event(GUI::MouseEvent& event)
         int const x_start = get_note_for_x(m_mousedown_event.value().x());
         int const x_end = get_note_for_x(event.x());
 
-        const u32 on_sample = round(roll_length * (static_cast<double>(min(x_start, x_end)) / m_num_notes));
-        const u32 off_sample = round(roll_length * (static_cast<double>(max(x_start, x_end) + 1) / m_num_notes)) - 1;
+        u32 const on_sample = round(roll_length * (static_cast<double>(min(x_start, x_end)) / m_num_notes));
+        u32 const off_sample = round(roll_length * (static_cast<double>(max(x_start, x_end) + 1) / m_num_notes)) - 1;
         auto const note = RollNote { on_sample, off_sample, get_pitch_for_y(m_mousedown_event.value().y()), 127 };
 
         m_track_manager.current_track()->set_note(note);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -248,8 +248,8 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
         }
 
         // Mouse position indicator
-        const Gfx::IntPoint indicator_x({ m_mouse_position.x(), m_ruler_thickness });
-        const Gfx::IntPoint indicator_y({ m_ruler_thickness, m_mouse_position.y() });
+        Gfx::IntPoint const indicator_x({ m_mouse_position.x(), m_ruler_thickness });
+        Gfx::IntPoint const indicator_y({ m_ruler_thickness, m_mouse_position.y() });
         painter.draw_triangle(indicator_x, indicator_x + Gfx::IntPoint(-m_mouse_indicator_triangle_size, -m_mouse_indicator_triangle_size), indicator_x + Gfx::IntPoint(m_mouse_indicator_triangle_size, -m_mouse_indicator_triangle_size), mouse_indicator_color);
         painter.draw_triangle(indicator_y, indicator_y + Gfx::IntPoint(-m_mouse_indicator_triangle_size, -m_mouse_indicator_triangle_size), indicator_y + Gfx::IntPoint(-m_mouse_indicator_triangle_size, m_mouse_indicator_triangle_size), mouse_indicator_color);
 
@@ -276,15 +276,15 @@ int ImageEditor::calculate_ruler_step_size() const
 
 Gfx::IntRect ImageEditor::mouse_indicator_rect_x() const
 {
-    const Gfx::IntPoint top_left({ m_ruler_thickness, m_ruler_thickness - m_mouse_indicator_triangle_size });
-    const Gfx::IntSize size({ width() + 1, m_mouse_indicator_triangle_size + 1 });
+    Gfx::IntPoint const top_left({ m_ruler_thickness, m_ruler_thickness - m_mouse_indicator_triangle_size });
+    Gfx::IntSize const size({ width() + 1, m_mouse_indicator_triangle_size + 1 });
     return Gfx::IntRect(top_left, size);
 }
 
 Gfx::IntRect ImageEditor::mouse_indicator_rect_y() const
 {
-    const Gfx::IntPoint top_left({ m_ruler_thickness - m_mouse_indicator_triangle_size, m_ruler_thickness });
-    const Gfx::IntSize size({ m_mouse_indicator_triangle_size + 1, height() + 1 });
+    Gfx::IntPoint const top_left({ m_ruler_thickness - m_mouse_indicator_triangle_size, m_ruler_thickness });
+    Gfx::IntSize const size({ m_mouse_indicator_triangle_size + 1, height() + 1 });
     return Gfx::IntRect(top_left, size);
 }
 

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -343,7 +343,7 @@ void GradientTool::calculate_gradient_lines()
     m_editor->update();
 }
 
-void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, const Gfx::FloatPoint drawing_offset, float scale, Optional<Gfx::IntRect const&> gradient_clip)
+void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, Gfx::FloatPoint const drawing_offset, float scale, Optional<Gfx::IntRect const&> gradient_clip)
 {
     auto t_gradient_begin_line = m_gradient_begin_line.scaled(scale, scale).translated(drawing_offset);
     auto t_gradient_center_line = m_gradient_center_line.scaled(scale, scale).translated(drawing_offset);

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.h
@@ -72,7 +72,7 @@ private:
 
     void calculate_gradient_lines();
     void calculate_transversal_points(float scale_fraction);
-    void draw_gradient(GUI::Painter&, bool with_guidelines = false, const Gfx::FloatPoint drawing_offset = { 0.0f, 0.0f }, float scale = 1, Optional<Gfx::IntRect const&> gradient_clip = {});
+    void draw_gradient(GUI::Painter&, bool with_guidelines = false, Gfx::FloatPoint const drawing_offset = { 0.0f, 0.0f }, float scale = 1, Optional<Gfx::IntRect const&> gradient_clip = {});
     bool has_gradient_data() { return m_gradient_center.has_value() && m_gradient_end.has_value() && m_gradient_start.has_value(); }
     void move_gradient_position(Gfx::IntPoint const movement_delta);
     void rasterize_gradient();

--- a/Userland/Applications/SoundPlayer/Playlist.h
+++ b/Userland/Applications/SoundPlayer/Playlist.h
@@ -41,8 +41,8 @@ private:
     class BloomFilter {
     public:
         void reset() { m_bitmap = 0; }
-        void add(const StringView key) { m_bitmap |= mask_for_key(key); }
-        bool maybe_contains(const StringView key) const
+        void add(StringView const key) { m_bitmap |= mask_for_key(key); }
+        bool maybe_contains(StringView const key) const
         {
             auto mask = mask_for_key(key);
             return (m_bitmap & mask) == mask;

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -122,12 +122,12 @@ void TreeMapWidget::lay_out_children(TreeNode const& node, Gfx::IntRect const& r
     Gfx::IntRect canvas = rect;
     bool remaining_nodes_are_too_small = false;
     for (size_t i = 0; !remaining_nodes_are_too_small && i < node.num_children(); i++) {
-        const i64 i_node_area = node.child_at(i).area();
+        i64 const i_node_area = node.child_at(i).area();
         if (i_node_area == 0)
             break;
 
-        const size_t long_side_size = max(canvas.width(), canvas.height());
-        const size_t short_side_size = min(canvas.width(), canvas.height());
+        size_t const long_side_size = max(canvas.width(), canvas.height());
+        size_t const short_side_size = min(canvas.width(), canvas.height());
 
         size_t row_or_column_size = long_side_size * i_node_area / total_area;
         i64 node_area_sum = i_node_area;
@@ -163,7 +163,7 @@ void TreeMapWidget::lay_out_children(TreeNode const& node, Gfx::IntRect const& r
 
         // Paint the elements from 'i' up to and including 'k-1'.
         {
-            const size_t fixed_side_size = row_or_column_size;
+            size_t const fixed_side_size = row_or_column_size;
             i64 placement_area = node_area_sum;
             size_t main_dim = short_side_size;
 

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -163,7 +163,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 continue;
             }
 
-            const TreeNode* node = tree_map_widget.path_node(k);
+            TreeNode const* node = tree_map_widget.path_node(k);
 
             builder.append('/');
             builder.append(node->name());

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -145,7 +145,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
         type_list.set_model(*GUI::ItemListModel<ByteString>::create(g_types));
         type_list.set_should_hide_unnecessary_scrollbars(true);
         type_list.on_selection_change = [&] {
-            const auto& index = type_list.selection().first();
+            auto const& index = type_list.selection().first();
             if (!index.is_valid()) {
                 m_type = nullptr;
                 return;

--- a/Userland/Applications/Spreadsheet/Readers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.h
@@ -107,7 +107,7 @@ public:
         size_t index() const { return m_index; }
         size_t size() const { return m_xsv.headers().size(); }
 
-        using ConstIterator = AK::SimpleIterator<const Row, StringView const>;
+        using ConstIterator = AK::SimpleIterator<Row const, StringView const>;
         using Iterator = AK::SimpleIterator<Row, StringView>;
 
         constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
@@ -168,7 +168,7 @@ public:
         size_t m_index { 0 };
     };
 
-    const Row operator[](size_t index) const;
+    Row const operator[](size_t index) const;
     Row operator[](size_t index);
 
     Row at(size_t index) const;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -455,7 +455,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
             auto conditional_formats = obj.get_array("conditional_formats"sv);
             auto cformats = cell->conditional_formats();
             if (conditional_formats.has_value()) {
-                conditional_formats->for_each([&](const auto& fmt_val) {
+                conditional_formats->for_each([&](auto const& fmt_val) {
                     if (!fmt_val.is_object())
                         return IterationDecision::Continue;
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -193,7 +193,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto& sheet = *worksheet_ptr;
         auto& cells = sheet.selected_cells();
         VERIFY(!cells.is_empty());
-        const auto& data = GUI::Clipboard::the().fetch_data_and_type();
+        auto const& data = GUI::Clipboard::the().fetch_data_and_type();
         if (auto spreadsheet_data = data.metadata.get("text/x-spreadsheet-data"); spreadsheet_data.has_value()) {
             Vector<Spreadsheet::Position> source_positions, target_positions;
             auto lines = spreadsheet_data.value().split_view('\n');

--- a/Userland/Demos/Gradient/Gradient.cpp
+++ b/Userland/Demos/Gradient/Gradient.cpp
@@ -56,7 +56,7 @@ void Gradient::timer_event(Core::TimerEvent&)
 
 void Gradient::draw()
 {
-    const Color colors[] {
+    Color const colors[] {
         Color::Blue,
         Color::Cyan,
         Color::Green,
@@ -65,7 +65,7 @@ void Gradient::draw()
         Color::Yellow,
     };
 
-    const Orientation orientations[] {
+    Orientation const orientations[] {
         Gfx::Orientation::Horizontal,
         Gfx::Orientation::Vertical
     };

--- a/Userland/DevTools/HackStudio/ClassViewWidget.cpp
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.cpp
@@ -19,11 +19,11 @@ ClassViewWidget::ClassViewWidget()
     m_class_tree = add<GUI::TreeView>();
 
     m_class_tree->on_selection_change = [this] {
-        const auto& index = m_class_tree->selection().first();
+        auto const& index = m_class_tree->selection().first();
         if (!index.is_valid())
             return;
 
-        auto* node = static_cast<const ClassViewNode*>(index.internal_data());
+        auto* node = static_cast<ClassViewNode const*>(index.internal_data());
         if (!node->declaration)
             return;
 

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
@@ -81,7 +81,7 @@ DebugInfoWidget::DebugInfoWidget()
     variables_tab_widget.add_widget(build_registers_tab());
 
     m_backtrace_view->on_selection_change = [this] {
-        const auto& index = m_backtrace_view->selection().first();
+        auto const& index = m_backtrace_view->selection().first();
 
         if (!index.is_valid()) {
             return;

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -187,7 +187,7 @@ int Debugger::debugger_loop(Debug::DebugSession::DesiredInitialDebugeeState init
         }
         remove_temporary_breakpoints();
         VERIFY(optional_regs.has_value());
-        const PtraceRegisters& regs = optional_regs.value();
+        PtraceRegisters const& regs = optional_regs.value();
 
         auto source_position = m_debug_session->get_source_position(regs.ip());
         if (!source_position.has_value())

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -128,7 +128,7 @@ FindInFilesWidget::FindInFilesWidget()
     m_result_view = add<GUI::TableView>();
 
     m_result_view->on_activation = [](auto& index) {
-        auto& match = *(const Match*)index.internal_data();
+        auto& match = *(Match const*)index.internal_data();
         open_file(match.filename);
         current_editor().set_selection(match.range);
         current_editor().set_focus(true);

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -43,11 +43,11 @@ GitWidget::GitWidget()
         [this](auto const& file) { stage_file(file); },
         Gfx::Bitmap::load_from_file("/res/icons/16x16/plus.png"sv).release_value_but_fixme_should_propagate_errors());
     m_unstaged_files->on_selection_change = [this] {
-        const auto& index = m_unstaged_files->selection().first();
+        auto const& index = m_unstaged_files->selection().first();
         if (!index.is_valid())
             return;
 
-        const auto& selected = index.data().as_string();
+        auto const& selected = index.data().as_string();
         show_diff(selected);
     };
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1044,7 +1044,7 @@ void HackStudioWidget::initialize_debugger()
         m_project->root_path(),
         [this](PtraceRegisters const& regs) {
             VERIFY(Debugger::the().session());
-            const auto& debug_session = *Debugger::the().session();
+            auto const& debug_session = *Debugger::the().session();
             auto source_position = debug_session.get_source_position(regs.ip());
             if (!source_position.has_value()) {
                 dbgln("Could not find source position for address: {:p}", regs.ip());

--- a/Userland/DevTools/HackStudio/ProjectTemplate.h
+++ b/Userland/DevTools/HackStudio/ProjectTemplate.h
@@ -29,7 +29,7 @@ public:
     ByteString const& name() const { return m_name; }
     ByteString const& description() const { return m_description; }
     const GUI::Icon& icon() const { return m_icon; }
-    const ByteString content_path() const
+    ByteString const content_path() const
     {
         return LexicalPath::canonicalized_path(ByteString::formatted("{}/{}", templates_path(), m_id));
     }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -121,8 +121,8 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
         float hdx = h * cosf(phi);
         float hdy = h * sinf(phi);
 
-        const auto cos_pi_2_phi = cosf(float { M_PI_2 } - phi);
-        const auto sin_pi_2_phi = sinf(float { M_PI_2 } - phi);
+        auto const cos_pi_2_phi = cosf(float { M_PI_2 } - phi);
+        auto const sin_pi_2_phi = sinf(float { M_PI_2 } - phi);
 
         Gfx::FloatPoint A1(A.x() - (w1 / 2) * cos_pi_2_phi, A.y() - (w1 / 2) * sin_pi_2_phi);
         Gfx::FloatPoint B3(A.x() + (w1 / 2) * cos_pi_2_phi, A.y() + (w1 / 2) * sin_pi_2_phi);

--- a/Userland/Games/FlappyBug/Game.h
+++ b/Userland/Games/FlappyBug/Game.h
@@ -176,8 +176,8 @@ private:
     float m_difficulty {};
     float m_restart_cooldown {};
     NonnullRefPtr<Gfx::Bitmap> m_background_bitmap { Gfx::Bitmap::load_from_file("/res/graphics/flappybug/background.png"sv).release_value_but_fixme_should_propagate_errors() };
-    const Gfx::IntRect m_score_rect { 10, 10, 20, 20 };
-    const Gfx::IntRect m_text_rect { game_width / 2 - 80, game_height / 2 - 40, 160, 80 };
+    Gfx::IntRect const m_score_rect { 10, 10, 20, 20 };
+    Gfx::IntRect const m_text_rect { game_width / 2 - 80, game_height / 2 - 40, 160, 80 };
 
     Game(Bug, Cloud);
 };

--- a/Userland/Libraries/LibAudio/Resampler.h
+++ b/Userland/Libraries/LibAudio/Resampler.h
@@ -90,8 +90,8 @@ public:
     u32 target() const { return m_target; }
 
 private:
-    const u32 m_source;
-    const u32 m_target;
+    u32 const m_source;
+    u32 const m_target;
     u32 m_current_ratio { 0 };
     SampleType m_last_sample_l {};
     SampleType m_last_sample_r {};

--- a/Userland/Libraries/LibC/net.cpp
+++ b/Userland/Libraries/LibC/net.cpp
@@ -11,8 +11,8 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
-const in6_addr in6addr_any = IN6ADDR_ANY_INIT;
-const in6_addr in6addr_loopback = IN6ADDR_LOOPBACK_INIT;
+in6_addr const in6addr_any = IN6ADDR_ANY_INIT;
+in6_addr const in6addr_loopback = IN6ADDR_LOOPBACK_INIT;
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/if_nametoindex.html
 unsigned int if_nametoindex([[maybe_unused]] char const* ifname)

--- a/Userland/Libraries/LibC/qsort.cpp
+++ b/Userland/Libraries/LibC/qsort.cpp
@@ -31,7 +31,7 @@ template<>
 inline void swap(SizedObject const& a, SizedObject const& b)
 {
     VERIFY(a.size() == b.size());
-    const size_t size = a.size();
+    size_t const size = a.size();
     auto const a_data = reinterpret_cast<char*>(a.data());
     auto const b_data = reinterpret_cast<char*>(b.data());
     for (auto i = 0u; i < size; ++i) {
@@ -49,7 +49,7 @@ public:
         , m_element_size(element_size)
     {
     }
-    const SizedObject operator[](size_t index)
+    SizedObject const operator[](size_t index)
     {
         return { static_cast<char*>(m_data) + index * m_element_size, m_element_size };
     }

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -316,7 +316,7 @@ private:
         return invert ^ scan_set.contains(c);
     }
 
-    const StringView scan_set;
+    StringView const scan_set;
     bool invert { false };
 };
 

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -144,7 +144,7 @@ private:
         return m_sign != Sign::Negative;
     }
 
-    const T m_base;
+    T const m_base;
     T m_num;
     T m_cutoff;
     int m_max_digit_after_cutoff;
@@ -313,7 +313,7 @@ static T c_str_to_floating_point(char const* str, char** endptr)
     // - One of INF or INFINITY, ignoring case
     // - One of NAN or NAN(n-char-sequenceopt), ignoring case in the NAN part
 
-    const Sign sign = strtosign(parse_ptr, &parse_ptr);
+    Sign const sign = strtosign(parse_ptr, &parse_ptr);
 
     if (is_infinity_string(parse_ptr, endptr)) {
         // Don't set errno to ERANGE here:
@@ -973,7 +973,7 @@ long long strtoll(char const* str, char** endptr, int base)
     // Parse spaces and sign
     char* parse_ptr = const_cast<char*>(str);
     strtons(parse_ptr, &parse_ptr);
-    const Sign sign = strtosign(parse_ptr, &parse_ptr);
+    Sign const sign = strtosign(parse_ptr, &parse_ptr);
 
     // Parse base
     if (base == 0) {

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -103,7 +103,7 @@ public:
     bool is_disabled() const { return m_disabled; }
     Gfx::Color color() const { return (m_suit == Suit::Diamonds || m_suit == Suit::Hearts) ? Color::Red : Color::Black; }
 
-    void set_position(const Gfx::IntPoint p) { m_rect.set_location(p); }
+    void set_position(Gfx::IntPoint const p) { m_rect.set_location(p); }
     void set_moving(bool moving) { m_moving = moving; }
     void set_upside_down(bool upside_down) { m_upside_down = upside_down; }
     void set_inverted(bool inverted) { m_inverted = inverted; }

--- a/Userland/Libraries/LibChess/Chess.cpp
+++ b/Userland/Libraries/LibChess/Chess.cpp
@@ -116,7 +116,7 @@ ErrorOr<String> Move::to_long_algebraic() const
     return builder.to_string();
 }
 
-Move Move::from_algebraic(StringView algebraic, const Color turn, Board const& board)
+Move Move::from_algebraic(StringView algebraic, Color const turn, Board const& board)
 {
     auto move_string = algebraic;
     Move move({ 50, 50 }, { 50, 50 });
@@ -294,7 +294,7 @@ ErrorOr<String> Board::to_fen() const
     int empty = 0;
     for (int rank = 0; rank < 8; rank++) {
         for (int file = 0; file < 8; file++) {
-            const Piece p(get_piece({ 7 - rank, file }));
+            Piece const p(get_piece({ 7 - rank, file }));
             if (p.type == Type::None) {
                 empty++;
                 continue;

--- a/Userland/Libraries/LibChess/Chess.h
+++ b/Userland/Libraries/LibChess/Chess.h
@@ -117,7 +117,7 @@ struct Move {
     }
     bool operator==(Move const& other) const { return from == other.from && to == other.to && promote_to == other.promote_to; }
 
-    static Move from_algebraic(StringView algebraic, const Color turn, Board const& board);
+    static Move from_algebraic(StringView algebraic, Color const turn, Board const& board);
     ErrorOr<String> to_long_algebraic() const;
     ErrorOr<String> to_algebraic() const;
 };

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
@@ -206,7 +206,7 @@ Vector<StringView> CppComprehensionEngine::scope_of_reference_to_symbol(ASTNode 
     return scope_parts;
 }
 
-Vector<CodeComprehension::AutocompleteResultEntry> CppComprehensionEngine::autocomplete_property(DocumentData const& document, MemberExpression const& parent, const ByteString partial_text) const
+Vector<CodeComprehension::AutocompleteResultEntry> CppComprehensionEngine::autocomplete_property(DocumentData const& document, MemberExpression const& parent, ByteString const partial_text) const
 {
     VERIFY(parent.object());
     auto type = type_of(document, *parent.object());

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.h
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.h
@@ -95,7 +95,7 @@ private:
         HashTable<ByteString> m_available_headers;
     };
 
-    Vector<CodeComprehension::AutocompleteResultEntry> autocomplete_property(DocumentData const&, MemberExpression const&, const ByteString partial_text) const;
+    Vector<CodeComprehension::AutocompleteResultEntry> autocomplete_property(DocumentData const&, MemberExpression const&, ByteString const partial_text) const;
     Vector<AutocompleteResultEntry> autocomplete_name(DocumentData const&, ASTNode const&, ByteString const& partial_text) const;
     ByteString type_of(DocumentData const&, Expression const&) const;
     ByteString type_of_property(DocumentData const&, Identifier const&) const;

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -532,7 +532,7 @@ void DeflateCompressor::close()
 // Knuth's multiplicative hash on 4 bytes
 u16 DeflateCompressor::hash_sequence(u8 const* bytes)
 {
-    constexpr const u32 knuth_constant = 2654435761; // shares no common factors with 2^32
+    constexpr u32 const knuth_constant = 2654435761; // shares no common factors with 2^32
     return ((bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24) * knuth_constant) >> (32 - hash_bits);
 }
 

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -25,7 +25,7 @@ ErrorOr<AllProcessesStatistics> ProcessStatisticsReader::get_all(SeekableStream&
     auto file_contents = TRY(proc_all_file.read_until_eof());
     auto json_obj = TRY(JsonValue::from_string(file_contents)).as_object();
     json_obj.get_array("processes"sv)->for_each([&](auto& value) {
-        const JsonObject& process_object = value.as_object();
+        JsonObject const& process_object = value.as_object();
         Core::ProcessStatistics process;
 
         // kernel data first

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -146,7 +146,7 @@ Optional<FlatPtr> Reader::peek_memory(FlatPtr address) const
     return value;
 }
 
-const JsonObject Reader::process_info() const
+JsonObject const Reader::process_info() const
 {
     const ELF::Core::ProcessInfo* process_info_notes_entry = nullptr;
     NotesEntryIterator it(bit_cast<u8 const*>(m_coredump_image.program_header(m_notes_segment_index).raw_data()));

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -105,7 +105,7 @@ private:
     // Private as we don't need anyone poking around in this JsonObject
     // manually - we know very well what should be included and expose that
     // as getters with the appropriate (non-JsonValue) types.
-    const JsonObject process_info() const;
+    JsonObject const process_info() const;
 
     // For uncompressed coredumps, we keep the MappedFile
     OwnPtr<Core::MappedFile> m_mapped_file;

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -86,7 +86,7 @@ GHash::TagType GHash::process(ReadonlyBytes aad, ReadonlyBytes cipher)
 
 /// Galois Field multiplication using <x^127 + x^7 + x^2 + x + 1>.
 /// Note that x, y, and z are strictly BE.
-void galois_multiply(u32 (&z)[4], const u32 (&_x)[4], const u32 (&_y)[4])
+void galois_multiply(u32 (&z)[4], u32 const (&_x)[4], u32 const (&_y)[4])
 {
     u32 x[4] { _x[0], _x[1], _x[2], _x[3] };
     u32 y[4] { _y[0], _y[1], _y[2], _y[3] };

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.h
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.h
@@ -17,7 +17,7 @@
 
 namespace Crypto::Authentication {
 
-void galois_multiply(u32 (&z)[4], const u32 (&x)[4], const u32 (&y)[4]);
+void galois_multiply(u32 (&z)[4], u32 const (&x)[4], u32 const (&y)[4]);
 
 struct GHashDigest {
     constexpr static size_t Size = 16;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -545,8 +545,8 @@ u32 UnsignedBigInteger::hash() const
 
 void UnsignedBigInteger::set_bit_inplace(size_t bit_index)
 {
-    const size_t word_index = bit_index / UnsignedBigInteger::BITS_IN_WORD;
-    const size_t inner_word_index = bit_index % UnsignedBigInteger::BITS_IN_WORD;
+    size_t const word_index = bit_index / UnsignedBigInteger::BITS_IN_WORD;
+    size_t const inner_word_index = bit_index % UnsignedBigInteger::BITS_IN_WORD;
 
     m_words.ensure_capacity(word_index + 1);
 

--- a/Userland/Libraries/LibCrypto/Hash/BLAKE2b.cpp
+++ b/Userland/Libraries/LibCrypto/Hash/BLAKE2b.cpp
@@ -61,7 +61,7 @@ BLAKE2b::DigestType BLAKE2b::digest()
     return digest;
 }
 
-void BLAKE2b::increment_counter_by(const u64 amount)
+void BLAKE2b::increment_counter_by(u64 const amount)
 {
     m_internal_state.message_byte_offset[0] += amount;
     m_internal_state.message_byte_offset[1] += (m_internal_state.message_byte_offset[0] < amount);

--- a/Userland/Libraries/LibCrypto/Hash/BLAKE2b.h
+++ b/Userland/Libraries/LibCrypto/Hash/BLAKE2b.h
@@ -86,7 +86,7 @@ private:
     BLAKE2bState m_internal_state {};
 
     void mix(u64* work_vector, u64 a, u64 b, u64 c, u64 d, u64 x, u64 y);
-    void increment_counter_by(const u64 amount);
+    void increment_counter_by(u64 const amount);
     void transform(u8 const*);
 };
 

--- a/Userland/Libraries/LibDiff/Applier.cpp
+++ b/Userland/Libraries/LibDiff/Applier.cpp
@@ -81,7 +81,7 @@ static Optional<Location> locate_hunk(Vector<StringView> const& content, Hunk co
             line += prefix_fuzz;
 
             // Ensure that all of the lines in the hunk match starting from 'line', ignoring the specified number of context lines.
-            return all_of(hunk.lines.begin() + prefix_fuzz, hunk.lines.end() - suffix_fuzz, [&](const Line& hunk_line) {
+            return all_of(hunk.lines.begin() + prefix_fuzz, hunk.lines.end() - suffix_fuzz, [&](Line const& hunk_line) {
                 // Ignore additions in our increment of line and comparison as they are not part of the 'original file'
                 if (hunk_line.operation == Line::Operation::Addition)
                     return true;

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -439,7 +439,7 @@ static Optional<DlErrorMessage> verify_tls_for_dlopen(DynamicLoader const& loade
         if (program_header.type() != PT_TLS)
             return IterationDecision::Continue;
 
-        auto* tls_data = (const u8*)loader.image().base_address() + program_header.offset();
+        auto* tls_data = (u8 const*)loader.image().base_address() + program_header.offset();
         for (size_t i = 0; i < program_header.size_in_image(); ++i) {
             if (tls_data[i] != 0) {
                 tls_data_is_all_zero = false;

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -772,7 +772,7 @@ void DynamicLoader::copy_initial_tls_data_into(ByteBuffer& buffer) const
         VERIFY(program_header.size_in_image() <= program_header.size_in_memory());
         VERIFY(program_header.size_in_memory() <= m_tls_size_of_current_object);
         VERIFY(tls_start_in_buffer + program_header.size_in_memory() <= buffer.size());
-        memcpy(buffer.data() + tls_start_in_buffer, static_cast<const u8*>(m_file_data) + program_header.offset(), program_header.size_in_image());
+        memcpy(buffer.data() + tls_start_in_buffer, static_cast<u8 const*>(m_file_data) + program_header.offset(), program_header.size_in_image());
 
         return IterationDecision::Break;
     });

--- a/Userland/Libraries/LibELF/Hashes.h
+++ b/Userland/Libraries/LibELF/Hashes.h
@@ -22,7 +22,7 @@ constexpr u32 compute_sysv_hash(StringView name)
         hash = hash << 4;
         hash += ch;
 
-        const u32 top_nibble_of_hash = hash & 0xf0000000u;
+        u32 const top_nibble_of_hash = hash & 0xf0000000u;
         hash ^= top_nibble_of_hash >> 24;
         hash &= ~top_nibble_of_hash;
     }

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.h
@@ -47,7 +47,7 @@ private:
     virtual void resize_event(ResizeEvent&) override;
 
     struct Segment {
-        RefPtr<const Gfx::Bitmap> icon;
+        RefPtr<Gfx::Bitmap const> icon;
         ByteString text;
         ByteString data;
         int width { 0 };

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -29,7 +29,7 @@ public:
     void set_selected(bool selected);
     Color color() const { return m_color; }
 
-    Function<void(const Color)> on_click;
+    Function<void(Color const)> on_click;
 
 protected:
     virtual void click(unsigned modifiers = 0) override;

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -124,7 +124,7 @@ ComboBox::ComboBox()
     m_list_view->set_activates_on_selection(true);
     m_list_view->on_selection_change = [this] {
         VERIFY(model());
-        const auto& index = m_list_view->selection().first();
+        auto const& index = m_list_view->selection().first();
         if (m_updating_model)
             selection_updated(index);
     };

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -260,7 +260,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
         auto index = m_view->selection().first();
         auto& filter_model = (SortingProxyModel&)*m_view->model();
         auto local_index = filter_model.map_to_source(index);
-        const FileSystemModel::Node& node = m_model->node(local_index);
+        FileSystemModel::Node const& node = m_model->node(local_index);
 
         auto should_open_folder = m_mode == Mode::OpenFolder;
         if (should_open_folder == node.is_directory()) {
@@ -273,7 +273,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     m_view->on_activation = [this](auto& index) {
         auto& filter_model = (SortingProxyModel&)*m_view->model();
         auto local_index = filter_model.map_to_source(index);
-        const FileSystemModel::Node& node = m_model->node(local_index);
+        FileSystemModel::Node const& node = m_model->node(local_index);
         auto path = node.full_path();
 
         if (node.is_directory() || node.is_symlink_to_directory()) {

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -56,7 +56,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     quick_sort(m_families);
 
     m_family_list_view->on_selection_change = [this] {
-        const auto& index = m_family_list_view->selection().first();
+        auto const& index = m_family_list_view->selection().first();
         m_family = MUST(String::from_byte_string(index.data().to_byte_string()));
         m_variants.clear();
         Gfx::FontDatabase::the().for_each_typeface([&](auto& typeface) {
@@ -76,7 +76,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     };
 
     m_variant_list_view->on_selection_change = [this] {
-        const auto& index = m_variant_list_view->selection().first();
+        auto const& index = m_variant_list_view->selection().first();
         bool font_is_fixed_size = false;
         m_variant = MUST(String::from_byte_string(index.data().to_byte_string()));
         m_sizes.clear();
@@ -132,7 +132,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     };
 
     m_size_list_view->on_selection_change = [this] {
-        const auto& index = m_size_list_view->selection().first();
+        auto const& index = m_size_list_view->selection().first();
         auto size = index.data().to_i32();
         Optional<size_t> index_of_new_size_in_list = m_sizes.find_first_index(size);
         if (index_of_new_size_in_list.has_value()) {

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -537,7 +537,7 @@ void IconView::paint_event(PaintEvent& event)
 
         auto font = font_for_index(item_data.index);
 
-        const auto& text_rect = item_data.text_rect;
+        auto const& text_rect = item_data.text_rect;
 
         if (m_edit_index != item_data.index)
             painter.fill_rect(text_rect, background_color);
@@ -550,7 +550,7 @@ void IconView::paint_event(PaintEvent& event)
         if (!item_data.wrapped_text_lines.is_empty()) {
             // Item text would not fit in the item text rect, let's break it up into lines..
 
-            const auto& lines = item_data.wrapped_text_lines;
+            auto const& lines = item_data.wrapped_text_lines;
             size_t number_of_text_lines = min((size_t)text_rect.height() / font->pixel_size_rounded_up(), lines.size());
             size_t previous_line_lengths = 0;
             for (size_t line_index = 0; line_index < number_of_text_lines; ++line_index) {

--- a/Userland/Libraries/LibGUI/SeparatorWidget.h
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.h
@@ -25,7 +25,7 @@ private:
     virtual Optional<UISize> calculated_preferred_size() const override;
     virtual Optional<UISize> calculated_min_size() const override;
 
-    const Gfx::Orientation m_orientation;
+    Gfx::Orientation const m_orientation;
 };
 
 class VerticalSeparator final : public SeparatorWidget {

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -732,7 +732,7 @@ bool InsertTextCommand::merge_with(GUI::Command const& other)
 
 void InsertTextCommand::perform_formatting(TextDocument::Client const& client)
 {
-    const size_t tab_width = client.soft_tab_width();
+    size_t const tab_width = client.soft_tab_width();
     auto const& dest_line = m_document.line(m_range.start().line());
     bool const should_auto_indent = client.is_automatic_indentation_enabled();
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1947,7 +1947,7 @@ void TextEditor::did_change(AllowCallback allow_callback)
     if (on_change && allow_callback == AllowCallback::Yes)
         on_change();
 }
-void TextEditor::set_mode(const Mode mode)
+void TextEditor::set_mode(Mode const mode)
 {
     if (m_mode == mode)
         return;

--- a/Userland/Libraries/LibGUI/Toolbar.h
+++ b/Userland/Libraries/LibGUI/Toolbar.h
@@ -53,7 +53,7 @@ private:
     RefPtr<Menu> m_overflow_menu;
     RefPtr<Action> m_overflow_action;
     RefPtr<Button> m_overflow_button;
-    const Gfx::Orientation m_orientation;
+    Gfx::Orientation const m_orientation;
     int m_button_size { 24 };
     bool m_collapsible { false };
     bool m_grouped { false };

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -536,7 +536,7 @@ void TreeView::move_cursor(CursorMovement movement, SelectionUpdate selection_up
     if (!cursor_index().is_valid())
         set_cursor(model.index(0, model.tree_column(), cursor_index()), SelectionUpdate::Set);
 
-    auto find_last_index_in_tree = [&](const ModelIndex tree_index) -> ModelIndex {
+    auto find_last_index_in_tree = [&](ModelIndex const tree_index) -> ModelIndex {
         auto last_index = tree_index;
         size_t row_count = model.row_count(last_index);
         while (row_count > 0) {
@@ -555,7 +555,7 @@ void TreeView::move_cursor(CursorMovement movement, SelectionUpdate selection_up
         return last_index;
     };
 
-    auto step_up = [&](const ModelIndex current_index) -> ModelIndex {
+    auto step_up = [&](ModelIndex const current_index) -> ModelIndex {
         // Traverse into parent index if we're at the top of our subtree
         if (current_index.row() == 0) {
             auto parent_index = current_index.parent();
@@ -576,7 +576,7 @@ void TreeView::move_cursor(CursorMovement movement, SelectionUpdate selection_up
         return find_last_index_in_tree(previous_index);
     };
 
-    auto step_down = [&](const ModelIndex current_index) -> ModelIndex {
+    auto step_down = [&](ModelIndex const current_index) -> ModelIndex {
         if (!current_index.is_valid())
             return current_index;
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -215,7 +215,7 @@ public:
     bool focus_preempted() const { return m_focus_preempted; }
     void set_focus_preempted(bool b) { m_focus_preempted = b; }
 
-    Function<void(bool const, const FocusSource)> on_focus_change;
+    Function<void(bool const, FocusSource const)> on_focus_change;
 
     // Returns true if this widget or one of its descendants is focused.
     bool has_focus_within() const;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -57,7 +57,7 @@ public:
 
 private:
     NonnullRefPtr<Gfx::Bitmap> m_bitmap;
-    const i32 m_serial;
+    i32 const m_serial;
     Gfx::IntSize m_visible_size;
 };
 

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -268,7 +268,7 @@ Optional<Creator> parse_profile_creator(ICCHeader const& header)
 }
 
 template<size_t N>
-bool all_bytes_are_zero(const u8 (&bytes)[N])
+bool all_bytes_are_zero(u8 const (&bytes)[N])
 {
     for (u8 byte : bytes) {
         if (byte != 0)
@@ -1229,7 +1229,7 @@ Crypto::Hash::MD5::DigestType Profile::compute_id(ReadonlyBytes bytes)
     //  and profile ID field (bytes 84 to 99)
     //  in the profile header temporarily set to zeros (00h),
     //  shall be used to calculate the ID."
-    const u8 zero[16] = {};
+    u8 const zero[16] = {};
     Crypto::Hash::MD5 md5;
     md5.update(bytes.slice(0, 44));
     md5.update(ReadonlyBytes { zero, 4 }); // profile flags field

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPWriter.cpp
@@ -101,7 +101,7 @@ ErrorOr<ByteBuffer> BMPWriter::dump(Bitmap const& bitmap, Options options)
         m_include_alpha_channel = true;
     }
 
-    const size_t file_header_size = 14;
+    size_t const file_header_size = 14;
     size_t header_size = file_header_size + (u32)dib_header;
 
     int pixel_row_data_size = (m_bytes_per_pixel * 8 * bitmap.width() + 31) / 32 * 4;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossyTables.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossyTables.h
@@ -14,7 +14,7 @@ using Prob = u8;
 using TreeIndex = i8;
 
 // https://datatracker.ietf.org/doc/html/rfc6386#section-10 "Segment-Based Feature Adjustments"
-const TreeIndex MACROBLOCK_SEGMENT_TREE[2 * (4 - 1)] = {
+TreeIndex const MACROBLOCK_SEGMENT_TREE[2 * (4 - 1)] = {
     2, 4,   /* root: "0", "1" subtrees */
     -0, -1, /* "00" = 0th value, "01" = 1st value */
     -2, -3  /* "10" = 2nd value, "11" = 3rd value */

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -23,8 +23,8 @@ template<typename T>
 [[nodiscard]] Point<T> Point<T>::end_point_for_aspect_ratio(Point<T> const& previous_end_point, float aspect_ratio) const
 {
     VERIFY(aspect_ratio > 0);
-    const T x_sign = previous_end_point.x() >= x() ? 1 : -1;
-    const T y_sign = previous_end_point.y() >= y() ? 1 : -1;
+    T const x_sign = previous_end_point.x() >= x() ? 1 : -1;
+    T const y_sign = previous_end_point.y() >= y() ? 1 : -1;
     T dx = AK::abs(previous_end_point.x() - x());
     T dy = AK::abs(previous_end_point.y() - y());
     if (dx > dy) {

--- a/Userland/Libraries/LibIMAP/Objects.cpp
+++ b/Userland/Libraries/LibIMAP/Objects.cpp
@@ -160,7 +160,7 @@ ByteString SearchKey::serialize() const
             StringBuilder sb;
             sb.append('(');
             bool first = true;
-            for (const auto& item : x.keys) {
+            for (auto const& item : x.keys) {
                 if (!first)
                     sb.append(", "sv);
                 sb.append(item->serialize());

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -400,7 +400,7 @@ ALWAYS_INLINE bool Lexer::is_unicode_character() const
 
 ALWAYS_INLINE u32 Lexer::current_code_point() const
 {
-    static constexpr const u32 REPLACEMENT_CHARACTER = 0xFFFD;
+    static constexpr u32 const REPLACEMENT_CHARACTER = 0xFFFD;
     if (m_position == 0)
         return REPLACEMENT_CHARACTER;
     auto substring = m_source.substring_view(m_position - 1);

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -521,7 +521,7 @@ private:
     };
 
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
-    static constexpr const OperatorPrecedence m_operator_precedence[] = {
+    static constexpr OperatorPrecedence const m_operator_precedence[] = {
         { TokenType::Period, 20 },
         { TokenType::BracketOpen, 20 },
         { TokenType::ParenOpen, 20 },

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -17,7 +17,7 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(BigIntConstructor);
 
-static const Crypto::SignedBigInteger BIGINT_ONE { 1 };
+static Crypto::SignedBigInteger const BIGINT_ONE { 1 };
 
 BigIntConstructor::BigIntConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.BigInt.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -10,8 +10,8 @@
 
 namespace JS {
 
-constexpr const size_t SPARSE_ARRAY_HOLE_THRESHOLD = 200;
-constexpr const size_t LENGTH_SETTER_GENERIC_STORAGE_THRESHOLD = 4 * MiB;
+constexpr size_t const SPARSE_ARRAY_HOLE_THRESHOLD = 200;
+constexpr size_t const LENGTH_SETTER_GENERIC_STORAGE_THRESHOLD = 4 * MiB;
 
 SimpleIndexedPropertyStorage::SimpleIndexedPropertyStorage(Vector<Value>&& initial_values)
     : IndexedPropertyStorage(IsSimpleStorage::Yes)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -190,7 +190,7 @@ ThrowCompletionOr<BigInt*> add_instant(VM& vm, BigInt const& epoch_nanoseconds, 
 // 8.5.6 DifferenceInstant ( ns1, ns2, roundingIncrement, smallestUnit, largestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differenceinstant
 TimeDurationRecord difference_instant(VM& vm, BigInt const& nanoseconds1, BigInt const& nanoseconds2, u64 rounding_increment, StringView smallest_unit, StringView largest_unit, StringView rounding_mode)
 {
-    static const Crypto::UnsignedBigInteger BIGINT_ONE_THOUSAND { 1'000 };
+    static Crypto::UnsignedBigInteger const BIGINT_ONE_THOUSAND { 1'000 };
 
     // 1. Let difference be ℝ(ns2) - ℝ(ns1).
     auto difference = nanoseconds2.big_integer().minus(nanoseconds1.big_integer());

--- a/Userland/Libraries/LibJS/Runtime/ValueTraits.h
+++ b/Userland/Libraries/LibJS/Runtime/ValueTraits.h
@@ -37,7 +37,7 @@ struct ValueTraits : public Traits<Value> {
 
         return u64_hash(value.encoded()); // FIXME: Is this the best way to hash pointers, doubles & ints?
     }
-    static bool equals(const Value a, const Value b)
+    static bool equals(Value const a, Value const b)
     {
         return same_value_zero(a, b);
     }

--- a/Userland/Libraries/LibJS/Token.h
+++ b/Userland/Libraries/LibJS/Token.h
@@ -15,25 +15,25 @@ namespace JS {
 
 // U+2028 LINE SEPARATOR
 constexpr char const line_separator_chars[] { (char)0xe2, (char)0x80, (char)0xa8, 0 };
-constexpr const StringView LINE_SEPARATOR_STRING { line_separator_chars, sizeof(line_separator_chars) - 1 };
-constexpr const u32 LINE_SEPARATOR { 0x2028 };
+constexpr StringView const LINE_SEPARATOR_STRING { line_separator_chars, sizeof(line_separator_chars) - 1 };
+constexpr u32 const LINE_SEPARATOR { 0x2028 };
 
 // U+2029 PARAGRAPH SEPARATOR
 constexpr char const paragraph_separator_chars[] { (char)0xe2, (char)0x80, (char)0xa9, 0 };
-constexpr const StringView PARAGRAPH_SEPARATOR_STRING { paragraph_separator_chars, sizeof(paragraph_separator_chars) - 1 };
-constexpr const u32 PARAGRAPH_SEPARATOR { 0x2029 };
+constexpr StringView const PARAGRAPH_SEPARATOR_STRING { paragraph_separator_chars, sizeof(paragraph_separator_chars) - 1 };
+constexpr u32 const PARAGRAPH_SEPARATOR { 0x2029 };
 
 // U+00A0 NO BREAK SPACE
-constexpr const u32 NO_BREAK_SPACE { 0x00A0 };
+constexpr u32 const NO_BREAK_SPACE { 0x00A0 };
 
 // U+200C ZERO WIDTH NON-JOINER
-constexpr const u32 ZERO_WIDTH_NON_JOINER { 0x200C };
+constexpr u32 const ZERO_WIDTH_NON_JOINER { 0x200C };
 
 // U+FEFF ZERO WIDTH NO-BREAK SPACE
-constexpr const u32 ZERO_WIDTH_NO_BREAK_SPACE { 0xFEFF };
+constexpr u32 const ZERO_WIDTH_NO_BREAK_SPACE { 0xFEFF };
 
 // U+200D ZERO WIDTH JOINER
-constexpr const u32 ZERO_WIDTH_JOINER { 0x200D };
+constexpr u32 const ZERO_WIDTH_JOINER { 0x200D };
 
 #define ENUMERATE_JS_TOKENS                                     \
     __ENUMERATE_JS_TOKEN(Ampersand, Operator)                   \

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -217,7 +217,7 @@ public:
     void insert(ByteString const&);
     void insert(StringView);
     void insert(Utf32View const&);
-    void insert(const u32);
+    void insert(u32 const);
     void stylize(Span const&, Style const&);
     void strip_styles(bool strip_anchored = false);
 
@@ -246,7 +246,7 @@ public:
 
     bool is_editing() const { return m_is_editing; }
 
-    const Utf32View buffer_view() const { return { m_buffer.data(), m_buffer.size() }; }
+    Utf32View const buffer_view() const { return { m_buffer.data(), m_buffer.size() }; }
 
     auto prohibit_input()
     {

--- a/Userland/Libraries/LibPCIDB/Database.cpp
+++ b/Userland/Libraries/LibPCIDB/Database.cpp
@@ -23,7 +23,7 @@ RefPtr<Database> Database::open(ByteString const& filename)
     return res;
 }
 
-const StringView Database::get_vendor(u16 vendor_id) const
+StringView const Database::get_vendor(u16 vendor_id) const
 {
     auto const& vendor = m_vendors.get(vendor_id);
     if (!vendor.has_value())
@@ -31,7 +31,7 @@ const StringView Database::get_vendor(u16 vendor_id) const
     return vendor.value()->name;
 }
 
-const StringView Database::get_device(u16 vendor_id, u16 device_id) const
+StringView const Database::get_device(u16 vendor_id, u16 device_id) const
 {
     auto const& vendor = m_vendors.get(vendor_id);
     if (!vendor.has_value())
@@ -42,7 +42,7 @@ const StringView Database::get_device(u16 vendor_id, u16 device_id) const
     return device.value()->name;
 }
 
-const StringView Database::get_subsystem(u16 vendor_id, u16 device_id, u16 subvendor_id, u16 subdevice_id) const
+StringView const Database::get_subsystem(u16 vendor_id, u16 device_id, u16 subvendor_id, u16 subdevice_id) const
 {
     auto const& vendor = m_vendors.get(vendor_id);
     if (!vendor.has_value())
@@ -56,7 +56,7 @@ const StringView Database::get_subsystem(u16 vendor_id, u16 device_id, u16 subve
     return subsystem.value()->name;
 }
 
-const StringView Database::get_class(u8 class_id) const
+StringView const Database::get_class(u8 class_id) const
 {
     auto const& xclass = m_classes.get(class_id);
     if (!xclass.has_value())
@@ -64,7 +64,7 @@ const StringView Database::get_class(u8 class_id) const
     return xclass.value()->name;
 }
 
-const StringView Database::get_subclass(u8 class_id, u8 subclass_id) const
+StringView const Database::get_subclass(u8 class_id, u8 subclass_id) const
 {
     auto const& xclass = m_classes.get(class_id);
     if (!xclass.has_value())
@@ -75,7 +75,7 @@ const StringView Database::get_subclass(u8 class_id, u8 subclass_id) const
     return subclass.value()->name;
 }
 
-const StringView Database::get_programming_interface(u8 class_id, u8 subclass_id, u8 programming_interface_id) const
+StringView const Database::get_programming_interface(u8 class_id, u8 subclass_id, u8 programming_interface_id) const
 {
     auto const& xclass = m_classes.get(class_id);
     if (!xclass.has_value())

--- a/Userland/Libraries/LibPCIDB/Database.h
+++ b/Userland/Libraries/LibPCIDB/Database.h
@@ -56,12 +56,12 @@ public:
     static RefPtr<Database> open(ByteString const& filename);
     static RefPtr<Database> open() { return open("/res/pci.ids"); }
 
-    const StringView get_vendor(u16 vendor_id) const;
-    const StringView get_device(u16 vendor_id, u16 device_id) const;
-    const StringView get_subsystem(u16 vendor_id, u16 device_id, u16 subvendor_id, u16 subdevice_id) const;
-    const StringView get_class(u8 class_id) const;
-    const StringView get_subclass(u8 class_id, u8 subclass_id) const;
-    const StringView get_programming_interface(u8 class_id, u8 subclass_id, u8 programming_interface_id) const;
+    StringView const get_vendor(u16 vendor_id) const;
+    StringView const get_device(u16 vendor_id, u16 device_id) const;
+    StringView const get_subsystem(u16 vendor_id, u16 device_id, u16 subvendor_id, u16 subdevice_id) const;
+    StringView const get_class(u8 class_id) const;
+    StringView const get_subclass(u8 class_id, u8 subclass_id) const;
+    StringView const get_programming_interface(u8 class_id, u8 subclass_id, u8 programming_interface_id) const;
 
 private:
     explicit Database(NonnullOwnPtr<Core::MappedFile> file)

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -464,7 +464,7 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
 
     auto field_to_long = [](ReadonlyBytes field) -> long {
         long value = 0;
-        const u8 max = (field.size() - 1) * 8;
+        u8 const max = (field.size() - 1) * 8;
         for (size_t i = 0; i < field.size(); ++i) {
             value |= static_cast<long>(field[i]) << (max - (i * 8));
         }
@@ -642,13 +642,13 @@ PDFErrorOr<DocumentParser::PageOffsetHintTable> DocumentParser::parse_page_offse
     size_t offset = 0;
 
     auto read_u32 = [&] {
-        u32 data = reinterpret_cast<const u32*>(hint_stream_bytes.data() + offset)[0];
+        u32 data = reinterpret_cast<u32 const*>(hint_stream_bytes.data() + offset)[0];
         offset += 4;
         return AK::convert_between_host_and_big_endian(data);
     };
 
     auto read_u16 = [&] {
-        u16 data = reinterpret_cast<const u16*>(hint_stream_bytes.data() + offset)[0];
+        u16 data = reinterpret_cast<u16 const*>(hint_stream_bytes.data() + offset)[0];
         offset += 2;
         return AK::convert_between_host_and_big_endian(data);
     };

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1315,7 +1315,7 @@ void Renderer::show_empty_image(Gfx::IntSize size)
     m_painter.stroke_path(rect_path(image_border), Color::Black, 1);
 }
 
-static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> apply_alpha_channel(NonnullRefPtr<Gfx::Bitmap> image_bitmap, NonnullRefPtr<const Gfx::Bitmap> mask_bitmap, bool invert_alpha = false)
+static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> apply_alpha_channel(NonnullRefPtr<Gfx::Bitmap> image_bitmap, NonnullRefPtr<Gfx::Bitmap const> mask_bitmap, bool invert_alpha = false)
 {
     // Make alpha mask same size as image.
     if (mask_bitmap->size() != image_bitmap->size()) {

--- a/Userland/Libraries/LibPartition/MBRPartitionTable.h
+++ b/Userland/Libraries/LibPartition/MBRPartitionTable.h
@@ -56,7 +56,7 @@ private:
     bool initialize();
     bool m_valid { false };
     bool m_header_valid { false };
-    const u32 m_start_lba;
+    u32 const m_start_lba;
     ByteBuffer m_cached_header;
 };
 

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -32,8 +32,8 @@ struct Block {
 
 }
 
-static constexpr const size_t c_max_recursion = 5000;
-static constexpr const size_t c_match_preallocation_count = 0;
+static constexpr size_t const c_max_recursion = 5000;
+static constexpr size_t const c_match_preallocation_count = 0;
 
 struct RegexResult final {
     bool success { false };

--- a/Userland/Libraries/LibTLS/Extensions.h
+++ b/Userland/Libraries/LibTLS/Extensions.h
@@ -801,7 +801,7 @@ constexpr static StringView enum_to_string(AlertDescription descriptor)
 #undef _ENUM_KEY_VALUE
 }
 
-constexpr static const StringView enum_to_value(AlertDescription descriptor)
+constexpr static StringView const enum_to_value(AlertDescription descriptor)
 {
     switch (descriptor) {
     case AlertDescription::UNEXPECTED_MESSAGE:

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -460,7 +460,7 @@ ssize_t TLSv12::handle_message(ReadonlyBytes buffer)
 
                 length -= mac_size;
 
-                const u8* message_hmac = decrypted_span.offset(length);
+                u8 const* message_hmac = decrypted_span.offset(length);
                 u8 temp_buf[5];
                 memcpy(temp_buf, buffer.offset_pointer(0), 3);
                 *(u16*)(temp_buf + 3) = AK::convert_between_host_and_network_endian(length);

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -384,7 +384,7 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
 
         VERIFY(suite_value.is_object());
 
-        suite_value.as_object().for_each_member([&](const ByteString& test_name, const JsonValue& test_value) {
+        suite_value.as_object().for_each_member([&](ByteString const& test_name, JsonValue const& test_value) {
             Test::Case test { test_name, Test::Result::Fail, "", 0 };
 
             VERIFY(test_value.is_object());

--- a/Userland/Libraries/LibUSBDB/Database.cpp
+++ b/Userland/Libraries/LibUSBDB/Database.cpp
@@ -23,7 +23,7 @@ RefPtr<Database> Database::open(ByteString const& filename)
     return res;
 }
 
-const StringView Database::get_vendor(u16 vendor_id) const
+StringView const Database::get_vendor(u16 vendor_id) const
 {
     auto const& vendor = m_vendors.get(vendor_id);
     if (!vendor.has_value())
@@ -31,7 +31,7 @@ const StringView Database::get_vendor(u16 vendor_id) const
     return vendor.value()->name;
 }
 
-const StringView Database::get_device(u16 vendor_id, u16 device_id) const
+StringView const Database::get_device(u16 vendor_id, u16 device_id) const
 {
     auto const& vendor = m_vendors.get(vendor_id);
     if (!vendor.has_value()) {
@@ -43,7 +43,7 @@ const StringView Database::get_device(u16 vendor_id, u16 device_id) const
     return device.value()->name;
 }
 
-const StringView Database::get_interface(u16 vendor_id, u16 device_id, u16 interface_id) const
+StringView const Database::get_interface(u16 vendor_id, u16 device_id, u16 interface_id) const
 {
     auto const& vendor = m_vendors.get(vendor_id);
     if (!vendor.has_value())
@@ -57,7 +57,7 @@ const StringView Database::get_interface(u16 vendor_id, u16 device_id, u16 inter
     return interface.value()->name;
 }
 
-const StringView Database::get_class(u8 class_id) const
+StringView const Database::get_class(u8 class_id) const
 {
     auto const& xclass = m_classes.get(class_id);
     if (!xclass.has_value())
@@ -65,7 +65,7 @@ const StringView Database::get_class(u8 class_id) const
     return xclass.value()->name;
 }
 
-const StringView Database::get_subclass(u8 class_id, u8 subclass_id) const
+StringView const Database::get_subclass(u8 class_id, u8 subclass_id) const
 {
     auto const& xclass = m_classes.get(class_id);
     if (!xclass.has_value())
@@ -76,7 +76,7 @@ const StringView Database::get_subclass(u8 class_id, u8 subclass_id) const
     return subclass.value()->name;
 }
 
-const StringView Database::get_protocol(u8 class_id, u8 subclass_id, u8 protocol_id) const
+StringView const Database::get_protocol(u8 class_id, u8 subclass_id, u8 protocol_id) const
 {
     auto const& xclass = m_classes.get(class_id);
     if (!xclass.has_value())

--- a/Userland/Libraries/LibUSBDB/Database.h
+++ b/Userland/Libraries/LibUSBDB/Database.h
@@ -55,12 +55,12 @@ public:
     static RefPtr<Database> open(ByteString const& filename);
     static RefPtr<Database> open() { return open("/res/usb.ids"); }
 
-    const StringView get_vendor(u16 vendor_id) const;
-    const StringView get_device(u16 vendor_id, u16 device_id) const;
-    const StringView get_interface(u16 vendor_id, u16 device_id, u16 interface_id) const;
-    const StringView get_class(u8 class_id) const;
-    const StringView get_subclass(u8 class_id, u8 subclass_id) const;
-    const StringView get_protocol(u8 class_id, u8 subclass_id, u8 protocol_id) const;
+    StringView const get_vendor(u16 vendor_id) const;
+    StringView const get_device(u16 vendor_id, u16 device_id) const;
+    StringView const get_interface(u16 vendor_id, u16 device_id, u16 interface_id) const;
+    StringView const get_class(u8 class_id) const;
+    StringView const get_subclass(u8 class_id, u8 subclass_id) const;
+    StringView const get_protocol(u8 class_id, u8 subclass_id, u8 protocol_id) const;
 
 private:
     explicit Database(NonnullOwnPtr<Core::MappedFile> file)

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -94,7 +94,7 @@ public:
 
     void set_startup_process_id(pid_t pid) { m_startup_process_id = pid; }
 
-    const StringView color_scheme_name() const { return m_color_scheme_name; }
+    StringView const color_scheme_name() const { return m_color_scheme_name; }
 
     Function<void(StringView)> on_title_change;
     Function<void(Gfx::IntSize)> on_terminal_size_change;

--- a/Userland/Libraries/LibVideo/Color/ColorPrimaries.cpp
+++ b/Userland/Libraries/LibVideo/Color/ColorPrimaries.cpp
@@ -45,8 +45,8 @@ ALWAYS_INLINE constexpr FloatVector3 matrix_row(FloatMatrix3x3 matrix, size_t ro
 ALWAYS_INLINE constexpr FloatMatrix3x3 generate_rgb_to_xyz_matrix(FloatVector2 red_xy, FloatVector2 green_xy, FloatVector2 blue_xy, FloatVector2 white_xy)
 {
     // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
-    const FloatMatrix3x3 matrix = primaries_matrix(red_xy, green_xy, blue_xy);
-    const FloatVector3 scale_vector = matrix.inverse() * primaries_to_xyz(white_xy);
+    FloatMatrix3x3 const matrix = primaries_matrix(red_xy, green_xy, blue_xy);
+    FloatVector3 const scale_vector = matrix.inverse() * primaries_to_xyz(white_xy);
     return vectors_to_matrix(matrix_row(matrix, 0) * scale_vector, matrix_row(matrix, 1) * scale_vector, matrix_row(matrix, 2) * scale_vector);
 }
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -1317,7 +1317,7 @@ inline DecoderErrorOr<void> Decoder::inverse_walsh_hadamard_transform(Span<Inter
 
 inline i32 Decoder::cos64(u8 angle)
 {
-    const i32 cos64_lookup[33] = { 16384, 16364, 16305, 16207, 16069, 15893, 15679, 15426, 15137, 14811, 14449, 14053, 13623, 13160, 12665, 12140, 11585, 11003, 10394, 9760, 9102, 8423, 7723, 7005, 6270, 5520, 4756, 3981, 3196, 2404, 1606, 804, 0 };
+    i32 const cos64_lookup[33] = { 16384, 16364, 16305, 16207, 16069, 15893, 15679, 15426, 15137, 14811, 14449, 14053, 13623, 13160, 12665, 12140, 11585, 11003, 10394, 9760, 9102, 8423, 7723, 7005, 6270, 5520, 4756, 3981, 3196, 2404, 1606, 804, 0 };
 
     // 1. Set a variable angle2 equal to angle & 127.
     angle &= 127;
@@ -1570,10 +1570,10 @@ inline void Decoder::inverse_asymmetric_discrete_sine_transform_output_array_per
 inline void Decoder::inverse_asymmetric_discrete_sine_transform_4(Span<Intermediate> data)
 {
     VERIFY(data.size() == 4);
-    const i64 sinpi_1_9 = 5283;
-    const i64 sinpi_2_9 = 9929;
-    const i64 sinpi_3_9 = 13377;
-    const i64 sinpi_4_9 = 15212;
+    i64 const sinpi_1_9 = 5283;
+    i64 const sinpi_2_9 = 9929;
+    i64 const sinpi_3_9 = 13377;
+    i64 const sinpi_4_9 = 15212;
 
     // Steps are derived from pseudocode in (8.7.1.6):
     // s0 = SINPI_1_9 * T[ 0 ]

--- a/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.cpp
+++ b/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.cpp
@@ -36,7 +36,7 @@ SyntaxElementCounter::SyntaxElementCounter()
 }
 
 template<typename T, size_t size>
-static void sum_arrays(T (&destination)[size], const T (&left)[size], const T (&right)[size])
+static void sum_arrays(T (&destination)[size], T const (&left)[size], T const (&right)[size])
 {
     for (size_t i = 0; i < size; i++) {
         destination[i] = left[i] + right[i];
@@ -44,7 +44,7 @@ static void sum_arrays(T (&destination)[size], const T (&left)[size], const T (&
 }
 
 template<typename T, size_t size, size_t size_2>
-static void sum_arrays(T (&destination)[size][size_2], const T (&left)[size][size_2], const T (&right)[size][size_2])
+static void sum_arrays(T (&destination)[size][size_2], T const (&left)[size][size_2], T const (&right)[size][size_2])
 {
     for (size_t i = 0; i < size; i++) {
         sum_arrays(destination[i], left[i], right[i]);

--- a/Userland/Libraries/LibVideo/VP9/Utilities.h
+++ b/Userland/Libraries/LibVideo/VP9/Utilities.h
@@ -28,7 +28,7 @@ u16 clip_1(u8 bit_depth, T x)
     if (x < 0) {
         return 0u;
     }
-    const T max = (1u << bit_depth) - 1u;
+    T const max = (1u << bit_depth) - 1u;
     if (x > max)
         return max;
     return x;

--- a/Userland/Libraries/LibVideo/VideoFrame.cpp
+++ b/Userland/Libraries/LibVideo/VideoFrame.cpp
@@ -78,7 +78,7 @@ ALWAYS_INLINE DecoderErrorOr<void> convert_to_bitmap_subsampled(Convert convert,
     interpolate_row<subsampling_horizontal>(0, width, plane_u.data(), plane_v.data(), u_row_a, v_row_a);
 
     // Do interpolation for all inner rows.
-    const u32 rows_end = height - subsampling_vertical;
+    u32 const rows_end = height - subsampling_vertical;
     for (u32 row = 0; row < rows_end; row += vertical_step) {
         // Horizontally scale the row if subsampled.
         auto uv_row = row >> subsampling_vertical;

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -264,7 +264,7 @@ Optional<UnixDateTime> parse_date_time(StringView date_string)
         if (parts.size() != 3)
             return false;
 
-        for (const auto& part : parts) {
+        for (auto const& part : parts) {
             if (part.is_empty() || part.length() > 2)
                 return false;
         }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -639,7 +639,7 @@ void TableFormattingContext::distribute_width_to_columns()
 
     // The assignable table width is the used width of the table minus the total horizontal border spacing (if any).
     // This is the width that we will be able to allocate to the columns.
-    const CSSPixels available_width = m_state.get(table_box()).content_width() - total_horizontal_border_spacing;
+    CSSPixels const available_width = m_state.get(table_box()).content_width() - total_horizontal_border_spacing;
 
     Vector<CSSPixels> candidate_widths;
     candidate_widths.resize(m_columns.size());
@@ -1219,7 +1219,7 @@ const CSS::BorderData& TableFormattingContext::border_data_conflicting_edge(Tabl
     }
 }
 
-const Painting::PaintableBox::BorderDataWithElementKind TableFormattingContext::border_data_with_element_kind_from_conflicting_edge(ConflictingEdge const& conflicting_edge)
+Painting::PaintableBox::BorderDataWithElementKind const TableFormattingContext::border_data_with_element_kind_from_conflicting_edge(ConflictingEdge const& conflicting_edge)
 {
     auto const& border_data = border_data_conflicting_edge(conflicting_edge);
     return { .border_data = border_data, .element_kind = conflicting_edge.element_kind };

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -140,7 +140,7 @@ struct NamedPropertyID {
 
 void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
-    static const Array attribute_style_properties {
+    static Array const attribute_style_properties {
         // FIXME: The `fill` attribute and CSS `fill` property are not the same! But our support is limited enough that they are equivalent for now.
         NamedPropertyID(CSS::PropertyID::Fill),
         // FIXME: The `stroke` attribute and CSS `stroke` property are not the same! But our support is limited enough that they are equivalent for now.

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -374,9 +374,9 @@ void Compositor::compose()
         dbgln_if(COMPOSE_DEBUG, "  window {} frame rect: {}", window.title(), frame_rect);
 
         RefPtr<Gfx::Bitmap> backing_store = window.backing_store();
-        auto compose_window_rect = [&](Screen& screen, Gfx::Painter& painter, const Gfx::IntRect& rect) {
+        auto compose_window_rect = [&](Screen& screen, Gfx::Painter& painter, Gfx::IntRect const& rect) {
             if (!window.is_fullscreen()) {
-                rect.for_each_intersected(frame_rects, [&](const Gfx::IntRect& intersected_rect) {
+                rect.for_each_intersected(frame_rects, [&](Gfx::IntRect const& intersected_rect) {
                     Gfx::PainterStateSaver saver(painter);
                     painter.add_clip_rect(intersected_rect);
                     painter.translate(transition_offset);
@@ -390,7 +390,7 @@ void Compositor::compose()
             if (update_window_rect.is_empty())
                 return;
 
-            auto clear_window_rect = [&](const Gfx::IntRect& clear_rect) {
+            auto clear_window_rect = [&](Gfx::IntRect const& clear_rect) {
                 painter.fill_rect(clear_rect, wm.palette().window());
             };
 
@@ -468,7 +468,7 @@ void Compositor::compose()
         // Render opaque portions directly to the back buffer
         auto& opaque_rects = window.opaque_rects();
         if (!opaque_rects.is_empty()) {
-            opaque_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
+            opaque_rects.for_each_intersected(dirty_rects, [&](Gfx::IntRect const& render_rect) {
                 for (auto* screen : window.screens()) {
                     auto screen_render_rect = render_rect.intersected(screen->rect());
                     if (screen_render_rect.is_empty())
@@ -489,7 +489,7 @@ void Compositor::compose()
         // the wallpaper
         auto& transparency_wallpaper_rects = window.transparency_wallpaper_rects();
         if (!transparency_wallpaper_rects.is_empty()) {
-            transparency_wallpaper_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
+            transparency_wallpaper_rects.for_each_intersected(dirty_rects, [&](Gfx::IntRect const& render_rect) {
                 for (auto* screen : window.screens()) {
                     auto screen_rect = screen->rect();
                     auto screen_render_rect = render_rect.intersected(screen_rect);
@@ -506,7 +506,7 @@ void Compositor::compose()
         }
         auto& transparency_rects = window.transparency_rects();
         if (!transparency_rects.is_empty()) {
-            transparency_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
+            transparency_rects.for_each_intersected(dirty_rects, [&](Gfx::IntRect const& render_rect) {
                 for (auto* screen : window.screens()) {
                     auto screen_rect = screen->rect();
                     auto screen_render_rect = render_rect.intersected(screen_rect);
@@ -687,7 +687,7 @@ void Compositor::flush(Screen& screen)
         //       rects from the backing bitmap to the display framebuffer.
 
         Gfx::ARGB32* to_ptr;
-        const Gfx::ARGB32* from_ptr;
+        Gfx::ARGB32 const* from_ptr;
 
         if (screen_data.m_screen_can_set_buffer) {
             to_ptr = back_ptr;
@@ -699,7 +699,7 @@ void Compositor::flush(Screen& screen)
 
         for (int y = 0; y < scaled_rect.height(); ++y) {
             fast_u32_copy(to_ptr, from_ptr, scaled_rect.width());
-            from_ptr = (const Gfx::ARGB32*)((const u8*)from_ptr + pitch);
+            from_ptr = (Gfx::ARGB32 const*)((u8 const*)from_ptr + pitch);
             to_ptr = (Gfx::ARGB32*)((u8*)to_ptr + pitch);
         }
         if (device_can_flush_buffers) {

--- a/Userland/Services/WindowServer/Event.h
+++ b/Userland/Services/WindowServer/Event.h
@@ -144,7 +144,7 @@ private:
     int m_wheel_raw_delta_x { 0 };
     int m_wheel_raw_delta_y { 0 };
     bool m_drag { false };
-    RefPtr<const Core::MimeData> m_mime_data;
+    RefPtr<Core::MimeData const> m_mime_data;
 };
 
 class ResizeEvent final : public Event {

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -50,7 +50,7 @@ public:
     void on_receive_keyboard_data(::KeyEvent);
 
     Gfx::IntPoint cursor_location() const { return m_cursor_location; }
-    void set_cursor_location(const Gfx::IntPoint point) { m_cursor_location = point; }
+    void set_cursor_location(Gfx::IntPoint const point) { m_cursor_location = point; }
 
 private:
     Gfx::IntPoint m_cursor_location;

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -85,7 +85,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
             (void)shell->highlight(editor);
         };
-        editor->on_tab_complete = [&](const Line::Editor&) {
+        editor->on_tab_complete = [&](Line::Editor const&) {
             return shell->complete();
         };
         editor->on_paste = [&](Utf32View data, Line::Editor& editor) {

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -80,7 +80,7 @@ static NonnullOwnPtr<HashMap<FlatPtr, X86::Instruction>> instrument_code()
             if (section.name() != ".text")
                 return IterationDecision::Continue;
 
-            X86::SimpleInstructionStream stream((const u8*)((uintptr_t)lib.file->data() + section.offset()), section.size());
+            X86::SimpleInstructionStream stream((u8 const*)((uintptr_t)lib.file->data() + section.offset()), section.size());
             X86::Disassembler disassembler(stream);
             for (;;) {
                 auto offset = stream.offset();
@@ -143,12 +143,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
 #if ARCH(X86_64)
-        const FlatPtr ip = regs.value().rip;
+        FlatPtr const ip = regs.value().rip;
 #elif ARCH(AARCH64)
-        const FlatPtr ip = 0; // FIXME
+        FlatPtr const ip = 0; // FIXME
         TODO_AARCH64();
 #elif ARCH(RISCV64)
-        const FlatPtr ip = 0; // FIXME
+        FlatPtr const ip = 0; // FIXME
         TODO_RISCV64();
 #else
 #    error Unknown architecture

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -537,7 +537,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             outln("    common name suffix: \"{}\"", named_colors.suffix());
             outln("    {} colors:", named_colors.size());
             for (size_t i = 0; i < min(named_colors.size(), 5u); ++i) {
-                const auto& pcs = named_colors.pcs_coordinates(i);
+                auto const& pcs = named_colors.pcs_coordinates(i);
 
                 // FIXME: Display decoded values? (See ICC v4 6.3.4.2 and 10.8.)
                 out("        \"{}\", PCS coordinates: {:#04x} {:#04x} {:#04x}", TRY(named_colors.color_name(i)), pcs.xyz.x, pcs.xyz.y, pcs.xyz.z);

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -31,7 +31,7 @@
 
 static bool is_missing_file_acceptable(String const& filename)
 {
-    const StringView acceptable_missing_files[] = {
+    StringView const acceptable_missing_files[] = {
         // FIXME: Please write these manpages!
         "/usr/share/man/man2/exec.md"sv,
         "/usr/share/man/man2/fcntl.md"sv,

--- a/Userland/Utilities/network-settings.cpp
+++ b/Userland/Utilities/network-settings.cpp
@@ -36,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     auto config_file = TRY(Core::ConfigFile::open_for_system("Network", Core::ConfigFile::AllowWriting::Yes));
     json_object.for_each_member([&](ByteString const& adapter_name, JsonValue const& adapter_data) {
-        adapter_data.as_object().for_each_member([&](const ByteString& key, const JsonValue& value) {
+        adapter_data.as_object().for_each_member([&](ByteString const& key, JsonValue const& value) {
             switch (value.type()) {
             case JsonValue::Type::String:
                 config_file->write_entry(adapter_name, key, value.as_string());

--- a/Userland/Utilities/reboot.cpp
+++ b/Userland/Utilities/reboot.cpp
@@ -13,7 +13,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     auto file = TRY(Core::File::open("/sys/kernel/power_state"sv, Core::File::OpenMode::Write));
 
-    const ByteString file_contents = "1";
+    ByteString const file_contents = "1";
     TRY(file->write_until_depleted(file_contents.bytes()));
     file->close();
 

--- a/Userland/Utilities/shutdown.cpp
+++ b/Userland/Utilities/shutdown.cpp
@@ -17,7 +17,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     auto file = TRY(Core::File::open("/sys/kernel/power_state"sv, Core::File::OpenMode::Write));
 
-    const ByteString file_contents = "2";
+    ByteString const file_contents = "2";
     TRY(file->write_until_depleted(file_contents.bytes()));
     file->close();
 

--- a/Userland/Utilities/stty.cpp
+++ b/Userland/Utilities/stty.cpp
@@ -227,7 +227,7 @@ void print_human_readable(termios const& modes, winsize const& ws, bool verbose_
             out("\n");
     };
 
-    auto print_flags_of_type = [&](const TermiosFlag flags[], size_t flag_count, tcflag_t field_value, tcflag_t field_default) {
+    auto print_flags_of_type = [&](TermiosFlag const flags[], size_t flag_count, tcflag_t field_value, tcflag_t field_default) {
         bool first_in_line = true;
         for (size_t i = 0; i < flag_count; ++i) {
             auto& flag = flags[i];

--- a/Userland/Utilities/test-imap.cpp
+++ b/Userland/Utilities/test-imap.cpp
@@ -126,7 +126,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 .get<IMAP::FetchResponseData>()
                 .body_data()
                 .find_if([](Tuple<IMAP::FetchCommand::DataItem, ByteString>& data) {
-                    const auto data_item = data.get<0>();
+                    auto const data_item = data.get<0>();
                     return data_item.section.has_value() && data_item.section->type == IMAP::FetchCommand::DataItem::SectionType::HeaderFields;
                 })
                 ->get<1>());

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -69,7 +69,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         outln("\033[1m{:10} {:12} {:16} {:6} {}\033[0m", "USER", "TTY", "LOGIN@", "IDLE", "WHAT");
 
     TRY(json.as_object().try_for_each_member([&](ByteString const& tty, auto& value) -> ErrorOr<void> {
-        const JsonObject& entry = value.as_object();
+        JsonObject const& entry = value.as_object();
         auto uid = entry.get_u32("uid"sv).value_or(0);
         [[maybe_unused]] auto pid = entry.get_i32("pid"sv).value_or(0);
 

--- a/Userland/Utilities/watch.cpp
+++ b/Userland/Utilities/watch.cpp
@@ -24,7 +24,7 @@ static int opt_interval = 2;
 static bool flag_noheader = false;
 static bool flag_beep_on_fail = false;
 static int volatile exit_code = 0;
-static volatile pid_t child_pid = -1;
+static pid_t volatile child_pid = -1;
 
 static struct termios g_save;
 

--- a/Userland/Utilities/xargs.cpp
+++ b/Userland/Utilities/xargs.cpp
@@ -121,7 +121,7 @@ ErrorOr<int> serenity_main(Main::Arguments main_arguments)
         if (items_used_for_this_command == 0) {
             child_argv.ensure_capacity(initial_arguments.size());
 
-            initial_arguments.for_each_joined_argument(item, [&](const ByteString& string) {
+            initial_arguments.for_each_joined_argument(item, [&](ByteString const& string) {
                 total_command_length += string.length();
                 child_argv.append(strdup(string.characters()));
             });

--- a/Userland/Utilities/xxd.cpp
+++ b/Userland/Utilities/xxd.cpp
@@ -274,7 +274,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     Array<u8, BUFSIZ> contents;
     Bytes bytes;
     size_t total_bytes_read = 0x0;
-    const size_t max_read_size = contents.size() - (contents.size() % line_length_config);
+    size_t const max_read_size = contents.size() - (contents.size() % line_length_config);
     bool is_input_remaining = true;
 
     // TODO: seek relative to current stdin file position


### PR DESCRIPTION
This PR only contains changes that are compatible with the 16th version in CI. [The remaining incompatible changes](https://gist.github.com/DanShaders/a0e54da43e77e26fa32b100838fc5e3a) are quite small and are unlikely to cause a lot of trouble for people who use toolchain's clang-format.