### PR TITLE
LibGfx: Add APNG Writing Support to PNGWriter

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Pierre Hoffmeister
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Torben Jonas Virtmann
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,7 @@
 #include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImageFormats/AnimationWriter.h>
 #include <LibGfx/ImageFormats/PNGShared.h>
 
 namespace Gfx {
@@ -28,6 +30,7 @@ public:
     using Options = PNGWriterOptions;
 
     static ErrorOr<ByteBuffer> encode(Gfx::Bitmap const&, Options options = Options {});
+    static ErrorOr<NonnullOwnPtr<AnimationWriter>> start_encoding_animation(SeekableStream&, IntSize dimensions);
 
 private:
     PNGWriter() = default;
@@ -36,8 +39,10 @@ private:
     ErrorOr<void> add_chunk(PNGChunk&);
     ErrorOr<void> add_png_header();
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
+    ErrorOr<void> add_acTL_chunk(u32 num_frames, u32 num_plays);
+    ErrorOr<void> add_fcTL_chunk(u32 sequence_number, u32 width, u32 height, u16 delay_num, u16 delay_den, u8 dispose_op, u8 blend_op, u32 x_offset, u32 y_offset);
     ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data);
-    ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&);
+    ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&, bool animated, u32 sequence_number);
     ErrorOr<void> add_IEND_chunk();
 };
 


### PR DESCRIPTION
This is a relatively straight-forward commit, allowing programs to export APNG files, with a custom frame duration, blend mode, etc.
This is also my first non-image commit for SerenityOS! (Woohoo!)

To Summarize what this adds:
- writing of acTL Chunks (Animation Control)
- writing of fcTL Chunks (Frame Control)
- writing of fdAT Chunks (Frame Data)
- an overlying function, into which a bitmap vector can be passed, alongside a few parameters.

