### PR TITLE
LibWeb: Generate a simple error page when XML decode/parse fails

### DIFF
--- a/Tests/LibWeb/Text/data/bad.xml
+++ b/Tests/LibWeb/Text/data/bad.xml
@@ -1,0 +1,1 @@
+<this-will-not-parse

--- a/Tests/LibWeb/Text/expected/XML/error-page.txt
+++ b/Tests/LibWeb/Text/expected/XML/error-page.txt
@@ -1,0 +1,3 @@
+  Got load event
+[object HTMLDocument]
+Failed to parse XML document: Expected '>' at offset 21

--- a/Tests/LibWeb/Text/input/XML/error-page.html
+++ b/Tests/LibWeb/Text/input/XML/error-page.html
@@ -1,0 +1,13 @@
+<script src="../include.js"></script>
+<iframe id="i1"></iframe>
+<script>
+    asyncTest((done) => {
+        i1.src = '../../data/bad.xml';
+        i1.onload = function() {
+            println("Got load event");
+            println(i1.contentDocument);
+            println(i1.contentDocument.documentElement.innerText);
+            done();
+        }
+    });
+</script>


### PR DESCRIPTION
This fixes a regression on Acid3, since we are not expected to "best effort" parse XML. The test specifically checks that you don't create an incomplete, incorrect DOM.