### PR TITLE
LibWeb: Do not destroy document until whole subtree completed unloading

### DIFF
--- a/Tests/LibWeb/Text/data/iframe-unload-event.html
+++ b/Tests/LibWeb/Text/data/iframe-unload-event.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<iframe
+    name="test"
+    srcdoc="<script>window.addEventListener('unload', () => { window['test']; })</script>"
+></iframe>
+<script>
+    window.addEventListener("unload", () => {
+        window["test"];
+    });
+</script>

--- a/Tests/LibWeb/Text/expected/navigation/iframe-unloading-order.txt
+++ b/Tests/LibWeb/Text/expected/navigation/iframe-unloading-order.txt
@@ -1,0 +1,1 @@
+  Test passes if it is possible to navigate away without crashing.

--- a/Tests/LibWeb/Text/input/navigation/iframe-unloading-order.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-unloading-order.html
@@ -1,0 +1,7 @@
+<script src="../include.js"></script>
+<iframe id="iframe" src="../../data/iframe-unload-event.html"></iframe>
+<script>
+    test(() => {
+        println("Test passes if it is possible to navigate away without crashing.");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -92,6 +92,15 @@ bool Navigable::is_traversable() const
     return is<TraversableNavigable>(*this);
 }
 
+bool Navigable::is_ancestor_of(JS::NonnullGCPtr<Navigable> other) const
+{
+    for (auto ancestor = other->parent(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor == this)
+            return true;
+    }
+    return false;
+}
+
 Navigable::Navigable()
 {
     all_navigables().set(this);

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -59,6 +59,7 @@ public:
 
     String const& id() const { return m_id; }
     JS::GCPtr<Navigable> parent() const { return m_parent; }
+    bool is_ancestor_of(JS::NonnullGCPtr<Navigable>) const;
 
     bool is_closing() const { return m_closing; }
     void set_closing(bool value) { m_closing = value; }


### PR DESCRIPTION
Fixes crashing when "unload" event handler tries to access active document that has already been destroyed.