### PR TITLE
ImageDecoder: Handle decoding of images in an asynchronous manner

### DIFF
--- a/Ladybird/ImageCodecPlugin.cpp
+++ b/Ladybird/ImageCodecPlugin.cpp
@@ -20,7 +20,7 @@ namespace Ladybird {
 
 ImageCodecPlugin::~ImageCodecPlugin() = default;
 
-Optional<Web::Platform::DecodedImage> ImageCodecPlugin::decode_image(ReadonlyBytes bytes)
+NonnullRefPtr<Core::Promise<Web::Platform::DecodedImage>> ImageCodecPlugin::decode_image(ReadonlyBytes bytes, Function<ErrorOr<void>(Web::Platform::DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected)
 {
     if (!m_client) {
 #ifdef AK_OS_ANDROID
@@ -34,19 +34,30 @@ Optional<Web::Platform::DecodedImage> ImageCodecPlugin::decode_image(ReadonlyByt
         };
     }
 
-    auto result_or_empty = m_client->decode_image(bytes);
-    if (!result_or_empty.has_value())
-        return {};
-    auto result = result_or_empty.release_value();
+    auto promise = Core::Promise<Web::Platform::DecodedImage>::construct();
+    if (on_resolved)
+        promise->on_resolution = move(on_resolved);
+    if (on_rejected)
+        promise->on_rejection = move(on_rejected);
 
-    Web::Platform::DecodedImage decoded_image;
-    decoded_image.is_animated = result.is_animated;
-    decoded_image.loop_count = result.loop_count;
-    for (auto const& frame : result.frames) {
-        decoded_image.frames.empend(move(frame.bitmap), frame.duration);
-    }
+    auto image_decoder_promise = m_client->decode_image(
+        bytes,
+        [promise](ImageDecoderClient::DecodedImage& result) -> ErrorOr<void> {
+            // FIXME: Remove this codec plugin and just use the ImageDecoderClient directly to avoid these copies
+            Web::Platform::DecodedImage decoded_image;
+            decoded_image.is_animated = result.is_animated;
+            decoded_image.loop_count = result.loop_count;
+            for (auto const& frame : result.frames) {
+                decoded_image.frames.empend(move(frame.bitmap), frame.duration);
+            }
+            promise->resolve(move(decoded_image));
+            return {};
+        },
+        [promise](auto& error) {
+            promise->reject(Error::copy(error));
+        });
 
-    return decoded_image;
+    return promise;
 }
 
 }

--- a/Ladybird/ImageCodecPlugin.h
+++ b/Ladybird/ImageCodecPlugin.h
@@ -17,7 +17,7 @@ public:
     ImageCodecPlugin() = default;
     virtual ~ImageCodecPlugin() override;
 
-    virtual Optional<Web::Platform::DecodedImage> decode_image(ReadonlyBytes data) override;
+    virtual NonnullRefPtr<Core::Promise<Web::Platform::DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(Web::Platform::DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected) override;
 
 private:
     RefPtr<ImageDecoderClient::Client> m_client;

--- a/Tests/LibWeb/Text/input/createBitmap.html
+++ b/Tests/LibWeb/Text/input/createBitmap.html
@@ -1,7 +1,7 @@
 <script src="include.js"></script>
 <canvas id="test" width="2" height="2" hidden="hidden"></canvas>
 <script>
-    test(() => {
+    asyncTest((done) => {
         // The blob is a JXL image for a 2x2 checkerboard
         // Made with the following tree on https://jxl-art.lucaversari.it/:
         // Width 2
@@ -40,6 +40,8 @@
                 println(`Invalid value in the bitmap`);
             else
                 println(`Bitmap is correctly loaded`);
+
+            done();
         })
     });
 </script>

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -57,14 +57,9 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::decode_bitmap(ReadonlyBytes bitmap_da
     auto optional_mime_type = guessed_mime_type.map([](auto mime_type) { return mime_type.to_byte_string(); });
 
     // FIXME: Find a way to avoid the memory copying here.
-    auto maybe_decoded_image = client->decode_image(bitmap_data, OptionalNone {}, optional_mime_type);
-    if (!maybe_decoded_image.has_value())
-        return Error::from_string_literal("Image decode failed");
-
-    // FIXME: Support multi-frame images?
-    auto decoded_image = maybe_decoded_image.release_value();
-    if (decoded_image.frames.is_empty())
-        return Error::from_string_literal("Image decode failed (no frames)");
+    // FIXME: Support multi-frame images
+    // FIXME: Refactor image decoding to be more async-aware, and don't await this promise
+    auto decoded_image = TRY(client->decode_image(bitmap_data, {}, {}, OptionalNone {}, optional_mime_type)->await());
 
     return decoded_image.frames.first().bitmap;
 }

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidget.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidget.cpp
@@ -195,8 +195,9 @@ RefPtr<Gfx::Bitmap> SoundPlayerWidget::get_image_from_music_file()
 
     // FIXME: We randomly select the first picture available for the track,
     //        We might want to hardcode or let the user set a preference.
-    auto decoded_image_or_error = m_image_decoder_client.decode_image(pictures[0].data);
-    if (!decoded_image_or_error.has_value())
+    // FIXME: Refactor image decoding to be more async-aware, and don't await this promise
+    auto decoded_image_or_error = m_image_decoder_client.decode_image(pictures[0].data, {}, {})->await();
+    if (decoded_image_or_error.is_error())
         return {};
 
     auto const decoded_image = decoded_image_or_error.release_value();

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -717,9 +717,9 @@ static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_thumbnail(StringView path)
         }
 
         auto mime_type = Core::guess_mime_type_based_on_filename(path);
-        auto decoded_image = maybe_client->decode_image(file->bytes(), thumbnail_size, mime_type);
-        if (!decoded_image.has_value())
-            return Error::from_string_literal("Unable to decode the image.");
+
+        // FIXME: Refactor thumbnail rendering to be more async-aware. Possibly return this promise to the caller.
+        auto decoded_image = TRY(maybe_client->decode_image(file->bytes(), {}, {}, thumbnail_size, mime_type)->await());
 
         return decoded_image;
     }));

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -16,48 +16,101 @@ Client::Client(NonnullOwnPtr<Core::LocalSocket> socket)
 
 void Client::die()
 {
+    for (auto& [_, promise] : m_pending_decoded_images) {
+        promise->reject(Error::from_string_literal("ImageDecoder disconnected"));
+    }
+    m_pending_decoded_images.clear();
+
     if (on_death)
         on_death();
 }
 
-Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
+NonnullRefPtr<Core::Promise<DecodedImage>> Client::decode_image(ReadonlyBytes encoded_data, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
 {
-    if (encoded_data.is_empty())
-        return {};
+    auto promise = Core::Promise<DecodedImage>::construct();
+    if (on_resolved)
+        promise->on_resolution = move(on_resolved);
+    if (on_rejected)
+        promise->on_rejection = move(on_rejected);
+
+    if (encoded_data.is_empty()) {
+        promise->reject(Error::from_string_literal("No encoded data"));
+        return promise;
+    }
 
     auto encoded_buffer_or_error = Core::AnonymousBuffer::create_with_size(encoded_data.size());
     if (encoded_buffer_or_error.is_error()) {
-        dbgln("Could not allocate encoded buffer");
-        return {};
+        dbgln("Could not allocate encoded buffer: {}", encoded_buffer_or_error.error());
+        promise->reject(encoded_buffer_or_error.release_error());
+        return promise;
     }
     auto encoded_buffer = encoded_buffer_or_error.release_value();
 
     memcpy(encoded_buffer.data<void>(), encoded_data.data(), encoded_data.size());
-    auto response_or_error = try_decode_image(move(encoded_buffer), ideal_size, mime_type);
 
-    if (response_or_error.is_error()) {
-        dbgln("ImageDecoder died heroically");
-        return {};
+    auto response = send_sync_but_allow_failure<Messages::ImageDecoderServer::DecodeImage>(move(encoded_buffer), ideal_size, mime_type);
+    if (!response) {
+        dbgln("ImageDecoder disconnected trying to decode image");
+        promise->reject(Error::from_string_literal("ImageDecoder disconnected"));
+        return promise;
     }
 
-    auto& response = response_or_error.value();
+    m_pending_decoded_images.set(response->image_id(), promise);
 
-    if (response.bitmaps().is_empty())
+    return promise;
+}
+
+Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
+{
+    auto promise = decode_image(
+        encoded_data, [](auto) -> ErrorOr<void> { return {}; }, [](Error&) -> void {}, ideal_size, mime_type);
+    auto result = promise->await();
+    if (result.is_error())
         return {};
+    return result.release_value();
+}
+
+void Client::did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale)
+{
+    VERIFY(!bitmaps.is_empty());
+
+    auto maybe_promise = m_pending_decoded_images.take(image_id);
+    if (!maybe_promise.has_value()) {
+        dbgln("ImageDecoderClient: No pending image with ID {}", image_id);
+        return;
+    }
+    auto promise = maybe_promise.release_value();
 
     DecodedImage image;
-    image.is_animated = response.is_animated();
-    image.loop_count = response.loop_count();
-    image.scale = response.scale();
-    image.frames.ensure_capacity(response.bitmaps().size());
-    auto bitmaps = response.take_bitmaps();
+    image.is_animated = is_animated;
+    image.loop_count = loop_count;
+    image.scale = scale;
+    image.frames.ensure_capacity(bitmaps.size());
     for (size_t i = 0; i < bitmaps.size(); ++i) {
-        if (!bitmaps[i].is_valid())
-            return {};
+        if (!bitmaps[i].is_valid()) {
+            dbgln("ImageDecoderClient: Invalid bitmap for request {} at index {}", image_id, i);
+            promise->reject(Error::from_string_literal("Invalid bitmap"));
+            return;
+        }
 
-        image.frames.empend(*bitmaps[i].bitmap(), response.durations()[i]);
+        image.frames.empend(*bitmaps[i].bitmap(), durations[i]);
     }
-    return image;
+
+    promise->resolve(move(image));
+}
+
+void Client::did_fail_to_decode_image(i64 image_id, String const& error_message)
+{
+    auto maybe_promise = m_pending_decoded_images.take(image_id);
+    if (!maybe_promise.has_value()) {
+        dbgln("ImageDecoderClient: No pending image with ID {}", image_id);
+        return;
+    }
+    auto promise = maybe_promise.release_value();
+
+    dbgln("ImageDecoderClient: Failed to decode image with ID {}: {}", image_id, error_message);
+    // FIXME: Include the error message in the Error object when Errors are allowed to hold Strings
+    promise->reject(Error::from_string_literal("Image decoding failed or aborted"));
 }
 
 }

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -60,16 +60,6 @@ NonnullRefPtr<Core::Promise<DecodedImage>> Client::decode_image(ReadonlyBytes en
     return promise;
 }
 
-Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
-{
-    auto promise = decode_image(
-        encoded_data, [](auto) -> ErrorOr<void> { return {}; }, [](Error&) -> void {}, ideal_size, mime_type);
-    auto result = promise->await();
-    if (result.is_error())
-        return {};
-    return result.release_value();
-}
-
 void Client::did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale)
 {
     VERIFY(!bitmaps.is_empty());

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -36,9 +36,6 @@ public:
 
     NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
 
-    // FIXME: Move all clients to the promise-based API and get rid of this synchronous (i.e. EventLoop-spinning) one.
-    Optional<DecodedImage> decode_image(ReadonlyBytes, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
-
     Function<void()> on_death;
 
 private:

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -9,6 +9,7 @@
 #include <AK/HashMap.h>
 #include <ImageDecoder/ImageDecoderClientEndpoint.h>
 #include <ImageDecoder/ImageDecoderServerEndpoint.h>
+#include <LibCore/Promise.h>
 #include <LibIPC/ConnectionToServer.h>
 
 namespace ImageDecoderClient {
@@ -33,12 +34,20 @@ class Client final
 public:
     Client(NonnullOwnPtr<Core::LocalSocket>);
 
+    NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
+
+    // FIXME: Move all clients to the promise-based API and get rid of this synchronous (i.e. EventLoop-spinning) one.
     Optional<DecodedImage> decode_image(ReadonlyBytes, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
 
     Function<void()> on_death;
 
 private:
     virtual void die() override;
+
+    virtual void did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale) override;
+    virtual void did_fail_to_decode_image(i64 image_id, String const& error_message) override;
+
+    HashMap<i64, NonnullRefPtr<Core::Promise<DecodedImage>>> m_pending_decoded_images;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -463,21 +463,25 @@ void HTMLLinkElement::resource_did_load_favicon()
     document().check_favicon_after_loading_link_resource();
 }
 
-static bool decode_favicon(ReadonlyBytes favicon_data, URL::URL const& favicon_url, JS::GCPtr<Navigable> navigable)
+static NonnullRefPtr<Core::Promise<Web::Platform::DecodedImage>> decode_favicon(ReadonlyBytes favicon_data, URL::URL const& favicon_url, JS::GCPtr<Navigable> navigable)
 {
-    auto decoded_image = Platform::ImageCodecPlugin::the().decode_image(favicon_data);
-    if (!decoded_image.has_value() || decoded_image->frames.is_empty()) {
-        dbgln_if(IMAGE_DECODER_DEBUG, "Could not decode favicon {}", favicon_url);
-        return false;
-    }
+    auto on_failed_decode = [favicon_url]([[maybe_unused]] Error& error) {
+        dbgln_if(IMAGE_DECODER_DEBUG, "Failed to decode favicon {}: {}", favicon_url, error);
+    };
 
-    auto favicon_bitmap = decoded_image->frames[0].bitmap;
-    dbgln_if(IMAGE_DECODER_DEBUG, "Decoded favicon, {}", favicon_bitmap->size());
+    auto on_successful_decode = [navigable = JS::Handle(*navigable)](Web::Platform::DecodedImage& decoded_image) -> ErrorOr<void> {
+        auto favicon_bitmap = decoded_image.frames[0].bitmap;
+        dbgln_if(IMAGE_DECODER_DEBUG, "Decoded favicon, {}", favicon_bitmap->size());
 
-    if (navigable && navigable->is_traversable())
-        navigable->traversable_navigable()->page().client().page_did_change_favicon(*favicon_bitmap);
+        if (navigable && navigable->is_traversable())
+            navigable->traversable_navigable()->page().client().page_did_change_favicon(*favicon_bitmap);
 
-    return favicon_bitmap;
+        return {};
+    };
+
+    auto promise = Platform::ImageCodecPlugin::the().decode_image(favicon_data, move(on_successful_decode), move(on_failed_decode));
+
+    return promise;
 }
 
 bool HTMLLinkElement::load_favicon_and_use_if_window_is_active()
@@ -485,7 +489,10 @@ bool HTMLLinkElement::load_favicon_and_use_if_window_is_active()
     if (!has_loaded_icon())
         return false;
 
-    return decode_favicon(resource()->encoded_data(), resource()->url(), navigable());
+    // FIXME: Refactor the caller(s) to handle the async nature of image loading
+    auto promise = decode_favicon(resource()->encoded_data(), resource()->url(), navigable());
+    auto result = promise->await();
+    return !result.is_error();
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#rel-icon:the-link-element-3
@@ -519,7 +526,7 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(JS::N
         auto global = JS::NonnullGCPtr { realm.global_object() };
 
         auto process_body = JS::create_heap_function(realm.heap(), [document, request](ByteBuffer body) {
-            decode_favicon(body, request->url(), document->navigable());
+            (void)decode_favicon(body, request->url(), document->navigable());
         });
         auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::GCPtr<WebIDL::DOMException>) {
         });

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -141,46 +141,48 @@ void SharedImageRequest::handle_successful_fetch(URL::URL const& url_string, Str
 
     bool const is_svg_image = mime_type == "image/svg+xml"sv || url_string.basename().ends_with(".svg"sv);
 
-    JS::GCPtr<DecodedImageData> image_data;
-
-    auto handle_failed_decode = [&] {
-        m_state = State::Failed;
-        for (auto& callback : m_callbacks) {
+    auto handle_failed_decode = [strong_this = JS::Handle(*this)](Error&) -> void {
+        strong_this->m_state = State::Failed;
+        for (auto& callback : strong_this->m_callbacks) {
             if (callback.on_fail)
                 callback.on_fail->function()();
         }
     };
 
+    auto handle_successful_decode = [](SharedImageRequest& self) {
+        self.m_state = State::Finished;
+        for (auto& callback : self.m_callbacks) {
+            if (callback.on_finish)
+                callback.on_finish->function()();
+        }
+        self.m_callbacks.clear();
+    };
+
     if (is_svg_image) {
         auto result = SVG::SVGDecodedImageData::create(m_document->realm(), m_page, url_string, data);
-        if (result.is_error())
-            return handle_failed_decode();
+        if (result.is_error()) {
+            handle_failed_decode(result.error());
+        } else {
+            m_image_data = result.release_value();
+            handle_successful_decode(*this);
+        }
+        return;
+    }
 
-        image_data = result.release_value();
-    } else {
-        auto result = Web::Platform::ImageCodecPlugin::the().decode_image(data.bytes());
-        if (!result.has_value())
-            return handle_failed_decode();
-
+    auto handle_successful_bitmap_decode = [strong_this = JS::Handle(*this), handle_successful_decode = move(handle_successful_decode)](Web::Platform::DecodedImage& result) -> ErrorOr<void> {
         Vector<AnimatedBitmapDecodedImageData::Frame> frames;
-        for (auto& frame : result.value().frames) {
+        for (auto& frame : result.frames) {
             frames.append(AnimatedBitmapDecodedImageData::Frame {
                 .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap),
                 .duration = static_cast<int>(frame.duration),
             });
         }
-        image_data = AnimatedBitmapDecodedImageData::create(m_document->realm(), move(frames), result.value().loop_count, result.value().is_animated).release_value_but_fixme_should_propagate_errors();
-    }
+        strong_this->m_image_data = AnimatedBitmapDecodedImageData::create(strong_this->m_document->realm(), move(frames), result.loop_count, result.is_animated).release_value_but_fixme_should_propagate_errors();
+        handle_successful_decode(*strong_this);
+        return {};
+    };
 
-    m_image_data = image_data;
-
-    m_state = State::Finished;
-
-    for (auto& callback : m_callbacks) {
-        if (callback.on_finish)
-            callback.on_finish->function()();
-    }
-    m_callbacks.clear();
+    (void)Web::Platform::ImageCodecPlugin::the().decode_image(data.bytes(), move(handle_successful_bitmap_decode), move(handle_failed_decode));
 }
 
 void SharedImageRequest::handle_failed_fetch()

--- a/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.cpp
+++ b/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.cpp
@@ -25,4 +25,13 @@ void ImageCodecPlugin::install(ImageCodecPlugin& plugin)
     s_the = &plugin;
 }
 
+Optional<DecodedImage> ImageCodecPlugin::decode_image(ReadonlyBytes encoded_data)
+{
+    auto promise = decode_image(encoded_data, {}, {});
+    auto result = promise->await();
+    if (result.is_error())
+        return {};
+    return result.release_value();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.cpp
+++ b/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.cpp
@@ -25,13 +25,4 @@ void ImageCodecPlugin::install(ImageCodecPlugin& plugin)
     s_the = &plugin;
 }
 
-Optional<DecodedImage> ImageCodecPlugin::decode_image(ReadonlyBytes encoded_data)
-{
-    auto promise = decode_image(encoded_data, {}, {});
-    auto result = promise->await();
-    if (result.is_error())
-        return {};
-    return result.release_value();
-}
-
 }

--- a/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.h
@@ -33,7 +33,6 @@ public:
     virtual ~ImageCodecPlugin();
 
     virtual NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected) = 0;
-    Optional<DecodedImage> decode_image(ReadonlyBytes);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/ImageCodecPlugin.h
@@ -9,6 +9,7 @@
 
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
+#include <LibCore/Promise.h>
 #include <LibGfx/Forward.h>
 
 namespace Web::Platform {
@@ -31,7 +32,8 @@ public:
 
     virtual ~ImageCodecPlugin();
 
-    virtual Optional<DecodedImage> decode_image(ReadonlyBytes) = 0;
+    virtual NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected) = 0;
+    Optional<DecodedImage> decode_image(ReadonlyBytes);
 };
 
 }

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.h
@@ -24,9 +24,17 @@ public:
     virtual void die() override;
 
 private:
+    using Job = Function<void()>;
+
     explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
 
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&, Optional<Gfx::IntSize> const& ideal_size, Optional<ByteString> const& mime_type) override;
+    virtual void cancel_decoding(i64 image_id) override;
+
+    Job make_decode_image_job(i64 image_id, Core::AnonymousBuffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type);
+
+    i64 m_next_image_id { 0 };
+    HashMap<i64, Job> m_pending_jobs;
 };
 
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
@@ -1,6 +1,7 @@
-#include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/ShareableBitmap.h>
 
 endpoint ImageDecoderClient
 {
+    did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations, Gfx::FloatPoint scale) =|
+    did_fail_to_decode_image(i64 image_id, String error_message) =|
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -1,7 +1,7 @@
 #include <LibCore/AnonymousBuffer.h>
-#include <LibGfx/ShareableBitmap.h>
 
 endpoint ImageDecoderServer
 {
-    decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations, Gfx::FloatPoint scale)
+    decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (i64 image_id)
+    cancel_decoding(i64 image_id) =|
 }

--- a/Userland/Services/WebContent/ImageCodecPluginSerenity.h
+++ b/Userland/Services/WebContent/ImageCodecPluginSerenity.h
@@ -21,7 +21,7 @@ public:
     ImageCodecPluginSerenity();
     virtual ~ImageCodecPluginSerenity() override;
 
-    virtual Optional<Web::Platform::DecodedImage> decode_image(ReadonlyBytes) override;
+    virtual NonnullRefPtr<Core::Promise<Web::Platform::DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(Web::Platform::DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected) override;
 
 private:
     RefPtr<ImageDecoderClient::Client> m_client;


### PR DESCRIPTION
ImageDecoder now queues up image decoding requests and returns the
images back to the caller later. ImageDecoderClient has a new
promise-based API that allows callers to attach their own resolve/reject
handlers to the responses from ImageDecoder.