### PR TITLE
LibWeb+WebContent: Don't let PageClient keep documents alive

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -16,14 +16,22 @@ JS_DEFINE_ALLOCATOR(ConsoleObject);
 
 ConsoleObject::ConsoleObject(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
-    , m_console(make<Console>(realm))
 {
+}
+
+ConsoleObject::~ConsoleObject() = default;
+
+void ConsoleObject::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_console);
 }
 
 void ConsoleObject::initialize(Realm& realm)
 {
     auto& vm = this->vm();
     Base::initialize(realm);
+    m_console = vm.heap().allocate<Console>(realm, realm);
     u8 attr = Attribute::Writable | Attribute::Enumerable | Attribute::Configurable;
     define_native_function(realm, vm.names.assert, assert_, 0, attr);
     define_native_function(realm, vm.names.clear, clear, 0, attr);

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -16,12 +16,13 @@ class ConsoleObject final : public Object {
 
 public:
     virtual void initialize(Realm&) override;
-    virtual ~ConsoleObject() override = default;
+    virtual ~ConsoleObject() override;
 
     Console& console() { return *m_console; }
 
 private:
     explicit ConsoleObject(Realm&);
+    virtual void visit_edges(Visitor&) override;
 
     JS_DECLARE_NATIVE_FUNCTION(assert_);
     JS_DECLARE_NATIVE_FUNCTION(clear);
@@ -41,7 +42,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(time_log);
     JS_DECLARE_NATIVE_FUNCTION(time_end);
 
-    NonnullOwnPtr<Console> m_console;
+    GCPtr<Console> m_console;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -408,6 +408,12 @@ WebIDL::ExceptionOr<void> Document::populate_with_html_head_and_body()
     return {};
 }
 
+void Document::finalize()
+{
+    Base::finalize();
+    page().client().page_did_destroy_document(*this);
+}
+
 void Document::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
@@ -3070,8 +3076,6 @@ void Document::run_unloading_cleanup_steps()
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document
 void Document::destroy()
 {
-    page().client().page_did_destroy_document(*this);
-
     // NOTE: Abort needs to happen before destory. There is currently bug in the spec: https://github.com/whatwg/html/issues/9148
     // 4. Abort document.
     abort();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -658,6 +658,7 @@ public:
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
 
     Document(JS::Realm&, URL::URL const&);
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
@@ -13,6 +13,8 @@
 
 namespace Web::HTML {
 
+JS_DEFINE_ALLOCATOR(WorkerDebugConsoleClient);
+
 WorkerDebugConsoleClient::WorkerDebugConsoleClient(JS::Console& console)
     : ConsoleClient(console)
 {
@@ -34,7 +36,7 @@ void WorkerDebugConsoleClient::end_group()
 // 2.3. Printer(logLevel, args[, options]), https://console.spec.whatwg.org/#printer
 JS::ThrowCompletionOr<JS::Value> WorkerDebugConsoleClient::printer(JS::Console::LogLevel log_level, PrinterArguments arguments)
 {
-    auto& vm = m_console.realm().vm();
+    auto& vm = m_console->realm().vm();
 
     auto indent = TRY_OR_THROW_OOM(vm, String::repeated(' ', m_group_stack_depth * 2));
 
@@ -59,7 +61,7 @@ JS::ThrowCompletionOr<JS::Value> WorkerDebugConsoleClient::printer(JS::Console::
     }
 
     auto output = TRY(generically_format_values(arguments.get<JS::MarkedVector<JS::Value>>()));
-    m_console.output_debug_message(log_level, output);
+    m_console->output_debug_message(log_level, output);
 
     switch (log_level) {
     case JS::Console::LogLevel::Debug:

--- a/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.h
@@ -16,16 +16,18 @@ namespace Web::HTML {
 
 class WorkerDebugConsoleClient final
     : public JS::ConsoleClient
-    , public RefCounted<WorkerDebugConsoleClient>
     , public Weakable<WorkerDebugConsoleClient> {
-public:
-    WorkerDebugConsoleClient(JS::Console& console);
+    JS_CELL(WorkerDebugConsoleClient, JS::ConsoleClient);
+    JS_DECLARE_ALLOCATOR(WorkerDebugConsoleClient);
 
+public:
     virtual void clear() override;
     virtual void end_group() override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, PrinterArguments arguments) override;
 
 private:
+    WorkerDebugConsoleClient(JS::Console& console);
+
     int m_group_stack_depth { 0 };
 };
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -680,10 +680,10 @@ void PageClient::initialize_js_console(Web::DOM::Document& document)
 {
     auto& realm = document.realm();
     auto console_object = realm.intrinsics().console_object();
-    auto console_client = make<WebContentConsoleClient>(console_object->console(), document.realm(), *this);
+    auto console_client = heap().allocate_without_realm<WebContentConsoleClient>(console_object->console(), document.realm(), *this);
     console_object->console().set_client(*console_client);
 
-    m_console_clients.set(document, move(console_client));
+    m_console_clients.set(document, console_client);
 }
 
 void PageClient::destroy_js_console(Web::DOM::Document& document)

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -125,7 +125,6 @@ void PageClient::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_page);
-    visitor.visit(m_console_clients);
 }
 
 ConnectionFromClient& PageClient::client() const

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -195,7 +195,8 @@ private:
     };
     BackingStores m_backing_stores;
 
-    HashMap<JS::NonnullGCPtr<Web::DOM::Document>, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
+    // NOTE: These documents are not visited, but manually removed from the map on document finalization.
+    HashMap<JS::RawGCPtr<Web::DOM::Document>, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
     WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
 
     JS::Handle<JS::GlobalObject> m_console_global_object;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -196,7 +196,7 @@ private:
     BackingStores m_backing_stores;
 
     // NOTE: These documents are not visited, but manually removed from the map on document finalization.
-    HashMap<JS::RawGCPtr<Web::DOM::Document>, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
+    HashMap<JS::RawGCPtr<Web::DOM::Document>, JS::NonnullGCPtr<WebContentConsoleClient>> m_console_clients;
     WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
 
     JS::Handle<JS::GlobalObject> m_console_global_object;

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -20,14 +20,20 @@ namespace WebContent {
 
 class WebContentConsoleClient final : public JS::ConsoleClient
     , public Weakable<WebContentConsoleClient> {
+    JS_CELL(WebContentConsoleClient, JS::ConsoleClient);
+    JS_DECLARE_ALLOCATOR(WebContentConsoleClient);
+
 public:
-    WebContentConsoleClient(JS::Console&, JS::Realm&, PageClient&);
+    virtual ~WebContentConsoleClient() override;
 
     void handle_input(ByteString const& js_source);
     void send_messages(i32 start_index);
     void report_exception(JS::Error const&, bool) override;
 
 private:
+    WebContentConsoleClient(JS::Console&, JS::Realm&, PageClient&);
+
+    virtual void visit_edges(JS::Cell::Visitor&) override;
     virtual void clear() override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, PrinterArguments) override;
 
@@ -38,7 +44,7 @@ private:
     }
 
     JS::NonnullGCPtr<PageClient> m_client;
-    JS::Handle<ConsoleGlobalEnvironmentExtensions> m_console_global_environment_extensions;
+    JS::GCPtr<ConsoleGlobalEnvironmentExtensions> m_console_global_environment_extensions;
 
     void clear_output();
     void print_html(ByteString const& line);

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
@@ -55,7 +55,7 @@ void DedicatedWorkerHost::run(JS::NonnullGCPtr<Web::Page> page, Web::HTML::Trans
     auto inner_settings = Web::HTML::WorkerEnvironmentSettingsObject::setup(page, move(realm_execution_context));
 
     auto& console_object = *inner_settings->realm().intrinsics().console_object();
-    m_console = adopt_ref(*new Web::HTML::WorkerDebugConsoleClient(console_object.console()));
+    m_console = console_object.heap().allocate_without_realm<Web::HTML::WorkerDebugConsoleClient>(console_object.console());
     VERIFY(m_console);
     console_object.console().set_client(*m_console);
 

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.h
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.h
@@ -23,7 +23,7 @@ public:
     void run(JS::NonnullGCPtr<Web::Page>, Web::HTML::TransferDataHolder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const&);
 
 private:
-    RefPtr<Web::HTML::WorkerDebugConsoleClient> m_console;
+    JS::Handle<Web::HTML::WorkerDebugConsoleClient> m_console;
 
     URL::URL m_url;
     String m_type;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -497,7 +497,7 @@ public:
 
         auto output = TRY(generically_format_values(arguments.get<JS::MarkedVector<JS::Value>>()));
 #ifdef AK_OS_SERENITY
-        m_console.output_debug_message(log_level, output);
+        m_console->output_debug_message(log_level, output);
 #endif
 
         switch (log_level) {


### PR DESCRIPTION
We were inadvertently keeping all documents alive by installing a
console client for them. This patch fixes the issue by adding a
finalizer to Document, and having that be the way we detach console
clients. This breaks the cycle.

With this change, we can spam set .innerHTML in a loop and memory
usage remains stable.

Fixes #14612