### PR TITLE
LibWeb: Fix nodesToRemove collecting traversal in Range::delete_contents

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Range-deleteContents.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Range-deleteContents.txt
@@ -1,0 +1,1 @@
+before  after   

--- a/Tests/LibWeb/Text/input/DOM/Range-deleteContents.html
+++ b/Tests/LibWeb/Text/input/DOM/Range-deleteContents.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+before
+<div id="for-deletion">
+    <div>should</div>
+    <div>be</div>
+    <div>gone</div>
+</div>
+after
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const element = document.getElementById("for-deletion");
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        range.deleteContents();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -1118,7 +1118,7 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
 
     // 4. Let nodes to remove be a list of all the nodes that are contained in this, in tree order, omitting any node whose parent is also contained in this.
     JS::MarkedVector<Node*> nodes_to_remove(heap());
-    for (Node const* node = start_container(); node != end_container()->next_in_pre_order(); node = node->next_in_pre_order()) {
+    for (Node const* node = start_container(); node != end_container()->next_sibling(); node = node->next_in_pre_order()) {
         if (contains_node(*node) && (!node->parent_node() || !contains_node(*node->parent_node())))
             nodes_to_remove.append(const_cast<Node*>(node));
     }


### PR DESCRIPTION
With this change children are no longer skipped in tree traversal when start node of range equals to end node of range.

Fixes https://github.com/SerenityOS/serenity/issues/24036