### PR TITLE
LibCrypto+LibGfx: Fix GCC 14 compile errors

### DIFF
--- a/Userland/Libraries/LibCrypto/Cipher/Mode/CBC.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/CBC.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~CBC() = default;
     template<typename... Args>
-    explicit constexpr CBC<T>(Args... args)
+    explicit constexpr CBC(Args... args)
         : Mode<T>(args...)
     {
     }

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -32,7 +32,7 @@ public:
     }
 
     template<typename U>
-    explicit constexpr Size(Size<U> const& other)
+    requires(IsConstructible<T, U>) explicit constexpr Size(Size<U> const& other)
         : m_width(other.width())
         , m_height(other.height())
     {


### PR DESCRIPTION
The C++ standard does not allow specifying the template parameters in constructor declarations, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97202#c8.

Converting constructors have a higher priority that user-defined conversion functions; let's constrain `Gfx::Size<T>(Gfx::Size<U>)` to only be considered when `U` is convertible to `T`. This lets us fall back to conversion operators in the case of `UISize` -> `IntSize`, for instance. Clang is still okay without this, but MSVC would error out similarly: https://godbolt.org/z/PTbeYPM7s

Note that a not-yet-committed patch is required for full compilation: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114784#c3