### PR TITLE
Ladybird: Add an option to enable internals object outside of test mode

### DIFF
--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -53,10 +53,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.set_general_help("The Ladybird web browser");
     args_parser.add_positional_argument(raw_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
-    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting", 0);
-    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content", 0);
+    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting");
+    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
-    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions", 0);
+    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
     args_parser.parse(arguments);
 
     WebView::ProcessManager::initialize();

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -59,6 +59,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
                 arguments.append("--log-all-js-exceptions"sv);
             if (web_content_options.enable_idl_tracing == Ladybird::EnableIDLTracing::Yes)
                 arguments.append("--enable-idl-tracing"sv);
+            if (web_content_options.expose_internals_object == Ladybird::ExposeInternalsObject::Yes)
+                arguments.append("--expose-internals-object"sv);
             if (auto server = mach_server_name(); server.has_value()) {
                 arguments.append("--mach-server-name"sv);
                 arguments.append(server.value());

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -82,6 +82,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool enable_callgrind_profiling = false;
     bool disable_sql_database = false;
     bool enable_qt_networking = false;
+    bool expose_internals_object = false;
     bool use_gpu_painting = false;
     bool debug_web_content = false;
     bool log_all_js_exceptions = false;
@@ -99,6 +100,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
+    args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.parse(arguments);
 
     WebView::ProcessManager::initialize();
@@ -149,6 +151,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,
         .log_all_js_exceptions = log_all_js_exceptions ? Ladybird::LogAllJSExceptions::Yes : Ladybird::LogAllJSExceptions::No,
         .enable_idl_tracing = enable_idl_tracing ? Ladybird::EnableIDLTracing::Yes : Ladybird::EnableIDLTracing::No,
+        .expose_internals_object = expose_internals_object ? Ladybird::ExposeInternalsObject::Yes : Ladybird::ExposeInternalsObject::No,
     };
 
     Ladybird::BrowserWindow window(initial_urls, cookie_jar, web_content_options, webdriver_content_ipc_path);

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -92,13 +92,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(raw_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
     args_parser.add_option(enable_callgrind_profiling, "Enable Callgrind profiling", "enable-callgrind-profiling", 'P');
-    args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database", 0);
-    args_parser.add_option(enable_qt_networking, "Enable Qt as the backend networking service", "enable-qt-networking", 0);
-    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting", 0);
-    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content", 0);
+    args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");
+    args_parser.add_option(enable_qt_networking, "Enable Qt as the backend networking service", "enable-qt-networking");
+    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting");
+    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
-    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions", 0);
-    args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing", 0);
+    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
+    args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.parse(arguments);
 
     WebView::ProcessManager::initialize();

--- a/Ladybird/Types.h
+++ b/Ladybird/Types.h
@@ -45,6 +45,11 @@ enum class EnableIDLTracing {
     Yes
 };
 
+enum class ExposeInternalsObject {
+    No,
+    Yes
+};
+
 struct WebContentOptions {
     String command_line;
     String executable_path;
@@ -55,6 +60,7 @@ struct WebContentOptions {
     WaitForDebugger wait_for_debugger { WaitForDebugger::No };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };
     EnableIDLTracing enable_idl_tracing { EnableIDLTracing::No };
+    ExposeInternalsObject expose_internals_object { ExposeInternalsObject::No };
 };
 
 }

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -94,6 +94,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Vector<ByteString> certificates;
     int request_server_socket { -1 };
     bool is_layout_test_mode = false;
+    bool expose_internals_object = false;
     bool use_lagom_networking = false;
     bool use_gpu_painting = false;
     bool wait_for_debugger = false;
@@ -105,6 +106,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(executable_path, "Chrome process executable path", "executable-path", 0, "executable_path");
     args_parser.add_option(request_server_socket, "File descriptor of the socket for the RequestServer connection", "request-server-socket", 'r', "request_server_socket");
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode");
+    args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
     args_parser.add_option(use_gpu_painting, "Enable GPU painting", "use-gpu-painting");
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
@@ -117,6 +119,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (wait_for_debugger) {
         Core::Process::wait_for_debugger_and_break();
     }
+
+    // Layout test mode implies internals object is exposed
+    if (is_layout_test_mode)
+        expose_internals_object = true;
 
     Web::set_chrome_process_command_line(command_line);
     Web::set_chrome_process_executable_path(executable_path);
@@ -137,7 +143,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #endif
         TRY(initialize_lagom_networking(request_server_socket));
 
-    Web::HTML::Window::set_internals_object_exposed(is_layout_test_mode);
+    Web::HTML::Window::set_internals_object_exposed(expose_internals_object);
 
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode));
 

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -104,13 +104,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(command_line, "Chrome process command line", "command-line", 0, "command_line");
     args_parser.add_option(executable_path, "Chrome process executable path", "executable-path", 0, "executable_path");
     args_parser.add_option(request_server_socket, "File descriptor of the socket for the RequestServer connection", "request-server-socket", 'r', "request_server_socket");
-    args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
-    args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking", 0);
-    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "use-gpu-painting", 0);
-    args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger", 0);
+    args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode");
+    args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
+    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "use-gpu-painting");
+    args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
-    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions", 0);
-    args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing", 0);
+    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
+    args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
 
     args_parser.parse(arguments);
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/main.cpp
@@ -117,7 +117,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(passes_to_dump_cfg, "Dump CFG after specified passes.", "dump-cfg", 0, "{all|last|<pass-name>|-<pass-name>[,...]}");
 
     bool silence_diagnostics = false;
-    args_parser.add_option(silence_diagnostics, "Silence all diagnostics.", "silence-diagnostics", 0);
+    args_parser.add_option(silence_diagnostics, "Silence all diagnostics.", "silence-diagnostics");
 
     args_parser.parse(arguments);
 

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -209,7 +209,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(runner_command, "Command to run", "runner-command", 'r', "command");
     args_parser.add_option(pass_through_parameters, "Parameters to pass through to the runner, will split on spaces", "pass-through", 'p', "parameters");
     args_parser.add_option(dont_print_progress, "Hide progress information", "quiet", 'q');
-    args_parser.add_option(dont_disable_core_dump, "Enabled core dumps for runner (i.e. don't pass --disable-core-dump)", "enable-core-dumps", 0);
+    args_parser.add_option(dont_disable_core_dump, "Enabled core dumps for runner (i.e. don't pass --disable-core-dump)", "enable-core-dumps");
     args_parser.parse(arguments);
 
     // Normalize the path to ensure filenames are consistent

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -583,7 +583,7 @@ int main(int argc, char** argv)
     args_parser.add_option(s_parse_only, "Only parse the files", "parse-only", 'p');
     args_parser.add_option(timeout, "Seconds before test should timeout", "timeout", 't', "seconds");
     args_parser.add_option(enable_debug_printing, "Enable debug printing", "debug", 'd');
-    args_parser.add_option(disable_core_dumping, "Disable core dumping", "disable-core-dump", 0);
+    args_parser.add_option(disable_core_dumping, "Disable core dumping", "disable-core-dump");
     args_parser.parse(arguments);
 
 #ifdef AK_OS_GNU_HURD

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -175,7 +175,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Show information from an application crash coredump.");
     args_parser.add_positional_argument(coredump_path, "Coredump path", "coredump-path");
-    args_parser.add_option(unlink_on_exit, "Delete the coredump after its parsed", "unlink", 0);
+    args_parser.add_option(unlink_on_exit, "Delete the coredump after its parsed", "unlink");
     args_parser.parse(arguments);
 
     auto coredump = Coredump::Reader::create(coredump_path);

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -85,11 +85,11 @@ public:
     void print_version(FILE*);
 
     void add_option(Option&&);
-    void add_ignored(char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
-    void add_option(bool& value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_ignored(char const* long_name, char short_name = 0, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(bool& value, char const* help_string, char const* long_name, char short_name = 0, OptionHideMode hide_mode = OptionHideMode::None);
     /// If the option is present, set the enum to have the given `new_value`.
     template<Enum T>
-    void add_option(T& value, T new_value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None)
+    void add_option(T& value, T new_value, char const* help_string, char const* long_name, char short_name = 0, OptionHideMode hide_mode = OptionHideMode::None)
     {
         add_option({ .argument_mode = Core::ArgsParser::OptionArgumentMode::None,
             .help_string = help_string,

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
     });
 
     args_parser.add_option(print_json, "Show results as JSON", "json", 'j');
-    args_parser.add_option(per_file, "Show detailed per-file results as JSON (implies -j)", "per-file", 0);
+    args_parser.add_option(per_file, "Show detailed per-file results as JSON (implies -j)", "per-file");
     args_parser.add_option(g_collect_on_every_allocation, "Collect garbage after every allocation", "collect-often", 'g');
     args_parser.add_option(JS::Bytecode::g_dump_bytecode, "Dump the bytecode", "dump-bytecode", 'd');
     args_parser.add_option(test_glob, "Only run tests matching the given glob", "filter", 'f', "glob");

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -128,11 +128,11 @@ int TestSuite::main(ByteString const& suite_name, Span<StringView> arguments)
     bool do_list_cases = false;
     StringView search_string = "*"sv;
 
-    args_parser.add_option(do_tests_only, "Only run tests.", "tests", 0);
-    args_parser.add_option(do_benchmarks_only, "Only run benchmarks.", "bench", 0);
+    args_parser.add_option(do_tests_only, "Only run tests.", "tests");
+    args_parser.add_option(do_benchmarks_only, "Only run benchmarks.", "bench");
     args_parser.add_option(m_benchmark_repetitions, "Number of times to repeat each benchmark (default 1)", "benchmark_repetitions", 0, "N");
     args_parser.add_option(m_randomized_runs, "Number of times to run each RANDOMIZED_TEST_CASE (default 100)", "randomized_runs", 0, "RUNS");
-    args_parser.add_option(do_list_cases, "List available test cases.", "list", 0);
+    args_parser.add_option(do_list_cases, "List available test cases.", "list");
     args_parser.add_positional_argument(search_string, "Only run matching cases.", "pattern", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -174,11 +174,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser parser;
     parser.add_option(command_to_run, "String to read commands from", "command-string", 'c', "command-string");
-    parser.add_option(skip_rc_files, "Skip running shellrc files", "skip-shellrc", 0);
+    parser.add_option(skip_rc_files, "Skip running shellrc files", "skip-shellrc");
     parser.add_option(format, "Format the given file into stdout and exit", "format", 0, "file");
     parser.add_option(should_format_live, "Enable live formatting", "live-formatting", 'f');
-    parser.add_option(keep_open, "Keep the shell open after running the specified command or file", "keep-open", 0);
-    parser.add_option(posix_mode, "Behave like a POSIX-compatible shell", "posix", 0);
+    parser.add_option(keep_open, "Keep the shell open after running the specified command or file", "keep-open");
+    parser.add_option(posix_mode, "Behave like a POSIX-compatible shell", "posix");
     parser.add_positional_argument(file_to_read_from, "File to read commands from", "file", Core::ArgsParser::Required::No);
     parser.add_positional_argument(script_args, "Extra arguments to pass to the script (via $* and co)", "argument", Core::ArgsParser::Required::No);
 

--- a/Userland/Utilities/comm.cpp
+++ b/Userland/Utilities/comm.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(suppress_col3, "Suppress column 3 (lines common to both files)", nullptr, '3');
     args_parser.add_option(case_insensitive, "Use case-insensitive comparison of lines", nullptr, 'i');
     args_parser.add_option(color, "Always print colored output", "color", 'c');
-    args_parser.add_option(no_color, "Do not print colored output", "no-color", 0);
+    args_parser.add_option(no_color, "Do not print colored output", "no-color");
     args_parser.add_option(print_total, "Print a summary", "total", 't');
     args_parser.add_positional_argument(file1_path, "First file to compare", "file1");
     args_parser.add_positional_argument(file2_path, "Second file to compare", "file2");

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -116,9 +116,9 @@ ErrorOr<void> parse_args(Main::Arguments arguments, Vector<ByteString>& files, D
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Display actual or apparent disk usage of files or directories.");
     args_parser.add_option(du_option.all, "Write counts for all files, not just directories", "all", 'a');
-    args_parser.add_option(du_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size", 0);
+    args_parser.add_option(du_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size");
     args_parser.add_option(du_option.human_readable, "Print human-readable sizes", "human-readable", 'h');
-    args_parser.add_option(du_option.human_readable_si, "Print human-readable sizes in SI units", "si", 0);
+    args_parser.add_option(du_option.human_readable_si, "Print human-readable sizes in SI units", "si");
     args_parser.add_option(du_option.max_depth, "Print the total for a directory or file only if it is N or fewer levels below the command line argument", "max-depth", 'd', "N");
     args_parser.add_option(summarize, "Display only a total for each argument", "summarize", 's');
     args_parser.add_option(du_option.threshold, "Exclude entries smaller than size if positive, or entries greater than size if negative", "threshold", 't', "size");

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -204,7 +204,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             return true;
         },
     });
-    args_parser.add_option(disable_hyperlinks, "Disable hyperlinks", "no-hyperlinks", 0);
+    args_parser.add_option(disable_hyperlinks, "Disable hyperlinks", "no-hyperlinks");
     args_parser.add_option(count_lines, "Output line count instead of line contents", "count", 'c');
     args_parser.add_positional_argument(files, "File(s) to process", "file", Core::ArgsParser::Required::No);
     args_parser.parse(args);

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -674,7 +674,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(dump_failed_ref_tests, "Dump screenshots of failing ref tests", "dump-failed-ref-tests", 'D');
     args_parser.add_option(resources_folder, "Path of the base resources folder (defaults to /res)", "resources", 'r', "resources-root-path");
     args_parser.add_option(web_driver_ipc_path, "Path to the WebDriver IPC socket", "webdriver-ipc-path", 0, "path");
-    args_parser.add_option(is_layout_test_mode, "Enable layout test mode", "layout-test-mode", 0);
+    args_parser.add_option(is_layout_test_mode, "Enable layout test mode", "layout-test-mode");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_positional_argument(raw_url, "URL to open", "url", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -244,13 +244,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(reencode_out_path, "Reencode ICC profile to this path", "reencode-to", 0, "FILE");
 
     bool debug_roundtrip = false;
-    args_parser.add_option(debug_roundtrip, "Check how many u8 colors roundtrip losslessly through the profile. For debugging.", "debug-roundtrip", 0);
+    args_parser.add_option(debug_roundtrip, "Check how many u8 colors roundtrip losslessly through the profile. For debugging.", "debug-roundtrip");
 
     bool measure = false;
-    args_parser.add_option(measure, "For RGB ICC profiles, print perceptually smallest and largest color step", "measure", 0);
+    args_parser.add_option(measure, "For RGB ICC profiles, print perceptually smallest and largest color step", "measure");
 
     bool force_print = false;
-    args_parser.add_option(force_print, "Print profile even when writing ICC files", "print", 0);
+    args_parser.add_option(force_print, "Print profile even when writing ICC files", "print");
 
     args_parser.parse(arguments);
 

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -138,7 +138,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_hide_group, "In long format, do not show group information. Implies '-l'", nullptr, 'o');
     args_parser.add_option(flag_hide_owner, "In long format, do not show owner information. Implies '-l'", nullptr, 'g');
     args_parser.add_option(flag_human_readable, "Print human-readable sizes", "human-readable", 'h');
-    args_parser.add_option(flag_human_readable_si, "Print human-readable sizes in SI units", "si", 0);
+    args_parser.add_option(flag_human_readable_si, "Print human-readable sizes in SI units", "si");
     args_parser.add_option(flag_disable_hyperlinks, "Disable hyperlinks", "no-hyperlinks", 'K');
     args_parser.add_option(flag_recursive, "List subdirectories recursively", "recursive", 'R');
     args_parser.add_option(flag_force_newline, "List one file per line", nullptr, '1');

--- a/Userland/Utilities/paste.cpp
+++ b/Userland/Utilities/paste.cpp
@@ -57,7 +57,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Paste from the clipboard to stdout.");
-    args_parser.add_option(print_type, "Display the copied type", "print-type", 0);
+    args_parser.add_option(print_type, "Display the copied type", "print-type");
     args_parser.add_option(no_newline, "Do not append a newline", "no-newline", 'n');
     args_parser.add_option(watch, "Run a command when clipboard data changes", "watch", 'w');
     args_parser.add_positional_argument(watch_command, "Command to run in watch mode", "command", Core::ArgsParser::Required::No);

--- a/Userland/Utilities/rm.cpp
+++ b/Userland/Utilities/rm.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(recursive, "Delete directories recursively", "recursive", 'r');
     args_parser.add_option(force, "Ignore nonexistent files", "force", 'f');
     args_parser.add_option(verbose, "Verbose", "verbose", 'v');
-    args_parser.add_option(no_preserve_root, "Do not consider '/' specially", "no-preserve-root", 0);
+    args_parser.add_option(no_preserve_root, "Do not consider '/' specially", "no-preserve-root");
     args_parser.add_positional_argument(paths, "Path(s) to remove", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -352,7 +352,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(print_all_output, "Show all test output", "verbose", 'v');
     args_parser.add_option(run_benchmarks, "Run benchmarks as well", "benchmarks", 'b');
     args_parser.add_option(run_skipped_tests, "Run all matching tests, even those marked as 'skip'", "all", 'a');
-    args_parser.add_option(unlink_coredumps, "Unlink coredumps after printing backtraces", "unlink-coredumps", 0);
+    args_parser.add_option(unlink_coredumps, "Unlink coredumps after printing backtraces", "unlink-coredumps");
     args_parser.add_option(test_glob, "Only run tests matching the given glob", "filter", 'f', "glob");
     args_parser.add_option(exclude_pattern, "Regular expression to use to exclude paths from being considered tests", "exclude-pattern", 'e', "pattern");
     args_parser.add_option(config_file, "Configuration file to use", "config-file", 'c', "filename");

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -48,9 +48,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(list, "List contents", "list", 't');
     args_parser.add_option(verbose, "Print paths", "verbose", 'v');
     args_parser.add_option(gzip, "Compress or decompress file using gzip", "gzip", 'z');
-    args_parser.add_option(lzma, "Compress or decompress file using lzma", "lzma", 0);
+    args_parser.add_option(lzma, "Compress or decompress file using lzma", "lzma");
     args_parser.add_option(xz, "Compress or decompress file using xz", "xz", 'J');
-    args_parser.add_option(no_auto_compress, "Do not use the archive suffix to select the compression algorithm", "no-auto-compress", 0);
+    args_parser.add_option(no_auto_compress, "Do not use the archive suffix to select the compression algorithm", "no-auto-compress");
     args_parser.add_option(directory, "Directory to extract to/create from", "directory", 'C', "DIRECTORY");
     args_parser.add_option(archive_file, "Archive file", "file", 'f', "FILE");
     args_parser.add_option(dereference, "Follow symlinks", "dereference", 'h');

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -503,7 +503,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.add_option(print, "Print the parsed module", "print", 'p');
     parser.add_option(attempt_instantiate, "Attempt to instantiate the module", "instantiate", 'i');
     parser.add_option(exported_function_to_execute, "Attempt to execute the named exported function from the module (implies -i)", "execute", 'e', "name");
-    parser.add_option(export_all_imports, "Export noop functions corresponding to imports", "export-noop", 0);
+    parser.add_option(export_all_imports, "Export noop functions corresponding to imports", "export-noop");
     parser.add_option(shell_mode, "Launch a REPL in the module's context (implies -i)", "shell", 's');
     parser.add_option(wasi, "Enable WASI", "wasi", 'w');
     parser.add_option(Core::ArgsParser::Option {


### PR DESCRIPTION
Sometimes I like to play around with running Ladybird tests using full
blown Ladybird instead of just headless browser to interactively mess
around with the test page. One problem with this is that the internals
object is not exposed in this mode.

This supports this usecase by adding an option to specifically
expose the internals object without needing to run headless-browser
in test mode.

Also make it optional to pass through 'short_option' to args parser
as I questioned for a second what all of the 0's were at the end of all
of the `add_options`