### PR TITLE
LibWebView: Invalid URLs no longer replaced with a ":"

### DIFF
--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -75,7 +75,7 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
 
     auto format_search_engine = [&]() -> Optional<URL::URL> {
         if (!search_engine.has_value())
-            return MUST(String::formatted("https://{}"sv, url));        
+            return MUST(String::formatted("https://{}"sv, url));
 
         return MUST(String::formatted(*search_engine, URL::percent_decode(url)));
     };

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -16,7 +16,7 @@
 
 namespace WebView {
 
-static Optional<URL::URL> query_public_suffix_list(StringView url_string, Optional<StringView> search_engine)
+static Optional<URL::URL> query_public_suffix_list(StringView url_string)
 {
     auto out = MUST(String::from_utf8(url_string));
     if (!out.starts_with_bytes("about:"sv) && !out.contains("://"sv))
@@ -40,9 +40,6 @@ static Optional<URL::URL> query_public_suffix_list(StringView url_string, Option
 
         if (host.ends_with_bytes(".local"sv) || host.ends_with_bytes("localhost"sv))
             return url;
-    }
-    if (!search_engine.has_value()) {
-        return url;
     }
 
     return {};
@@ -77,8 +74,8 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
     }
 
     auto format_search_engine = [&]() -> Optional<URL::URL> {
-        if (!search_engine.has_value())
-            return {};
+        if (!search_engine.has_value()) 
+            return MUST(String::formatted("https://{}"sv, url));        
 
         return MUST(String::formatted(*search_engine, URL::percent_decode(url)));
     };
@@ -93,7 +90,7 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
         }
     }
 
-    auto result = query_public_suffix_list(url, search_engine);
+    auto result = query_public_suffix_list(url);
     if (!result.has_value())
         return format_search_engine();
 

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -74,7 +74,7 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
     }
 
     auto format_search_engine = [&]() -> Optional<URL::URL> {
-        if (!search_engine.has_value()) 
+        if (!search_engine.has_value())
             return MUST(String::formatted("https://{}"sv, url));        
 
         return MUST(String::formatted(*search_engine, URL::percent_decode(url)));

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -16,7 +16,7 @@
 
 namespace WebView {
 
-static Optional<URL::URL> query_public_suffix_list(StringView url_string)
+static Optional<URL::URL> query_public_suffix_list(StringView url_string, Optional<StringView> search_engine)
 {
     auto out = MUST(String::from_utf8(url_string));
     if (!out.starts_with_bytes("about:"sv) && !out.contains("://"sv))
@@ -40,6 +40,9 @@ static Optional<URL::URL> query_public_suffix_list(StringView url_string)
 
         if (host.ends_with_bytes(".local"sv) || host.ends_with_bytes("localhost"sv))
             return url;
+    }
+    if (!search_engine.has_value()) {
+        return url;
     }
 
     return {};
@@ -90,7 +93,7 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
         }
     }
 
-    auto result = query_public_suffix_list(url);
+    auto result = query_public_suffix_list(url, search_engine);
     if (!result.has_value())
         return format_search_engine();
 

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -75,7 +75,7 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
 
     auto format_search_engine = [&]() -> Optional<URL::URL> {
         if (!search_engine.has_value())
-            return MUST(String::formatted("https://{}"sv, url));
+            return MUST(String::formatted("https://{}"sv, MUST(String::from_utf8(url))));
 
         return MUST(String::formatted(*search_engine, URL::percent_decode(url)));
     };


### PR DESCRIPTION
Hi, we are students at the University of Utah working on a Ladybird fix for our final project. 

Attempting to navigate to an invalid URL or a non-existent file path (as described in issue #22473) while search is disabled causes the path to be replaced with a colon. To fix this, we added an extra condition to return the URL rather than nothing (which gets interpreted as a colon).

Typing "catdog" into the search bar of a new tab:
![Screenshot 2024-04-20 183329](https://github.com/SerenityOS/serenity/assets/122491927/444df043-b6c7-4b52-8e25-ecc1981283bb)

Typing "catdog" into the search bar after this change:
![Screenshot 2024-04-20 183156](https://github.com/SerenityOS/serenity/assets/122491927/0144507d-1387-4323-ab16-fd6f3a4de53e)

