### PR TITLE
LibWeb: Clear WebAssembly cache when all namespace objects are GCed 

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3830,7 +3830,7 @@ void @namespace_class@::initialize(JS::Realm& realm)
 void @namespace_class@::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    @name@::visit_edges(visitor);
+    @name@::visit_edges(*this, visitor);
 }
 )~~~");
     }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3703,6 +3703,12 @@ private:
 )~~~");
     }
 
+    if (interface.extended_attributes.contains("WithFinalizer"sv)) {
+        generator.append(R"~~~(
+    virtual void finalize() override;
+)~~~");
+    }
+
     for (auto const& overload_set : interface.overload_sets) {
         auto function_generator = generator.fork();
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
@@ -3831,6 +3837,15 @@ void @namespace_class@::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     @name@::visit_edges(*this, visitor);
+}
+)~~~");
+    }
+
+    if (interface.extended_attributes.contains("WithFinalizer"sv)) {
+        generator.append(R"~~~(
+void @namespace_class@::finalize()
+{
+    @name@::finalize(*this);
 }
 )~~~");
     }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3697,7 +3697,7 @@ public:
 private:
 )~~~");
 
-    if (interface.extended_attributes.contains("WithGCVistor"sv)) {
+    if (interface.extended_attributes.contains("WithGCVisitor"sv)) {
         generator.append(R"~~~(
     virtual void visit_edges(JS::Cell::Visitor&) override;
 )~~~");
@@ -3825,7 +3825,7 @@ void @namespace_class@::initialize(JS::Realm& realm)
 }
 )~~~");
 
-    if (interface.extended_attributes.contains("WithGCVistor"sv)) {
+    if (interface.extended_attributes.contains("WithGCVisitor"sv)) {
         generator.append(R"~~~(
 void @namespace_class@::visit_edges(JS::Cell::Visitor& visitor)
 {

--- a/Userland/Libraries/LibWeb/WebAssembly/Instance.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/Instance.h
@@ -11,8 +11,10 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibJS/Heap/Handle.h>
+#include <LibWasm/AbstractMachine/AbstractMachine.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/WebAssembly/WebAssembly.h>
 
 namespace Web::WebAssembly {
 
@@ -26,13 +28,16 @@ public:
     Object const* exports() const { return m_exports.ptr(); }
 
 private:
-    Instance(JS::Realm&, size_t index);
+    Instance(JS::Realm&, NonnullOwnPtr<Wasm::ModuleInstance>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;
 
     JS::NonnullGCPtr<Object> m_exports;
-    size_t m_index { 0 };
+    NonnullOwnPtr<Wasm::ModuleInstance> m_module_instance;
+    HashMap<Wasm::FunctionAddress, JS::GCPtr<JS::FunctionObject>> m_function_instances;
+    HashMap<Wasm::MemoryAddress, JS::GCPtr<WebAssembly::Memory>> m_memory_instances;
+    HashMap<Wasm::TableAddress, JS::GCPtr<WebAssembly::Table>> m_table_instances;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/Module.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Module.cpp
@@ -21,13 +21,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Module>> Module::construct_impl(JS::Realm& 
 {
     auto& vm = realm.vm();
 
-    auto index = TRY(Detail::parse_module(vm, bytes->raw_object()));
-    return vm.heap().allocate<Module>(realm, realm, index);
+    auto compiled_module = TRY(Detail::parse_module(vm, bytes->raw_object()));
+    return vm.heap().allocate<Module>(realm, realm, move(compiled_module));
 }
 
-Module::Module(JS::Realm& realm, size_t index)
+Module::Module(JS::Realm& realm, NonnullRefPtr<Detail::CompiledWebAssemblyModule> compiled_module)
     : Bindings::PlatformObject(realm)
-    , m_index(index)
+    , m_compiled_module(move(compiled_module))
 {
 }
 
@@ -35,11 +35,6 @@ void Module::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE_WITH_CUSTOM_NAME(Module, WebAssembly.Module);
-}
-
-Wasm::Module const& Module::module() const
-{
-    return Detail::s_compiled_modules.at(index())->module;
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/Module.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/Module.h
@@ -13,6 +13,7 @@
 #include <LibWasm/Types.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/WebAssembly/WebAssembly.h>
 
 namespace Web::WebAssembly {
 
@@ -23,15 +24,14 @@ class Module : public Bindings::PlatformObject {
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Module>> construct_impl(JS::Realm&, JS::Handle<WebIDL::BufferSource>& bytes);
 
-    size_t index() const { return m_index; }
-    Wasm::Module const& module() const;
+    NonnullRefPtr<Detail::CompiledWebAssemblyModule> compiled_module() const { return m_compiled_module; }
 
 private:
-    Module(JS::Realm&, size_t index);
+    Module(JS::Realm&, NonnullRefPtr<Detail::CompiledWebAssemblyModule>);
 
     virtual void initialize(JS::Realm&) override;
 
-    size_t m_index { 0 };
+    NonnullRefPtr<Detail::CompiledWebAssemblyModule> m_compiled_module;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -45,12 +45,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Table>> Table::construct_impl(JS::Realm& re
     Wasm::Limits limits { descriptor.initial, move(descriptor.maximum) };
     Wasm::TableType table_type { reference_type, move(limits) };
 
-    auto address = Detail::s_abstract_machine.store().allocate(table_type);
+    auto& cache = Detail::get_cache(realm);
+    auto address = cache.abstract_machine().store().allocate(table_type);
     if (!address.has_value())
         return vm.throw_completion<JS::TypeError>("Wasm Table allocation failed"sv);
 
     auto const& reference = reference_value.value().get<Wasm::Reference>();
-    auto& table = *Detail::s_abstract_machine.store().get(*address);
+    auto& table = *cache.abstract_machine().store().get(*address);
     for (auto& element : table.elements())
         element = reference;
 
@@ -74,7 +75,8 @@ WebIDL::ExceptionOr<u32> Table::grow(u32 delta, JS::Value value)
 {
     auto& vm = this->vm();
 
-    auto* table = Detail::s_abstract_machine.store().get(address());
+    auto& cache = Detail::get_cache(realm());
+    auto* table = cache.abstract_machine().store().get(address());
     if (!table)
         return vm.throw_completion<JS::RangeError>("Could not find the memory table to grow"sv);
 
@@ -94,7 +96,8 @@ WebIDL::ExceptionOr<JS::Value> Table::get(u32 index) const
 {
     auto& vm = this->vm();
 
-    auto* table = Detail::s_abstract_machine.store().get(address());
+    auto& cache = Detail::get_cache(realm());
+    auto* table = cache.abstract_machine().store().get(address());
     if (!table)
         return vm.throw_completion<JS::RangeError>("Could not find the memory table"sv);
 
@@ -114,7 +117,8 @@ WebIDL::ExceptionOr<void> Table::set(u32 index, JS::Value value)
 {
     auto& vm = this->vm();
 
-    auto* table = Detail::s_abstract_machine.store().get(address());
+    auto& cache = Detail::get_cache(realm());
+    auto* table = cache.abstract_machine().store().get(address());
     if (!table)
         return vm.throw_completion<JS::RangeError>("Could not find the memory table"sv);
 
@@ -134,7 +138,8 @@ WebIDL::ExceptionOr<u32> Table::length() const
 {
     auto& vm = this->vm();
 
-    auto* table = Detail::s_abstract_machine.store().get(address());
+    auto& cache = Detail::get_cache(realm());
+    auto* table = cache.abstract_machine().store().get(address());
     if (!table)
         return vm.throw_completion<JS::RangeError>("Could not find the memory table"sv);
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -48,6 +48,12 @@ void visit_edges(JS::Object& object, JS::Cell::Visitor& visitor)
     }
 }
 
+void finalize(JS::Object& object)
+{
+    auto& global_object = HTML::relevant_global_object(object);
+    Detail::s_caches.remove(global_object);
+}
+
 // https://webassembly.github.io/spec/js-api/#dom-webassembly-validate
 bool validate(JS::VM& vm, JS::Handle<WebIDL::BufferSource>& bytes)
 {

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -19,6 +19,7 @@
 namespace Web::WebAssembly {
 
 void visit_edges(JS::Object&, JS::Cell::Visitor&);
+void finalize(JS::Object&);
 
 bool validate(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes);
 WebIDL::ExceptionOr<JS::Value> compile(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.idl
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.idl
@@ -7,7 +7,7 @@ dictionary WebAssemblyInstantiatedSource {
 };
 
 // https://webassembly.github.io/spec/js-api/#webassembly-namespace
-[Exposed=*, WithGCVistor]
+[Exposed=*, WithGCVisitor]
 namespace WebAssembly {
     boolean validate(BufferSource bytes);
     Promise<Module> compile(BufferSource bytes);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.idl
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.idl
@@ -7,7 +7,7 @@ dictionary WebAssemblyInstantiatedSource {
 };
 
 // https://webassembly.github.io/spec/js-api/#webassembly-namespace
-[Exposed=*, WithGCVisitor]
+[Exposed=*, WithGCVisitor, WithFinalizer]
 namespace WebAssembly {
     boolean validate(BufferSource bytes);
     Promise<Module> compile(BufferSource bytes);


### PR DESCRIPTION
Previously, items in the cache would persist after all `WebAssemblyNamespace` objects had been garbage collected. This led to a UAF when accessing cached objects.

This should unblock #23835 and #24006, which currently cause CI failures.