### PR TITLE
LibWeb: Update document url after same-document back/forward navigation

### DIFF
--- a/Tests/LibWeb/Text/data/iframe-popstate-event.html
+++ b/Tests/LibWeb/Text/data/iframe-popstate-event.html
@@ -1,8 +1,10 @@
 <script>
-    window.history.pushState({}, '', '');
+    window.history.pushState({}, '', window.location.href + '#test');
 
     window.addEventListener('popstate', (e) => {
-        parent.postMessage('popstate event from iframe', '*');
+        const url = new URL(window.location.href);
+        const pathWithHash = url.pathname.split('/').pop() + url.hash;
+        parent.postMessage(`popstate event from iframe new_path=${pathWithHash}`, '*');
     });
 
     window.history.back();

--- a/Tests/LibWeb/Text/expected/navigation/history-popstate-event.txt
+++ b/Tests/LibWeb/Text/expected/navigation/history-popstate-event.txt
@@ -1,1 +1,1 @@
-  popstate event from iframe
+  popstate event from iframe new_path=iframe-popstate-event.html

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4070,6 +4070,9 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
 
         // 5. If documentIsNew is false, then:
         if (!document_is_new) {
+            // NOTE: Not in the spec, but otherwise document's url won't be updated in case of a same-document back/forward navigation.
+            set_url(entry->url());
+
             // AD HOC: Skip this in situations the spec steps don't account for
             if (update_navigation_api) {
                 // 1. Update the navigation API entries for a same-document navigation given navigation, entry, and "traverse".


### PR DESCRIPTION
Seems like a specification bug, but other browsers update url before popstate event is fired and so should we.

Fixes back/forward navigation on GitHub.