### PR TITLE
Kernel/riscv64: Implement Processor::read_cpu_counter

### DIFF
--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -30,6 +30,7 @@ enum class Address : u16 {
     SATP = 0x180,
 
     // Unprivileged Counters/Timers
+    CYCLE = 0xc00,
     TIME = 0xc01,
 };
 

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -211,7 +211,7 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 template<typename T>
 ALWAYS_INLINE u64 ProcessorBase<T>::read_cpu_counter()
 {
-    TODO_RISCV64();
+    return RISCV64::CSR::read(RISCV64::CSR::Address::CYCLE);
 }
 
 }


### PR DESCRIPTION
This simply reads the current cycle count from the cycle CSR.
x86-64 uses the similar rdtsc instruction here, which also may or may
not tick at a constant rate.