### PR TITLE
LibWebView: Do not update cookie access time when fetched with WebDriver

### DIFF
--- a/Userland/Libraries/LibWebView/CookieJar.cpp
+++ b/Userland/Libraries/LibWebView/CookieJar.cpp
@@ -447,6 +447,10 @@ Vector<Web::Cookie::Cookie> CookieJar::get_matching_cookies(const URL::URL& url,
         });
     });
 
+    // NOTE: The WebDriver spec expects only step 1 above to be executed to match cookies.
+    if (mode == MatchingCookiesSpecMode::WebDriver)
+        return cookie_list;
+
     // 3. Update the last-access-time of each cookie in the cookie-list to the current date and time.
     auto now = UnixDateTime::now();
 


### PR DESCRIPTION
When WebDriver accesses cookies, it specifically says to run:

    the first step of the algorithm in RFC6265 to compute cookie-string

So we should skip subsequent steps. We already skip step 2, which sorts the cookies, but neglected to skip step 3 to update their last access time.