### PR TITLE
LibELF: Get rid of DynamicLoader::m_cached_dynamic_object

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -98,23 +98,6 @@ DynamicLoader::~DynamicLoader()
     }
 }
 
-DynamicObject const& DynamicLoader::dynamic_object() const
-{
-    if (!m_cached_dynamic_object) {
-        VirtualAddress dynamic_section_address;
-
-        image().for_each_program_header([&dynamic_section_address](auto program_header) {
-            if (program_header.type() == PT_DYNAMIC) {
-                dynamic_section_address = VirtualAddress(program_header.raw_data());
-            }
-        });
-        VERIFY(!dynamic_section_address.is_null());
-
-        m_cached_dynamic_object = ELF::DynamicObject::create(m_filepath, VirtualAddress(image().base_address()), dynamic_section_address);
-    }
-    return *m_cached_dynamic_object;
-}
-
 void DynamicLoader::find_tls_size_and_alignment()
 {
     image().for_each_program_header([this](auto program_header) {

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -88,7 +88,7 @@ public:
     static Optional<DynamicObject::SymbolLookupResult> lookup_symbol(const ELF::DynamicObject::Symbol&);
     void copy_initial_tls_data_into(Bytes buffer) const;
 
-    DynamicObject const& dynamic_object() const;
+    DynamicObject const& dynamic_object() const { return *m_dynamic_object; }
 
     bool is_fully_relocated() const { return m_fully_relocated; }
     bool is_fully_initialized() const { return m_fully_initialized; }
@@ -177,8 +177,6 @@ private:
     Vector<DynamicObject::Relocation> m_unresolved_relocations;
     Vector<DynamicObject::Relocation> m_direct_ifunc_relocations;
     Vector<DynamicObject::Relocation> m_plt_ifunc_relocations;
-
-    mutable RefPtr<DynamicObject> m_cached_dynamic_object;
 
     bool m_fully_relocated { false };
     bool m_fully_initialized { false };


### PR DESCRIPTION
The strategy of recreating an object for the second time after DynamicLoader::map is interesting, of course, but it doesn't help comprehensibility of the code, unfortunately.