### PR TITLE
LibWeb: Allow moving StyleSheets between documents without falling apart

### DIFF
--- a/Tests/LibWeb/Text/expected/css/move-loaded-link-stylesheet-between-documents.txt
+++ b/Tests/LibWeb/Text/expected/css/move-loaded-link-stylesheet-between-documents.txt
@@ -1,0 +1,3 @@
+Sheets in old doc: 0
+Sheets in new doc: 1
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/move-loaded-link-stylesheet-between-documents.html
+++ b/Tests/LibWeb/Text/input/css/move-loaded-link-stylesheet-between-documents.html
@@ -1,0 +1,11 @@
+<script src="../include.js"></script>
+<script>
+    let doc = new DOMParser().parseFromString(`<link rel="stylesheet" href="data:text/css,div{}">`, `text/html`);
+    let link = doc.head.firstChild;
+    document.head.appendChild(link);
+    test(() => {
+        println("Sheets in old doc: " + doc.styleSheets.length)
+        println("Sheets in new doc: " + document.styleSheets.length)
+        println("PASS (didn't crash)");
+    })
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -46,6 +46,15 @@ void HTMLLinkElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLLinkElement);
 }
 
+void HTMLLinkElement::removed_from(Node* old_parent)
+{
+    Base::removed_from(old_parent);
+    if (m_loaded_style_sheet) {
+        document_or_shadow_root_style_sheets().remove_a_css_style_sheet(*m_loaded_style_sheet);
+        m_loaded_style_sheet = nullptr;
+    }
+}
+
 void HTMLLinkElement::inserted()
 {
     HTMLElement::inserted();

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -28,6 +28,7 @@ public:
     virtual ~HTMLLinkElement() override;
 
     virtual void inserted() override;
+    virtual void removed_from(Node* old_parent) override;
 
     String rel() const { return get_attribute_value(HTML::AttributeNames::rel); }
     String type() const { return get_attribute_value(HTML::AttributeNames::type); }


### PR DESCRIPTION
We have to unregister link element stylesheets from the old document's StyleSheetList when moving them into a new document.

This makes it possible to load GitHub contributor graphs. :^)

![Screenshot from 2024-04-21 19-52-52](https://github.com/SerenityOS/serenity/assets/5954907/4ad2380d-e945-4c9a-ae4f-9ce6bffc162e)
