### PR TITLE
[WIP] LibWeb+Ladybird: Support download anchors and revamp download mechanism

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -96,15 +96,18 @@ void HTMLAnchorElement::activation_behavior(Web::DOM::Event const& event)
     // 4. Let userInvolvement be event's user navigation involvement.
     auto user_involvement = user_navigation_involvement(event);
 
-    // FIXME: 5. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
-    // NOTE: That is, if the user has expressed a specific preference for downloading, this no longer counts as merely "activation".
+    // 5. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
+    //    NOTE: That is, if the user has expressed a specific preference for downloading, this no longer counts as merely "activation".
+    // Not applicable, see do_manual_download
 
-    // FIXME: 6. If element has a download attribute, or if the user has expressed a preference to download the
-    //     hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
-    //     userInvolvement set to userInvolvement.
-
-    // 7. Otherwise, follow the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and userInvolvement set to userInvolvement.
-    follow_the_hyperlink(hyperlink_suffix, user_involvement);
+    // 6. If element has a download attribute, or if the user has expressed a preference to download the
+    //    hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
+    //    userInvolvement set to userInvolvement.
+    if (has_attribute(HTML::AttributeNames::download)) {
+        // FIXME: Download the hyperlink
+    } else
+        // 7. Otherwise, follow the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and userInvolvement set to userInvolvement.
+        follow_the_hyperlink(hyperlink_suffix, user_involvement);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
@@ -158,6 +161,39 @@ WebIDL::ExceptionOr<void> HTMLAnchorElement::set_referrer_policy(String const& r
 {
     // The IDL attribute referrerPolicy must reflect the referrerpolicy content attribute, limited to only known values.
     return set_attribute(HTML::AttributeNames::referrerpolicy, referrer_policy);
+}
+
+// https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements
+void HTMLAnchorElement::do_manual_download()
+{
+    // NOTE: Performing a manual download of an anchor uses the same activation behavior algorithm, but does not create an event relevant for it
+
+    // The activation behavior of an a or area element element given an event event is:
+
+    // 1. If element has no href attribute, then return.
+    if (href().is_empty())
+        return;
+
+    // 2. Let hyperlinkSuffix be null.
+    Optional<String> hyperlink_suffix {};
+
+    // 3. If element is an a element, and event's target is an img with an ismap attribute specified, then:
+    // Not applicable: Attempting to perform a manual download on an img triggers seperate logic
+
+    // 4. Let userInvolvement be event's user navigation involvement.
+    // Not applicable
+
+    // 5. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
+    //    NOTE: That is, if the user has expressed a specific preference for downloading, this no longer counts as merely "activation".
+    [[maybe_unused]] auto user_involvement = UserNavigationInvolvement::BrowserUI;
+
+    // 6. If element has a download attribute, or if the user has expressed a preference to download the
+    //    hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
+    //    userInvolvement set to userInvolvement.
+    // FIXME: Download the hyperlink
+
+    // 7. Otherwise, follow the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and userInvolvement set to userInvolvement.
+    // Not applicable
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -30,6 +30,8 @@ public:
     StringView referrer_policy() const;
     WebIDL::ExceptionOr<void> set_referrer_policy(String const&);
 
+    void do_manual_download();
+
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-a-element
     virtual bool is_focusable() const override { return has_attribute(HTML::AttributeNames::href); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -63,6 +63,7 @@ protected:
 
     void set_the_url();
     void follow_the_hyperlink(Optional<String> hyperlink_suffix, UserNavigationInvolvement = UserNavigationInvolvement::None);
+    void download_the_hyperlink(Optional<String> hyperlink_suffix, UserNavigationInvolvement = UserNavigationInvolvement::None);
 
 private:
     void reinitialize_url() const;

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -302,7 +302,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                     if (button == GUI::MouseButton::Middle) {
                         m_navigable->page().client().page_did_middle_click_link(url, link->target().to_byte_string(), modifiers);
                     } else if (button == GUI::MouseButton::Secondary) {
-                        m_navigable->page().client().page_did_request_link_context_menu(top_level_position, url, link->target().to_byte_string(), modifiers);
+                        m_navigable->page().did_request_link_context_menu(link->unique_id(), top_level_position, url, link->target().to_byte_string(), modifiers);
                     }
                 } else if (button == GUI::MouseButton::Secondary) {
                     if (is<HTML::HTMLImageElement>(*node)) {

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
@@ -526,13 +527,12 @@ void Page::download_context_menu_element()
     if (dom_node == nullptr)
         return;
 
-    if (dom_node->is_html_anchor_element()) {
-        // download anchor
-    } else if (dom_node->is_html_image_element()) {
-        // download image
-    } else if (is<HTML::HTMLMediaElement>(dom_node)) {
-        // download media
-    }
+    if (dom_node->is_html_anchor_element())
+        static_cast<HTML::HTMLAnchorElement*>(dom_node)->do_manual_download();
+    else if (dom_node->is_html_image_element())
+        return;
+    else if (is<HTML::HTMLMediaElement>(dom_node))
+        return;
 }
 
 void Page::set_user_style(String source)

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -404,6 +404,12 @@ void Page::select_dropdown_closed(Optional<u32> const& selected_item_id)
     }
 }
 
+void Page::did_request_link_context_menu(i32 link_id, CSSPixelPoint position, URL::URL const& url, ByteString const& target, unsigned modifiers)
+{
+    m_context_menu_element_id = link_id;
+    client().page_did_request_link_context_menu(position, move(url), target, modifiers);
+}
+
 void Page::register_media_element(Badge<HTML::HTMLMediaElement>, int media_id)
 {
     m_media_elements.append(media_id);
@@ -418,7 +424,7 @@ void Page::unregister_media_element(Badge<HTML::HTMLMediaElement>, int media_id)
 
 void Page::did_request_media_context_menu(i32 media_id, CSSPixelPoint position, ByteString const& target, unsigned modifiers, MediaContextMenu menu)
 {
-    m_media_context_menu_element_id = media_id;
+    m_context_menu_element_id = media_id;
     client().page_did_request_media_context_menu(position, target, modifiers, move(menu));
 }
 
@@ -498,10 +504,10 @@ void Page::toggle_page_mute_state()
 
 JS::GCPtr<HTML::HTMLMediaElement> Page::media_context_menu_element()
 {
-    if (!m_media_context_menu_element_id.has_value())
+    if (!m_context_menu_element_id.has_value())
         return nullptr;
 
-    auto* dom_node = DOM::Node::from_unique_id(*m_media_context_menu_element_id);
+    auto* dom_node = DOM::Node::from_unique_id(*m_context_menu_element_id);
     if (dom_node == nullptr)
         return nullptr;
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -517,6 +517,24 @@ JS::GCPtr<HTML::HTMLMediaElement> Page::media_context_menu_element()
     return static_cast<HTML::HTMLMediaElement*>(dom_node);
 }
 
+void Page::download_context_menu_element()
+{
+    if (!m_context_menu_element_id.has_value())
+        return;
+
+    auto* dom_node = DOM::Node::from_unique_id(*m_context_menu_element_id);
+    if (dom_node == nullptr)
+        return;
+
+    if (dom_node->is_html_anchor_element()) {
+        // download anchor
+    } else if (dom_node->is_html_image_element()) {
+        // download image
+    } else if (is<HTML::HTMLMediaElement>(dom_node)) {
+        // download media
+    }
+}
+
 void Page::set_user_style(String source)
 {
     m_user_style_sheet_source = source;

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -175,6 +175,8 @@ public:
     HTML::MuteState page_mute_state() const { return m_mute_state; }
     void toggle_page_mute_state();
 
+    void download_context_menu_element();
+
     Optional<String> const& user_style() const { return m_user_style_sheet_source; }
     void set_user_style(String source);
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -153,6 +153,8 @@ public:
         Select,
     };
 
+    void did_request_link_context_menu(i32 link_id, CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers);
+
     void register_media_element(Badge<HTML::HTMLMediaElement>, int media_id);
     void unregister_media_element(Badge<HTML::HTMLMediaElement>, int media_id);
 
@@ -213,8 +215,9 @@ private:
     PendingNonBlockingDialog m_pending_non_blocking_dialog { PendingNonBlockingDialog::None };
     WeakPtr<HTML::HTMLElement> m_pending_non_blocking_dialog_target;
 
+    Optional<i32> m_context_menu_element_id;
+
     Vector<int> m_media_elements;
-    Optional<int> m_media_context_menu_element_id;
 
     Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -355,6 +355,11 @@ void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, We
         on_audio_play_state_changed(m_audio_play_state);
 }
 
+void ViewImplementation::download_context_menu_element()
+{
+    client().async_download_context_menu_element(page_id());
+}
+
 void ViewImplementation::did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const
 {
     if (on_navigation_buttons_state_changed)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -110,6 +110,8 @@ public:
     void did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState);
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
+    void download_context_menu_element();
+
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
 
     enum class ScreenshotType {

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1093,6 +1093,12 @@ void ConnectionFromClient::toggle_page_mute_state(u64 page_id)
         page->page().toggle_page_mute_state();
 }
 
+void ConnectionFromClient::download_context_menu_element(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().download_context_menu_element();
+}
+
 void ConnectionFromClient::set_user_style(u64 page_id, String const& source)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -115,6 +115,8 @@ private:
 
     virtual void toggle_page_mute_state(u64 page_id) override;
 
+    virtual void download_context_menu_element(u64 page_id) override;
+
     virtual void set_user_style(u64 page_id, String const&) override;
 
     virtual void enable_inspector_prototype(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -466,6 +466,11 @@ Web::WebIDL::ExceptionOr<void> PageClient::toggle_media_controls_state()
     return page().toggle_media_controls_state();
 }
 
+void PageClient::download_context_menu_element()
+{
+    page().download_context_menu_element();
+}
+
 void PageClient::set_user_style(String source)
 {
     page().set_user_style(source);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -59,6 +59,8 @@ public:
     Web::WebIDL::ExceptionOr<void> toggle_media_loop_state();
     Web::WebIDL::ExceptionOr<void> toggle_media_controls_state();
 
+    void download_context_menu_element();
+
     void alert_closed();
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -102,6 +102,8 @@ endpoint WebContentServer
 
     toggle_page_mute_state(u64 page_id) =|
 
+    download_context_menu_element(u64 page_id) =|
+
     set_user_style(u64 page_id, String source) =|
 
     enable_inspector_prototype(u64 page_id) =|


### PR DESCRIPTION
This PR aims to implement the `download` attribute of `<a>` elements and add more robust download support to Ladybird. Currently only the LibGUI chrome supports downloads, but not of blobs and not by clicking a download button.