### PR TITLE
LibWeb: brave.com is now scrollable

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -56,7 +56,10 @@ bool Box::is_scroll_container() const
 
 bool Box::is_user_scrollable() const
 {
-    // FIXME: Support horizontal scroll as well (overflow-x)
+    // FIXME: Support horizontal scroll as well (overflow-x).
+	if (computed_values().overflow_y() == CSS::Overflow::Hidden || computed_values().overflow_x() == CSS::Overflow::Hidden) 
+		return false;
+
     return computed_values().overflow_y() == CSS::Overflow::Scroll || computed_values().overflow_y() == CSS::Overflow::Auto;
 }
 


### PR DESCRIPTION
The is_user_scrollable method in Box now ignores overflow: hidden. This makes websites like brave.com scrollable via the mouse wheel.