### PR TITLE
LibWeb: Make NavigationParams be GC-allocated

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -373,6 +373,7 @@ set(SOURCES
     HTML/NavigationDestination.cpp
     HTML/NavigationCurrentEntryChangeEvent.cpp
     HTML/NavigationHistoryEntry.cpp
+    HTML/NavigationParams.cpp
     HTML/NavigationTransition.cpp
     HTML/Navigator.cpp
     HTML/NavigatorBeacon.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -52,6 +52,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOM/TreeWalker.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/FileAPI/BlobURLStore.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/BrowsingContext.h>

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 
 namespace Web {
 
@@ -54,21 +55,20 @@ JS::NonnullGCPtr<DOM::Document> create_document_for_inline_content(JS::GCPtr<HTM
     //    about base URL: null
     auto response = Fetch::Infrastructure::Response::create(vm);
     response->url_list().append(URL::URL("about:error")); // AD-HOC: https://github.com/whatwg/html/issues/9122
-    HTML::NavigationParams navigation_params {
-        .id = navigation_id,
-        .navigable = navigable,
-        .request = {},
-        .response = *response,
-        .fetch_controller = nullptr,
-        .commit_early_hints = nullptr,
-        .coop_enforcement_result = move(coop_enforcement_result),
-        .reserved_environment = {},
-        .origin = move(origin),
-        .policy_container = HTML::PolicyContainer {},
-        .final_sandboxing_flag_set = HTML::SandboxingFlagSet {},
-        .cross_origin_opener_policy = move(coop),
-        .about_base_url = {},
-    };
+    auto navigation_params = vm.heap().allocate_without_realm<HTML::NavigationParams>();
+    navigation_params->id = navigation_id;
+    navigation_params->navigable = navigable;
+    navigation_params->request = nullptr;
+    navigation_params->response = response;
+    navigation_params->fetch_controller = nullptr;
+    navigation_params->commit_early_hints = nullptr;
+    navigation_params->coop_enforcement_result = move(coop_enforcement_result);
+    navigation_params->reserved_environment = {};
+    navigation_params->origin = move(origin);
+    navigation_params->policy_container = HTML::PolicyContainer {};
+    navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
+    navigation_params->cross_origin_opener_policy = move(coop);
+    navigation_params->about_base_url = {};
 
     // 5. Let document be the result of creating and initializing a Document object given "html", "text/html", and navigationParams.
     auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -120,7 +120,7 @@ public:
         SourceSnapshotParams const& source_snapshot_params,
         TargetSnapshotParams const& target_snapshot_params,
         Optional<String> navigation_id = {},
-        Variant<Empty, NavigationParams, NonFetchSchemeNavigationParams> navigation_params = Empty {},
+        Variant<Empty, JS::NonnullGCPtr<NavigationParams>, JS::NonnullGCPtr<NonFetchSchemeNavigationParams>> navigation_params = Empty {},
         CSPNavigationType csp_navigation_type = CSPNavigationType::Other,
         bool allow_POST = false,
         Function<void()> completion_steps = [] {});

--- a/Userland/Libraries/LibWeb/HTML/NavigationParams.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigationParams.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Fetch/Infrastructure/FetchController.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/NavigationParams.h>
+
+namespace Web::HTML {
+
+JS_DEFINE_ALLOCATOR(NavigationParams);
+JS_DEFINE_ALLOCATOR(NonFetchSchemeNavigationParams);
+
+void NavigationParams::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(navigable);
+    visitor.visit(request);
+    visitor.visit(response);
+    visitor.visit(fetch_controller);
+}
+
+void NonFetchSchemeNavigationParams::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(navigable);
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigationParams.h
@@ -6,11 +6,14 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <LibJS/Heap/CellAllocator.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
 #include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicyEnforcementResult.h>
-#include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
@@ -18,12 +21,15 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params
-struct NavigationParams {
+struct NavigationParams : JS::Cell {
+    JS_CELL(NavigationParams, JS::Cell);
+    JS_DECLARE_ALLOCATOR(NavigationParams);
+
     // null or a navigation ID
     Optional<String> id;
 
     // the navigable to be navigated
-    JS::Handle<Navigable> navigable;
+    JS::GCPtr<Navigable> navigable;
 
     // null or a request that started the navigation
     JS::GCPtr<Fetch::Infrastructure::Request> request;
@@ -59,15 +65,20 @@ struct NavigationParams {
 
     // a URL or null used to populate the new Document's about base URL
     Optional<URL::URL> about_base_url;
+
+    void visit_edges(Visitor& visitor) override;
 };
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#non-fetch-scheme-navigation-params
-struct NonFetchSchemeNavigationParams {
+struct NonFetchSchemeNavigationParams : JS::Cell {
+    JS_CELL(NonFetchSchemeNavigationParams, JS::Cell);
+    JS_DECLARE_ALLOCATOR(NonFetchSchemeNavigationParams);
+
     // null or a navigation ID
     Optional<String> id;
 
     // the navigable to be navigated
-    JS::Handle<Navigable> navigable;
+    JS::GCPtr<Navigable> navigable;
 
     // a URL
     URL::URL url;
@@ -82,6 +93,8 @@ struct NonFetchSchemeNavigationParams {
     Origin initiator_origin;
 
     // FIXME: a NavigationTimingType used for creating the navigation timing entry for the new Document
+
+    void visit_edges(Visitor& visitor) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -35,21 +35,14 @@ ErrorOr<JS::NonnullGCPtr<SVGDecodedImageData>> SVGDecodedImageData::create(JS::R
     JS::NonnullGCPtr<HTML::Navigable> navigable = page->top_level_traversable();
     auto response = Fetch::Infrastructure::Response::create(navigable->vm());
     response->url_list().append(url);
-    HTML::NavigationParams navigation_params {
-        .id = {},
-        .navigable = navigable,
-        .request = nullptr,
-        .response = response,
-        .fetch_controller = nullptr,
-        .commit_early_hints = nullptr,
-        .coop_enforcement_result = HTML::CrossOriginOpenerPolicyEnforcementResult {},
-        .reserved_environment = {},
-        .origin = HTML::Origin {},
-        .policy_container = HTML::PolicyContainer {},
-        .final_sandboxing_flag_set = HTML::SandboxingFlagSet {},
-        .cross_origin_opener_policy = HTML::CrossOriginOpenerPolicy {},
-        .about_base_url = {},
-    };
+    auto navigation_params = navigable->heap().allocate_without_realm<HTML::NavigationParams>();
+    navigation_params->navigable = navigable;
+    navigation_params->response = response;
+    navigation_params->origin = HTML::Origin {};
+    navigation_params->policy_container = HTML::PolicyContainer {};
+    navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
+    navigation_params->cross_origin_opener_policy = HTML::CrossOriginOpenerPolicy {};
+
     // FIXME: Use Navigable::navigate() instead of manually replacing the navigable's document.
     auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params).release_value_but_fixme_should_propagate_errors();
     navigable->set_ongoing_navigation({});


### PR DESCRIPTION
Fixes GC-leak caused by using JS::Handle for navigable.