### PR TITLE
AK+Kernel: Convert many set-once boolean flags to SetOnce's

### DIFF
--- a/AK/SetOnce.h
+++ b/AK/SetOnce.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+class SetOnce {
+    AK_MAKE_NONCOPYABLE(SetOnce);
+    AK_MAKE_NONMOVABLE(SetOnce);
+
+public:
+    SetOnce() = default;
+
+    void set()
+    {
+        m_value = true;
+    }
+
+    bool was_set() const { return m_value; }
+
+private:
+    bool m_value { false };
+};
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::SetOnce;
+#endif

--- a/Kernel/Arch/Processor.cpp
+++ b/Kernel/Arch/Processor.cpp
@@ -23,7 +23,7 @@ void ProcessorBase<T>::check_invoke_scheduler()
     VERIFY(!m_in_irq);
     VERIFY(!m_in_critical);
     VERIFY(&Processor::current() == this);
-    if (m_invoke_scheduler_async && m_scheduler_initialized) {
+    if (m_invoke_scheduler_async && m_scheduler_initialized.was_set()) {
         m_invoke_scheduler_async = false;
         Scheduler::invoke_async();
     }

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/SetOnce.h>
 #include <Kernel/Arch/CPUID.h>
 #include <Kernel/Arch/DeferredCallEntry.h>
 #include <Kernel/Arch/DeferredCallPool.h>
@@ -195,7 +196,8 @@ private:
     //       they need to be FlatPtrs or everything becomes highly unsound and breaks. They are actually just booleans.
     FlatPtr m_in_scheduler;
     FlatPtr m_invoke_scheduler_async;
-    FlatPtr m_scheduler_initialized;
+
+    SetOnce m_scheduler_initialized;
 
     DeferredCallPool m_deferred_call_pool {};
 };

--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -7,6 +7,7 @@
 #include <AK/Singleton.h>
 #include <AK/Types.h>
 
+#include <AK/SetOnce.h>
 #include <Kernel/Arch/Delay.h>
 #include <Kernel/Bus/PCI/Initializer.h>
 #include <Kernel/Sections.h>
@@ -26,13 +27,13 @@ void microseconds_delay(u32)
 // Initializer.cpp
 namespace Kernel::PCI {
 
-bool g_pci_access_io_probe_failed { false };
-bool g_pci_access_is_disabled_from_commandline { true };
+SetOnce g_pci_access_io_probe_failed;
+SetOnce g_pci_access_is_disabled_from_commandline;
 
 void initialize()
 {
     dbgln("PCI: FIXME: Enable PCI for aarch64 platforms");
-    g_pci_access_io_probe_failed = true;
+    g_pci_access_io_probe_failed.set();
 }
 
 }

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -157,7 +157,7 @@ void ProcessorBase<T>::initialize_context_switching(Thread& initial_thread)
 {
     VERIFY(initial_thread.process().is_kernel_process());
 
-    m_scheduler_initialized = true;
+    m_scheduler_initialized.set();
 
     // FIXME: Figure out if we need to call {pre_,post_,}init_finished once aarch64 supports SMP
     Processor::set_current_in_scheduler(true);

--- a/Kernel/Arch/riscv64/PCI/Initializer.cpp
+++ b/Kernel/Arch/riscv64/PCI/Initializer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/SetOnce.h>
 #include <Kernel/Arch/CPU.h>
 #include <Kernel/Boot/CommandLine.h>
 #include <Kernel/Bus/PCI/API.h>
@@ -15,14 +16,15 @@
 
 namespace Kernel::PCI {
 
-bool g_pci_access_io_probe_failed { false };
-bool g_pci_access_is_disabled_from_commandline;
+SetOnce g_pci_access_io_probe_failed;
+SetOnce g_pci_access_is_disabled_from_commandline;
 
 void initialize()
 {
-    g_pci_access_is_disabled_from_commandline = kernel_command_line().is_pci_disabled();
-    if (g_pci_access_is_disabled_from_commandline)
+    if (kernel_command_line().is_pci_disabled()) {
+        g_pci_access_is_disabled_from_commandline.set();
         return;
+    }
 
     new Access();
 

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -187,7 +187,7 @@ void ProcessorBase<T>::initialize_context_switching(Thread& initial_thread)
 {
     VERIFY(initial_thread.process().is_kernel_process());
 
-    m_scheduler_initialized = true;
+    m_scheduler_initialized.set();
 
     // FIXME: Figure out if we need to call {pre_,post_,}init_finished once riscv64 supports SMP
     Processor::set_current_in_scheduler(true);

--- a/Kernel/Arch/x86_64/Firmware/PCBIOS/SysFSDirectory.cpp
+++ b/Kernel/Arch/x86_64/Firmware/PCBIOS/SysFSDirectory.cpp
@@ -68,7 +68,7 @@ void SysFSBIOSDirectory::create_components()
 UNMAP_AFTER_INIT void SysFSBIOSDirectory::initialize_dmi_exposer()
 {
     VERIFY(!(m_dmi_entry_point.is_null()));
-    if (m_using_64bit_dmi_entry_point) {
+    if (m_using_64bit_dmi_entry_point.was_set()) {
         set_dmi_64_bit_entry_initialization_values();
     } else {
         set_dmi_32_bit_entry_initialization_values();
@@ -87,7 +87,7 @@ UNMAP_AFTER_INIT SysFSBIOSDirectory::SysFSBIOSDirectory(SysFSFirmwareDirectory& 
     auto entry_64bit = find_dmi_entry64bit_point();
     if (entry_64bit.has_value()) {
         m_dmi_entry_point = entry_64bit.value();
-        m_using_64bit_dmi_entry_point = true;
+        m_using_64bit_dmi_entry_point.set();
     }
     if (m_dmi_entry_point.is_null())
         return;

--- a/Kernel/Arch/x86_64/Firmware/PCBIOS/SysFSDirectory.h
+++ b/Kernel/Arch/x86_64/Firmware/PCBIOS/SysFSDirectory.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/SetOnce.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Firmware/Directory.h>
@@ -34,7 +35,7 @@ private:
 
     PhysicalAddress m_dmi_entry_point;
     PhysicalAddress m_smbios_structure_table;
-    bool m_using_64bit_dmi_entry_point { false };
+    SetOnce m_using_64bit_dmi_entry_point;
     size_t m_smbios_structure_table_length { 0 };
     size_t m_dmi_entry_point_length { 0 };
 };

--- a/Kernel/Arch/x86_64/Interrupts/APIC.h
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/SetOnce.h>
 #include <AK/Types.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Time/HardwareTimer.h>
@@ -99,7 +100,7 @@ private:
     u32 m_processor_cnt { 0 };
     u32 m_processor_enabled_cnt { 0 };
     APICTimer* m_apic_timer { nullptr };
-    bool m_is_x2 { false };
+    SetOnce m_is_x2;
 
     static PhysicalAddress get_base();
     void set_base(PhysicalAddress const& base);

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/Concepts.h>
 #include <AK/Function.h>
+#include <AK/SetOnce.h>
 #include <AK/Types.h>
 
 #include <Kernel/Arch/DeferredCallEntry.h>
@@ -72,7 +73,7 @@ private:
     static Atomic<u32> s_idle_cpu_mask;
 
     TSS m_tss;
-    bool m_has_qemu_hvf_quirk;
+    SetOnce m_has_qemu_hvf_quirk;
 
     ProcessorInfo* m_info;
 

--- a/Kernel/Arch/x86_64/VGA/IOArbiter.cpp
+++ b/Kernel/Arch/x86_64/VGA/IOArbiter.cpp
@@ -28,7 +28,7 @@ void VGAIOArbiter::disable_vga_emulation_access_permanently(Badge<GraphicsManage
     u8 sr1 = IO::in8(0x3c5);
     IO::out8(0x3c5, sr1 | 1 << 5);
     microseconds_delay(1000);
-    m_vga_access_is_disabled = true;
+    m_vga_access_is_disabled.set();
 }
 
 void VGAIOArbiter::enable_vga_text_mode_console_cursor(Badge<GraphicsManagement>)
@@ -39,7 +39,7 @@ void VGAIOArbiter::enable_vga_text_mode_console_cursor(Badge<GraphicsManagement>
 void VGAIOArbiter::enable_vga_text_mode_console_cursor()
 {
     SpinlockLocker locker(m_main_vga_lock);
-    if (m_vga_access_is_disabled)
+    if (m_vga_access_is_disabled.was_set())
         return;
     IO::out8(0x3D4, 0xA);
     IO::out8(0x3D5, 0);
@@ -53,7 +53,7 @@ void VGAIOArbiter::disable_vga_text_mode_console_cursor(Badge<GraphicsManagement
 void VGAIOArbiter::disable_vga_text_mode_console_cursor()
 {
     SpinlockLocker locker(m_main_vga_lock);
-    if (m_vga_access_is_disabled)
+    if (m_vga_access_is_disabled.was_set())
         return;
     IO::out8(0x3D4, 0xA);
     IO::out8(0x3D5, 0x20);
@@ -62,7 +62,7 @@ void VGAIOArbiter::disable_vga_text_mode_console_cursor()
 void VGAIOArbiter::unblank_screen(Badge<GraphicsManagement>)
 {
     SpinlockLocker locker(m_main_vga_lock);
-    if (m_vga_access_is_disabled)
+    if (m_vga_access_is_disabled.was_set())
         return;
     IO::out8(0x3c0, 0x20);
 }
@@ -70,7 +70,7 @@ void VGAIOArbiter::unblank_screen(Badge<GraphicsManagement>)
 void VGAIOArbiter::set_vga_text_mode_cursor(Badge<GraphicsManagement>, size_t console_width, size_t x, size_t y)
 {
     SpinlockLocker locker(m_main_vga_lock);
-    if (m_vga_access_is_disabled)
+    if (m_vga_access_is_disabled.was_set())
         return;
     enable_vga_text_mode_console_cursor();
     u16 value = y * console_width + x;

--- a/Kernel/Arch/x86_64/VGA/IOArbiter.h
+++ b/Kernel/Arch/x86_64/VGA/IOArbiter.h
@@ -8,6 +8,7 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Platform.h>
+#include <AK/SetOnce.h>
 #include <AK/Types.h>
 #include <Kernel/Locking/Spinlock.h>
 
@@ -34,7 +35,7 @@ private:
     void enable_vga_text_mode_console_cursor();
 
     RecursiveSpinlock<LockRank::None> m_main_vga_lock {};
-    bool m_vga_access_is_disabled { false };
+    SetOnce m_vga_access_is_disabled;
 };
 
 }

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -41,12 +41,12 @@ bool Access::is_initialized()
 
 bool Access::is_hardware_disabled()
 {
-    return g_pci_access_io_probe_failed;
+    return g_pci_access_io_probe_failed.was_set();
 }
 
 bool Access::is_disabled()
 {
-    return g_pci_access_is_disabled_from_commandline || g_pci_access_io_probe_failed;
+    return g_pci_access_is_disabled_from_commandline.was_set() || g_pci_access_io_probe_failed.was_set();
 }
 
 UNMAP_AFTER_INIT bool Access::find_and_register_pci_host_bridges_from_acpi_mcfg_table(PhysicalAddress mcfg_table)

--- a/Kernel/Bus/PCI/Initializer.h
+++ b/Kernel/Bus/PCI/Initializer.h
@@ -6,10 +6,12 @@
 
 #pragma once
 
+#include <AK/SetOnce.h>
+
 namespace Kernel::PCI {
 
-extern bool g_pci_access_io_probe_failed;
-extern bool g_pci_access_is_disabled_from_commandline;
+extern SetOnce g_pci_access_io_probe_failed;
+extern SetOnce g_pci_access_is_disabled_from_commandline;
 
 void initialize();
 

--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -40,8 +40,8 @@ void Device::set_status_bit(u8 status_bit)
 
 ErrorOr<void> Device::accept_device_features(u64 device_features, u64 accepted_features)
 {
-    VERIFY(!m_did_accept_features);
-    m_did_accept_features = true;
+    VERIFY(!m_did_accept_features.was_set());
+    m_did_accept_features.set();
 
     if (is_feature_set(device_features, VIRTIO_F_VERSION_1)) {
         accepted_features |= VIRTIO_F_VERSION_1; // let the device know were not a legacy driver
@@ -89,8 +89,8 @@ ErrorOr<void> Device::setup_queue(u16 queue_index)
 
 ErrorOr<void> Device::setup_queues(u16 requested_queue_count)
 {
-    VERIFY(!m_did_setup_queues);
-    m_did_setup_queues = true;
+    VERIFY(!m_did_setup_queues.was_set());
+    m_did_setup_queues.set();
 
     auto* common_cfg = TRY(m_transport_entity->get_config(ConfigurationType::Common));
     if (common_cfg) {
@@ -120,8 +120,8 @@ ErrorOr<void> Device::setup_queues(u16 requested_queue_count)
 
 void Device::finish_init()
 {
-    VERIFY(m_did_accept_features);                 // ensure features were negotiated
-    VERIFY(m_did_setup_queues);                    // ensure queues were set-up
+    VERIFY(m_did_accept_features.was_set());       // ensure features were negotiated
+    VERIFY(m_did_setup_queues.was_set());          // ensure queues were set-up
     VERIFY(!(m_status & DEVICE_STATUS_DRIVER_OK)); // ensure we didn't already finish the initialization
 
     set_status_bit(DEVICE_STATUS_DRIVER_OK);

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/SetOnce.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Bus/VirtIO/Definitions.h>
@@ -66,7 +67,7 @@ protected:
     }
     bool is_feature_accepted(u64 feature) const
     {
-        VERIFY(m_did_accept_features);
+        VERIFY(m_did_accept_features.was_set());
         return is_feature_set(m_accepted_features, feature);
     }
 
@@ -91,8 +92,8 @@ private:
     u16 m_queue_count { 0 };
     u8 m_status { 0 };
     u64 m_accepted_features { 0 };
-    bool m_did_accept_features { false };
-    bool m_did_setup_queues { false };
+    SetOnce m_did_accept_features;
+    SetOnce m_did_setup_queues;
 
     NonnullOwnPtr<TransportEntity> const m_transport_entity;
 };

--- a/Kernel/Bus/VirtIO/Transport/Entity.cpp
+++ b/Kernel/Bus/VirtIO/Transport/Entity.cpp
@@ -10,7 +10,7 @@ namespace Kernel::VirtIO {
 
 auto TransportEntity::mapping_for_resource_index(u8 resource_index) -> IOWindow&
 {
-    VERIFY(m_use_mmio);
+    VERIFY(m_use_mmio.was_set());
     VERIFY(m_register_bases[resource_index]);
     return *m_register_bases[resource_index];
 }

--- a/Kernel/Bus/VirtIO/Transport/Entity.h
+++ b/Kernel/Bus/VirtIO/Transport/Entity.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/SetOnce.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/VirtIO/Definitions.h>
 #include <Kernel/Bus/VirtIO/Queue.h>
@@ -90,7 +91,7 @@ protected:
 
     IOWindow& base_io_window();
     Array<OwnPtr<IOWindow>, 6> m_register_bases;
-    bool m_use_mmio { false };
+    SetOnce m_use_mmio;
 
     u32 m_notify_multiplier { 0 };
 };

--- a/Kernel/Bus/VirtIO/Transport/PCIe/TransportLink.cpp
+++ b/Kernel/Bus/VirtIO/Transport/PCIe/TransportLink.cpp
@@ -123,7 +123,7 @@ ErrorOr<void> PCIeTransportLink::locate_configurations_and_resources(Badge<VirtI
             }
             dbgln_if(VIRTIO_DEBUG, "{}: Found configuration {}, resource: {}, offset: {}, length: {}", device_name(), (u32)config.cfg_type, config.resource_index, config.offset, config.length);
             if (config.cfg_type == ConfigurationType::Common)
-                m_use_mmio = true;
+                m_use_mmio.set();
             else if (config.cfg_type == ConfigurationType::Notify)
                 m_notify_multiplier = capability.read32(0x10);
 
@@ -131,7 +131,7 @@ ErrorOr<void> PCIeTransportLink::locate_configurations_and_resources(Badge<VirtI
         }
     }
 
-    if (m_use_mmio) {
+    if (m_use_mmio.was_set()) {
         for (auto& cfg : m_configs) {
             auto mapping_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), static_cast<PCI::HeaderType0BaseRegister>(cfg.resource_index)));
             m_register_bases[cfg.resource_index] = move(mapping_io_window);

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -452,7 +452,7 @@ static void* kmalloc_impl(size_t size, size_t alignment, CallerWillInitializeMem
     SpinlockLocker lock(s_lock);
     ++g_kmalloc_call_count;
 
-    if (g_dump_kmalloc_stacks && Kernel::g_kernel_symbols_available) {
+    if (g_dump_kmalloc_stacks && Kernel::g_kernel_symbols_available.was_set()) {
         dbgln("kmalloc({})", size);
         Kernel::dump_backtrace();
     }

--- a/Kernel/KSyms.h
+++ b/Kernel/KSyms.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/SetOnce.h>
 
 namespace Kernel {
 
@@ -24,7 +25,7 @@ FlatPtr address_for_kernel_symbol(StringView name);
 KernelSymbol const* symbolicate_kernel_address(FlatPtr);
 void load_kernel_symbol_table();
 
-extern bool g_kernel_symbols_available;
+extern SetOnce g_kernel_symbols_available;
 extern FlatPtr g_lowest_kernel_symbol_address;
 extern FlatPtr g_highest_kernel_symbol_address;
 

--- a/Kernel/Library/KString.cpp
+++ b/Kernel/Library/KString.cpp
@@ -5,10 +5,11 @@
  */
 
 #include <AK/Format.h>
+#include <AK/SetOnce.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/Library/KString.h>
 
-extern bool g_in_early_boot;
+extern SetOnce g_not_in_early_boot;
 
 namespace Kernel {
 
@@ -33,7 +34,7 @@ ErrorOr<NonnullOwnPtr<KString>> KString::vformatted(StringView fmtstr, AK::TypeE
 NonnullOwnPtr<KString> KString::must_create(StringView string)
 {
     // We can only enforce success during early boot.
-    VERIFY(g_in_early_boot);
+    VERIFY(!g_not_in_early_boot.was_set());
     return KString::try_create(string).release_value();
 }
 
@@ -51,7 +52,7 @@ ErrorOr<NonnullOwnPtr<KString>> KString::try_create_uninitialized(size_t length,
 NonnullOwnPtr<KString> KString::must_create_uninitialized(size_t length, char*& characters)
 {
     // We can only enforce success during early boot.
-    VERIFY(g_in_early_boot);
+    VERIFY(!g_not_in_early_boot.was_set());
     return KString::try_create_uninitialized(length, characters).release_value();
 }
 

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -10,6 +10,7 @@
 #include <AK/EnumBits.h>
 #include <AK/IntrusiveList.h>
 #include <AK/IntrusiveRedBlackTree.h>
+#include <AK/SetOnce.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Library/KString.h>
 #include <Kernel/Library/LockWeakable.h>
@@ -89,8 +90,8 @@ public:
     [[nodiscard]] bool is_stack() const { return m_stack; }
     void set_stack(bool stack) { m_stack = stack; }
 
-    [[nodiscard]] bool is_immutable() const { return m_immutable; }
-    void set_immutable() { m_immutable = true; }
+    [[nodiscard]] bool is_immutable() const { return m_immutable.was_set(); }
+    void set_immutable() { m_immutable.set(); }
 
     [[nodiscard]] bool is_mmap() const { return m_mmap; }
 
@@ -243,11 +244,12 @@ private:
     bool m_cacheable : 1 { false };
     bool m_stack : 1 { false };
     bool m_mmap : 1 { false };
-    bool m_immutable : 1 { false };
     bool m_syscall_region : 1 { false };
     bool m_write_combine : 1 { false };
     bool m_mmapped_from_readable : 1 { false };
     bool m_mmapped_from_writable : 1 { false };
+
+    SetOnce m_immutable;
 
     IntrusiveRedBlackTreeNode<FlatPtr, Region, RawPtr<Region>> m_tree_node;
     IntrusiveListNode<Region> m_vmobject_list_node;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -97,19 +97,19 @@ void IPv4Socket::get_peer_address(sockaddr* address, socklen_t* address_size)
 
 ErrorOr<void> IPv4Socket::ensure_bound()
 {
-    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket::ensure_bound() m_bound {}", m_bound);
-    if (m_bound)
+    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket::ensure_bound() m_bound {}", m_bound.was_set());
+    if (m_bound.was_set())
         return {};
 
     auto result = protocol_bind();
     if (!result.is_error())
-        m_bound = true;
+        m_bound.set();
     return result;
 }
 
 ErrorOr<void> IPv4Socket::bind(Credentials const& credentials, Userspace<sockaddr const*> user_address, socklen_t address_size)
 {
-    if (m_bound)
+    if (m_bound.was_set())
         return set_so_error(EINVAL);
 
     VERIFY(setup_state() == SetupState::Unstarted);

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/SetOnce.h>
 #include <AK/SinglyLinkedList.h>
 #include <Kernel/Library/DoubleBuffer.h>
 #include <Kernel/Library/KBuffer.h>
@@ -73,7 +74,7 @@ protected:
     IPv4Socket(int type, int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer, OwnPtr<KBuffer> optional_scratch_buffer);
     virtual StringView class_name() const override { return "IPv4Socket"sv; }
 
-    void set_bound(bool bound) { m_bound = bound; }
+    void set_bound() { m_bound.set(); }
     ErrorOr<void> ensure_bound();
 
     virtual ErrorOr<void> protocol_bind() { return {}; }
@@ -107,7 +108,7 @@ private:
 
     Vector<IPv4Address> m_multicast_memberships;
     bool m_multicast_loop { true };
-    bool m_bound { false };
+    SetOnce m_bound;
 
     struct ReceivedPacket {
         IPv4Address peer_address;

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -221,7 +221,7 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
     dmesgln("E1000e: IO base: {}", m_registers_io_window);
     dmesgln("E1000e: Interrupt line: {}", interrupt_number());
     detect_eeprom();
-    dmesgln("E1000e: Has EEPROM? {}", m_has_eeprom);
+    dmesgln("E1000e: Has EEPROM? {}", m_has_eeprom.was_set());
     read_mac_address();
     auto const& mac = mac_address();
     dmesgln("E1000e: MAC address: {}", mac.to_string());
@@ -252,12 +252,13 @@ UNMAP_AFTER_INIT E1000ENetworkAdapter::~E1000ENetworkAdapter() = default;
 UNMAP_AFTER_INIT void E1000ENetworkAdapter::detect_eeprom()
 {
     // Section 13.4.3 of https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf
-    m_has_eeprom = in32(REG_EECD) & EECD_PRES;
+    if (in32(REG_EECD) & EECD_PRES)
+        m_has_eeprom.set();
 }
 
 UNMAP_AFTER_INIT u32 E1000ENetworkAdapter::read_eeprom(u8 address)
 {
-    VERIFY(m_has_eeprom);
+    VERIFY(m_has_eeprom.was_set());
     u16 data = 0;
     u32 tmp = 0;
     out32(REG_EEPROM, ((u32)address << 2) | 1);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <AK/SetOnce.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Interrupts/IRQHandler.h>
@@ -96,7 +97,7 @@ protected:
     NonnullOwnPtr<Memory::Region> m_tx_buffer_region;
     Array<void*, number_of_rx_descriptors> m_rx_buffers;
     Array<void*, number_of_tx_descriptors> m_tx_buffers;
-    bool m_has_eeprom { false };
+    SetOnce m_has_eeprom;
     bool m_link_up { false };
     EntropySource m_entropy_source;
 

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -156,13 +156,13 @@ ErrorOr<void> LocalSocket::bind(Credentials const& credentials, Userspace<sockad
     m_inode = inode;
 
     m_path = move(path);
-    m_bound = true;
+    m_bound.set();
     return {};
 }
 
 ErrorOr<void> LocalSocket::connect(Credentials const& credentials, OpenFileDescription& description, Userspace<sockaddr const*> user_address, socklen_t address_size)
 {
-    if (m_bound)
+    if (m_bound.was_set())
         return set_so_error(EISCONN);
 
     if (address_size > sizeof(sockaddr_un))
@@ -260,7 +260,7 @@ void LocalSocket::detach(OpenFileDescription& description)
         VERIFY(m_accept_side_fd_open);
         m_accept_side_fd_open = false;
 
-        if (m_bound) {
+        if (m_bound.was_set()) {
             if (m_inode)
                 m_inode->unbind_socket();
         }

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/IntrusiveList.h>
+#include <AK/SetOnce.h>
 #include <Kernel/Library/DoubleBuffer.h>
 #include <Kernel/Net/Socket.h>
 
@@ -94,7 +95,7 @@ private:
         return m_role;
     }
 
-    bool m_bound { false };
+    SetOnce m_bound;
     bool m_accept_side_fd_open { false };
     OwnPtr<KString> m_path;
 

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -157,7 +157,7 @@ ErrorOr<NonnullRefPtr<TCPSocket>> TCPSocket::try_create_client(IPv4Address const
         client->set_local_port(new_local_port);
         client->set_peer_address(new_peer_address);
         client->set_peer_port(new_peer_port);
-        client->set_bound(true);
+        client->set_bound();
         client->set_direction(Direction::Incoming);
         client->set_originator(*this);
 

--- a/Kernel/SanCov.cpp
+++ b/Kernel/SanCov.cpp
@@ -5,12 +5,13 @@
  */
 
 #include <AK/Platform.h>
+#include <AK/SetOnce.h>
 #include <AK/TemporaryChange.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Devices/KCOVDevice.h>
 #include <Kernel/Library/Panic.h>
 
-extern bool g_in_early_boot;
+extern SetOnce g_not_in_early_boot;
 
 #ifdef ENABLE_KERNEL_COVERAGE_COLLECTION_DEBUG
 // Set kcov_emergency_off=true before making calls from __sanitizer_cov_trace_pc to coverage
@@ -36,7 +37,7 @@ static void crash_and_burn(Thread* thread)
 extern "C" void __sanitizer_cov_trace_pc(void);
 extern "C" void __sanitizer_cov_trace_pc(void)
 {
-    if (g_in_early_boot) [[unlikely]]
+    if (!g_not_in_early_boot.was_set()) [[unlikely]]
         return;
 
     auto* thread = Processor::current_thread();

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -519,7 +519,7 @@ void Process::crash(int signal, Optional<RegisterState const&> regs, bool out_of
     if (out_of_memory) {
         dbgln("\033[31;1mOut of memory\033[m, killing: {}", *this);
     } else {
-        if (ip >= kernel_load_base && g_kernel_symbols_available) {
+        if (ip >= kernel_load_base && g_kernel_symbols_available.was_set()) {
             auto const* symbol = symbolicate_kernel_address(ip);
             dbgln("\033[31;1m{:p}  {} +{}\033[0m\n", ip, (symbol ? symbol->name : "(k?)"), (symbol ? ip - symbol->address : 0));
         } else {

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -118,7 +118,7 @@ MonotonicTime TimeManagement::monotonic_time(TimePrecision precision) const
     u64 seconds;
     u32 ticks;
 
-    bool do_query = precision == TimePrecision::Precise && m_can_query_precise_time;
+    bool do_query = precision == TimePrecision::Precise && m_can_query_precise_time.was_set();
 
     u32 update_iteration;
     do {
@@ -380,7 +380,7 @@ UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_x86_non_legacy_hardware_time
     // Use the HPET main counter frequency for time purposes. This is likely
     // a much higher frequency than the interrupt itself and allows us to
     // keep a more accurate time
-    m_can_query_precise_time = true;
+    m_can_query_precise_time.set();
     m_time_ticks_per_second = HPET::the().frequency();
 
     m_system_timer->try_to_set_frequency(m_system_timer->calculate_nearest_possible_frequency(OPTIMAL_TICKS_PER_SECOND_RATE));

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -9,6 +9,7 @@
 #include <AK/Error.h>
 #include <AK/OwnPtr.h>
 #include <AK/Platform.h>
+#include <AK/SetOnce.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -72,7 +73,7 @@ public:
     // FIXME: Most likely broken, because it does not check m_update[12] for in-progress updates.
     void set_remaining_epoch_time_adjustment(Duration adjustment) { m_remaining_epoch_time_adjustment = adjustment; }
 
-    bool can_query_precise_time() const { return m_can_query_precise_time; }
+    bool can_query_precise_time() const { return m_can_query_precise_time.was_set(); }
 
     Memory::VMObject& time_page_vmobject();
 
@@ -108,7 +109,7 @@ private:
     Atomic<u32> m_update2 { 0 };
 
     u32 m_time_ticks_per_second { 0 }; // may be different from interrupts/second (e.g. hpet)
-    bool m_can_query_precise_time { false };
+    SetOnce m_can_query_precise_time;
     bool m_updating_time { false }; // may only be accessed from the BSP!
 
     LockRefPtr<HardwareTimerBase> m_system_timer;


### PR DESCRIPTION
Part of this work was taken from #22968.
The idea is to semantically mark these kernel flags as set-once, and then to never worry about them changing in other places in kernel code.
As you can see, many flags that are matching the said functionality were replaced with `SetOnce` - I simply found those use-cases by searching for ` = true;` statement and then reviewed the results so these things popped almost immediately.

Although I'm pretty sure the `was_set` method is OK on its own (as it explicitly marks that the tested flag is a `SetOnce`), we could just override the boolean operator if we want to. If that's desired, I'd like to be notified about it so we can discuss the matter.