### PR TITLE
Meta: Trim the CI ccache down to files used in the current build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -156,14 +156,12 @@ jobs:
 
       - name: Show ccache stats before build and configure
         run: |
-          # We only have 5 GiB of cache available *in total*. Beyond that, GitHub deletes caches.
-          # Currently, we use about 130 MB for the toolchains (x86_64), and 2 ccache caches:
-          # One with ALL_DEBUG (x86_64), and one with NORMAL_DEBUG (x86_64).
-          # Therefore, using 1.6 GB or more per cache causes disaster.
-          # Building from scratch fills the ccache cache from 0 to about 0.7 GB, and after compression it comes out to
-          # about 0.25 GB, so 3 GB (1GB after compression) should be plenty, all while comfortably fitting in the cache.
-          ccache -M 3000M
+          # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
+          find ${{ github.workspace }}/.ccache | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
+          ccache -M 0
           ccache -s
+          ccache -z
+
       - name: Create build directory
         run: |
           mkdir -p ${{ github.workspace }}/Build/${{ matrix.arch }}
@@ -221,6 +219,10 @@ jobs:
       - name: Build Serenity and Tests
         working-directory: ${{ github.workspace }}/Build/superbuild
         run: cmake --build .
+
+      - name: Prune obsolete ccache files
+        run: ccache --evict-older-than 1d
+
       - name: Show ccache stats after build
         run: ccache -s
 

--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -6,9 +6,7 @@ parameters:
   download_cache_path: ''
   ccache_version: 1 # Increment this number if CI has trouble with ccache.
   serenity_ccache_path: ''
-  serenity_ccache_size: '5G'
   toolchain_ccache_path: ''
-  toolchain_ccache_size: $(CCACHE_MAXSIZE)
   with_remote_data_caches: true
 
 steps:
@@ -40,8 +38,11 @@ steps:
         displayName: 'Toolchain Compiler Cache'
 
       - script: |
-          CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -M ${{ parameters.toolchain_ccache_size }}
+          # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
+          find ${{ parameters.toolchain_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
+          CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -M 0
           CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -s
+          CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -z
         displayName: 'Configure Toolchain ccache'
 
   - ${{ if ne(parameters.serenity_ccache_path, '') }}:
@@ -54,9 +55,11 @@ steps:
       displayName: 'Serenity Compiler Cache'
 
     - script: |
-        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M ${{ parameters.serenity_ccache_size }}
-        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -c
+        # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
+        find ${{ parameters.serenity_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
+        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M 0
         CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -s
+        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -z
       displayName: 'Configure Serenity ccache'
 
   - ${{ if eq(parameters.with_remote_data_caches, true) }}:

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -56,7 +56,6 @@ jobs:
         with_remote_data_caches: true
         ${{ if eq(parameters.os, 'macOS') }}:
           ccache_version: 2
-        serenity_ccache_size: '2G'
 
     - ${{ if eq(parameters.os, 'Android') }}:
       - script: |
@@ -211,6 +210,10 @@ jobs:
           # FIXME: enable detect_stack_use_after_return=1 #7420
           ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0:allocator_may_return_null=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
+
+    - script: |
+        CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache --evict-older-than 1d
+      displayName: 'Prune obsolete ccache files'
 
     - script: |
         CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache -s

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -9,8 +9,6 @@ jobs:
     variables:
     - name: LLVM_CCACHE_DIR
       value: $(Build.SourcesDirectory)/Toolchain/.ccache
-    - name: LLVM_CCACHE_MAXSIZE
-      value: 20GB
     - name: SERENITY_CCACHE_DIR
       value: $(Build.SourcesDirectory)/.ccache
 
@@ -29,7 +27,6 @@ jobs:
         toolchain: 'clang'
         download_cache_path: 'Build/caches'
         toolchain_ccache_path: '$(LLVM_CCACHE_DIR)'
-        toolchain_ccache_size: '$(LLVM_CCACHE_MAXSIZE)'
         serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
 
     - script: ./Toolchain/BuildClang.sh --ci
@@ -126,6 +123,13 @@ jobs:
           artifactType: 'pipeline'
           artifactName: 'Coverage'
 
+    - script: |
+        echo "##[section]Toolchain Cache"
+        CCACHE_DIR='$(LLVM_CCACHE_DIR)' ccache --evict-older-than 1d
+
+        echo "##[section]Serenity Cache"
+        CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache --evict-older-than 1d
+      displayName: 'Prune obsolete ccache files'
 
     - script: |
         echo "##[section]Toolchain Cache"

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -293,8 +293,7 @@ pushd "$DIR/Build/clang"
             ${link_lld:+"-DLLVM_ENABLE_LLD=ON"} \
             ${dev:+"-DLLVM_CCACHE_BUILD=ON"} \
             ${ci:+"-DLLVM_CCACHE_BUILD=ON"} \
-            ${ci:+"-DLLVM_CCACHE_DIR=$LLVM_CCACHE_DIR"} \
-            ${ci:+"-DLLVM_CCACHE_MAXSIZE=$LLVM_CCACHE_MAXSIZE"}
+            ${ci:+"-DLLVM_CCACHE_DIR=$LLVM_CCACHE_DIR"}
 
         buildstep_ninja "llvm/build" ninja -j "$MAKEJOBS"
         buildstep_ninja "llvm/install" ninja install/strip


### PR DESCRIPTION
This should allow us to keep the ccache as lean as possible without having to rely on manually balanced size information (or on the cleanup logic that apparently isn't that cache friendly).

The cache sizes change roughly as follows:

```
(GCC, x86_64, ALL_DEBUG)     | 1.36G -> 0.70G
(GCC, x86_64, NORMAL_DEBUG)  | 1.02G -> 0.46G
(GCC, aarch64, NORMAL_DEBUG) | 1.02G -> 0.46G
(Lagom, Linux, NoFuzz)       | 1.80G -> 0.74G
(Lagom, Linux, Fuzz)         | 1.82G -> 0.25G
(Lagom, macOS, NoFuzz)       | 1.90G -> 0.30G
(Clang, x86_64, Toolchain)   | 0.88G -> 0.23G
(Clang, x86_64, Serenity)    | 4.45G -> 0.33G
```