### PR TITLE
LibJS+LibWeb: Fix some more GC leaks

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
@@ -90,8 +90,8 @@ PromiseJob create_promise_reaction_job(VM& vm, PromiseReaction& reaction, Value 
 {
     // 1. Let job be a new Job Abstract Closure with no parameters that captures reaction and argument and performs the following steps when called:
     //    See run_reaction_job for "the following steps".
-    auto job = create_heap_function(vm.heap(), [&vm, reaction = make_handle(&reaction), argument = make_handle(argument)] {
-        return run_reaction_job(vm, *reaction.cell(), argument.value());
+    auto job = create_heap_function(vm.heap(), [&vm, &reaction, argument] {
+        return run_reaction_job(vm, reaction, argument);
     });
 
     // 2. Let handlerRealm be null.
@@ -164,8 +164,8 @@ PromiseJob create_promise_resolve_thenable_job(VM& vm, Promise& promise_to_resol
 
     // 1. Let job be a new Job Abstract Closure with no parameters that captures promiseToResolve, thenable, and then and performs the following steps when called:
     //    See run_resolve_thenable_job() for "the following steps".
-    auto job = create_heap_function(vm.heap(), [&vm, promise_to_resolve = make_handle(promise_to_resolve), thenable = make_handle(thenable), then]() mutable {
-        return run_resolve_thenable_job(vm, *promise_to_resolve.cell(), thenable.value(), then);
+    auto job = create_heap_function(vm.heap(), [&vm, &promise_to_resolve, thenable, then]() mutable {
+        return run_resolve_thenable_job(vm, promise_to_resolve, thenable, then);
     });
 
     // 6. Return the Record { [[Job]]: job, [[Realm]]: thenRealm }.

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -84,23 +84,23 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_markdown_docume
 
     return create_document_for_inline_content(navigation_params.navigable.ptr(), navigation_params.id, [&](DOM::Document& document) {
         auto& realm = document.realm();
-        auto process_body = [&document, url = navigation_params.response->url().value(), extra_head_contents](ByteBuffer data) {
+        auto process_body = JS::create_heap_function(realm.heap(), [&document, url = navigation_params.response->url().value(), extra_head_contents](ByteBuffer data) {
             auto markdown_document = Markdown::Document::parse(data);
             if (!markdown_document)
                 return;
 
             auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(extra_head_contents), "utf-8"sv);
             parser->run(url);
-        };
+        });
 
-        auto process_body_error = [](auto) {
+        auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::GCPtr<WebIDL::DOMException>) {
             dbgln("FIXME: Load html page with an error if read of body failed.");
-        };
+        });
 
         navigation_params.response->body()->fully_read(
                                               realm,
-                                              move(process_body),
-                                              move(process_body_error),
+                                              process_body,
+                                              process_body_error,
                                               JS::NonnullGCPtr { realm.global_object() })
             .release_value_but_fixme_should_propagate_errors();
     });
@@ -162,19 +162,19 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_html_document(H
     //    causes a load event to be fired.
     else {
         // FIXME: Parse as we receive the document data, instead of waiting for the whole document to be fetched first.
-        auto process_body = [document, url = navigation_params.response->url().value()](ByteBuffer data) {
+        auto process_body = JS::create_heap_function(document->heap(), [document, url = navigation_params.response->url().value()](ByteBuffer data) {
             Platform::EventLoopPlugin::the().deferred_invoke([document = document, data = move(data), url = url] {
                 auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, data);
                 parser->run(url);
             });
-        };
+        });
 
-        auto process_body_error = [](auto) {
+        auto process_body_error = JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {
             dbgln("FIXME: Load html page with an error if read of body failed.");
-        };
+        });
 
         auto& realm = document->realm();
-        TRY(navigation_params.response->body()->fully_read(realm, move(process_body), move(process_body_error), JS::NonnullGCPtr { realm.global_object() }));
+        TRY(navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }));
     }
 
     // 4. Return document.
@@ -217,7 +217,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_xml_document(HT
     if (auto maybe_encoding = type.parameters().get("charset"sv); maybe_encoding.has_value())
         content_encoding = maybe_encoding.value();
 
-    auto process_body = [document, url = navigation_params.response->url().value(), content_encoding = move(content_encoding)](ByteBuffer data) {
+    auto process_body = JS::create_heap_function(document->heap(), [document, url = navigation_params.response->url().value(), content_encoding = move(content_encoding)](ByteBuffer data) {
         Optional<TextCodec::Decoder&> decoder;
         // The actual HTTP headers and other metadata, not the headers as mutated or implied by the algorithms given in this specification,
         // are the ones that must be used when determining the character encoding according to the rules given in the above specifications.
@@ -258,14 +258,14 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_xml_document(HT
 
             // NOTE: XMLDocumentBuilder ensures that the `load` event gets fired. We don't need to do anything else here.
         }
-    };
+    });
 
-    auto process_body_error = [](auto) {
+    auto process_body_error = JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {
         dbgln("FIXME: Load html page with an error if read of body failed.");
-    };
+    });
 
     auto& realm = document->realm();
-    TRY(navigation_params.response->body()->fully_read(realm, move(process_body), move(process_body_error), JS::NonnullGCPtr { realm.global_object() }));
+    TRY(navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }));
 
     return document;
 }
@@ -297,7 +297,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_text_document(H
     //    document's relevant global object to have the parser to process the implied EOF character, which eventually causes a
     //    load event to be fired.
     // FIXME: Parse as we receive the document data, instead of waiting for the whole document to be fetched first.
-    auto process_body = [document, url = navigation_params.response->url().value()](ByteBuffer data) {
+    auto process_body = JS::create_heap_function(document->heap(), [document, url = navigation_params.response->url().value()](ByteBuffer data) {
         auto encoding = run_encoding_sniffing_algorithm(document, data);
         dbgln_if(HTML_PARSER_DEBUG, "The encoding sniffing algorithm returned encoding '{}'", encoding);
 
@@ -321,14 +321,14 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_text_document(H
         MUST(document->head()->append_child(title_element));
         auto title_text = document->heap().allocate<DOM::Text>(document->realm(), document, title);
         MUST(title_element->append_child(*title_text));
-    };
+    });
 
-    auto process_body_error = [](auto) {
+    auto process_body_error = JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {
         dbgln("FIXME: Load html page with an error if read of body failed.");
-    };
+    });
 
     auto& realm = document->realm();
-    TRY(navigation_params.response->body()->fully_read(realm, move(process_body), move(process_body_error), JS::NonnullGCPtr { realm.global_object() }));
+    TRY(navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }));
 
     // 6. Return document.
     return document;
@@ -418,8 +418,8 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_media_document(
     auto& realm = document->realm();
     TRY(navigation_params.response->body()->fully_read(
         realm,
-        [document](auto) { HTML::HTMLParser::the_end(document); },
-        [](auto) {},
+        JS::create_heap_function(document->heap(), [document](ByteBuffer) { HTML::HTMLParser::the_end(document); }),
+        JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {}),
         JS::NonnullGCPtr { realm.global_object() }));
 
     // 9. Return document.

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -72,19 +72,19 @@ WebIDL::ExceptionOr<void> Body::fully_read(JS::Realm& realm, Web::Fetch::Infrast
     auto task_destination_object = task_destination.get<JS::NonnullGCPtr<JS::Object>>();
 
     // 2. Let successSteps given a byte sequence bytes be to queue a fetch task to run processBody given bytes, with taskDestination.
-    auto success_steps = [&realm, process_body = move(process_body), task_destination_object = JS::make_handle(task_destination_object)](ByteBuffer const& bytes) mutable -> ErrorOr<void> {
+    auto success_steps = [&realm, process_body, task_destination_object = task_destination_object](ByteBuffer const& bytes) mutable -> ErrorOr<void> {
         // Make a copy of the bytes, as the source of the bytes may disappear between the time the task is queued and executed.
         auto bytes_copy = TRY(ByteBuffer::copy(bytes));
-        queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body = move(process_body), bytes_copy = move(bytes_copy)]() {
-            process_body(move(bytes_copy));
+        queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body, bytes_copy = move(bytes_copy)]() {
+            process_body->function()(move(bytes_copy));
         }));
         return {};
     };
 
     // 3. Let errorSteps optionally given an exception exception be to queue a fetch task to run processBodyError given exception, with taskDestination.
-    auto error_steps = [&realm, process_body_error = move(process_body_error), task_destination_object = JS::make_handle(task_destination_object)](JS::GCPtr<WebIDL::DOMException> exception) mutable {
-        queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body_error = move(process_body_error), exception = JS::make_handle(exception)]() {
-            process_body_error(*exception);
+    auto error_steps = [&realm, process_body_error, task_destination_object](JS::GCPtr<WebIDL::DOMException> exception) mutable {
+        queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body_error = move(process_body_error), exception]() {
+            process_body_error->function()(*exception);
         }));
     };
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -28,9 +28,9 @@ class Body final : public JS::Cell {
 public:
     using SourceType = Variant<Empty, ByteBuffer, JS::Handle<FileAPI::Blob>>;
     // processBody must be an algorithm accepting a byte sequence.
-    using ProcessBodyCallback = JS::SafeFunction<void(ByteBuffer)>;
+    using ProcessBodyCallback = JS::NonnullGCPtr<JS::HeapFunction<void(ByteBuffer)>>;
     // processBodyError must be an algorithm optionally accepting an exception.
-    using ProcessBodyErrorCallback = JS::SafeFunction<void(JS::GCPtr<WebIDL::DOMException>)>;
+    using ProcessBodyErrorCallback = JS::NonnullGCPtr<JS::HeapFunction<void(JS::GCPtr<WebIDL::DOMException>)>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>);
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>, SourceType, Optional<u64>);

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -518,15 +518,15 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(JS::N
         auto& realm = document->realm();
         auto global = JS::NonnullGCPtr { realm.global_object() };
 
-        auto process_body = [document, request](auto body) {
+        auto process_body = JS::create_heap_function(realm.heap(), [document, request](ByteBuffer body) {
             decode_favicon(body, request->url(), document->navigable());
-        };
-        auto process_body_error = [](auto) {
-        };
+        });
+        auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::GCPtr<WebIDL::DOMException>) {
+        });
 
         // 3. Use response's unsafe response as an icon as if it had been declared using the icon keyword.
         if (auto body = response->unsafe_response()->body())
-            body->fully_read(realm, move(process_body), move(process_body_error), global).release_value_but_fixme_should_propagate_errors();
+            body->fully_read(realm, process_body, process_body_error, global).release_value_but_fixme_should_propagate_errors();
     };
 
     TRY(Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input))));

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -178,7 +178,7 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
             response = filtered_response.internal_response();
         }
 
-        auto on_image_data_read = [this](auto image_data) mutable {
+        auto on_image_data_read = JS::create_heap_function(heap(), [this](ByteBuffer image_data) mutable {
             m_fetch_controller = nullptr;
 
             // 6. If an image is thus obtained, the poster frame is that image. Otherwise, there is no poster frame.
@@ -187,12 +187,12 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
                 return;
 
             m_poster_frame = move(image.release_value().frames[0].bitmap);
-        };
+        });
 
         VERIFY(response->body());
-        auto empty_algorithm = [](auto) {};
+        auto empty_algorithm = JS::create_heap_function(heap(), [](JS::GCPtr<WebIDL::DOMException>) {});
 
-        response->body()->fully_read(realm, move(on_image_data_read), move(empty_algorithm), JS::NonnullGCPtr { global }).release_value_but_fixme_should_propagate_errors();
+        response->body()->fully_read(realm, on_image_data_read, empty_algorithm, JS::NonnullGCPtr { global }).release_value_but_fixme_should_propagate_errors();
     };
 
     m_fetch_controller = TRY(Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input))));


### PR DESCRIPTION
More `HeapFunction` goodness. With these changes, we are down from 91 to 13 leaked `Window` objects at the end of a full test run. :^)