### PR TITLE
LibWeb: Fix division by zero in `solve_replaced_size_constraint()`

### DIFF
--- a/Tests/LibWeb/Layout/expected/zero-height-replaced-box-with-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/zero-height-replaced-box-with-aspect-ratio.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 10x0 children: inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
+        SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 800x108]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 100x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 10x0] overflow: [8,8 100x100]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/zero-height-replaced-box-with-aspect-ratio.html
+++ b/Tests/LibWeb/Layout/input/zero-height-replaced-box-with-aspect-ratio.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><style>
+svg {
+    aspect-ratio: 1 / 1;
+    min-width: 100px;
+    min-height: 100px;
+}
+</style><div style="width: 10px; height: 0px"><svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -283,7 +283,7 @@ CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_w
     if (input_width > max_width && input_height < min_height)
         return { max_width, min_height };
 
-    if (input_width > 0) {
+    if (input_width > 0 && input_height > 0) {
         if (input_width > max_width && input_height > max_height && max_width / input_width <= max_height / input_height)
             return { max_width, max(min_height, max_width / aspect_ratio) };
         if (input_width > max_width && input_height > max_height && max_width / input_width > max_height / input_height)


### PR DESCRIPTION
Happened when input_width > 0 but input_height == 0.

Fixes crashing on Discord that happens after clicking on direct messages conversation.