### PR TITLE
Utilities: Fix various bugs in uniq

### DIFF
--- a/Tests/Utilities/CMakeLists.txt
+++ b/Tests/Utilities/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestSed.cpp
     TestPatch.cpp
+    TestUniq.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/Utilities/TestUniq.cpp
+++ b/Tests/Utilities/TestUniq.cpp
@@ -50,3 +50,13 @@ TEST_CASE(long_line)
 
     run_uniq({}, StringView { input }, StringView { expected_output });
 }
+
+TEST_CASE(duplicate_flag)
+{
+    run_uniq({ "-d" }, "AAA\nAAA\nBBB\n"sv, "AAA\n"sv);
+}
+
+TEST_CASE(count_flag)
+{
+    run_uniq({ "-c" }, "AAA\nAAA\n"sv, "2 AAA\n"sv);
+}

--- a/Tests/Utilities/TestUniq.cpp
+++ b/Tests/Utilities/TestUniq.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Rodrigo Tobar <rtobarc@gmail.com>.
+ * Copyright (c) 2024, Daniel Gaston <tfd@tuta.io>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ScopeGuard.h>
+#include <AK/StringView.h>
+#include <LibCore/Command.h>
+#include <LibCore/File.h>
+#include <LibTest/Macros.h>
+#include <LibTest/TestCase.h>
+
+static void run_uniq(Vector<char const*>&& arguments, StringView standard_input, StringView expected_stdout)
+{
+    MUST(arguments.try_insert(0, "uniq"));
+    MUST(arguments.try_append(nullptr));
+    auto uniq = MUST(Core::Command::create("uniq"sv, arguments.data()));
+    MUST(uniq->write(standard_input));
+    auto [stdout, stderr] = MUST(uniq->read_all());
+    auto status = MUST(uniq->status());
+    if (status != Core::Command::ProcessResult::DoneWithZeroExitCode) {
+        FAIL(ByteString::formatted("uniq didn't exit cleanly: status: {}, stdout: {}, stderr: {}", static_cast<int>(status), StringView { stdout.bytes() }, StringView { stderr.bytes() }));
+    }
+    EXPECT_EQ(StringView { expected_stdout.bytes() }, StringView { stdout.bytes() });
+}
+
+TEST_CASE(two_duplicate_lines)
+{
+    run_uniq({}, "AAA\nAAA\n"sv, "AAA\n"sv);
+}
+
+TEST_CASE(two_unique_lines)
+{
+    run_uniq({}, "AAA\nAaA\n"sv, "AAA\nAaA\n"sv);
+}
+
+TEST_CASE(long_line)
+{
+    auto input = Array<u8, 4096> {};
+    auto expected_output = Array<u8, 2048> {};
+    // Create two lines of 2047 A's and a newline.
+    input.fill('A');
+    input[2047] = '\n';
+    input[4095] = '\n';
+
+    expected_output.fill('A');
+    expected_output[2047] = '\n';
+
+    run_uniq({}, StringView { input }, StringView { expected_output });
+}

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -83,7 +83,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto infile = TRY(Core::InputBufferedFile::create(TRY(Core::File::open_file_or_standard_stream(inpath, Core::File::OpenMode::Read))));
     auto outfile = TRY(Core::File::open_file_or_standard_stream(outpath, Core::File::OpenMode::Write));
 
-    size_t count = 0;
+    // The count starts at 1 since each line will appear at least once.
+    // Otherwise the -d and -c flags do not work as expected.
+    size_t count = 1;
     ByteBuffer previous_buf = TRY(ByteBuffer::create_uninitialized(1024));
     ByteBuffer current_buf = TRY(ByteBuffer::create_uninitialized(1024));
 


### PR DESCRIPTION
There were several bugs and inconsistencies with coreutils that this pull request addresses. First, lines were capped at 1024 bytes, which is addressed by using the `read_line_with_resize` method instead of `read_line`. Second, there were a couple of off-by-one errors that caused the `-c` and `-f` flags to not function as expected. Finally, the final line of a series of repeated lines was being written instead of the first, as specified by [the spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uniq.html). The test file was adapted from `TestSed` and covers all of these changes.