### PR TITLE
LibJS: Save min and max block addresses in CellAllocator

### DIFF
--- a/Userland/Libraries/LibJS/Heap/CellAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.cpp
@@ -25,6 +25,11 @@ Cell* CellAllocator::allocate_cell(Heap& heap)
 
     if (m_usable_blocks.is_empty()) {
         auto block = HeapBlock::create_with_cell_size(heap, *this, m_cell_size, m_class_name);
+        auto block_ptr = reinterpret_cast<FlatPtr>(block.ptr());
+        if (m_min_block_address > block_ptr)
+            m_min_block_address = block_ptr;
+        if (m_max_block_address < block_ptr)
+            m_max_block_address = block_ptr;
         m_usable_blocks.append(*block.leak_ptr());
     }
 

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -51,6 +51,8 @@ public:
     using List = IntrusiveList<&CellAllocator::m_list_node>;
 
     BlockAllocator& block_allocator() { return m_block_allocator; }
+    FlatPtr min_block_address() const { return m_min_block_address; }
+    FlatPtr max_block_address() const { return m_max_block_address; }
 
 private:
     char const* const m_class_name { nullptr };
@@ -61,6 +63,8 @@ private:
     using BlockList = IntrusiveList<&HeapBlock::m_list_node>;
     BlockList m_full_blocks;
     BlockList m_usable_blocks;
+    FlatPtr m_min_block_address { explode_byte(0xff) };
+    FlatPtr m_max_block_address { 0 };
 };
 
 template<typename T>

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -112,11 +112,10 @@ void Heap::find_min_and_max_block_addresses(FlatPtr& min_address, FlatPtr& max_a
 {
     min_address = explode_byte(0xff);
     max_address = 0;
-    for_each_block([&](auto& block) {
-        min_address = min(min_address, reinterpret_cast<FlatPtr>(&block));
-        max_address = max(max_address, reinterpret_cast<FlatPtr>(&block) + HeapBlockBase::block_size);
-        return IterationDecision::Continue;
-    });
+    for (auto& allocator : m_all_cell_allocators) {
+        min_address = min(min_address, allocator.min_block_address());
+        max_address = max(max_address, allocator.max_block_address() + HeapBlockBase::block_size);
+    }
 }
 
 template<typename Callback>


### PR DESCRIPTION
This allows to skip iterating through all allocated blocks in `find_min_and_max_block_addresses()`.

With this change `collect_garbage()` in profiles of Discord goes down from 17% to 8%.