### PR TITLE
headless-browser: Call `platform_init()` for path of resources folder

### DIFF
--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -675,6 +675,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     ByteString test_glob;
     Vector<ByteString> certificates;
 
+#if !defined(AK_OS_SERENITY)
+    platform_init();
+    resources_folder = s_serenity_resource_root;
+#endif
+
     Core::ArgsParser args_parser;
     args_parser.set_general_help("This utility runs the Browser in headless mode.");
     args_parser.add_option(screenshot_timeout, "Take a screenshot after [n] seconds (default: 1)", "screenshot", 's', "n");


### PR DESCRIPTION
Currently `headless-browser` normal non-test use case fails:

```console
$ ./Meta/serenity.sh run lagom headless-browser about:newtab
Runtime error: Don't know how to load certs!
Runtime error: Failed to connect to RequestServer
```

because, `RequestServer` cannot find `cacert.pem` file.

On SerenityOS, the certificates file is not in `/res` as `/res/ladybird/cacert.pem` but in `/etc` as `/etc/cacert.pem`.

For other platforms though, it is `serenity/Build/lagom/share/Lagom/ladybird/cacert.pem`.

So, I don't think `platform_init()` is any use for resources folder (`WebContent` can find resources on its own?), but for certificates file for `RequestServer`.
