### PR TITLE
CI: Test using Clang for ASAN+UBSAN on linux

### DIFF
--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -2,6 +2,8 @@ parameters:
   os: 'Linux'
   fuzzer: 'NoFuzz'
   lagom_lints: false
+  host_cc: 'cc'
+  host_cxx: 'cxx'
 
 jobs:
   - job: 'Lagom_${{ parameters.os }}_${{ parameters.fuzzer }}'
@@ -19,21 +21,15 @@ jobs:
 
     - name: toolchain
       ${{ if eq(parameters.fuzzer, 'Fuzz') }}:
-        value: clang
+        value: '${{ parameters.host_cc }}_Fuzz'
       ${{ if eq(parameters.fuzzer, 'NoFuzz') }}:
-        value: gcc
+        value: '${{ parameters.host_cc }}'
 
     - name: host-cc
-      ${{ if eq(parameters.os, 'macOS') }}:
-        value: $(brew --prefix llvm@18)/bin/clang
-      ${{ if not(eq(parameters.os, 'macOS')) }}:
-        value: gcc-13
+      value: '${{ parameters.host_cc }}'
 
     - name: host-cxx
-      ${{ if eq(parameters.os, 'macOS') }}:
-        value: $(brew --prefix llvm@18)/bin/clang++
-      ${{ if not(eq(parameters.os, 'macOS')) }}:
-        value: g++-13
+      value: '${{ parameters.host_cxx }}'
 
     - name: ndk_version # only relevant for Android
       value: '25.2.9519653'
@@ -103,6 +99,8 @@ jobs:
               -DBUILD_LAGOM=OFF \
               -DENABLE_LAGOM_CCACHE=ON \
               -DCMAKE_INSTALL_PREFIX=tool-install \
+              -DCMAKE_C_COMPILER=$(host-cc) \
+              -DCMAKE_CXX_COMPILER=$(host-cxx) \
               -Dpackage=LagomTools
           ninja -C tools-build install
           cmake -GNinja -B Build \

--- a/Meta/Azure/nightly-pipeline.yml
+++ b/Meta/Azure/nightly-pipeline.yml
@@ -26,3 +26,13 @@ stages:
       - template: Lagom.yml
         parameters:
           os: 'Android'
+
+  - stage: Lagom_GCC
+    dependsOn: []
+    jobs:
+      - template: Lagom.yml
+        parameters:
+          os: 'Linux'
+          fuzzer: 'NoFuzz'
+          host_cc: 'gcc-13'
+          host_cxx: 'g++-13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,15 +13,21 @@ stages:
         parameters:
           os: 'Linux'
           lagom_lints: true
+          host_cc: 'clang-18'
+          host_cxx: 'clang++-18'
 
       - template: Meta/Azure/Lagom.yml
         parameters:
           os: 'Linux'
           fuzzer: 'Fuzz'
+          host_cc: 'gcc-13'
+          host_cxx: 'g++-13'
 
       - template: Meta/Azure/Lagom.yml
         parameters:
           os: 'macOS'
+          host_cc: '$(brew --prefix llvm@18)/bin/clang'
+          host_cxx: '$(brew --prefix llvm@18)/bin/clang++'
 
   - stage: SerenityOS
     dependsOn: []


### PR DESCRIPTION
Azure Experiment that panned out nicely. A GCC build on Lagom Linux is about 30-40% slower than a Clang build.