### PR TITLE
LibIDL+IDLGenerators: Don't duplicate include statements for each import 

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3756,9 +3756,6 @@ void generate_namespace_implementation(IDL::Interface const& interface, StringBu
 
 )~~~");
 
-    for (auto& path : interface.required_imported_paths)
-        generate_include_for(generator, path);
-
     emit_includes_for_all_imports(interface, generator, interface.pair_iterator_types.has_value());
 
     generator.append(R"~~~(
@@ -4012,9 +4009,6 @@ void generate_constructor_implementation(IDL::Interface const& interface, String
 )~~~");
         }
     }
-
-    for (auto& path : interface.required_imported_paths)
-        generate_include_for(generator, path);
 
     emit_includes_for_all_imports(interface, generator, interface.pair_iterator_types.has_value());
 
@@ -4285,9 +4279,6 @@ void generate_prototype_implementation(IDL::Interface const& interface, StringBu
 #include <LibWeb/Bindings/MainThreadVM.h>
 )~~~");
     }
-
-    for (auto& path : interface.required_imported_paths)
-        generate_include_for(generator, path);
 
     emit_includes_for_all_imports(interface, generator, interface.pair_iterator_types.has_value());
 
@@ -4578,9 +4569,6 @@ void generate_global_mixin_implementation(IDL::Interface const& interface, Strin
 #include <LibWeb/WebIDL/Types.h>
 
 )~~~");
-
-    for (auto& path : interface.required_imported_paths)
-        generate_include_for(generator, path);
 
     emit_includes_for_all_imports(interface, generator, interface.pair_iterator_types.has_value());
 

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -1011,7 +1011,6 @@ Interface& Parser::parse()
 
     Vector<Interface&> imports;
     {
-        HashTable<ByteString> required_imported_paths;
         while (lexer.consume_specific("#import"sv)) {
             consume_whitespace();
             assert_specific('<');
@@ -1019,13 +1018,10 @@ Interface& Parser::parse()
             lexer.ignore();
             auto maybe_interface = resolve_import(path);
             if (maybe_interface.has_value()) {
-                for (auto& entry : maybe_interface.value().required_imported_paths)
-                    required_imported_paths.set(entry);
                 imports.append(maybe_interface.release_value());
             }
             consume_whitespace();
         }
-        interface.required_imported_paths = move(required_imported_paths);
     }
 
     parse_non_interface_entities(true, interface);
@@ -1185,8 +1181,6 @@ Interface& Parser::parse()
         }
     }
 
-    if (interface.will_generate_code())
-        interface.required_imported_paths.set(this_module);
     interface.imported_modules = move(imports);
 
     if (top_level_parser() == this)

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -306,7 +306,6 @@ public:
     HashMap<ByteString, HashTable<ByteString>> included_mixins;
 
     ByteString module_own_path;
-    HashTable<ByteString> required_imported_paths;
     Vector<Interface&> imported_modules;
 
     HashMap<ByteString, Vector<Function&>> overload_sets;


### PR DESCRIPTION
Previously, all `#import` statements generated two identical includes in the generated C++ source code.