### PR TITLE
LibC: Add fenv+rounding support for RISC-V (and test fenv in the first place)

### DIFF
--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -18,15 +18,16 @@ union FloatExtractor;
 #ifdef AK_HAS_FLOAT_128
 template<>
 union FloatExtractor<f128> {
+    using ComponentType = unsigned __int128;
     static constexpr int mantissa_bits = 112;
-    static constexpr unsigned __int128 mantissa_max = (((unsigned __int128)1) << 112) - 1;
+    static constexpr ComponentType mantissa_max = (((ComponentType)1) << 112) - 1;
     static constexpr int exponent_bias = 16383;
     static constexpr int exponent_bits = 15;
     static constexpr unsigned exponent_max = 32767;
     struct [[gnu::packed]] {
-        unsigned __int128 mantissa : 112;
-        unsigned __int128 exponent : 15;
-        unsigned __int128 sign : 1;
+        ComponentType mantissa : 112;
+        ComponentType exponent : 15;
+        ComponentType sign : 1;
     };
     f128 d;
 };
@@ -38,15 +39,21 @@ static_assert(AssertSize<FloatExtractor<f128>, sizeof(f128)>());
 #ifdef AK_HAS_FLOAT_80
 template<>
 union FloatExtractor<f80> {
+    using ComponentType = unsigned long long;
     static constexpr int mantissa_bits = 64;
-    static constexpr unsigned long long mantissa_max = ~0u;
+    static constexpr ComponentType mantissa_max = ~0ull;
     static constexpr int exponent_bias = 16383;
     static constexpr int exponent_bits = 15;
     static constexpr unsigned exponent_max = 32767;
     struct [[gnu::packed]] {
-        unsigned long long mantissa;
-        unsigned long long exponent : 15;
-        unsigned long long sign : 1;
+        // This is technically wrong: Extended floating point values really only have 63 bits of mantissa
+        // and an "integer bit" that behaves in various strange, unintuitive and non-IEEE-754 ways.
+        // However, since all bit-fiddling float code assumes IEEE floats, it cannot handle this properly.
+        // If we pretend that 80-bit floats are IEEE floats with 64-bit mantissas, almost everything works correctly
+        // and we just need a few special cases.
+        ComponentType mantissa : 64;
+        ComponentType exponent : 15;
+        ComponentType sign : 1;
     };
     f80 d;
 };
@@ -55,8 +62,9 @@ static_assert(AssertSize<FloatExtractor<f80>, sizeof(f80)>());
 
 template<>
 union FloatExtractor<f64> {
+    using ComponentType = unsigned long long;
     static constexpr int mantissa_bits = 52;
-    static constexpr unsigned long long mantissa_max = (1ull << 52) - 1;
+    static constexpr ComponentType mantissa_max = (1ull << 52) - 1;
     static constexpr int exponent_bias = 1023;
     static constexpr int exponent_bits = 11;
     static constexpr unsigned exponent_max = 2047;
@@ -68,9 +76,9 @@ union FloatExtractor<f64> {
         //        very intuitive and portable behaviour on windows, but it doesn't
         //        work with the msvc ABI.
         //        See <https://github.com/llvm/llvm-project/issues/24757>
-        unsigned long long mantissa : 52;
-        unsigned long long exponent : 11;
-        unsigned long long sign : 1;
+        ComponentType mantissa : 52;
+        ComponentType exponent : 11;
+        ComponentType sign : 1;
     };
     f64 d;
 };
@@ -78,15 +86,16 @@ static_assert(AssertSize<FloatExtractor<f64>, sizeof(f64)>());
 
 template<>
 union FloatExtractor<f32> {
+    using ComponentType = unsigned;
     static constexpr int mantissa_bits = 23;
-    static constexpr unsigned mantissa_max = (1 << 23) - 1;
+    static constexpr ComponentType mantissa_max = (1 << 23) - 1;
     static constexpr int exponent_bias = 127;
     static constexpr int exponent_bits = 8;
-    static constexpr unsigned exponent_max = 255;
+    static constexpr ComponentType exponent_max = 255;
     struct [[gnu::packed]] {
-        unsigned mantissa : 23;
-        unsigned exponent : 8;
-        unsigned sign : 1;
+        ComponentType mantissa : 23;
+        ComponentType exponent : 8;
+        ComponentType sign : 1;
     };
     f32 d;
 };

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SOURCES
     TestAssert.cpp
     TestCType.cpp
     TestEnvironment.cpp
+    TestFenv.cpp
     TestIo.cpp
     TestLibCExec.cpp
     TestLibCGrp.cpp
@@ -40,6 +41,8 @@ set(TEST_SOURCES
 
 set_source_files_properties(TestMath.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
 set_source_files_properties(TestStrtodAccuracy.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin-strtod")
+# Don't assume default rounding behavior is used for testing rounding behavior modifications.
+set_source_files_properties(TestFenv.cpp PROPERTIES COMPILE_FLAGS "-frounding-math")
 
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibC)

--- a/Tests/LibC/TestFenv.cpp
+++ b/Tests/LibC/TestFenv.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <fenv.h>
+
+// TODO: Add tests for floating-point exception management.
+
+static constexpr auto reset_rounding_mode = [] { fesetround(FE_TONEAREST); };
+
+#if !ARCH(RISCV64)
+#    define TOMAXMAGNITUDE_DECAYS_TO_TONEAREST
+#endif
+
+TEST_CASE(float_round_up)
+{
+    // Non-default rounding mode should not escape files with -frounding-math.
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_UPWARD);
+    EXPECT_EQ(0.1f + 0.2f, 0.3f);
+    EXPECT_EQ(0.1f + 0.3f, 0.40000004f);
+    EXPECT_EQ(0.1f + 0.4f, 0.50000006f);
+    EXPECT_EQ(-1.f + -0.1f, -1.0999999f);
+    EXPECT_EQ(1.f + 0.1f, 1.1f);
+}
+
+TEST_CASE(float_round_down)
+{
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_DOWNWARD);
+    EXPECT_EQ(0.1f + 0.2f, 0.29999998f);
+    EXPECT_EQ(0.1f + 0.3f, 0.4f);
+    EXPECT_EQ(0.1f + 0.4f, 0.5f);
+    EXPECT_EQ(-1.f + -0.1f, -1.1f);
+    EXPECT_EQ(1.f + 0.1f, 1.0999999f);
+}
+
+TEST_CASE(float_round_to_zero)
+{
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_TOWARDZERO);
+    EXPECT_EQ(0.1f + 0.2f, 0.29999998f);
+    EXPECT_EQ(0.1f + 0.3f, 0.4f);
+    EXPECT_EQ(0.1f + 0.4f, 0.5f);
+    EXPECT_EQ(-1.f + -0.1f, -1.0999999f);
+    EXPECT_EQ(1.f + 0.1f, 1.0999999f);
+}
+
+TEST_CASE(float_round_to_nearest)
+{
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_TONEAREST);
+    EXPECT_EQ(0.1f + 0.2f, 0.3f);
+    EXPECT_EQ(0.1f + 0.3f, 0.4f);
+    EXPECT_EQ(0.1f + 0.4f, 0.5f);
+    EXPECT_EQ(-1.f + -0.1f, -1.1f);
+    EXPECT_EQ(1.f + 0.1f, 1.1f);
+    EXPECT_EQ(1.f + 5.9604645e-08f, 1.f);
+}
+
+TEST_CASE(float_round_to_max_magnitude)
+{
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_TOMAXMAGNITUDE);
+    EXPECT_EQ(0.1f + 0.2f, 0.3f);
+    EXPECT_EQ(0.1f + 0.3f, 0.4f);
+    EXPECT_EQ(0.1f + 0.4f, 0.5f);
+    EXPECT_EQ(-1.f + -0.1f, -1.1f);
+    EXPECT_EQ(1.f + 0.1f, 1.1f);
+#ifdef TOMAXMAGNITUDE_DECAYS_TO_TONEAREST
+    EXPECT_EQ(1.f + 5.9604645e-08f, 1.f);
+#else
+    EXPECT_EQ(1.f + 5.9604645e-08f, 1.0000001f);
+#endif
+}
+
+TEST_CASE(store_round_in_env)
+{
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_DOWNWARD);
+    fenv_t env;
+    fegetenv(&env);
+    fesetround(FE_UPWARD);
+    // This result only happens under upward rounding.
+    EXPECT_EQ(-1.f + -0.1f, -1.0999999f);
+    fesetenv(&env);
+    // ... and this only under downward rounding.
+    EXPECT_EQ(-1.f + -0.1f, -1.1f);
+}
+
+TEST_CASE(save_restore_round)
+{
+    ScopeGuard rounding_mode_guard = reset_rounding_mode;
+
+    fesetround(FE_DOWNWARD);
+    auto rounding_mode = fegetround();
+    EXPECT_EQ(rounding_mode, FE_DOWNWARD);
+
+    fesetround(FE_UPWARD);
+    EXPECT_EQ(fegetround(), FE_UPWARD);
+    EXPECT_EQ(-1.f + -0.1f, -1.0999999f);
+    fesetround(rounding_mode);
+    EXPECT_EQ(-1.f + -0.1f, -1.1f);
+
+    fesetround(FE_TOMAXMAGNITUDE);
+#ifdef TOMAXMAGNITUDE_DECAYS_TO_TONEAREST
+    // Max-magnitude rounding is not supported by x86, so we expect fesetround to decay it to some other rounding mode.
+    EXPECT_EQ(fegetround(), FE_TONEAREST);
+#else
+    EXPECT_EQ(fegetround(), FE_TOMAXMAGNITUDE);
+#endif
+}

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -56,12 +56,6 @@ TEST_CASE(trig)
     EXPECT_APPROXIMATE(atan(555.5), 1.568996);
 }
 
-TEST_CASE(other)
-{
-    EXPECT_EQ(trunc(9999999999999.5), 9999999999999.0);
-    EXPECT_EQ(trunc(-9999999999999.5), -9999999999999.0);
-}
-
 TEST_CASE(exponents)
 {
     struct values {
@@ -272,22 +266,77 @@ TEST_CASE(acos)
 
 TEST_CASE(floor)
 {
-    EXPECT_EQ(floor(0.125), 0);
-    EXPECT_EQ(floor(-0.125), -1.0);
-    EXPECT_EQ(floor(0.5), 0);
-    EXPECT_EQ(floor(-0.5), -1.0);
-    EXPECT_EQ(floor(0.25), 0);
-    EXPECT_EQ(floor(-0.25), -1.0);
-    EXPECT_EQ(floor(-3.0 / 2.0), -2.0);
+    // NOTE: We run tests for all three float types since architecture-specific code may vary significantly between types.
+#define TEST_FLOOR_FOR(suffix)                \
+    EXPECT_EQ(floor##suffix(0.125f), 0.f);    \
+    EXPECT_EQ(floor##suffix(-0.125f), -1.0f); \
+    EXPECT_EQ(floor##suffix(0.5f), 0.f);      \
+    EXPECT_EQ(floor##suffix(-0.5f), -1.0f);   \
+    EXPECT_EQ(floor##suffix(0.25f), 0.f);     \
+    EXPECT_EQ(floor##suffix(-0.25f), -1.0f);  \
+    EXPECT_EQ(floor##suffix(-3.0f / 2.0f), -2.0f);
+
+    TEST_FLOOR_FOR();
+    TEST_FLOOR_FOR(f);
+    TEST_FLOOR_FOR(l);
+
+    EXPECT_EQ(floor(-9999999999999.5), -10000000000000.0);
+    EXPECT_EQ(floor(9999999999999.5), 9999999999999.0);
 }
 
 TEST_CASE(ceil)
 {
-    EXPECT_EQ(ceil(0.125), 1.0);
-    EXPECT_EQ(ceil(-0.125), 0);
-    EXPECT_EQ(ceil(0.5), 1.0);
-    EXPECT_EQ(ceil(-0.5), 0);
-    EXPECT_EQ(ceil(0.25), 1.0);
-    EXPECT_EQ(ceil(-0.25), 0);
-    EXPECT_EQ(ceil(-3.0 / 2.0), -1.0);
+#define TEST_CEIL_FOR(suffix)                            \
+    EXPECT_EQ(ceil##suffix(0.125##suffix), 1.0##suffix); \
+    EXPECT_EQ(ceil##suffix(-0.125##suffix), 0.##suffix); \
+    EXPECT_EQ(ceil##suffix(0.5##suffix), 1.0##suffix);   \
+    EXPECT_EQ(ceil##suffix(-0.5##suffix), 0.##suffix);   \
+    EXPECT_EQ(ceil##suffix(0.25##suffix), 1.0##suffix);  \
+    EXPECT_EQ(ceil##suffix(-0.25##suffix), 0.##suffix);  \
+    EXPECT_EQ(ceil##suffix(-3.0##suffix / 2.0##suffix), -1.0##suffix);
+
+    TEST_CEIL_FOR();
+    TEST_CEIL_FOR(f);
+    TEST_CEIL_FOR(l);
+
+    EXPECT_EQ(ceil(9999999999999.5), 10000000000000.0);
+    EXPECT_EQ(ceil(-9999999999999.5), -9999999999999.0);
+}
+
+TEST_CASE(trunc)
+{
+#define TEST_TRUNC_FOR(suffix)                            \
+    EXPECT_EQ(trunc##suffix(0.125##suffix), 0.##suffix);  \
+    EXPECT_EQ(trunc##suffix(-0.125##suffix), 0.##suffix); \
+    EXPECT_EQ(trunc##suffix(0.5##suffix), 0.##suffix);    \
+    EXPECT_EQ(trunc##suffix(-0.5##suffix), 0.##suffix);   \
+    EXPECT_EQ(trunc##suffix(0.25##suffix), 0.##suffix);   \
+    EXPECT_EQ(trunc##suffix(-0.25##suffix), 0.##suffix);  \
+    EXPECT_EQ(trunc##suffix(-3.0##suffix / 2.0##suffix), -1.0##suffix);
+
+    TEST_TRUNC_FOR();
+    TEST_TRUNC_FOR(f);
+    TEST_TRUNC_FOR(l);
+
+    EXPECT_EQ(trunc(9999999999999.5), 9999999999999.0);
+    EXPECT_EQ(trunc(-9999999999999.5), -9999999999999.0);
+}
+
+TEST_CASE(round)
+{
+#define TEST_ROUND_FOR(suffix)                            \
+    EXPECT_EQ(round##suffix(0.125##suffix), 0.##suffix);  \
+    EXPECT_EQ(round##suffix(-0.125##suffix), 0.##suffix); \
+    EXPECT_EQ(round##suffix(0.5##suffix), 1.0##suffix);   \
+    EXPECT_EQ(round##suffix(-0.5##suffix), -1.0##suffix); \
+    EXPECT_EQ(round##suffix(0.25##suffix), 0.##suffix);   \
+    EXPECT_EQ(round##suffix(-0.25##suffix), 0.##suffix);  \
+    EXPECT_EQ(round##suffix(-3.0##suffix / 2.0##suffix), -2.0##suffix);
+
+    TEST_ROUND_FOR();
+    TEST_ROUND_FOR(f);
+    TEST_ROUND_FOR(l);
+
+    EXPECT_EQ(round(9999999999999.5), 10000000000000.0);
+    EXPECT_EQ(round(-9999999999999.5), -10000000000000.0);
 }

--- a/Userland/Libraries/LibC/arch/aarch64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/aarch64/fenv.cpp
@@ -69,8 +69,11 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
         return 1;
+
+    if (rounding_mode == FE_TOMAXMAGNITUDE)
+        rounding_mode = FE_TONEAREST;
 
     TODO_AARCH64();
     return 0;

--- a/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
@@ -5,8 +5,165 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/EnumBits.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <fenv.h>
+
+static_assert(AssertSize<fenv_t, 4>());
+
+// RISC-V F extension version 2.2
+// Table 11.1 (frm rounding mode encoding)
+enum class RoundingMode : u8 {
+    // Round to Nearest, ties to Even
+    RNE = 0b000,
+    // Round towards Zero
+    RTZ = 0b001,
+    // Round Down (towards −∞)
+    RDN = 0b010,
+    // Round Up (towards +∞)
+    RUP = 0b011,
+    // Round to Nearest, ties to Max Magnitude
+    RMM = 0b100,
+    // Reserved for future use.
+    Reserved5 = 0b101,
+    Reserved6 = 0b110,
+    // In instruction’s rm field, selects dynamic rounding mode; In Rounding Mode register, Invalid.
+    DYN = 0b111,
+};
+
+static RoundingMode frm_from_feround(int c_rounding_mode)
+{
+    switch (c_rounding_mode) {
+    case FE_TONEAREST:
+        return RoundingMode::RNE;
+    case FE_TOWARDZERO:
+        return RoundingMode::RTZ;
+    case FE_DOWNWARD:
+        return RoundingMode::RDN;
+    case FE_UPWARD:
+        return RoundingMode::RUP;
+    case FE_TOMAXMAGNITUDE:
+        return RoundingMode::RMM;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+static int feround_from_frm(RoundingMode frm)
+{
+    switch (frm) {
+    case RoundingMode::RNE:
+        return FE_TONEAREST;
+    case RoundingMode::RTZ:
+        return FE_TOWARDZERO;
+    case RoundingMode::RDN:
+        return FE_DOWNWARD;
+    case RoundingMode::RUP:
+        return FE_UPWARD;
+    case RoundingMode::RMM:
+        return FE_TOMAXMAGNITUDE;
+    default:
+        // DYN is invalid in the frm register and therefore should never appear here.
+    case RoundingMode::DYN:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+static RoundingMode get_rounding_mode()
+{
+    size_t rounding_mode;
+    asm volatile("frrm %0"
+                 : "=r"(rounding_mode));
+    return static_cast<RoundingMode>(rounding_mode);
+}
+
+// Returns the old rounding mode, since we get that for free.
+static RoundingMode set_rounding_mode(RoundingMode frm)
+{
+    size_t old_rounding_mode;
+    size_t const new_rounding_mode = to_underlying(frm);
+    asm volatile("fsrm %0, %1"
+                 : "=r"(old_rounding_mode)
+                 : "r"(new_rounding_mode));
+    return static_cast<RoundingMode>(old_rounding_mode);
+}
+
+// Figure 11.2 (fflags)
+enum class AccruedExceptions : u8 {
+    None = 0,
+    // Inexact
+    NX = 1 << 0,
+    // Underflow
+    UF = 1 << 1,
+    // Overflow
+    OF = 1 << 2,
+    // Divide by Zero
+    DZ = 1 << 3,
+    // Invalid Operation
+    NV = 1 << 4,
+    All = NX | UF | OF | DZ | NV,
+};
+
+AK_ENUM_BITWISE_OPERATORS(AccruedExceptions);
+
+static AccruedExceptions fflags_from_fexcept(fexcept_t c_exceptions)
+{
+    AccruedExceptions exceptions = AccruedExceptions::None;
+    if ((c_exceptions & FE_INEXACT) != 0)
+        exceptions |= AccruedExceptions::NX;
+    if ((c_exceptions & FE_UNDERFLOW) != 0)
+        exceptions |= AccruedExceptions::UF;
+    if ((c_exceptions & FE_OVERFLOW) != 0)
+        exceptions |= AccruedExceptions::OF;
+    if ((c_exceptions & FE_DIVBYZERO) != 0)
+        exceptions |= AccruedExceptions::DZ;
+    if ((c_exceptions & FE_INVALID) != 0)
+        exceptions |= AccruedExceptions::NV;
+
+    return exceptions;
+}
+
+static fexcept_t fexcept_from_fflags(AccruedExceptions fflags)
+{
+    fexcept_t c_exceptions = 0;
+    if ((fflags & AccruedExceptions::NX) != AccruedExceptions::None)
+        c_exceptions |= FE_INEXACT;
+    if ((fflags & AccruedExceptions::UF) != AccruedExceptions::None)
+        c_exceptions |= FE_UNDERFLOW;
+    if ((fflags & AccruedExceptions::OF) != AccruedExceptions::None)
+        c_exceptions |= FE_OVERFLOW;
+    if ((fflags & AccruedExceptions::DZ) != AccruedExceptions::None)
+        c_exceptions |= FE_DIVBYZERO;
+    if ((fflags & AccruedExceptions::NV) != AccruedExceptions::None)
+        c_exceptions |= FE_INVALID;
+
+    return c_exceptions;
+}
+
+static AccruedExceptions get_accrued_exceptions()
+{
+    size_t fflags;
+    asm volatile("frflags %0"
+                 : "=r"(fflags));
+    return static_cast<AccruedExceptions>(fflags);
+}
+
+// Returns the old exceptions, since we get them for free.
+static AccruedExceptions set_accrued_exceptions(AccruedExceptions exceptions)
+{
+    size_t old_exceptions;
+    size_t const new_exceptions = to_underlying(exceptions);
+    asm volatile("fsflags %0, %1"
+                 : "=r"(old_exceptions)
+                 : "r"(new_exceptions));
+    return static_cast<AccruedExceptions>(old_exceptions);
+}
+
+static void clear_accrued_exceptions(AccruedExceptions exceptions)
+{
+    asm volatile("csrc fcsr, %0" ::"r"(to_underlying(exceptions)));
+}
 
 extern "C" {
 
@@ -15,8 +172,11 @@ int fegetenv(fenv_t* env)
     if (!env)
         return 1;
 
-    (void)env;
-    TODO_RISCV64();
+    FlatPtr fcsr;
+    asm volatile("csrr %0, fcsr"
+                 : "=r"(fcsr));
+    env->fcsr = fcsr;
+
     return 0;
 }
 
@@ -25,8 +185,8 @@ int fesetenv(fenv_t const* env)
     if (!env)
         return 1;
 
-    (void)env;
-    TODO_RISCV64();
+    FlatPtr fcsr = env->fcsr;
+    asm volatile("csrw fcsr, %0" ::"r"(fcsr));
     return 0;
 }
 
@@ -34,13 +194,8 @@ int feholdexcept(fenv_t* env)
 {
     fegetenv(env);
 
-    fenv_t current_env;
-    fegetenv(&current_env);
-
-    (void)env;
-    TODO_RISCV64();
-
-    fesetenv(&current_env);
+    // RISC-V does not have trapping floating point exceptions. Therefore, feholdexcept just clears fflags.
+    clear_accrued_exceptions(AccruedExceptions::All);
     return 0;
 }
 
@@ -49,30 +204,28 @@ int fesetexceptflag(fexcept_t const* except, int exceptions)
     if (!except)
         return 1;
 
-    fenv_t current_env;
-    fegetenv(&current_env);
-
     exceptions &= FE_ALL_EXCEPT;
 
-    (void)exceptions;
-    (void)except;
-    TODO_RISCV64();
+    auto exceptions_to_set = fflags_from_fexcept(*except) & fflags_from_fexcept(exceptions);
+    set_accrued_exceptions(exceptions_to_set);
 
-    fesetenv(&current_env);
     return 0;
 }
 
 int fegetround()
 {
-    TODO_RISCV64();
+    auto rounding_mode = get_rounding_mode();
+    return feround_from_frm(rounding_mode);
 }
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
         return 1;
 
-    TODO_RISCV64();
+    auto frm = frm_from_feround(rounding_mode);
+    set_rounding_mode(frm);
+
     return 0;
 }
 
@@ -80,20 +233,19 @@ int feclearexcept(int exceptions)
 {
     exceptions &= FE_ALL_EXCEPT;
 
-    fenv_t current_env;
-    fegetenv(&current_env);
+    auto exception_clear_flag = fflags_from_fexcept(exceptions);
+    // Use CSRRC to directly clear exception flags in fcsr which is faster.
+    // Conveniently, the exception flags are the lower bits, so we don't need to shift anything around.
+    clear_accrued_exceptions(exception_clear_flag);
 
-    (void)exceptions;
-    TODO_RISCV64();
-
-    fesetenv(&current_env);
     return 0;
 }
 
 int fetestexcept(int exceptions)
 {
-    (void)exceptions;
-    TODO_RISCV64();
+    auto fflags = get_accrued_exceptions();
+    auto mask = fflags_from_fexcept(exceptions);
+    return fexcept_from_fflags(fflags & mask);
 }
 
 int feraiseexcept(int exceptions)
@@ -103,7 +255,9 @@ int feraiseexcept(int exceptions)
 
     exceptions &= FE_ALL_EXCEPT;
 
-    (void)exceptions;
-    TODO_RISCV64();
+    // RISC-V does not have trapping floating-point exceptions, so this function behaves as a simple exception setter.
+    set_accrued_exceptions(fflags_from_fexcept(exceptions));
+
+    return 0;
 }
 }

--- a/Userland/Libraries/LibC/arch/riscv64/fenv.h
+++ b/Userland/Libraries/LibC/arch/riscv64/fenv.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/cdefs.h>
+
+#if !defined(__riscv) || __riscv_xlen != 64
+#    error "This file should not be included on architectures other than riscv64."
+#endif
+
+__BEGIN_DECLS
+
+// Chapter numbers from RISC-V Unprivileged ISA V20191213
+// RISC-V F extension version 2.2, Figure 11.1
+typedef struct fenv_t {
+    union {
+        // 11.2: fcsr is always 32 bits, even for the D and Q extensions, since only the lowest byte of data is in use.
+        uint32_t fcsr;
+        struct {
+            // Accrued exceptions (fflags).
+            uint8_t inexact : 1;           // NX
+            uint8_t underflow : 1;         // UF
+            uint8_t overflow : 1;          // OF
+            uint8_t divide_by_zero : 1;    // DZ
+            uint8_t invalid_operation : 1; // NV
+            uint8_t rounding_mode : 3;     // frm
+            uint32_t reserved : 24;
+        };
+    };
+} fenv_t;
+
+__END_DECLS

--- a/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
@@ -7,6 +7,9 @@
 #include <AK/Types.h>
 #include <fenv.h>
 
+// This is the size of the floating point environment image in protected mode
+static_assert(sizeof(__x87_floating_point_environment) == 28);
+
 static u16 read_status_register()
 {
     u16 status_register;
@@ -114,8 +117,11 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
         return 1;
+
+    if (rounding_mode == FE_TOMAXMAGNITUDE)
+        rounding_mode = FE_TONEAREST;
 
     auto control_word = read_control_word();
 

--- a/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
@@ -109,7 +109,7 @@ int fesetexceptflag(fexcept_t const* except, int exceptions)
 int fegetround()
 {
     // There's no way to signal whether the SSE rounding mode and x87 ones are different, so we assume they're the same
-    return (read_status_register() >> 10) & 3;
+    return (read_control_word() >> 10) & 3;
 }
 
 int fesetround(int rounding_mode)

--- a/Userland/Libraries/LibC/arch/x86_64/fenv.h
+++ b/Userland/Libraries/LibC/arch/x86_64/fenv.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/cdefs.h>
+
+#if !defined(__x86_64__)
+#    error "This file should not be included on architectures other than x86_64."
+#endif
+
+__BEGIN_DECLS
+
+struct __x87_floating_point_environment {
+    uint16_t __control_word;
+    uint16_t __reserved1;
+    uint16_t __status_word;
+    uint16_t __reserved2;
+    uint16_t __tag_word;
+    uint16_t __reserved3;
+    uint32_t __fpu_ip_offset;
+    uint16_t __fpu_ip_selector;
+    uint16_t __opcode : 11;
+    uint16_t __reserved4 : 5;
+    uint32_t __fpu_data_offset;
+    uint16_t __fpu_data_selector;
+    uint16_t __reserved5;
+};
+
+typedef struct fenv_t {
+    struct __x87_floating_point_environment __x87_fpu_env;
+    uint32_t __mxcsr;
+} fenv_t;
+
+__END_DECLS

--- a/Userland/Libraries/LibC/fenv.cpp
+++ b/Userland/Libraries/LibC/fenv.cpp
@@ -7,9 +7,6 @@
 #include <AK/Types.h>
 #include <fenv.h>
 
-// This is the size of the floating point environment image in protected mode
-static_assert(sizeof(__x87_floating_point_environment) == 28);
-
 extern "C" {
 
 int feupdateenv(fenv_t const* env)

--- a/Userland/Libraries/LibC/fenv.h
+++ b/Userland/Libraries/LibC/fenv.h
@@ -9,28 +9,21 @@
 #include <stdint.h>
 #include <sys/cdefs.h>
 
-__BEGIN_DECLS
+#if defined(__x86_64__)
+#    include <arch/x86_64/fenv.h>
+#elif defined(__aarch64__)
 
-struct __x87_floating_point_environment {
-    uint16_t __control_word;
-    uint16_t __reserved1;
-    uint16_t __status_word;
-    uint16_t __reserved2;
-    uint16_t __tag_word;
-    uint16_t __reserved3;
-    uint32_t __fpu_ip_offset;
-    uint16_t __fpu_ip_selector;
-    uint16_t __opcode : 11;
-    uint16_t __reserved4 : 5;
-    uint32_t __fpu_data_offset;
-    uint16_t __fpu_data_selector;
-    uint16_t __reserved5;
-};
-
+// TODO: Implement this.
 typedef struct fenv_t {
-    struct __x87_floating_point_environment __x87_fpu_env;
-    uint32_t __mxcsr;
 } fenv_t;
+
+#elif defined(__riscv) && __riscv_xlen == 64
+#    include <arch/riscv64/fenv.h>
+#else
+#    error "Unknown architecture"
+#endif
+
+__BEGIN_DECLS
 
 #define FE_DFL_ENV ((fenv_t const*)-1)
 
@@ -58,6 +51,8 @@ int feraiseexcept(int exceptions);
 #define FE_DOWNWARD 1
 #define FE_UPWARD 2
 #define FE_TOWARDZERO 3
+// Only exists in RISC-V at the moment; on other architectures this is replaced with FE_TONEAREST.
+#define FE_TOMAXMAGNITUDE 4
 
 int fesetround(int round);
 int fegetround(void);

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -57,7 +57,9 @@ enum class RoundingMode {
     ToZero = FE_TOWARDZERO,
     Up = FE_UPWARD,
     Down = FE_DOWNWARD,
-    ToEven = FE_TONEAREST
+    ToEven = FE_TONEAREST,
+    // Round to nearest, ties away from zero.
+    ToMaxMagnitude = FE_TOMAXMAGNITUDE,
 };
 
 // This is much branchier than it really needs to be
@@ -117,6 +119,9 @@ static FloatType internal_to_integer(FloatType x, RoundingMode rounding_mode)
             should_round = has_nonhalf_fraction || has_half_fraction;
         break;
     case RoundingMode::ToZero:
+        break;
+    case RoundingMode::ToMaxMagnitude:
+        should_round = true;
         break;
     }
 
@@ -397,6 +402,14 @@ double trunc(double x) NOEXCEPT
             : [temp] "m"(temp));
         return x;
     }
+#elif ARCH(RISCV64)
+    if (fabs(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rtz"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<double>(output);
+    }
 #endif
 
     return internal_to_integer(x, RoundingMode::ToZero);
@@ -413,6 +426,14 @@ float truncf(float x) NOEXCEPT
             : "+t"(x)
             : [temp] "m"(temp));
         return x;
+    }
+#elif ARCH(RISCV64)
+    if (fabsf(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rtz"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<float>(output);
     }
 #endif
 
@@ -444,8 +465,12 @@ double rint(double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.d %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return static_cast<double>(output);
 #elif ARCH(X86_64)
     double res;
     asm(
@@ -463,8 +488,12 @@ float rintf(float value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.s %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return static_cast<float>(output);
 #elif ARCH(X86_64)
     float res;
     asm(
@@ -503,8 +532,12 @@ long lrint(double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.d %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return output;
 #elif ARCH(X86_64)
     long res;
     asm(
@@ -523,8 +556,12 @@ long lrintf(float value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.s %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return output;
 #elif ARCH(X86_64)
     long res;
     asm(
@@ -544,8 +581,8 @@ long long llrintl(long double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    // NOTE: RISC-V LP64 specifies long long == long.
+    return static_cast<long long>(lrintl(value));
 #elif ARCH(X86_64)
     long long res;
     asm(
@@ -564,8 +601,8 @@ long long llrint(double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    // NOTE: RISC-V LP64 specifies long long == long.
+    return static_cast<long long>(lrint(value));
 #elif ARCH(X86_64)
     long long res;
     asm(
@@ -584,8 +621,8 @@ long long llrintf(float value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    // NOTE: RISC-V LP64 specifies long long == long.
+    return static_cast<long long>(lrintf(value));
 #elif ARCH(X86_64)
     long long res;
     asm(
@@ -680,16 +717,34 @@ long double frexpl(long double x, int* exp) NOEXCEPT
     return scalbnl(x, -(*exp));
 }
 
-#if !(ARCH(X86_64))
-
-double round(double value) NOEXCEPT
+double round(double x) NOEXCEPT
 {
-    return internal_to_integer(value, RoundingMode::ToEven);
+#if ARCH(RISCV64)
+    if (fabs(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rmm"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<double>(output);
+    }
+#endif
+
+    return internal_to_integer(x, RoundingMode::ToEven);
 }
 
-float roundf(float value) NOEXCEPT
+float roundf(float x) NOEXCEPT
 {
-    return internal_to_integer(value, RoundingMode::ToEven);
+#if ARCH(RISCV64)
+    if (fabsf(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rmm"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<float>(output);
+    }
+#endif
+
+    return internal_to_integer(x, RoundingMode::ToEven);
 }
 
 long double roundl(long double value) NOEXCEPT
@@ -699,174 +754,163 @@ long double roundl(long double value) NOEXCEPT
 
 long lroundf(float value) NOEXCEPT
 {
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long lround(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long lroundl(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long long llroundf(float value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long long llround(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long long llroundd(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-float floorf(float value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Down);
-}
-
-double floor(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Down);
-}
-
-long double floorl(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Down);
-}
-
-float ceilf(float value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Up);
-}
-
-double ceil(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Up);
-}
-
-long double ceill(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Up);
-}
-
-#else
-
-double round(double x) NOEXCEPT
-{
-    // Note: This is break-tie-away-from-zero, so not the hw's understanding of
-    //       "nearest", which would be towards even.
-    if (x == 0.)
-        return x;
-    if (x > 0.)
-        return floor(x + .5);
-    return ceil(x - .5);
-}
-
-float roundf(float x) NOEXCEPT
-{
-    if (x == 0.f)
-        return x;
-    if (x > 0.f)
-        return floorf(x + .5f);
-    return ceilf(x - .5f);
-}
-
-long double roundl(long double x) NOEXCEPT
-{
-    if (x == 0.L)
-        return x;
-    if (x > 0.L)
-        return floorl(x + .5L);
-    return ceill(x - .5L);
-}
-
-long lroundf(float value) NOEXCEPT
-{
-    return static_cast<long>(roundf(value));
-}
-
-long lround(double value) NOEXCEPT
-{
-    return static_cast<long>(round(value));
-}
-
-long lroundl(long double value) NOEXCEPT
-{
-    return static_cast<long>(roundl(value));
-}
-
-long long llroundf(float value) NOEXCEPT
-{
-    return static_cast<long long>(roundf(value));
-}
-
-long long llround(double value) NOEXCEPT
-{
-    return static_cast<long long>(round(value));
-}
-
-long long llroundd(long double value) NOEXCEPT
-{
-    return static_cast<long long>(roundl(value));
-}
-
-float floorf(float value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-double floor(double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-long double floorl(long double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-float ceilf(float value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-double ceil(double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-long double ceill(long double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.s %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
 #endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long lround(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.d %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
+#endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long lroundl(long double value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long long llroundf(float value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.s %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
+#endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long long llround(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.d %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
+#endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long long llroundd(long double value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+float floorf(float value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabsf(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rdn"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<float>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Down);
+}
+
+double floor(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabs(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rdn"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<double>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Down);
+}
+
+long double floorl(long double value) NOEXCEPT
+{
+#if ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Down);
+}
+
+float ceilf(float value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabsf(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rup"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<float>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Up);
+}
+
+double ceil(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabs(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rup"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<double>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Up);
+}
+
+long double ceill(long double value) NOEXCEPT
+{
+#if ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Up);
+}
 
 long double modfl(long double x, long double* intpart) NOEXCEPT
 {


### PR DESCRIPTION
Revival of #21161, original description:

Because the new tests failed on x86 extended floating point (a truly cursed float format), you're getting two x87 fixes for free!