### PR TITLE
ImageDecoder: Schedule decode jobs on the LibThreading background thread

### DIFF
--- a/Ladybird/ImageDecoder/CMakeLists.txt
+++ b/Ladybird/ImageDecoder/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(ImageDecoder PRIVATE imagedecoder LibMain)
 
 target_include_directories(imagedecoder PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
 target_include_directories(imagedecoder PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(imagedecoder PRIVATE LibCore LibGfx LibIPC LibImageDecoderClient LibMain)
+target_link_libraries(imagedecoder PRIVATE LibCore LibGfx LibIPC LibImageDecoderClient LibMain LibThreading)

--- a/Meta/gn/secondary/Ladybird/ImageDecoder/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/ImageDecoder/BUILD.gn
@@ -11,6 +11,7 @@ executable("ImageDecoder") {
     "//Userland/Libraries/LibIPC",
     "//Userland/Libraries/LibImageDecoderClient",
     "//Userland/Libraries/LibMain",
+    "//Userland/Libraries/LibThreading",
   ]
   sources = [
     "//Userland/Services/ImageDecoder/ConnectionFromClient.cpp",

--- a/Userland/Libraries/LibThreading/BackgroundAction.cpp
+++ b/Userland/Libraries/LibThreading/BackgroundAction.cpp
@@ -15,15 +15,15 @@ static pthread_mutex_t s_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t s_condition = PTHREAD_COND_INITIALIZER;
 static Queue<Function<void()>>* s_all_actions;
 static Threading::Thread* s_background_thread;
+static Atomic<bool> s_background_thread_should_run = true;
 
 static intptr_t background_thread_func()
 {
     Vector<Function<void()>> actions;
-    while (true) {
-
+    while (s_background_thread_should_run.load(AK::MemoryOrder::memory_order_acquire)) {
         pthread_mutex_lock(&s_mutex);
 
-        while (s_all_actions->is_empty())
+        while (s_all_actions->is_empty() && s_background_thread_should_run.load(AK::MemoryOrder::memory_order_acquire))
             pthread_cond_wait(&s_condition, &s_mutex);
 
         while (!s_all_actions->is_empty())
@@ -31,11 +31,13 @@ static intptr_t background_thread_func()
 
         pthread_mutex_unlock(&s_mutex);
 
-        for (auto& action : actions)
-            action();
-
+        for (auto& action : actions) {
+            if (s_background_thread_should_run.load(AK::MemoryOrder::memory_order_acquire))
+                action();
+        }
         actions.clear();
     }
+    return 0;
 }
 
 static void init()
@@ -43,6 +45,24 @@ static void init()
     s_all_actions = new Queue<Function<void()>>;
     s_background_thread = &Threading::Thread::construct(background_thread_func, "Background Thread"sv).leak_ref();
     s_background_thread->start();
+}
+
+void Threading::quit_background_thread()
+{
+    s_background_thread_should_run.store(false, AK::MemoryOrder::memory_order_release);
+
+    pthread_mutex_lock(&s_mutex);
+    pthread_cond_broadcast(&s_condition);
+    pthread_mutex_unlock(&s_mutex);
+
+    MUST(s_background_thread->join());
+
+    delete s_all_actions;
+    s_background_thread->unref();
+    s_all_actions = nullptr;
+    s_background_thread = nullptr;
+
+    s_background_thread_should_run.store(true, AK::MemoryOrder::memory_order_release);
 }
 
 Threading::Thread& Threading::BackgroundActionBase::background_thread()

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -118,4 +118,6 @@ private:
     bool m_canceled { false };
 };
 
+void quit_background_thread();
+
 }

--- a/Userland/Services/ImageDecoder/CMakeLists.txt
+++ b/Userland/Services/ImageDecoder/CMakeLists.txt
@@ -17,4 +17,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_bin(ImageDecoder)
-target_link_libraries(ImageDecoder PRIVATE LibCore LibGfx LibIPC LibMain)
+target_link_libraries(ImageDecoder PRIVATE LibCore LibGfx LibIPC LibMain LibThreading)


### PR DESCRIPTION
This allows the ImageDecoder service to handle new IPC requests while decoding in parallel.

To make this happen, I needed to add a way to cancel and join the LibThreading background thread. This allows processes using BackgroundAction to actually exit when all their threads have exited.