### PR TITLE
CI: Configure ccache before modifying its contents (if any)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -156,9 +156,11 @@ jobs:
 
       - name: Show ccache stats before build and configure
         run: |
+          ccache -M 0
+
           # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
           find ${{ github.workspace }}/.ccache | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
-          ccache -M 0
+
           ccache -s
           ccache -z
 

--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -38,9 +38,11 @@ steps:
         displayName: 'Toolchain Compiler Cache'
 
       - script: |
+          CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -M 0
+
           # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
           find ${{ parameters.toolchain_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
-          CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -M 0
+
           CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -s
           CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -z
         displayName: 'Configure Toolchain ccache'
@@ -55,9 +57,11 @@ steps:
       displayName: 'Serenity Compiler Cache'
 
     - script: |
+        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M 0
+
         # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
         find ${{ parameters.serenity_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
-        CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M 0
+
         CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -s
         CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -z
       displayName: 'Configure Serenity ccache'


### PR DESCRIPTION
If there is a cache miss while downloading the ccache from GitHub/Azure, the .ccache directory won't exist when we try to update the modification time of its contents. Configure the ccache size first, which will create the .ccache directory if it doesn't exist.