### PR TITLE
LibWeb: Allocate dataset lazily for HTML/SVG/MathML elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -50,14 +50,19 @@ void HTMLElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLElement);
-
-    m_dataset = DOMStringMap::create(*this);
 }
 
 void HTMLElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_dataset);
+}
+
+JS::NonnullGCPtr<DOMStringMap> HTMLElement::dataset()
+{
+    if (!m_dataset)
+        m_dataset = DOMStringMap::create(*this);
+    return *m_dataset;
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-dir

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -53,8 +53,7 @@ public:
 
     bool cannot_navigate() const;
 
-    DOMStringMap* dataset() { return m_dataset.ptr(); }
-    DOMStringMap const* dataset() const { return m_dataset.ptr(); }
+    [[nodiscard]] JS::NonnullGCPtr<DOMStringMap> dataset();
 
     void focus();
 

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -23,8 +23,13 @@ void MathMLElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(MathMLElement);
+}
 
-    m_dataset = HTML::DOMStringMap::create(*this);
+JS::NonnullGCPtr<HTML::DOMStringMap> MathMLElement::dataset()
+{
+    if (!m_dataset)
+        m_dataset = HTML::DOMStringMap::create(*this);
+    return *m_dataset;
 }
 
 Optional<ARIA::Role> MathMLElement::default_role() const

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.h
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.h
@@ -20,8 +20,7 @@ class MathMLElement : public DOM::Element
 public:
     virtual ~MathMLElement() override;
 
-    HTML::DOMStringMap* dataset() { return m_dataset.ptr(); }
-    HTML::DOMStringMap const* dataset() const { return m_dataset.ptr(); }
+    [[nodiscard]] JS::NonnullGCPtr<HTML::DOMStringMap> dataset();
 
     virtual Optional<ARIA::Role> default_role() const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -25,14 +25,19 @@ void SVGElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGElement);
-
-    m_dataset = HTML::DOMStringMap::create(*this);
 }
 
 void SVGElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_dataset);
+}
+
+JS::NonnullGCPtr<HTML::DOMStringMap> SVGElement::dataset()
+{
+    if (!m_dataset)
+        m_dataset = HTML::DOMStringMap::create(*this);
+    return *m_dataset;
 }
 
 void SVGElement::attribute_changed(FlyString const& name, Optional<String> const& value)

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -23,8 +23,7 @@ public:
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
 
-    HTML::DOMStringMap* dataset() { return m_dataset.ptr(); }
-    HTML::DOMStringMap const* dataset() const { return m_dataset.ptr(); }
+    [[nodiscard]] JS::NonnullGCPtr<HTML::DOMStringMap> dataset();
 
     void focus();
     void blur();


### PR DESCRIPTION
Most elements never need a dataset object, so we can avoid creating lots of objects by making them lazy.