### PR TITLE
LibWeb: Skip HTMLLinkElement resource fetching for inactive documents

### DIFF
--- a/Tests/LibWeb/Text/expected/css/move-loaded-link-stylesheet-between-documents.txt
+++ b/Tests/LibWeb/Text/expected/css/move-loaded-link-stylesheet-between-documents.txt
@@ -1,3 +1,3 @@
 Sheets in old doc: 0
-Sheets in new doc: 1
+Sheets in new doc: 0
 PASS (didn't crash)

--- a/Tests/LibWeb/Text/expected/favicon-in-inactive-document.txt
+++ b/Tests/LibWeb/Text/expected/favicon-in-inactive-document.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/favicon-in-inactive-document.html
+++ b/Tests/LibWeb/Text/input/favicon-in-inactive-document.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const parser = new DOMParser();
+        const htmlString = '<head><link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAEElEQVR4nGNgGAWjYBTAAAADEAABPywr7AAAAABJRU5ErkJggg=="></head>';
+        const doc = parser.parseFromString(htmlString, "text/html");
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -59,6 +59,10 @@ void HTMLLinkElement::inserted()
 {
     HTMLElement::inserted();
 
+    if (!document().browsing_context()) {
+        return;
+    }
+
     if (m_relationship & Relationship::Stylesheet) {
         // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:fetch-and-process-the-linked-resource
         // The appropriate times to fetch and process this type of link are:


### PR DESCRIPTION
Fixes crashing after following steps:
1. Open https://github.com/SerenityOS/serenity
2. Click on "Pull requests" tab

The problem was `navigable` null pointer dereferencing in `decode_favicon()`. But navigable is null because the document was created by `parseFromString()` DOMParser API.

With this change we skip fetching initiated by HTMLLinkElement if document is not fully active:
- Favicons are not displayed for inactive documents so no need to fetch.
- Stylesheets fetching won't affect inactive document because style or layout does not run for them.