### PR TITLE
CI: Do not prune the toolchain ccache

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -39,10 +39,6 @@ steps:
 
       - script: |
           CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -M 0
-
-          # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
-          find ${{ parameters.toolchain_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
-
           CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -s
           CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -z
         displayName: 'Configure Toolchain ccache'

--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -21,6 +21,12 @@ steps:
           key: '"toolchain" | "x86_64" | Toolchain/BuildClang.sh | Toolchain/Patches/llvm/*.patch | Toolchain/CMake/*.cmake | Userland/Libraries/LibC/**/*.h'
           path: $(Build.SourcesDirectory)/Toolchain/Cache
         displayName: 'Toolchain Prebuilt Cache'
+
+      - script: |
+          source $(Build.SourcesDirectory)/Ports/llvm/package.sh
+          echo "##vso[task.setvariable variable=toolchain_version]$(echo ${version} | cut -d'.' -f1)"
+        displayName: 'Toolchain Version'
+
     - ${{ if eq(parameters.toolchain, 'gcc') }}:
       - task: Cache@2
         inputs:
@@ -28,12 +34,17 @@ steps:
           path: $(Build.SourcesDirectory)/Toolchain/Cache
         displayName: 'Toolchain Prebuilt Cache'
 
+      - script: |
+          source $(Build.SourcesDirectory)/Ports/gcc/package.sh
+          echo "##vso[task.setvariable variable=toolchain_version]$(echo ${version} | cut -d'.' -f1)"
+        displayName: 'Toolchain Version'
+
     - ${{ if ne(parameters.toolchain_ccache_path, '') }}:
       - task: Cache@2
         inputs:
-          key: '"toolchain ccache" | "x86_64" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}" | "$(timestamp)"'
+          key: '"toolchain ccache" | "x86_64" | "${{ parameters.toolchain }}" | "$(toolchain_version)" | "${{ parameters.ccache_version }}" | "$(timestamp)"'
           restoreKeys: |
-            "toolchain ccache" | "x86_64" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}"
+            "toolchain ccache" | "x86_64" | "${{ parameters.toolchain }}" | "$(toolchain_version)" | "${{ parameters.ccache_version }}"
           path: ${{ parameters.toolchain_ccache_path }}
         displayName: 'Toolchain Compiler Cache'
 

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -124,9 +124,6 @@ jobs:
           artifactName: 'Coverage'
 
     - script: |
-        echo "##[section]Toolchain Cache"
-        CCACHE_DIR='$(LLVM_CCACHE_DIR)' ccache --evict-older-than 1d
-
         echo "##[section]Serenity Cache"
         CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache --evict-older-than 1d
       displayName: 'Prune obsolete ccache files'


### PR DESCRIPTION
Currently, if the prebuilt toolchain cache gets used, we will not try to build the toolchain. Thus, the toolchain's ccache does not get used, and is then pruned entirely at the end of the run.

So for now, let's just not prune the toolchain ccache. After a few years it only reached 0.8 GB in size. And now that we are starting from empty again, it will likely be a few more years before we reach 0.8 GB again.

Then, we can clear the toolchain ccache when the toolchain's major version changes. This would ultimately be a clean build anyways, so we can take that opportunity to stop carrying the previous version's ccache forward.