### PR TITLE
Ladybird: Use RequestServer for networking by default

### DIFF
--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -91,7 +91,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .command_line = MUST(command_line_builder.to_string()),
         .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
         .enable_gpu_painting = use_gpu_painting ? Ladybird::EnableGPUPainting::Yes : Ladybird::EnableGPUPainting::No,
-        .use_lagom_networking = Ladybird::UseLagomNetworking::Yes,
         .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,
         .log_all_js_exceptions = log_all_js_exceptions ? Ladybird::LogAllJSExceptions::Yes : Ladybird::LogAllJSExceptions::No,
     };

--- a/Ladybird/Types.h
+++ b/Ladybird/Types.h
@@ -56,7 +56,7 @@ struct WebContentOptions {
     EnableCallgrindProfiling enable_callgrind_profiling { EnableCallgrindProfiling::No };
     EnableGPUPainting enable_gpu_painting { EnableGPUPainting::No };
     IsLayoutTestMode is_layout_test_mode { IsLayoutTestMode::No };
-    UseLagomNetworking use_lagom_networking { UseLagomNetworking::No };
+    UseLagomNetworking use_lagom_networking { UseLagomNetworking::Yes };
     WaitForDebugger wait_for_debugger { WaitForDebugger::No };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };
     EnableIDLTracing enable_idl_tracing { EnableIDLTracing::No };


### PR DESCRIPTION
This really only affects headless-browser when it is linked with Qt. In
that case, it currently uses Qt networking by default and does not have
a flag to use RequestServer instead. Change the default to use RS so it
can undergo sanitized testing in CI.