### PR TITLE
LibWeb: Stop the video decoder thread when the video element is GC'd

### DIFF
--- a/Tests/LibWeb/Text/data/video-gc-frame.html
+++ b/Tests/LibWeb/Text/data/video-gc-frame.html
@@ -1,0 +1,1 @@
+<video autoplay src="../../../../Base/home/anon/Videos/test-webm.webm"></video>

--- a/Tests/LibWeb/Text/expected/video-gc.txt
+++ b/Tests/LibWeb/Text/expected/video-gc.txt
@@ -1,0 +1,1 @@
+   PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/video-gc.html
+++ b/Tests/LibWeb/Text/input/video-gc.html
@@ -1,0 +1,25 @@
+<iframe id=iframe></iframe>
+<script src="include.js"></script>
+<script>
+    function navigateIframe(src) {
+        return new Promise(resolve => {
+            iframe.addEventListener("load", () => {
+                resolve();
+            });
+            iframe.src = src;
+        });
+    }
+
+    asyncTest(async done => {
+        await navigateIframe("../data/video-gc-frame.html");
+        await navigateIframe("../data/iframe-test-content-1.html");
+        iframe.remove();
+
+        for (let i = 0; i < 5; ++i) {
+            internals.gc();
+        }
+
+        println("PASS (didn't crash)");
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -122,6 +122,7 @@ public:
     void resume_playback();
     void pause_playback();
     void restart_playback();
+    void terminate_playback();
     void seek_to_timestamp(Duration, SeekMode = DEFAULT_SEEK_MODE);
     bool is_playing() const
     {

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -70,6 +70,7 @@ void HTMLMediaElement::initialize(JS::Realm& realm)
 
 void HTMLMediaElement::finalize()
 {
+    Base::finalize();
     document().page().unregister_media_element({}, unique_id());
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/VideoTrack.h>
+#include <LibWeb/HTML/VideoTrackList.h>
 #include <LibWeb/Layout/VideoBox.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
@@ -34,6 +35,14 @@ void HTMLVideoElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLVideoElement);
+}
+
+void HTMLVideoElement::finalize()
+{
+    Base::finalize();
+
+    for (auto video_track : video_tracks()->video_tracks())
+        video_track->stop_video({});
 }
 
 void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -46,6 +46,7 @@ private:
     HTMLVideoElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void finalize() override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -98,6 +98,11 @@ void VideoTrack::pause_video(Badge<HTMLVideoElement>)
     m_playback_manager->pause_playback();
 }
 
+void VideoTrack::stop_video(Badge<HTMLVideoElement>)
+{
+    m_playback_manager->terminate_playback();
+}
+
 Duration VideoTrack::position() const
 {
     return m_playback_manager->current_playback_time();
@@ -141,7 +146,7 @@ void VideoTrack::set_selected(bool selected)
     // no longer in a VideoTrackList object, then the track being selected or unselected has no effect beyond changing the value of
     // the attribute on the VideoTrack object.)
     if (m_video_track_list) {
-        for (auto video_track : m_video_track_list->video_tracks({})) {
+        for (auto video_track : m_video_track_list->video_tracks()) {
             if (video_track.ptr() != this)
                 video_track->m_selected = false;
         }

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.h
@@ -25,6 +25,7 @@ public:
 
     void play_video(Badge<HTMLVideoElement>);
     void pause_video(Badge<HTMLVideoElement>);
+    void stop_video(Badge<HTMLVideoElement>);
 
     Duration position() const;
     Duration duration() const;

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
@@ -22,7 +22,7 @@ public:
     ErrorOr<void> add_track(Badge<HTMLMediaElement>, JS::NonnullGCPtr<VideoTrack>);
     void remove_all_tracks(Badge<HTMLMediaElement>);
 
-    Span<JS::NonnullGCPtr<VideoTrack>> video_tracks(Badge<VideoTrack>) { return m_video_tracks; }
+    Span<JS::NonnullGCPtr<VideoTrack>> video_tracks() { return m_video_tracks; }
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-videotracklist-length
     size_t length() const { return m_video_tracks.size(); }


### PR DESCRIPTION
Otherwise, the thread will continue to run and access the media data
buffer, which will have been freed.

Fixes #24044