### PR TITLE
LibWeb: Run page activation behavior when skipping context menu events

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -270,10 +270,15 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
 
             bool run_activation_behavior = false;
             if (node.ptr() == m_mousedown_target) {
-                if (button == GUI::MouseButton::Primary)
+                if (button == GUI::MouseButton::Primary) {
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
-                else if (button == GUI::MouseButton::Secondary && !(modifiers & Mod_Shift)) // Allow the user to bypass custom context menus by holding shift, like Firefox.
-                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
+                } else if (button == GUI::MouseButton::Secondary) {
+                    // Allow the user to bypass custom context menus by holding shift, like Firefox.
+                    if ((modifiers & Mod_Shift) == 0)
+                        run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
+                    else
+                        run_activation_behavior = true;
+                }
             }
 
             if (run_activation_behavior) {


### PR DESCRIPTION
We partially supported this feature, but not enough for the chrome's context menu to open. We now propagate the event back to the chrome.

With this, we can use the chrome's context menu on discord, which is a feature I use in firefox all the time:

https://github.com/SerenityOS/serenity/assets/5600524/cd5e7d6d-2582-49b0-9aae-9f0665012d1f





