### PR TITLE
LibWeb: Only react to link element attribute changes when BC connected

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -335,6 +335,13 @@ bool Node::is_connected() const
     return shadow_including_root().is_document();
 }
 
+// https://html.spec.whatwg.org/multipage/infrastructure.html#browsing-context-connected
+bool Node::is_browsing_context_connected() const
+{
+    // A node is browsing-context connected when it is connected and its shadow-including root's browsing context is non-null.
+    return is_connected() && shadow_including_root().document().browsing_context();
+}
+
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
 WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child) const
 {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -185,6 +185,8 @@ public:
 
     bool is_connected() const;
 
+    [[nodiscard]] bool is_browsing_context_connected() const;
+
     Node* parent_node() { return parent(); }
     Node const* parent_node() const { return parent(); }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -134,17 +134,19 @@ void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> 
         // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:fetch-and-process-the-linked-resource
         // The appropriate times to fetch and process this type of link are:
         if (
-            // AD-HOC: When the rel attribute changes
-            name == AttributeNames::rel ||
-            // - When the href attribute of the link element of an external resource link that is already browsing-context connected is changed.
-            name == AttributeNames::href ||
-            // - When the disabled attribute of the link element of an external resource link that is already browsing-context connected is set, changed, or removed.
-            name == AttributeNames::disabled ||
-            // - When the crossorigin attribute of the link element of an external resource link that is already browsing-context connected is set, changed, or removed.
-            name == AttributeNames::crossorigin
-            // FIXME: - When the type attribute of the link element of an external resource link that is already browsing-context connected is set or changed to a value that does not or no longer matches the Content-Type metadata of the previous obtained external resource, if any.
-            // FIXME: - When the type attribute of the link element of an external resource link that is already browsing-context connected, but was previously not obtained due to the type attribute specifying an unsupported type, is removed or changed.
-        ) {
+            is_browsing_context_connected()
+            && (
+                // AD-HOC: When the rel attribute changes
+                name == AttributeNames::rel ||
+                // - When the href attribute of the link element of an external resource link that is already browsing-context connected is changed.
+                name == AttributeNames::href ||
+                // - When the disabled attribute of the link element of an external resource link that is already browsing-context connected is set, changed, or removed.
+                name == AttributeNames::disabled ||
+                // - When the crossorigin attribute of the link element of an external resource link that is already browsing-context connected is set, changed, or removed.
+                name == AttributeNames::crossorigin
+                // FIXME: - When the type attribute of the link element of an external resource link that is already browsing-context connected is set or changed to a value that does not or no longer matches the Content-Type metadata of the previous obtained external resource, if any.
+                // FIXME: - When the type attribute of the link element of an external resource link that is already browsing-context connected, but was previously not obtained due to the type attribute specifying an unsupported type, is removed or changed.
+                )) {
             fetch_and_process_linked_resource();
         }
     }


### PR DESCRIPTION
Link elements that aren't "browsing-context connected" should not trigger a resource fetch when their attributes change.

This fixes an issue where we'd waste time by loading every style sheet twice! :^)