### PR TITLE
LibWeb: Remove OOM propagation from Fetch::Infrastructure

### DIFF
--- a/Tests/LibWeb/TestFetchInfrastructure.cpp
+++ b/Tests/LibWeb/TestFetchInfrastructure.cpp
@@ -16,14 +16,14 @@ TEST_CASE(collect_an_http_quoted_string)
         auto test = "\"\""_string;
         GenericLexer lexer { test };
 
-        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        auto result = Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer);
         EXPECT_EQ(result, "\"\""_string);
     }
     {
         auto test = "\"abc\""_string;
         GenericLexer lexer { test };
 
-        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        auto result = Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer);
         EXPECT_EQ(result, "\"abc\""_string);
     }
     {
@@ -32,7 +32,7 @@ TEST_CASE(collect_an_http_quoted_string)
         GenericLexer lexer { test };
         lexer.ignore(4);
 
-        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        auto result = Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer);
         EXPECT_EQ(result, "\"abc\""_string);
     }
     {
@@ -41,7 +41,7 @@ TEST_CASE(collect_an_http_quoted_string)
         GenericLexer lexer { test };
         lexer.ignore(4);
 
-        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        auto result = Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer);
         EXPECT_EQ(result, "\"abc\""_string);
     }
     {
@@ -50,14 +50,14 @@ TEST_CASE(collect_an_http_quoted_string)
         GenericLexer lexer { test };
         lexer.ignore(4);
 
-        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        auto result = Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer);
         EXPECT_EQ(result, "\"abc\""_string);
     }
     {
         auto test = "\"abc\" bar"_string;
         GenericLexer lexer { test };
 
-        auto result = MUST(Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer));
+        auto result = Web::Fetch::Infrastructure::collect_an_http_quoted_string(lexer);
         EXPECT_EQ(result, "\"abc\""_string);
     }
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -301,7 +301,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
     document->m_window = window;
 
     // NOTE: Non-standard: Pull out the Last-Modified header for use in the lastModified property.
-    if (auto maybe_last_modified = MUST(navigation_params.response->header_list()->get("Last-Modified"sv.bytes())); maybe_last_modified.has_value())
+    if (auto maybe_last_modified = navigation_params.response->header_list()->get("Last-Modified"sv.bytes()); maybe_last_modified.has_value())
         document->m_last_modified = Core::DateTime::parse("%a, %d %b %Y %H:%M:%S %Z"sv, maybe_last_modified.value());
 
     // 11. Set window's associated Document to document.

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -98,11 +98,10 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_markdown_docume
         });
 
         navigation_params.response->body()->fully_read(
-                                              realm,
-                                              process_body,
-                                              process_body_error,
-                                              JS::NonnullGCPtr { realm.global_object() })
-            .release_value_but_fixme_should_propagate_errors();
+            realm,
+            process_body,
+            process_body_error,
+            JS::NonnullGCPtr { realm.global_object() });
     });
 }
 
@@ -174,7 +173,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_html_document(H
         });
 
         auto& realm = document->realm();
-        TRY(navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }));
+        navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() });
     }
 
     // 4. Return document.
@@ -265,7 +264,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_xml_document(HT
     });
 
     auto& realm = document->realm();
-    TRY(navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }));
+    navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() });
 
     return document;
 }
@@ -328,7 +327,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_text_document(H
     });
 
     auto& realm = document->realm();
-    TRY(navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }));
+    navigation_params.response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() });
 
     // 6. Return document.
     return document;
@@ -416,11 +415,11 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_media_document(
     //        However, if we don't, then we get stuck in HTMLParser::the_end() waiting for the media file to load, which
     //        never happens.
     auto& realm = document->realm();
-    TRY(navigation_params.response->body()->fully_read(
+    navigation_params.response->body()->fully_read(
         realm,
         JS::create_heap_function(document->heap(), [document](ByteBuffer) { HTML::HTMLParser::the_end(document); }),
         JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {}),
-        JS::NonnullGCPtr { realm.global_object() }));
+        JS::NonnullGCPtr { realm.global_object() });
 
     // 9. Return document.
     return document;

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -469,7 +469,7 @@ JS::GCPtr<DOM::Document> load_document(HTML::NavigationParams const& navigation_
     // and origin initiatorOrigin, perform the following steps. They return a Document or null.
 
     // 1. Let type be the computed type of navigationParams's response.
-    auto extracted_mime_type = navigation_params.response->header_list()->extract_mime_type().release_value_but_fixme_should_propagate_errors();
+    auto extracted_mime_type = navigation_params.response->header_list()->extract_mime_type();
     if (!extracted_mime_type.has_value())
         return nullptr;
     auto type = extracted_mime_type.release_value();

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -201,7 +201,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm& realm
     }
     // 6. Otherwise, fully read object’s body given successSteps, errorSteps, and object’s relevant global object.
     else {
-        TRY(body->fully_read(realm, success_steps, error_steps, JS::NonnullGCPtr { HTML::relevant_global_object(object.as_platform_object()) }));
+        body->fully_read(realm, success_steps, error_steps, JS::NonnullGCPtr { HTML::relevant_global_object(object.as_platform_object()) });
     }
 
     // 7. Return promise.

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Checks.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Checks.cpp
@@ -15,7 +15,7 @@ namespace Web::Fetch::Fetching {
 ErrorOr<bool> cors_check(Infrastructure::Request const& request, Infrastructure::Response const& response)
 {
     // 1. Let origin be the result of getting `Access-Control-Allow-Origin` from response’s header list.
-    auto origin = TRY(response.header_list()->get("Access-Control-Allow-Origin"sv.bytes()));
+    auto origin = response.header_list()->get("Access-Control-Allow-Origin"sv.bytes());
 
     // 2. If origin is null, then return failure.
     // NOTE: Null is not `null`.
@@ -35,7 +35,7 @@ ErrorOr<bool> cors_check(Infrastructure::Request const& request, Infrastructure:
         return true;
 
     // 6. Let credentials be the result of getting `Access-Control-Allow-Credentials` from response’s header list.
-    auto credentials = TRY(response.header_list()->get("Access-Control-Allow-Credentials"sv.bytes()));
+    auto credentials = response.header_list()->get("Access-Control-Allow-Credentials"sv.bytes());
 
     // 7. If credentials is `true`, then return success.
     if (credentials.has_value() && credentials->span() == "true"sv.bytes())
@@ -53,7 +53,7 @@ ErrorOr<bool> tao_check(Infrastructure::Request const& request, Infrastructure::
         return false;
 
     // 2. Let values be the result of getting, decoding, and splitting `Timing-Allow-Origin` from response’s header list.
-    auto values = TRY(response.header_list()->get_decode_and_split("Timing-Allow-Origin"sv.bytes()));
+    auto values = response.header_list()->get_decode_and_split("Timing-Allow-Origin"sv.bytes());
 
     // 3. If values contains "*", then return success.
     if (values.has_value() && values->contains_slow("*"sv))

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Checks.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Checks.cpp
@@ -12,7 +12,7 @@
 namespace Web::Fetch::Fetching {
 
 // https://fetch.spec.whatwg.org/#concept-cors-check
-ErrorOr<bool> cors_check(Infrastructure::Request const& request, Infrastructure::Response const& response)
+bool cors_check(Infrastructure::Request const& request, Infrastructure::Response const& response)
 {
     // 1. Let origin be the result of getting `Access-Control-Allow-Origin` from response’s header list.
     auto origin = response.header_list()->get("Access-Control-Allow-Origin"sv.bytes());
@@ -27,7 +27,7 @@ ErrorOr<bool> cors_check(Infrastructure::Request const& request, Infrastructure:
         return true;
 
     // 4. If the result of byte-serializing a request origin with request is not origin, then return failure.
-    if (TRY(request.byte_serialize_origin()) != *origin)
+    if (request.byte_serialize_origin() != *origin)
         return false;
 
     // 5. If request’s credentials mode is not "include", then return success.
@@ -46,7 +46,7 @@ ErrorOr<bool> cors_check(Infrastructure::Request const& request, Infrastructure:
 }
 
 // https://fetch.spec.whatwg.org/#concept-tao-check
-ErrorOr<bool> tao_check(Infrastructure::Request const& request, Infrastructure::Response const& response)
+bool tao_check(Infrastructure::Request const& request, Infrastructure::Response const& response)
 {
     // 1. If request’s timing allow failed flag is set, then return failure.
     if (request.timing_allow_failed())
@@ -60,7 +60,7 @@ ErrorOr<bool> tao_check(Infrastructure::Request const& request, Infrastructure::
         return true;
 
     // 4. If values contains the result of serializing a request origin with request, then return success.
-    if (values.has_value() && values->contains_slow(TRY(request.serialize_origin())))
+    if (values.has_value() && values->contains_slow(request.serialize_origin()))
         return true;
 
     // 5. If request’s mode is "navigate" and request’s current URL’s origin is not same origin with request’s origin, then return failure.

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Checks.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Checks.h
@@ -11,7 +11,7 @@
 
 namespace Web::Fetch::Fetching {
 
-ErrorOr<bool> cors_check(Infrastructure::Request const&, Infrastructure::Response const&);
-ErrorOr<bool> tao_check(Infrastructure::Request const&, Infrastructure::Response const&);
+[[nodiscard]] bool cors_check(Infrastructure::Request const&, Infrastructure::Response const&);
+[[nodiscard]] bool tao_check(Infrastructure::Request const&, Infrastructure::Response const&);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -495,7 +495,7 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm& realm, Inf
                 // 1. Let processBodyError be this step: run fetch response handover given fetchParams and a network
                 //    error.
                 auto process_body_error = JS::create_heap_function(vm.heap(), [&realm, &vm, &fetch_params](JS::GCPtr<WebIDL::DOMException>) {
-                    TRY_OR_IGNORE(fetch_response_handover(realm, fetch_params, Infrastructure::Response::network_error(vm, "Response body could not be processed"sv)));
+                    fetch_response_handover(realm, fetch_params, Infrastructure::Response::network_error(vm, "Response body could not be processed"sv));
                 });
 
                 // 2. If response’s body is null, then run processBodyError and abort these steps.
@@ -516,15 +516,15 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm& realm, Inf
                     response->set_body(TRY_OR_IGNORE(Infrastructure::byte_sequence_as_body(realm, bytes)));
 
                     // 3. Run fetch response handover given fetchParams and response.
-                    TRY_OR_IGNORE(fetch_response_handover(realm, fetch_params, *response));
+                    fetch_response_handover(realm, fetch_params, *response);
                 });
 
                 // 4. Fully read response’s body given processBody and processBodyError.
-                TRY_OR_IGNORE(response->body()->fully_read(realm, move(process_body), move(process_body_error), fetch_params.task_destination()));
+                response->body()->fully_read(realm, process_body, process_body_error, fetch_params.task_destination());
             }
             // 23. Otherwise, run fetch response handover given fetchParams and response.
             else {
-                TRY_OR_IGNORE(fetch_response_handover(realm, fetch_params, *response));
+                fetch_response_handover(realm, fetch_params, *response);
             }
         });
     });
@@ -533,7 +533,7 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm& realm, Inf
 }
 
 // https://fetch.spec.whatwg.org/#fetch-finale
-WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const& fetch_params, Infrastructure::Response& response)
+void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const& fetch_params, Infrastructure::Response& response)
 {
     dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'fetch response handover' with: fetch_params @ {}, response @ {}", &fetch_params, &response);
 
@@ -681,11 +681,9 @@ WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm& realm, Infrastructu
         // 4. Otherwise, fully read internalResponse body given processBody, processBodyError, and fetchParams’s task
         //    destination.
         else {
-            TRY(internal_response->body()->fully_read(realm, process_body, process_body_error, fetch_params.task_destination()));
+            internal_response->body()->fully_read(realm, process_body, process_body_error, fetch_params.task_destination());
         }
     }
-
-    return {};
 }
 
 // https://fetch.spec.whatwg.org/#concept-scheme-fetch

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -417,16 +417,16 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm& realm, Inf
 
                 // 2. Set response to the following filtered response with response as its internal response, depending
                 //    on request’s response tainting:
-                response = TRY_OR_IGNORE([&]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<Infrastructure::Response>> {
+                response = [&]() -> JS::NonnullGCPtr<Infrastructure::Response> {
                     switch (request->response_tainting()) {
                     // -> "basic"
                     case Infrastructure::Request::ResponseTainting::Basic:
                         // basic filtered response
-                        return TRY_OR_THROW_OOM(vm, Infrastructure::BasicFilteredResponse::create(vm, *response));
+                        return Infrastructure::BasicFilteredResponse::create(vm, *response);
                     // -> "cors"
                     case Infrastructure::Request::ResponseTainting::CORS:
                         // CORS filtered response
-                        return TRY_OR_THROW_OOM(vm, Infrastructure::CORSFilteredResponse::create(vm, *response));
+                        return Infrastructure::CORSFilteredResponse::create(vm, *response);
                     // -> "opaque"
                     case Infrastructure::Request::ResponseTainting::Opaque:
                         // opaque filtered response
@@ -434,7 +434,7 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm& realm, Inf
                     default:
                         VERIFY_NOT_REACHED();
                     }
-                }());
+                }();
             }
 
             // 15. Let internalResponse be response, if response is a network error, and response’s internal response

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -994,13 +994,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm& rea
             // NOTE: As the CORS check is not to be applied to responses whose status is 304 or 407, or responses from
             //       a service worker for that matter, it is applied here.
             if (request->response_tainting() == Infrastructure::Request::ResponseTainting::CORS
-                && !TRY_OR_IGNORE(cors_check(request, *response))) {
+                && !cors_check(request, *response)) {
                 returned_pending_response->resolve(Infrastructure::Response::network_error(vm, "Request with 'cors' response tainting failed CORS check"_string));
                 return;
             }
 
             // 5. If the TAO check for request and response returns failure, then set request’s timing allow failed flag.
-            if (!TRY_OR_IGNORE(tao_check(request, *response)))
+            if (!tao_check(request, *response))
                 request->set_timing_allow_failed(true);
         }
 
@@ -1353,7 +1353,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
         }
 
         // 12. Append a request `Origin` header for httpRequest.
-        TRY_OR_THROW_OOM(vm, http_request->add_origin_header());
+        http_request->add_origin_header();
 
         // FIXME: 13. Append the Fetch metadata headers for httpRequest.
 
@@ -1876,7 +1876,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::
 
         // 7. If a CORS check for request and response returns success and response’s status is an ok status, then:
         // NOTE: The CORS check is done on request rather than preflight to ensure the correct credentials mode is used.
-        if (TRY_OR_IGNORE(cors_check(request, response)) && Infrastructure::is_ok_status(response->status())) {
+        if (cors_check(request, response) && Infrastructure::is_ok_status(response->status())) {
             // 1. Let methods be the result of extracting header list values given `Access-Control-Allow-Methods` and response’s header list.
             auto methods_or_failure = Infrastructure::extract_header_list_values("Access-Control-Allow-Methods"sv.bytes(), response->header_list());
 

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -31,7 +31,7 @@ ENUMERATE_BOOL_PARAMS
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Infrastructure::FetchController>> fetch(JS::Realm&, Infrastructure::Request&, Infrastructure::FetchAlgorithms const&, UseParallelQueue use_parallel_queue = UseParallelQueue::No);
 WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm&, Infrastructure::FetchParams const&, Recursive recursive = Recursive::No);
-WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
+void fetch_response_handover(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> scheme_fetch(JS::Realm&, Infrastructure::FetchParams const&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm&, Infrastructure::FetchParams const&, MakeCORSPreflight make_cors_preflight = MakeCORSPreflight::No);
 WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
@@ -21,7 +21,7 @@ public:
 
     virtual ~HeadersIterator() override;
 
-    JS::ThrowCompletionOr<JS::Object*> next();
+    JS::NonnullGCPtr<JS::Object> next();
 
 private:
     virtual void initialize(JS::Realm&) override;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
@@ -12,7 +12,7 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#collect-an-http-quoted-string
-ErrorOr<String> collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value)
+String collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value)
 {
     // To collect an HTTP quoted string from a string input, given a position variable position and optionally an extract-value flag, run these steps:
     // 1. Let positionStart be position.
@@ -69,10 +69,10 @@ ErrorOr<String> collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStr
 
     // 6. If the extract-value flag is set, then return value.
     if (extract_value == HttpQuotedStringExtractValue::Yes)
-        return value.to_string();
+        return MUST(value.to_string());
 
     // 7. Return the code points from positionStart to position, inclusive, within input.
-    return String::from_utf8(lexer.input().substring_view(position_start, lexer.tell() - position_start));
+    return MUST(String::from_utf8(lexer.input().substring_view(position_start, lexer.tell() - position_start)));
 }
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
@@ -37,6 +37,6 @@ enum class HttpQuotedStringExtractValue {
     Yes,
 };
 
-ErrorOr<String> collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value = HttpQuotedStringExtractValue::No);
+[[nodiscard]] String collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value = HttpQuotedStringExtractValue::No);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -75,7 +75,7 @@ WebIDL::ExceptionOr<void> Body::fully_read(JS::Realm& realm, Web::Fetch::Infrast
     auto success_steps = [&realm, process_body, task_destination_object = task_destination_object](ByteBuffer const& bytes) mutable -> ErrorOr<void> {
         // Make a copy of the bytes, as the source of the bytes may disappear between the time the task is queued and executed.
         auto bytes_copy = TRY(ByteBuffer::copy(bytes));
-        queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body, bytes_copy = move(bytes_copy)]() {
+        queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body, bytes_copy = move(bytes_copy)]() mutable {
             process_body->function()(move(bytes_copy));
         }));
         return {};

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -41,7 +41,7 @@ public:
 
     [[nodiscard]] JS::NonnullGCPtr<Body> clone(JS::Realm&);
 
-    WebIDL::ExceptionOr<void> fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination) const;
+    void fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination) const;
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -150,7 +150,7 @@ Optional<Vector<String>> get_decode_and_split_header_value(ReadonlyBytes value)
             // 1. If the code point at position within input is U+0022 ("), then:
             if (lexer.peek() == '"') {
                 // 1. Append the result of collecting an HTTP quoted string from input, given position, to temporaryValue.
-                temporary_value_builder.append(MUST(collect_an_http_quoted_string(lexer)));
+                temporary_value_builder.append(collect_an_http_quoted_string(lexer));
 
                 // 2. If position is not past the end of input, then continue.
                 if (!lexer.is_eof())

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -26,7 +26,7 @@ struct Header {
     ByteBuffer name;
     ByteBuffer value;
 
-    static ErrorOr<Header> from_string_pair(StringView, StringView);
+    static Header from_string_pair(StringView, StringView);
 };
 
 // https://fetch.spec.whatwg.org/#concept-header-list
@@ -46,24 +46,22 @@ public:
     [[nodiscard]] static JS::NonnullGCPtr<HeaderList> create(JS::VM&);
 
     [[nodiscard]] bool contains(ReadonlyBytes) const;
-    [[nodiscard]] ErrorOr<Optional<ByteBuffer>> get(ReadonlyBytes) const;
-    [[nodiscard]] ErrorOr<Optional<Vector<String>>> get_decode_and_split(ReadonlyBytes) const;
-    [[nodiscard]] ErrorOr<void> append(Header);
+    [[nodiscard]] Optional<ByteBuffer> get(ReadonlyBytes) const;
+    [[nodiscard]] Optional<Vector<String>> get_decode_and_split(ReadonlyBytes) const;
+    void append(Header);
     void delete_(ReadonlyBytes name);
-    [[nodiscard]] ErrorOr<void> set(Header);
-    [[nodiscard]] ErrorOr<void> combine(Header);
-    [[nodiscard]] ErrorOr<Vector<Header>> sort_and_combine() const;
+    void set(Header);
+    void combine(Header);
+    [[nodiscard]] Vector<Header> sort_and_combine() const;
 
-    struct ExtractLengthFailure {
-    };
-
+    struct ExtractLengthFailure { };
     using ExtractLengthResult = Variant<u64, ExtractLengthFailure, Empty>;
 
-    [[nodiscard]] ErrorOr<ExtractLengthResult> extract_length() const;
+    [[nodiscard]] ExtractLengthResult extract_length() const;
 
-    [[nodiscard]] ErrorOr<Optional<MimeSniff::MimeType>> extract_mime_type() const;
+    [[nodiscard]] Optional<MimeSniff::MimeType> extract_mime_type() const;
 
-    ErrorOr<Vector<ByteBuffer>> unique_names() const;
+    [[nodiscard]] Vector<ByteBuffer> unique_names() const;
 };
 
 struct RangeHeaderValue {
@@ -75,24 +73,24 @@ struct ExtractHeaderParseFailure {
 };
 
 [[nodiscard]] StringView legacy_extract_an_encoding(Optional<MimeSniff::MimeType> const& mime_type, StringView fallback_encoding);
-[[nodiscard]] ErrorOr<Optional<Vector<String>>> get_decode_and_split_header_value(ReadonlyBytes);
-[[nodiscard]] ErrorOr<OrderedHashTable<ByteBuffer>> convert_header_names_to_a_sorted_lowercase_set(Span<ReadonlyBytes>);
+[[nodiscard]] Optional<Vector<String>> get_decode_and_split_header_value(ReadonlyBytes);
+[[nodiscard]] OrderedHashTable<ByteBuffer> convert_header_names_to_a_sorted_lowercase_set(Span<ReadonlyBytes>);
 [[nodiscard]] bool is_header_name(ReadonlyBytes);
 [[nodiscard]] bool is_header_value(ReadonlyBytes);
-[[nodiscard]] ErrorOr<ByteBuffer> normalize_header_value(ReadonlyBytes);
+[[nodiscard]] ByteBuffer normalize_header_value(ReadonlyBytes);
 [[nodiscard]] bool is_cors_safelisted_request_header(Header const&);
 [[nodiscard]] bool is_cors_unsafe_request_header_byte(u8);
-[[nodiscard]] ErrorOr<OrderedHashTable<ByteBuffer>> get_cors_unsafe_header_names(HeaderList const&);
+[[nodiscard]] OrderedHashTable<ByteBuffer> get_cors_unsafe_header_names(HeaderList const&);
 [[nodiscard]] bool is_cors_non_wildcard_request_header_name(ReadonlyBytes);
 [[nodiscard]] bool is_privileged_no_cors_request_header_name(ReadonlyBytes);
 [[nodiscard]] bool is_cors_safelisted_response_header_name(ReadonlyBytes, Span<ReadonlyBytes>);
 [[nodiscard]] bool is_no_cors_safelisted_request_header_name(ReadonlyBytes);
 [[nodiscard]] bool is_no_cors_safelisted_request_header(Header const&);
-[[nodiscard]] ErrorOr<bool> is_forbidden_request_header(Header const&);
+[[nodiscard]] bool is_forbidden_request_header(Header const&);
 [[nodiscard]] bool is_forbidden_response_header_name(ReadonlyBytes);
 [[nodiscard]] bool is_request_body_header_name(ReadonlyBytes);
-[[nodiscard]] ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_values(Header const&);
-[[nodiscard]] ErrorOr<Variant<Vector<ByteBuffer>, ExtractHeaderParseFailure, Empty>> extract_header_list_values(ReadonlyBytes, HeaderList const&);
+[[nodiscard]] Optional<Vector<ByteBuffer>> extract_header_values(Header const&);
+[[nodiscard]] Variant<Vector<ByteBuffer>, ExtractHeaderParseFailure, Empty> extract_header_list_values(ReadonlyBytes, HeaderList const&);
 [[nodiscard]] Optional<RangeHeaderValue> parse_single_range_header_value(ReadonlyBytes);
 [[nodiscard]] ByteBuffer default_user_agent_value();
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Methods.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Methods.cpp
@@ -36,10 +36,10 @@ bool is_forbidden_method(ReadonlyBytes method)
 }
 
 // https://fetch.spec.whatwg.org/#concept-method-normalize
-ErrorOr<ByteBuffer> normalize_method(ReadonlyBytes method)
+ByteBuffer normalize_method(ReadonlyBytes method)
 {
     // To normalize a method, if it is a byte-case-insensitive match for `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, or `PUT`, byte-uppercase it.
-    auto bytes = TRY(ByteBuffer::copy(method));
+    auto bytes = MUST(ByteBuffer::copy(method));
     if (StringView { method }.is_one_of_ignoring_ascii_case("DELETE"sv, "GET"sv, "HEAD"sv, "OPTIONS"sv, "POST"sv, "PUT"sv))
         Infra::byte_uppercase(bytes);
     return bytes;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Methods.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Methods.h
@@ -13,6 +13,6 @@ namespace Web::Fetch::Infrastructure {
 [[nodiscard]] bool is_method(ReadonlyBytes);
 [[nodiscard]] bool is_cors_safelisted_method(ReadonlyBytes);
 [[nodiscard]] bool is_forbidden_method(ReadonlyBytes);
-[[nodiscard]] ErrorOr<ByteBuffer> normalize_method(ReadonlyBytes);
+[[nodiscard]] ByteBuffer normalize_method(ReadonlyBytes);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -214,7 +214,7 @@ JS::NonnullGCPtr<Request> Request::clone(JS::Realm& realm) const
     new_request->set_method(m_method);
     new_request->set_local_urls_only(m_local_urls_only);
     for (auto const& header : *m_header_list)
-        MUST(new_request->header_list()->append(header));
+        new_request->header_list()->append(header);
     new_request->set_unsafe_request(m_unsafe_request);
     new_request->set_client(m_client);
     new_request->set_reserved_client(m_reserved_client);
@@ -284,7 +284,7 @@ ErrorOr<void> Request::add_range_header(u64 first, Optional<u64> const& last)
         .name = MUST(ByteBuffer::copy("Range"sv.bytes())),
         .value = move(range_value),
     };
-    TRY(m_header_list->append(move(header)));
+    m_header_list->append(move(header));
 
     return {};
 }
@@ -301,7 +301,7 @@ ErrorOr<void> Request::add_origin_header()
             .name = MUST(ByteBuffer::copy("Origin"sv.bytes())),
             .value = move(serialized_origin),
         };
-        TRY(m_header_list->append(move(header)));
+        m_header_list->append(move(header));
     }
     // 3. Otherwise, if request’s method is neither `GET` nor `HEAD`, then:
     else if (!StringView { m_method }.is_one_of("GET"sv, "HEAD"sv)) {
@@ -343,7 +343,7 @@ ErrorOr<void> Request::add_origin_header()
             .name = MUST(ByteBuffer::copy("Origin"sv.bytes())),
             .value = move(serialized_origin),
         };
-        TRY(m_header_list->append(move(header)));
+        m_header_list->append(move(header));
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -302,13 +302,13 @@ public:
 
     [[nodiscard]] bool has_redirect_tainted_origin() const;
 
-    [[nodiscard]] ErrorOr<String> serialize_origin() const;
-    [[nodiscard]] ErrorOr<ByteBuffer> byte_serialize_origin() const;
+    [[nodiscard]] String serialize_origin() const;
+    [[nodiscard]] ByteBuffer byte_serialize_origin() const;
 
     [[nodiscard]] JS::NonnullGCPtr<Request> clone(JS::Realm&) const;
 
-    [[nodiscard]] ErrorOr<void> add_range_header(u64 first, Optional<u64> const& last);
-    [[nodiscard]] ErrorOr<void> add_origin_header();
+    void add_range_header(u64 first, Optional<u64> const& last);
+    void add_origin_header();
 
     [[nodiscard]] bool cross_origin_embedder_policy_allows_credentials() const;
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -124,7 +124,7 @@ ErrorOr<Optional<URL::URL>> Response::location_url(Optional<String> const& reque
         return Optional<URL::URL> {};
 
     // 2. Let location be the result of extracting header list values given `Location` and response’s header list.
-    auto location_values_or_failure = TRY(extract_header_list_values("Location"sv.bytes(), m_header_list));
+    auto location_values_or_failure = extract_header_list_values("Location"sv.bytes(), m_header_list);
     if (location_values_or_failure.has<Infrastructure::ExtractHeaderParseFailure>() || location_values_or_failure.has<Empty>())
         return Optional<URL::URL> {};
 
@@ -173,7 +173,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::clone(JS::Realm& realm
     new_response->set_status(m_status);
     new_response->set_status_message(m_status_message);
     for (auto const& header : *m_header_list)
-        MUST(new_response->header_list()->append(header));
+        new_response->header_list()->append(header);
     new_response->set_cache_state(m_cache_state);
     new_response->set_cors_exposed_header_name_list(m_cors_exposed_header_name_list);
     new_response->set_range_requested(m_range_requested);
@@ -238,7 +238,7 @@ ErrorOr<JS::NonnullGCPtr<BasicFilteredResponse>> BasicFilteredResponse::create(J
     auto header_list = HeaderList::create(vm);
     for (auto const& header : *internal_response->header_list()) {
         if (!is_forbidden_response_header_name(header.name))
-            TRY(header_list->append(header));
+            header_list->append(header);
     }
 
     return vm.heap().allocate_without_realm<BasicFilteredResponse>(internal_response, header_list);
@@ -268,7 +268,7 @@ ErrorOr<JS::NonnullGCPtr<CORSFilteredResponse>> CORSFilteredResponse::create(JS:
     auto header_list = HeaderList::create(vm);
     for (auto const& header : *internal_response->header_list()) {
         if (is_cors_safelisted_response_header_name(header.name, cors_exposed_header_name_list))
-            TRY(header_list->append(header));
+            header_list->append(header);
     }
 
     return vm.heap().allocate_without_realm<CORSFilteredResponse>(internal_response, header_list);

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -146,18 +146,18 @@ ErrorOr<Optional<URL::URL>> Response::location_url(Optional<String> const& reque
 }
 
 // https://fetch.spec.whatwg.org/#concept-response-clone
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::clone(JS::Realm& realm) const
+JS::NonnullGCPtr<Response> Response::clone(JS::Realm& realm) const
 {
     // To clone a response response, run these steps:
     auto& vm = realm.vm();
 
     // 1. If response is a filtered response, then return a new identical filtered response whose internal response is a clone of response’s internal response.
     if (is<FilteredResponse>(*this)) {
-        auto internal_response = TRY(static_cast<FilteredResponse const&>(*this).internal_response()->clone(realm));
+        auto internal_response = static_cast<FilteredResponse const&>(*this).internal_response()->clone(realm);
         if (is<BasicFilteredResponse>(*this))
-            return TRY_OR_THROW_OOM(vm, BasicFilteredResponse::create(vm, internal_response));
+            return BasicFilteredResponse::create(vm, internal_response);
         if (is<CORSFilteredResponse>(*this))
-            return TRY_OR_THROW_OOM(vm, CORSFilteredResponse::create(vm, internal_response));
+            return CORSFilteredResponse::create(vm, internal_response);
         if (is<OpaqueFilteredResponse>(*this))
             return OpaqueFilteredResponse::create(vm, internal_response);
         if (is<OpaqueRedirectFilteredResponse>(*this))
@@ -231,7 +231,7 @@ void FilteredResponse::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_internal_response);
 }
 
-ErrorOr<JS::NonnullGCPtr<BasicFilteredResponse>> BasicFilteredResponse::create(JS::VM& vm, JS::NonnullGCPtr<Response> internal_response)
+JS::NonnullGCPtr<BasicFilteredResponse> BasicFilteredResponse::create(JS::VM& vm, JS::NonnullGCPtr<Response> internal_response)
 {
     // A basic filtered response is a filtered response whose type is "basic" and header list excludes
     // any headers in internal response’s header list whose name is a forbidden response-header name.
@@ -256,7 +256,7 @@ void BasicFilteredResponse::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_header_list);
 }
 
-ErrorOr<JS::NonnullGCPtr<CORSFilteredResponse>> CORSFilteredResponse::create(JS::VM& vm, JS::NonnullGCPtr<Response> internal_response)
+JS::NonnullGCPtr<CORSFilteredResponse> CORSFilteredResponse::create(JS::VM& vm, JS::NonnullGCPtr<Response> internal_response)
 {
     // A CORS filtered response is a filtered response whose type is "cors" and header list excludes
     // any headers in internal response’s header list whose name is not a CORS-safelisted response-header

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -109,7 +109,7 @@ public:
     [[nodiscard]] Optional<URL::URL const&> url() const;
     [[nodiscard]] ErrorOr<Optional<URL::URL>> location_url(Optional<String> const& request_fragment) const;
 
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> clone(JS::Realm&) const;
+    [[nodiscard]] JS::NonnullGCPtr<Response> clone(JS::Realm&) const;
 
     [[nodiscard]] JS::NonnullGCPtr<Response> unsafe_response();
 
@@ -227,7 +227,7 @@ class BasicFilteredResponse final : public FilteredResponse {
     JS_DECLARE_ALLOCATOR(BasicFilteredResponse);
 
 public:
-    [[nodiscard]] static ErrorOr<JS::NonnullGCPtr<BasicFilteredResponse>> create(JS::VM&, JS::NonnullGCPtr<Response>);
+    [[nodiscard]] static JS::NonnullGCPtr<BasicFilteredResponse> create(JS::VM&, JS::NonnullGCPtr<Response>);
 
     [[nodiscard]] virtual Type type() const override { return Type::Basic; }
     [[nodiscard]] virtual JS::NonnullGCPtr<HeaderList> header_list() const override { return m_header_list; }
@@ -246,7 +246,7 @@ class CORSFilteredResponse final : public FilteredResponse {
     JS_DECLARE_ALLOCATOR(CORSFilteredResponse);
 
 public:
-    [[nodiscard]] static ErrorOr<JS::NonnullGCPtr<CORSFilteredResponse>> create(JS::VM&, JS::NonnullGCPtr<Response>);
+    [[nodiscard]] static JS::NonnullGCPtr<CORSFilteredResponse> create(JS::VM&, JS::NonnullGCPtr<Response>);
 
     [[nodiscard]] virtual Type type() const override { return Type::CORS; }
     [[nodiscard]] virtual JS::NonnullGCPtr<HeaderList> header_list() const override { return m_header_list; }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/MimeTypeBlocking.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/MimeTypeBlocking.cpp
@@ -11,10 +11,10 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#ref-for-should-response-to-request-be-blocked-due-to-mime-type?
-ErrorOr<RequestOrResponseBlocking> should_response_to_request_be_blocked_due_to_its_mime_type(Response const& response, Request const& request)
+RequestOrResponseBlocking should_response_to_request_be_blocked_due_to_its_mime_type(Response const& response, Request const& request)
 {
     // 1. Let mimeType be the result of extracting a MIME type from response’s header list.
-    auto mime_type = TRY(response.header_list()->extract_mime_type());
+    auto mime_type = response.header_list()->extract_mime_type();
 
     // 2. If mimeType is failure, then return allowed.
     if (!mime_type.has_value())

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/MimeTypeBlocking.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/MimeTypeBlocking.h
@@ -11,6 +11,6 @@
 
 namespace Web::Fetch::Infrastructure {
 
-ErrorOr<RequestOrResponseBlocking> should_response_to_request_be_blocked_due_to_its_mime_type(Response const&, Request const&);
+[[nodiscard]] RequestOrResponseBlocking should_response_to_request_be_blocked_due_to_its_mime_type(Response const&, Request const&);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/NoSniffBlocking.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/NoSniffBlocking.cpp
@@ -13,10 +13,10 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#determine-nosniff
-ErrorOr<bool> determine_nosniff(HeaderList const& list)
+bool determine_nosniff(HeaderList const& list)
 {
     // 1. Let values be the result of getting, decoding, and splitting `X-Content-Type-Options` from list.
-    auto values = TRY(list.get_decode_and_split("X-Content-Type-Options"sv.bytes()));
+    auto values = list.get_decode_and_split("X-Content-Type-Options"sv.bytes());
 
     // 2. If values is null, then return false.
     if (!values.has_value())
@@ -31,14 +31,14 @@ ErrorOr<bool> determine_nosniff(HeaderList const& list)
 }
 
 // https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?
-ErrorOr<RequestOrResponseBlocking> should_response_to_request_be_blocked_due_to_nosniff(Response const& response, Request const& request)
+RequestOrResponseBlocking should_response_to_request_be_blocked_due_to_nosniff(Response const& response, Request const& request)
 {
     // 1. If determine nosniff with response’s header list is false, then return allowed.
-    if (!TRY(determine_nosniff(response.header_list())))
+    if (!determine_nosniff(response.header_list()))
         return RequestOrResponseBlocking::Allowed;
 
     // 2. Let mimeType be the result of extracting a MIME type from response’s header list.
-    auto mime_type = TRY(response.header_list()->extract_mime_type());
+    auto mime_type = response.header_list()->extract_mime_type();
 
     // 3. Let destination be request’s destination.
     auto const& destination = request.destination();

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/NoSniffBlocking.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/NoSniffBlocking.h
@@ -12,7 +12,7 @@
 
 namespace Web::Fetch::Infrastructure {
 
-ErrorOr<bool> determine_nosniff(HeaderList const&);
-ErrorOr<RequestOrResponseBlocking> should_response_to_request_be_blocked_due_to_nosniff(Response const&, Request const&);
+[[nodiscard]] bool determine_nosniff(HeaderList const&);
+[[nodiscard]] RequestOrResponseBlocking should_response_to_request_be_blocked_due_to_nosniff(Response const&, Request const&);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -188,7 +188,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
     //     A copy of request’s header list.
     auto header_list_copy = Infrastructure::HeaderList::create(vm);
     for (auto& header : *input_request->header_list())
-        TRY_OR_THROW_OOM(vm, header_list_copy->append(header));
+        header_list_copy->append(header);
     request->set_header_list(header_list_copy);
 
     // unsafe-request flag
@@ -427,7 +427,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
         // 4. If headers is a Headers object, then for each header of its header list, append header to this’s headers.
         if (auto* header_list = headers.get_pointer<JS::NonnullGCPtr<Infrastructure::HeaderList>>()) {
             for (auto& header : *header_list->ptr())
-                TRY(request_object->headers()->append(TRY_OR_THROW_OOM(vm, Infrastructure::Header::from_string_pair(header.name, header.value))));
+                TRY(request_object->headers()->append(Infrastructure::Header::from_string_pair(header.name, header.value)));
         }
         // 5. Otherwise, fill this’s headers with headers.
         else {
@@ -460,7 +460,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
 
         // 4. If type is non-null and this’s headers’s header list does not contain `Content-Type`, then append (`Content-Type`, type) to this’s headers.
         if (type.has_value() && !request_object->headers()->header_list()->contains("Content-Type"sv.bytes()))
-            TRY(request_object->headers()->append(TRY_OR_THROW_OOM(vm, Infrastructure::Header::from_string_pair("Content-Type"sv, type->span()))));
+            TRY(request_object->headers()->append(Infrastructure::Header::from_string_pair("Content-Type"sv, type->span())));
     }
 
     // 38. Let inputOrInitBody be initBody if it is non-null; otherwise inputBody.

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -373,7 +373,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
             return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Method must not be one of CONNECT, TRACE, or TRACK"sv };
 
         // 3. Normalize method.
-        method = TRY_OR_THROW_OOM(vm, String::from_utf8(TRY_OR_THROW_OOM(vm, Infrastructure::normalize_method(method.bytes()))));
+        method = TRY_OR_THROW_OOM(vm, String::from_utf8(Infrastructure::normalize_method(method.bytes())));
 
         // 4. Set request’s method to method.
         request->set_method(MUST(ByteBuffer::copy(method.bytes())));

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<void> Response::initialize_response(ResponseInit const& init
                 .name = MUST(ByteBuffer::copy("Content-Type"sv.bytes())),
                 .value = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(body->type->span())),
             };
-            TRY_OR_THROW_OOM(vm, m_response->header_list()->append(move(header)));
+            m_response->header_list()->append(move(header));
         }
     }
 
@@ -191,8 +191,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::redirect(JS::VM& vm, S
     auto value = parsed_url.serialize();
 
     // 7. Append (`Location`, value) to responseObject’s response’s header list.
-    auto header = TRY_OR_THROW_OOM(vm, Infrastructure::Header::from_string_pair("Location"sv, value));
-    TRY_OR_THROW_OOM(vm, response_object->response()->header_list()->append(move(header)));
+    auto header = Infrastructure::Header::from_string_pair("Location"sv, value);
+    response_object->response()->header_list()->append(move(header));
 
     // 8. Return responseObject.
     return response_object;

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -289,7 +289,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::clone() const
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Response is unusable"sv };
 
     // 2. Let clonedResponse be the result of cloning this’s response.
-    auto cloned_response = TRY(m_response->clone(realm));
+    auto cloned_response = m_response->clone(realm);
 
     // 3. Return the result of creating a Response object, given clonedResponse, this’s headers’s guard, and this’s relevant Realm.
     return Response::create(HTML::relevant_realm(*this), cloned_response, m_headers->guard());

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -320,7 +320,7 @@ void HTMLLinkElement::default_fetch_and_process_linked_resource()
 void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const& response, Variant<Empty, Fetch::Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag, ByteBuffer> body_bytes)
 {
     // 1. If the resource's Content-Type metadata is not text/css, then set success to false.
-    auto extracted_mime_type = response.header_list()->extract_mime_type().release_value_but_fixme_should_propagate_errors();
+    auto extracted_mime_type = response.header_list()->extract_mime_type();
     if (!extracted_mime_type.has_value() || extracted_mime_type->essence() != "text/css") {
         success = false;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -539,7 +539,7 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(JS::N
 
         // 3. Use response's unsafe response as an icon as if it had been declared using the icon keyword.
         if (auto body = response->unsafe_response()->body())
-            body->fully_read(realm, process_body, process_body_error, global).release_value_but_fixme_should_propagate_errors();
+            body->fully_read(realm, process_body, process_body_error, global);
     };
 
     TRY(Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input))));

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1016,7 +1016,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::fetch_resource(URL::URL const& url_r
             // FIXME: We are "fully" reading the response here, rather than "incrementally". Memory concerns aside, this should be okay for now as we are
             //        always setting byteRange to "entire resource". However, we should switch to incremental reads when that is implemented, and then
             //        implement the processEndOfMedia step.
-            response->body()->fully_read(realm, update_media, empty_algorithm, JS::NonnullGCPtr { global }).release_value_but_fixme_should_propagate_errors();
+            response->body()->fully_read(realm, update_media, empty_algorithm, JS::NonnullGCPtr { global });
         };
 
         m_fetch_controller = TRY(Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input))));

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -204,7 +204,7 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
         VERIFY(response->body());
         auto empty_algorithm = JS::create_heap_function(heap(), [](JS::GCPtr<WebIDL::DOMException>) {});
 
-        response->body()->fully_read(realm, on_image_data_read, empty_algorithm, JS::NonnullGCPtr { global }).release_value_but_fixme_should_propagate_errors();
+        response->body()->fully_read(realm, on_image_data_read, empty_algorithm, JS::NonnullGCPtr { global });
     };
 
     m_fetch_controller = TRY(Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input))));

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -620,8 +620,10 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<NavigationParams>> create_navigation
     //    body: the UTF-8 encoding of documentResource, as a body
     auto response = Fetch::Infrastructure::Response::create(vm);
     response->url_list().append(URL::URL("about:srcdoc"));
-    auto header = TRY_OR_THROW_OOM(vm, Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv));
-    TRY_OR_THROW_OOM(vm, response->header_list()->append(move(header)));
+
+    auto header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv);
+    response->header_list()->append(move(header));
+
     response->set_body(TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, document_resource.get<String>().bytes())));
 
     // 3. Let responseOrigin be the result of determining the origin given response's URL, targetSnapshotParams's sandboxing flags, and entry's document state's origin.
@@ -740,8 +742,8 @@ static WebIDL::ExceptionOr<Variant<Empty, JS::NonnullGCPtr<NavigationParams>, JS
                 VERIFY_NOT_REACHED();
             }
         }();
-        auto header = TRY_OR_THROW_OOM(vm, Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, request_content_type_string));
-        TRY_OR_THROW_OOM(vm, request->header_list()->append(move(header)));
+        auto header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, request_content_type_string);
+        request->header_list()->append(move(header));
     }
 
     // 5. If entry's document state's reload pending is true, then set request's reload-navigation flag.
@@ -1591,8 +1593,10 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> Navigable::evaluate_javascript_url
     //     body: the UTF-8 encoding of result, as a body
     auto response = Fetch::Infrastructure::Response::create(vm);
     response->url_list().append(active_document()->url());
-    auto header = TRY_OR_THROW_OOM(vm, Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv));
-    TRY_OR_THROW_OOM(vm, response->header_list()->append(move(header)));
+
+    auto header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv);
+    response->header_list()->append(move(header));
+
     response->set_body(TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, result.bytes())));
 
     // 12. Let policyContainer be targetNavigable's active document's policy container.

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
@@ -58,12 +58,12 @@ WebIDL::ExceptionOr<bool> NavigatorBeaconMixin::send_beacon(String const& url, O
             cors_mode = Fetch::Infrastructure::Request::Mode::CORS;
 
             // If contentType value is a CORS-safelisted request-header value for the Content-Type header, set corsMode to "no-cors".
-            auto content_type_header = MUST(Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, content_type.value()));
+            auto content_type_header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, content_type.value());
             if (Fetch::Infrastructure::is_cors_safelisted_request_header(content_type_header))
                 cors_mode = Fetch::Infrastructure::Request::Mode::NoCORS;
 
             // Append a Content-Type header with value contentType to headerList.
-            MUST(header_list->append(content_type_header));
+            header_list->append(content_type_header);
         }
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -313,7 +313,7 @@ WebIDL::ExceptionOr<void> fetch_classic_script(JS::NonnullGCPtr<HTMLScriptElemen
         }
 
         // 3. Let potentialMIMETypeForEncoding be the result of extracting a MIME type given response's header list.
-        auto potential_mime_type_for_encoding = response->header_list()->extract_mime_type().release_value_but_fixme_should_propagate_errors();
+        auto potential_mime_type_for_encoding = response->header_list()->extract_mime_type();
 
         // 4. Set character encoding to the result of legacy extracting an encoding given potentialMIMETypeForEncoding
         //    and character encoding.
@@ -381,7 +381,7 @@ WebIDL::ExceptionOr<void> fetch_classic_worker_script(URL::URL const& url, Envir
         // 3. If all of the following are true:
         // - response's URL's scheme is an HTTP(S) scheme; and
         // - the result of extracting a MIME type from response's header list is not a JavaScript MIME type,
-        auto maybe_mime_type = MUST(response->header_list()->extract_mime_type());
+        auto maybe_mime_type = response->header_list()->extract_mime_type();
         auto mime_type_is_javascript = maybe_mime_type.has_value() && maybe_mime_type->is_javascript();
 
         if (response->url().has_value() && Fetch::Infrastructure::is_http_or_https_scheme(response->url()->scheme()) && !mime_type_is_javascript) {
@@ -684,7 +684,7 @@ void fetch_single_module_script(JS::Realm& realm,
         auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes.get<ByteBuffer>()).release_value_but_fixme_should_propagate_errors();
 
         // 3. Let mimeType be the result of extracting a MIME type from response's header list.
-        auto mime_type = response->header_list()->extract_mime_type().release_value_but_fixme_should_propagate_errors();
+        auto mime_type = response->header_list()->extract_mime_type();
 
         // 4. Let moduleScript be null.
         JS::GCPtr<JavaScriptModuleScript> module_script;

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -86,7 +86,7 @@ void SharedImageRequest::fetch_image(JS::Realm& realm, JS::NonnullGCPtr<Fetch::I
         response = response->unsafe_response();
 
         auto process_body = JS::create_heap_function(heap(), [this, request, response](ByteBuffer data) {
-            auto extracted_mime_type = response->header_list()->extract_mime_type().release_value_but_fixme_should_propagate_errors();
+            auto extracted_mime_type = response->header_list()->extract_mime_type();
             auto mime_type = extracted_mime_type.has_value() ? extracted_mime_type.value().essence().bytes_as_string_view() : StringView {};
             handle_successful_fetch(request->url(), mime_type, move(data));
         });

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -95,7 +95,7 @@ void SharedImageRequest::fetch_image(JS::Realm& realm, JS::NonnullGCPtr<Fetch::I
         });
 
         if (response->body())
-            response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() }).release_value_but_fixme_should_propagate_errors();
+            response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() });
         else
             handle_failed_fetch();
     };

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -152,7 +152,7 @@ ErrorOr<Optional<MimeType>> MimeType::parse(StringView string)
         // 8. If the code point at position within input is U+0022 ("), then:
         if (lexer.peek() == '"') {
             // 1. Set parameterValue to the result of collecting an HTTP quoted string from input, given position and the extract-value flag.
-            parameter_value = TRY(Fetch::Infrastructure::collect_an_http_quoted_string(lexer, Fetch::Infrastructure::HttpQuotedStringExtractValue::Yes));
+            parameter_value = Fetch::Infrastructure::collect_an_http_quoted_string(lexer, Fetch::Infrastructure::HttpQuotedStringExtractValue::Yes);
 
             // 2. Collect a sequence of code points that are not U+003B (;) from input, given position.
             lexer.ignore_until(';');

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -475,7 +475,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
         return WebIDL::SecurityError::create(realm(), "Forbidden method, must not be 'CONNECT', 'TRACE', or 'TRACK'"_fly_string);
 
     // 4. Normalize method.
-    auto normalized_method = TRY_OR_THROW_OOM(vm(), Fetch::Infrastructure::normalize_method(method));
+    auto normalized_method = Fetch::Infrastructure::normalize_method(method);
 
     // 5. Let parsedURL be the result of parsing url with this’s relevant settings object’s API base URL and this’s relevant settings object’s API URL character encoding.
     // FIXME: Pass in this’s relevant settings object’s API URL character encoding.


### PR DESCRIPTION
Let's start untangling Fetch :sweat_smile: 

This covers the Fetch/Infrastructure folder. Each commit tries to be self-contained, but if an error removal caused a calling function to also have no errors, then that commit handles making that caller infallible as well (which didn't propagate too far, it's mostly fetch things calling other fetch things).

The one place this does not remove OOM handling from is `Fetch::Infrastructure::Body::fully_read`. That method can cause huge allocations, and actually has a spec-compliant way to handle the OOM error without forcing ourselves to crash.

Ref #20449 