### PR TITLE
LibWebView: Create plumbing for a single UI process 

### DIFF
--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -6,6 +6,7 @@
 
 #include "Application.h"
 #include "StringUtils.h"
+#include "TaskManagerWindow.h"
 #include <LibWebView/URL.h>
 #include <QFileOpenEvent>
 
@@ -14,6 +15,11 @@ namespace Ladybird {
 Application::Application(int& argc, char** argv)
     : QApplication(argc, argv)
 {
+}
+
+Application::~Application()
+{
+    close_task_manager_window();
 }
 
 bool Application::event(QEvent* event)
@@ -35,6 +41,35 @@ bool Application::event(QEvent* event)
     }
 
     return QApplication::event(event);
+}
+
+void Application::show_task_manager_window()
+{
+    if (!m_task_manager_window) {
+        m_task_manager_window = new TaskManagerWindow(nullptr);
+    }
+    m_task_manager_window->show();
+    m_task_manager_window->activateWindow();
+    m_task_manager_window->raise();
+}
+
+void Application::close_task_manager_window()
+{
+    if (m_task_manager_window) {
+        m_task_manager_window->close();
+        delete m_task_manager_window;
+        m_task_manager_window = nullptr;
+    }
+}
+
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path)
+{
+    auto* window = new BrowserWindow(initial_urls, cookie_jar, web_content_options, webdriver_content_ipc_path);
+    set_active_window(*window);
+    window->show();
+    window->activateWindow();
+    window->raise();
+    return *window;
 }
 
 }

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/HashTable.h>
+#include <Ladybird/Qt/BrowserWindow.h>
 #include <LibProtocol/RequestClient.h>
 #include <LibURL/URL.h>
 #include <QApplication>
@@ -18,11 +20,24 @@ class Application : public QApplication {
 
 public:
     Application(int& argc, char** argv);
+    virtual ~Application() override;
 
     virtual bool event(QEvent* event) override;
 
     Function<void(URL::URL)> on_open_file;
     RefPtr<Protocol::RequestClient> request_server_client;
+
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path);
+
+    void show_task_manager_window();
+    void close_task_manager_window();
+
+    BrowserWindow& active_window() { return *m_active_window; }
+    void set_active_window(BrowserWindow& w) { m_active_window = &w; }
+
+private:
+    TaskManagerWindow* m_task_manager_window { nullptr };
+    BrowserWindow* m_active_window { nullptr };
 };
 
 }

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -57,6 +57,11 @@ public:
         return *m_new_tab_action;
     }
 
+    QAction& new_window_action()
+    {
+        return *m_new_window_action;
+    }
+
     QAction& copy_selection_action()
     {
         return *m_copy_selection_action;
@@ -141,9 +146,6 @@ private:
     QString tool_tip_for_page_mute_state(Tab&) const;
     QTabBar::ButtonPosition audio_button_position_for_tab(int tab_index) const;
 
-    void show_task_manager_window();
-    void close_task_manager_window();
-
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
 
@@ -155,6 +157,7 @@ private:
     QAction* m_go_forward_action { nullptr };
     QAction* m_reload_action { nullptr };
     QAction* m_new_tab_action { nullptr };
+    QAction* m_new_window_action { nullptr };
     QAction* m_copy_selection_action { nullptr };
     QAction* m_paste_action { nullptr };
     QAction* m_select_all_action { nullptr };
@@ -162,9 +165,6 @@ private:
     QAction* m_inspect_dom_node_action { nullptr };
 
     SettingsDialog* m_settings_dialog { nullptr };
-
-    // FIXME: This should be owned at a higher level in case we have multiple browser windows
-    TaskManagerWindow* m_task_manager_window { nullptr };
 
     WebView::CookieJar& m_cookie_jar;
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -35,6 +35,7 @@ public:
     WebContentView& view() const { return m_current_tab->view(); }
 
     int tab_index(Tab*);
+    Tab& create_new_tab(Web::HTML::ActivateTab activate_tab);
 
     QAction& go_back_action()
     {
@@ -117,7 +118,6 @@ private:
     virtual void wheelEvent(QWheelEvent*) override;
     virtual void closeEvent(QCloseEvent*) override;
 
-    Tab& create_new_tab(Web::HTML::ActivateTab activate_tab);
     Tab& create_new_tab(Web::HTML::ActivateTab, Tab& parent, Web::HTML::WebViewHints, Optional<u64> page_index);
     void initialize_tab(Tab*);
 

--- a/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
@@ -84,6 +84,28 @@ compiled_action("WebDriverServerEndpoint") {
   ]
 }
 
+compiled_action("UIProcessClientEndpoint") {
+  tool = "//Meta/Lagom/Tools/CodeGenerators/IPCCompiler"
+  inputs = [ "//Userland/Libraries/LibWebView/UIProcessClient.ipc" ]
+  outputs = [ "$root_gen_dir/LibWebView/UIProcessClientEndpoint.h" ]
+  args = [
+    rebase_path(inputs[0], root_build_dir),
+    "-o",
+    rebase_path(outputs[0], root_build_dir),
+  ]
+}
+
+compiled_action("UIProcessServerEndpoint") {
+  tool = "//Meta/Lagom/Tools/CodeGenerators/IPCCompiler"
+  inputs = [ "//Userland/Libraries/LibWebView/UIProcessServer.ipc" ]
+  outputs = [ "$root_gen_dir/LibWebView/UIProcessServerEndpoint.h" ]
+  args = [
+    rebase_path(inputs[0], root_build_dir),
+    "-o",
+    rebase_path(outputs[0], root_build_dir),
+  ]
+}
+
 embed_as_string_view("generate_native_stylesheet_source") {
   input = "Native.css"
   output = "$target_gen_dir/NativeStyleSheetSource.cpp"
@@ -100,6 +122,8 @@ shared_library("LibWebView") {
     "$target_gen_dir/..",
   ]
   deps = [
+    ":UIProcessClientEndpoint",
+    ":UIProcessServerEndpoint",
     ":WebContentClientEndpoint",
     ":WebContentServerEndpoint",
     ":WebDriverClientEndpoint",
@@ -118,6 +142,7 @@ shared_library("LibWebView") {
   ]
   sources = [
     "Attribute.cpp",
+    "ChromeProcess.cpp",
     "CookieJar.cpp",
     "Database.cpp",
     "InspectorClient.cpp",
@@ -136,6 +161,8 @@ shared_library("LibWebView") {
              get_target_outputs(":WebContentServerEndpoint") +
              get_target_outputs(":WebDriverClientEndpoint") +
              get_target_outputs(":WebDriverServerEndpoint") +
+             get_target_outputs(":UIProcessClientEndpoint") +
+             get_target_outputs(":UIProcessServerEndpoint") +
              get_target_outputs(":generate_native_stylesheet_source")
   if (enable_public_suffix_list_download) {
     deps += [ ":generate_public_suffix_list_sources" ]

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -47,6 +47,17 @@ ErrorOr<void> LocalServer::take_over_from_system_server(ByteString const& socket
     return {};
 }
 
+ErrorOr<void> LocalServer::take_over_fd(int socket_fd)
+{
+    if (m_listening)
+        return Error::from_string_literal("Core::LocalServer: Can't perform socket takeover when already listening");
+
+    m_fd = socket_fd;
+    m_listening = true;
+    setup_notifier();
+    return {};
+}
+
 void LocalServer::setup_notifier()
 {
     m_notifier = Notifier::construct(m_fd, Notifier::Type::Read, this);

--- a/Userland/Libraries/LibCore/LocalServer.h
+++ b/Userland/Libraries/LibCore/LocalServer.h
@@ -17,6 +17,7 @@ public:
     virtual ~LocalServer() override;
 
     ErrorOr<void> take_over_from_system_server(ByteString const& path = ByteString());
+    ErrorOr<void> take_over_fd(int socket_fd);
     bool is_listening() const { return m_listening; }
     bool listen(ByteString const& address);
 

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -379,7 +379,7 @@ ErrorOr<IPCProcess::ProcessAndIPCSocket> IPCProcess::spawn_and_connect_to_proces
     return ProcessAndIPCSocket { move(process), move(ipc_socket) };
 }
 
-static ErrorOr<Optional<pid_t>> get_process_pid(StringView process_name, StringView pid_path)
+ErrorOr<Optional<pid_t>> IPCProcess::get_process_pid(StringView process_name, StringView pid_path)
 {
     if (System::stat(pid_path).is_error())
         return OptionalNone {};
@@ -416,7 +416,7 @@ static ErrorOr<Optional<pid_t>> get_process_pid(StringView process_name, StringV
 }
 
 // This is heavily based on how SystemServer's Service creates its socket.
-static ErrorOr<int> create_ipc_socket(ByteString const& socket_path)
+ErrorOr<int> IPCProcess::create_ipc_socket(ByteString const& socket_path)
 {
     if (!System::stat(socket_path).is_error())
         TRY(System::unlink(socket_path));
@@ -444,11 +444,7 @@ static ErrorOr<int> create_ipc_socket(ByteString const& socket_path)
     return socket_fd;
 }
 
-struct ProcessPaths {
-    ByteString socket_path;
-    ByteString pid_path;
-};
-static ErrorOr<ProcessPaths> paths_for_process(StringView process_name)
+ErrorOr<IPCProcess::ProcessPaths> IPCProcess::paths_for_process(StringView process_name)
 {
     auto runtime_directory = TRY(StandardPaths::runtime_directory());
     auto socket_path = ByteString::formatted("{}/{}.socket", runtime_directory, process_name);

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -138,6 +138,14 @@ public:
         return ProcessAndIPCClient<ClientType> { move(process), move(client) };
     }
 
+    struct ProcessPaths {
+        ByteString socket_path;
+        ByteString pid_path;
+    };
+    static ErrorOr<ProcessPaths> paths_for_process(StringView process_name);
+    static ErrorOr<Optional<pid_t>> get_process_pid(StringView process_name, StringView pid_path);
+    static ErrorOr<int> create_ipc_socket(ByteString const& socket_path);
+
     pid_t pid() const { return m_process.pid(); }
 
 private:

--- a/Userland/Libraries/LibIPC/MultiServer.h
+++ b/Userland/Libraries/LibIPC/MultiServer.h
@@ -23,6 +23,11 @@ public:
         return adopt_nonnull_own_or_enomem(new (nothrow) MultiServer(move(server)));
     }
 
+    static ErrorOr<NonnullOwnPtr<MultiServer>> try_create(NonnullRefPtr<Core::LocalServer> server)
+    {
+        return adopt_nonnull_own_or_enomem(new (nothrow) MultiServer(move(server)));
+    }
+
     Function<void(ConnectionFromClientType&)> on_new_client;
 
 private:

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -2,6 +2,7 @@ include(${SerenityOS_SOURCE_DIR}/Meta/CMake/public_suffix.cmake)
 
 set(SOURCES
     Attribute.cpp
+    ChromeProcess.cpp
     CookieJar.cpp
     Database.cpp
     InspectorClient.cpp
@@ -32,6 +33,9 @@ embed_as_string_view(
     NAMESPACE "WebView"
 )
 
+compile_ipc(UIProcessServer.ipc UIProcessServerEndpoint.h)
+compile_ipc(UIProcessClient.ipc UIProcessClientEndpoint.h)
+
 set(GENERATED_SOURCES
     ${GENERATED_SOURCES}
     ../../Services/RequestServer/RequestClientEndpoint.h
@@ -41,6 +45,8 @@ set(GENERATED_SOURCES
     ../../Services/WebContent/WebDriverClientEndpoint.h
     ../../Services/WebContent/WebDriverServerEndpoint.h
     NativeStyleSheetSource.cpp
+    UIProcessClientEndpoint.h
+    UIProcessServerEndpoint.h
 )
 
 serenity_lib(LibWebView webview)

--- a/Userland/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Userland/Libraries/LibWebView/ChromeProcess.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteString.h>
+#include <LibCore/Process.h>
+#include <LibCore/StandardPaths.h>
+#include <LibIPC/ConnectionToServer.h>
+#include <LibWebView/ChromeProcess.h>
+
+namespace WebView {
+
+static HashMap<int, RefPtr<UIProcessConnectionFromClient>> s_connections;
+
+class UIProcessClient final
+    : public IPC::ConnectionToServer<UIProcessClientEndpoint, UIProcessServerEndpoint> {
+    C_OBJECT(UIProcessClient);
+
+private:
+    UIProcessClient(NonnullOwnPtr<Core::LocalSocket>);
+};
+
+ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteString> const& raw_urls, bool new_window)
+{
+    static constexpr auto process_name = "Ladybird"sv;
+
+    auto [socket_path, pid_path] = TRY(Core::IPCProcess::paths_for_process(process_name));
+
+    if (auto pid = TRY(Core::IPCProcess::get_process_pid(process_name, pid_path)); pid.has_value()) {
+        TRY(connect_as_client(socket_path, raw_urls, new_window));
+        return ProcessDisposition::ExitProcess;
+    }
+
+    TRY(connect_as_server(socket_path));
+
+    m_pid_path = pid_path;
+    m_pid_file = TRY(Core::File::open(pid_path, Core::File::OpenMode::Write));
+    TRY(m_pid_file->write_until_depleted(ByteString::number(::getpid())));
+
+    return ProcessDisposition::ContinueMainProcess;
+}
+
+ErrorOr<void> ChromeProcess::connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, bool new_window)
+{
+    auto socket = TRY(Core::LocalSocket::connect(socket_path));
+    auto client = UIProcessClient::construct(move(socket));
+
+    if (new_window) {
+        if (!client->send_sync_but_allow_failure<Messages::UIProcessServer::CreateNewWindow>(raw_urls))
+            dbgln("Failed to send CreateNewWindow message to UIProcess");
+    } else {
+        if (!client->send_sync_but_allow_failure<Messages::UIProcessServer::CreateNewTab>(raw_urls))
+            dbgln("Failed to send CreateNewTab message to UIProcess");
+    }
+
+    return {};
+}
+
+ErrorOr<void> ChromeProcess::connect_as_server(ByteString const& socket_path)
+{
+    auto socket_fd = TRY(Core::IPCProcess::create_ipc_socket(socket_path));
+    m_socket_path = socket_path;
+    auto local_server = TRY(Core::LocalServer::try_create());
+    TRY(local_server->take_over_fd(socket_fd));
+    m_server_connection = TRY(IPC::MultiServer<UIProcessConnectionFromClient>::try_create(move(local_server)));
+
+    m_server_connection->on_new_client = [this](auto& client) {
+        client.on_new_tab = [this](auto raw_urls) {
+            if (this->on_new_tab)
+                this->on_new_tab(raw_urls);
+        };
+
+        client.on_new_window = [this](auto raw_urls) {
+            if (this->on_new_window)
+                this->on_new_window(raw_urls);
+        };
+    };
+
+    return {};
+}
+
+ChromeProcess::~ChromeProcess()
+{
+    if (m_pid_file) {
+        MUST(m_pid_file->truncate(0));
+        MUST(Core::System::unlink(m_pid_path));
+    }
+
+    if (!m_socket_path.is_empty())
+        MUST(Core::System::unlink(m_socket_path));
+}
+
+UIProcessClient::UIProcessClient(NonnullOwnPtr<Core::LocalSocket> socket)
+    : IPC::ConnectionToServer<UIProcessClientEndpoint, UIProcessServerEndpoint>(*this, move(socket))
+{
+}
+
+UIProcessConnectionFromClient::UIProcessConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> socket, int client_id)
+    : IPC::ConnectionFromClient<UIProcessClientEndpoint, UIProcessServerEndpoint>(*this, move(socket), client_id)
+{
+    s_connections.set(client_id, *this);
+}
+
+void UIProcessConnectionFromClient::die()
+{
+    s_connections.remove(client_id());
+}
+
+void UIProcessConnectionFromClient::create_new_tab(Vector<ByteString> const& urls)
+{
+    if (on_new_tab)
+        on_new_tab(urls);
+}
+
+void UIProcessConnectionFromClient::create_new_window(Vector<ByteString> const& urls)
+{
+    if (on_new_window)
+        on_new_window(urls);
+}
+
+}

--- a/Userland/Libraries/LibWebView/ChromeProcess.h
+++ b/Userland/Libraries/LibWebView/ChromeProcess.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/OwnPtr.h>
+#include <AK/Types.h>
+#include <LibCore/Socket.h>
+#include <LibIPC/ConnectionFromClient.h>
+#include <LibIPC/Forward.h>
+#include <LibIPC/MultiServer.h>
+#include <LibWebView/UIProcessClientEndpoint.h>
+#include <LibWebView/UIProcessServerEndpoint.h>
+
+namespace WebView {
+
+class UIProcessConnectionFromClient final
+    : public IPC::ConnectionFromClient<UIProcessClientEndpoint, UIProcessServerEndpoint> {
+    C_OBJECT(UIProcessConnectionFromClient);
+
+public:
+    virtual ~UIProcessConnectionFromClient() override = default;
+
+    virtual void die() override;
+
+    Function<void(Vector<ByteString> const& urls)> on_new_tab;
+    Function<void(Vector<ByteString> const& urls)> on_new_window;
+
+private:
+    UIProcessConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>, int client_id);
+
+    virtual void create_new_tab(Vector<ByteString> const& urls) override;
+    virtual void create_new_window(Vector<ByteString> const& urls) override;
+};
+
+class ChromeProcess {
+    AK_MAKE_NONCOPYABLE(ChromeProcess);
+    AK_MAKE_NONMOVABLE(ChromeProcess);
+
+public:
+    enum class ProcessDisposition : u8 {
+        ContinueMainProcess,
+        ExitProcess,
+    };
+
+    ChromeProcess() = default;
+    ~ChromeProcess();
+
+    ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, bool new_window);
+
+    Function<void(Vector<ByteString> const& raw_urls)> on_new_tab;
+    Function<void(Vector<ByteString> const& raw_urls)> on_new_window;
+
+private:
+    ErrorOr<void> connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, bool new_window);
+    ErrorOr<void> connect_as_server(ByteString const& socket_path);
+
+    OwnPtr<IPC::MultiServer<UIProcessConnectionFromClient>> m_server_connection;
+    OwnPtr<Core::File> m_pid_file;
+    ByteString m_pid_path;
+    ByteString m_socket_path;
+};
+
+}

--- a/Userland/Libraries/LibWebView/UIProcessClient.ipc
+++ b/Userland/Libraries/LibWebView/UIProcessClient.ipc
@@ -1,0 +1,2 @@
+endpoint UIProcessClient {
+}

--- a/Userland/Libraries/LibWebView/UIProcessServer.ipc
+++ b/Userland/Libraries/LibWebView/UIProcessServer.ipc
@@ -1,0 +1,4 @@
+endpoint UIProcessServer {
+    create_new_tab(Vector<ByteString> urls) => ()
+    create_new_window(Vector<ByteString> urls) => ()
+}


### PR DESCRIPTION
This allows main UI processes created while there is a currently
running one to request a new tab or a new window with the initial urls
provided on the command line. This matches (almost) the behavior of
Chromium and Firefox.

Add a new IPC protocol between two UI processes. The main UI process
will create an IPC server socket, while secondary UI processes will
connect to that socket and send over the URLs and action it wants the
main process to take.

Bikeshedding on these names is welcome, because the ones I chose for the LibWebView class and the IPC protocol are pretty awful :)


https://github.com/SerenityOS/serenity/assets/8388494/9080fd68-3a70-49dc-bc0d-bc7890f36958

