### PR TITLE
LibWeb: Remove Bindings/Forward.h from LibWeb/Forward.h

### DIFF
--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -192,7 +192,7 @@ function (generate_js_bindings target)
 
     function(generate_exposed_interface_files)
         set(exposed_interface_sources
-            Forward.h IntrinsicDefinitions.cpp
+            IntrinsicDefinitions.cpp
             DedicatedWorkerExposedInterfaces.cpp DedicatedWorkerExposedInterfaces.h
             SharedWorkerExposedInterfaces.cpp SharedWorkerExposedInterfaces.h
             WindowExposedInterfaces.cpp WindowExposedInterfaces.h)
@@ -201,7 +201,6 @@ function (generate_js_bindings target)
             OUTPUT  ${exposed_interface_sources}
             COMMAND "${CMAKE_COMMAND}" -E make_directory "tmp"
             COMMAND $<TARGET_FILE:Lagom::GenerateWindowOrWorkerInterfaces> -o "${CMAKE_CURRENT_BINARY_DIR}/tmp" -b "${LIBWEB_INPUT_FOLDER}" ${LIBWEB_ALL_IDL_FILES}
-            COMMAND "${CMAKE_COMMAND}" -E copy_if_different tmp/Forward.h "Bindings/Forward.h"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different tmp/IntrinsicDefinitions.cpp "Bindings/IntrinsicDefinitions.cpp"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different tmp/DedicatedWorkerExposedInterfaces.h "Bindings/DedicatedWorkerExposedInterfaces.h"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different tmp/DedicatedWorkerExposedInterfaces.cpp "Bindings/DedicatedWorkerExposedInterfaces.cpp"

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -4565,6 +4565,7 @@ void generate_global_mixin_implementation(IDL::Interface const& interface, Strin
     SourceGenerator generator { builder };
 
     generator.set("class_name", interface.global_mixin_class);
+    generator.set("prototype_name", interface.prototype_class);
 
     generator.append(R"~~~(
 #include <AK/Function.h>
@@ -4579,6 +4580,7 @@ void generate_global_mixin_implementation(IDL::Interface const& interface, Strin
 #include <LibJS/Runtime/Value.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/@class_name@.h>
+#include <LibWeb/Bindings/@prototype_name@.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -58,70 +58,6 @@ static Optional<LegacyConstructor> const& lookup_legacy_constructor(IDL::Interfa
     return s_legacy_constructors.get(interface.name).value();
 }
 
-static ErrorOr<void> generate_forwarding_header(StringView output_path, Vector<IDL::Interface&>& exposed_interfaces)
-{
-    StringBuilder builder;
-    SourceGenerator generator(builder);
-
-    generator.append(R"~~~(
-#pragma once
-
-namespace Web::Bindings {
-)~~~");
-
-    auto add_namespace = [](SourceGenerator& gen, StringView namespace_class) {
-        gen.set("namespace_class", namespace_class);
-
-        gen.append(R"~~~(
-class @namespace_class@;)~~~");
-    };
-
-    auto add_interface = [](SourceGenerator& gen, StringView prototype_class, StringView constructor_class, Optional<LegacyConstructor> const& legacy_constructor, StringView named_properties_class) {
-        gen.set("prototype_class", prototype_class);
-        gen.set("constructor_class", constructor_class);
-
-        gen.append(R"~~~(
-class @prototype_class@;
-class @constructor_class@;)~~~");
-
-        if (legacy_constructor.has_value()) {
-            gen.set("legacy_constructor_class", legacy_constructor->constructor_class);
-            gen.append(R"~~~(
-class @legacy_constructor_class@;)~~~");
-        }
-        if (!named_properties_class.is_empty()) {
-            gen.set("named_properties_class", named_properties_class);
-            gen.append(R"~~~(
-class @named_properties_class@;)~~~");
-        }
-    };
-
-    for (auto& interface : exposed_interfaces) {
-        auto gen = generator.fork();
-
-        String named_properties_class;
-        if (interface.extended_attributes.contains("Global") && interface.supports_named_properties()) {
-            named_properties_class = MUST(String::formatted("{}Properties", interface.name));
-        }
-
-        if (interface.is_namespace)
-            add_namespace(gen, interface.namespace_class);
-        else
-            add_interface(gen, interface.prototype_class, interface.constructor_class, lookup_legacy_constructor(interface), named_properties_class);
-    }
-
-    generator.append(R"~~~(
-
-}
-)~~~");
-
-    auto generated_forward_path = LexicalPath(output_path).append("Forward.h"sv).string();
-    auto generated_forward_file = TRY(Core::File::open(generated_forward_path, Core::File::OpenMode::Write));
-    TRY(generated_forward_file->write_until_depleted(generator.as_string_view().bytes()));
-
-    return {};
-}
-
 static ErrorOr<void> generate_intrinsic_definitions(StringView output_path, Vector<IDL::Interface&>& exposed_interfaces)
 {
     StringBuilder builder;
@@ -446,7 +382,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         parsers.append(move(parser));
     }
 
-    TRY(generate_forwarding_header(output_path, intrinsics));
     TRY(generate_intrinsic_definitions(output_path, intrinsics));
 
     TRY(generate_exposed_interface_header("Window"sv, output_path));

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Animations/AnimationPlaybackEvent.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
+#include <LibWeb/Bindings/AnimationPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Animations/AnimationTimeline.h>
+#include <LibWeb/Bindings/AnimationEffectPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/Animations/AnimationPlaybackEvent.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationPlaybackEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Animations/AnimationPlaybackEvent.h>
+#include <LibWeb/Bindings/AnimationPlaybackEventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 
 namespace Web::Animations {

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/AnimationTimeline.h>
+#include <LibWeb/Bindings/AnimationTimelinePrototype.h>
 #include <LibWeb/DOM/Document.h>
 
 namespace Web::Animations {

--- a/Userland/Libraries/LibWeb/Animations/DocumentTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/DocumentTimeline.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
+#include <LibWeb/Bindings/DocumentTimelinePrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/Performance.h>

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/Iterator.h>
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/KeyframeEffect.h>
+#include <LibWeb/Bindings/KeyframeEffectPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/Layout/Node.h>

--- a/Userland/Libraries/LibWeb/CSS/AnimationEvent.cpp
+++ b/Userland/Libraries/LibWeb/CSS/AnimationEvent.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AnimationEventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 

--- a/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSAnimation.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Animations/KeyframeEffect.h>
+#include <LibWeb/Bindings/CSSAnimationPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSRulePrototype.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 

--- a/Userland/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CSSTransitionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/CSSTransition.h>

--- a/Userland/Libraries/LibWeb/CSS/ScreenOrientation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ScreenOrientation.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ScreenOrientationPrototype.h>
 #include <LibWeb/CSS/ScreenOrientation.h>
 #include <LibWeb/HTML/EventNames.h>
 

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/StyleSheetPrototype.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/StyleSheet.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/Realm.h>
 #include <LibTextCodec/Decoder.h>
+#include <LibWeb/Bindings/ClipboardPrototype.h>
 #include <LibWeb/Bindings/HostDefined.h>
 #include <LibWeb/Clipboard/Clipboard.h>
 #include <LibWeb/FileAPI/Blob.h>

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -8,6 +8,7 @@
 #include <AK/Random.h>
 #include <AK/StringBuilder.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/CryptoPrototype.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Crypto/Crypto.h>

--- a/Userland/Libraries/LibWeb/Crypto/CryptoKey.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoKey.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Memory.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibWeb/Bindings/CryptoKeyPrototype.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Crypto/CryptoKey.h>
 

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/Promise.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SubtleCryptoPrototype.h>
 #include <LibWeb/Crypto/KeyAlgorithms.h>
 #include <LibWeb/Crypto/SubtleCrypto.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>

--- a/Userland/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AbortControllerPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/AbortController.h>
 #include <LibWeb/DOM/AbortSignal.h>

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AbortSignalPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/AbortSignal.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AbstractRangePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/AbstractRange.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AttrPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CDATASectionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/CDATASection.h>
 

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Bindings/CustomEventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/CustomEvent.h>
 

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMImplementationPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/DOMImplementation.h>

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <LibWeb/Bindings/DOMTokenListPrototype.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/Animations/AnimationPlaybackEvent.h>
 #include <LibWeb/Animations/AnimationTimeline.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
+#include <LibWeb/Bindings/DocumentPrototype.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 #include <LibWeb/CSS/CSSAnimation.h>

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DocumentFragmentPrototype.h>
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/HTML/Window.h>
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DocumentTypePrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentType.h>
 

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <LibWeb/Bindings/EventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Node.h>

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLCollectionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLFormControlsCollectionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/HTMLCollection.h>

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/MutationObserverPrototype.h>
 #include <LibWeb/DOM/MutationObserver.h>
 #include <LibWeb/DOM/Node.h>
 

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MutationRecordPrototype.h>
 #include <LibWeb/DOM/MutationRecord.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeList.h>

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/NamedNodeMapPrototype.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/NamedNodeMap.h>

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/NodeFilterPrototype.h>
 #include <LibWeb/DOM/NodeFilter.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/NodeIteratorPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeIterator.h>

--- a/Userland/Libraries/LibWeb/DOM/NodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/NodeListPrototype.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeList.h>
 

--- a/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ProcessingInstructionPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/Layout/TextNode.h>

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/RangePrototype.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentFragment.h>

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/DOM/AdoptedStyleSheets.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>

--- a/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/TypeCasts.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/StaticRangePrototype.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/StaticRange.h>

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TextPrototype.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/Scripting/Environments.h>

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TreeWalkerPrototype.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeFilter.h>
 #include <LibWeb/DOM/TreeWalker.h>

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/XMLSerializerPrototype.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CDATASection.h>
 #include <LibWeb/DOM/Comment.h>

--- a/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -9,6 +9,7 @@
 #include <AK/IPv4Address.h>
 #include <AK/IPv6Address.h>
 #include <LibURL/Parser.h>
+#include <LibWeb/Bindings/DOMURLPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/FileAPI/Blob.h>

--- a/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -12,6 +12,7 @@
 #include <LibURL/Parser.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/URLSearchParamsPrototype.h>
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/DOMURL/URLSearchParams.h>
 

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -7,6 +7,7 @@
 #include <AK/FlyString.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TextDecoderPrototype.h>
 #include <LibWeb/Encoding/TextDecoder.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/Buffers.h>

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TextEncoderPrototype.h>
 #include <LibWeb/Encoding/TextEncoder.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Headers.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/HeadersPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Fetch/Headers.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/ResponsePrototype.h>
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Fetch/Enums.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Time.h>
 #include <LibJS/Runtime/Completion.h>
+#include <LibWeb/Bindings/FilePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/FileAPI/File.h>
 #include <LibWeb/Infra/Strings.h>

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Bindings/FileListPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/FileAPI/FileList.h>

--- a/Userland/Libraries/LibWeb/FileAPI/FileReader.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/FileReader.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibTextCodec/Decoder.h>
+#include <LibWeb/Bindings/FileReaderPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventTarget.h>

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <LibJS/Forward.h>
-#include <LibWeb/Bindings/Forward.h>
 
 namespace Web {
 class EditEventHandler;

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/DOMMatrixPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/DOMMatrixReadOnlyPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ShorthandStyleValue.h>

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMPointPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMPoint.h>
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMPointReadOnlyPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/Geometry/DOMPointReadOnly.h>

--- a/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMQuadPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMQuad.h>
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMRectPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Heap/Handle.h>
+#include <LibWeb/Bindings/DOMRectListPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/Geometry/DOMRectList.h>

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMRectReadOnlyPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRectReadOnly.h>
 #include <LibWeb/HTML/StructuredSerialize.h>

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibWeb/Bindings/CanvasGradientPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/CanvasGradient.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibWeb/Bindings/CanvasPatternPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/CanvasPattern.h>
 #include <LibWeb/HTML/CanvasRenderingContext2D.h>

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CloseEventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/CloseEvent.h>
 

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <LibWeb/Bindings/DOMStringMapPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/HTML/DataTransfer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DataTransfer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Bindings/DataTransferPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/DataTransfer.h>
 

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/ErrorEventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/ErrorEvent.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/PropertyKey.h>
+#include <LibWeb/Bindings/HTMLAllCollectionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/Bindings/HTMLAnchorElementPrototype.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/Bindings/HTMLAreaElementPrototype.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/Window.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLAudioElementPrototype.h>
 #include <LibWeb/HTML/AudioTrack.h>
 #include <LibWeb/HTML/AudioTrackList.h>
 #include <LibWeb/HTML/HTMLAudioElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLBRElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/Layout/BreakNode.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLBaseElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLBaseElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLBodyElementPrototype.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLButtonElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -11,6 +11,7 @@
 #include <LibGfx/ImageFormats/JPEGWriter.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/HTMLCanvasElementPrototype.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RatioStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLDListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDListElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDListElementPrototype.h>
 #include <LibWeb/HTML/HTMLDListElement.h>
 #include <LibWeb/HTML/Window.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDataElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDataElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDataListElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLDataListElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDetailsElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDialogElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLDirectoryElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDirectoryElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDirectoryElementPrototype.h>
 #include <LibWeb/HTML/HTMLDirectoryElement.h>
 #include <LibWeb/HTML/Window.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDivElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLDocument.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDocument.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLDocumentPrototype.h>
 #include <LibWeb/HTML/HTMLDocument.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -7,6 +7,7 @@
 #include <AK/StringBuilder.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/HTMLElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOM/ShadowRoot.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLEmbedElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLEmbedElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLFieldSetElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/GenericLexer.h>
+#include <LibWeb/Bindings/HTMLFontElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/Parser/ParsingContext.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -10,6 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/HTMLFormElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/HTMLFormControlsCollection.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLFrameElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLFrameElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLFrameSetElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLFrameSetElement.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLHRElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHRElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLHRElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHRElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLHeadElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLHeadingElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLHtmlElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/Node.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLIFrameElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/BrowsingContext.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -7,6 +7,7 @@
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/Bindings/HTMLImageElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -10,6 +10,7 @@
 
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/NativeFunction.h>
+#include <LibWeb/Bindings/HTMLInputElementPrototype.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLIElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLIElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLLIElementPrototype.h>
 #include <LibWeb/HTML/HTMLLIElement.h>
 #include <LibWeb/HTML/Window.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLLabelElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLLabelElement.h>
 #include <LibWeb/Layout/Label.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLLegendElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLLegendElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -11,6 +11,7 @@
 #include <AK/Debug.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Bindings/HTMLLinkElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLMapElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLMapElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLMarqueeElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLMenuElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLMenuElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLMetaElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/Parser/ParsingContext.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLMeterElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/ShadowRoot.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLModElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <LibWeb/Bindings/HTMLModElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLModElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLOListElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOListElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibWeb/Bindings/HTMLObjectElementPrototype.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentLoading.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLOptGroupElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/Bindings/HTMLOptionElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Text.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLOptionsCollectionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLOutputElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLOutputElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLParagraphElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLParamElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParamElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLParamElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLParamElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLPictureElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLPictureElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLPreElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLProgressElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/ShadowRoot.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Assertions.h>
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/Bindings/HTMLQuoteElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLQuoteElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -8,6 +8,7 @@
 #include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <LibTextCodec/Decoder.h>
+#include <LibWeb/Bindings/HTMLScriptElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLSelectElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLSlotElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Text.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLSourceElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLSpanElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLSpanElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLStyleElementPrototype.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTableCaptionElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTableCellElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleProperties.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTableColElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/HTML/Numbers.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTableElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleProperties.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTableRowElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/Parser/ParsingContext.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTableSectionElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/HTMLCollection.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTemplateElementPrototype.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTextAreaElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTimeElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTimeElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTitleElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLTitleElement.h>
 #include <LibWeb/HTML/TraversableNavigable.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLTrackElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLTrackElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLUListElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUListElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLUListElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLUListElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HTMLUnknownElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLUnknownElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibWeb/Bindings/HTMLVideoElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/HistoryPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/History.h>

--- a/Userland/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibWeb/Bindings/ImageBitmapPrototype.h>
 #include <LibWeb/HTML/ImageBitmap.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ImageData.cpp
@@ -7,6 +7,7 @@
 
 #include <LibGfx/Bitmap.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/ImageDataPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/ImageData.h>
 #include <LibWeb/WebIDL/Buffers.h>

--- a/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MessageChannelPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/MessageChannel.h>
 #include <LibWeb/HTML/MessagePort.h>

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/Array.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MessageEventPrototype.h>
 #include <LibWeb/HTML/MessageEvent.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MimeType.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MimeTypePrototype.h>
 #include <LibWeb/HTML/MimeType.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MimeTypeArrayPrototype.h>
 #include <LibWeb/HTML/MimeTypeArray.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/NavigatorPrototype.h>
 #include <LibWeb/Clipboard/Clipboard.h>
 #include <LibWeb/HTML/Navigator.h>
 #include <LibWeb/HTML/Scripting/Environments.h>

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/PageTransitionEventPrototype.h>
 #include <LibWeb/HTML/PageTransitionEvent.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/Path2DPrototype.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/HTML/Path2D.h>
 #include <LibWeb/SVG/AttributeParser.h>

--- a/Userland/Libraries/LibWeb/HTML/Plugin.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/PluginPrototype.h>
 #include <LibWeb/HTML/Plugin.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/PluginArrayPrototype.h>
 #include <LibWeb/HTML/PluginArray.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/PromiseRejectionEventPrototype.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/String.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/StoragePrototype.h>
 #include <LibWeb/HTML/Storage.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SubmitEventPrototype.h>
 #include <LibWeb/HTML/SubmitEvent.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TextMetricsPrototype.h>
 #include <LibWeb/HTML/TextMetrics.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/WorkerPrototype.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Worker.h>

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibURL/Parser.h>
+#include <LibWeb/Bindings/WorkerLocationPrototype.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HTML/WorkerLocation.h>
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerNavigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerNavigator.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Heap/Heap.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/WorkerNavigatorPrototype.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HTML/WorkerNavigator.h>
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/PerformancePrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventDispatcher.h>

--- a/Userland/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/InternalAnimationTimelinePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibWeb/Bindings/IntersectionObserverPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserverEntry.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserverEntry.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/IntersectionObserverEntryPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserverEntry.h>

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/MathMLElementPrototype.h>
 #include <LibWeb/MathML/MathMLElement.h>
 #include <LibWeb/MathML/TagNames.h>
 

--- a/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
+++ b/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/PerformanceTimingPrototype.h>
 #include <LibWeb/NavigationTiming/PerformanceTiming.h>
 
 namespace Web::NavigationTiming {

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/IdleDeadlinePrototype.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ResizeObserverPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
 #include <LibWeb/HTML/Window.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGAnimatedLengthPrototype.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGAnimatedNumberPrototype.h>
 #include <LibWeb/SVG/SVGAnimatedNumber.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedString.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedString.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGAnimatedStringPrototype.h>
 #include <LibWeb/SVG/SVGAnimatedString.h>
 #include <LibWeb/SVG/SVGElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedTransformList.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedTransformList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGAnimatedTransformListPrototype.h>
 #include <LibWeb/SVG/SVGAnimatedTransformList.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGCircleElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/SVG/AttributeNames.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGClipPathElementPrototype.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGDefsElementPrototype.h>
 #include <LibWeb/Layout/SVGBox.h>
 #include <LibWeb/SVG/SVGDefsElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDescElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDescElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGDescElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/SVG/SVGDescElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -7,6 +7,7 @@
 
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGElementPrototype.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ShadowRoot.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/SVGEllipseElementPrototype.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGForeignObjectElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/SVGForeignObjectBox.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGGeometryElementPrototype.h>
 #include <LibWeb/Layout/SVGGeometryBox.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGGradientElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGGradientElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGGraphicsElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Node.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGLengthPrototype.h>
 #include <LibWeb/CSS/PercentageOr.h>
 #include <LibWeb/SVG/SVGLength.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGLineElementPrototype.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGLineElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGLinearGradientElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -7,6 +7,7 @@
 #include <AK/Debug.h>
 #include <AK/Optional.h>
 #include <LibGfx/Path.h>
+#include <LibWeb/Bindings/SVGPathElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/Layout/SVGGeometryBox.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGPolygonElementPrototype.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGPolygonElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGPolylineElementPrototype.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGPolylineElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGRadialGradientElementPrototype.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGRadialGradientElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGRectElementPrototype.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/SVGSVGElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/SVGScriptElementPrototype.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/SVG/AttributeNames.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGStopElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/SVG/AttributeNames.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/SVGStyleElementPrototype.h>
 #include <LibWeb/SVG/SVGStyleElement.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGSymbolElementPrototype.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/SVGTSpanElementPrototype.h>
 #include <LibWeb/Layout/SVGTextBox.h>
 #include <LibWeb/SVG/SVGTSpanElement.h>
 #include <LibWeb/SVG/SVGTextElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -8,6 +8,7 @@
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Utf16String.h>
+#include <LibWeb/Bindings/SVGTextContentElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/SVGTextBox.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGTextElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/SVGTextElementPrototype.h>
 #include <LibWeb/Layout/SVGTextBox.h>
 #include <LibWeb/SVG/SVGTextElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibURL/URL.h>
+#include <LibWeb/Bindings/SVGTextPathElementPrototype.h>
 #include <LibWeb/Layout/SVGTextPathBox.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGTextPathElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -8,6 +8,7 @@
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Utf16String.h>
+#include <LibWeb/Bindings/SVGTextPositioningElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/SVG/AttributeNames.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGTitleElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/SVG/SVGTitleElement.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGTransform.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTransform.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGTransformPrototype.h>
 #include <LibWeb/SVG/SVGTransform.h>
 
 namespace Web::SVG {

--- a/Userland/Libraries/LibWeb/SVG/SVGTransformList.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTransformList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGTransformListPrototype.h>
 #include <LibWeb/SVG/SVGTransformList.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SVGUseElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/SelectionPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/Selection/Selection.h>

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -7,6 +7,7 @@
 
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ReadableByteStreamControllerPrototype.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStream.h>

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -8,6 +8,7 @@
 
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ReadableStreamPrototype.h>
 #include <LibWeb/DOM/AbortSignal.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ReadableStreamBYOBReaderPrototype.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamBYOBReader.h>

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
@@ -7,6 +7,7 @@
 
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ReadableStreamBYOBRequestPrototype.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStreamBYOBRequest.h>
 #include <LibWeb/WebIDL/Buffers.h>

--- a/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TransformStreamPrototype.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/TransformStream.h>
 #include <LibWeb/Streams/TransformStreamDefaultController.h>

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TransformStreamDefaultControllerPrototype.h>
 #include <LibWeb/Streams/TransformStream.h>
 #include <LibWeb/Streams/TransformStreamDefaultController.h>
 

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/WritableStreamDefaultControllerPrototype.h>
 #include <LibWeb/DOM/AbortSignal.h>
 #include <LibWeb/Streams/WritableStream.h>
 #include <LibWeb/Streams/WritableStreamDefaultController.h>

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/FocusEventPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/UIEvents/FocusEvent.h>
 

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -7,6 +7,7 @@
 #include <AK/CharacterTypes.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/KeyboardEventPrototype.h>
 #include <LibWeb/UIEvents/KeyboardEvent.h>
 
 namespace Web::UIEvents {

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/API/KeyCode.h>
 #include <LibGUI/Event.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MouseEventPrototype.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/MouseEvent.h>

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/UIEventPrototype.h>
 #include <LibWeb/UIEvents/UIEvent.h>
 
 namespace Web::UIEvents {

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -6,6 +6,7 @@
 
 #include <Kernel/API/KeyCode.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/WheelEventPrototype.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/WheelEvent.h>

--- a/Userland/Libraries/LibWeb/WebAssembly/Memory.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Memory.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibWasm/Types.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MemoryPrototype.h>
 #include <LibWeb/WebAssembly/Memory.h>
 #include <LibWeb/WebAssembly/WebAssembly.h>
 

--- a/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibWasm/Types.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/TablePrototype.h>
 #include <LibWeb/WebAssembly/Table.h>
 #include <LibWeb/WebAssembly/WebAssembly.h>
 

--- a/Userland/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/AudioBufferPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAudio/AudioBuffer.h>
 #include <LibWeb/WebAudio/BaseAudioContext.h>

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AudioContextPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/BaseAudioContextPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/WebAudio/BaseAudioContext.h>

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/WebGLContextEventPrototype.h>
 #include <LibWeb/WebGL/WebGLContextEvent.h>
 
 namespace Web::WebGL {

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/WebGLRenderingContextPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/WebGL/EventNames.h>

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/DOMExceptionPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebIDL/DOMException.h>
 

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -8,6 +8,7 @@
 #include <AK/QuickSort.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/FunctionObject.h>
+#include <LibWeb/Bindings/WebSocketPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventDispatcher.h>

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/ProgressEventPrototype.h>
 #include <LibWeb/XHR/ProgressEvent.h>
 
 namespace Web::XHR {

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequestEventTarget.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequestEventTarget.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/XMLHttpRequestEventTargetPrototype.h>
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/XHR/EventNames.h>
 #include <LibWeb/XHR/XMLHttpRequestEventTarget.h>


### PR DESCRIPTION
 This was resulting in a whole lot of rebuilding whenever a new IDL
 interface was added.

 Instead, just directly include the prototype in every C++ file which
 needs it. While we only really need a forward declaration in each cpp
 file; including the full prototype header (which itself only includes
 LibJS/Object.h, which is already transitively brought in by
 PlatformObject) - it seems like a small price to pay compared to what feels
 like a full rebuild of LibWeb whenever a new IDL file is added.

 Given all of these includes are only needed for the ::initialize
 method, there is probably a smart way of avoiding this problem
 altogether. I've considered both using some macro trickery or generating
 these functions somehow instead.