### PR TITLE
LibWeb: Integrate TransformStream into fetch_response_handover() and Streams into XHR::send()

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo-Writer-close-callback-called.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-pipeTo-Writer-close-callback-called.txt
@@ -1,0 +1,1 @@
+Writer has been closed.

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo-Writer-close-callback-called.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeTo-Writer-close-callback-called.html
@@ -1,0 +1,20 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const writableStream = new WritableStream({
+                close() {
+                    println("Writer has been closed.");
+                }
+            }
+        );
+        const stream = new ReadableStream({
+            pull(controller) {
+                controller.close();
+            }
+        });
+
+        stream.pipeTo(writableStream).then(() => {
+            done();
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -221,6 +221,7 @@ set(SOURCES
     Fetch/Infrastructure/HTTP/Requests.cpp
     Fetch/Infrastructure/HTTP/Responses.cpp
     Fetch/Infrastructure/HTTP/Statuses.cpp
+    Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
     Fetch/Infrastructure/MimeTypeBlocking.cpp
     Fetch/Infrastructure/NoSniffBlocking.cpp
     Fetch/Infrastructure/PortBlocking.cpp

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -93,7 +93,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_markdown_docume
             parser->run(url);
         });
 
-        auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::GCPtr<WebIDL::DOMException>) {
+        auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::Value) {
             dbgln("FIXME: Load html page with an error if read of body failed.");
         });
 
@@ -168,7 +168,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_html_document(H
             });
         });
 
-        auto process_body_error = JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {
+        auto process_body_error = JS::create_heap_function(document->heap(), [](JS::Value) {
             dbgln("FIXME: Load html page with an error if read of body failed.");
         });
 
@@ -259,7 +259,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_xml_document(HT
         }
     });
 
-    auto process_body_error = JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {
+    auto process_body_error = JS::create_heap_function(document->heap(), [](JS::Value) {
         dbgln("FIXME: Load html page with an error if read of body failed.");
     });
 
@@ -322,7 +322,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_text_document(H
         MUST(title_element->append_child(*title_text));
     });
 
-    auto process_body_error = JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {
+    auto process_body_error = JS::create_heap_function(document->heap(), [](JS::Value) {
         dbgln("FIXME: Load html page with an error if read of body failed.");
     });
 
@@ -418,7 +418,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_media_document(
     navigation_params.response->body()->fully_read(
         realm,
         JS::create_heap_function(document->heap(), [document](ByteBuffer) { HTML::HTMLParser::the_end(document); }),
-        JS::create_heap_function(document->heap(), [](JS::GCPtr<WebIDL::DOMException>) {}),
+        JS::create_heap_function(document->heap(), [](JS::Value) {}),
         JS::NonnullGCPtr { realm.global_object() });
 
     // 9. Return document.

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -182,7 +182,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm& realm
 
     // 3. Let errorSteps given error be to reject promise with error.
     // NOTE: `promise` and `realm` is protected by JS::SafeFunction.
-    auto error_steps = JS::create_heap_function(realm.heap(), [promise, &realm](JS::GCPtr<WebIDL::DOMException> error) {
+    auto error_steps = JS::create_heap_function(realm.heap(), [promise, &realm](JS::Value error) {
         // AD-HOC: An execution context is required for Promise's reject function.
         HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
         WebIDL::reject_promise(realm, promise, error);

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -502,7 +502,7 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> main_fetch(JS::Realm& realm, Inf
             if (!request->integrity_metadata().is_empty()) {
                 // 1. Let processBodyError be this step: run fetch response handover given fetchParams and a network
                 //    error.
-                auto process_body_error = JS::create_heap_function(vm.heap(), [&realm, &vm, &fetch_params](JS::GCPtr<WebIDL::DOMException>) {
+                auto process_body_error = JS::create_heap_function(vm.heap(), [&realm, &vm, &fetch_params](JS::Value) {
                     fetch_response_handover(realm, fetch_params, Infrastructure::Response::network_error(vm, "Response body could not be processed"sv));
                 });
 
@@ -686,7 +686,7 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
 
         // 2. Let processBodyError be this step: run fetchParams’s process response consume body given response and
         //    failure.
-        auto process_body_error = JS::create_heap_function(vm.heap(), [&fetch_params, &response](JS::GCPtr<WebIDL::DOMException>) {
+        auto process_body_error = JS::create_heap_function(vm.heap(), [&fetch_params, &response](JS::Value) {
             (fetch_params.algorithms()->process_response_consume_body())(response, Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag {});
         });
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -82,7 +82,7 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
     // 3. Let errorSteps optionally given an exception exception be to queue a fetch task to run processBodyError given exception, with taskDestination.
     auto error_steps = [&realm, process_body_error, task_destination_object](JS::GCPtr<WebIDL::DOMException> exception) {
         queue_fetch_task(*task_destination_object, JS::create_heap_function(realm.heap(), [process_body_error, exception]() {
-            process_body_error->function()(*exception);
+            process_body_error->function()(exception);
         }));
     };
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Fetch/BodyInit.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
+#include <LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h>
 #include <LibWeb/Fetch/Infrastructure/Task.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/Streams/AbstractOperations.h>
@@ -101,6 +102,35 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
         [&](Empty) {
             error_steps(WebIDL::DOMException::create(realm, "DOMException"_fly_string, "Reading from Blob, FormData or null source is not yet implemented"_fly_string));
         });
+}
+
+// https://fetch.spec.whatwg.org/#body-incrementally-read
+void Body::incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination)
+{
+    HTML::TemporaryExecutionContext const execution_context { Bindings::host_defined_environment_settings_object(m_stream->realm()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+    VERIFY(task_destination.has<JS::NonnullGCPtr<JS::Object>>());
+    // FIXME: 1. If taskDestination is null, then set taskDestination to the result of starting a new parallel queue.
+    // FIXME: Handle 'parallel queue' task destination
+
+    // 2. Let reader be the result of getting a reader for body’s stream.
+    // NOTE: This operation will not throw an exception.
+    auto reader = MUST(Streams::acquire_readable_stream_default_reader(m_stream));
+
+    // 3. Perform the incrementally-read loop given reader, taskDestination, processBodyChunk, processEndOfBody, and processBodyError.
+    incrementally_read_loop(reader, task_destination.get<JS::NonnullGCPtr<JS::Object>>(), process_body_chunk, process_end_of_body, process_body_error);
+}
+
+// https://fetch.spec.whatwg.org/#incrementally-read-loop
+void Body::incrementally_read_loop(Streams::ReadableStreamDefaultReader& reader, JS::NonnullGCPtr<JS::Object> task_destination, ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error)
+
+{
+    auto& realm = reader.realm();
+    // 1. Let readRequest be the following read request:
+    auto read_request = realm.heap().allocate<IncrementalReadLoopReadRequest>(realm, *this, reader, task_destination, process_body_chunk, process_end_of_body, process_body_error);
+
+    // 2. Read a chunk from reader given readRequest.
+    reader.read_a_chunk(read_request);
 }
 
 // https://fetch.spec.whatwg.org/#byte-sequence-as-a-body

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -36,6 +36,7 @@ public:
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>, SourceType, Optional<u64>);
 
     [[nodiscard]] JS::NonnullGCPtr<Streams::ReadableStream> stream() const { return *m_stream; }
+    void set_stream(JS::NonnullGCPtr<Streams::ReadableStream> value) { m_stream = value; }
     [[nodiscard]] SourceType const& source() const { return m_source; }
     [[nodiscard]] Optional<u64> const& length() const { return m_length; }
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -30,7 +30,7 @@ public:
     // processBody must be an algorithm accepting a byte sequence.
     using ProcessBodyCallback = JS::NonnullGCPtr<JS::HeapFunction<void(ByteBuffer)>>;
     // processBodyError must be an algorithm optionally accepting an exception.
-    using ProcessBodyErrorCallback = JS::NonnullGCPtr<JS::HeapFunction<void(JS::GCPtr<WebIDL::DOMException>)>>;
+    using ProcessBodyErrorCallback = JS::NonnullGCPtr<JS::HeapFunction<void(JS::Value)>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>);
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>, SourceType, Optional<u64>);

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -31,6 +31,10 @@ public:
     using ProcessBodyCallback = JS::NonnullGCPtr<JS::HeapFunction<void(ByteBuffer)>>;
     // processBodyError must be an algorithm optionally accepting an exception.
     using ProcessBodyErrorCallback = JS::NonnullGCPtr<JS::HeapFunction<void(JS::Value)>>;
+    // processBodyChunk must be an algorithm accepting a byte sequence.
+    using ProcessBodyChunkCallback = JS::NonnullGCPtr<JS::HeapFunction<void(ByteBuffer)>>;
+    // processEndOfBody must be an algorithm accepting no arguments
+    using ProcessEndOfBodyCallback = JS::NonnullGCPtr<JS::HeapFunction<void()>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>);
     [[nodiscard]] static JS::NonnullGCPtr<Body> create(JS::VM&, JS::NonnullGCPtr<Streams::ReadableStream>, SourceType, Optional<u64>);
@@ -43,6 +47,8 @@ public:
     [[nodiscard]] JS::NonnullGCPtr<Body> clone(JS::Realm&);
 
     void fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination) const;
+    void incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination);
+    void incrementally_read_loop(Streams::ReadableStreamDefaultReader& reader, JS::NonnullGCPtr<JS::Object> task_destination, ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/HostDefined.h>
+#include <LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+
+namespace Web::Fetch::Infrastructure {
+
+JS_DEFINE_ALLOCATOR(IncrementalReadLoopReadRequest);
+
+void IncrementalReadLoopReadRequest::on_chunk(JS::Value chunk)
+{
+    auto& realm = m_reader->realm();
+    // 1. Let continueAlgorithm be null.
+    JS::GCPtr<JS::HeapFunction<void()>> continue_algorithm;
+
+    // 2. If chunk is not a Uint8Array object, then set continueAlgorithm to this step: run processBodyError given a TypeError.
+    if (!chunk.is_object() || !is<JS::Uint8Array>(chunk.as_object())) {
+        continue_algorithm = JS::create_heap_function(realm.heap(), [&realm, process_body_error = m_process_body_error] {
+            process_body_error->function()(JS::TypeError::create(realm, "Chunk data is not Uint8Array"sv));
+        });
+    }
+    // 3. Otherwise:
+    else {
+        // 1. Let bytes be a copy of chunk.
+        // NOTE: Implementations are strongly encouraged to use an implementation strategy that avoids this copy where possible.
+        auto& uint8_array = static_cast<JS::Uint8Array&>(chunk.as_object());
+        auto bytes = MUST(ByteBuffer::copy(uint8_array.data()));
+        // 2. Set continueAlgorithm to these steps:
+        continue_algorithm = JS::create_heap_function(realm.heap(), [bytes = move(bytes), body = m_body, reader = m_reader, task_destination = m_task_destination, process_body_chunk = m_process_body_chunk, process_end_of_body = m_process_end_of_body, process_body_error = m_process_body_error] {
+            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(reader->realm()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            // 1. Run processBodyChunk given bytes.
+            process_body_chunk->function()(move(bytes));
+
+            // 2. Perform the incrementally-read loop given reader, taskDestination, processBodyChunk, processEndOfBody, and processBodyError.
+            body->incrementally_read_loop(reader, task_destination, process_body_chunk, process_end_of_body, process_body_error);
+        });
+    }
+
+    // 4. Queue a fetch task given continueAlgorithm and taskDestination.
+    Fetch::Infrastructure::queue_fetch_task(m_task_destination, *continue_algorithm);
+}
+
+void IncrementalReadLoopReadRequest::on_close()
+{
+    // 1. Queue a fetch task given processEndOfBody and taskDestination.
+    Fetch::Infrastructure::queue_fetch_task(m_task_destination, JS::create_heap_function(m_reader->heap(), [this] {
+        m_process_end_of_body->function()();
+    }));
+}
+
+void IncrementalReadLoopReadRequest::on_error(JS::Value error)
+{
+    // 1. Queue a fetch task to run processBodyError given e, with taskDestination.
+    Fetch::Infrastructure::queue_fetch_task(m_task_destination, JS::create_heap_function(m_reader->heap(), [this, error = move(error)] {
+        m_process_body_error->function()(error);
+    }));
+}
+
+IncrementalReadLoopReadRequest::IncrementalReadLoopReadRequest(JS::NonnullGCPtr<Body> body, JS::NonnullGCPtr<Streams::ReadableStreamDefaultReader> reader, JS::NonnullGCPtr<JS::Object> task_destination, Body::ProcessBodyChunkCallback process_body_chunk, Body::ProcessEndOfBodyCallback process_end_of_body, Body::ProcessBodyErrorCallback process_body_error)
+    : m_body(body)
+    , m_reader(reader)
+    , m_task_destination(task_destination)
+    , m_process_body_chunk(process_body_chunk)
+    , m_process_end_of_body(process_end_of_body)
+    , m_process_body_error(process_body_error)
+{
+}
+
+void IncrementalReadLoopReadRequest::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_body);
+    visitor.visit(m_reader);
+    visitor.visit(m_task_destination);
+    visitor.visit(m_process_body_chunk);
+    visitor.visit(m_process_end_of_body);
+    visitor.visit(m_process_body_error);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
+#include <LibWeb/Streams/ReadableStreamDefaultReader.h>
+
+namespace Web::Fetch::Infrastructure {
+
+// https://fetch.spec.whatwg.org/#incrementally-read-loop
+class IncrementalReadLoopReadRequest : public Streams::ReadRequest {
+    JS_CELL(IncrementalReadLoopReadRequest, JS::Cell);
+    JS_DECLARE_ALLOCATOR(IncrementalReadLoopReadRequest);
+
+public:
+    IncrementalReadLoopReadRequest(JS::NonnullGCPtr<Body>, JS::NonnullGCPtr<Streams::ReadableStreamDefaultReader>, JS::NonnullGCPtr<JS::Object> task_destination, Body::ProcessBodyChunkCallback, Body::ProcessEndOfBodyCallback, Body::ProcessBodyErrorCallback);
+
+    virtual void on_chunk(JS::Value chunk) override;
+    virtual void on_close() override;
+    virtual void on_error(JS::Value error) override;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    JS::NonnullGCPtr<Body> m_body;
+    JS::NonnullGCPtr<Streams::ReadableStreamDefaultReader> m_reader;
+    JS::NonnullGCPtr<JS::Object> m_task_destination;
+    Body::ProcessBodyChunkCallback m_process_body_chunk;
+    Body::ProcessEndOfBodyCallback m_process_end_of_body;
+    Body::ProcessBodyErrorCallback m_process_body_error;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -305,6 +305,7 @@ class FetchController;
 class FetchParams;
 class FetchTimingInfo;
 class HeaderList;
+class IncrementalReadLoopReadRequest;
 class Request;
 class Response;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -548,7 +548,7 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(JS::N
         auto process_body = JS::create_heap_function(realm.heap(), [document, request](ByteBuffer body) {
             (void)decode_favicon(body, request->url(), document->navigable());
         });
-        auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::GCPtr<WebIDL::DOMException>) {
+        auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::Value) {
         });
 
         // 3. Use response's unsafe response as an icon as if it had been declared using the icon keyword.

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1011,7 +1011,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::fetch_resource(URL::URL const& url_r
             // 5. Otherwise, incrementally read response's body given updateMedia, processEndOfMedia, an empty algorithm, and global.
 
             VERIFY(response->body());
-            auto empty_algorithm = JS::create_heap_function(heap(), [](JS::GCPtr<WebIDL::DOMException>) {});
+            auto empty_algorithm = JS::create_heap_function(heap(), [](JS::Value) {});
 
             // FIXME: We are "fully" reading the response here, rather than "incrementally". Memory concerns aside, this should be okay for now as we are
             //        always setting byteRange to "entire resource". However, we should switch to incremental reads when that is implemented, and then

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -203,7 +203,7 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
         });
 
         VERIFY(response->body());
-        auto empty_algorithm = JS::create_heap_function(heap(), [](JS::GCPtr<WebIDL::DOMException>) {});
+        auto empty_algorithm = JS::create_heap_function(heap(), [](JS::Value) {});
 
         response->body()->fully_read(realm, on_image_data_read, empty_algorithm, JS::NonnullGCPtr { global });
     };

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -90,7 +90,7 @@ void SharedImageRequest::fetch_image(JS::Realm& realm, JS::NonnullGCPtr<Fetch::I
             auto mime_type = extracted_mime_type.has_value() ? extracted_mime_type.value().essence().bytes_as_string_view() : StringView {};
             handle_successful_fetch(request->url(), mime_type, move(data));
         });
-        auto process_body_error = JS::create_heap_function(heap(), [this](JS::GCPtr<WebIDL::DOMException>) {
+        auto process_body_error = JS::create_heap_function(heap(), [this](JS::Value) {
             handle_failed_fetch();
         });
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -314,11 +314,17 @@ JS::NonnullGCPtr<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     };
 
-    auto success_steps = [promise, &realm](ByteBuffer) {
+    auto success_steps = [promise, &realm, writer](ByteBuffer) {
+        // Make sure we close the acquired writer.
+        WebIDL::resolve_promise(realm, writable_stream_default_writer_close(*writer), JS::js_undefined());
+
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     };
 
-    auto failure_steps = [promise, &realm](JS::Value error) {
+    auto failure_steps = [promise, &realm, writer](JS::Value error) {
+        // Make sure we close the acquired writer.
+        WebIDL::resolve_promise(realm, writable_stream_default_writer_close(*writer), JS::js_undefined());
+
         WebIDL::reject_promise(realm, promise, error);
     };
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -306,9 +306,11 @@ JS::NonnullGCPtr<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source
 
     // FIXME: Currently a naive implementation that uses ReadableStreamDefaultReader::read_all_chunks() to read all chunks
     //        from the source and then through the callback success_steps writes those chunks to the destination.
-    auto chunk_steps = [&realm, writer](ByteBuffer chunk) {
-        auto buffer = JS::ArrayBuffer::create(realm, move(chunk));
-        auto promise = writable_stream_default_writer_write(writer, JS::Value { buffer });
+    auto chunk_steps = [&realm, writer](ByteBuffer buffer) {
+        auto array_buffer = JS::ArrayBuffer::create(realm, move(buffer));
+        auto chunk = JS::Uint8Array::create(realm, array_buffer->byte_length(), *array_buffer);
+
+        auto promise = writable_stream_default_writer_write(writer, chunk);
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     };
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -179,6 +179,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_pull_algorithm
 void transform_stream_error(TransformStream&, JS::Value error);
 void transform_stream_error_writable_and_unblock_write(TransformStream&, JS::Value error);
 void transform_stream_set_backpressure(TransformStream&, bool backpressure);
+void transform_stream_set_up(TransformStream&, JS::NonnullGCPtr<TransformAlgorithm>, JS::GCPtr<FlushAlgorithm> = {}, JS::GCPtr<CancelAlgorithm> = {});
 
 bool is_non_negative_number(JS::Value);
 bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -166,6 +166,26 @@ WebIDL::ExceptionOr<ReadableStreamPair> ReadableStream::tee()
     return TRY(readable_stream_tee(realm(), *this, true));
 }
 
+// https://streams.spec.whatwg.org/#readablestream-close
+void ReadableStream::close()
+{
+    controller()->visit(
+        // 1. If stream.[[controller]] implements ReadableByteStreamController
+        [&](JS::NonnullGCPtr<ReadableByteStreamController> controller) {
+            // 1. Perform ! ReadableByteStreamControllerClose(stream.[[controller]]).
+            MUST(readable_byte_stream_controller_close(controller));
+
+            // 2. If stream.[[controller]].[[pendingPullIntos]] is not empty, perform ! ReadableByteStreamControllerRespond(stream.[[controller]], 0).
+            if (!controller->pending_pull_intos().is_empty())
+                MUST(readable_byte_stream_controller_respond(controller, 0));
+        },
+
+        // 2. Otherwise, perform ! ReadableStreamDefaultControllerClose(stream.[[controller]]).
+        [&](JS::NonnullGCPtr<ReadableStreamDefaultController> controller) {
+            readable_stream_default_controller_close(*controller);
+        });
+}
+
 void ReadableStream::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -79,6 +79,8 @@ public:
     JS::NonnullGCPtr<JS::Object> pipe_to(WritableStream& destination, StreamPipeOptions const& = {});
     WebIDL::ExceptionOr<ReadableStreamPair> tee();
 
+    void close();
+
     Optional<ReadableStreamController>& controller() { return m_controller; }
     void set_controller(Optional<ReadableStreamController> value) { m_controller = move(value); }
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ReadableStreamDefaultReaderPrototype.h>
+#include <LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamDefaultReader.h>
@@ -185,6 +186,13 @@ JS::NonnullGCPtr<JS::Promise> ReadableStreamDefaultReader::read()
 
     // 5. Return promise.
     return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+}
+
+void ReadableStreamDefaultReader::read_a_chunk(Fetch::Infrastructure::IncrementalReadLoopReadRequest& read_request)
+{
+    // To read a chunk from a ReadableStreamDefaultReader reader, given a read request readRequest,
+    // perform ! ReadableStreamDefaultReaderRead(reader, readRequest).
+    readable_stream_default_reader_read(*this, read_request);
 }
 
 // https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -79,6 +79,7 @@ public:
 
     JS::NonnullGCPtr<JS::Promise> read();
 
+    void read_a_chunk(Fetch::Infrastructure::IncrementalReadLoopReadRequest& read_request);
     void read_all_bytes(ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
     void read_all_chunks(ReadLoopReadRequest::ChunkSteps, ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
     JS::NonnullGCPtr<WebIDL::Promise> read_all_bytes_deprecated();


### PR DESCRIPTION
This implements:
- the concept incrementally read a body, and uses that implementation in XHR::send().
- the missing steps for TransformStream in fetch_response_handover().

Fixes a couple bugs:
- LibWeb: Provide an UInt8Array to AO writable_stream_default_writer_write
- LibWeb: Close acquired writer in AO readable_stream_pipe_to()