### PR TITLE
LibWeb: Cache combined CSS transform on pre-paint phase 

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -527,6 +527,7 @@ set(SOURCES
     Painting/CommandExecutorCPU.cpp
     Painting/CommandList.cpp
     Painting/CheckBoxPaintable.cpp
+    Painting/ClippableAndScrollable.cpp
     Painting/GradientPainting.cpp
     Painting/FilterPainting.cpp
     Painting/ImagePaintable.cpp

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/InlinePaintable.h>
+#include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Painting {
 

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -31,8 +31,7 @@ Optional<CSSPixelRect> ClippableAndScrollable::clip_rect() const
         //       Otherwise, the transform will be applied twice to the clip rect.
         //       Similarly, for hit-testing, the transform must be removed from the clip rectangle since the position
         //       includes the transform.
-        auto combined_transform = compute_combined_css_transform_for_clippable_and_scrollable();
-        rect.translate_by(-combined_transform.translation().to_type<CSSPixels>());
+        rect.translate_by(-m_combined_css_transform.translation().to_type<CSSPixels>());
         return rect;
     }
     return {};

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Painting/ClippableAndScrollable.h>
+
+namespace Web::Painting {
+
+Optional<int> ClippableAndScrollable::scroll_frame_id() const
+{
+    if (m_enclosing_scroll_frame)
+        return m_enclosing_scroll_frame->id;
+    return {};
+}
+
+Optional<CSSPixelPoint> ClippableAndScrollable::enclosing_scroll_frame_offset() const
+{
+    if (m_enclosing_scroll_frame)
+        return m_enclosing_scroll_frame->offset;
+    return {};
+}
+
+Optional<CSSPixelRect> ClippableAndScrollable::clip_rect() const
+{
+    if (m_enclosing_clip_frame) {
+        auto rect = m_enclosing_clip_frame->rect();
+        // NOTE: Since the painting command executor applies a CSS transform and the clip rect is calculated
+        //       with this transform taken into account, we need to remove the transform from the clip rect.
+        //       Otherwise, the transform will be applied twice to the clip rect.
+        //       Similarly, for hit-testing, the transform must be removed from the clip rectangle since the position
+        //       includes the transform.
+        auto combined_transform = compute_combined_css_transform_for_clippable_and_scrollable();
+        rect.translate_by(-combined_transform.translation().to_type<CSSPixels>());
+        return rect;
+    }
+    return {};
+}
+
+Span<BorderRadiiClip const> ClippableAndScrollable::border_radii_clips() const
+{
+    if (m_enclosing_clip_frame)
+        return m_enclosing_clip_frame->border_radii_clips();
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Painting/ClipFrame.h>
+
+namespace Web::Painting {
+
+struct ScrollFrame : public RefCounted<ScrollFrame> {
+    i32 id { -1 };
+    CSSPixelPoint offset;
+};
+
+class ClippableAndScrollable {
+public:
+    virtual ~ClippableAndScrollable() = default;
+
+    void set_enclosing_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_enclosing_scroll_frame = scroll_frame; }
+    void set_enclosing_clip_frame(RefPtr<ClipFrame> clip_frame) { m_enclosing_clip_frame = clip_frame; }
+
+    [[nodiscard]] Optional<int> scroll_frame_id() const;
+    [[nodiscard]] Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const;
+    [[nodiscard]] Optional<CSSPixelRect> clip_rect() const;
+    [[nodiscard]] Span<BorderRadiiClip const> border_radii_clips() const;
+
+    virtual Gfx::AffineTransform compute_combined_css_transform_for_clippable_and_scrollable() const = 0;
+
+private:
+    RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
+    RefPtr<ClipFrame const> m_enclosing_clip_frame;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -27,11 +27,14 @@ public:
     [[nodiscard]] Optional<CSSPixelRect> clip_rect() const;
     [[nodiscard]] Span<BorderRadiiClip const> border_radii_clips() const;
 
-    virtual Gfx::AffineTransform compute_combined_css_transform_for_clippable_and_scrollable() const = 0;
+    Gfx::AffineTransform const& combined_css_transform() const { return m_combined_css_transform; }
+    void set_combined_css_transform(Gfx::AffineTransform const& transform) { m_combined_css_transform = transform; }
 
 private:
     RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
     RefPtr<ClipFrame const> m_enclosing_clip_frame;
+
+    Gfx::AffineTransform m_combined_css_transform;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -30,35 +30,6 @@ Layout::InlineNode const& InlinePaintable::layout_node() const
     return static_cast<Layout::InlineNode const&>(Paintable::layout_node());
 }
 
-Optional<int> InlinePaintable::scroll_frame_id() const
-{
-    if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->id;
-    return {};
-}
-
-Optional<CSSPixelPoint> InlinePaintable::enclosing_scroll_frame_offset() const
-{
-    if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->offset;
-    return {};
-}
-
-Optional<CSSPixelRect> InlinePaintable::clip_rect() const
-{
-    if (m_enclosing_clip_frame) {
-        auto rect = m_enclosing_clip_frame->rect();
-
-        // NOTE: Since the painting command executor applies a CSS transform and the clip rect is calculated
-        //       with this transform taken into account, we need to remove the transform from the clip rect.
-        //       Otherwise, the transform will be applied twice to the clip rect.
-        auto combined_transform = compute_combined_css_transform();
-        rect.translate_by(-combined_transform.translation().to_type<CSSPixels>());
-        return rect;
-    }
-    return {};
-}
-
 void InlinePaintable::before_paint(PaintContext& context, PaintPhase) const
 {
     if (scroll_frame_id().has_value()) {
@@ -218,7 +189,7 @@ void InlinePaintable::for_each_fragment(Callback callback) const
 
 TraversalDecision InlinePaintable::hit_test(CSSPixelPoint position, HitTestType type, Function<TraversalDecision(HitTestResult)> const& callback) const
 {
-    if (m_clip_rect.has_value() && !m_clip_rect.value().contains(position))
+    if (clip_rect().has_value() && !clip_rect().value().contains(position))
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -46,11 +46,6 @@ public:
     void set_outline_offset(CSSPixels outline_offset) { m_outline_offset = outline_offset; }
     CSSPixels outline_offset() const { return m_outline_offset; }
 
-    virtual Gfx::AffineTransform compute_combined_css_transform_for_clippable_and_scrollable() const override
-    {
-        return compute_combined_css_transform();
-    }
-
 private:
     InlinePaintable(Layout::InlineNode const&);
 

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -7,12 +7,14 @@
 #pragma once
 
 #include <LibWeb/Layout/InlineNode.h>
-#include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/ClippableAndScrollable.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableFragment.h>
 
 namespace Web::Painting {
 
-class InlinePaintable final : public Paintable {
+class InlinePaintable final : public Paintable
+    , public ClippableAndScrollable {
     JS_CELL(InlinePaintable, Paintable);
     JS_DECLARE_ALLOCATOR(InlinePaintable);
 
@@ -44,22 +46,16 @@ public:
     void set_outline_offset(CSSPixels outline_offset) { m_outline_offset = outline_offset; }
     CSSPixels outline_offset() const { return m_outline_offset; }
 
-    void set_enclosing_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_enclosing_scroll_frame = scroll_frame; }
-    void set_enclosing_clip_frame(RefPtr<ClipFrame> clip_frame) { m_enclosing_clip_frame = clip_frame; }
-
-    Optional<int> scroll_frame_id() const;
-    Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const;
-    Optional<CSSPixelRect> clip_rect() const;
+    virtual Gfx::AffineTransform compute_combined_css_transform_for_clippable_and_scrollable() const override
+    {
+        return compute_combined_css_transform();
+    }
 
 private:
     InlinePaintable(Layout::InlineNode const&);
 
     template<typename Callback>
     void for_each_fragment(Callback) const;
-
-    Optional<CSSPixelRect> m_clip_rect;
-    RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
-    RefPtr<ClipFrame const> m_enclosing_clip_frame;
 
     Vector<ShadowData> m_box_shadow_data;
     Optional<BordersData> m_outline_data;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -483,7 +483,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
         context.recording_painter().add_clip_rect(context.enclosing_device_rect(overflow_clip_rect).to_type<int>());
         auto const& border_radii_clips = this->border_radii_clips();
         m_corner_clipper_ids.resize(border_radii_clips.size());
-        auto combined_transform = compute_combined_css_transform();
+        auto const& combined_transform = combined_css_transform();
         for (size_t corner_clip_index = 0; corner_clip_index < border_radii_clips.size(); ++corner_clip_index) {
             auto const& corner_clip = border_radii_clips[corner_clip_index];
             auto corners = corner_clip.radii.as_corners(context);
@@ -504,7 +504,7 @@ void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase ph
 
     if (m_clipping_overflow) {
         m_clipping_overflow = false;
-        auto combined_transform = compute_combined_css_transform();
+        auto const& combined_transform = combined_css_transform();
         auto const& border_radii_clips = this->border_radii_clips();
         for (size_t corner_clip_index = 0; corner_clip_index < border_radii_clips.size(); ++corner_clip_index) {
             auto const& corner_clip = border_radii_clips[corner_clip_index];

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -209,43 +209,6 @@ Optional<CSSPixelRect> PaintableBox::get_clip_rect() const
     return {};
 }
 
-Optional<int> PaintableBox::scroll_frame_id() const
-{
-    if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->id;
-    return {};
-}
-
-Optional<CSSPixelPoint> PaintableBox::enclosing_scroll_frame_offset() const
-{
-    if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->offset;
-    return {};
-}
-
-Optional<CSSPixelRect> PaintableBox::clip_rect() const
-{
-    if (m_enclosing_clip_frame) {
-        auto rect = m_enclosing_clip_frame->rect();
-        // NOTE: Since the painting command executor applies a CSS transform and the clip rect is calculated
-        //       with this transform in account, we need to remove the transform from the clip rect.
-        //       Otherwise, the transform will be applied twice to the clip rect.
-        //       Similarly, for hit-testing, the transform must be removed from the clip rectangle since the position
-        //       includes the transform.
-        auto combined_transform = compute_combined_css_transform();
-        rect.translate_by(-combined_transform.translation().to_type<CSSPixels>());
-        return rect;
-    }
-    return {};
-}
-
-Span<BorderRadiiClip const> PaintableBox::border_radii_clips() const
-{
-    if (m_enclosing_clip_frame)
-        return m_enclosing_clip_frame->border_radii_clips();
-    return {};
-}
-
 void PaintableBox::before_paint(PaintContext& context, [[maybe_unused]] PaintPhase phase) const
 {
     if (!is_visible())

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -203,11 +203,6 @@ public:
 
     Optional<CSSPixelRect> get_clip_rect() const;
 
-    virtual Gfx::AffineTransform compute_combined_css_transform_for_clippable_and_scrollable() const override
-    {
-        return compute_combined_css_transform();
-    }
-
 protected:
     explicit PaintableBox(Layout::Box const&);
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -9,18 +9,15 @@
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/ClipFrame.h>
+#include <LibWeb/Painting/ClippableAndScrollable.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableFragment.h>
 #include <LibWeb/Painting/ShadowPainting.h>
 
 namespace Web::Painting {
 
-struct ScrollFrame : public RefCounted<ScrollFrame> {
-    i32 id { -1 };
-    CSSPixelPoint offset;
-};
-
-class PaintableBox : public Paintable {
+class PaintableBox : public Paintable
+    , public ClippableAndScrollable {
     JS_CELL(PaintableBox, Paintable);
 
 public:
@@ -206,13 +203,10 @@ public:
 
     Optional<CSSPixelRect> get_clip_rect() const;
 
-    void set_enclosing_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_enclosing_scroll_frame = scroll_frame; }
-    void set_enclosing_clip_frame(RefPtr<ClipFrame> clip_frame) { m_enclosing_clip_frame = clip_frame; }
-
-    Optional<int> scroll_frame_id() const;
-    Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const;
-    Optional<CSSPixelRect> clip_rect() const;
-    Span<BorderRadiiClip const> border_radii_clips() const;
+    virtual Gfx::AffineTransform compute_combined_css_transform_for_clippable_and_scrollable() const override
+    {
+        return compute_combined_css_transform();
+    }
 
 protected:
     explicit PaintableBox(Layout::Box const&);

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -440,6 +440,16 @@ void ViewportPaintable::resolve_paint_only_properties()
             inline_paintable.set_outline_offset(outline_offset);
         }
 
+        if (is_paintable_box) {
+            auto& paintable_box = static_cast<Painting::PaintableBox&>(paintable);
+            auto combined_transform = paintable.compute_combined_css_transform();
+            paintable_box.set_combined_css_transform(combined_transform);
+        } else if (is_inline_paintable) {
+            auto& inline_paintable = static_cast<Painting::InlinePaintable&>(paintable);
+            auto combined_transform = paintable.compute_combined_css_transform();
+            inline_paintable.set_combined_css_transform(combined_transform);
+        }
+
         return TraversalDecision::Continue;
     });
 }


### PR DESCRIPTION
Makes 5% of `compute_combined_css_transform()` in Discord profiles gone.