### PR TITLE
Ladybird: Retreive the tab title from the underlying Tab

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -402,8 +402,11 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     });
     QObject::connect(quit_action, &QAction::triggered, this, &QMainWindow::close);
     QObject::connect(m_tabs_container, &QTabWidget::currentChanged, [this](int index) {
-        setWindowTitle(QString("%1 - Ladybird").arg(m_tabs_container->tabText(index)));
-        set_current_tab(verify_cast<Tab>(m_tabs_container->widget(index)));
+        auto* tab = verify_cast<Tab>(m_tabs_container->widget(index));
+        if (tab)
+            setWindowTitle(QString("%1 - Ladybird").arg(tab->title()));
+
+        set_current_tab(tab);
     });
     QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::close_current_tab);

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -52,6 +52,7 @@ public:
     void show_inspector_window(InspectorTarget = InspectorTarget::Document);
 
     QIcon const& favicon() const { return m_favicon; }
+    QString const& title() const { return m_title; }
 
     void update_navigation_buttons_state();
 


### PR DESCRIPTION
Rather than getting the tab name from the tab container. This resolves an issue where ampersands were being introduced to the window title when changing tabs.

cc @trflynn89 as he also mentioned this occurring on Discord.

# Reproduction

- Open new tab
- Switch to original tab
- See ampersand (`&` in window title)

## Before

![image](https://github.com/SerenityOS/serenity/assets/5103549/f3f235a7-c7c2-4d46-a2cf-6860c56bf597)

## After

![image](https://github.com/SerenityOS/serenity/assets/5103549/ca6ee5f4-db02-4a6d-b6e3-89d2dbd196c7)
