### PR TITLE
LibGfx/JPEG2000: Remove an incorrect VERIFY in TagTree construction

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -881,7 +881,6 @@ struct TagTreeNode {
             return node;
         }
 
-        VERIFY(x_count > 1 || y_count > 1);
         u32 top_left_x_child_count = min(x_count, 1u << (max(level, 1) - 1));
         u32 top_left_y_child_count = min(y_count, 1u << (max(level, 1) - 1));
         for (u32 y = 0; y < 2; ++y) {


### PR DESCRIPTION
...and add a test case that shows why it's incorrect.

If one dimension is 2^n + 1 and the other side is just 1, then the topmost node will have 2^n x 1 and 1 x 1 children. The first child will have n levels of children. The 1 x 1 child could end immediately, or it could require that it also has n levels of (all 1 x 1) children. The spec isn't clear on which of the two alternatives should happen. We currently have n levels of 1 x 1 blocks.

This test case shows that a VERIFY we had was incorrect, so remove it.

The alternative implementation is to keep the VERIFY and to add a

    if (x_count == 1 && y_count == 1)
        level = 0;

to the top of TagTreeNode::create(). Then we don't have multiple levels of 1 x 1 nodes, and we need to read fewer bits.

The images in the spec suggest that all nodes should have the same number of levels, so go with that interpretation for now. Once we can actually decode images, we'll hopefully see which of the two interpretations is correct.

(The removed VERIFY() is hit when decoding
Tests/LibGfx/test-inputs/jpeg2000/buggie-gray.jpf in a local branch that has some image decoding implemented. That file contains a packet with 1x3 code-blocks, which hits this case.)

---

I think this now matches the behavior of the original by-layer implementation in #23938 (still available for reading here: https://github.com/SerenityOS/serenity/compare/master...nico:serenity:jpeg-2000-tagtree-old). If the other behavior turns out to be the right one, then the current recursive code makes it much easier to implement that approach.