### PR TITLE
LibWeb: Skip unnecessary sample corner and blit corner commands

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2164,6 +2164,7 @@ void Navigable::paint(Painting::RecordingPainter& recording_painter, PaintConfig
             scroll_offsets_by_frame_id[scrollable_frame->id] = scroll_offset;
         }
         recording_painter.commands_list().apply_scroll_offsets(scroll_offsets_by_frame_id);
+        recording_painter.commands_list().mark_unnecessary_commands();
     }
 
     m_needs_repaint = false;

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -96,15 +96,17 @@ public:
     void append(Command&& command, Optional<i32> scroll_frame_id);
 
     void apply_scroll_offsets(Vector<Gfx::IntPoint> const& offsets_by_frame_id);
+    void mark_unnecessary_commands();
     void execute(CommandExecutor&);
 
 private:
-    struct CommandWithScrollFrame {
+    struct CommandListItem {
         Optional<i32> scroll_frame_id;
         Command command;
+        bool skip { false };
     };
 
-    AK::SegmentedVector<CommandWithScrollFrame, 512> m_commands;
+    AK::SegmentedVector<CommandListItem, 512> m_commands;
 };
 
 }


### PR DESCRIPTION
Before this change we were recording and executing sample/blit commands for each painting phase, even if there are no painting commands in-between sample and blit that produce result visible on a canvas.

This change adds an optimization pass that goes through recorded painting commands list and marks sample and blit commands that could be skipped.

Reduces sample and blit corners executing from 17% to 8% on Discord.