### PR TITLE
LibDeviceTree+Kernel: Some devicetree related work

### DIFF
--- a/Kernel/Bus/PCI/Controller/HostController.cpp
+++ b/Kernel/Bus/PCI/Controller/HostController.cpp
@@ -245,7 +245,13 @@ void HostController::configure_attached_devices(PCIConfiguration& config)
         write16_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), PCI::RegisterOffset::COMMAND, command_value);
         // assign interrupt number
         auto interrupt_pin = read8_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), PCI::RegisterOffset::INTERRUPT_PIN);
-        auto masked_identifier = (((u32)device_identifier.address().bus() << 16) | ((u32)device_identifier.address().device() << 11) | ((u32)device_identifier.address().function() << 8) | interrupt_pin) & config.interrupt_mask;
+        auto masked_identifier = PCIInterruptSpecifier{
+            .interrupt_pin = interrupt_pin,
+            .function = device_identifier.address().function(),
+            .device = device_identifier.address().device(),
+            .bus = device_identifier.address().bus()
+        };
+        masked_identifier &= config.interrupt_mask;
         auto interrupt_number = config.masked_interrupt_mapping.get(masked_identifier);
         if (interrupt_number.has_value())
             write8_field(device_identifier.address().bus(), device_identifier.address().device(), device_identifier.address().function(), PCI::RegisterOffset::INTERRUPT_LINE, interrupt_number.value());

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -458,6 +458,12 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_fdt(MemoryManager::GlobalD
                     break;
                 case State::InReservedMemoryChild:
                     // FIXME: Handle non static allocations,
+                    if (!state.start.has_value()) {
+                        VERIFY(state.size.has_value());
+                        dbgln("MM: Non static reserved memory range {} of size {:#x}, skipping for now", node_name, state.size.value());
+                        state.state = State::InReservedMemory;
+                        break;
+                    }
                     VERIFY(state.start.has_value() && state.size.has_value());
                     dbgln("MM: Reserved Range {}: address: {} size {:#x}", node_name, PhysicalAddress { state.start.value() }, state.size.value());
                     global_data.physical_memory_ranges.append(PhysicalMemoryRange { PhysicalMemoryRangeType::Reserved, PhysicalAddress { state.start.value() }, state.size.value() });

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from shutil import which
 from subprocess import run
 from typing import Any, Callable, Literal
+import shlex
 
 QEMU_MINIMUM_REQUIRED_MAJOR_VERSION = 6
 QEMU_MINIMUM_REQUIRED_MINOR_VERSION = 2
@@ -826,6 +827,8 @@ def assemble_arguments(config: Configuration) -> list[str | Path]:
         boch_src = Path(config.serenity_src or ".", "Meta/bochsrc")
         return [config.bochs_binary, "-q", "-f", boch_src]
 
+    passed_qemu_args = shlex.split(environ.get("SERENITY_EXTRA_QEMU_ARGS", ""))
+
     return [
         config.qemu_binary or "",
         # Deviate from standard order here:
@@ -851,6 +854,7 @@ def assemble_arguments(config: Configuration) -> list[str | Path]:
         *config.network_default_arguments,
         *config.boot_drive_arguments,
         *config.character_device_arguments,
+        *passed_qemu_args,
     ]
 
 

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -19,6 +19,20 @@
 namespace DeviceTree {
 
 struct DeviceTreeProperty {
+    class ValueStream : public FixedMemoryStream {
+    public:
+        using AK::FixedMemoryStream::FixedMemoryStream;
+
+        ErrorOr<FlatPtr> read_cells(u32 cell_size)
+        {
+            // FIXME: There are rare cases of 3 cell size big values, even in addresses, especially in addresses
+            VERIFY(cell_size <= 2);
+            if (cell_size == 1)
+                return read_value<BigEndian<u32>>();
+            return read_value<BigEndian<u64>>();
+        }
+    };
+
     ReadonlyBytes raw_data;
 
     size_t size() const { return raw_data.size(); }
@@ -73,7 +87,7 @@ struct DeviceTreeProperty {
         return {};
     }
 
-    FixedMemoryStream as_stream() const { return FixedMemoryStream { raw_data }; }
+    ValueStream as_stream() const { return ValueStream { raw_data }; }
 };
 
 class DeviceTreeNodeView {

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -23,6 +23,11 @@ struct DeviceTreeProperty {
     public:
         using AK::FixedMemoryStream::FixedMemoryStream;
 
+        ErrorOr<u32> read_cell()
+        {
+            return read_value<BigEndian<u32>>();
+        }
+
         ErrorOr<FlatPtr> read_cells(u32 cell_size)
         {
             // FIXME: There are rare cases of 3 cell size big values, even in addresses, especially in addresses
@@ -91,6 +96,9 @@ struct DeviceTreeProperty {
 };
 
 class DeviceTreeNodeView {
+    AK_MAKE_NONCOPYABLE(DeviceTreeNodeView);
+    AK_MAKE_DEFAULT_MOVABLE(DeviceTreeNodeView);
+
 public:
     bool has_property(StringView prop) const { return m_properties.contains(prop); }
     bool has_child(StringView child) const { return m_children.contains(child); }


### PR DESCRIPTION
Mainly extracted from #23703
CC: @spholz Fixed the phandle bug here as well

----

### Meta/run.py: Bring back `SERENITY_EXTRA_QEMU_ARGS`


### LibDeviceTree: Fix stale pointers in phandle and parent handling

We need to set them after we've created the full tree, as otherwise the
HashMap containing the nodes may reallocate and invalidate the pointers.

### LibDeviceTree: Make DeviceTreeProperty::as_stream return a `ValueStream`

This new Stream class adds an interface to work in cell-sized chunks,
which is useful for parsing the data in a DeviceTreeProperty.

### Kernel/MM: Skip non static reserved memory regions instead of crashing

Crashing seems a bit harsh, so let's just skip them instead, as they
actually show up in the device tree of RPis.

### Kernel/MM: Parse /mem_reserve_block node in FDT memory map mode

These seem to be actually used in the RPi FTDs

