### PR TITLE
Ladybird: Add a context menu to the tab bar

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -625,6 +625,11 @@ void BrowserWindow::close_tab(int index)
         close();
 }
 
+void BrowserWindow::move_tab(int old_index, int new_index)
+{
+    m_tabs_container->tabBar()->moveTab(old_index, new_index);
+}
+
 void BrowserWindow::open_file()
 {
     m_current_tab->open_file();

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -34,6 +34,7 @@ public:
 
     WebContentView& view() const { return m_current_tab->view(); }
 
+    int tab_count() { return m_tabs_container->count(); }
     int tab_index(Tab*);
     Tab& create_new_tab(Web::HTML::ActivateTab activate_tab);
 
@@ -98,6 +99,7 @@ public slots:
     Tab& new_child_tab(Web::HTML::ActivateTab, Tab& parent, Web::HTML::WebViewHints, Optional<u64> page_index);
     void activate_tab(int index);
     void close_tab(int index);
+    void move_tab(int old_index, int new_index);
     void close_current_tab();
     void open_next_tab();
     void open_previous_tab();

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -54,6 +54,8 @@ public:
     QIcon const& favicon() const { return m_favicon; }
     QString const& title() const { return m_title; }
 
+    QMenu* context_menu() const { return m_context_menu; }
+
     void update_navigation_buttons_state();
 
 public slots:
@@ -90,6 +92,8 @@ private:
     QString m_title;
     QLabel* m_hover_label { nullptr };
     QIcon m_favicon;
+
+    QMenu* m_context_menu { nullptr };
 
     QMenu* m_page_context_menu { nullptr };
     Optional<String> m_page_context_menu_search_text;

--- a/Ladybird/Qt/TabBar.cpp
+++ b/Ladybird/Qt/TabBar.cpp
@@ -1,15 +1,24 @@
 /*
  * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "Tab.h"
 #include <AK/StdLibExtras.h>
+#include <AK/TypeCasts.h>
 #include <Ladybird/Qt/TabBar.h>
+#include <QContextMenuEvent>
 #include <QEvent>
 #include <QPushButton>
 
 namespace Ladybird {
+
+TabBar::TabBar(QWidget* parent)
+    : QTabBar(parent)
+{
+}
 
 QSize TabBar::tabSizeHint(int index) const
 {
@@ -22,11 +31,19 @@ QSize TabBar::tabSizeHint(int index) const
     return hint;
 }
 
+void TabBar::contextMenuEvent(QContextMenuEvent* event)
+{
+    auto* tab_widget = verify_cast<QTabWidget>(this->parent());
+    auto* tab = verify_cast<Tab>(tab_widget->widget(tabAt(event->pos())));
+    if (tab)
+        tab->context_menu()->exec(event->globalPos());
+}
+
 TabWidget::TabWidget(QWidget* parent)
     : QTabWidget(parent)
 {
     // This must be called first, otherwise several of the options below have no effect.
-    setTabBar(new TabBar());
+    setTabBar(new TabBar(this));
 
     setDocumentMode(true);
     setElideMode(Qt::TextElideMode::ElideRight);

--- a/Ladybird/Qt/TabBar.cpp
+++ b/Ladybird/Qt/TabBar.cpp
@@ -15,7 +15,7 @@ QSize TabBar::tabSizeHint(int index) const
 {
     auto width = this->width() / count();
     width = min(225, width);
-    width = max(64, width);
+    width = max(128, width);
 
     auto hint = QTabBar::tabSizeHint(index);
     hint.setWidth(width);

--- a/Ladybird/Qt/TabBar.h
+++ b/Ladybird/Qt/TabBar.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,7 @@
 #include <QTabBar>
 #include <QTabWidget>
 
+class QContextMenuEvent;
 class QEvent;
 class QIcon;
 class QWidget;
@@ -20,7 +22,10 @@ class TabBar : public QTabBar {
     Q_OBJECT
 
 public:
+    explicit TabBar(QWidget* parent = nullptr);
+
     virtual QSize tabSizeHint(int index) const override;
+    virtual void contextMenuEvent(QContextMenuEvent* event) override;
 };
 
 class TabWidget : public QTabWidget {


### PR DESCRIPTION
The first commit here increases the minimum tab width, so that more is shown that the favicon when lots of tabs are open (at least Firefox shows some of the title too).

| Before | After |
| --- | --- |
| ![image](https://github.com/SerenityOS/serenity/assets/5103549/7bb2e47a-5c44-43be-abad-a33b8bea75bb) | ![image](https://github.com/SerenityOS/serenity/assets/5103549/364a310c-2453-4dd9-910a-7e0ad2cacb95) |

I can open this change in a separate pull request if desired :)

---

The main part of this pull request is to add a context menu to tabs in the tab bar.

![image](https://github.com/SerenityOS/serenity/assets/5103549/c68812d5-fc05-4a66-994d-691ca0c1269e)

I have based the layout and naming of the context menu after Firefox's.