### PR TITLE
Kernel/Ext2FS: Allocate blocks lazily + support writing holes

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -220,6 +220,16 @@ public:
         return false;
     }
 
+    template<typename V>
+    [[nodiscard]] constexpr bool filled_with(V const& value) const
+    {
+        for (size_t i = 0; i < size(); ++i) {
+            if (!Traits<RemoveReference<T>>::equals(at(i), value))
+                return false;
+        }
+        return true;
+    }
+
     [[nodiscard]] constexpr bool starts_with(ReadonlySpan<T> other) const
     {
         if (size() < other.size())

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -619,10 +619,9 @@ ErrorOr<void> Ext2FS::free_inode(Ext2FSInode& inode)
     // Mark all blocks used by this inode as free.
     {
         auto blocks = TRY(inode.compute_block_list_with_meta_blocks());
-        for (auto block_index : blocks) {
-            VERIFY(block_index <= super_block().s_blocks_count);
-            if (block_index.value())
-                TRY(set_block_allocation_state(block_index, false));
+        for (auto const& [_, block_index] : blocks) {
+            VERIFY(block_index <= super_block().s_blocks_count && block_index != 0);
+            TRY(set_block_allocation_state(block_index, false));
         }
     }
 

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -105,16 +105,6 @@ private:
 
     using BlockList = HashMap<BlockBasedFileSystem::BlockIndex, BlockBasedFileSystem::BlockIndex>;
 
-    struct BlockListShape {
-        unsigned direct_blocks { 0 };
-        unsigned indirect_blocks { 0 };
-        unsigned doubly_indirect_blocks { 0 };
-        unsigned triply_indirect_blocks { 0 };
-        unsigned meta_blocks { 0 };
-    };
-
-    BlockListShape compute_block_list_shape(unsigned blocks) const;
-
     u64 m_block_group_count { 0 };
 
     mutable ext2_super_block m_super_block {};

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -103,6 +103,8 @@ private:
     void uncache_inode(InodeIndex);
     ErrorOr<void> free_inode(Ext2FSInode&);
 
+    using BlockList = HashMap<BlockBasedFileSystem::BlockIndex, BlockBasedFileSystem::BlockIndex>;
+
     struct BlockListShape {
         unsigned direct_blocks { 0 };
         unsigned indirect_blocks { 0 };

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -45,8 +45,8 @@ private:
     virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<int> get_block_address(int) override;
 
+    ErrorOr<BlockBasedFileSystem::BlockIndex> get_or_allocate_block(BlockBasedFileSystem::BlockIndex, bool zero_newly_allocated_block, bool allow_cache);
     BlockBasedFileSystem::BlockIndex get_block(BlockBasedFileSystem::BlockIndex) const;
-    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_blocks(BlockBasedFileSystem::BlockIndex first_block_index, u64 count) const;
     ErrorOr<u32> allocate_and_zero_block();
 
     ErrorOr<void> write_directory(Vector<Ext2FSDirectoryEntry>&);

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -45,6 +45,9 @@ private:
     virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<int> get_block_address(int) override;
 
+    BlockBasedFileSystem::BlockIndex get_block(BlockBasedFileSystem::BlockIndex) const;
+    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_blocks(BlockBasedFileSystem::BlockIndex first_block_index, u64 count) const;
+
     ErrorOr<void> write_directory(Vector<Ext2FSDirectoryEntry>&);
     ErrorOr<void> populate_lookup_cache();
     ErrorOr<void> resize(u64);
@@ -56,16 +59,16 @@ private:
     ErrorOr<void> flush_block_list();
 
     ErrorOr<void> compute_block_list_with_exclusive_locking();
-    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> compute_block_list() const;
-    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> compute_block_list_with_meta_blocks() const;
-    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> compute_block_list_impl(bool include_block_list_blocks) const;
-    ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> compute_block_list_impl_internal(ext2_inode const&, bool include_block_list_blocks) const;
+    ErrorOr<Ext2FS::BlockList> compute_block_list() const;
+    ErrorOr<Ext2FS::BlockList> compute_block_list_with_meta_blocks() const;
+    ErrorOr<Ext2FS::BlockList> compute_block_list_impl(bool include_block_list_blocks) const;
+    ErrorOr<Vector<Ext2FS::BlockIndex>> compute_block_list_impl_internal(ext2_inode const&, bool include_block_list_blocks) const;
 
     Ext2FS& fs();
     Ext2FS const& fs() const;
     Ext2FSInode(Ext2FS&, InodeIndex);
 
-    Vector<BlockBasedFileSystem::BlockIndex> m_block_list;
+    Ext2FS::BlockList m_block_list;
     HashMap<NonnullOwnPtr<KString>, InodeIndex> m_lookup_cache;
     ext2_inode m_raw_inode {};
 

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -47,22 +47,39 @@ private:
 
     BlockBasedFileSystem::BlockIndex get_block(BlockBasedFileSystem::BlockIndex) const;
     ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_blocks(BlockBasedFileSystem::BlockIndex first_block_index, u64 count) const;
+    ErrorOr<u32> allocate_and_zero_block();
 
     ErrorOr<void> write_directory(Vector<Ext2FSDirectoryEntry>&);
     ErrorOr<void> populate_lookup_cache();
     ErrorOr<void> resize(u64);
-    ErrorOr<void> write_indirect_block(BlockBasedFileSystem::BlockIndex, Span<BlockBasedFileSystem::BlockIndex>);
-    ErrorOr<void> grow_doubly_indirect_block(BlockBasedFileSystem::BlockIndex, size_t, Span<BlockBasedFileSystem::BlockIndex>, Vector<BlockBasedFileSystem::BlockIndex>&, unsigned&);
-    ErrorOr<void> shrink_doubly_indirect_block(BlockBasedFileSystem::BlockIndex, size_t, size_t, unsigned&);
-    ErrorOr<void> grow_triply_indirect_block(BlockBasedFileSystem::BlockIndex, size_t, Span<BlockBasedFileSystem::BlockIndex>, Vector<BlockBasedFileSystem::BlockIndex>&, unsigned&);
-    ErrorOr<void> shrink_triply_indirect_block(BlockBasedFileSystem::BlockIndex, size_t, size_t, unsigned&);
-    ErrorOr<void> flush_block_list();
+    ErrorOr<void> write_singly_indirect_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
+    ErrorOr<void> write_doubly_indirect_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
+    ErrorOr<void> write_triply_indirect_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
+    ErrorOr<void> write_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
+    ErrorOr<void> flush_block_list(Ext2FS::BlockList const& old_block_list);
 
     ErrorOr<void> compute_block_list_with_exclusive_locking();
     ErrorOr<Ext2FS::BlockList> compute_block_list() const;
-    ErrorOr<Ext2FS::BlockList> compute_block_list_with_meta_blocks() const;
-    ErrorOr<Ext2FS::BlockList> compute_block_list_impl(bool include_block_list_blocks) const;
-    ErrorOr<Vector<Ext2FS::BlockIndex>> compute_block_list_impl_internal(ext2_inode const&, bool include_block_list_blocks) const;
+    ErrorOr<Ext2FS::BlockList> compute_block_list_impl(Vector<Ext2FS::BlockIndex>* meta_blocks = nullptr) const;
+    ErrorOr<Vector<Ext2FS::BlockIndex>> compute_meta_blocks() const;
+
+    u64 singly_indirect_block_capacity() const
+    {
+        auto const entries_per_block = EXT2_ADDR_PER_BLOCK(&fs().super_block());
+        return EXT2_NDIR_BLOCKS + entries_per_block;
+    }
+
+    u64 doubly_indirect_block_capacity() const
+    {
+        auto const entries_per_block = EXT2_ADDR_PER_BLOCK(&fs().super_block());
+        return singly_indirect_block_capacity() + entries_per_block * entries_per_block;
+    }
+
+    u64 triply_indirect_block_capacity() const
+    {
+        auto const entries_per_block = EXT2_ADDR_PER_BLOCK(&fs().super_block());
+        return doubly_indirect_block_capacity() + entries_per_block * entries_per_block * entries_per_block;
+    }
 
     Ext2FS& fs();
     Ext2FS const& fs() const;


### PR DESCRIPTION
... and also do a thorough refactor to be able to accomplish that, because the old implementation was extremely dependent on all blocks being sequential. There's a fairly long explanation of that in the relevant commit message.

This also accidentally fixes various situations where the filesystem would get slightly corrupted, such as when running the second of the following two commands:
```
dd if=/usr/lib/libweb.so.serenity of=foo.bin bs=1M count=50
truncate -s 35M foo.bin
```

Here's a more complete script that I used to test the correctness of this PR:
```
# test direct + singly indirect + doubly indirect blocks
dd status=none if=/usr/lib/libweb.so.serenity of=foo.bin bs=1M count=50
dd status=none if=/usr/lib/libweb.so.serenity of=/tmp/foo.bin bs=1M count=50
sha512sum /tmp/foo.bin | sed 's,/tmp/,,' | sha512sum -c

rm /tmp/*.bin

# test doubly indirect + triply indirect blocks
dd status=none if=/usr/lib/libweb.so.serenity of=bar.bin bs=1M count=50 seek=4096
dd status=none if=bar.bin bs=1M skip=4000 of=/tmp/bar.bin
dd status=none if=/usr/lib/libweb.so.serenity of=/tmp/foo.bin bs=1M count=50 seek=96
sha512sum /tmp/foo.bin | sed 's,foo,bar,' | sha512sum -c
```
Closes #6236.