### PR TITLE
LibGfx: Make non-shared Bitmaps be malloc-backed (+ cleanups)

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -573,43 +573,6 @@ void Bitmap::fill(Color color)
     }
 }
 
-void Bitmap::set_volatile()
-{
-    if (m_volatile)
-        return;
-#ifdef AK_OS_SERENITY
-    int rc = madvise(m_data, size_in_bytes(), MADV_SET_VOLATILE);
-    if (rc < 0) {
-        perror("madvise(MADV_SET_VOLATILE)");
-        VERIFY_NOT_REACHED();
-    }
-#endif
-    m_volatile = true;
-}
-
-[[nodiscard]] bool Bitmap::set_nonvolatile(bool& was_purged)
-{
-    if (!m_volatile) {
-        was_purged = false;
-        return true;
-    }
-
-#ifdef AK_OS_SERENITY
-    int rc = madvise(m_data, size_in_bytes(), MADV_SET_NONVOLATILE);
-    if (rc < 0) {
-        if (errno == ENOMEM) {
-            was_purged = true;
-            return false;
-        }
-        perror("madvise(MADV_SET_NONVOLATILE)");
-        VERIFY_NOT_REACHED();
-    }
-    was_purged = rc != 0;
-#endif
-    m_volatile = false;
-    return true;
-}
-
 Gfx::ShareableBitmap Bitmap::to_shareable_bitmap() const
 {
     auto bitmap_or_error = to_bitmap_backed_by_anonymous_buffer();

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -565,14 +565,6 @@ void Bitmap::strip_alpha_channel()
     m_format = BitmapFormat::BGRx8888;
 }
 
-void Bitmap::set_mmap_name([[maybe_unused]] ByteString const& name)
-{
-    VERIFY(m_needs_munmap);
-#ifdef AK_OS_SERENITY
-    ::set_mmap_name(m_data, size_in_bytes(), name.characters());
-#endif
-}
-
 void Bitmap::fill(Color color)
 {
     for (int y = 0; y < physical_height(); ++y) {

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -204,8 +204,6 @@ public:
     // Call only for BGRx8888 and BGRA8888 bitmaps.
     void strip_alpha_channel();
 
-    void set_mmap_name(ByteString const&);
-
     [[nodiscard]] static constexpr size_t size_in_bytes(size_t pitch, int physical_height) { return pitch * physical_height; }
     [[nodiscard]] size_t size_in_bytes() const { return size_in_bytes(m_pitch, physical_height()); }
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -244,7 +244,7 @@ private:
     void* m_data { nullptr };
     size_t m_pitch { 0 };
     BitmapFormat m_format { BitmapFormat::Invalid };
-    bool m_needs_munmap { false };
+    bool m_data_is_malloced { false };
     Core::AnonymousBuffer m_buffer;
 };
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -223,13 +223,6 @@ public:
         set_pixel(physical_position.x(), physical_position.y(), color);
     }
 
-    [[nodiscard]] bool is_volatile() const { return m_volatile; }
-    void set_volatile();
-
-    // Returns true if making the bitmap non-volatile succeeded. `was_purged` indicates status of contents.
-    // Returns false if there was not enough memory.
-    [[nodiscard]] bool set_nonvolatile(bool& was_purged);
-
     [[nodiscard]] Core::AnonymousBuffer& anonymous_buffer() { return m_buffer; }
     [[nodiscard]] Core::AnonymousBuffer const& anonymous_buffer() const { return m_buffer; }
 
@@ -252,7 +245,6 @@ private:
     size_t m_pitch { 0 };
     BitmapFormat m_format { BitmapFormat::Invalid };
     bool m_needs_munmap { false };
-    bool m_volatile { false };
     Core::AnonymousBuffer m_buffer;
 };
 


### PR DESCRIPTION
Using `malloc()` instead of `mmap()` is faster and avoids wasting memory by rounding up every bitmap allocation to a multiple of 4096 bytes.