### PR TITLE
Kernel/USB: Don't include UHCIController.h in USBPipe.h

### DIFF
--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -7,7 +7,7 @@
 
 #include <AK/StdLibExtras.h>
 #include <Kernel/Bus/USB/PacketTypes.h>
-#include <Kernel/Bus/USB/UHCI/UHCIController.h>
+#include <Kernel/Bus/USB/USBController.h>
 #include <Kernel/Bus/USB/USBPipe.h>
 #include <Kernel/Bus/USB/USBTransfer.h>
 

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -10,6 +10,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/USB/USBDescriptors.h>
+#include <Kernel/Library/UserOrKernelBuffer.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Memory/Region.h>
 


### PR DESCRIPTION
The USB::Pipe is abstracted from the actual USB host controller implementation, so don't include the UHCIController.h file. Also, we missed an include to UserOrKernelBuffer.h, so this is added to ensure the code can still compile.

This patch was taken from #23448, in attempt to make that PR less clunky to review.