### PR TITLE
LibWeb: Paint non-positioned SC with z-index=0 in paint_descendants()

### DIFF
--- a/Tests/LibWeb/Ref/non-positioned-stacking-context-with-z-index-0.html
+++ b/Tests/LibWeb/Ref/non-positioned-stacking-context-with-z-index-0.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<link rel="match" href="reference/non-positioned-stacking-context-with-z-index-0-ref.html"/>
+<style>
+* { outline: 1px solid black; }
+html { display: flex; }
+body { z-index: 0; }
+</style><body><div>Hello

--- a/Tests/LibWeb/Ref/reference/non-positioned-stacking-context-with-z-index-0-ref.html
+++ b/Tests/LibWeb/Ref/reference/non-positioned-stacking-context-with-z-index-0-ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<style>
+* { outline: 1px solid black; }
+html { display: flex; }
+</style><body><div>Hello

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -107,7 +107,7 @@ void StackingContext::paint_descendants(PaintContext& context, Paintable const& 
             return;
         }
 
-        if (stacking_context && z_index.has_value())
+        if (stacking_context && z_index.value_or(0) != 0)
             return;
         if (child.is_positioned() && !z_index.has_value())
             return;


### PR DESCRIPTION
Fixes the bug when non-positioned boxes that establish a stacking context and have z-index=0 are ignored during paint commands recording.