### PR TITLE
LibWeb: Fix paint recording to stop visiting stacking context twice

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -109,7 +109,7 @@ void StackingContext::paint_descendants(PaintContext& context, Paintable const& 
 
         if (stacking_context && z_index.value_or(0) != 0)
             return;
-        if (child.is_positioned() && !z_index.has_value())
+        if (child.is_positioned() && z_index.value_or(0) == 0)
             return;
 
         if (stacking_context) {


### PR DESCRIPTION
...if its box is positioned and has z-index=0.