### PR TITLE
LibWeb: Improve serialization of media queries

### DIFF
--- a/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
+++ b/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
@@ -1,15 +1,10 @@
 @media screen {
-
 }
 @media screen and ((min-width: 20px) and (max-width: 40px)) {
-
 }
 @media screen and (min-resolution: 1dppx) {
-
 }
 @media screen and (min-resolution: 2dppx) {
-
 }
 @media screen and (min-resolution: 2.54dppx) {
-
 }

--- a/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
+++ b/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
@@ -1,15 +1,15 @@
 @media screen {
 
 }
-@media screen and ((min-width:20px) and (max-width:40px)) {
+@media screen and ((min-width: 20px) and (max-width: 40px)) {
 
 }
-@media screen and (min-resolution:1dppx) {
+@media screen and (min-resolution: 1dppx) {
 
 }
-@media screen and (min-resolution:2dppx) {
+@media screen and (min-resolution: 2dppx) {
 
 }
-@media screen and (min-resolution:2.54dppx) {
+@media screen and (min-resolution: 2.54dppx) {
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -54,6 +54,11 @@ String CSSMediaRule::serialized() const
     builder.append(condition_text());
     // 3. A single SPACE (U+0020), followed by the string "{", i.e., LEFT CURLY BRACKET (U+007B), followed by a newline.
     builder.append(" {\n"sv);
+    // AD-HOC: All modern browsers omit the ending newline if there are no CSS rules, so let's do the same.
+    if (css_rules().length() == 0) {
+        builder.append('}');
+        return MUST(builder.to_string());
+    }
     // 4. The result of performing serialize a CSS rule on each rule in the rule’s cssRules list, separated by a newline and indented by two spaces.
     for (size_t i = 0; i < css_rules().length(); i++) {
         auto rule = css_rules().item(i);

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -64,11 +64,11 @@ String MediaFeature::to_string() const
     case Type::IsTrue:
         return MUST(String::from_utf8(string_from_media_feature_id(m_id)));
     case Type::ExactValue:
-        return MUST(String::formatted("{}:{}", string_from_media_feature_id(m_id), m_value->to_string()));
+        return MUST(String::formatted("{}: {}", string_from_media_feature_id(m_id), m_value->to_string()));
     case Type::MinValue:
-        return MUST(String::formatted("min-{}:{}", string_from_media_feature_id(m_id), m_value->to_string()));
+        return MUST(String::formatted("min-{}: {}", string_from_media_feature_id(m_id), m_value->to_string()));
     case Type::MaxValue:
-        return MUST(String::formatted("max-{}:{}", string_from_media_feature_id(m_id), m_value->to_string()));
+        return MUST(String::formatted("max-{}: {}", string_from_media_feature_id(m_id), m_value->to_string()));
     case Type::Range:
         if (!m_range->right_comparison.has_value())
             return MUST(String::formatted("{} {} {}", m_range->left_value.to_string(), comparison_string(m_range->left_comparison), string_from_media_feature_id(m_id)));


### PR DESCRIPTION
This PR makes 2 changes to align the serialization of media queries with other modern browsers:

* We now include a space between media feature name and value. This follows the specification.
* If a media at-rule contains no CSS rules we don't include a final newline. This deviates from the specification, but all modern browsers do this. [This web platform test](http://wpt.live/css/cssom/serialize-media-rule.html) relies on this behavior.

This makes the following WPT test pass: http://wpt.live/css/cssom/MediaList.html

and increases the number of subtest passes for this WPT test: http://wpt.live/css/cssom/serialize-media-rule.html