### PR TITLE
LibWeb/Fetch: Append fetch metadata headers

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2078,4 +2078,29 @@ void set_sec_fetch_site_header(Infrastructure::Request& request)
     request.header_list()->append(move(header));
 }
 
+// https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-set-user
+void set_sec_fetch_user_header(Infrastructure::Request& request)
+{
+    // 1. Assert: r’s url is a potentially trustworthy URL.
+    VERIFY(SecureContexts::is_url_potentially_trustworthy(request.url()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy);
+
+    // 2. If r is not a navigation request, or if r’s user-activation is false, return.
+    if (!request.is_navigation_request() || !request.user_activation())
+        return;
+
+    // 3. Let header be a Structured Header whose value is a token.
+    // FIXME: This is handled below, as Serenity doesn't have APIs for RFC 8941.
+
+    // 4. Set header’s value to true.
+    // NOTE: See https://datatracker.ietf.org/doc/html/rfc8941#name-booleans for boolean format in RFC 8941.
+    auto header_value = MUST(ByteBuffer::copy("?1"sv.bytes()));
+
+    // 5. Set a structured field value `Sec-Fetch-User`/header in r’s header list.
+    auto header = Infrastructure::Header {
+        .name = MUST(ByteBuffer::copy("Sec-Fetch-User"sv.bytes())),
+        .value = move(header_value),
+    };
+    request.header_list()->append(move(header));
+}
+
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1355,7 +1355,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
         // 12. Append a request `Origin` header for httpRequest.
         http_request->add_origin_header();
 
-        // FIXME: 13. Append the Fetch metadata headers for httpRequest.
+        // 13. Append the Fetch metadata headers for httpRequest.
+        append_fetch_metadata_headers_for_request(*http_request);
 
         // 14. If httpRequest’s header list does not contain `User-Agent`, then user agents should append
         //     (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
@@ -2101,6 +2102,26 @@ void set_sec_fetch_user_header(Infrastructure::Request& request)
         .value = move(header_value),
     };
     request.header_list()->append(move(header));
+}
+
+// https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-append-the-fetch-metadata-headers-for-a-request
+void append_fetch_metadata_headers_for_request(Infrastructure::Request& request)
+{
+    // 1. If r’s url is not an potentially trustworthy URL, return.
+    if (SecureContexts::is_url_potentially_trustworthy(request.url()) != SecureContexts::Trustworthiness::PotentiallyTrustworthy)
+        return;
+
+    // 2. Set the Sec-Fetch-Dest header for r.
+    set_sec_fetch_dest_header(request);
+
+    // 3. Set the Sec-Fetch-Mode header for r.
+    set_sec_fetch_mode_header(request);
+
+    // 4. Set the Sec-Fetch-Site header for r.
+    set_sec_fetch_site_header(request);
+
+    // 5. Set the Sec-Fetch-User header for r.
+    set_sec_fetch_user_header(request);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2019,4 +2019,24 @@ void set_sec_fetch_dest_header(Infrastructure::Request& request)
     request.header_list()->append(move(header));
 }
 
+// https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-set-dest
+void set_sec_fetch_mode_header(Infrastructure::Request& request)
+{
+    // 1. Assert: r’s url is a potentially trustworthy URL.
+    VERIFY(SecureContexts::is_url_potentially_trustworthy(request.url()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy);
+
+    // 2. Let header be a Structured Header whose value is a token.
+    // FIXME: This is handled below, as Serenity doesn't have APIs for RFC 8941.
+
+    // 3. Set header’s value to r’s mode.
+    auto header_value = MUST(ByteBuffer::copy(Infrastructure::request_mode_to_string(request.mode()).bytes()));
+
+    // 4. Set a structured field value `Sec-Fetch-Mode`/header in r’s header list.
+    auto header = Infrastructure::Header {
+        .name = MUST(ByteBuffer::copy("Sec-Fetch-Mode"sv.bytes())),
+        .value = move(header_value),
+    };
+    request.header_list()->append(move(header));
+}
+
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -40,4 +40,5 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_loader_file_or_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);
 void set_sec_fetch_dest_header(Infrastructure::Request&);
+void set_sec_fetch_mode_header(Infrastructure::Request&);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -42,4 +42,5 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::
 void set_sec_fetch_dest_header(Infrastructure::Request&);
 void set_sec_fetch_mode_header(Infrastructure::Request&);
 void set_sec_fetch_site_header(Infrastructure::Request&);
+void set_sec_fetch_user_header(Infrastructure::Request&);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -38,4 +39,5 @@ WebIDL::ExceptionOr<JS::GCPtr<PendingResponse>> http_redirect_fetch(JS::Realm&, 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fetch(JS::Realm&, Infrastructure::FetchParams const&, IsAuthenticationFetch is_authentication_fetch = IsAuthenticationFetch::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_loader_file_or_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);
+void set_sec_fetch_dest_header(Infrastructure::Request&);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -43,4 +43,5 @@ void set_sec_fetch_dest_header(Infrastructure::Request&);
 void set_sec_fetch_mode_header(Infrastructure::Request&);
 void set_sec_fetch_site_header(Infrastructure::Request&);
 void set_sec_fetch_user_header(Infrastructure::Request&);
+void append_fetch_metadata_headers_for_request(Infrastructure::Request&);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -41,4 +41,5 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);
 void set_sec_fetch_dest_header(Infrastructure::Request&);
 void set_sec_fetch_mode_header(Infrastructure::Request&);
+void set_sec_fetch_site_header(Infrastructure::Request&);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -367,4 +367,55 @@ bool Request::cross_origin_embedder_policy_allows_credentials() const
     return request_origin->is_same_origin(DOMURL::url_origin(current_url())) && !has_redirect_tainted_origin();
 }
 
+StringView request_destination_to_string(Request::Destination destination)
+{
+    switch (destination) {
+    case Request::Destination::Audio:
+        return "audio"sv;
+    case Request::Destination::AudioWorklet:
+        return "audioworklet"sv;
+    case Request::Destination::Document:
+        return "document"sv;
+    case Request::Destination::Embed:
+        return "embed"sv;
+    case Request::Destination::Font:
+        return "font"sv;
+    case Request::Destination::Frame:
+        return "frame"sv;
+    case Request::Destination::IFrame:
+        return "iframe"sv;
+    case Request::Destination::Image:
+        return "image"sv;
+    case Request::Destination::JSON:
+        return "json"sv;
+    case Request::Destination::Manifest:
+        return "manifest"sv;
+    case Request::Destination::Object:
+        return "object"sv;
+    case Request::Destination::PaintWorklet:
+        return "paintworklet"sv;
+    case Request::Destination::Report:
+        return "report"sv;
+    case Request::Destination::Script:
+        return "script"sv;
+    case Request::Destination::ServiceWorker:
+        return "serviceworker"sv;
+    case Request::Destination::SharedWorker:
+        return "sharedworker"sv;
+    case Request::Destination::Style:
+        return "style"sv;
+    case Request::Destination::Track:
+        return "track"sv;
+    case Request::Destination::Video:
+        return "video"sv;
+    case Request::Destination::WebIdentity:
+        return "webidentity"sv;
+    case Request::Destination::Worker:
+        return "worker"sv;
+    case Request::Destination::XSLT:
+        return "xslt"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -418,4 +418,21 @@ StringView request_destination_to_string(Request::Destination destination)
     VERIFY_NOT_REACHED();
 }
 
+StringView request_mode_to_string(Request::Mode mode)
+{
+    switch (mode) {
+    case Request::Mode::SameOrigin:
+        return "same-origin"sv;
+    case Request::Mode::CORS:
+        return "cors"sv;
+    case Request::Mode::NoCORS:
+        return "no-cors"sv;
+    case Request::Mode::Navigate:
+        return "navigate"sv;
+    case Request::Mode::WebSocket:
+        return "websocket"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -56,6 +56,7 @@ public:
         Frame,
         IFrame,
         Image,
+        JSON,
         Manifest,
         Object,
         PaintWorklet,
@@ -388,7 +389,7 @@ private:
 
     // https://fetch.spec.whatwg.org/#concept-request-destination
     // A request has an associated destination, which is the empty string, "audio", "audioworklet", "document",
-    // "embed", "font", "frame", "iframe", "image", "manifest", "object", "paintworklet", "report", "script",
+    // "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script",
     // "serviceworker", "sharedworker", "style", "track", "video", "webidentity", "worker", or "xslt". Unless stated
     // otherwise it is the empty string.
     // NOTE: These are reflected on RequestDestination except for "serviceworker" and "webidentity" as fetches with

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -517,4 +517,6 @@ private:
     Vector<JS::NonnullGCPtr<Fetching::PendingResponse>> m_pending_responses;
 };
 
+StringView request_destination_to_string(Request::Destination);
+
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -518,5 +518,6 @@ private:
 };
 
 StringView request_destination_to_string(Request::Destination);
+StringView request_mode_to_string(Request::Mode);
 
 }


### PR DESCRIPTION
Further work towards GH-23632.

Serenity doesn't have any APIs for structured headers introduced in RFC 8941, so this creates the headers as they would ultimately be made.