### PR TITLE
Meta+Documentation+Ports: Move from C++20 to C++23

### DIFF
--- a/Base/home/anon/Source/little/Makefile
+++ b/Base/home/anon/Source/little/Makefile
@@ -1,6 +1,6 @@
 PROGRAM = little
 OBJS = main.o other.o
-CXXFLAGS = -g -std=c++2a
+CXXFLAGS = -g -std=c++23
 
 all: $(PROGRAM)
 

--- a/Base/res/devel/templates/cpp-basic.postcreate
+++ b/Base/res/devel/templates/cpp-basic.postcreate
@@ -3,7 +3,7 @@
 echo > $2/Makefile <<-EOF
 PROGRAM = $1
 OBJS = main.o
-CXXFLAGS = -g -std=c++2a
+CXXFLAGS = -g -std=c++23
 
 all: \$(PROGRAM)
 

--- a/Base/res/devel/templates/cpp-library.postcreate
+++ b/Base/res/devel/templates/cpp-library.postcreate
@@ -12,7 +12,7 @@ sed -i "s/\\\$LibName/$3/g" $2/Class1.cpp
 echo > $2/Makefile <<-EOF
 LIBRARY = $1.so
 OBJS = Class1.o
-CXXFLAGS = -g -std=c++2a
+CXXFLAGS = -g -std=c++23
 
 all: \$(LIBRARY)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 
 **Do:**
 
-* Write in idiomatic SerenityOS C++20, using the `AK` containers in all code.
+* Write in idiomatic SerenityOS C++23, using the `AK` containers in all code.
 * Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 18 or later) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-18.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits (i.e. A commit per feature or fix, where the build, tests and the system are all functioning).

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -13,7 +13,7 @@ Optional: `fuse2fs` for [building images without root](https://github.com/Sereni
 
 #### GCC 12 or Clang 15
 
-A host compiler that supports C++20 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-15.
+A host compiler that supports C++23 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-15.
 
 On Ubuntu gcc-12 is available in the repositories of 22.04 (Jammy) and later.
 If you are running an older version, you will either need to upgrade, or find an alternative installation source.

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -2,7 +2,7 @@
 
 ## Build Prerequisites
 
-Qt6 development packages and a C++20 capable compiler are required. g++-12 or clang-15 are required at a minimum for c++20 support.
+Qt6 development packages and a C++23 capable compiler are required. g++-12 or clang-15 are required at a minimum for c++23 support.
 
 NOTE: In all of the below lists of packages, the Qt6 multimedia package is not needed if your Linux system supports PulseAudio.
 
@@ -52,7 +52,7 @@ nix-shell --command bash Ladybird
 
 On macOS:
 
-Note that Xcode 13.x does not have sufficient C++20 support to build ladybird. Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or clang from homebrew may be required to successfully build ladybird.
+Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or clang from homebrew may be required to successfully build ladybird.
 
 ```
 xcode-select --install

--- a/Documentation/Links.md
+++ b/Documentation/Links.md
@@ -24,7 +24,7 @@ This is a roughly categorized list of pages relating to SerenityOS and its subpr
 -   [SonarCloud Static Analysis](https://sonarcloud.io/project/overview?id=SerenityOS_serenity)
 -   [LibJS website](https://serenityos.github.io/libjs-website/)
     -   [Try LibJS Online!](https://serenityos.github.io/libjs-website/repl/)
--   [Compiler Explorer](https://serenity.godbolt.org/): Select "Lagom trunk" under "Libraries" and add the compiler option `-std=c++20`
+-   [Compiler Explorer](https://serenity.godbolt.org/): Select "Lagom trunk" under "Libraries" and add the compiler option `-std=c++23`
 
 ## Related Projects
 

--- a/Documentation/NvimConfiguration.md
+++ b/Documentation/NvimConfiguration.md
@@ -45,7 +45,7 @@ system and customize the `inlayHints.sep` based on your preference.
 
 ```json
 {
-    "clangd.fallbackFlags": ["-std=c++20"],
+    "clangd.fallbackFlags": ["-std=c++23"],
     "clangd.arguments": ["--query-driver=${workspaceFolder}/Toolchain/Local/**/*"],
     "semanticTokens.enable": true,
     "inlayHint.subSeparator": "︴",

--- a/Documentation/QtCreatorConfiguration.md
+++ b/Documentation/QtCreatorConfiguration.md
@@ -25,7 +25,7 @@ First, make sure you have a working toolchain and can build and run SerenityOS. 
     #define __SSE__
     ```
     If you're working on the Kernel, just uncomment `#define KERNEL`.
-* Edit the `serenity.cxxflags` file to say `-std=c++20 -fsigned-char -fconcepts -fno-exceptions -fno-semantic-interposition -fPIC`
+* Edit the `serenity.cxxflags` file to say `-std=c++23 -fsigned-char -fconcepts -fno-exceptions -fno-semantic-interposition -fPIC`
 * Edit the `serenity.includes` file to list the following lines:
     ```
     ./

--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -83,7 +83,7 @@ following ``c_cpp_properties.json`` to circumvent some errors. Even with the con
             ],
             "compilerPath": "${workspaceFolder}/Toolchain/Local/x86_64/bin/x86_64-pc-serenity-g++",
             "cStandard": "c17",
-            "cppStandard": "c++20",
+            "cppStandard": "c++23",
             "intelliSenseMode": "linux-gcc-x86",
             "compileCommands": "Build/x86_64/compile_commands.json",
             "compilerArgs": [

--- a/Ladybird/Android/build.gradle.kts
+++ b/Ladybird/Android/build.gradle.kts
@@ -32,7 +32,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
-                cppFlags += "-std=c++20"
+                cppFlags += "-std=c++23"
                 arguments += listOf(
                     "-DLagomTools_DIR=$buildDir/lagom-tools-install/share/LagomTools",
                     "-DSERENITY_CACHE_DIR=$cacheDir"

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -1,5 +1,5 @@
 # Flags shared by Lagom (including Ladybird) and Serenity.
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -90,7 +90,7 @@ config("compiler_defaults") {
     ldflags += [ "-Wl,--color-diagnostics" ]
   }
   cflags_cc += [
-    "-std=c++20",
+    "-std=c++23",
     "-fvisibility-inlines-hidden",
   ]
 

--- a/Ports/OpenJDK/patches/0002-make-Build-with-c-23-when-targeting-serenity.patch
+++ b/Ports/OpenJDK/patches/0002-make-Build-with-c-23-when-targeting-serenity.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Kaster <andrewdkaster@gmail.com>
 Date: Sun, 12 Jun 2022 23:13:56 -0600
-Subject: [PATCH] make: Build with c++20 when targeting serenity
+Subject: [PATCH] make: Build with c++23 when targeting serenity
 
 ---
  make/autoconf/flags-cflags.m4                 | 8 ++++++--
@@ -39,7 +39,7 @@ index 88679489fc09019212286e0cb75885a05103dc85..63126c98054760f8a657d6ba7d51d5ae
      AC_MSG_ERROR([Don't know how to enable C++14 for this toolchain])
    fi
 +  if test "x$OPENJDK_TARGET_OS" = xserenity; then
-+    LANGSTD_CXXFLAGS="-std=c++20"
++    LANGSTD_CXXFLAGS="-std=c++23"
 +  fi
    TOOLCHAIN_CFLAGS_JDK_CXXONLY="$TOOLCHAIN_CFLAGS_JDK_CXXONLY $LANGSTD_CXXFLAGS"
    TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM $LANGSTD_CXXFLAGS"

--- a/Ports/OpenJDK/patches/ReadMe.md
+++ b/Ports/OpenJDK/patches/ReadMe.md
@@ -5,9 +5,9 @@
 make: Add Serenity support, masquerading as BSD when necessary
 
 
-## `0002-make-Build-with-c-20-when-targeting-serenity.patch`
+## `0002-make-Build-with-c-23-when-targeting-serenity.patch`
 
-make: Build with c++20 when targeting serenity
+make: Build with c++23 when targeting serenity
 
 
 ## `0003-make-Remove-CUPS-dependency.patch`

--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -137,7 +137,7 @@ index c4aec174e35ee653c4c4e0449939054e0f68ad9d..2f88b7f8790df95838e7de7a45789804
 +    set(HAVE_SDL_VIDEO TRUE)
 +    set(HAVE_SDL_AUDIO TRUE)
 +
-+    set(CMAKE_CXX_FLAGS "-std=c++2a ${CMAKE_CXX_FLAGS}")
++    set(CMAKE_CXX_FLAGS "-std=c++23 ${CMAKE_CXX_FLAGS}")
 +    file(GLOB SERENITY_SOURCES ${SDL2_SOURCE_DIR}/src/video/serenity/*.cpp ${SDL2_SOURCE_DIR}/src/audio/serenity/*.cpp)
 +    set(SOURCE_FILES ${SOURCE_FILES} ${SERENITY_SOURCES})
 +    set(SDL_VIDEO_DRIVER_SERENITY 1)

--- a/Ports/stpuzzles/package.sh
+++ b/Ports/stpuzzles/package.sh
@@ -9,7 +9,7 @@ files=(
 )
 
 configure() {
-    run cmake "${configopts[@]}" -DCMAKE_CXX_FLAGS="-std=c++2a -O2"
+    run cmake "${configopts[@]}" -DCMAKE_CXX_FLAGS="-std=c++23 -O2"
 }
 
 install() {

--- a/Ports/xmp-cli/patches/0001-Add-support-for-Serenity-LibAudio.patch
+++ b/Ports/xmp-cli/patches/0001-Add-support-for-Serenity-LibAudio.patch
@@ -21,7 +21,7 @@ index b65eb85244acec722b2f240976f184f06db11a27..840845dc1f5d7459bfbb339071b817ad
  
  AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}/${PACKAGE_NAME}\" ${LIBXMP_CFLAGS} \
 -              ${alsa_CFLAGS} ${pulseaudio_CFLAGS}
-+              ${alsa_CFLAGS} ${pulseaudio_CFLAGS} -std=c++2a 
++              ${alsa_CFLAGS} ${pulseaudio_CFLAGS} -std=c++23
  AM_CFLAGS   = -Wall
  
  bin_PROGRAMS = xmp


### PR DESCRIPTION
Now that oss-fuzz is on a clang commit > the 17.x release candidates, we can start looking at some shiny new features to enable.