### PR TITLE
Ladybird+LibWebView: Introduce a cache for cookies backed by SQL storage

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -24,7 +24,7 @@
 
 - (nullable instancetype)init:(Vector<URL::URL>)initial_urls
                 newTabPageURL:(URL::URL)new_tab_page_url
-                withCookieJar:(WebView::CookieJar)cookie_jar
+                withCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar
             webContentOptions:(Ladybird::WebContentOptions const&)web_content_options
       webdriverContentIPCPath:(StringView)webdriver_content_ipc_path;
 

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -24,7 +24,7 @@
     URL::URL m_new_tab_page_url;
 
     // This will always be populated, but we cannot have a non-default constructible instance variable.
-    Optional<WebView::CookieJar> m_cookie_jar;
+    OwnPtr<WebView::CookieJar> m_cookie_jar;
 
     Ladybird::WebContentOptions m_web_content_options;
     Optional<StringView> m_webdriver_content_ipc_path;
@@ -56,7 +56,7 @@
 
 - (instancetype)init:(Vector<URL::URL>)initial_urls
               newTabPageURL:(URL::URL)new_tab_page_url
-              withCookieJar:(WebView::CookieJar)cookie_jar
+              withCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar
           webContentOptions:(Ladybird::WebContentOptions const&)web_content_options
     webdriverContentIPCPath:(StringView)webdriver_content_ipc_path
 {

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -185,10 +185,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     chrome_process.on_new_window = [&](auto const& urls) {
-        app.new_window(sanitize_urls(urls), cookie_jar, web_content_options, webdriver_content_ipc_path);
+        app.new_window(sanitize_urls(urls), *cookie_jar, web_content_options, webdriver_content_ipc_path);
     };
 
-    auto& window = app.new_window(sanitize_urls(raw_urls), cookie_jar, web_content_options, webdriver_content_ipc_path);
+    auto& window = app.new_window(sanitize_urls(raw_urls), *cookie_jar, web_content_options, webdriver_content_ipc_path);
     window.setWindowTitle("Ladybird");
 
     if (Ladybird::Settings::the()->is_maximized()) {

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -217,7 +217,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto cookie_jar = TRY(WebView::CookieJar::create(*database));
-    auto window = Browser::BrowserWindow::construct(cookie_jar, sanitize_urls(specified_urls), man_file);
+    auto window = Browser::BrowserWindow::construct(*cookie_jar, sanitize_urls(specified_urls), man_file);
 
     chrome_process.on_new_tab = [&](auto const& raw_urls) {
         open_urls_from_client(*window, raw_urls, NewWindow::No);

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -164,7 +164,7 @@ public:
     }
 
 private:
-    HeadlessWebContentView(NonnullRefPtr<WebView::Database> database, WebView::CookieJar cookie_jar, RefPtr<Protocol::RequestClient> request_client = nullptr)
+    HeadlessWebContentView(NonnullRefPtr<WebView::Database> database, NonnullOwnPtr<WebView::CookieJar> cookie_jar, RefPtr<Protocol::RequestClient> request_client = nullptr)
         : m_database(move(database))
         , m_cookie_jar(move(cookie_jar))
         , m_request_client(move(request_client))
@@ -183,11 +183,11 @@ private:
         };
 
         on_get_cookie = [this](auto const& url, auto source) {
-            return m_cookie_jar.get_cookie(url, source);
+            return m_cookie_jar->get_cookie(url, source);
         };
 
         on_set_cookie = [this](auto const& url, auto const& cookie, auto source) {
-            m_cookie_jar.set_cookie(url, cookie, source);
+            m_cookie_jar->set_cookie(url, cookie, source);
         };
 
         on_request_worker_agent = [this]() {
@@ -213,7 +213,7 @@ private:
     RefPtr<Core::Promise<RefPtr<Gfx::Bitmap>>> m_pending_screenshot;
 
     NonnullRefPtr<WebView::Database> m_database;
-    WebView::CookieJar m_cookie_jar;
+    NonnullOwnPtr<WebView::CookieJar> m_cookie_jar;
     RefPtr<Protocol::RequestClient> m_request_client;
 };
 


### PR DESCRIPTION
Now that the chrome process is a singleton on all platforms, we can safely add a cache to the CookieJar to greatly speed up access. The way this works is we read all cookies upfront from the database. As cookies are updated by the web, we store a list of "dirty" cookies that need to be flushed to the database. We do that synchronization every 30 seconds and at shutdown.

There's plenty of room for improvement here, some of which is marked with FIXMEs in the CookieJar.

Before these changes, in a SQL database populated with 300 cookies, browsing to https://twinings.co.uk/ WebContent spent:

    19,806ms waiting for a get-cookie response
    505ms waiting for a set-cookie response

With these changes, it spends:

    24ms waiting for a get-cookie response
    15ms waiting for a set-cookie response

This is obviously very noticeable while loading the page, not only in time, but in SQLServer CPU usage.

Here's waiting for twinings to load without these changes:

https://github.com/SerenityOS/serenity/assets/5600524/0f5cf4b7-a40c-486d-ba86-6491c1080fb1

And with these changes:

https://github.com/SerenityOS/serenity/assets/5600524/1fc11654-92ea-48af-8042-ea3def6bd021

Fixes #23307
