### PR TITLE
LibWeb: Honor intrinsic constraints on available space in table widths

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/table-width-max-content-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width-max-content-containing-block.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 425.828125x17 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 425.828125x17 [BFC] children: not-inline
+        Box <div> at (8,8) content-size 425.828125x17 table-box [TFC] children: inline
+          Box <(anonymous)> at (8,8) content-size 425.828125x17 table-row children: inline
+            BlockContainer <(anonymous)> at (8,8) content-size 425.828125x17 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 1, length: 56, rect: [8,8 425.828125x17] baseline: 13.296875
+                  "well hello friends well hello friends well hello friends"
+              TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 425.828125x17]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 425.828125x17]
+        PaintableBox (Box<DIV>) [8,8 425.828125x17]
+          PaintableBox (Box(anonymous)) [8,8 425.828125x17]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 425.828125x17]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-width-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width-max-content.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 425.828125x17 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 425.828125x17 [BFC] children: not-inline
+        Box <div> at (8,8) content-size 425.828125x17 table-box [TFC] children: inline
+          Box <(anonymous)> at (8,8) content-size 425.828125x17 table-row children: inline
+            BlockContainer <(anonymous)> at (8,8) content-size 425.828125x17 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 1, length: 56, rect: [8,8 425.828125x17] baseline: 13.296875
+                  "well hello friends well hello friends well hello friends"
+              TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 425.828125x17]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 425.828125x17]
+        PaintableBox (Box<DIV>) [8,8 425.828125x17]
+          PaintableBox (Box(anonymous)) [8,8 425.828125x17]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 425.828125x17]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-width-min-content-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width-min-content-containing-block.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x169 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 55.359375x153 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 55.359375x153 [BFC] children: not-inline
+        Box <div> at (8,8) content-size 55.359375x153 table-box [TFC] children: inline
+          Box <(anonymous)> at (8,8) content-size 55.359375x153 table-row children: inline
+            BlockContainer <(anonymous)> at (8,8) content-size 55.359375x153 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 1, length: 4, rect: [8,8 28.40625x17] baseline: 13.296875
+                  "well"
+              frag 1 from TextNode start: 6, length: 5, rect: [8,25 36.84375x17] baseline: 13.296875
+                  "hello"
+              frag 2 from TextNode start: 12, length: 7, rect: [8,42 55.359375x17] baseline: 13.296875
+                  "friends"
+              frag 3 from TextNode start: 20, length: 4, rect: [8,59 28.40625x17] baseline: 13.296875
+                  "well"
+              frag 4 from TextNode start: 25, length: 5, rect: [8,76 36.84375x17] baseline: 13.296875
+                  "hello"
+              frag 5 from TextNode start: 31, length: 7, rect: [8,93 55.359375x17] baseline: 13.296875
+                  "friends"
+              frag 6 from TextNode start: 39, length: 4, rect: [8,110 28.40625x17] baseline: 13.296875
+                  "well"
+              frag 7 from TextNode start: 44, length: 5, rect: [8,127 36.84375x17] baseline: 13.296875
+                  "hello"
+              frag 8 from TextNode start: 50, length: 7, rect: [8,144 55.359375x17] baseline: 13.296875
+                  "friends"
+              TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x169]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 55.359375x153]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 55.359375x153]
+        PaintableBox (Box<DIV>) [8,8 55.359375x153]
+          PaintableBox (Box(anonymous)) [8,8 55.359375x153]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 55.359375x153]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-width-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width-min-content.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x169 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 55.359375x153 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 55.359375x153 [BFC] children: not-inline
+        Box <div> at (8,8) content-size 55.359375x153 table-box [TFC] children: inline
+          Box <(anonymous)> at (8,8) content-size 55.359375x153 table-row children: inline
+            BlockContainer <(anonymous)> at (8,8) content-size 55.359375x153 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 1, length: 4, rect: [8,8 28.40625x17] baseline: 13.296875
+                  "well"
+              frag 1 from TextNode start: 6, length: 5, rect: [8,25 36.84375x17] baseline: 13.296875
+                  "hello"
+              frag 2 from TextNode start: 12, length: 7, rect: [8,42 55.359375x17] baseline: 13.296875
+                  "friends"
+              frag 3 from TextNode start: 20, length: 4, rect: [8,59 28.40625x17] baseline: 13.296875
+                  "well"
+              frag 4 from TextNode start: 25, length: 5, rect: [8,76 36.84375x17] baseline: 13.296875
+                  "hello"
+              frag 5 from TextNode start: 31, length: 7, rect: [8,93 55.359375x17] baseline: 13.296875
+                  "friends"
+              frag 6 from TextNode start: 39, length: 4, rect: [8,110 28.40625x17] baseline: 13.296875
+                  "well"
+              frag 7 from TextNode start: 44, length: 5, rect: [8,127 36.84375x17] baseline: 13.296875
+                  "hello"
+              frag 8 from TextNode start: 50, length: 7, rect: [8,144 55.359375x17] baseline: 13.296875
+                  "friends"
+              TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x169]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 55.359375x153]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 55.359375x153]
+        PaintableBox (Box<DIV>) [8,8 55.359375x153]
+          PaintableBox (Box(anonymous)) [8,8 55.359375x153]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 55.359375x153]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/table/table-width-max-content-containing-block.html
+++ b/Tests/LibWeb/Layout/input/table/table-width-max-content-containing-block.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { width: max-content; }
+    div { display: table; }
+</style><body><div>
+well hello friends
+well hello friends
+well hello friends

--- a/Tests/LibWeb/Layout/input/table/table-width-max-content.html
+++ b/Tests/LibWeb/Layout/input/table/table-width-max-content.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { width: min-content; }
+    div { display: table; width: max-content; }
+</style><body><div>
+well hello friends
+well hello friends
+well hello friends

--- a/Tests/LibWeb/Layout/input/table/table-width-min-content-containing-block.html
+++ b/Tests/LibWeb/Layout/input/table/table-width-min-content-containing-block.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { width: min-content; }
+    div { display: table; }
+</style><body><div>
+well hello friends
+well hello friends
+well hello friends

--- a/Tests/LibWeb/Layout/input/table/table-width-min-content.html
+++ b/Tests/LibWeb/Layout/input/table/table-width-min-content.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { width: min-content; }
+    div { display: table; width: min-content; }
+</style><body><div>
+well hello friends
+well hello friends
+well hello friends

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -482,7 +482,11 @@ void TableFormattingContext::compute_table_width()
     }
 
     CSSPixels used_width;
-    if (width_is_auto_relative_to_state(computed_values.width(), containing_block_state)) {
+    if (m_available_space->width.is_min_content()) {
+        used_width = grid_min;
+    } else if (m_available_space->width.is_max_content()) {
+        used_width = grid_max;
+    } else if (width_is_auto_relative_to_state(computed_values.width(), containing_block_state)) {
         // If the table-root has 'width: auto', the used width is the greater of
         // min(GRIDMAX, the table’s containing block width), the used min-width of the table.
         if (width_of_table_containing_block.is_definite())


### PR DESCRIPTION
When a table's containing block provides min-content or max-content available space, we now size the table's width accordingly.