### PR TITLE
LibWeb: Add and use an ad-hoc ReadableStreamDefaultReader::read_all_chunks AO

### DIFF
--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -312,7 +312,7 @@ JS::NonnullGCPtr<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     };
 
-    auto success_steps = [promise, &realm](Vector<ByteBuffer> const&) {
+    auto success_steps = [promise, &realm](ByteBuffer) {
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     };
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -88,7 +88,7 @@ void ReadLoopReadRequest::on_chunk(JS::Value chunk)
     auto const& buffer = array.viewed_array_buffer()->buffer();
 
     // 2. Append the bytes represented by chunk to bytes.
-    m_byte_chunks.append(buffer);
+    m_bytes.append(buffer);
 
     if (m_chunk_steps) {
         // FIXME: Can we move the buffer out of the `chunk`? Unclear if that is safe.
@@ -107,7 +107,7 @@ void ReadLoopReadRequest::on_chunk(JS::Value chunk)
 void ReadLoopReadRequest::on_close()
 {
     // 1. Call successSteps with bytes.
-    m_success_steps(m_byte_chunks);
+    m_success_steps(m_bytes);
 }
 
 // error steps, given e
@@ -226,12 +226,8 @@ JS::NonnullGCPtr<WebIDL::Promise> ReadableStreamDefaultReader::read_all_bytes_de
 
     auto promise = WebIDL::create_promise(realm);
 
-    auto success_steps = [promise, &realm](Vector<ByteBuffer> const& byte_chunks) {
-        ByteBuffer concatenated_byte_chunks;
-        for (auto const& chunk : byte_chunks)
-            concatenated_byte_chunks.append(chunk);
-
-        auto buffer = JS::ArrayBuffer::create(realm, move(concatenated_byte_chunks));
+    auto success_steps = [promise, &realm](ByteBuffer bytes) {
+        auto buffer = JS::ArrayBuffer::create(realm, move(bytes));
         WebIDL::resolve_promise(realm, promise, buffer);
     };
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -107,7 +107,7 @@ void ReadLoopReadRequest::on_chunk(JS::Value chunk)
 void ReadLoopReadRequest::on_close()
 {
     // 1. Call successSteps with bytes.
-    m_success_steps(m_bytes);
+    m_success_steps(move(m_bytes));
 }
 
 // error steps, given e

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -42,7 +42,10 @@ public:
     // failureSteps, which is an algorithm accepting a JavaScript value
     using FailureSteps = JS::SafeFunction<void(JS::Value error)>;
 
-    ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, SuccessSteps success_steps, FailureSteps failure_steps);
+    // AD-HOC: callback triggered on every chunk received from the stream.
+    using ChunkSteps = JS::SafeFunction<void(ByteBuffer)>;
+
+    ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, SuccessSteps success_steps, FailureSteps failure_steps, ChunkSteps chunk_steps = {});
 
     virtual void on_chunk(JS::Value chunk) override;
 
@@ -59,6 +62,7 @@ private:
     Vector<ByteBuffer> m_byte_chunks;
     SuccessSteps m_success_steps;
     FailureSteps m_failure_steps;
+    ChunkSteps m_chunk_steps;
 };
 
 // https://streams.spec.whatwg.org/#readablestreamdefaultreader
@@ -76,6 +80,7 @@ public:
     JS::NonnullGCPtr<JS::Promise> read();
 
     void read_all_bytes(ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
+    void read_all_chunks(ReadLoopReadRequest::ChunkSteps, ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
     JS::NonnullGCPtr<WebIDL::Promise> read_all_bytes_deprecated();
 
     void release_lock();

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -37,7 +37,7 @@ class ReadLoopReadRequest final : public ReadRequest {
 
 public:
     // successSteps, which is an algorithm accepting a byte sequence
-    using SuccessSteps = JS::SafeFunction<void(Vector<ByteBuffer> const&)>;
+    using SuccessSteps = JS::SafeFunction<void(ByteBuffer)>;
 
     // failureSteps, which is an algorithm accepting a JavaScript value
     using FailureSteps = JS::SafeFunction<void(JS::Value error)>;
@@ -59,7 +59,7 @@ private:
     JS::VM& m_vm;
     JS::NonnullGCPtr<JS::Realm> m_realm;
     JS::NonnullGCPtr<ReadableStreamDefaultReader> m_reader;
-    Vector<ByteBuffer> m_byte_chunks;
+    ByteBuffer m_bytes;
     SuccessSteps m_success_steps;
     FailureSteps m_failure_steps;
     ChunkSteps m_chunk_steps;


### PR DESCRIPTION
Ref https://github.com/SerenityOS/serenity/pull/24132#issuecomment-2086477483

These patches were done as part of making fetch use streams to read response bodies. That ultimately has some issues to be worked out, but in the meantime, this affords some cleanup that aligns us back closer to the spec.
