### PR TITLE
LibJS: Merge CallFrame into ExecutionContext

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -647,7 +647,7 @@ inline ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM& vm, Value supe
 
     // NOTE: NewClass expects classEnv to be active lexical environment
     auto* class_environment = vm.lexical_environment();
-    vm.running_execution_context().lexical_environment = interpreter.saved_lexical_environment_stack().take_last();
+    vm.running_execution_context().lexical_environment = vm.running_execution_context().saved_lexical_environments.take_last();
 
     Optional<DeprecatedFlyString> binding_name;
     DeprecatedFlyString class_name;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -106,18 +106,6 @@ static ByteString format_value_list(StringView name, ReadonlySpan<Value> values)
     return builder.to_byte_string();
 }
 
-NonnullOwnPtr<CallFrame> CallFrame::create(size_t register_count)
-{
-    size_t allocation_size = sizeof(CallFrame) + sizeof(Value) * register_count;
-    auto* memory = malloc(allocation_size);
-    VERIFY(memory);
-    auto call_frame = adopt_own(*new (memory) CallFrame);
-    call_frame->register_count = register_count;
-    for (auto i = 0u; i < register_count; ++i)
-        new (&call_frame->register_values[i]) Value();
-    return call_frame;
-}
-
 ALWAYS_INLINE static ThrowCompletionOr<Value> loosely_inequals(VM& vm, Value src1, Value src2)
 {
     if (src1.tag() == src2.tag()) {
@@ -161,13 +149,6 @@ Interpreter::Interpreter(VM& vm)
 
 Interpreter::~Interpreter()
 {
-}
-
-void Interpreter::visit_edges(Cell::Visitor& visitor)
-{
-    for (auto& frame : m_call_frames) {
-        frame.visit([&](auto& value) { value->visit_edges(visitor); });
-    }
 }
 
 ALWAYS_INLINE Value Interpreter::get(Operand op) const
@@ -263,11 +244,11 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Envir
                 executable->dump();
 
             // a. Set result to the result of evaluating script.
-            auto result_or_error = run_and_return_frame(*executable, nullptr);
+            auto result_or_error = run_executable(*executable, nullptr);
             if (result_or_error.value.is_error())
                 result = result_or_error.value.release_error();
             else
-                result = result_or_error.frame->registers()[0];
+                result = result_or_error.return_register_value;
         }
     }
 
@@ -384,7 +365,8 @@ void Interpreter::run_bytecode()
                     do_return(saved_return_value());
                     break;
                 }
-                auto const* old_scheduled_jump = call_frame().previously_scheduled_jumps.take_last();
+                auto& running_execution_context = vm().running_execution_context();
+                auto const* old_scheduled_jump = running_execution_context.previously_scheduled_jumps.take_last();
                 if (m_scheduled_jump) {
                     // FIXME: If we `break` or `continue` in the finally, we need to clear
                     //        this field
@@ -418,7 +400,8 @@ void Interpreter::run_bytecode()
                 if (!handler && !finalizer)
                     return;
 
-                auto& unwind_context = unwind_contexts().last();
+                auto& running_execution_context = vm().running_execution_context();
+                auto& unwind_context = running_execution_context.unwind_contexts.last();
                 VERIFY(unwind_context.executable == m_current_executable);
 
                 if (handler) {
@@ -453,7 +436,8 @@ void Interpreter::run_bytecode()
         }
 
         if (auto const* finalizer = m_current_block->finalizer(); finalizer && !will_yield) {
-            auto& unwind_context = unwind_contexts().last();
+            auto& running_execution_context = vm().running_execution_context();
+            auto& unwind_context = running_execution_context.unwind_contexts.last();
             VERIFY(unwind_context.executable == m_current_executable);
             reg(Register::saved_return_value()) = reg(Register::return_value());
             reg(Register::return_value()) = {};
@@ -470,7 +454,7 @@ void Interpreter::run_bytecode()
     }
 }
 
-Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executable, BasicBlock const* entry_point, CallFrame* in_frame)
+Interpreter::ResultAndReturnRegister Interpreter::run_executable(Executable& executable, BasicBlock const* entry_point)
 {
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {:p}", &executable);
 
@@ -484,12 +468,13 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executa
 
     TemporaryChange restore_current_block { m_current_block, entry_point ?: executable.basic_blocks.first() };
 
-    if (in_frame)
-        push_call_frame(in_frame);
-    else
-        push_call_frame(CallFrame::create(executable.number_of_registers));
+    auto& running_execution_context = vm().running_execution_context();
+    if (running_execution_context.registers.size() < executable.number_of_registers)
+        running_execution_context.registers.resize(executable.number_of_registers);
 
-    vm().execution_context_stack().last()->executable = &executable;
+    reg(Register::return_value()) = {};
+
+    running_execution_context.executable = &executable;
 
     run_bytecode();
 
@@ -513,48 +498,39 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executa
         return_value = reg(Register::saved_return_value());
     auto exception = reg(Register::exception());
 
-    auto frame = pop_call_frame();
-
-    // NOTE: The return value from a called function is put into $0 in the caller context.
-    if (!m_call_frames.is_empty())
-        call_frame().registers()[0] = return_value;
-
     // At this point we may have already run any queued promise jobs via on_call_stack_emptied,
     // in which case this is a no-op.
     vm().run_queued_promise_jobs();
 
     vm().finish_execution_generation();
 
-    if (!exception.is_empty()) {
-        if (auto* call_frame = frame.get_pointer<NonnullOwnPtr<CallFrame>>())
-            return { throw_completion(exception), move(*call_frame) };
-        return { throw_completion(exception), nullptr };
-    }
-
-    if (auto* call_frame = frame.get_pointer<NonnullOwnPtr<CallFrame>>())
-        return { return_value, move(*call_frame) };
-    return { return_value, nullptr };
+    if (!exception.is_empty())
+        return { throw_completion(exception), vm().running_execution_context().registers[0] };
+    return { return_value, vm().running_execution_context().registers[0] };
 }
 
 void Interpreter::enter_unwind_context()
 {
-    unwind_contexts().empend(
+    auto& running_execution_context = vm().running_execution_context();
+    running_execution_context.unwind_contexts.empend(
         m_current_executable,
         vm().running_execution_context().lexical_environment);
-    call_frame().previously_scheduled_jumps.append(m_scheduled_jump);
+    running_execution_context.previously_scheduled_jumps.append(m_scheduled_jump);
     m_scheduled_jump = nullptr;
 }
 
 void Interpreter::leave_unwind_context()
 {
-    unwind_contexts().take_last();
+    auto& running_execution_context = vm().running_execution_context();
+    running_execution_context.unwind_contexts.take_last();
 }
 
 void Interpreter::catch_exception(Operand dst)
 {
     set(dst, reg(Register::exception()));
     reg(Register::exception()) = {};
-    auto& context = unwind_contexts().last();
+    auto& running_execution_context = vm().running_execution_context();
+    auto& context = running_execution_context.unwind_contexts.last();
     VERIFY(!context.handler_called);
     VERIFY(context.executable == &current_executable());
     context.handler_called = true;
@@ -563,9 +539,10 @@ void Interpreter::catch_exception(Operand dst)
 
 void Interpreter::enter_object_environment(Object& object)
 {
-    auto& old_environment = vm().running_execution_context().lexical_environment;
-    saved_lexical_environment_stack().append(old_environment);
-    vm().running_execution_context().lexical_environment = new_object_environment(object, true, old_environment);
+    auto& running_execution_context = vm().running_execution_context();
+    auto& old_environment = running_execution_context.lexical_environment;
+    running_execution_context.saved_lexical_environments.append(old_environment);
+    running_execution_context.lexical_environment = new_object_environment(object, true, old_environment);
 }
 
 ThrowCompletionOr<NonnullGCPtr<Bytecode::Executable>> compile(VM& vm, ASTNode const& node, ReadonlySpan<FunctionParameter> parameters, FunctionKind kind, DeprecatedFlyString const& name)
@@ -581,20 +558,6 @@ ThrowCompletionOr<NonnullGCPtr<Bytecode::Executable>> compile(VM& vm, ASTNode co
         bytecode_executable->dump();
 
     return bytecode_executable;
-}
-
-void Interpreter::push_call_frame(Variant<NonnullOwnPtr<CallFrame>, CallFrame*> frame)
-{
-    m_call_frames.append(move(frame));
-    m_current_call_frame = this->call_frame().registers();
-    reg(Register::return_value()) = {};
-}
-
-Variant<NonnullOwnPtr<CallFrame>, CallFrame*> Interpreter::pop_call_frame()
-{
-    auto frame = m_call_frames.take_last();
-    m_current_call_frame = m_call_frames.is_empty() ? Span<Value> {} : this->call_frame().registers();
-    return frame;
 }
 
 }
@@ -1039,7 +1002,8 @@ ThrowCompletionOr<void> CreateLexicalEnvironment::execute_impl(Bytecode::Interpr
         swap(old_environment, environment);
         return environment;
     };
-    interpreter.saved_lexical_environment_stack().append(make_and_swap_envs(interpreter.vm().running_execution_context().lexical_environment));
+    auto& running_execution_context = interpreter.vm().running_execution_context();
+    running_execution_context.saved_lexical_environments.append(make_and_swap_envs(running_execution_context.lexical_environment));
     return {};
 }
 
@@ -1453,7 +1417,8 @@ ThrowCompletionOr<void> ScheduleJump::execute_impl(Bytecode::Interpreter&) const
 
 ThrowCompletionOr<void> LeaveLexicalEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.vm().running_execution_context().lexical_environment = interpreter.saved_lexical_environment_stack().take_last();
+    auto& running_execution_context = interpreter.vm().running_execution_context();
+    running_execution_context.lexical_environment = running_execution_context.saved_lexical_environments.take_last();
     return {};
 }
 
@@ -1643,9 +1608,10 @@ ThrowCompletionOr<void> BlockDeclarationInstantiation::execute_impl(Bytecode::In
 {
     auto& vm = interpreter.vm();
     auto old_environment = vm.running_execution_context().lexical_environment;
-    interpreter.saved_lexical_environment_stack().append(old_environment);
-    vm.running_execution_context().lexical_environment = new_declarative_environment(*old_environment);
-    m_scope_node.block_declaration_instantiation(vm, vm.running_execution_context().lexical_environment);
+    auto& running_execution_context = vm.running_execution_context();
+    running_execution_context.saved_lexical_environments.append(old_environment);
+    running_execution_context.lexical_environment = new_declarative_environment(*old_environment);
+    m_scope_node.block_declaration_instantiation(vm, running_execution_context.lexical_environment);
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -19,31 +19,6 @@ namespace JS::Bytecode {
 
 class InstructionStreamIterator;
 
-struct CallFrame {
-    static NonnullOwnPtr<CallFrame> create(size_t register_count);
-
-    void operator delete(void* ptr) { free(ptr); }
-
-    void visit_edges(Cell::Visitor& visitor)
-    {
-        visitor.visit(registers());
-        visitor.visit(saved_lexical_environments);
-        for (auto& context : unwind_contexts) {
-            visitor.visit(context.lexical_environment);
-        }
-    }
-
-    Vector<GCPtr<Environment>> saved_lexical_environments;
-    Vector<UnwindInfo> unwind_contexts;
-    Vector<BasicBlock const*> previously_scheduled_jumps;
-
-    Span<Value> registers() { return { register_values, register_count }; }
-    ReadonlySpan<Value> registers() const { return { register_values, register_count }; }
-
-    size_t register_count { 0 };
-    Value register_values[];
-};
-
 class Interpreter {
 public:
     explicit Interpreter(VM&);
@@ -60,26 +35,29 @@ public:
 
     ThrowCompletionOr<Value> run(Bytecode::Executable& executable, Bytecode::BasicBlock const* entry_point = nullptr)
     {
-        auto value_and_frame = run_and_return_frame(executable, entry_point);
-        return move(value_and_frame.value);
+        auto result_and_return_register = run_executable(executable, entry_point);
+        return move(result_and_return_register.value);
     }
 
-    struct ValueAndFrame {
+    struct ResultAndReturnRegister {
         ThrowCompletionOr<Value> value;
-        OwnPtr<CallFrame> frame;
+        Value return_register_value;
     };
-    ValueAndFrame run_and_return_frame(Bytecode::Executable&, Bytecode::BasicBlock const* entry_point, CallFrame* = nullptr);
+    ResultAndReturnRegister run_executable(Bytecode::Executable&, Bytecode::BasicBlock const* entry_point);
 
     ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
     ALWAYS_INLINE Value& saved_return_value() { return reg(Register::saved_return_value()); }
-    Value& reg(Register const& r) { return registers()[r.index()]; }
-    Value reg(Register const& r) const { return registers()[r.index()]; }
+    Value& reg(Register const& r)
+    {
+        return vm().running_execution_context().registers[r.index()];
+    }
+    Value reg(Register const& r) const
+    {
+        return vm().running_execution_context().registers[r.index()];
+    }
 
     [[nodiscard]] Value get(Operand) const;
     void set(Operand, Value);
-
-    auto& saved_lexical_environment_stack() { return call_frame().saved_lexical_environments; }
-    auto& unwind_contexts() { return call_frame().unwind_contexts; }
 
     void do_return(Value value)
     {
@@ -98,30 +76,13 @@ public:
     BasicBlock const& current_block() const { return *m_current_block; }
     Optional<InstructionStreamIterator const&> instruction_stream_iterator() const { return m_pc; }
 
-    void visit_edges(Cell::Visitor&);
-
-    Span<Value> registers() { return m_current_call_frame; }
-    ReadonlySpan<Value> registers() const { return m_current_call_frame; }
+    Vector<Value>& registers() { return vm().running_execution_context().registers; }
+    Vector<Value> const& registers() const { return vm().running_execution_context().registers; }
 
 private:
     void run_bytecode();
 
-    CallFrame& call_frame()
-    {
-        return m_call_frames.last().visit([](auto& x) -> CallFrame& { return *x; });
-    }
-
-    CallFrame const& call_frame() const
-    {
-        return const_cast<Interpreter*>(this)->call_frame();
-    }
-
-    void push_call_frame(Variant<NonnullOwnPtr<CallFrame>, CallFrame*>);
-    [[nodiscard]] Variant<NonnullOwnPtr<CallFrame>, CallFrame*> pop_call_frame();
-
     VM& m_vm;
-    Vector<Variant<NonnullOwnPtr<CallFrame>, CallFrame*>> m_call_frames;
-    Span<Value> m_current_call_frame;
     BasicBlock const* m_scheduled_jump { nullptr };
     GCPtr<Executable> m_current_executable { nullptr };
     BasicBlock const* m_current_block { nullptr };

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -259,7 +259,6 @@ AK::JsonObject Heap::dump_graph()
     HashMap<Cell*, HeapRoot> roots;
     gather_roots(roots);
     GraphConstructorVisitor visitor(*this, roots);
-    vm().bytecode_interpreter().visit_edges(visitor);
     visitor.visit_all_cells();
     return visitor.dump();
 }
@@ -456,8 +455,6 @@ void Heap::mark_live_cells(HashMap<Cell*, HeapRoot> const& roots)
     dbgln_if(HEAP_DEBUG, "mark_live_cells:");
 
     MarkingVisitor visitor(*this, roots);
-
-    vm().bytecode_interpreter().visit_edges(visitor);
 
     visitor.mark_all_live_cells();
 

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -693,11 +693,11 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
     executable->name = "eval"sv;
     if (Bytecode::g_dump_bytecode)
         executable->dump();
-    auto result_or_error = vm.bytecode_interpreter().run_and_return_frame(*executable, nullptr);
+    auto result_or_error = vm.bytecode_interpreter().run_executable(*executable, nullptr);
     if (result_or_error.value.is_error())
         return result_or_error.value.release_error();
 
-    auto& result = result_or_error.frame->registers()[0];
+    auto& result = result_or_error.return_register_value;
     if (!result.is_empty())
         eval_result = result;
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -28,7 +28,7 @@ public:
         Completed,
     };
 
-    static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, NonnullOwnPtr<Bytecode::CallFrame>);
+    static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>);
 
     virtual ~AsyncGenerator() override = default;
 
@@ -60,7 +60,6 @@ private:
 
     GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;
-    OwnPtr<Bytecode::CallFrame> m_frame;
     GCPtr<Promise> m_current_promise;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -43,6 +43,10 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
     copy->executable = executable;
     copy->arguments = arguments;
     copy->locals = locals;
+    copy->registers = registers;
+    copy->unwind_contexts = unwind_contexts;
+    copy->saved_lexical_environments = saved_lexical_environments;
+    copy->previously_scheduled_jumps = previously_scheduled_jumps;
     return copy;
 }
 
@@ -61,6 +65,11 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(function_name);
     visitor.visit(arguments);
     visitor.visit(locals);
+    visitor.visit(registers);
+    for (auto& context : unwind_contexts) {
+        visitor.visit(context.lexical_environment);
+    }
+    visitor.visit(saved_lexical_environments);
     script_or_module.visit(
         [](Empty) {},
         [&](auto& script_or_module) {

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -10,6 +10,7 @@
 
 #include <AK/DeprecatedFlyString.h>
 #include <AK/WeakPtr.h>
+#include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Module.h>
@@ -75,6 +76,10 @@ public:
 
     Vector<Value> arguments;
     Vector<Value> locals;
+    Vector<Value> registers;
+    Vector<Bytecode::UnwindInfo> unwind_contexts;
+    Vector<Bytecode::BasicBlock const*> previously_scheduled_jumps;
+    Vector<GCPtr<Environment>> saved_lexical_environments;
 };
 
 struct StackTraceElement {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -17,7 +17,7 @@ class GeneratorObject : public Object {
     JS_DECLARE_ALLOCATOR(GeneratorObject);
 
 public:
-    static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, NonnullOwnPtr<Bytecode::CallFrame>);
+    static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>);
     virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
 
@@ -43,7 +43,6 @@ private:
     NonnullOwnPtr<ExecutionContext> m_execution_context;
     GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;
-    OwnPtr<Bytecode::CallFrame> m_frame;
     GeneratorState m_generator_state { GeneratorState::SuspendedStart };
     Optional<StringView> m_generator_brand;
 };

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -180,12 +180,12 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
         else {
             auto executable = maybe_executable.release_value();
 
-            auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(*executable, nullptr);
-            if (value_and_frame.value.is_error()) {
-                result = value_and_frame.value.release_error();
+            auto result_and_return_register = vm.bytecode_interpreter().run_executable(*executable, nullptr);
+            if (result_and_return_register.value.is_error()) {
+                result = result_and_return_register.value.release_error();
             } else {
                 // Resulting value is in the accumulator.
-                result = value_and_frame.frame->registers()[0].value_or(js_undefined());
+                result = result_and_return_register.return_register_value.value_or(js_undefined());
             }
         }
     }

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -717,12 +717,12 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
         else {
             auto executable = maybe_executable.release_value();
 
-            auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(*executable, nullptr);
-            if (value_and_frame.value.is_error()) {
-                result = value_and_frame.value.release_error();
+            auto result_and_return_register = vm.bytecode_interpreter().run_executable(*executable, nullptr);
+            if (result_and_return_register.value.is_error()) {
+                result = result_and_return_register.value.release_error();
             } else {
                 // Resulting value is in the accumulator.
-                result = value_and_frame.frame->registers()[0].value_or(js_undefined());
+                result = result_and_return_register.return_register_value.value_or(js_undefined());
             }
         }
 


### PR DESCRIPTION
Before this change both ExecutionContext and CallFrame were created before executing function/module/script with a couple exceptions:
- executable created for default function argument evaluation has to run in function's execution context.
- `execute_ast_node()` where executable compiled for ASTNode has to be executed in running execution context.

This change moves all members previously owned by CallFrame into ExecutionContext, and makes two exceptions where an executable that does not have a corresponding execution context saves and restores registers before running.

Now, all execution state lives in a single entity, which makes it a bit easier to reason about and opens opportunities for optimizations, such as moving registers and local variables into a single array.