### PR TITLE
Kernel+DynamicLoader: Allow syscalls from dynamic loader more often

### DIFF
--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -102,6 +102,9 @@ public:
         m_mmapped_from_writable = description_was_writable;
     }
 
+    [[nodiscard]] bool is_initially_loaded_executable_segment() const { return m_initially_loaded_executable_segment.was_set(); }
+    void set_initially_loaded_executable_segment() { m_initially_loaded_executable_segment.set(); }
+
     [[nodiscard]] bool is_write_combine() const { return m_write_combine; }
     ErrorOr<void> set_write_combine(bool);
 
@@ -250,6 +253,7 @@ private:
     bool m_mmapped_from_writable : 1 { false };
 
     SetOnce m_immutable;
+    SetOnce m_initially_loaded_executable_segment;
 
     IntrusiveRedBlackTreeNode<FlatPtr, Region, RawPtr<Region>> m_tree_node;
     IntrusiveListNode<Region> m_vmobject_list_node;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -347,6 +347,8 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
         size_t rounded_range_end = TRY(Memory::page_round_up(program_header.vaddr().offset(load_offset).offset(program_header.size_in_memory()).get()));
         auto range_end = VirtualAddress { rounded_range_end };
         auto region = TRY(new_space.allocate_region_with_vmobject(Memory::RandomizeVirtualAddress::Yes, range_base, range_end.get() - range_base.get(), program_header.alignment(), *vmobject, program_header.offset(), elf_name->view(), prot, true));
+        if (program_header.is_executable())
+            region->set_initially_loaded_executable_segment();
 
         if (should_allow_syscalls == ShouldAllowSyscalls::Yes)
             region->set_syscall_region(true);

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -542,7 +542,7 @@ ErrorOr<FlatPtr> Process::sys$annotate_mapping(Userspace<void*> address, int fla
         if (!region)
             return EINVAL;
 
-        if (!region->is_mmap())
+        if (!region->is_mmap() && !region->is_initially_loaded_executable_segment())
             return EINVAL;
         if (region->is_immutable())
             return EPERM;


### PR DESCRIPTION
Previously, if DynamicLoader were invoked directly, it wasn't able to perform syscalls after the point just before the call to the main executable entry. This made dlopen to crash if it were called from within an executable that was itself executed using `/usr/lib/Loader.so <executable>`.