### PR TITLE
LibWeb: Use GCPtr for Element::layout_node

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -917,7 +917,7 @@ Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
     if (!body_element)
         return {};
 
-    auto* body_layout_node = body_element->layout_node();
+    auto body_layout_node = body_element->layout_node();
     if (!body_layout_node)
         return {};
 
@@ -1003,7 +1003,7 @@ static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewpo
     // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
     // UAs must apply the overflow-* values set on the root element to the viewport
     // when the root element’s display value is not none.
-    auto* overflow_origin_node = root_element.layout_node();
+    auto overflow_origin_node = root_element.layout_node();
     auto& viewport_computed_values = viewport.mutable_computed_values();
 
     // However, when the root element is an [HTML] html element (including XML syntax for HTML)
@@ -1011,7 +1011,7 @@ static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewpo
     // a body element whose display value is also not none,
     // user agents must instead apply the overflow-* values of the first such child element to the viewport.
     if (root_element.is_html_html_element()) {
-        auto* root_element_layout_node = root_element.layout_node();
+        auto root_element_layout_node = root_element.layout_node();
         auto& root_element_computed_values = root_element_layout_node->mutable_computed_values();
         if (root_element_computed_values.overflow_x() == CSS::Overflow::Visible && root_element_computed_values.overflow_y() == CSS::Overflow::Visible) {
             auto* body_element = root_element.first_child_of_type<HTML::HTMLBodyElement>();

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2070,12 +2070,12 @@ void Element::for_each_attribute(Function<void(FlyString const&, String const&)>
     });
 }
 
-Layout::NodeWithStyle* Element::layout_node()
+JS::GCPtr<Layout::NodeWithStyle> Element::layout_node()
 {
     return static_cast<Layout::NodeWithStyle*>(Node::layout_node());
 }
 
-Layout::NodeWithStyle const* Element::layout_node() const
+JS::GCPtr<Layout::NodeWithStyle const> Element::layout_node() const
 {
     return static_cast<Layout::NodeWithStyle const*>(Node::layout_node());
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -160,8 +160,8 @@ public:
     Optional<CSS::Selector::PseudoElement::Type> use_pseudo_element() const { return m_use_pseudo_element; }
     void set_use_pseudo_element(Optional<CSS::Selector::PseudoElement::Type> use_pseudo_element) { m_use_pseudo_element = move(use_pseudo_element); }
 
-    Layout::NodeWithStyle* layout_node();
-    Layout::NodeWithStyle const* layout_node() const;
+    JS::GCPtr<Layout::NodeWithStyle> layout_node();
+    JS::GCPtr<Layout::NodeWithStyle const> layout_node() const;
 
     CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -48,7 +48,7 @@ void SVGCircleElement::apply_presentational_hints(CSS::StyleProperties& style) c
 
 Gfx::Path SVGCircleElement::get_path(CSSPixelSize viewport_size)
 {
-    auto* node = layout_node();
+    auto node = layout_node();
     auto cx = float(node->computed_values().cx().to_px(*node, viewport_size.width()));
     auto cy = float(node->computed_values().cy().to_px(*node, viewport_size.height()));
     // Percentages refer to the normalized diagonal of the current SVG viewport

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -238,7 +238,7 @@ Optional<float> SVGGraphicsElement::stroke_width() const
     CSSPixels viewport_width = 0;
     CSSPixels viewport_height = 0;
     if (auto* svg_svg_element = shadow_including_first_ancestor_of_type<SVGSVGElement>()) {
-        if (auto* svg_svg_layout_node = svg_svg_element->layout_node()) {
+        if (auto svg_svg_layout_node = svg_svg_element->layout_node()) {
             viewport_width = svg_svg_layout_node->computed_values().width().to_px(*svg_svg_layout_node, 0);
             viewport_height = svg_svg_layout_node->computed_values().height().to_px(*svg_svg_layout_node, 0);
         }


### PR DESCRIPTION
This improves debuggability by converting a SIGSEGV into a verification failed on a null dereference.

edit: feels worthwhile as I've run into this one a bunch! latest ref: https://github.com/SerenityOS/serenity/issues/24186