### PR TITLE
CI: Use common cache restore and cache save action on GitHub Actions

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -54,19 +54,18 @@ runs:
       id: 'toolchain-stamp'
       if: ${{ inputs.arch != 'Lagom' }}
       run: |
-        if [[ ${{ inputs.toolchain }} == 'clang' ]]; then
-          hashed_files='${{ hashFiles('Toolchain/BuildClang.sh', 'Toolchain/Patches/llvm/*.patch', 'Toolchain/CMake/*.cmake', 'Userland/Libraries/LibC/**/*.h') }}
+        if [[ ${{ inputs.toolchain  == 'clang' }} ]]; then
+          hashed_files='${{ hashFiles('Toolchain/BuildClang.sh', 'Toolchain/Patches/llvm/*.patch', 'Toolchain/CMake/*.cmake', 'Userland/Libraries/LibC/**/*.h') }}'
           echo "toolchain_stamp=${hashed_files}" >> "$GITHUB_OUTPUT"
           source $GITHUB_WORKSPACE/Ports/llvm/package.sh
           echo "toolchain_version=$(echo ${version} | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
           echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/clang" >> "$GITHUB_OUTPUT"
-        elif [[ ${{ inputs.toolchain }} == 'gcc' ]]; then
-          hashed_files='${{ hashFiles('Toolchain/BuildGNU.sh', 'Toolchain/Patches/binutils/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Userland/Libraries/LibC/**/*.h') }}
+        elif [[ ${{ inputs.toolchain == 'gcc' }} ]]; then
+          hashed_files='${{ hashFiles('Toolchain/BuildGNU.sh', 'Toolchain/Patches/binutils/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Userland/Libraries/LibC/**/*.h') }}'
           echo "toolchain_stamp=$hashed_files" >> $GITHUB_OUTPUT
           source $GITHUB_WORKSPACE/Ports/gcc/package.sh
           echo "toolchain_version=$(echo ${version} | cut -d'.' -f1)" >> $GITHUB_OUTPUT
           echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
         fi
 
     - name: 'Test Outputs'

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -62,11 +62,19 @@ runs:
           echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/clang" >> "$GITHUB_OUTPUT"
         elif [[ ${{ inputs.toolchain }} == 'gcc' ]]; then
           hashed_files='${{ hashFiles('Toolchain/BuildGNU.sh', 'Toolchain/Patches/binutils/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Userland/Libraries/LibC/**/*.h') }}
-          echo "toolchain_stamp=${hashed_files}" >> "$GITHUB_OUTPUT"
+          echo "toolchain_stamp=$hashed_files" >> $GITHUB_OUTPUT
           source $GITHUB_WORKSPACE/Ports/gcc/package.sh
-          echo "toolchain_version=$(echo ${version} | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
-          echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}" >> "$GITHUB_OUTPUT"
+          echo "toolchain_version=$(echo ${version} | cut -d'.' -f1)" >> $GITHUB_OUTPUT
+          echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
         fi
+
+    - name: 'Test Outputs'
+      shell: bash
+      run: |
+        echo "toolchain_stamp=${{ steps.toolchain-stamp.outputs.toolchain_stamp }}"
+        echo "toolchain_version=${{ steps.toolchain-stamp.outputs.toolchain_version }}"
+        echo "toolchain_path=${{ steps.toolchain-stamp.outputs.toolchain_path }}"
 
     - name: 'Toolchain Prebuilt Cache'
       uses: actions/cache/restore@v4

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -38,9 +38,29 @@ inputs:
     description: 'Path to the download cache directory'
     required: false
     default: 'caches'
-
+outputs:
+  toolchain_cache_primary_key:
+    description: 'Primary key for the toolchain cache'
+    value: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
+  toolchain_cache_hit:
+    description: 'Whether the toolchain cache was hit'
+    value: ${{ steps.toolchain-cache.outputs.cache-hit }}
+  toolchain_cache_path:
+    description: 'Path to the cached toolchain'
+    value: ${{ steps.toolchain-stamp.outputs.toolchain_path }}
+  qemu_cache_primary_key:
+    description: 'Primary key for the AArch64 QEMU cache'
+    value: ${{ steps.qemu-cache.outputs.cache-primary-key }}
+  qemu_cache_hit:
+    description: 'Whether the AArch64 QEMU cache was hit'
+    value: ${{ steps.qemu-cache.outputs.cache-hit }}
+  serenity_ccache_primary_key:
+    description: 'Primary key for the Serenity ccache'
+    value: ${{ steps.serenity-ccache.outputs.cache-primary-key }}
+  toolchain_ccache_primary_key:
+    description: 'Primary key for the Toolchain ccache'
+    value: ${{ steps.toolchain-ccache.outputs.cache-hit }}
 runs:
-
   using: "composite"
   steps:
     - name: 'Date Stamp'
@@ -125,10 +145,10 @@ runs:
       shell: bash
       run: |
           CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -M 0
-        
+
           # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
           find ${{ inputs.serenity_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
-        
+
           CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -s
           CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -z
 
@@ -136,7 +156,7 @@ runs:
       uses: actions/cache@v4
       if: ${{ inputs.with_remote_data_caches == 'true' }}
       with:
-        path: ${{ github.workspace }}/Build/${{ inputs.download_cache_path }}/TZDB
+        path: ${{ inputs.download_cache_path }}/TZDB
         key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
         restore-keys: |
           TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
@@ -145,7 +165,7 @@ runs:
       uses: actions/cache@v4
       if: ${{ inputs.with_remote_data_caches == 'true' }}
       with:
-          path: ${{ github.workspace }}/Build/${{ inputs.download_cache_path }}/UCD
+          path: ${{ inputs.download_cache_path }}/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
           restore-keys: |
             UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
@@ -154,7 +174,7 @@ runs:
       uses: actions/cache@v4
       if: ${{ inputs.with_remote_data_caches == 'true' }}
       with:
-          path: ${{ github.workspace }}/Build/${{ inputs.download_cache_path }}/CLDR
+          path: ${{ inputs.download_cache_path }}/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
           restore-keys: |
               UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -1,0 +1,153 @@
+name: 'Cache Restore action'
+description: 'Restores caches of downloaded files and build artifacts.'
+author: 'Andrew Kaster <akaster@serenityos.org>'
+inputs:
+  os:
+    description: 'Operating System to restore caches for'
+    required: true
+    default: 'Linux'
+  arch:
+    description: 'Target Architecture to restore caches for'
+    required: false
+    default: 'x86_64'
+  toolchain:
+    description: 'Toolchain to restore caches for'
+    required: false
+    default: 'gcc'
+  cache_key_extra:
+    description: 'Code coverage setting, ON or OFF, or debug setting, ALL or NORMAL'
+    required: false
+    default: 'OFF'
+  ccache_version:
+    description: 'Increment this number if CI has trouble with ccache.'
+    required: false
+    default: '0'
+  serenity_ccache_path:
+    description: 'Path to the SerenityOS ccache directory'
+    required: false
+    default: ''
+  toolchain_ccache_path:
+    description: 'Path to the toolchain ccache directory'
+    required: false
+    default: ''
+  with_remote_data_caches:
+    description: 'Whether to use remote data caches'
+    required: false
+    default: 'true'
+  download_cache_path:
+    description: 'Path to the download cache directory'
+    required: false
+    default: 'caches'
+
+runs:
+
+  using: "composite"
+  steps:
+    - name: 'Date Stamp'
+      shell: bash
+      id: 'date-stamp'
+      run: |
+        echo "timestamp=$(date -u "+%Y%m%d%H%M_%S")" >> "$GITHUB_OUTPUT"
+
+    - name: 'Toolchain Prebuilt Cache Stamp'
+      shell: bash
+      id: 'toolchain-stamp'
+      if: ${{ inputs.arch != 'Lagom' }}
+      run: |
+        if [[ ${{ inputs.toolchain }} == 'clang' ]]; then
+          hashed_files='${{ hashFiles('Toolchain/BuildClang.sh', 'Toolchain/Patches/llvm/*.patch', 'Toolchain/CMake/*.cmake', 'Userland/Libraries/LibC/**/*.h') }}
+          echo "toolchain_stamp=${hashed_files}" >> "$GITHUB_OUTPUT"
+          source $GITHUB_WORKSPACE/Ports/llvm/package.sh
+          echo "toolchain_version=$(echo ${version} | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
+          echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/clang" >> "$GITHUB_OUTPUT"
+        elif [[ ${{ inputs.toolchain }} == 'gcc' ]]; then
+          hashed_files='${{ hashFiles('Toolchain/BuildGNU.sh', 'Toolchain/Patches/binutils/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Userland/Libraries/LibC/**/*.h') }}
+          echo "toolchain_stamp=${hashed_files}" >> "$GITHUB_OUTPUT"
+          source $GITHUB_WORKSPACE/Ports/gcc/package.sh
+          echo "toolchain_version=$(echo ${version} | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
+          echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: 'Toolchain Prebuilt Cache'
+      uses: actions/cache/restore@v4
+      id: 'toolchain-cache'
+      if: ${{ inputs.arch != 'Lagom' }}
+      with:
+        path: ${{ steps.toolchain-stamp.outputs.toolchain_path }}
+        key: '"toolchain" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ steps.toolchain-stamp.outputs.toolchain_stamp }}"'
+
+    # FIXME: Remove manually built QEMU when we bump QEMU to >=8.1.x
+    - name: 'AArch64 QEMU Cache'
+      id: 'qemu-cache'
+      uses: actions/cache/restore@v4
+      if: ${{ inputs.arch == 'aarch64' }}
+      with:
+        path: ${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}/qemu
+        key: ${{ runner.os }}-qemu-${{ hashFiles('Ports/qemu/version.sh', 'Toolchain/BuildQemu.sh') }}
+
+    - name: 'Toolchain Compiler Cache'
+      uses: actions/cache/restore@v4
+      id: 'toolchain-ccache'
+      if: ${{ inputs.toolchain_ccache_path != '' }}
+      with:
+          path: ${{ inputs.toolchain_ccache_path }}
+          key: '"toolchain ccache" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ steps.toolchain-stamp.outputs.toolchain_version }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
+          restore-keys: |
+            "toolchain ccache" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ steps.toolchain-stamp.outputs.toolchain_version }}" | "${{ inputs.ccache_version }}"
+
+    - name: 'Configure Toolchain ccache'
+      if: ${{ inputs.toolchain_ccache_path != '' }}
+      shell: bash
+      run: |
+          CCACHE_DIR=${{ inputs.toolchain_ccache_path }} ccache -M 0
+          CCACHE_DIR=${{ inputs.toolchain_ccache_path }} ccache -s
+          CCACHE_DIR=${{ inputs.toolchain_ccache_path }} ccache -z
+
+    - name: 'Serenity Compiler Cache'
+      uses: actions/cache/restore@v4
+      id: 'serenity-ccache'
+      if: ${{ inputs.serenity_ccache_path != '' }}
+      with:
+          path: ${{ inputs.serenity_ccache_path }}
+          key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
+          restore-keys: |
+              "ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
+
+    - name: 'Configure Serenity ccache'
+      if: ${{ inputs.serenity_ccache_path != '' }}
+      shell: bash
+      run: |
+          CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -M 0
+        
+          # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
+          find ${{ inputs.serenity_ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
+        
+          CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -s
+          CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -z
+
+    - name: 'TimeZoneData cache'
+      uses: actions/cache@v4
+      if: ${{ inputs.with_remote_data_caches == 'true' }}
+      with:
+        path: ${{ github.workspace }}/Build/${{ inputs.download_cache_path }}/TZDB
+        key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
+        restore-keys: |
+          TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
+
+    - name: 'UnicodeData cache'
+      uses: actions/cache@v4
+      if: ${{ inputs.with_remote_data_caches == 'true' }}
+      with:
+          path: ${{ github.workspace }}/Build/${{ inputs.download_cache_path }}/UCD
+          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
+          restore-keys: |
+            UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
+
+    - name: 'UnicodeLocale cache'
+      uses: actions/cache@v4
+      if: ${{ inputs.with_remote_data_caches == 'true' }}
+      with:
+          path: ${{ github.workspace }}/Build/${{ inputs.download_cache_path }}/CLDR
+          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
+          restore-keys: |
+              UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -88,13 +88,6 @@ runs:
           echo "toolchain_path=${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}" >> $GITHUB_OUTPUT
         fi
 
-    - name: 'Test Outputs'
-      shell: bash
-      run: |
-        echo "toolchain_stamp=${{ steps.toolchain-stamp.outputs.toolchain_stamp }}"
-        echo "toolchain_version=${{ steps.toolchain-stamp.outputs.toolchain_version }}"
-        echo "toolchain_path=${{ steps.toolchain-stamp.outputs.toolchain_path }}"
-
     - name: 'Toolchain Prebuilt Cache'
       uses: actions/cache/restore@v4
       id: 'toolchain-cache'

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -1,0 +1,76 @@
+name: 'Cache Save action'
+description: 'Saves caches of build artifacts.'
+author: 'Andrew Kaster <akaster@serenityos.org>'
+inputs:
+  arch:
+    description: 'Target Architecture to restore caches for'
+    required: false
+    default: 'x86_64'
+  toolchain:
+    description: 'Toolchain to restore caches for'
+    required: false
+    default: 'gcc'
+  serenity_ccache_path:
+    description: 'Path to the SerenityOS ccache directory'
+    required: false
+    default: ''
+  toolchain_ccache_path:
+    description: 'Path to the toolchain ccache directory'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Toolchain Prebuilt Cache'
+      uses: actions/cache/save@v4
+      # Do not waste time and storage space by updating the toolchain cache from a PR,
+      # as it would be discarded after being merged anyway.
+      if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit && inputs.arch != 'Lagom' && inputs.toolchain == 'clang' }}
+      with:
+        path: ${{ github.workspace }}/Toolchain/Local/clang
+        key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
+
+    - name: 'Toolchain Prebuilt Cache'
+      uses: actions/cache/save@v4
+      if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit && inputs.arch != 'Lagom' && inputs.toolchain == 'gcc' }}
+      with:
+        path: ${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}
+        key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
+
+    # FIXME: Remove manually built QEMU when we bump QEMU to >=8.1.x
+    - name: 'AArch64 QEMU Cache'
+      uses: actions/cache/save@v4
+      if: ${{ github.event_name != 'pull_request' && inputs.arch == 'aarch64' && !steps.qemu-cache.outputs.cache-hit }}
+      with:
+        path: ${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}/qemu
+        key: ${{ steps.qemu-cache.outputs.cache-primary-key }}
+
+    - name: 'Toolchain Compiler Cache'
+      uses: actions/cache/save@v4
+      if: ${{ github.event_name != 'pull_request' && inputs.toolchain_ccache_path != '' }}
+      with:
+        path: ${{ inputs.toolchain_ccache_path }}
+        key: ${{ steps.toolchain-ccache.outputs.cache-primary-key }}
+
+    - name: 'Prune obsolete ccache files'
+      shell: bash
+      if: ${{ inputs.serenity_ccache_path != '' }}
+      run: |
+        CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache --evict-older-than=1d
+
+    - name: 'Serenity Compiler Cache'
+      uses: actions/cache/save@v4
+      if: ${{ inputs.serenity_ccache_path != '' }}
+      with:
+        path: ${{ inputs.serenity_ccache_path }}
+        key: ${{ steps.serenity-ccache.outputs.timestamp }}
+        
+    - name: 'Cache Stats'
+      shell: bash
+      run: |
+        echo "Serenity Compiler Cache"
+        CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -s
+        
+        echo "Toolchain Compiler Cache"
+        CCACHE_DIR=${{ inputs.toolchain_ccache_path }} ccache -s

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -19,6 +19,28 @@ inputs:
     required: false
     default: ''
 
+  toolchain_cache_primary_key:
+    description: 'Primary key for the toolchain cache'
+    required: true
+  toolchain_cache_hit:
+    description: 'Whether the toolchain cache was hit'
+    required: true
+  toolchain_cache_path:
+    description: 'Path to the cached toolchain'
+    required: true
+  qemu_cache_primary_key:
+    description: 'Primary key for the AArch64 QEMU cache'
+    required: true
+  qemu_cache_hit:
+    description: 'Whether the AArch64 QEMU cache was hit'
+    required: true
+  serenity_ccache_primary_key:
+    description: 'Primary key for the Serenity ccache'
+    required: true
+  toolchain_ccache_primary_key:
+    description: 'Primary key for the Toolchain ccache'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -26,32 +48,25 @@ runs:
       uses: actions/cache/save@v4
       # Do not waste time and storage space by updating the toolchain cache from a PR,
       # as it would be discarded after being merged anyway.
-      if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit && inputs.arch != 'Lagom' && inputs.toolchain == 'clang' }}
+      if: ${{ github.event_name != 'pull_request' && !inputs.toolchain_cache_hit && inputs.arch != 'Lagom' }}
       with:
-        path: ${{ github.workspace }}/Toolchain/Local/clang
-        key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
-
-    - name: 'Toolchain Prebuilt Cache'
-      uses: actions/cache/save@v4
-      if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit && inputs.arch != 'Lagom' && inputs.toolchain == 'gcc' }}
-      with:
-        path: ${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}
-        key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
+        path: ${{ inputs.toolchain_cache_path }}
+        key: ${{ inputs.toolchain_cache_primary_key }}
 
     # FIXME: Remove manually built QEMU when we bump QEMU to >=8.1.x
     - name: 'AArch64 QEMU Cache'
       uses: actions/cache/save@v4
-      if: ${{ github.event_name != 'pull_request' && inputs.arch == 'aarch64' && !steps.qemu-cache.outputs.cache-hit }}
+      if: ${{ github.event_name != 'pull_request' && inputs.arch == 'aarch64' && !inputs.qemu_cache_hit }}
       with:
         path: ${{ github.workspace }}/Toolchain/Local/${{ inputs.arch }}/qemu
-        key: ${{ steps.qemu-cache.outputs.cache-primary-key }}
+        key: ${{ inputs.qemu_cache_primary_key }}
 
     - name: 'Toolchain Compiler Cache'
       uses: actions/cache/save@v4
       if: ${{ github.event_name != 'pull_request' && inputs.toolchain_ccache_path != '' }}
       with:
         path: ${{ inputs.toolchain_ccache_path }}
-        key: ${{ steps.toolchain-ccache.outputs.cache-primary-key }}
+        key: ${{ inputs.toolchain_ccache_primary_key }}
 
     - name: 'Prune obsolete ccache files'
       shell: bash
@@ -64,13 +79,13 @@ runs:
       if: ${{ inputs.serenity_ccache_path != '' }}
       with:
         path: ${{ inputs.serenity_ccache_path }}
-        key: ${{ steps.serenity-ccache.outputs.timestamp }}
-        
+        key: ${{ inputs.serenity_ccache_primary_key }}
+
     - name: 'Cache Stats'
       shell: bash
       run: |
         echo "Serenity Compiler Cache"
         CCACHE_DIR=${{ inputs.serenity_ccache_path }} ccache -s
-        
+
         echo "Toolchain Compiler Cache"
         CCACHE_DIR=${{ inputs.toolchain_ccache_path }} ccache -s

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Restore Caches
         uses: ./.github/actions/cache-restore
+        id: 'cache-restore'
         with:
           os: 'Serenity'
           arch: ${{ matrix.arch }}
@@ -167,5 +168,12 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           toolchain: 'gcc'
-          serenity_ccache_path: ${{ github.workspace }}/.ccache
-          toolchain_ccache_path: ${{ github.workspace }}/Toolchain/.ccache
+          serenity_ccache_path: ${{ env.SERENITY_CCACHE_DIR }}
+          toolchain_ccache_path: ${{ env.TOOLCHAIN_CCACHE_DIR }}
+          toolchain_cache_primary_key: ${{ steps.cache-restore.outputs.toolchain_cache_primary_key }}
+          toolchain_cache_hit: ${{ steps.cache-restore.outputs.toolchain_cache_hit }}
+          toolchain_cache_path: ${{ steps.cache-restore.outputs.toolchain_cache_path }}
+          qemu_cache_primary_key: ${{ steps.cache-restore.outputs.qemu_cache_primary_key }}
+          qemu_cache_hit: ${{ steps.cache-restore.outputs.qemu_cache_hit }}
+          serenity_ccache_primary_key: ${{ steps.cache-restore.outputs.serenity_ccache_primary_key }}
+          toolchain_ccache_primary_key: ${{ steps.cache-restore.outputs.toolchain_ccache_primary_key }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,8 @@ env:
   # runner.workspace = /home/runner/work/serenity
   # github.workspace = /home/runner/work/serenity/serenity
   SERENITY_SOURCE_DIR: ${{ github.workspace }}
-  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  SERENITY_CCACHE_DIR: ${{ github.workspace }}/.ccache
+  TOOLCHAIN_CCACHE_DIR: ${{ github.workspace }}/Toolchain/.ccache
 
 concurrency:
   group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
@@ -52,107 +53,31 @@ jobs:
 
       - name: Lint (Phase 1/2)
         run: ${{ github.workspace }}/Meta/lint-ci.sh
-      - name: Prepare useful stamps
-        id: stamps
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y_%m_%d_%H_%M_%S" UTC)
-          # Output everything twice to make it visible both in the logs
-          # *and* as actual output variable, in this order.
-          message("  set-output name=time::${current_date}")
-          message("::set-output name=time::${current_date}")
-          message("  set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildGNU.sh') }}")
-          message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildGNU.sh') }}")
 
-      - name: Toolchain cache
-        uses: actions/cache/restore@v4
-        id: toolchain-cache
+      - name: Restore Caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: ${{ github.workspace }}/Toolchain/Local/${{ matrix.arch }}
-          # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
-          # This is wrong, and causes more Toolchain rebuilds than necessary.
-          # However, we want to avoid false cache hits at all costs.
-          key: ${{ runner.os }}-toolchain-${{ matrix.arch }}-${{ steps.stamps.outputs.libc_headers }}
+          os: 'Serenity'
+          arch: ${{ matrix.arch }}
+          toolchain: 'gcc'
+          cache_key_extra: ${{ matrix.debug-options }}
+          serenity_ccache_path: ${{ env.SERENITY_CCACHE_DIR }}
+          toolchain_ccache_path: ${{ env.TOOLCHAIN_CCACHE_DIR }}
+          with_remote_data_caches: true
+          download_cache_path: ${{ github.workspace }}/Build/caches
 
       - name: Build toolchain
         if: ${{ !steps.toolchain-cache.outputs.cache-hit }}
         run: ARCH="${{ matrix.arch }}" ${{ github.workspace }}/Toolchain/BuildGNU.sh
-
-      - name: Update toolchain cache
-        uses: actions/cache/save@v4
-        # Do not waste time and storage space by updating the toolchain cache from a PR,
-        # as it would be discarded after being merged anyway.
-        if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit }}
-        with:
-          path: ${{ github.workspace }}/Toolchain/Local/${{ matrix.arch }}
-          key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
-
-      # FIXME: Qemu currently needs a local patch for AArch64 testing. It is included in Qemu 8.1; remove this when upgrading!
-      - name: AArch64 Qemu cache
-        id: qemu-cache
-        uses: actions/cache/restore@v4
-        if: ${{ matrix.arch == 'aarch64' }}
-        with:
-          path: ${{ github.workspace }}/Toolchain/Local/qemu
-          key: ${{ runner.os }}-qemu-${{ hashFiles('Ports/qemu/version.sh', 'Toolchain/BuildQemu.sh') }}
+        env:
+          CCACHE_DIR: ${{ env.TOOLCHAIN_CCACHE_DIR }}
 
       - name: Build AArch64 Qemu
         if: ${{ matrix.arch == 'aarch64' && !steps.qemu-cache.outputs.cache-hit }}
         run: ${{ github.workspace }}/Toolchain/BuildQemu.sh
+        env:
+          CCACHE_DIR: ${{ env.TOOLCHAIN_CCACHE_DIR }}
 
-      - name: Update AArch64 Qemu cache
-        uses: actions/cache/save@v4
-        if: ${{ github.event_name != 'pull_request' && matrix.arch == 'aarch64' && !steps.qemu-cache.outputs.cache-hit }}
-        with:
-          path: ${{ github.workspace }}/Toolchain/Local/qemu
-          key: ${{ steps.qemu-cache.outputs.cache-primary-key }}
-
-      - name: ccache(1) cache
-        # Pull the ccache *after* building the toolchain, in case building the Toolchain somehow interferes.
-        uses: actions/cache/restore@v4
-        id: ccache
-        with:
-          path: ${{ github.workspace }}/.ccache
-          # If you're here because ccache broke (it never should), increment matrix.ccache-mark.
-          # We want to always reuse the last cache, but upload a new one.
-          # This is achieved by using the "prefix-timestamp" format,
-          # and permitting the restore-key "prefix-" without specifying a timestamp.
-          # For this trick to work, the timestamp *must* come last, and it *must* be missing in 'restore-keys'.
-          key: ${{ runner.os }}-ccache-${{ matrix.arch }}-v${{ matrix.ccache-mark }}-D${{ matrix.debug-options }}-toolchain_${{steps.stamps.outputs.libc_headers}}-time${{ steps.stamps.outputs.time }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-${{ matrix.arch }}-v${{ matrix.ccache-mark }}-D${{ matrix.debug-options }}-toolchain_${{steps.stamps.outputs.libc_headers}}-
-
-      - name: Show ccache stats before build and configure
-        run: |
-          ccache -M 0
-
-          # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
-          find ${{ github.workspace }}/.ccache | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
-
-          ccache -s
-          ccache -z
-
-      - name: Create build directory
-        run: |
-          mkdir -p ${{ github.workspace }}/Build/${{ matrix.arch }}
-          mkdir -p ${{ github.workspace }}/Build/caches/TZDB
-          mkdir -p ${{ github.workspace }}/Build/caches/UCD
-          mkdir -p ${{ github.workspace }}/Build/caches/CLDR
-      - name: TimeZoneData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/TZDB
-          key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
-      - name: UnicodeData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
-      - name: UnicodeLocale Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
       - name: Create build environment with extra debug options
         # Build the entire project with all available debug options turned on, to prevent code rot.
         # However, it is unwieldy and slow to run tests with them enabled, so we will build twice.
@@ -167,6 +92,8 @@ jobs:
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF
         if: ${{ matrix.debug-options == 'ALL_DEBUG' }}
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
       - name: Create build environment
         working-directory: ${{ github.workspace }}
         # Note that we do not set BUILD_LAGOM for the normal debug build
@@ -183,25 +110,16 @@ jobs:
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF
         if: ${{ matrix.debug-options == 'NORMAL_DEBUG' }}
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       # === ACTUALLY BUILD ===
 
       - name: Build Serenity and Tests
         working-directory: ${{ github.workspace }}/Build/superbuild
         run: cmake --build .
-
-      - name: Prune obsolete ccache files
-        run: ccache --evict-older-than 1d
-
-      - name: Show ccache stats after build
-        run: ccache -s
-
-      - name: Update ccache(1) cache
-        uses: actions/cache/save@v4
-        if: ${{ github.event_name != 'pull_request' }}
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ steps.ccache.outputs.cache-primary-key }}
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       - name: Lint (Phase 2/2)
         working-directory: ${{ github.workspace }}/Meta
@@ -243,3 +161,11 @@ jobs:
         if: ${{ !cancelled() && matrix.debug-options == 'NORMAL_DEBUG'}}
         working-directory: ${{ github.workspace }}/Build/${{ matrix.arch }}
         run: '[ ! -e debug.log ] || cat debug.log'
+
+      - name: Save Caches
+        uses: ./.github/actions/cache-save
+        with:
+          arch: ${{ matrix.arch }}
+          toolchain: 'gcc'
+          serenity_ccache_path: ${{ github.workspace }}/.ccache
+          toolchain_ccache_path: ${{ github.workspace }}/Toolchain/.ccache

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -74,7 +74,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: 'Linux'
-          arch: 'x86_64'
+          arch: 'Lagom'
           with_remote_data_caches: true
           download_cache_path: ${{ github.workspace }}/libjs-test262/Build/caches
 

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -70,23 +70,13 @@ jobs:
       - name: Check versions
         run: set +e; g++ --version; g++-13 --version; python --version; python3 --version; ninja --version
 
-      - name: TimeZoneData cache
-        uses: actions/cache@v4
+      - name: Data Caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: ${{ github.workspace }}/libjs-test262/Build/caches/TZDB
-          key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
-
-      - name: UnicodeData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/libjs-test262/Build/caches/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
-
-      - name: UnicodeLocale cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/libjs-test262/Build/caches/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+          os: 'Linux'
+          arch: 'x86_64'
+          with_remote_data_caches: true
+          download_cache_path: ${{ github.workspace }}/libjs-test262/Build/caches
 
       - name: Get previous results
         run: |

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+env:
+  SERENITY_CCACHE_DIR: ${{ github.workspace }}/.ccache
+  TOOLCHAIN_CCACHE_DIR: ${{ github.workspace }}/Toolchain/.ccache
+
 jobs:
   build:
     name: Static Analysis
@@ -33,55 +37,23 @@ jobs:
       - name: Check versions
         run: set +e; g++ --version; g++-13 --version; ninja --version;
 
-      - name: Prepare useful stamps
-        id: stamps
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y_%m_%d_%H_%M_%S" UTC)
-          # Output everything twice to make it visible both in the logs
-          # *and* as actual output variable, in this order.
-          message("  set-output name=time::${current_date}")
-          message("::set-output name=time::${current_date}")
-          message("  set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildGNU.sh') }}")
-          message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildGNU.sh') }}")
-
-      - name: Toolchain cache
-        # This job should always read the cache, never populate it.
-        uses: actions/cache/restore@v4
-        id: toolchain-cache
+      - name: Restore Caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: ${{ github.workspace }}/Toolchain/Local/${{ env.PVS_STUDIO_ANALYSIS_ARCH }}
-          # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
-          # This is wrong, and causes more Toolchain rebuilds than necessary.
-          # However, we want to avoid false cache hits at all costs.
-          key: ${{ runner.os }}-toolchain-${{ env.PVS_STUDIO_ANALYSIS_ARCH }}-${{ steps.stamps.outputs.libc_headers }}
+          os: 'Serenity'
+          arch: ${{ env.PVS_STUDIO_ANALYSIS_ARCH }}
+          toolchain: 'gcc'
+          cache_key_extra: NORMAL_DEBUG
+          serenity_ccache_path: ${{ env.SERENITY_CCACHE_DIR }}
+          toolchain_ccache_path: ${{ env.TOOLCHAIN_CCACHE_DIR }}
+          with_remote_data_caches: true
+          download_cache_path: ${{ github.workspace }}/Build/caches
 
       - name: Build toolchain
         if: ${{ !steps.toolchain-cache.outputs.cache-hit }}
         run: ARCH="${{ env.PVS_STUDIO_ANALYSIS_ARCH }}" ${{ github.workspace }}/Toolchain/BuildGNU.sh
-
-      - name: Create build directory
-        run: |
-          mkdir -p ${{ github.workspace }}/Build/${{ env.PVS_STUDIO_ANALYSIS_ARCH }}
-          mkdir -p ${{ github.workspace }}/Build/caches/TZDB
-          mkdir -p ${{ github.workspace }}/Build/caches/UCD
-          mkdir -p ${{ github.workspace }}/Build/caches/CLDR
-
-      - name: TimeZoneData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/TZDB
-          key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
-      - name: UnicodeData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
-      - name: UnicodeLocale Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+        env:
+          CCACHE_DIR: ${{ env.TOOLCHAIN_CCACHE_DIR }}
 
       - name: Create build environment
         working-directory: ${{ github.workspace }}
@@ -92,7 +64,10 @@ jobs:
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_CXX_COMPILER=g++-13 \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
-            -DENABLE_USB_IDS_DOWNLOAD=OFF
+            -DENABLE_USB_IDS_DOWNLOAD=OFF \
+            -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       - name: Build generated sources so they are available for analysis.
         working-directory: ${{ github.workspace }}
@@ -103,6 +78,8 @@ jobs:
           ninja -C Build/superbuild serenity-configure
           cmake -B Build/${{ env.PVS_STUDIO_ANALYSIS_ARCH }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           ninja -C Build/${{ env.PVS_STUDIO_ANALYSIS_ARCH }} all_generated
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       - name: Configure PVS-Studio License
         env:

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -34,29 +34,14 @@ jobs:
           os: ${{ matrix.os_name }}
           arch: 'Lagom'
 
-      - name: Create build directory
-        run: |
-          mkdir -p Build/TZDB
-          mkdir -p Build/UCD
-          mkdir -p Build/CLDR
-
-      - name: TimeZoneData cache
-        uses: actions/cache@v4
+      # NOTE: We don't restore ccache here, the Lagom ccache will have ASAN/UBSAN
+      - name: Data Caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: ${{ github.workspace }}/libjs-test262/Build/TZDB
-          key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
-
-      - name: UnicodeData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/libjs-test262/Build/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
-
-      - name: UnicodeLocale cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/libjs-test262/Build/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+          os: 'Linux'
+          arch: 'x86_64'
+          with_remote_data_caches: true
+          download_cache_path: ${{ github.workspace }}/caches
 
       - name: Create build directory Ubuntu
         run: |
@@ -64,6 +49,7 @@ jobs:
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_CXX_COMPILER=g++-13 \
             -DBUILD_LAGOM=ON
+            -DSERENITY_CACHE_DIR=${{ github.workspace }}/caches
         if: ${{ matrix.os == 'ubuntu-22.04' }}
 
       - name: Create build directory macOS
@@ -74,6 +60,7 @@ jobs:
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
             -DBUILD_LAGOM=ON
+            -DSERENITY_CACHE_DIR=${{ github.workspace }}/caches
         if: ${{ matrix.os == 'macos-14' }}
 
       - name: Build and package js

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Data Caches
         uses: ./.github/actions/cache-restore
         with:
-          os: 'Linux'
-          arch: 'x86_64'
+          os: ${{ matris.os_name }}
+          arch: 'Lagom'
           with_remote_data_caches: true
           download_cache_path: ${{ github.workspace }}/caches
 

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+env:
+  SERENITY_CCACHE_DIR: ${{ github.workspace }}/.ccache
+  TOOLCHAIN_CCACHE_DIR: ${{ github.workspace }}/Toolchain/.ccache
+
 jobs:
   build:
     name: Static Analysis
@@ -57,55 +61,23 @@ jobs:
           os: 'Serenity'
           arch: ${{ env.SONAR_ANALYSIS_ARCH }}
 
-      - name: Prepare useful stamps
-        id: stamps
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y_%m_%d_%H_%M_%S" UTC)
-          # Output everything twice to make it visible both in the logs
-          # *and* as actual output variable, in this order.
-          message("  set-output name=time::${current_date}")
-          message("::set-output name=time::${current_date}")
-          message("  set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildGNU.sh') }}")
-          message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildGNU.sh') }}")
-
-      - name: Toolchain cache
-        # This job should always read the cache, never populate it.
-        uses: actions/cache/restore@v4
-        id: toolchain-cache
+      - name: Restore Caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: ${{ github.workspace }}/Toolchain/Local/${{ env.SONAR_ANALYSIS_ARCH }}
-          # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
-          # This is wrong, and causes more Toolchain rebuilds than necessary.
-          # However, we want to avoid false cache hits at all costs.
-          key: ${{ runner.os }}-toolchain-${{ env.SONAR_ANALYSIS_ARCH }}-${{ steps.stamps.outputs.libc_headers }}
+          os: 'Serenity'
+          arch: ${{ env.SONAR_ANALYSIS_ARCH }}
+          toolchain: 'gcc'
+          cache_key_extra: NORMAL_DEBUG
+          serenity_ccache_path: ${{ env.SERENITY_CCACHE_DIR }}
+          toolchain_ccache_path: ${{ env.TOOLCHAIN_CCACHE_DIR }}
+          with_remote_data_caches: true
+          download_cache_path: ${{ github.workspace }}/Build/caches
 
       - name: Build toolchain
         if: ${{ !steps.toolchain-cache.outputs.cache-hit }}
         run: ARCH="${{ env.SONAR_ANALYSIS_ARCH }}" ${{ github.workspace }}/Toolchain/BuildGNU.sh
-
-      - name: Create build directory
-        run: |
-          mkdir -p ${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}
-          mkdir -p ${{ github.workspace }}/Build/caches/TZDB
-          mkdir -p ${{ github.workspace }}/Build/caches/UCD
-          mkdir -p ${{ github.workspace }}/Build/caches/CLDR
-
-      - name: TimeZoneData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/TZDB
-          key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
-      - name: UnicodeData cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
-      - name: UnicodeLocale Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+        env:
+          CCACHE_DIR: ${{ env.TOOLCHAIN_CCACHE_DIR }}
 
       - name: Create build environment
         working-directory: ${{ github.workspace }}
@@ -117,6 +89,8 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++-13 \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       - name: Build generated sources so they are available for analysis.
         working-directory: ${{ github.workspace }}
@@ -127,6 +101,8 @@ jobs:
           ninja -C Build/superbuild serenity-configure
           cmake -B Build/${{ env.SONAR_ANALYSIS_ARCH }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           ninja -C Build/${{ env.SONAR_ANALYSIS_ARCH }} all_generated
+        env:
+          CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       - name: Run sonar-scanner, upload results
         env:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         with:
           os: 'Linux'
-          arch: 'x86_64'
+          arch: 'Lagom'
           with_remote_data_caches: true
           download_cache_path: ${{ github.workspace }}/Build/caches
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -37,26 +37,15 @@ jobs:
           repository: SerenityOS/libjs-data
           path: libjs-data
           ref: libjs-wasm
-      - name: "Create build directories"
-        run: |
-          mkdir -p ${{ github.workspace }}/Build/caches/TZDB
-          mkdir -p ${{ github.workspace }}/Build/caches/UCD
-          mkdir -p ${{ github.workspace }}/Build/caches/CLDR
-      - name: "TimeZoneData cache"
-        uses: actions/cache@v4
+
+      - name: Data Caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: ${{ github.workspace }}/Build/caches/TZDB
-          key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
-      - name: "UnicodeData cache"
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
-      - name: "UnicodeLocale cache"
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/Build/caches/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+          os: 'Linux'
+          arch: 'x86_64'
+          with_remote_data_caches: true
+          download_cache_path: ${{ github.workspace }}/Build/caches
+
       - name: "Build host lagom tools"
         run: |
           cmake -GNinja \


### PR DESCRIPTION
Unfortunately a composite action cannot have a `post:`` step like JavaScript actions are allowed to have, so we need to explicitly call the post/save actions ourselves from the workflow file when we want to save Toolchain/QEMU/ccache caches.