### PR TITLE
LibWeb/Fetch: Use "json" destination

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -36,6 +36,18 @@ void ShadowRoot::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(ShadowRoot);
 }
 
+// https://dom.spec.whatwg.org/#dom-shadowroot-onslotchange
+void ShadowRoot::set_onslotchange(WebIDL::CallbackType* event_handler)
+{
+    set_event_handler_attribute(HTML::EventNames::slotchange, event_handler);
+}
+
+// https://dom.spec.whatwg.org/#dom-shadowroot-onslotchange
+WebIDL::CallbackType* ShadowRoot::onslotchange()
+{
+    return event_handler_attribute(HTML::EventNames::slotchange);
+}
+
 // https://dom.spec.whatwg.org/#ref-for-get-the-parent%E2%91%A6
 EventTarget* ShadowRoot::get_parent(Event const& event)
 {

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -25,6 +25,9 @@ public:
     bool delegates_focus() const { return m_delegates_focus; }
     void set_delegates_focus(bool delegates_focus) { m_delegates_focus = delegates_focus; }
 
+    void set_onslotchange(WebIDL::CallbackType*);
+    WebIDL::CallbackType* onslotchange();
+
     bool available_to_element_internals() const { return m_available_to_element_internals; }
     void set_available_to_element_internals(bool available_to_element_internals) { m_available_to_element_internals = available_to_element_internals; }
 

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -9,7 +9,7 @@ interface ShadowRoot : DocumentFragment {
     readonly attribute boolean delegatesFocus;
     readonly attribute SlotAssignmentMode slotAssignment;
     readonly attribute Element host;
-    // FIXME: attribute EventHandler onslotchange;
+    attribute EventHandler onslotchange;
 };
 
 ShadowRoot includes InnerHTML;

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -6,7 +6,7 @@
 [Exposed=Window]
 interface ShadowRoot : DocumentFragment {
     readonly attribute ShadowRootMode mode;
-    // FIXME: readonly attribute boolean delegatesFocus;
+    readonly attribute boolean delegatesFocus;
     readonly attribute SlotAssignmentMode slotAssignment;
     readonly attribute Element host;
     // FIXME: attribute EventHandler onslotchange;

--- a/Userland/Libraries/LibWeb/Fetch/Enums.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Enums.cpp
@@ -160,6 +160,8 @@ Bindings::RequestDestination to_bindings_enum(Optional<Infrastructure::Request::
         return Bindings::RequestDestination::Iframe;
     case Infrastructure::Request::Destination::Image:
         return Bindings::RequestDestination::Image;
+    case Infrastructure::Request::Destination::JSON:
+        return Bindings::RequestDestination::Json;
     case Infrastructure::Request::Destination::Manifest:
         return Bindings::RequestDestination::Manifest;
     case Infrastructure::Request::Destination::Object:

--- a/Userland/Libraries/LibWeb/Fetch/Enums.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Enums.cpp
@@ -113,6 +113,20 @@ Infrastructure::Request::RedirectMode from_bindings_enum(Bindings::RequestRedire
     }
 }
 
+Infrastructure::Request::Priority from_bindings_enum(Bindings::RequestPriority request_priority)
+{
+    switch (request_priority) {
+    case Bindings::RequestPriority::High:
+        return Infrastructure::Request::Priority::High;
+    case Bindings::RequestPriority::Low:
+        return Infrastructure::Request::Priority::Low;
+    case Bindings::RequestPriority::Auto:
+        return Infrastructure::Request::Priority::Auto;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 Bindings::ReferrerPolicy to_bindings_enum(ReferrerPolicy::ReferrerPolicy referrer_policy)
 {
     switch (referrer_policy) {

--- a/Userland/Libraries/LibWeb/Fetch/Enums.h
+++ b/Userland/Libraries/LibWeb/Fetch/Enums.h
@@ -18,6 +18,7 @@ namespace Web::Fetch {
 [[nodiscard]] Infrastructure::Request::CredentialsMode from_bindings_enum(Bindings::RequestCredentials);
 [[nodiscard]] Infrastructure::Request::CacheMode from_bindings_enum(Bindings::RequestCache);
 [[nodiscard]] Infrastructure::Request::RedirectMode from_bindings_enum(Bindings::RequestRedirect);
+[[nodiscard]] Infrastructure::Request::Priority from_bindings_enum(Bindings::RequestPriority);
 
 [[nodiscard]] Bindings::ReferrerPolicy to_bindings_enum(ReferrerPolicy::ReferrerPolicy);
 [[nodiscard]] Bindings::RequestDestination to_bindings_enum(Optional<Infrastructure::Request::Destination> const&);

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -165,6 +165,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Infrastructure::FetchController>> fetch(JS:
                 // `image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`
                 value = "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"sv;
                 break;
+            // -> "json"
+            case Infrastructure::Request::Destination::JSON:
+                // `application/json,*/*;q=0.5`
+                value = "application/json,*/*;q=0.5"sv;
+                break;
             // -> "style"
             case Infrastructure::Request::Destination::Style:
                 // `text/css,*/*;q=0.1`

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -99,12 +99,13 @@ bool Request::destination_is_script_like() const
 // https://fetch.spec.whatwg.org/#subresource-request
 bool Request::is_subresource_request() const
 {
-    // A subresource request is a request whose destination is "audio", "audioworklet", "font", "image", "manifest", "paintworklet", "script", "style", "track", "video", "xslt", or the empty string.
+    // A subresource request is a request whose destination is "audio", "audioworklet", "font", "image", "json", "manifest", "paintworklet", "script", "style", "track", "video", "xslt", or the empty string.
     static constexpr Array subresource_request_destinations = {
         Destination::Audio,
         Destination::AudioWorklet,
         Destination::Font,
         Destination::Image,
+        Destination::JSON,
         Destination::Manifest,
         Destination::PaintWorklet,
         Destination::Script,

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/PortBlocking.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/PortBlocking.cpp
@@ -100,6 +100,7 @@ bool is_bad_port(u16 port)
         2049,  // nfs
         3659,  // apple-sasl
         4045,  // npp
+        4190,  // sieve
         5060,  // sip
         5061,  // sips
         6000,  // x11
@@ -109,6 +110,7 @@ bool is_bad_port(u16 port)
         6667,  // ircu
         6668,  // ircu
         6669,  // ircu
+        6679,  // osaut
         6697,  // ircs-u
         10080, // amanda
     };

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -383,7 +383,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
     if (init.signal.has_value())
         input_signal = *init.signal;
 
-    // FIXME: 27. If init["priority"] exists, then:
+    // 27. If init["priority"] exists, then:
+    if (init.priority.has_value())
+        request->set_priority(from_bindings_enum(*init.priority));
 
     // 28. Set this’s request to request.
     // NOTE: This is done at the beginning as the 'this' value Request object

--- a/Userland/Libraries/LibWeb/Fetch/Request.h
+++ b/Userland/Libraries/LibWeb/Fetch/Request.h
@@ -37,6 +37,7 @@ struct RequestInit {
     Optional<bool> keepalive;
     Optional<JS::GCPtr<DOM::AbortSignal>> signal;
     Optional<Bindings::RequestDuplex> duplex;
+    Optional<Bindings::RequestPriority> priority;
     Optional<JS::Value> window;
 
     // https://infra.spec.whatwg.org/#map-is-empty
@@ -55,6 +56,7 @@ struct RequestInit {
             || keepalive.has_value()
             || signal.has_value()
             || duplex.has_value()
+            || priority.has_value()
             || window.has_value());
     }
 };

--- a/Userland/Libraries/LibWeb/Fetch/Request.idl
+++ b/Userland/Libraries/LibWeb/Fetch/Request.idl
@@ -49,7 +49,7 @@ dictionary RequestInit {
     any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/Userland/Libraries/LibWeb/Fetch/Request.idl
+++ b/Userland/Libraries/LibWeb/Fetch/Request.idl
@@ -46,6 +46,7 @@ dictionary RequestInit {
     boolean keepalive;
     AbortSignal? signal;
     RequestDuplex duplex;
+    RequestPriority priority;
     any window; // can only be set to null
 };
 
@@ -55,6 +56,7 @@ enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };
 enum RequestRedirect { "follow", "error", "manual" };
 enum RequestDuplex { "half" };
+enum RequestPriority { "high", "low", "auto" };
 
 // https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy
 enum ReferrerPolicy {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -60,6 +60,7 @@ enum class RequestCredentials;
 enum class RequestDestination;
 enum class RequestDuplex;
 enum class RequestMode;
+enum class RequestPriority;
 enum class RequestRedirect;
 enum class ResizeObserverBoxOptions;
 enum class ResponseType;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -593,6 +593,21 @@ void fetch_descendants_of_a_module_script(JS::Realm& realm, JavaScriptModuleScri
     }
 }
 
+// https://html.spec.whatwg.org/multipage/webappapis.html#fetch-destination-from-module-type
+Fetch::Infrastructure::Request::Destination fetch_destination_from_module_type(Fetch::Infrastructure::Request::Destination default_destination, ByteString const& module_type)
+{
+    // 1. If moduleType is "json", then return "json".
+    if (module_type == "json"sv)
+        return Fetch::Infrastructure::Request::Destination::JSON;
+
+    // 2. If moduleType is "css", then return "style".
+    if (module_type == "css"sv)
+        return Fetch::Infrastructure::Request::Destination::Style;
+
+    // 3. Return defaultDestination.
+    return default_destination;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
 void fetch_single_module_script(JS::Realm& realm,
     URL::URL const& url,

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -99,5 +99,7 @@ void fetch_single_imported_module_script(JS::Realm&, URL::URL const&, Environmen
 void fetch_descendants_of_a_module_script(JS::Realm&, JavaScriptModuleScript& module_script, EnvironmentSettingsObject& fetch_client_settings_object, Fetch::Infrastructure::Request::Destination, HashTable<ModuleLocationTuple> visited_set, PerformTheFetchHook, OnFetchScriptComplete callback);
 void fetch_descendants_of_and_link_a_module_script(JS::Realm&, JavaScriptModuleScript&, EnvironmentSettingsObject&, Fetch::Infrastructure::Request::Destination, PerformTheFetchHook, OnFetchScriptComplete on_complete);
 
+Fetch::Infrastructure::Request::Destination fetch_destination_from_module_type(Fetch::Infrastructure::Request::Destination, ByteString const&);
+
 void fetch_single_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, EnvironmentSettingsObject& settings_object, Web::Fetch::Infrastructure::Request::ReferrerType const&, Optional<JS::ModuleRequest> const&, TopLevelModule, PerformTheFetchHook, OnFetchScriptComplete callback);
 }


### PR DESCRIPTION
This is a follow up to a previous commit (https://github.com/SerenityOS/serenity/commit/da8d0d82c0c0e733e6485717f12a3956f1776881) I made as part of https://github.com/SerenityOS/serenity/pull/24164. This completes more of the implementation of the following spec changes:

- https://github.com/whatwg/fetch/commit/49bff76
- https://github.com/whatwg/html/commit/37659e9