### PR TITLE
LibDebug: Don't assume compilation unit index == line program index

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
+++ b/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
@@ -8,7 +8,7 @@
 
 #include "AbbreviationsMap.h"
 #include <AK/Noncopyable.h>
-#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/Types.h>
 
 namespace Debug::Dwarf {
@@ -22,7 +22,7 @@ class CompilationUnit {
     AK_MAKE_NONMOVABLE(CompilationUnit);
 
 public:
-    CompilationUnit(DwarfInfo const& dwarf_info, u32 offset, CompilationUnitHeader const&, NonnullOwnPtr<LineProgram>&& line_program);
+    static ErrorOr<NonnullOwnPtr<CompilationUnit>> create(DwarfInfo const& dwarf_info, u32 offset, CompilationUnitHeader const&, ReadonlyBytes debug_line_data);
     ~CompilationUnit();
 
     u32 offset() const { return m_offset; }
@@ -49,11 +49,14 @@ public:
     ErrorOr<u64> range_lists_base() const;
 
 private:
+    CompilationUnit(DwarfInfo const& dwarf_info, u32 offset, CompilationUnitHeader const&);
+    ErrorOr<void> populate_line_program(ReadonlyBytes debug_line_data);
+
     DwarfInfo const& m_dwarf_info;
     u32 m_offset { 0 };
     CompilationUnitHeader m_header;
     AbbreviationsMap m_abbreviations;
-    NonnullOwnPtr<LineProgram> m_line_program;
+    OwnPtr<LineProgram> m_line_program;
     mutable bool m_has_cached_base_address : 1 { false };
     mutable bool m_has_cached_address_table_base : 1 { false };
     mutable bool m_has_cached_string_offsets_base : 1 { false };

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -13,13 +13,13 @@
 
 namespace Debug::Dwarf {
 
-LineProgram::LineProgram(DwarfInfo& dwarf_info, size_t unit_offset)
+LineProgram::LineProgram(DwarfInfo const& dwarf_info, size_t unit_offset)
     : m_dwarf_info(dwarf_info)
     , m_unit_offset(unit_offset)
 {
 }
 
-ErrorOr<NonnullOwnPtr<LineProgram>> LineProgram::create(DwarfInfo& dwarf_info, SeekableStream& stream)
+ErrorOr<NonnullOwnPtr<LineProgram>> LineProgram::create(DwarfInfo const& dwarf_info, SeekableStream& stream)
 {
     auto offset = TRY(stream.tell());
     auto program = TRY(adopt_nonnull_own_or_enomem(new (nothrow) LineProgram(dwarf_info, offset)));

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -134,21 +134,21 @@ public:
     bool looks_like_embedded_resource() const;
 
 private:
-    LineProgram(DwarfInfo& dwarf_info, SeekableStream& stream, size_t unit_offset);
+    LineProgram(DwarfInfo& dwarf_info, size_t unit_offset);
 
-    ErrorOr<void> parse_unit_header();
-    ErrorOr<void> parse_source_directories();
-    ErrorOr<void> parse_source_files();
-    ErrorOr<void> run_program();
+    ErrorOr<void> parse_unit_header(SeekableStream& stream);
+    ErrorOr<void> parse_source_directories(SeekableStream& stream);
+    ErrorOr<void> parse_source_files(SeekableStream& stream);
+    ErrorOr<void> run_program(SeekableStream& stream);
 
     void append_to_line_info();
     void reset_registers();
 
-    ErrorOr<void> handle_extended_opcode();
-    ErrorOr<void> handle_standard_opcode(u8 opcode);
+    ErrorOr<void> handle_extended_opcode(SeekableStream& stream);
+    ErrorOr<void> handle_standard_opcode(SeekableStream& stream, u8 opcode);
     void handle_special_opcode(u8 opcode);
 
-    ErrorOr<void> parse_path_entries(Function<void(PathEntry& entry)> callback, PathListType list_type);
+    ErrorOr<void> parse_path_entries(SeekableStream& stream, Function<void(PathEntry& entry)> callback, PathListType list_type);
 
     enum StandardOpcodes {
         Copy = 1,
@@ -176,7 +176,6 @@ private:
     static constexpr u16 MAX_DWARF_VERSION = 5;
 
     DwarfInfo& m_dwarf_info;
-    SeekableStream& m_stream;
 
     size_t m_unit_offset { 0 };
     LineProgramUnitHeader32 m_unit_header {};

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -109,7 +109,7 @@ class LineProgram {
     AK_MAKE_NONMOVABLE(LineProgram);
 
 public:
-    static ErrorOr<NonnullOwnPtr<LineProgram>> create(DwarfInfo& dwarf_info, SeekableStream& stream);
+    static ErrorOr<NonnullOwnPtr<LineProgram>> create(DwarfInfo const& dwarf_info, SeekableStream& stream);
 
     struct LineInfo {
         FlatPtr address { 0 };
@@ -134,7 +134,7 @@ public:
     bool looks_like_embedded_resource() const;
 
 private:
-    LineProgram(DwarfInfo& dwarf_info, size_t unit_offset);
+    LineProgram(DwarfInfo const& dwarf_info, size_t unit_offset);
 
     ErrorOr<void> parse_unit_header(SeekableStream& stream);
     ErrorOr<void> parse_source_directories(SeekableStream& stream);
@@ -175,7 +175,7 @@ private:
     static constexpr u16 MIN_DWARF_VERSION = 3;
     static constexpr u16 MAX_DWARF_VERSION = 5;
 
-    DwarfInfo& m_dwarf_info;
+    DwarfInfo const& m_dwarf_info;
 
     size_t m_unit_offset { 0 };
     LineProgramUnitHeader32 m_unit_header {};


### PR DESCRIPTION
This causes CrashReporter to no longer crash (and therefore creating an infinite crash loop) on riscv64 clang, as riscv64 clang for some reason inserts an empty line program entry at the beginning and end of `.debug_line` of libc.so that has no matching compilation unit entry.