### PR TITLE
LibJS: Cache access to properties found in prototype chain

### DIFF
--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -113,7 +113,7 @@ JS::ThrowCompletionOr<bool> SheetGlobalObject::internal_has_property(JS::Propert
     return Object::internal_has_property(name);
 }
 
-JS::ThrowCompletionOr<JS::Value> SheetGlobalObject::internal_get(const JS::PropertyKey& property_name, JS::Value receiver, JS::CacheablePropertyMetadata*) const
+JS::ThrowCompletionOr<JS::Value> SheetGlobalObject::internal_get(const JS::PropertyKey& property_name, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const
 {
     if (property_name.is_string()) {
         if (property_name.as_string() == "value") {

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -29,7 +29,7 @@ public:
     virtual ~SheetGlobalObject() override = default;
 
     virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyKey const& name) const override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
 
     JS_DECLARE_NATIVE_FUNCTION(get_real_cell_contents);

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -333,7 +333,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
         }
     }
 
-    auto prototype = Object::create(realm, proto_parent);
+    auto prototype = Object::create_prototype(realm, proto_parent);
     VERIFY(prototype);
 
     vm.running_execution_context().lexical_environment = class_environment;

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -24,6 +24,8 @@ namespace JS::Bytecode {
 struct PropertyLookupCache {
     WeakPtr<Shape> shape;
     Optional<u32> property_offset;
+    WeakPtr<Object> prototype;
+    WeakPtr<PrototypeChainValidity> prototype_chain_validity;
 };
 
 struct GlobalVariableCache : public PropertyLookupCache {

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -217,6 +217,7 @@ class Symbol;
 class Token;
 class Utf16String;
 class VM;
+class PrototypeChainValidity;
 class Value;
 class WeakContainer;
 class WrappedFunction;

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -12,6 +12,7 @@
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/StringView.h>
+#include <AK/Weakable.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibJS/Heap/Internals.h>
@@ -27,7 +28,7 @@ public:                                            \
     }                                              \
     friend class JS::Heap;
 
-class Cell {
+class Cell : public Weakable<Cell> {
     AK_MAKE_NONCOPYABLE(Cell);
     AK_MAKE_NONMOVABLE(Cell);
 

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -50,11 +50,7 @@ Heap::Heap(VM& vm)
     gc_perf_string_id = perf_register_string(gc_signpost_string.characters_without_null_termination(), gc_signpost_string.length());
 #endif
 
-    if constexpr (HeapBlock::min_possible_cell_size <= 16) {
-        m_size_based_cell_allocators.append(make<CellAllocator>(16));
-    }
-    static_assert(HeapBlock::min_possible_cell_size <= 24, "Heap Cell tracking uses too much data!");
-    m_size_based_cell_allocators.append(make<CellAllocator>(32));
+    static_assert(HeapBlock::min_possible_cell_size <= 32, "Heap Cell tracking uses too much data!");
     m_size_based_cell_allocators.append(make<CellAllocator>(64));
     m_size_based_cell_allocators.append(make<CellAllocator>(96));
     m_size_based_cell_allocators.append(make<CellAllocator>(128));

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -33,7 +33,7 @@ void ArgumentsObject::visit_edges(Cell::Visitor& visitor)
 }
 
 // 10.4.4.3 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-arguments-exotic-objects-get-p-receiver
-ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata) const
+ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     // 1. Let map be args.[[ParameterMap]].
     auto& map = *m_parameter_map;
@@ -44,7 +44,7 @@ ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& proper
     // 3. If isMapped is false, then
     if (!is_mapped) {
         // a. Return ? OrdinaryGet(args, P, Receiver).
-        return Object::internal_get(property_key, receiver, cacheable_metadata);
+        return Object::internal_get(property_key, receiver, cacheable_metadata, phase);
     }
 
     // FIXME: a. Assert: map contains a formal parameter mapping for P.

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -24,7 +24,7 @@ public:
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*) const override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -350,17 +350,17 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
         Object* prototype = nullptr;
         switch (m_kind) {
         case FunctionKind::Normal:
-            prototype = vm.heap().allocate<Object>(realm, realm.intrinsics().new_ordinary_function_prototype_object_shape());
+            prototype = Object::create_prototype(realm, realm.intrinsics().object_prototype());
             MUST(prototype->define_property_or_throw(vm.names.constructor, { .value = this, .writable = true, .enumerable = false, .configurable = true }));
             break;
         case FunctionKind::Generator:
             // prototype is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
-            prototype = Object::create(realm, realm.intrinsics().generator_function_prototype_prototype());
+            prototype = Object::create_prototype(realm, realm.intrinsics().generator_function_prototype_prototype());
             break;
         case FunctionKind::Async:
             break;
         case FunctionKind::AsyncGenerator:
-            prototype = Object::create(realm, realm.intrinsics().async_generator_function_prototype_prototype());
+            prototype = Object::create_prototype(realm, realm.intrinsics().async_generator_function_prototype_prototype());
             break;
         }
         // 27.7.4 AsyncFunction Instances, https://tc39.es/ecma262/#sec-async-function-instances

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -227,7 +227,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     // 30. If kind is generator, then
     if (kind == FunctionKind::Generator) {
         // a. Let prototype be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-        prototype = Object::create(realm, realm.intrinsics().generator_function_prototype_prototype());
+        prototype = Object::create_prototype(realm, realm.intrinsics().generator_function_prototype_prototype());
 
         // b. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         function->define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
@@ -235,7 +235,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     // 31. Else if kind is asyncGenerator, then
     else if (kind == FunctionKind::AsyncGenerator) {
         // a. Let prototype be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
-        prototype = Object::create(realm, realm.intrinsics().async_generator_function_prototype_prototype());
+        prototype = Object::create_prototype(realm, realm.intrinsics().async_generator_function_prototype_prototype());
 
         // b. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         function->define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
@@ -243,7 +243,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     // 32. Else if kind is normal, perform MakeConstructor(F).
     else if (kind == FunctionKind::Normal) {
         // FIXME: Implement MakeConstructor
-        prototype = Object::create(realm, realm.intrinsics().object_prototype());
+        prototype = Object::create_prototype(realm, realm.intrinsics().object_prototype());
         prototype->define_direct_property(vm.names.constructor, function, Attribute::Writable | Attribute::Configurable);
         function->define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
     }

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -181,14 +181,12 @@ ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
     // These are done first since other prototypes depend on their presence.
     m_empty_object_shape = heap().allocate_without_realm<Shape>(realm);
     m_object_prototype = heap().allocate_without_realm<ObjectPrototype>(realm);
+    m_object_prototype->convert_to_prototype_if_needed();
     m_function_prototype = heap().allocate_without_realm<FunctionPrototype>(realm);
+    m_function_prototype->convert_to_prototype_if_needed();
 
     m_new_object_shape = heap().allocate_without_realm<Shape>(realm);
     m_new_object_shape->set_prototype_without_transition(m_object_prototype);
-
-    m_new_ordinary_function_prototype_object_shape = heap().allocate_without_realm<Shape>(realm);
-    m_new_ordinary_function_prototype_object_shape->set_prototype_without_transition(m_object_prototype);
-    m_new_ordinary_function_prototype_object_shape->add_property_without_transition(vm.names.constructor, Attribute::Writable | Attribute::Configurable);
 
     // OPTIMIZATION: A lot of runtime algorithms create an "iterator result" object.
     //               We pre-bake a shape for these objects and remember the property offsets.
@@ -367,7 +365,6 @@ void Intrinsics::visit_edges(Visitor& visitor)
     visitor.visit(m_realm);
     visitor.visit(m_empty_object_shape);
     visitor.visit(m_new_object_shape);
-    visitor.visit(m_new_ordinary_function_prototype_object_shape);
     visitor.visit(m_iterator_result_object_shape);
     visitor.visit(m_proxy_constructor);
     visitor.visit(m_async_from_sync_iterator_prototype);

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -21,7 +21,6 @@ public:
     NonnullGCPtr<Shape> empty_object_shape() { return *m_empty_object_shape; }
 
     NonnullGCPtr<Shape> new_object_shape() { return *m_new_object_shape; }
-    NonnullGCPtr<Shape> new_ordinary_function_prototype_object_shape() { return *m_new_ordinary_function_prototype_object_shape; }
 
     [[nodiscard]] NonnullGCPtr<Shape> iterator_result_object_shape() { return *m_iterator_result_object_shape; }
     [[nodiscard]] u32 iterator_result_object_value_offset() { return m_iterator_result_object_value_offset; }
@@ -125,7 +124,6 @@ private:
 
     GCPtr<Shape> m_empty_object_shape;
     GCPtr<Shape> m_new_object_shape;
-    GCPtr<Shape> m_new_ordinary_function_prototype_object_shape;
 
     GCPtr<Shape> m_iterator_result_object_shape;
     u32 m_iterator_result_object_value_offset { 0 };

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -137,14 +137,14 @@ ThrowCompletionOr<bool> ModuleNamespaceObject::internal_has_property(PropertyKey
 }
 
 // 10.4.6.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver
-ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata) const
+ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     auto& vm = this->vm();
 
     // 1. If Type(P) is Symbol, then
     if (property_key.is_symbol()) {
         // a. Return ! OrdinaryGet(O, P, Receiver).
-        return MUST(Object::internal_get(property_key, receiver, cacheable_metadata));
+        return MUST(Object::internal_get(property_key, receiver, cacheable_metadata, phase));
     }
 
     // 2. Let exports be O.[[Exports]].

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -26,7 +26,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr) const override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -138,7 +138,11 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&);
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr) const;
+    enum class PropertyLookupPhase {
+        OwnProperty,
+        PrototypeChain,
+    };
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) const;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata* = nullptr);
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&);
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const;

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2024, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -46,9 +46,11 @@ struct CacheablePropertyMetadata {
     enum class Type {
         NotCacheable,
         OwnProperty,
+        InPrototypeChain,
     };
     Type type { Type::NotCacheable };
     Optional<u32> property_offset;
+    GCPtr<Object const> prototype;
 };
 
 class Object : public Cell {
@@ -56,6 +58,7 @@ class Object : public Cell {
     JS_DECLARE_ALLOCATOR(Object);
 
 public:
+    static NonnullGCPtr<Object> create_prototype(Realm&, Object* prototype);
     static NonnullGCPtr<Object> create(Realm&, Object* prototype);
     static NonnullGCPtr<Object> create_with_premade_shape(Shape&);
 
@@ -214,6 +217,8 @@ public:
 
     Shape& shape() { return *m_shape; }
     Shape const& shape() const { return *m_shape; }
+
+    void convert_to_prototype_if_needed();
 
     template<typename T>
     bool fast_is() const = delete;

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -455,7 +455,7 @@ ThrowCompletionOr<bool> ProxyObject::internal_has_property(PropertyKey const& pr
 }
 
 // 10.5.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
-ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata*) const
+ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const
 {
     // NOTE: We don't return any cacheable metadata for proxy lookups.
 

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -39,7 +39,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*) const override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -20,9 +20,7 @@
 namespace JS {
 
 // 9.3 Realms, https://tc39.es/ecma262/#realm-record
-class Realm final
-    : public Cell
-    , public Weakable<Realm> {
+class Realm final : public Cell {
     JS_CELL(Realm, Cell);
     JS_DECLARE_ALLOCATOR(Realm);
 

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2024, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,6 +11,15 @@
 namespace JS {
 
 JS_DEFINE_ALLOCATOR(Shape);
+JS_DEFINE_ALLOCATOR(PrototypeChainValidity);
+
+static HashTable<JS::GCPtr<Shape>> s_all_prototype_shapes;
+
+Shape::~Shape()
+{
+    if (m_is_prototype_shape)
+        s_all_prototype_shapes.remove(this);
+}
 
 NonnullGCPtr<Shape> Shape::create_cacheable_dictionary_transition()
 {
@@ -18,6 +27,7 @@ NonnullGCPtr<Shape> Shape::create_cacheable_dictionary_transition()
     new_shape->m_dictionary = true;
     new_shape->m_cacheable = true;
     new_shape->m_prototype = m_prototype;
+    invalidate_prototype_if_needed_for_new_prototype(new_shape);
     ensure_property_table();
     new_shape->ensure_property_table();
     (*new_shape->m_property_table) = *m_property_table;
@@ -31,6 +41,7 @@ NonnullGCPtr<Shape> Shape::create_uncacheable_dictionary_transition()
     new_shape->m_dictionary = true;
     new_shape->m_cacheable = true;
     new_shape->m_prototype = m_prototype;
+    invalidate_prototype_if_needed_for_new_prototype(new_shape);
     ensure_property_table();
     new_shape->ensure_property_table();
     (*new_shape->m_property_table) = *m_property_table;
@@ -38,8 +49,10 @@ NonnullGCPtr<Shape> Shape::create_uncacheable_dictionary_transition()
     return new_shape;
 }
 
-Shape* Shape::get_or_prune_cached_forward_transition(TransitionKey const& key)
+GCPtr<Shape> Shape::get_or_prune_cached_forward_transition(TransitionKey const& key)
 {
+    if (m_is_prototype_shape)
+        return nullptr;
     if (!m_forward_transitions)
         return nullptr;
     auto it = m_forward_transitions->find(key);
@@ -50,11 +63,13 @@ Shape* Shape::get_or_prune_cached_forward_transition(TransitionKey const& key)
         m_forward_transitions->remove(it);
         return nullptr;
     }
-    return it->value;
+    return it->value.ptr();
 }
 
 GCPtr<Shape> Shape::get_or_prune_cached_delete_transition(StringOrSymbol const& key)
 {
+    if (m_is_prototype_shape)
+        return nullptr;
     if (!m_delete_transitions)
         return nullptr;
     auto it = m_delete_transitions->find(key);
@@ -68,8 +83,10 @@ GCPtr<Shape> Shape::get_or_prune_cached_delete_transition(StringOrSymbol const& 
     return it->value.ptr();
 }
 
-Shape* Shape::get_or_prune_cached_prototype_transition(Object* prototype)
+GCPtr<Shape> Shape::get_or_prune_cached_prototype_transition(Object* prototype)
 {
+    if (m_is_prototype_shape)
+        return nullptr;
     if (!m_prototype_transitions)
         return nullptr;
     auto it = m_prototype_transitions->find(prototype);
@@ -80,41 +97,52 @@ Shape* Shape::get_or_prune_cached_prototype_transition(Object* prototype)
         m_prototype_transitions->remove(it);
         return nullptr;
     }
-    return it->value;
+    return it->value.ptr();
 }
 
-Shape* Shape::create_put_transition(StringOrSymbol const& property_key, PropertyAttributes attributes)
+NonnullGCPtr<Shape> Shape::create_put_transition(StringOrSymbol const& property_key, PropertyAttributes attributes)
 {
     TransitionKey key { property_key, attributes };
-    if (auto* existing_shape = get_or_prune_cached_forward_transition(key))
-        return existing_shape;
+    if (auto existing_shape = get_or_prune_cached_forward_transition(key))
+        return *existing_shape;
     auto new_shape = heap().allocate_without_realm<Shape>(*this, property_key, attributes, TransitionType::Put);
-    if (!m_forward_transitions)
-        m_forward_transitions = make<HashMap<TransitionKey, WeakPtr<Shape>>>();
-    m_forward_transitions->set(key, new_shape.ptr());
+    invalidate_prototype_if_needed_for_new_prototype(new_shape);
+    if (!m_is_prototype_shape) {
+        if (!m_forward_transitions)
+            m_forward_transitions = make<HashMap<TransitionKey, WeakPtr<Shape>>>();
+        m_forward_transitions->set(key, new_shape.ptr());
+    }
     return new_shape;
 }
 
-Shape* Shape::create_configure_transition(StringOrSymbol const& property_key, PropertyAttributes attributes)
+NonnullGCPtr<Shape> Shape::create_configure_transition(StringOrSymbol const& property_key, PropertyAttributes attributes)
 {
     TransitionKey key { property_key, attributes };
-    if (auto* existing_shape = get_or_prune_cached_forward_transition(key))
-        return existing_shape;
+    if (auto existing_shape = get_or_prune_cached_forward_transition(key))
+        return *existing_shape;
     auto new_shape = heap().allocate_without_realm<Shape>(*this, property_key, attributes, TransitionType::Configure);
-    if (!m_forward_transitions)
-        m_forward_transitions = make<HashMap<TransitionKey, WeakPtr<Shape>>>();
-    m_forward_transitions->set(key, new_shape.ptr());
+    invalidate_prototype_if_needed_for_new_prototype(new_shape);
+    if (!m_is_prototype_shape) {
+        if (!m_forward_transitions)
+            m_forward_transitions = make<HashMap<TransitionKey, WeakPtr<Shape>>>();
+        m_forward_transitions->set(key, new_shape.ptr());
+    }
     return new_shape;
 }
 
-Shape* Shape::create_prototype_transition(Object* new_prototype)
+NonnullGCPtr<Shape> Shape::create_prototype_transition(Object* new_prototype)
 {
-    if (auto* existing_shape = get_or_prune_cached_prototype_transition(new_prototype))
-        return existing_shape;
+    if (new_prototype)
+        new_prototype->convert_to_prototype_if_needed();
+    if (auto existing_shape = get_or_prune_cached_prototype_transition(new_prototype))
+        return *existing_shape;
     auto new_shape = heap().allocate_without_realm<Shape>(*this, new_prototype);
-    if (!m_prototype_transitions)
-        m_prototype_transitions = make<HashMap<GCPtr<Object>, WeakPtr<Shape>>>();
-    m_prototype_transitions->set(new_prototype, new_shape.ptr());
+    invalidate_prototype_if_needed_for_new_prototype(new_shape);
+    if (!m_is_prototype_shape) {
+        if (!m_prototype_transitions)
+            m_prototype_transitions = make<HashMap<GCPtr<Object>, WeakPtr<Shape>>>();
+        m_prototype_transitions->set(new_prototype, new_shape.ptr());
+    }
     return new_shape;
 }
 
@@ -178,6 +206,8 @@ void Shape::visit_edges(Cell::Visitor& visitor)
         for (auto& it : *m_delete_transitions)
             it.key.visit_edges(visitor);
     }
+
+    visitor.visit(m_prototype_chain_validity);
 }
 
 Optional<PropertyMetadata> Shape::lookup(StringOrSymbol const& property_key) const
@@ -245,6 +275,7 @@ NonnullGCPtr<Shape> Shape::create_delete_transition(StringOrSymbol const& proper
     if (auto existing_shape = get_or_prune_cached_delete_transition(property_key))
         return *existing_shape;
     auto new_shape = heap().allocate_without_realm<Shape>(*this, property_key, TransitionType::Delete);
+    invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_delete_transitions)
         m_delete_transitions = make<HashMap<StringOrSymbol, WeakPtr<Shape>>>();
     m_delete_transitions->set(property_key, new_shape.ptr());
@@ -287,6 +318,79 @@ void Shape::remove_property_without_transition(StringOrSymbol const& property_ke
         VERIFY(it.value.offset != offset);
         if (it.value.offset > offset)
             --it.value.offset;
+    }
+}
+
+NonnullGCPtr<Shape> Shape::create_for_prototype(NonnullGCPtr<Realm> realm, GCPtr<Object> prototype)
+{
+    auto new_shape = realm->heap().allocate_without_realm<Shape>(realm);
+    s_all_prototype_shapes.set(new_shape);
+    new_shape->m_is_prototype_shape = true;
+    new_shape->m_prototype = prototype;
+    new_shape->m_prototype_chain_validity = realm->heap().allocate_without_realm<PrototypeChainValidity>();
+    return new_shape;
+}
+
+NonnullGCPtr<Shape> Shape::clone_for_prototype()
+{
+    VERIFY(!m_is_prototype_shape);
+    VERIFY(!m_prototype_chain_validity);
+    auto new_shape = heap().allocate_without_realm<Shape>(m_realm);
+    s_all_prototype_shapes.set(new_shape);
+    new_shape->m_is_prototype_shape = true;
+    new_shape->m_prototype = m_prototype;
+    ensure_property_table();
+    new_shape->ensure_property_table();
+    (*new_shape->m_property_table) = *m_property_table;
+    new_shape->m_property_count = new_shape->m_property_table->size();
+    new_shape->m_prototype_chain_validity = heap().allocate_without_realm<PrototypeChainValidity>();
+    return new_shape;
+}
+
+void Shape::set_prototype_without_transition(Object* new_prototype)
+{
+    VERIFY(new_prototype);
+    new_prototype->convert_to_prototype_if_needed();
+    m_prototype = new_prototype;
+}
+
+void Shape::set_prototype_shape()
+{
+    VERIFY(!m_is_prototype_shape);
+    s_all_prototype_shapes.set(this);
+    m_is_prototype_shape = true;
+    m_prototype_chain_validity = heap().allocate_without_realm<PrototypeChainValidity>();
+}
+
+void Shape::invalidate_prototype_if_needed_for_new_prototype(NonnullGCPtr<Shape> new_prototype_shape)
+{
+    if (!m_is_prototype_shape)
+        return;
+    new_prototype_shape->set_prototype_shape();
+    m_prototype_chain_validity->set_valid(false);
+
+    invalidate_all_prototype_chains_leading_to_this();
+}
+
+void Shape::invalidate_all_prototype_chains_leading_to_this()
+{
+    HashTable<Shape*> shapes_to_invalidate;
+    for (auto& candidate : s_all_prototype_shapes) {
+        if (!candidate->m_prototype)
+            continue;
+        for (auto* current_prototype_shape = &candidate->m_prototype->shape(); current_prototype_shape; current_prototype_shape = current_prototype_shape->prototype() ? &current_prototype_shape->prototype()->shape() : nullptr) {
+            if (current_prototype_shape == this) {
+                VERIFY(candidate->m_is_prototype_shape);
+                shapes_to_invalidate.set(candidate);
+                break;
+            }
+        }
+    }
+    if (shapes_to_invalidate.is_empty())
+        return;
+    for (auto* shape : shapes_to_invalidate) {
+        shape->m_prototype_chain_validity->set_valid(false);
+        shape->m_prototype_chain_validity = heap().allocate_without_realm<PrototypeChainValidity>();
     }
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -34,9 +34,7 @@ struct TransitionKey {
     }
 };
 
-class Shape final
-    : public Cell
-    , public Weakable<Shape> {
+class Shape final : public Cell {
     JS_CELL(Shape, Cell);
     JS_DECLARE_ALLOCATOR(Shape);
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -317,7 +317,7 @@ public:
     }
 
     // 10.4.5.4 [[Get]] ( P, Receiver ), 10.4.5.4 [[Get]] ( P, Receiver )
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata) const override
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const override
     {
         VERIFY(!receiver.is_empty());
 
@@ -339,7 +339,7 @@ public:
         }
 
         // 2. Return ? OrdinaryGet(O, P, Receiver).
-        return Object::internal_get(property_key, receiver, cacheable_metadata);
+        return Object::internal_get(property_key, receiver, cacheable_metadata, phase);
     }
 
     // 10.4.5.5 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-set-p-v-receiver

--- a/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -22,9 +22,7 @@ namespace Web::Bindings {
     }
 
 // https://webidl.spec.whatwg.org/#dfn-platform-object
-class PlatformObject
-    : public JS::Object
-    , public Weakable<PlatformObject> {
+class PlatformObject : public JS::Object {
     JS_OBJECT(PlatformObject, JS::Object);
 
 public:

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -409,15 +409,15 @@ JS::ThrowCompletionOr<bool> CSSStyleDeclaration::internal_has_property(JS::Prope
     return property_id_from_name(name.to_string()) != CSS::PropertyID::Invalid;
 }
 
-JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyKey const& name, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata) const
+JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyKey const& name, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     if (name.is_number())
         return { JS::PrimitiveString::create(vm(), item(name.as_number())) };
     if (!name.is_string())
-        return Base::internal_get(name, receiver, cacheable_metadata);
+        return Base::internal_get(name, receiver, cacheable_metadata, phase);
     auto property_id = property_id_from_name(name.to_string());
     if (property_id == CSS::PropertyID::Invalid)
-        return Base::internal_get(name, receiver, cacheable_metadata);
+        return Base::internal_get(name, receiver, cacheable_metadata, phase);
     if (auto maybe_property = property(property_id); maybe_property.has_value())
         return { JS::PrimitiveString::create(vm(), maybe_property->value->to_string()) };
     return { JS::PrimitiveString::create(vm(), String {}) };

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -42,7 +42,7 @@ public:
     virtual String serialized() const = 0;
 
     virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyKey const& name) const override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -25,9 +25,7 @@ struct CSSStyleSheetInit {
     bool disabled { false };
 };
 
-class CSSStyleSheet final
-    : public StyleSheet
-    , public Weakable<CSSStyleSheet> {
+class CSSStyleSheet final : public StyleSheet {
     WEB_PLATFORM_OBJECT(CSSStyleSheet, StyleSheet);
     JS_DECLARE_ALLOCATOR(CSSStyleSheet);
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -28,8 +28,7 @@
 
 namespace Web::HTML {
 
-class BrowsingContext final : public JS::Cell
-    , public Weakable<BrowsingContext> {
+class BrowsingContext final : public JS::Cell {
     JS_CELL(BrowsingContext, JS::Cell);
     JS_DECLARE_ALLOCATOR(BrowsingContext);
 

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -483,13 +483,13 @@ JS::ThrowCompletionOr<bool> Location::internal_define_own_property(JS::PropertyK
 }
 
 // 7.10.5.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-get
-JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata) const
+JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     auto& vm = this->vm();
 
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ? OrdinaryGet(this, P, Receiver).
     if (HTML::is_platform_object_same_origin(*this))
-        return JS::Object::internal_get(property_key, receiver, cacheable_metadata);
+        return JS::Object::internal_get(property_key, receiver, cacheable_metadata, phase);
 
     // 2. Return ? CrossOriginGet(this, P, Receiver).
     return HTML::cross_origin_get(vm, static_cast<JS::Object const&>(*this), property_key, receiver);

--- a/Userland/Libraries/LibWeb/HTML/Location.h
+++ b/Userland/Libraries/LibWeb/HTML/Location.h
@@ -60,7 +60,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -45,9 +45,7 @@ struct TargetSnapshotParams {
 };
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#navigable
-class Navigable
-    : public JS::Cell
-    , public Weakable<Navigable> {
+class Navigable : public JS::Cell {
     JS_CELL(Navigable, JS::Cell);
     JS_DECLARE_ALLOCATOR(Navigable);
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -153,7 +153,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
 }
 
 // 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-get
-JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata*) const
+JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.h
@@ -27,7 +27,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.h
@@ -14,9 +14,7 @@ namespace Web::HTML {
 
 // NOTE: Temporary class to handle console messages from inside Workers
 
-class WorkerDebugConsoleClient final
-    : public JS::ConsoleClient
-    , public Weakable<WorkerDebugConsoleClient> {
+class WorkerDebugConsoleClient final : public JS::ConsoleClient {
     JS_CELL(WorkerDebugConsoleClient, JS::ConsoleClient);
     JS_DECLARE_ALLOCATOR(WorkerDebugConsoleClient);
 

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -37,8 +37,7 @@ enum class LayoutMode {
 
 class Node
     : public JS::Cell
-    , public TreeNode<Node>
-    , public Weakable<Node> {
+    , public TreeNode<Node> {
     JS_CELL(Node, JS::Cell);
 
 public:

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -55,7 +55,7 @@ HTML::Navigable& Page::focused_navigable()
 
 void Page::set_focused_navigable(Badge<EventHandler>, HTML::Navigable& navigable)
 {
-    m_focused_navigable = navigable.make_weak_ptr();
+    m_focused_navigable = navigable;
 }
 
 void Page::load(URL::URL const& url)

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -18,8 +18,7 @@
 
 namespace WebContent {
 
-class WebContentConsoleClient final : public JS::ConsoleClient
-    , public Weakable<WebContentConsoleClient> {
+class WebContentConsoleClient final : public JS::ConsoleClient {
     JS_CELL(WebContentConsoleClient, JS::ConsoleClient);
     JS_DECLARE_ALLOCATOR(WebContentConsoleClient);
 


### PR DESCRIPTION
We already had fast access to own properties via shape-based IC.
This patch extends the mechanism to properties on the prototype chain,
using the "validity cell" technique from V8.
    
- Prototype objects now have unique shape
- Each prototype has an associated `PrototypeChainValidity`
- When a prototype shape is mutated, every prototype shape "below" it
  in any prototype chain is invalidated.
- Invalidation happens by marking the validity object as invalid,
  and then replacing it with a new validity object.
- Property caches keep a pointer to the last seen valid validity.
  If there is no validity, or the validity is invalid, the cache
  misses and gets repopulated.
    
This is very helpful when using JavaScript to access DOM objects,
as we frequently have to traverse 4+ prototype objects before finding
the property we're interested in on e.g `EventTarget` or `Node`.
