### PR TITLE
LibWeb: Fix painting non-local SVG clipPaths/masks

### DIFF
--- a/Tests/LibWeb/Ref/reference/svg-non-local-clip-path-display-none-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-non-local-clip-path-display-none-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<svg>
+</svg>
+<svg>
+  <rect fill="red" width="100" height="100">
+</svg>

--- a/Tests/LibWeb/Ref/reference/svg-non-local-clip-path-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-non-local-clip-path-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<svg>
+</svg>
+<svg>
+  <rect fill="red" x="10" y="10" width="50" height="50">
+</svg>

--- a/Tests/LibWeb/Ref/svg-non-local-clip-path-display-none.html
+++ b/Tests/LibWeb/Ref/svg-non-local-clip-path-display-none.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="match" href="reference/svg-non-local-clip-path-display-none-ref.html" />
+<svg>
+    <clipPath id="jeez" style="display:none">
+      <rect x="10" y="10" width="50" height="50">
+    </clipPath>
+</svg>
+<svg>
+    <g clip-path="url(#jeez)">
+      <rect fill="red" width="100" height="100">
+      </rect>
+    </g>
+</svg>

--- a/Tests/LibWeb/Ref/svg-non-local-clip-path.html
+++ b/Tests/LibWeb/Ref/svg-non-local-clip-path.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="match" href="reference/svg-non-local-clip-path-ref.html" />
+<svg>
+    <clipPath id="jeez">
+      <rect x="10" y="10" width="50" height="50">
+    </clipPath>
+</svg>
+<svg>
+    <g clip-path="url(#jeez)">
+      <rect fill="red" width="100" height="100">
+      </rect>
+    </g>
+</svg>

--- a/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -7,7 +7,7 @@
 
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibWeb/Painting/SVGPathPaintable.h>
-#include <LibWeb/SVG/SVGSVGElement.h>
+#include <LibWeb/Painting/SVGSVGPaintable.h>
 
 namespace Web::Painting {
 
@@ -62,14 +62,14 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     auto& geometry_element = layout_box().dom_node();
 
-    auto const* svg_element = geometry_element.shadow_including_first_ancestor_of_type<SVG::SVGSVGElement>();
-    auto svg_element_rect = svg_element->paintable_box()->absolute_rect();
+    auto const* svg_node = layout_box().first_ancestor_of_type<Layout::SVGSVGBox>();
+    auto svg_element_rect = svg_node->paintable_box()->absolute_rect();
 
     // FIXME: This should not be trucated to an int.
     RecordingPainterStateSaver save_painter { context.recording_painter() };
 
     auto offset = context.floored_device_point(svg_element_rect.location()).to_type<int>().to_type<float>();
-    auto maybe_view_box = svg_element->view_box();
+    auto maybe_view_box = svg_node->dom_node().view_box();
 
     auto paint_transform = computed_transforms().svg_to_device_pixels_transform(context);
     Gfx::Path path = computed_path()->copy_transformed(paint_transform);


### PR DESCRIPTION
The crash has already been fixed, so this PR simply fixes the painting issues found in [#24070](https://github.com/SerenityOS/serenity/issues/24070).

So a non-local `clipPath` like:
```html
<!doctype html>
<svg>
    <clippath id="jeez">
      <circle cx="50" cy="50" r="50" />
    </clippath>
</svg>
<svg>
    <g clip-path="url(#jeez)">
      <rect fill="red" width="100" height="100">
      </rect>
    </g>
</svg>
```

Is applied correctly:
![image](https://github.com/SerenityOS/serenity/assets/11597044/9da5f747-79a6-44a2-b72c-c24f9e40cad3)
