### PR TITLE
HexEditor: Move endianness selector to Value Inspector panel

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.gml
+++ b/Userland/Applications/HexEditor/HexEditorWidget.gml
@@ -47,6 +47,24 @@
                 preferred_height: "grow"
                 visible: false
 
+                @GUI::ToolbarContainer {
+                    name: "value_inspector_toolbar_container"
+
+                    @GUI::Toolbar {
+                        name: "value_inspector_toolbar"
+
+                        @GUI::Label {
+                            text: "Mode:"
+                            preferred_width: 40
+                        }
+
+                        @GUI::ComboBox {
+                            name: "value_inspector_endianness"
+                            preferred_width: 120
+                        }
+                    }
+                }
+
                 @GUI::TableView {
                     name: "value_inspector"
                     activates_on_selection: true

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -48,6 +48,7 @@ private:
     void set_search_results_visible(bool visible);
     void set_value_inspector_visible(bool visible);
     void update_inspector_values(size_t position);
+    void set_inspector_little_endian(bool little_endian, bool force = false);
 
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
@@ -91,7 +92,6 @@ private:
     GUI::ActionGroup m_offset_format_actions;
 
     GUI::ActionGroup m_bytes_per_row_actions;
-    GUI::ActionGroup m_value_inspector_mode_actions;
 
     RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::Toolbar> m_toolbar;
@@ -99,8 +99,11 @@ private:
     RefPtr<GUI::TableView> m_search_results;
     RefPtr<GUI::Widget> m_search_results_container;
     RefPtr<GUI::DynamicWidgetContainer> m_side_panel_container;
+
     RefPtr<GUI::Widget> m_value_inspector_container;
     RefPtr<GUI::TableView> m_value_inspector;
+    RefPtr<GUI::ComboBox> m_value_inspector_endianness;
+    Vector<ByteString> m_endianness_options;
 
     RefPtr<GUI::Widget> m_annotations_container;
     RefPtr<GUI::TableView> m_annotations;

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -69,7 +69,7 @@ public:
         case Column::Type:
             return "Type"_string;
         case Column::Value:
-            return m_is_little_endian ? "Value (Little Endian)"_string : "Value (Big Endian)"_string;
+            return "Value"_string;
         }
         VERIFY_NOT_REACHED();
     }


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/1ccbfdff-0373-4403-9d89-934722b0b6b7)

It's clearer to have the choice here than hidden away in a menu. It also means we don't need the column heading to say the endianness.