### PR TITLE
AK: Address is_power_of rounding issues when base != 2

### DIFF
--- a/AK/IntegralMath.h
+++ b/AK/IntegralMath.h
@@ -57,15 +57,17 @@ constexpr I pow(I base, I exponent)
 template<auto base, Unsigned U = decltype(base)>
 constexpr bool is_power_of(U x)
 {
-    if constexpr (base == 2)
+    if constexpr (base == 0)
+        return x == 0;
+    else if constexpr (base == 2)
         return is_power_of_two(x);
 
-    // FIXME: I am naive! A log2-based approach (pow<U>(base, (log2(x) / log2(base))) == x) does not work due to rounding errors.
-    for (U exponent = 0; exponent <= log2(x) / log2(base) + 1; ++exponent) {
-        if (pow<U>(base, exponent) == x)
-            return true;
+    while (x != 1) {
+        if (x % base != 0)
+            return false;
+        x /= base;
     }
-    return false;
+    return true;
 }
 
 }


### PR DESCRIPTION
### Context
I'm currently working on adding MSVC support for AK to make it a fully cross platform library, with 565 tests and 10 benchmarks passing at the moment.

![msvc_AK_tests](https://github.com/SerenityOS/serenity/assets/11325341/62eb3fa6-79f3-4b78-8e5e-b4b5c11d381d)

Besides a lot of ifdef's to replace GCC/Clang-specific compiler built-ins with MSVC equivalents, so far I have not had to change/touch the existing code for any of the tests I have gotten to pass on MSVC.

### Problem
On MSVC in `TestIntegerMath.cpp` the `is_power_of` test case was getting a lot of failues with `prime != 2`.
![msvc_intmath_test_fail](https://github.com/SerenityOS/serenity/assets/11325341/01697724-dde9-4213-8081-0c5477da572d)

This new implementation makes all the tests pass on MSVC. Since that code had a FIXME comment I decided to submit my fix to upstream.

### Results

#### MSVC
![msvc_intmath_test](https://github.com/SerenityOS/serenity/assets/11325341/336aa023-381a-45b3-a39e-ac5a2900925c)

#### GCC
![gcc_intmath_test](https://github.com/SerenityOS/serenity/assets/11325341/1d2c0dfb-342e-4994-a87b-31d897fa31cc)


