### PR TITLE
BackgroundPainting: Added a check to compute_text_clip_paths to ensure we are able to produce a path for a given font

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -73,6 +73,12 @@ static Vector<Gfx::Path> compute_text_clip_paths(PaintContext& context, Paintabl
             if (glyph.has<Gfx::DrawGlyph>()) {
                 auto const& draw_glyph = glyph.get<Gfx::DrawGlyph>();
 
+                if (!is<Gfx::ScaledFont>(draw_glyph.font)) {
+                    // FIXME: This API only accepts Gfx::Font for ease of use.
+                    dbgln("Cannot path-ify bitmap fonts!");
+                    return;
+                }
+
                 // Get the path for the glyph.
                 Gfx::Path glyph_path;
                 auto const& scaled_font = static_cast<Gfx::ScaledFont const&>(*draw_glyph.font);


### PR DESCRIPTION
**Context:** 
Before this commit Ladybird would crash on websites attempting to utilize the clip-background: text property on a node rendered using a bitmap font

This was the case as `compute_text_clip_paths` assumed the glyph font was a derived instance of type `ScaledFont`. In reality `BitmapFont` was passed to the function under the above condition 

This commit omits rendering text using the above property for bitmap fonts whilst maintaining it for vector based scaled fonts 

This is done by coping the check / error message code from the Gfx library code used when attempting to path-ify bitmap fonts

The optimal solution would be to implement a way for us to calculate outline paths for bitmap fonts however I wanted to reach out and seek some advice of how useful this would be before perusing this. 

**Test Case:** 

```
<html>
    <style>
        .bitmap {
            background-clip: text;
            background-color: blanchedalmond;
        }
        .vector {
            background-clip: text;
            background-color: blueviolet;
            font-family: "Ubuntu";
        }
    </style>
    <body>
        <div class="bitmap"> this is a test of a bitmap font</div>
        <div class="vector"> this is a test of a vector font</div>
    </body>
</html>
```

![image](https://github.com/SerenityOS/serenity/assets/10763507/224b5649-acce-4571-b8b1-3ea0e9bb3c75)
