### PR TITLE
LibPDF: Added empty read check to parse_hex_string

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -362,6 +362,10 @@ PDFErrorOr<ByteString> Parser::parse_hex_string()
 
             for (int i = 0; i < 2; i++) {
                 m_reader.consume_whitespace();
+
+                if (m_reader.done())
+                    return error("unterminated hex string");
+
                 auto ch = m_reader.consume();
                 if (ch == '>') {
                     // The hex string contains an odd number of characters, and the last character


### PR DESCRIPTION
While fuzzing, found the following PDF that causes a crash 
[crash-025e245bd05e9b291b031417fb941c797086f0ba.pdf](https://github.com/SerenityOS/serenity/files/15211437/crash-025e245bd05e9b291b031417fb941c797086f0ba.pdf)
Its a simple fix for the bug.