### PR TITLE
LibWeb: Do not consume scroll event in PaintableBox without overflow

### DIFF
--- a/Tests/LibWeb/Ref/box-without-scrollable-overflow-should-not-consume-scroll-events.html
+++ b/Tests/LibWeb/Ref/box-without-scrollable-overflow-should-not-consume-scroll-events.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/box-without-scrollable-overflow-should-not-consume-scroll-events-ref.html" />
+<style>
+    .item {
+        width: 100px;
+        height: 100px;
+        box-sizing: border-box;
+        border: 1px solid black;
+    }
+    .item1 { overflow: auto; }
+    .scrollable {
+        overflow-y: scroll;
+        width: 100px;
+        height: 300px;
+        scrollbar-width: none;
+    }
+</style>
+<div class="scrollable">
+    <div class="item item1">1</div>
+    <div class="item">2</div>
+    <div class="item">3</div>
+    <div class="item">4</div>
+</div>
+<script>
+    internals.wheel(10, 10, 0, 100);
+</script>

--- a/Tests/LibWeb/Ref/reference/box-without-scrollable-overflow-should-not-consume-scroll-events-ref.html
+++ b/Tests/LibWeb/Ref/reference/box-without-scrollable-overflow-should-not-consume-scroll-events-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    .scrollable {
+        overflow-y: scroll;
+        width: 100px;
+        height: 300px;
+        scrollbar-width: none;
+    }
+    .item {
+        width: 100px;
+        height: 100px;
+        box-sizing: border-box;
+        border: 1px solid black;
+    }
+</style>
+<div class="scrollable">
+    <div class="item">2</div>
+    <div class="item">3</div>
+    <div class="item">4</div>
+</div>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -731,6 +731,11 @@ bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigne
 {
     if (!layout_box().is_user_scrollable())
         return false;
+
+    // TODO: Vertical and horizontal scroll overflow should be handled seperately.
+    if (!has_scrollable_overflow())
+        return false;
+
     scroll_by(wheel_delta_x, wheel_delta_y);
     return true;
 }


### PR DESCRIPTION
Specifically, without scrollable overflow.
Fixes https://github.com/SerenityOS/serenity/issues/24009, both on brave.com and on the reduction.
This fixes the bug that on old reddit with an expando open you could not scroll when having the cursor over the expando. Behaviour is now the same as on Chromium and Firefox.

The issue minimized to the following code: (Where with mouse over the blue box scroll inputs have no effect.)
```html
<!DOCTYPE html>
<body>
   <div style="overflow: auto; height: 250px; width: 250px; background-color: blue;"></div>
   <div style="height: 1080px; width: 50px; background-color: black;"></div>
</body>

</html>
```

A process question:
My commit title is less then 70 characters as the pre commit hook required. Would it be okay to expand the github title to longer to include the extra context that this is about scrollable overflow in the title here even if it goes past the 70 character view?