### PR TITLE
CI: Run `brew update` before installing macOS packages

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -41,7 +41,7 @@ runs:
         wget https://github.com/WebAssembly/wabt/releases/download/1.0.23/wabt-1.0.23-ubuntu.tar.gz
         tar -xzf ./wabt-1.0.23-ubuntu.tar.gz
         rm ./wabt-1.0.23-ubuntu.tar.gz
-        
+
     - name: 'Install JS dependencies'
       if: ${{ inputs.os == 'Linux' || inputs.os == 'Serenity' }}
       shell: bash
@@ -64,7 +64,7 @@ runs:
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
         sudo apt-get update
         sudo apt-get install clang-format-18 ccache e2fsprogs gcc-13 g++-13 libstdc++-13-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja libegl1-mesa-dev
-        
+
         if ${{ inputs.arch == 'aarch64' }}; then
             # FIXME: Remove this when we no longer build our own Qemu binary.
             sudo apt-get install libgtk-3-dev libpixman-1-dev libsdl2-dev libslirp-dev
@@ -83,4 +83,5 @@ runs:
       shell: bash
       run: |
         set -e
+        brew update
         brew install coreutils bash ninja wabt ccache unzip qt llvm@18


### PR DESCRIPTION
This is needed to update brew's internal list of formulae, otherwise it does not know about llvm-18.

This fixes the JS artifacts build:
https://github.com/trflynn89/serenity/actions/runs/8968586657/job/24628304185?pr=7