### PR TITLE
LibWeb: Ignore setting zero, negative, or non-finite CRC2D.lineWidths

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.h
@@ -16,8 +16,20 @@ class CanvasPathDrawingStyles {
 public:
     ~CanvasPathDrawingStyles() = default;
 
-    void set_line_width(float line_width) { my_drawing_state().line_width = line_width; }
-    float line_width() const { return my_drawing_state().line_width; }
+    // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-linewidth
+    void set_line_width(float line_width)
+    {
+        // On setting, zero, negative, infinite, and NaN values must be ignored, leaving the value unchanged;
+        if (line_width <= 0 || !isfinite(line_width))
+            return;
+        // other values must change the current value to the new value.
+        my_drawing_state().line_width = line_width;
+    }
+    float line_width() const
+    {
+        // On getting, it must return the current value.
+        return my_drawing_state().line_width;
+    }
 
 protected:
     CanvasPathDrawingStyles() = default;


### PR DESCRIPTION
This is part of the spec but was missed. This fixes a crash on: https://www.kevs3d.co.uk/dev/phoria/test1d.html