### PR TITLE
Ladybird: Remove menu indicator on hamburger icon

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -77,6 +77,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_hamburger_button->setIcon(create_tvg_icon_with_theme_colors("hamburger", palette()));
     m_hamburger_button->setPopupMode(QToolButton::InstantPopup);
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
+    m_hamburger_button->setStyleSheet(":menu-indicator {image: none}");
 
     recreate_toolbar_icons();
 


### PR DESCRIPTION
**Before:**
![Screenshot from 2024-05-06 13-48-32](https://github.com/SerenityOS/serenity/assets/11597044/12ed2038-8283-4273-84e8-cfb063e3ecc0)

Note: Little arrow in corner (looks unbalanced)

**After:**

![image](https://github.com/SerenityOS/serenity/assets/11597044/83a412fa-f49c-4174-8f5f-8eda2e02b9f8)
