### PR TITLE
LibJS: Flatten the bytecode representation and make interpreter fast

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -310,7 +310,7 @@ bool String::equals_ignoring_ascii_case(StringView other) const
 
 ErrorOr<String> String::repeated(String const& input, size_t count)
 {
-    if (Checked<size_t>::multiplication_would_overflow(count, input.bytes().size()))
+    if (Checked<u32>::multiplication_would_overflow(count, input.bytes().size()))
         return Error::from_errno(EOVERFLOW);
 
     String result;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -787,8 +787,8 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> DoWhileStatement::g
     // body
     // jump always (true) test
     // end
-    auto& test_block = generator.make_block();
     auto& body_block = generator.make_block();
+    auto& test_block = generator.make_block();
     auto& load_result_and_jump_to_end_block = generator.make_block();
     auto& end_block = generator.make_block();
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -851,8 +851,6 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> ForStatement::gener
     Bytecode::BasicBlock* body_block_ptr { nullptr };
     Bytecode::BasicBlock* update_block_ptr { nullptr };
 
-    auto& end_block = generator.make_block();
-
     bool has_lexical_environment = false;
 
     if (m_init) {
@@ -896,6 +894,8 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> ForStatement::gener
         test_block_ptr = &generator.make_block();
     else
         test_block_ptr = body_block_ptr;
+
+    auto& end_block = generator.make_block();
 
     generator.emit<Bytecode::Op::Jump>(Bytecode::Label { *test_block_ptr });
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -888,15 +888,15 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> ForStatement::gener
 
     body_block_ptr = &generator.make_block();
 
-    if (m_test)
-        test_block_ptr = &generator.make_block();
-    else
-        test_block_ptr = body_block_ptr;
-
     if (m_update)
         update_block_ptr = &generator.make_block();
     else
         update_block_ptr = body_block_ptr;
+
+    if (m_test)
+        test_block_ptr = &generator.make_block();
+    else
+        test_block_ptr = body_block_ptr;
 
     generator.emit<Bytecode::Op::Jump>(Bytecode::Label { *test_block_ptr });
 

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
@@ -10,13 +10,14 @@
 
 namespace JS::Bytecode {
 
-NonnullOwnPtr<BasicBlock> BasicBlock::create(String name)
+NonnullOwnPtr<BasicBlock> BasicBlock::create(u32 index, String name)
 {
-    return adopt_own(*new BasicBlock(move(name)));
+    return adopt_own(*new BasicBlock(index, move(name)));
 }
 
-BasicBlock::BasicBlock(String name)
-    : m_name(move(name))
+BasicBlock::BasicBlock(u32 index, String name)
+    : m_index(index)
+    , m_name(move(name))
 {
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
@@ -30,27 +30,6 @@ BasicBlock::~BasicBlock()
     }
 }
 
-void BasicBlock::dump(Bytecode::Executable const& executable) const
-{
-    Bytecode::InstructionStreamIterator it(instruction_stream());
-
-    if (!m_name.is_empty())
-        warn("{}", m_name);
-    if (m_handler || m_finalizer) {
-        warn(" [");
-        if (m_handler)
-            warn(" Handler: {}", Label { *m_handler });
-        if (m_finalizer)
-            warn(" Finalizer: {}", Label { *m_finalizer });
-        warn(" ]");
-    }
-    warnln(":");
-    while (!it.at_end()) {
-        warnln("[{:4x}] {}", it.offset(), (*it).to_byte_string(executable));
-        ++it;
-    }
-}
-
 void BasicBlock::grow(size_t additional_size)
 {
     m_buffer.grow_capacity(m_buffer.size() + additional_size);

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -27,7 +27,6 @@ public:
     static NonnullOwnPtr<BasicBlock> create(String name);
     ~BasicBlock();
 
-    void dump(Executable const&) const;
     ReadonlyBytes instruction_stream() const { return m_buffer.span(); }
     u8* data() { return m_buffer.data(); }
     u8 const* data() const { return m_buffer.data(); }

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -25,8 +25,10 @@ class BasicBlock {
     AK_MAKE_NONCOPYABLE(BasicBlock);
 
 public:
-    static NonnullOwnPtr<BasicBlock> create(String name);
+    static NonnullOwnPtr<BasicBlock> create(u32 index, String name);
     ~BasicBlock();
+
+    u32 index() const { return m_index; }
 
     ReadonlyBytes instruction_stream() const { return m_buffer.span(); }
     u8* data() { return m_buffer.data(); }
@@ -50,8 +52,9 @@ public:
     void add_source_map_entry(size_t bytecode_offset, SourceRecord const& source_record) { m_source_map.set(bytecode_offset, source_record); }
 
 private:
-    explicit BasicBlock(String name);
+    explicit BasicBlock(u32 index, String name);
 
+    u32 m_index { 0 };
     Vector<u8> m_buffer;
     BasicBlock const* m_handler { nullptr };
     BasicBlock const* m_finalizer { nullptr };

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -8,6 +8,7 @@
 
 #include <AK/Badge.h>
 #include <AK/String.h>
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 
@@ -45,6 +46,9 @@ public:
     BasicBlock const* handler() const { return m_handler; }
     BasicBlock const* finalizer() const { return m_finalizer; }
 
+    auto const& source_map() const { return m_source_map; }
+    void add_source_map_entry(size_t bytecode_offset, SourceRecord const& source_record) { m_source_map.set(bytecode_offset, source_record); }
+
 private:
     explicit BasicBlock(String name);
 
@@ -53,6 +57,8 @@ private:
     BasicBlock const* m_finalizer { nullptr };
     String m_name;
     bool m_terminated { false };
+
+    HashMap<size_t, SourceRecord> m_source_map;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.cpp
@@ -106,11 +106,13 @@ UnrealizedSourceRange Executable::source_range_at(size_t offset) const
         return {};
     auto it = InstructionStreamIterator(bytecode.span().slice(offset), this);
     VERIFY(!it.at_end());
-    auto& instruction = *it;
+    auto mapping = source_map.get(offset);
+    if (!mapping.has_value())
+        return {};
     return UnrealizedSourceRange {
         .source_code = source_code,
-        .start_offset = instruction.source_record().source_start_offset,
-        .end_offset = instruction.source_record().source_end_offset,
+        .start_offset = mapping->source_start_offset,
+        .end_offset = mapping->source_end_offset,
     };
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.cpp
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2024, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Executable.h>
+#include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/RegexTable.h>
 #include <LibJS/SourceCode.h>
 
@@ -14,6 +15,7 @@ namespace JS::Bytecode {
 JS_DEFINE_ALLOCATOR(Executable);
 
 Executable::Executable(
+    Vector<u8> bytecode,
     NonnullOwnPtr<IdentifierTable> identifier_table,
     NonnullOwnPtr<StringTable> string_table,
     NonnullOwnPtr<RegexTable> regex_table,
@@ -23,9 +25,8 @@ Executable::Executable(
     size_t number_of_global_variable_caches,
     size_t number_of_environment_variable_caches,
     size_t number_of_registers,
-    Vector<NonnullOwnPtr<BasicBlock>> basic_blocks,
     bool is_strict_mode)
-    : basic_blocks(move(basic_blocks))
+    : bytecode(move(bytecode))
     , string_table(move(string_table))
     , identifier_table(move(identifier_table))
     , regex_table(move(regex_table))
@@ -44,8 +45,42 @@ Executable::~Executable() = default;
 void Executable::dump() const
 {
     warnln("\033[37;1mJS bytecode executable\033[0m \"{}\"", name);
-    for (auto& block : basic_blocks)
-        block->dump(*this);
+    InstructionStreamIterator it(bytecode, this);
+
+    size_t basic_block_offset_index = 0;
+
+    while (!it.at_end()) {
+        bool print_basic_block_marker = false;
+        if (basic_block_offset_index < basic_block_start_offsets.size()
+            && it.offset() == basic_block_start_offsets[basic_block_offset_index]) {
+            ++basic_block_offset_index;
+            print_basic_block_marker = true;
+        }
+
+        StringBuilder builder;
+        builder.appendff("[{:4x}] ", it.offset());
+        if (print_basic_block_marker)
+            builder.appendff("{:4}: ", basic_block_offset_index - 1);
+        else
+            builder.append("      "sv);
+        builder.append((*it).to_byte_string(*this));
+
+        warnln("{}", builder.string_view());
+
+        ++it;
+    }
+
+    if (!exception_handlers.is_empty()) {
+        warnln("");
+        warnln("Exception handlers:");
+        for (auto& handlers : exception_handlers) {
+            warnln("    from {:4x} to {:4x} handler {:4x} finalizer {:4x}",
+                handlers.start_offset,
+                handlers.end_offset,
+                handlers.handler_offset.value_or(0),
+                handlers.finalizer_offset.value_or(0));
+        }
+    }
 
     warnln("");
 }
@@ -54,6 +89,29 @@ void Executable::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(constants);
+}
+
+Optional<Executable::ExceptionHandlers const&> Executable::exception_handlers_for_offset(size_t offset) const
+{
+    for (auto& handlers : exception_handlers) {
+        if (handlers.start_offset <= offset && offset < handlers.end_offset)
+            return handlers;
+    }
+    return {};
+}
+
+UnrealizedSourceRange Executable::source_range_at(size_t offset) const
+{
+    if (offset >= bytecode.size())
+        return {};
+    auto it = InstructionStreamIterator(bytecode.span().slice(offset), this);
+    VERIFY(!it.at_end());
+    auto& instruction = *it;
+    return UnrealizedSourceRange {
+        .source_code = source_code,
+        .start_offset = instruction.source_record().source_start_offset,
+        .end_offset = instruction.source_record().source_end_offset,
+    };
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -84,6 +84,8 @@ public:
     Vector<ExceptionHandlers> exception_handlers;
     Vector<size_t> basic_block_start_offsets;
 
+    HashMap<size_t, SourceRecord> source_map;
+
     ByteString const& get_string(StringTableIndex index) const { return string_table->get(index); }
     DeprecatedFlyString const& get_identifier(IdentifierTableIndex index) const { return identifier_table->get(index); }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -135,7 +135,7 @@ CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::generate(VM& vm, ASTN
     }
     for (auto label_offset : label_offsets) {
         auto& label = *reinterpret_cast<Label*>(bytecode.data() + label_offset);
-        auto* block = &label.block();
+        auto* block = generator.m_root_basic_blocks[label.basic_block_index()].ptr();
         label.set_address(block_offsets.get(block).value());
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -77,8 +77,7 @@ public:
         new (slot) OpType(forward<Args>(args)...);
         if constexpr (OpType::IsTerminator)
             m_current_basic_block->terminate({});
-        auto* op = static_cast<OpType*>(slot);
-        op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
+        m_current_basic_block->add_source_map_entry(slot_offset, { m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
     }
 
     template<typename OpType, typename ExtraSlotType, typename... Args>
@@ -93,8 +92,7 @@ public:
         new (slot) OpType(forward<Args>(args)...);
         if constexpr (OpType::IsTerminator)
             m_current_basic_block->terminate({});
-        auto* op = static_cast<OpType*>(slot);
-        op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
+        m_current_basic_block->add_source_map_entry(slot_offset, { m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
     }
 
     template<typename OpType, typename... Args>

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -150,12 +150,12 @@ public:
     {
         if (name.is_empty())
             name = MUST(String::number(m_next_block++));
-        auto block = BasicBlock::create(name);
+        auto block = BasicBlock::create(m_root_basic_blocks.size(), name);
         if (auto const* context = m_current_unwind_context) {
             if (context->handler().has_value())
-                block->set_handler(context->handler().value().block());
+                block->set_handler(*m_root_basic_blocks[context->handler().value().basic_block_index()]);
             if (m_current_unwind_context->finalizer().has_value())
-                block->set_finalizer(context->finalizer().value().block());
+                block->set_finalizer(*m_root_basic_blocks[context->finalizer().value().basic_block_index()]);
         }
         m_root_basic_blocks.append(move(block));
         return *m_root_basic_blocks.last();

--- a/Userland/Libraries/LibJS/Bytecode/IdentifierTable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/IdentifierTable.cpp
@@ -11,12 +11,13 @@ namespace JS::Bytecode {
 IdentifierTableIndex IdentifierTable::insert(DeprecatedFlyString string)
 {
     m_identifiers.append(move(string));
-    return m_identifiers.size() - 1;
+    VERIFY(m_identifiers.size() <= NumericLimits<u32>::max());
+    return { static_cast<u32>(m_identifiers.size() - 1) };
 }
 
 DeprecatedFlyString const& IdentifierTable::get(IdentifierTableIndex index) const
 {
-    return m_identifiers[index.value()];
+    return m_identifiers[index.value];
 }
 
 void IdentifierTable::dump() const

--- a/Userland/Libraries/LibJS/Bytecode/IdentifierTable.h
+++ b/Userland/Libraries/LibJS/Bytecode/IdentifierTable.h
@@ -12,7 +12,10 @@
 
 namespace JS::Bytecode {
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, IdentifierTableIndex, Comparison);
+struct IdentifierTableIndex {
+    bool is_valid() const { return value != NumericLimits<u32>::max(); }
+    u32 value { 0 };
+};
 
 class IdentifierTable {
     AK_MAKE_NONMOVABLE(IdentifierTable);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -26,6 +26,22 @@ void Instruction::destroy(Instruction& instruction)
 #undef __BYTECODE_OP
 }
 
+void Instruction::visit_labels(Function<void(JS::Bytecode::Label&)> visitor)
+{
+#define __BYTECODE_OP(op)                                             \
+    case Type::op:                                                    \
+        static_cast<Op::op&>(*this).visit_labels_impl(move(visitor)); \
+        return;
+
+    switch (type()) {
+        ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+#undef __BYTECODE_OP
+}
+
 UnrealizedSourceRange InstructionStreamIterator::source_range() const
 {
     VERIFY(m_executable);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -10,13 +10,6 @@
 
 namespace JS::Bytecode {
 
-Instruction::Instruction(Type type, size_t length)
-    : m_type(type)
-    , m_length(length)
-{
-    VERIFY(length <= NumericLimits<u32>::max());
-}
-
 void Instruction::destroy(Instruction& instruction)
 {
 #define __BYTECODE_OP(op)                        \
@@ -39,6 +32,42 @@ void Instruction::visit_labels(Function<void(JS::Bytecode::Label&)> visitor)
     case Type::op:                                                    \
         static_cast<Op::op&>(*this).visit_labels_impl(move(visitor)); \
         return;
+
+    switch (type()) {
+        ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+#undef __BYTECODE_OP
+}
+
+template<typename Op>
+concept HasVariableLength = Op::IsVariableLength;
+
+template<typename Op>
+concept HasFixedLength = !Op::IsVariableLength;
+
+template<HasVariableLength Op>
+size_t get_length_impl(Op const& op)
+{
+    return op.length_impl();
+}
+
+// Function template for types without a length_impl method
+template<HasFixedLength Op>
+size_t get_length_impl(Op const&)
+{
+    return sizeof(Op);
+}
+
+size_t Instruction::length() const
+{
+#define __BYTECODE_OP(op)                                   \
+    case Type::op: {                                        \
+        auto& typed_op = static_cast<Op::op const&>(*this); \
+        return get_length_impl(typed_op);                   \
+    }
 
     switch (type()) {
         ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -52,7 +52,7 @@ void Instruction::visit_labels(Function<void(JS::Bytecode::Label&)> visitor)
 UnrealizedSourceRange InstructionStreamIterator::source_range() const
 {
     VERIFY(m_executable);
-    auto record = dereference().source_record();
+    auto record = m_executable->source_map.get(offset()).value();
     return {
         .source_code = m_executable->source_code,
         .start_offset = record.source_start_offset,

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -10,6 +10,13 @@
 
 namespace JS::Bytecode {
 
+Instruction::Instruction(Type type, size_t length)
+    : m_type(type)
+    , m_length(length)
+{
+    VERIFY(length <= NumericLimits<u32>::max());
+}
+
 void Instruction::destroy(Instruction& instruction)
 {
 #define __BYTECODE_OP(op)                        \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -138,20 +138,22 @@ public:
     };
 
     Type type() const { return m_type; }
-    size_t length() const { return m_length; }
+    size_t length() const;
     ByteString to_byte_string(Bytecode::Executable const&) const;
     ThrowCompletionOr<void> execute(Bytecode::Interpreter&) const;
     void visit_labels(Function<void(Label&)> visitor);
     static void destroy(Instruction&);
 
 protected:
-    Instruction(Type, size_t length);
+    explicit Instruction(Type type)
+        : m_type(type)
+    {
+    }
 
     void visit_labels_impl(Function<void(Label&)>) { }
 
 private:
     Type m_type {};
-    u32 m_length {};
 };
 
 class InstructionStreamIterator {

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Function.h>
 #include <AK/Span.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Forward.h>
@@ -140,17 +141,12 @@ public:
     void visit_labels(Function<void(Label&)> visitor);
     static void destroy(Instruction&);
 
-    // FIXME: Find a better way to organize this information
-    void set_source_record(SourceRecord rec) { m_source_record = rec; }
-    SourceRecord source_record() const { return m_source_record; }
-
 protected:
     Instruction(Type, size_t length);
 
     void visit_labels_impl(Function<void(Label&)>) { }
 
 private:
-    SourceRecord m_source_record {};
     Type m_type {};
     u32 m_length {};
 };

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -69,8 +69,10 @@
     O(IteratorNext)                    \
     O(IteratorToArray)                 \
     O(Jump)                            \
+    O(JumpFalse)                       \
     O(JumpIf)                          \
     O(JumpNullish)                     \
+    O(JumpTrue)                        \
     O(JumpUndefined)                   \
     O(LeaveFinally)                    \
     O(LeaveLexicalEnvironment)         \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -137,6 +137,7 @@ public:
     size_t length() const { return m_length; }
     ByteString to_byte_string(Bytecode::Executable const&) const;
     ThrowCompletionOr<void> execute(Bytecode::Interpreter&) const;
+    void visit_labels(Function<void(Label&)> visitor);
     static void destroy(Instruction&);
 
     // FIXME: Find a better way to organize this information
@@ -149,6 +150,8 @@ protected:
         , m_length(length)
     {
     }
+
+    void visit_labels_impl(Function<void(Label&)>) { }
 
 private:
     SourceRecord m_source_record {};

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -128,6 +128,7 @@ namespace JS::Bytecode {
 class alignas(void*) Instruction {
 public:
     constexpr static bool IsTerminator = false;
+    static constexpr bool IsVariableLength = false;
 
     enum class Type {
 #define __BYTECODE_OP(op) \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -145,18 +145,14 @@ public:
     SourceRecord source_record() const { return m_source_record; }
 
 protected:
-    Instruction(Type type, size_t length)
-        : m_type(type)
-        , m_length(length)
-    {
-    }
+    Instruction(Type, size_t length);
 
     void visit_labels_impl(Function<void(Label&)>) { }
 
 private:
     SourceRecord m_source_record {};
     Type m_type {};
-    size_t m_length {};
+    u32 m_length {};
 };
 
 class InstructionStreamIterator {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -100,7 +100,7 @@ static ByteString format_value_list(StringView name, ReadonlySpan<Value> values)
 {
     StringBuilder builder;
     if (!name.is_empty())
-        builder.appendff(", \033[32m{}\033[0m:[", name);
+        builder.appendff("\033[32m{}\033[0m:[", name);
     builder.join(", "sv, values);
     builder.append("]"sv);
     return builder.to_byte_string();

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -339,6 +339,11 @@ Interpreter::HandleExceptionResponse Interpreter::handle_exception(size_t& progr
 
 FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 {
+    if (vm().did_reach_stack_space_limit()) {
+        reg(Register::exception()) = vm().throw_completion<InternalError>(ErrorType::CallStackSizeExceeded).release_value().value();
+        return;
+    }
+
     auto& running_execution_context = vm().running_execution_context();
     auto* locals = running_execution_context.locals.data();
     auto& accumulator = this->accumulator();

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -330,7 +330,14 @@ Interpreter::HandleExceptionResponse Interpreter::handle_exception(size_t& progr
     VERIFY_NOT_REACHED();
 }
 
-void Interpreter::run_bytecode(size_t entry_point)
+// FIXME: GCC takes a *long* time to compile with flattening, and it will time out our CI. :|
+#if defined(AK_COMPILER_CLANG)
+#    define FLATTEN_ON_CLANG FLATTEN
+#else
+#    define FLATTEN_ON_CLANG
+#endif
+
+FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 {
     auto& running_execution_context = vm().running_execution_context();
     auto* locals = running_execution_context.locals.data();

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1758,7 +1758,7 @@ ByteString GetGlobal::to_byte_string_impl(Bytecode::Executable const& executable
 
 ByteString DeleteVariable::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
-    return ByteString::formatted("DeleteVariable {} ({})", m_identifier, executable.identifier_table->get(m_identifier));
+    return ByteString::formatted("DeleteVariable {}", executable.identifier_table->get(m_identifier));
 }
 
 ByteString CreateLexicalEnvironment::to_byte_string_impl(Bytecode::Executable const&) const
@@ -1769,7 +1769,7 @@ ByteString CreateLexicalEnvironment::to_byte_string_impl(Bytecode::Executable co
 ByteString CreateVariable::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
     auto mode_string = m_mode == EnvironmentMode::Lexical ? "Lexical" : "Variable";
-    return ByteString::formatted("CreateVariable env:{} immutable:{} global:{} {} ({})", mode_string, m_is_immutable, m_is_global, m_identifier, executable.identifier_table->get(m_identifier));
+    return ByteString::formatted("CreateVariable env:{} immutable:{} global:{} {}", mode_string, m_is_immutable, m_is_global, executable.identifier_table->get(m_identifier));
 }
 
 ByteString EnterObjectEnvironment::to_byte_string_impl(Executable const& executable) const
@@ -2010,7 +2010,7 @@ ByteString NewClass::to_byte_string_impl(Bytecode::Executable const& executable)
     if (!name.is_empty())
         builder.appendff(", {}", name);
     if (m_lhs_name.has_value())
-        builder.appendff(", lhs_name:{}"sv, m_lhs_name.value());
+        builder.appendff(", lhs_name:{}"sv, executable.get_identifier(m_lhs_name.value()));
     return builder.to_byte_string();
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Label.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Label.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Bytecode/BasicBlock.h>
+#include <LibJS/Bytecode/Label.h>
+
+namespace JS::Bytecode {
+
+Label::Label(Bytecode::BasicBlock const& basic_block)
+    : m_address_or_basic_block_index(basic_block.index())
+{
+}
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/Label.h
+++ b/Userland/Libraries/LibJS/Bytecode/Label.h
@@ -14,27 +14,23 @@ class BasicBlock;
 
 class Label {
 public:
-    explicit Label(BasicBlock const& block)
-        : m_block(&block)
+    explicit Label(BasicBlock const&);
+
+    explicit Label(u32 basic_block_index)
+        : m_address_or_basic_block_index(basic_block_index)
     {
     }
 
     // Used while compiling.
-    BasicBlock const& block() const { return *m_block; }
+    size_t basic_block_index() const { return m_address_or_basic_block_index; }
 
     // Used after compiling.
-    size_t address() const { return m_address; }
+    size_t address() const { return m_address_or_basic_block_index; }
 
-    void set_address(size_t address) { m_address = address; }
+    void set_address(size_t address) { m_address_or_basic_block_index = address; }
 
 private:
-    union {
-        // Relevant while compiling.
-        BasicBlock const* m_block { nullptr };
-
-        // Relevant after compiling.
-        size_t m_address;
-    };
+    u32 m_address_or_basic_block_index { 0 };
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Label.h
+++ b/Userland/Libraries/LibJS/Bytecode/Label.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include <AK/Format.h>
-#include <LibJS/Bytecode/BasicBlock.h>
 
 namespace JS::Bytecode {
+
+class BasicBlock;
 
 class Label {
 public:

--- a/Userland/Libraries/LibJS/Bytecode/Label.h
+++ b/Userland/Libraries/LibJS/Bytecode/Label.h
@@ -18,18 +18,30 @@ public:
     {
     }
 
-    auto& block() const { return *m_block; }
+    // Used while compiling.
+    BasicBlock const& block() const { return *m_block; }
+
+    // Used after compiling.
+    size_t address() const { return m_address; }
+
+    void set_address(size_t address) { m_address = address; }
 
 private:
-    BasicBlock const* m_block { nullptr };
+    union {
+        // Relevant while compiling.
+        BasicBlock const* m_block { nullptr };
+
+        // Relevant after compiling.
+        size_t m_address;
+    };
 };
 
 }
 
 template<>
 struct AK::Formatter<JS::Bytecode::Label> : AK::Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, JS::Bytecode::Label const& value)
+    ErrorOr<void> format(FormatBuilder& builder, JS::Bytecode::Label const& label)
     {
-        return AK::Formatter<FormatString>::format(builder, "@{}"sv, value.block().name());
+        return AK::Formatter<FormatString>::format(builder, "@{:x}"sv, label.address());
     }
 };

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -554,12 +554,12 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
-    size_t index() const { return m_index; }
+    u32 index() const { return m_index; }
     Operand dst() const { return Operand(Operand::Type::Local, m_index); }
     Operand src() const { return m_src; }
 
 private:
-    size_t m_index;
+    u32 m_index;
     Operand m_src;
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -209,6 +209,8 @@ JS_ENUMERATE_NEW_BUILTIN_ERROR_OPS(JS_DECLARE_NEW_BUILTIN_ERROR_OP)
 // NOTE: This instruction is variable-width depending on the number of excluded names
 class CopyObjectExcludingProperties final : public Instruction {
 public:
+    static constexpr bool IsVariableLength = true;
+
     CopyObjectExcludingProperties(Operand dst, Operand from_object, Vector<Operand> const& excluded_names)
         : Instruction(Type::CopyObjectExcludingProperties, length_impl(excluded_names.size()))
         , m_dst(dst)
@@ -242,6 +244,8 @@ private:
 // NOTE: This instruction is variable-width depending on the number of elements!
 class NewArray final : public Instruction {
 public:
+    static constexpr bool IsVariableLength = true;
+
     explicit NewArray(Operand dst)
         : Instruction(Type::NewArray, length_impl(0))
         , m_dst(dst)
@@ -290,6 +294,8 @@ private:
 
 class NewPrimitiveArray final : public Instruction {
 public:
+    static constexpr bool IsVariableLength = true;
+
     NewPrimitiveArray(Operand dst, ReadonlySpan<Value> elements)
         : Instruction(Type::NewPrimitiveArray, length_impl(elements.size()))
         , m_dst(dst)
@@ -1230,6 +1236,8 @@ enum class CallType {
 
 class Call final : public Instruction {
 public:
+    static constexpr bool IsVariableLength = true;
+
     Call(CallType type, Operand dst, Operand callee, Operand this_value, ReadonlySpan<Operand> arguments, Optional<StringTableIndex> expression_string = {}, Optional<Builtin> builtin = {})
         : Instruction(Type::Call, length_impl(arguments.size()))
         , m_dst(dst)

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -34,7 +34,7 @@ namespace JS::Bytecode::Op {
 class Mov final : public Instruction {
 public:
     Mov(Operand dst, Operand src)
-        : Instruction(Type::Mov, sizeof(*this))
+        : Instruction(Type::Mov)
         , m_dst(dst)
         , m_src(src)
     {
@@ -81,7 +81,7 @@ private:
     class OpTitleCase final : public Instruction {                          \
     public:                                                                 \
         explicit OpTitleCase(Operand dst, Operand lhs, Operand rhs)         \
-            : Instruction(Type::OpTitleCase, sizeof(*this))                 \
+            : Instruction(Type::OpTitleCase)                                \
             , m_dst(dst)                                                    \
             , m_lhs(lhs)                                                    \
             , m_rhs(rhs)                                                    \
@@ -116,7 +116,7 @@ JS_ENUMERATE_COMMON_BINARY_OPS_WITH_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
     class OpTitleCase final : public Instruction {                          \
     public:                                                                 \
         OpTitleCase(Operand dst, Operand src)                               \
-            : Instruction(Type::OpTitleCase, sizeof(*this))                 \
+            : Instruction(Type::OpTitleCase)                                \
             , m_dst(dst)                                                    \
             , m_src(src)                                                    \
         {                                                                   \
@@ -139,7 +139,7 @@ JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
 class NewObject final : public Instruction {
 public:
     explicit NewObject(Operand dst)
-        : Instruction(Type::NewObject, sizeof(*this))
+        : Instruction(Type::NewObject)
         , m_dst(dst)
     {
     }
@@ -156,7 +156,7 @@ private:
 class NewRegExp final : public Instruction {
 public:
     NewRegExp(Operand dst, StringTableIndex source_index, StringTableIndex flags_index, RegexTableIndex regex_index)
-        : Instruction(Type::NewRegExp, sizeof(*this))
+        : Instruction(Type::NewRegExp)
         , m_dst(dst)
         , m_source_index(source_index)
         , m_flags_index(flags_index)
@@ -186,7 +186,7 @@ private:
     class New##ErrorName final : public Instruction {                       \
     public:                                                                 \
         New##ErrorName(Operand dst, StringTableIndex error_string)          \
-            : Instruction(Type::New##ErrorName, sizeof(*this))              \
+            : Instruction(Type::New##ErrorName)                             \
             , m_dst(dst)                                                    \
             , m_error_string(error_string)                                  \
         {                                                                   \
@@ -212,7 +212,7 @@ public:
     static constexpr bool IsVariableLength = true;
 
     CopyObjectExcludingProperties(Operand dst, Operand from_object, Vector<Operand> const& excluded_names)
-        : Instruction(Type::CopyObjectExcludingProperties, length_impl(excluded_names.size()))
+        : Instruction(Type::CopyObjectExcludingProperties)
         , m_dst(dst)
         , m_from_object(from_object)
         , m_excluded_names_count(excluded_names.size())
@@ -224,9 +224,9 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
-    size_t length_impl(size_t excluded_names_count) const
+    size_t length_impl() const
     {
-        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * excluded_names_count);
+        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_excluded_names_count);
     }
 
     Operand dst() const { return m_dst; }
@@ -247,14 +247,14 @@ public:
     static constexpr bool IsVariableLength = true;
 
     explicit NewArray(Operand dst)
-        : Instruction(Type::NewArray, length_impl(0))
+        : Instruction(Type::NewArray)
         , m_dst(dst)
         , m_element_count(0)
     {
     }
 
     NewArray(Operand dst, AK::Array<Operand, 2> const& elements_range)
-        : Instruction(Type::NewArray, length_impl(elements_range[1].index() - elements_range[0].index() + 1))
+        : Instruction(Type::NewArray)
         , m_dst(dst)
         , m_element_count(elements_range[1].index() - elements_range[0].index() + 1)
     {
@@ -267,9 +267,9 @@ public:
 
     Operand dst() const { return m_dst; }
 
-    size_t length_impl(size_t element_count) const
+    size_t length_impl() const
     {
-        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * (element_count == 0 ? 0 : 2));
+        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * (m_element_count == 0 ? 0 : 2));
     }
 
     Operand start() const
@@ -297,7 +297,7 @@ public:
     static constexpr bool IsVariableLength = true;
 
     NewPrimitiveArray(Operand dst, ReadonlySpan<Value> elements)
-        : Instruction(Type::NewPrimitiveArray, length_impl(elements.size()))
+        : Instruction(Type::NewPrimitiveArray)
         , m_dst(dst)
         , m_element_count(elements.size())
     {
@@ -305,9 +305,9 @@ public:
             m_elements[i] = elements[i];
     }
 
-    size_t length_impl(size_t element_count) const
+    size_t length_impl() const
     {
-        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Value) * element_count);
+        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Value) * m_element_count);
     }
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
@@ -325,7 +325,7 @@ private:
 class ArrayAppend final : public Instruction {
 public:
     ArrayAppend(Operand dst, Operand src, bool is_spread)
-        : Instruction(Type::ArrayAppend, sizeof(*this))
+        : Instruction(Type::ArrayAppend)
         , m_dst(dst)
         , m_src(src)
         , m_is_spread(is_spread)
@@ -348,7 +348,7 @@ private:
 class ImportCall final : public Instruction {
 public:
     ImportCall(Operand dst, Operand specifier, Operand options)
-        : Instruction(Type::ImportCall, sizeof(*this))
+        : Instruction(Type::ImportCall)
         , m_dst(dst)
         , m_specifier(specifier)
         , m_options(options)
@@ -371,7 +371,7 @@ private:
 class IteratorToArray final : public Instruction {
 public:
     explicit IteratorToArray(Operand dst, Operand iterator)
-        : Instruction(Type::IteratorToArray, sizeof(*this))
+        : Instruction(Type::IteratorToArray)
         , m_dst(dst)
         , m_iterator(iterator)
     {
@@ -391,7 +391,7 @@ private:
 class ConcatString final : public Instruction {
 public:
     explicit ConcatString(Operand dst, Operand src)
-        : Instruction(Type::ConcatString, sizeof(*this))
+        : Instruction(Type::ConcatString)
         , m_dst(dst)
         , m_src(src)
     {
@@ -416,7 +416,7 @@ enum class EnvironmentMode {
 class CreateLexicalEnvironment final : public Instruction {
 public:
     explicit CreateLexicalEnvironment()
-        : Instruction(Type::CreateLexicalEnvironment, sizeof(*this))
+        : Instruction(Type::CreateLexicalEnvironment)
     {
     }
 
@@ -427,7 +427,7 @@ public:
 class EnterObjectEnvironment final : public Instruction {
 public:
     explicit EnterObjectEnvironment(Operand object)
-        : Instruction(Type::EnterObjectEnvironment, sizeof(*this))
+        : Instruction(Type::EnterObjectEnvironment)
         , m_object(object)
     {
     }
@@ -444,7 +444,7 @@ private:
 class Catch final : public Instruction {
 public:
     explicit Catch(Operand dst)
-        : Instruction(Type::Catch, sizeof(*this))
+        : Instruction(Type::Catch)
         , m_dst(dst)
     {
     }
@@ -461,7 +461,7 @@ private:
 class LeaveFinally final : public Instruction {
 public:
     explicit LeaveFinally()
-        : Instruction(Type::LeaveFinally, sizeof(*this))
+        : Instruction(Type::LeaveFinally)
     {
     }
 
@@ -472,7 +472,7 @@ public:
 class RestoreScheduledJump final : public Instruction {
 public:
     explicit RestoreScheduledJump()
-        : Instruction(Type::RestoreScheduledJump, sizeof(*this))
+        : Instruction(Type::RestoreScheduledJump)
     {
     }
 
@@ -483,7 +483,7 @@ public:
 class CreateVariable final : public Instruction {
 public:
     explicit CreateVariable(IdentifierTableIndex identifier, EnvironmentMode mode, bool is_immutable, bool is_global = false, bool is_strict = false)
-        : Instruction(Type::CreateVariable, sizeof(*this))
+        : Instruction(Type::CreateVariable)
         , m_identifier(identifier)
         , m_mode(mode)
         , m_is_immutable(is_immutable)
@@ -516,7 +516,7 @@ public:
         Set,
     };
     explicit SetVariable(IdentifierTableIndex identifier, Operand src, u32 cache_index, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
-        : Instruction(Type::SetVariable, sizeof(*this))
+        : Instruction(Type::SetVariable)
         , m_identifier(identifier)
         , m_src(src)
         , m_mode(mode)
@@ -545,7 +545,7 @@ private:
 class SetLocal final : public Instruction {
 public:
     SetLocal(size_t index, Operand src)
-        : Instruction(Type::SetLocal, sizeof(*this))
+        : Instruction(Type::SetLocal)
         , m_index(index)
         , m_src(src)
     {
@@ -566,7 +566,7 @@ private:
 class GetCalleeAndThisFromEnvironment final : public Instruction {
 public:
     explicit GetCalleeAndThisFromEnvironment(Operand callee, Operand this_value, IdentifierTableIndex identifier, u32 cache_index)
-        : Instruction(Type::GetCalleeAndThisFromEnvironment, sizeof(*this))
+        : Instruction(Type::GetCalleeAndThisFromEnvironment)
         , m_identifier(identifier)
         , m_callee(callee)
         , m_this_value(this_value)
@@ -592,7 +592,7 @@ private:
 class GetVariable final : public Instruction {
 public:
     explicit GetVariable(Operand dst, IdentifierTableIndex identifier, u32 cache_index)
-        : Instruction(Type::GetVariable, sizeof(*this))
+        : Instruction(Type::GetVariable)
         , m_dst(dst)
         , m_identifier(identifier)
         , m_cache_index(cache_index)
@@ -615,7 +615,7 @@ private:
 class GetGlobal final : public Instruction {
 public:
     GetGlobal(Operand dst, IdentifierTableIndex identifier, u32 cache_index)
-        : Instruction(Type::GetGlobal, sizeof(*this))
+        : Instruction(Type::GetGlobal)
         , m_dst(dst)
         , m_identifier(identifier)
         , m_cache_index(cache_index)
@@ -638,7 +638,7 @@ private:
 class DeleteVariable final : public Instruction {
 public:
     explicit DeleteVariable(Operand dst, IdentifierTableIndex identifier)
-        : Instruction(Type::DeleteVariable, sizeof(*this))
+        : Instruction(Type::DeleteVariable)
         , m_dst(dst)
         , m_identifier(identifier)
     {
@@ -658,7 +658,7 @@ private:
 class GetById final : public Instruction {
 public:
     GetById(Operand dst, Operand base, IdentifierTableIndex property, Optional<IdentifierTableIndex> base_identifier, u32 cache_index)
-        : Instruction(Type::GetById, sizeof(*this))
+        : Instruction(Type::GetById)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -686,7 +686,7 @@ private:
 class GetByIdWithThis final : public Instruction {
 public:
     GetByIdWithThis(Operand dst, Operand base, IdentifierTableIndex property, Operand this_value, u32 cache_index)
-        : Instruction(Type::GetByIdWithThis, sizeof(*this))
+        : Instruction(Type::GetByIdWithThis)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -715,7 +715,7 @@ private:
 class GetPrivateById final : public Instruction {
 public:
     explicit GetPrivateById(Operand dst, Operand base, IdentifierTableIndex property)
-        : Instruction(Type::GetPrivateById, sizeof(*this))
+        : Instruction(Type::GetPrivateById)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -738,7 +738,7 @@ private:
 class HasPrivateId final : public Instruction {
 public:
     HasPrivateId(Operand dst, Operand base, IdentifierTableIndex property)
-        : Instruction(Type::HasPrivateId, sizeof(*this))
+        : Instruction(Type::HasPrivateId)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -770,7 +770,7 @@ enum class PropertyKind {
 class PutById final : public Instruction {
 public:
     explicit PutById(Operand base, IdentifierTableIndex property, Operand src, PropertyKind kind, u32 cache_index, Optional<IdentifierTableIndex> base_identifier = {})
-        : Instruction(Type::PutById, sizeof(*this))
+        : Instruction(Type::PutById)
         , m_base(base)
         , m_property(property)
         , m_src(src)
@@ -801,7 +801,7 @@ private:
 class PutByIdWithThis final : public Instruction {
 public:
     PutByIdWithThis(Operand base, Operand this_value, IdentifierTableIndex property, Operand src, PropertyKind kind, u32 cache_index)
-        : Instruction(Type::PutByIdWithThis, sizeof(*this))
+        : Instruction(Type::PutByIdWithThis)
         , m_base(base)
         , m_this_value(this_value)
         , m_property(property)
@@ -833,7 +833,7 @@ private:
 class PutPrivateById final : public Instruction {
 public:
     explicit PutPrivateById(Operand base, IdentifierTableIndex property, Operand src, PropertyKind kind = PropertyKind::KeyValue)
-        : Instruction(Type::PutPrivateById, sizeof(*this))
+        : Instruction(Type::PutPrivateById)
         , m_base(base)
         , m_property(property)
         , m_src(src)
@@ -858,7 +858,7 @@ private:
 class DeleteById final : public Instruction {
 public:
     explicit DeleteById(Operand dst, Operand base, IdentifierTableIndex property)
-        : Instruction(Type::DeleteById, sizeof(*this))
+        : Instruction(Type::DeleteById)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -881,7 +881,7 @@ private:
 class DeleteByIdWithThis final : public Instruction {
 public:
     DeleteByIdWithThis(Operand dst, Operand base, Operand this_value, IdentifierTableIndex property)
-        : Instruction(Type::DeleteByIdWithThis, sizeof(*this))
+        : Instruction(Type::DeleteByIdWithThis)
         , m_dst(dst)
         , m_base(base)
         , m_this_value(this_value)
@@ -907,7 +907,7 @@ private:
 class GetByValue final : public Instruction {
 public:
     GetByValue(Operand dst, Operand base, Operand property, Optional<IdentifierTableIndex> base_identifier = {})
-        : Instruction(Type::GetByValue, sizeof(*this))
+        : Instruction(Type::GetByValue)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -934,7 +934,7 @@ private:
 class GetByValueWithThis final : public Instruction {
 public:
     GetByValueWithThis(Operand dst, Operand base, Operand property, Operand this_value)
-        : Instruction(Type::GetByValueWithThis, sizeof(*this))
+        : Instruction(Type::GetByValueWithThis)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -960,7 +960,7 @@ private:
 class PutByValue final : public Instruction {
 public:
     PutByValue(Operand base, Operand property, Operand src, PropertyKind kind = PropertyKind::KeyValue, Optional<IdentifierTableIndex> base_identifier = {})
-        : Instruction(Type::PutByValue, sizeof(*this))
+        : Instruction(Type::PutByValue)
         , m_base(base)
         , m_property(property)
         , m_src(src)
@@ -988,7 +988,7 @@ private:
 class PutByValueWithThis final : public Instruction {
 public:
     PutByValueWithThis(Operand base, Operand property, Operand this_value, Operand src, PropertyKind kind = PropertyKind::KeyValue)
-        : Instruction(Type::PutByValueWithThis, sizeof(*this))
+        : Instruction(Type::PutByValueWithThis)
         , m_base(base)
         , m_property(property)
         , m_this_value(this_value)
@@ -1017,7 +1017,7 @@ private:
 class DeleteByValue final : public Instruction {
 public:
     DeleteByValue(Operand dst, Operand base, Operand property)
-        : Instruction(Type::DeleteByValue, sizeof(*this))
+        : Instruction(Type::DeleteByValue)
         , m_dst(dst)
         , m_base(base)
         , m_property(property)
@@ -1040,7 +1040,7 @@ private:
 class DeleteByValueWithThis final : public Instruction {
 public:
     DeleteByValueWithThis(Operand dst, Operand base, Operand this_value, Operand property)
-        : Instruction(Type::DeleteByValueWithThis, sizeof(*this))
+        : Instruction(Type::DeleteByValueWithThis)
         , m_dst(dst)
         , m_base(base)
         , m_this_value(this_value)
@@ -1068,7 +1068,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit Jump(Label target)
-        : Instruction(Type::Jump, sizeof(*this))
+        : Instruction(Type::Jump)
         , m_target(target)
     {
     }
@@ -1091,7 +1091,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit JumpIf(Operand condition, Label true_target, Label false_target)
-        : Instruction(Type::JumpIf, sizeof(*this))
+        : Instruction(Type::JumpIf)
         , m_condition(condition)
         , m_true_target(true_target)
         , m_false_target(false_target)
@@ -1121,7 +1121,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit JumpTrue(Operand condition, Label target)
-        : Instruction(Type::JumpTrue, sizeof(*this))
+        : Instruction(Type::JumpTrue)
         , m_condition(condition)
         , m_target(target)
     {
@@ -1147,7 +1147,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit JumpFalse(Operand condition, Label target)
-        : Instruction(Type::JumpFalse, sizeof(*this))
+        : Instruction(Type::JumpFalse)
         , m_condition(condition)
         , m_target(target)
     {
@@ -1173,7 +1173,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit JumpNullish(Operand condition, Label true_target, Label false_target)
-        : Instruction(Type::JumpNullish, sizeof(*this))
+        : Instruction(Type::JumpNullish)
         , m_condition(condition)
         , m_true_target(true_target)
         , m_false_target(false_target)
@@ -1203,7 +1203,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit JumpUndefined(Operand condition, Label true_target, Label false_target)
-        : Instruction(Type::JumpUndefined, sizeof(*this))
+        : Instruction(Type::JumpUndefined)
         , m_condition(condition)
         , m_true_target(true_target)
         , m_false_target(false_target)
@@ -1239,7 +1239,7 @@ public:
     static constexpr bool IsVariableLength = true;
 
     Call(CallType type, Operand dst, Operand callee, Operand this_value, ReadonlySpan<Operand> arguments, Optional<StringTableIndex> expression_string = {}, Optional<Builtin> builtin = {})
-        : Instruction(Type::Call, length_impl(arguments.size()))
+        : Instruction(Type::Call)
         , m_dst(dst)
         , m_callee(callee)
         , m_this_value(this_value)
@@ -1252,9 +1252,9 @@ public:
             m_arguments[i] = arguments[i];
     }
 
-    size_t length_impl(size_t argument_count) const
+    size_t length_impl() const
     {
-        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * argument_count);
+        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_argument_count);
     }
 
     CallType call_type() const { return m_type; }
@@ -1284,7 +1284,7 @@ private:
 class CallWithArgumentArray final : public Instruction {
 public:
     CallWithArgumentArray(CallType type, Operand dst, Operand callee, Operand this_value, Operand arguments, Optional<StringTableIndex> expression_string = {})
-        : Instruction(Type::CallWithArgumentArray, sizeof(*this))
+        : Instruction(Type::CallWithArgumentArray)
         , m_dst(dst)
         , m_callee(callee)
         , m_this_value(this_value)
@@ -1316,7 +1316,7 @@ private:
 class SuperCallWithArgumentArray : public Instruction {
 public:
     explicit SuperCallWithArgumentArray(Operand dst, Operand arguments, bool is_synthetic)
-        : Instruction(Type::SuperCallWithArgumentArray, sizeof(*this))
+        : Instruction(Type::SuperCallWithArgumentArray)
         , m_dst(dst)
         , m_arguments(arguments)
         , m_is_synthetic(is_synthetic)
@@ -1339,7 +1339,7 @@ private:
 class NewClass final : public Instruction {
 public:
     explicit NewClass(Operand dst, Optional<Operand> super_class, ClassExpression const& class_expression, Optional<IdentifierTableIndex> lhs_name)
-        : Instruction(Type::NewClass, sizeof(*this))
+        : Instruction(Type::NewClass)
         , m_dst(dst)
         , m_super_class(super_class)
         , m_class_expression(class_expression)
@@ -1365,7 +1365,7 @@ private:
 class NewFunction final : public Instruction {
 public:
     explicit NewFunction(Operand dst, FunctionExpression const& function_node, Optional<IdentifierTableIndex> lhs_name, Optional<Operand> home_object = {})
-        : Instruction(Type::NewFunction, sizeof(*this))
+        : Instruction(Type::NewFunction)
         , m_dst(dst)
         , m_function_node(function_node)
         , m_lhs_name(lhs_name)
@@ -1391,7 +1391,7 @@ private:
 class BlockDeclarationInstantiation final : public Instruction {
 public:
     explicit BlockDeclarationInstantiation(ScopeNode const& scope_node)
-        : Instruction(Type::BlockDeclarationInstantiation, sizeof(*this))
+        : Instruction(Type::BlockDeclarationInstantiation)
         , m_scope_node(scope_node)
     {
     }
@@ -1410,7 +1410,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit Return(Optional<Operand> value = {})
-        : Instruction(Type::Return, sizeof(*this))
+        : Instruction(Type::Return)
         , m_value(value)
     {
     }
@@ -1427,7 +1427,7 @@ private:
 class Increment final : public Instruction {
 public:
     explicit Increment(Operand dst)
-        : Instruction(Type::Increment, sizeof(*this))
+        : Instruction(Type::Increment)
         , m_dst(dst)
     {
     }
@@ -1444,7 +1444,7 @@ private:
 class PostfixIncrement final : public Instruction {
 public:
     explicit PostfixIncrement(Operand dst, Operand src)
-        : Instruction(Type::PostfixIncrement, sizeof(*this))
+        : Instruction(Type::PostfixIncrement)
         , m_dst(dst)
         , m_src(src)
     {
@@ -1464,7 +1464,7 @@ private:
 class Decrement final : public Instruction {
 public:
     explicit Decrement(Operand dst)
-        : Instruction(Type::Decrement, sizeof(*this))
+        : Instruction(Type::Decrement)
         , m_dst(dst)
     {
     }
@@ -1481,7 +1481,7 @@ private:
 class PostfixDecrement final : public Instruction {
 public:
     explicit PostfixDecrement(Operand dst, Operand src)
-        : Instruction(Type::PostfixDecrement, sizeof(*this))
+        : Instruction(Type::PostfixDecrement)
         , m_dst(dst)
         , m_src(src)
     {
@@ -1503,7 +1503,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit Throw(Operand src)
-        : Instruction(Type::Throw, sizeof(*this))
+        : Instruction(Type::Throw)
         , m_src(src)
     {
     }
@@ -1520,7 +1520,7 @@ private:
 class ThrowIfNotObject final : public Instruction {
 public:
     ThrowIfNotObject(Operand src)
-        : Instruction(Type::ThrowIfNotObject, sizeof(*this))
+        : Instruction(Type::ThrowIfNotObject)
         , m_src(src)
     {
     }
@@ -1537,7 +1537,7 @@ private:
 class ThrowIfNullish final : public Instruction {
 public:
     explicit ThrowIfNullish(Operand src)
-        : Instruction(Type::ThrowIfNullish, sizeof(*this))
+        : Instruction(Type::ThrowIfNullish)
         , m_src(src)
     {
     }
@@ -1554,7 +1554,7 @@ private:
 class ThrowIfTDZ final : public Instruction {
 public:
     explicit ThrowIfTDZ(Operand src)
-        : Instruction(Type::ThrowIfTDZ, sizeof(*this))
+        : Instruction(Type::ThrowIfTDZ)
         , m_src(src)
     {
     }
@@ -1573,7 +1573,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     EnterUnwindContext(Label entry_point)
-        : Instruction(Type::EnterUnwindContext, sizeof(*this))
+        : Instruction(Type::EnterUnwindContext)
         , m_entry_point(move(entry_point))
     {
     }
@@ -1605,7 +1605,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     ScheduleJump(Label target)
-        : Instruction(Type::ScheduleJump, sizeof(*this))
+        : Instruction(Type::ScheduleJump)
         , m_target(target)
     {
     }
@@ -1626,7 +1626,7 @@ private:
 class LeaveLexicalEnvironment final : public Instruction {
 public:
     LeaveLexicalEnvironment()
-        : Instruction(Type::LeaveLexicalEnvironment, sizeof(*this))
+        : Instruction(Type::LeaveLexicalEnvironment)
     {
     }
 
@@ -1637,7 +1637,7 @@ public:
 class LeaveUnwindContext final : public Instruction {
 public:
     LeaveUnwindContext()
-        : Instruction(Type::LeaveUnwindContext, sizeof(*this))
+        : Instruction(Type::LeaveUnwindContext)
     {
     }
 
@@ -1650,7 +1650,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit ContinuePendingUnwind(Label resume_target)
-        : Instruction(Type::ContinuePendingUnwind, sizeof(*this))
+        : Instruction(Type::ContinuePendingUnwind)
         , m_resume_target(resume_target)
     {
     }
@@ -1673,14 +1673,14 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit Yield(Label continuation_label, Operand value)
-        : Instruction(Type::Yield, sizeof(*this))
+        : Instruction(Type::Yield)
         , m_continuation_label(continuation_label)
         , m_value(value)
     {
     }
 
     explicit Yield(nullptr_t, Operand value)
-        : Instruction(Type::Yield, sizeof(*this))
+        : Instruction(Type::Yield)
         , m_value(value)
     {
     }
@@ -1706,7 +1706,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit Await(Label continuation_label, Operand argument)
-        : Instruction(Type::Await, sizeof(*this))
+        : Instruction(Type::Await)
         , m_continuation_label(continuation_label)
         , m_argument(argument)
     {
@@ -1730,7 +1730,7 @@ private:
 class GetIterator final : public Instruction {
 public:
     GetIterator(Operand dst, Operand iterable, IteratorHint hint = IteratorHint::Sync)
-        : Instruction(Type::GetIterator, sizeof(*this))
+        : Instruction(Type::GetIterator)
         , m_dst(dst)
         , m_iterable(iterable)
         , m_hint(hint)
@@ -1753,7 +1753,7 @@ private:
 class GetObjectFromIteratorRecord final : public Instruction {
 public:
     GetObjectFromIteratorRecord(Operand object, Operand iterator_record)
-        : Instruction(Type::GetObjectFromIteratorRecord, sizeof(*this))
+        : Instruction(Type::GetObjectFromIteratorRecord)
         , m_object(object)
         , m_iterator_record(iterator_record)
     {
@@ -1773,7 +1773,7 @@ private:
 class GetNextMethodFromIteratorRecord final : public Instruction {
 public:
     GetNextMethodFromIteratorRecord(Operand next_method, Operand iterator_record)
-        : Instruction(Type::GetNextMethodFromIteratorRecord, sizeof(*this))
+        : Instruction(Type::GetNextMethodFromIteratorRecord)
         , m_next_method(next_method)
         , m_iterator_record(iterator_record)
     {
@@ -1793,7 +1793,7 @@ private:
 class GetMethod final : public Instruction {
 public:
     GetMethod(Operand dst, Operand object, IdentifierTableIndex property)
-        : Instruction(Type::GetMethod, sizeof(*this))
+        : Instruction(Type::GetMethod)
         , m_dst(dst)
         , m_object(object)
         , m_property(property)
@@ -1816,7 +1816,7 @@ private:
 class GetObjectPropertyIterator final : public Instruction {
 public:
     GetObjectPropertyIterator(Operand dst, Operand object)
-        : Instruction(Type::GetObjectPropertyIterator, sizeof(*this))
+        : Instruction(Type::GetObjectPropertyIterator)
         , m_dst(dst)
         , m_object(object)
     {
@@ -1836,7 +1836,7 @@ private:
 class IteratorClose final : public Instruction {
 public:
     IteratorClose(Operand iterator_record, Completion::Type completion_type, Optional<Value> completion_value)
-        : Instruction(Type::IteratorClose, sizeof(*this))
+        : Instruction(Type::IteratorClose)
         , m_iterator_record(iterator_record)
         , m_completion_type(completion_type)
         , m_completion_value(completion_value)
@@ -1859,7 +1859,7 @@ private:
 class AsyncIteratorClose final : public Instruction {
 public:
     AsyncIteratorClose(Operand iterator_record, Completion::Type completion_type, Optional<Value> completion_value)
-        : Instruction(Type::AsyncIteratorClose, sizeof(*this))
+        : Instruction(Type::AsyncIteratorClose)
         , m_iterator_record(iterator_record)
         , m_completion_type(completion_type)
         , m_completion_value(completion_value)
@@ -1882,7 +1882,7 @@ private:
 class IteratorNext final : public Instruction {
 public:
     IteratorNext(Operand dst, Operand iterator_record)
-        : Instruction(Type::IteratorNext, sizeof(*this))
+        : Instruction(Type::IteratorNext)
         , m_dst(dst)
         , m_iterator_record(iterator_record)
     {
@@ -1902,7 +1902,7 @@ private:
 class ResolveThisBinding final : public Instruction {
 public:
     explicit ResolveThisBinding(Operand dst)
-        : Instruction(Type::ResolveThisBinding, sizeof(*this))
+        : Instruction(Type::ResolveThisBinding)
         , m_dst(dst)
     {
     }
@@ -1919,7 +1919,7 @@ private:
 class ResolveSuperBase final : public Instruction {
 public:
     explicit ResolveSuperBase(Operand dst)
-        : Instruction(Type::ResolveSuperBase, sizeof(*this))
+        : Instruction(Type::ResolveSuperBase)
         , m_dst(dst)
     {
     }
@@ -1936,7 +1936,7 @@ private:
 class GetNewTarget final : public Instruction {
 public:
     explicit GetNewTarget(Operand dst)
-        : Instruction(Type::GetNewTarget, sizeof(*this))
+        : Instruction(Type::GetNewTarget)
         , m_dst(dst)
     {
     }
@@ -1953,7 +1953,7 @@ private:
 class GetImportMeta final : public Instruction {
 public:
     explicit GetImportMeta(Operand dst)
-        : Instruction(Type::GetImportMeta, sizeof(*this))
+        : Instruction(Type::GetImportMeta)
         , m_dst(dst)
     {
     }
@@ -1970,7 +1970,7 @@ private:
 class TypeofVariable final : public Instruction {
 public:
     TypeofVariable(Operand dst, IdentifierTableIndex identifier)
-        : Instruction(Type::TypeofVariable, sizeof(*this))
+        : Instruction(Type::TypeofVariable)
         , m_dst(dst)
         , m_identifier(identifier)
     {
@@ -1992,7 +1992,7 @@ public:
     constexpr static bool IsTerminator = true;
 
     explicit End(Operand value)
-        : Instruction(Type::End, sizeof(*this))
+        : Instruction(Type::End)
         , m_value(value)
     {
     }
@@ -2009,7 +2009,7 @@ private:
 class Dump final : public Instruction {
 public:
     explicit Dump(StringView text, Operand value)
-        : Instruction(Type::Dump, sizeof(*this))
+        : Instruction(Type::Dump)
         , m_text(text)
         , m_value(value)
     {

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1110,6 +1110,58 @@ private:
     Label m_false_target;
 };
 
+class JumpTrue final : public Instruction {
+public:
+    constexpr static bool IsTerminator = true;
+
+    explicit JumpTrue(Operand condition, Label target)
+        : Instruction(Type::JumpTrue, sizeof(*this))
+        , m_condition(condition)
+        , m_target(target)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_target);
+    }
+
+    Operand condition() const { return m_condition; }
+    auto& target() const { return m_target; }
+
+private:
+    Operand m_condition;
+    Label m_target;
+};
+
+class JumpFalse final : public Instruction {
+public:
+    constexpr static bool IsTerminator = true;
+
+    explicit JumpFalse(Operand condition, Label target)
+        : Instruction(Type::JumpFalse, sizeof(*this))
+        , m_condition(condition)
+        , m_target(target)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_target);
+    }
+
+    Operand condition() const { return m_condition; }
+    auto& target() const { return m_target; }
+
+private:
+    Operand m_condition;
+    Label m_target;
+};
+
 class JumpNullish final : public Instruction {
 public:
     constexpr static bool IsTerminator = true;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1069,6 +1069,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_target);
+    }
 
     auto& target() const { return m_target; }
 
@@ -1090,6 +1094,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_true_target);
+        visitor(m_false_target);
+    }
 
     Operand condition() const { return m_condition; }
     auto& true_target() const { return m_true_target; }
@@ -1115,6 +1124,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_true_target);
+        visitor(m_false_target);
+    }
 
     Operand condition() const { return m_condition; }
     auto& true_target() const { return m_true_target; }
@@ -1140,6 +1154,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_true_target);
+        visitor(m_false_target);
+    }
 
     Operand condition() const { return m_condition; }
     auto& true_target() const { return m_true_target; }
@@ -1501,6 +1520,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_entry_point);
+    }
 
     auto& entry_point() const { return m_entry_point; }
 
@@ -1531,6 +1554,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_target);
+    }
 
 private:
     Label m_target;
@@ -1570,6 +1597,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_resume_target);
+    }
 
     auto& resume_target() const { return m_resume_target; }
 
@@ -1596,6 +1627,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        if (m_continuation_label.has_value())
+            visitor(m_continuation_label.value());
+    }
 
     auto& continuation() const { return m_continuation_label; }
     Operand value() const { return m_value; }
@@ -1618,6 +1654,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_labels_impl(Function<void(Label&)> visitor)
+    {
+        visitor(m_continuation_label);
+    }
 
     auto& continuation() const { return m_continuation_label; }
     Operand argument() const { return m_argument; }

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     Bytecode/IdentifierTable.cpp
     Bytecode/Instruction.cpp
     Bytecode/Interpreter.cpp
+    Bytecode/Label.cpp
     Bytecode/RegexTable.cpp
     Bytecode/StringTable.cpp
     Console.cpp

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -693,7 +693,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
     executable->name = "eval"sv;
     if (Bytecode::g_dump_bytecode)
         executable->dump();
-    auto result_or_error = vm.bytecode_interpreter().run_executable(*executable, nullptr);
+    auto result_or_error = vm.bytecode_interpreter().run_executable(*executable, {});
     if (result_or_error.value.is_error())
         return result_or_error.value.release_error();
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -384,7 +384,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 
     // Non-standard
     callee_context->arguments.append(arguments_list.data(), arguments_list.size());
-    callee_context->instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
+    callee_context->program_counter = vm.bytecode_interpreter().program_counter();
 
     // 2. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
     // NOTE: We throw if the end of the native stack is reached, so unlike in the spec this _does_ need an exception check.
@@ -455,7 +455,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
 
     // Non-standard
     callee_context->arguments.append(arguments_list.data(), arguments_list.size());
-    callee_context->instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
+    callee_context->program_counter = vm.bytecode_interpreter().program_counter();
 
     // 4. Let calleeContext be PrepareForOrdinaryCall(F, newTarget).
     // NOTE: We throw if the end of the native stack is reached, so unlike in the spec this _does_ need an exception check.
@@ -726,7 +726,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                     for (size_t register_index = 0; register_index < saved_registers.size(); ++register_index)
                         saved_registers[register_index] = {};
 
-                    auto result_and_return_register = vm.bytecode_interpreter().run_executable(*m_default_parameter_bytecode_executables[default_parameter_index - 1], nullptr);
+                    auto result_and_return_register = vm.bytecode_interpreter().run_executable(*m_default_parameter_bytecode_executables[default_parameter_index - 1], {});
 
                     for (size_t register_index = 0; register_index < saved_registers.size(); ++register_index)
                         running_execution_context.registers[register_index] = saved_registers[register_index];
@@ -1124,7 +1124,7 @@ void async_block_start(VM& vm, T const& async_body, PromiseCapability const& pro
             if (maybe_executable.is_error())
                 result = maybe_executable.release_error();
             else
-                result = vm.bytecode_interpreter().run_executable(*maybe_executable.value(), nullptr).value;
+                result = vm.bytecode_interpreter().run_executable(*maybe_executable.value(), {}).value;
         }
         // b. Else,
         else {
@@ -1251,7 +1251,7 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
         }
     }
 
-    auto result_and_frame = vm.bytecode_interpreter().run_executable(*m_bytecode_executable, nullptr);
+    auto result_and_frame = vm.bytecode_interpreter().run_executable(*m_bytecode_executable, {});
 
     if (result_and_frame.value.is_error())
         return result_and_frame.value.release_error();

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -36,7 +36,7 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
     copy->lexical_environment = lexical_environment;
     copy->variable_environment = variable_environment;
     copy->private_environment = private_environment;
-    copy->instruction_stream_iterator = instruction_stream_iterator;
+    copy->program_counter = program_counter;
     copy->function_name = function_name;
     copy->this_value = this_value;
     copy->is_strict_mode = is_strict_mode;
@@ -60,8 +60,6 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(context_owner);
     visitor.visit(this_value);
     visitor.visit(executable);
-    if (instruction_stream_iterator.has_value())
-        visitor.visit(const_cast<Bytecode::Executable*>(instruction_stream_iterator.value().executable()));
     visitor.visit(function_name);
     visitor.visit(arguments);
     visitor.visit(locals);

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -11,7 +11,6 @@
 #include <AK/DeprecatedFlyString.h>
 #include <AK/WeakPtr.h>
 #include <LibJS/Bytecode/BasicBlock.h>
-#include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Module.h>
 #include <LibJS/Runtime/PrivateEnvironment.h>
@@ -51,7 +50,7 @@ public:
     // Non-standard: This points at something that owns this ExecutionContext, in case it needs to be protected from GC.
     GCPtr<Cell> context_owner;
 
-    Optional<Bytecode::InstructionStreamIterator> instruction_stream_iterator;
+    Optional<size_t> program_counter;
     GCPtr<PrimitiveString> function_name;
     Value this_value;
     bool is_strict_mode { false };
@@ -78,7 +77,7 @@ public:
     Vector<Value> locals;
     Vector<Value> registers;
     Vector<Bytecode::UnwindInfo> unwind_contexts;
-    Vector<Bytecode::BasicBlock const*> previously_scheduled_jumps;
+    Vector<Optional<size_t>> previously_scheduled_jumps;
     Vector<GCPtr<Environment>> saved_lexical_environments;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -147,7 +147,7 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Read
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
     callee_context->this_value = this_argument;
     callee_context->arguments.append(arguments_list.data(), arguments_list.size());
-    callee_context->instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
+    callee_context->program_counter = vm.bytecode_interpreter().program_counter();
 
     callee_context->lexical_environment = caller_context.lexical_environment;
     callee_context->variable_environment = caller_context.variable_environment;
@@ -210,7 +210,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Reado
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
     callee_context->arguments.append(arguments_list.data(), arguments_list.size());
-    callee_context->instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
+    callee_context->program_counter = vm.bytecode_interpreter().program_counter();
 
     callee_context->lexical_environment = caller_context.lexical_environment;
     callee_context->variable_environment = caller_context.variable_environment;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -180,7 +180,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
         else {
             auto executable = maybe_executable.release_value();
 
-            auto result_and_return_register = vm.bytecode_interpreter().run_executable(*executable, nullptr);
+            auto result_and_return_register = vm.bytecode_interpreter().run_executable(*executable, {});
             if (result_and_return_register.value.is_error()) {
                 result = result_and_return_register.value.release_error();
             } else {

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -717,7 +717,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
         else {
             auto executable = maybe_executable.release_value();
 
-            auto result_and_return_register = vm.bytecode_interpreter().run_executable(*executable, nullptr);
+            auto result_and_return_register = vm.bytecode_interpreter().run_executable(*executable, {});
             if (result_and_return_register.value.is_error()) {
                 result = result_and_return_register.value.release_error();
             } else {


### PR DESCRIPTION
tl;dr:
- Flatten the bytecode from disjoint basic blocks to contiguous byte sequence.
- Elide 0-length jumps
- Reorder codegen a bit to take advantage of 0-length jump elision
- Make bytecode interpreter threaded (as in "direct threaded", not multi-threaded)
- Make instructions smaller in various ways

Result: everything much faster!

Benchmark results before/after:
```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
Kraken      ai-astar.js                              1.707  4.960 ± 4.950 … 4.970        2.905 ± 2.860 … 2.950
Kraken      audio-beat-detection.js                  1.544  2.610 ± 2.560 … 2.660        1.690 ± 1.690 … 1.690
Kraken      audio-dft.js                             1.441  2.335 ± 2.300 … 2.370        1.620 ± 1.620 … 1.620
Kraken      audio-fft.js                             1.502  2.350 ± 2.330 … 2.370        1.565 ± 1.540 … 1.590
Kraken      audio-oscillator.js                      1.409  2.565 ± 2.550 … 2.580        1.820 ± 1.810 … 1.830
Kraken      imaging-darkroom.js                      1.327  3.325 ± 3.290 … 3.360        2.505 ± 2.500 … 2.510
Kraken      imaging-desaturate.js                    1.31   3.525 ± 3.520 … 3.530        2.690 ± 2.670 … 2.710
Kraken      imaging-gaussian-blur.js                 1.616  16.785 ± 16.710 … 16.860     10.385 ± 10.360 … 10.410
Kraken      json-parse-financial.js                  1      0.130 ± 0.130 … 0.130        0.130 ± 0.130 … 0.130
Kraken      json-stringify-tinderbox.js              1      0.170 ± 0.170 … 0.170        0.170 ± 0.170 … 0.170
Kraken      stanford-crypto-aes.js                   1.378  1.130 ± 1.120 … 1.140        0.820 ± 0.820 … 0.820
Kraken      stanford-crypto-ccm.js                   1.291  0.910 ± 0.900 … 0.920        0.705 ± 0.700 … 0.710
Kraken      stanford-crypto-pbkdf2.js                1.502  1.915 ± 1.900 … 1.930        1.275 ± 1.270 … 1.280
Kraken      stanford-crypto-sha256-iterative.js      1.385  0.720 ± 0.720 … 0.720        0.520 ± 0.520 … 0.520
Octane      box2d.js                                 1.276  4.320 ± 4.320 … 4.320        3.385 ± 3.370 … 3.400
Octane      code-load.js                             1.007  2.150 ± 2.140 … 2.160        2.135 ± 2.130 … 2.140
Octane      crypto.js                                1.368  10.120 ± 9.930 … 10.310      7.395 ± 7.360 … 7.430
Octane      deltablue.js                             1.494  3.040 ± 3.040 … 3.040        2.035 ± 2.030 … 2.040
Octane      earley-boyer.js                          1.069  22.055 ± 21.950 … 22.160     20.635 ± 20.570 … 20.700
Octane      gbemu.js                                 1.109  5.120 ± 5.120 … 5.120        4.615 ± 4.610 … 4.620
Octane      mandreel.js                              1.423  24.795 ± 24.600 … 24.990     17.425 ± 17.190 … 17.660
Octane      navier-stokes.js                         1.368  4.445 ± 4.440 … 4.450        3.250 ± 3.230 … 3.270
Octane      pdfjs.js                                 1.133  3.845 ± 3.840 … 3.850        3.395 ± 3.380 … 3.410
Octane      raytrace.js                              1.028  8.215 ± 8.140 … 8.290        7.995 ± 7.990 … 8.000
Octane      regexp.js                                1.035  24.300 ± 24.090 … 24.510     23.470 ± 23.200 … 23.740
Octane      richards.js                              1.002  2.025 ± 2.020 … 2.030        2.020 ± 2.020 … 2.020
Octane      splay.js                                 1.01   2.900 ± 2.900 … 2.900        2.870 ± 2.860 … 2.880
Octane      typescript.js                            1.131  52.625 ± 52.570 … 52.680     46.535 ± 46.470 … 46.600
Octane      zlib.js                                  1.74   198.025 ± 196.870 … 199.180  113.820 ± 112.970 … 114.670
Kraken      Total                                    1.508  43.430                       28.800
Octane      Total                                    1.41   367.980                      260.980
All Suites  Total                                    1.42   411.410                      289.780
```