### PR TITLE
LibJS: Save and restore exceptions on yields in finalizers

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -68,6 +68,7 @@ public:
     };
 
     template<typename OpType, typename... Args>
+    requires(requires { OpType(declval<Args>()...); })
     void emit(Args&&... args)
     {
         VERIFY(!is_current_block_terminated());
@@ -81,6 +82,7 @@ public:
     }
 
     template<typename OpType, typename ExtraSlotType, typename... Args>
+    requires(requires { OpType(declval<Args>()...); })
     void emit_with_extra_slots(size_t extra_slot_count, Args&&... args)
     {
         VERIFY(!is_current_block_terminated());
@@ -96,12 +98,14 @@ public:
     }
 
     template<typename OpType, typename... Args>
+    requires(requires { OpType(declval<Args>()...); })
     void emit_with_extra_operand_slots(size_t extra_operand_slots, Args&&... args)
     {
         emit_with_extra_slots<OpType, Operand>(extra_operand_slots, forward<Args>(args)...);
     }
 
     template<typename OpType, typename... Args>
+    requires(requires { OpType(declval<Args>()...); })
     void emit_with_extra_value_slots(size_t extra_operand_slots, Args&&... args)
     {
         emit_with_extra_slots<OpType, Value>(extra_operand_slots, forward<Args>(args)...);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -238,6 +238,8 @@ public:
         }
     }
 
+    bool is_in_finalizer() const { return m_boundaries.contains_slow(BlockBoundaryType::LeaveFinally); }
+
     void generate_break();
     void generate_break(DeprecatedFlyString const& break_label);
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1595,13 +1595,6 @@ class ScheduleJump final : public Instruction {
 public:
     // Note: We use this instruction to tell the next `finally` block to
     //       continue execution with a specific break/continue target;
-    // FIXME: We currently don't clear the interpreter internal flag, when we change
-    //        the control-flow (`break`, `continue`) in a finally-block,
-    // FIXME: .NET on x86_64 uses a call to the finally instead, which could make this
-    //        easier, at the cost of making control-flow changes (`break`, `continue`, `return`)
-    //        in the finally-block more difficult, but as stated above, those
-    //        aren't handled 100% correctly at the moment anyway
-    //        It might be worth investigating a similar mechanism
     constexpr static bool IsTerminator = true;
 
     ScheduleJump(Label target)

--- a/Userland/Libraries/LibJS/Tests/try-return-finally.js
+++ b/Userland/Libraries/LibJS/Tests/try-return-finally.js
@@ -24,3 +24,17 @@ test("return from outer finally with nested unwind contexts", () => {
 
     expect(value).toBe(2);
 });
+
+test("restore exception after generator yield in finally", () => {
+    let generator = (function* () {
+        try {
+            throw new Error("foo");
+        } finally {
+            yield 42;
+        }
+    })();
+
+    expect(generator.next().value).toBe(42);
+    expect(() => generator.next()).toThrowWithMessage(Error, "foo");
+    expect(generator.next().done).toBe(true);
+});


### PR DESCRIPTION
Also removes a bunch of related old FIXMEs.

----

Test262:
```
    test/built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-finally.js                       ❌ -> ✅
    test/built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-inner-try.js              ❌ -> ✅
    test/built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-catch.js                   ❌ -> ✅
    test/built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-outer-try-after-nested.js  ❌ -> ✅
    test/built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-outer-try-before-nested.js ❌ -> ✅
    test/built-ins/GeneratorPrototype/throw/try-finally-within-try.js                                      ❌ -> ✅
```` 