### PR TITLE
LibGfx/WebPWriter: Use one-element huffman tree for opaque images

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
@@ -33,7 +33,7 @@ static ErrorOr<void> write_chunk_header(Stream& stream, StringView chunk_fourcc,
 
 // https://developers.google.com/speed/webp/docs/riff_container#simple_file_format_lossless
 // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#7_overall_structure_of_the_format
-static ErrorOr<void> write_VP8L_header(Stream& stream, unsigned width, unsigned height, bool alpha_hint)
+static ErrorOr<void> write_VP8L_header(Stream& stream, unsigned width, unsigned height, bool alpha_is_used_hint)
 {
     // "The 14-bit precision for image width and height limits the maximum size of a WebP lossless image to 16384✕16384 pixels."
     if (width > 16384 || height > 16384)
@@ -53,7 +53,7 @@ static ErrorOr<void> write_VP8L_header(Stream& stream, unsigned width, unsigned 
 
     // "The alpha_is_used bit is a hint only, and should not impact decoding.
     //  It should be set to 0 when all alpha values are 255 in the picture, and 1 otherwise."
-    TRY(bit_stream.write_bits(alpha_hint, 1u));
+    TRY(bit_stream.write_bits(alpha_is_used_hint, 1u));
 
     // "The version_number is a 3 bit code that must be set to 0."
     TRY(bit_stream.write_bits(0u, 3u));

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
@@ -64,6 +64,15 @@ static ErrorOr<void> write_VP8L_header(Stream& stream, unsigned width, unsigned 
     return {};
 }
 
+static bool are_all_pixels_opaque(Bitmap const& bitmap)
+{
+    for (ARGB32 pixel : bitmap) {
+        if ((pixel >> 24) != 0xff)
+            return false;
+    }
+    return true;
+}
+
 static ErrorOr<void> write_VP8L_image_data(Stream& stream, Bitmap const& bitmap)
 {
     LittleEndianOutputBitStream bit_stream { MaybeOwned<Stream>(stream) };
@@ -177,10 +186,12 @@ static ErrorOr<void> align_to_two(AllocatingMemoryStream& stream)
 
 ErrorOr<void> WebPWriter::encode(Stream& stream, Bitmap const& bitmap, Options const& options)
 {
+    bool alpha_is_used_hint = !are_all_pixels_opaque(bitmap);
+
     // The chunk headers need to know their size, so we either need a SeekableStream or need to buffer the data. We're doing the latter.
     // FIXME: The whole writing-and-reading-into-buffer over-and-over is awkward and inefficient.
     AllocatingMemoryStream vp8l_header_stream;
-    TRY(write_VP8L_header(vp8l_header_stream, bitmap.width(), bitmap.height(), true));
+    TRY(write_VP8L_header(vp8l_header_stream, bitmap.width(), bitmap.height(), alpha_is_used_hint));
     auto vp8l_header_bytes = TRY(vp8l_header_stream.read_until_eof());
 
     AllocatingMemoryStream vp8l_data_stream;


### PR DESCRIPTION
That way, we can write 0 instead of 8 bits for every alpha byte.
Reduces the size of sunset-retro.png when saved as a webp file
from 3 MiB to 2.25 MiB, without affecting encode speed.

Once we use CanonicalCodes we'll get this for free for all channels,
but opaque images are common enough that it feels worth it to do this
before then.