### PR TITLE
LibWeb: Improve resolution of `ResolvedCSSStyleDeclaration` properties

### DIFF
--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -175,7 +175,7 @@ user-select: auto
 vertical-align: baseline
 visibility: visible
 white-space: normal
-width: auto
+width: 784px
 word-spacing: normal
 word-wrap: normal
 x: 0px

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-relative-property-values.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-relative-property-values.txt
@@ -1,0 +1,2 @@
+  height: 4px
+width: 5px

--- a/Tests/LibWeb/Text/input/css/getComputedStyle-relative-property-values.html
+++ b/Tests/LibWeb/Text/input/css/getComputedStyle-relative-property-values.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #outer {
+        width: 10px;
+        height: 20px;
+    }
+    #inner {
+        width: 50%;
+        height: 20%;
+    }
+</style>
+<div id="outer"><div id="inner"></div></div>
+<script>
+    test(() => {
+        const inner = document.getElementById("inner");
+        const style = getComputedStyle(inner);
+        const propertyValues = [
+            "height",
+            "width",
+        ];
+        for (const property of propertyValues) {
+            println(`${property}: ${style.getPropertyValue(property)}`);
+        }
+    });
+</script>


### PR DESCRIPTION
The resolved value is now correctly calculated for all margin, padding and width properties of a `ResolvedCSSStyleDeclaration`.

This means the correct values are returned when these properties are accessed from a `getComputedStyle()` call.

This allows the following WPT tests to pass:
* https://wpt.live/css/cssom/computed-style-001.html
* https://wpt.live/css/cssom/computed-style-002.html
* https://wpt.live/css/cssom/computed-style-003.html
* https://wpt.live/css/cssom/computed-style-004.html
* https://wpt.live/css/cssom/getComputedStyle-layout-dependent-removed-ib-sibling.html
* https://wpt.live/css/cssom/getComputedStyle-layout-dependent-replaced-into-ib-split.html
