### PR TITLE
LibGfx/WebPLossless: Update spec comments with newest version of spec

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -321,7 +321,7 @@ static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_image(ImageKind ima
 
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#52_encoding_of_image_data
     // "The encoded image data consists of several parts:
-    //    1. Decoding and building the prefix codes [AMENDED2]
+    //    1. Decoding and building the prefix codes
     //    2. Meta prefix codes
     //    3. Entropy-coded image data"
     // data                  =  prefix-codes lz77-coded-image
@@ -539,7 +539,7 @@ private:
         int pT = abs(pAlpha - (int)ALPHA(T)) + abs(pRed - (int)RED(T)) + abs(pGreen - (int)GREEN(T)) + abs(pBlue - (int)BLUE(T));
 
         // "Return either left or top, the one closer to the prediction."
-        if (pL < pT) { // "\[AMENDED\]"
+        if (pL < pT) {
             return L;
         } else {
             return T;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -875,13 +875,16 @@ ErrorOr<NonnullOwnPtr<ColorIndexingTransform>> ColorIndexingTransform::read(Litt
     auto palette_bitmap = TRY(decode_webp_chunk_VP8L_image(ImageKind::EntropyCoded, BitmapFormat::BGRA8888, palette_image_size, bit_stream));
 
     // "When the color table is small (equal to or less than 16 colors), several pixels are bundled into a single pixel..."
-    int pixels_per_pixel = 1;
+    int width_bits;
     if (color_table_size <= 2)
-        pixels_per_pixel = 8;
+        width_bits = 3;
     else if (color_table_size <= 4)
-        pixels_per_pixel = 4;
+        width_bits = 2;
     else if (color_table_size <= 16)
-        pixels_per_pixel = 2;
+        width_bits = 1;
+    else
+        width_bits = 0;
+    int pixels_per_pixel = 1 << width_bits;
 
     // "The color table is always subtraction-coded to reduce image entropy. [...]  In decoding, every final color in the color table
     //  can be obtained by adding the previous color component values by each ARGB component separately,

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -185,14 +185,10 @@ static ErrorOr<CanonicalCode> decode_webp_chunk_VP8L_prefix_code(LittleEndianInp
             return Error::from_string_literal("WebPImageDecoderPlugin: invalid max_symbol");
     }
 
-    auto const code_length_code = TRY(CanonicalCode::from_bytes({ code_length_code_lengths, sizeof(code_length_code_lengths) }));
-
-    // Next we extract the code lengths of the code that was used to encode the block.
-
-    u8 last_non_zero = 8; // "If code 16 is used before a non-zero value has been emitted, a value of 8 is repeated."
-
     // "A prefix table is then built from code_length_code_lengths and used to read up to max_symbol code lengths."
     dbgln_if(WEBP_DEBUG, "  reading {} symbols from at most {} codes", alphabet_size, max_symbol);
+    auto const code_length_code = TRY(CanonicalCode::from_bytes({ code_length_code_lengths, sizeof(code_length_code_lengths) }));
+    u8 last_non_zero = 8; // "If code 16 is used before a non-zero value has been emitted, a value of 8 is repeated."
     while (code_lengths.size() < alphabet_size) {
         if (max_symbol == 0)
             break;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -843,7 +843,7 @@ public:
     // If the palette has 5 to 16 colors, every index needs 4 bits and every pixel can encode 2 output pixels.
     // This returns how many output pixels one input pixel can encode after the color indexing transform.
     //
-    // The spec isn't very explicit about this, but this affects all images after the color indexing transform:
+    // This affects all images after the color indexing transform:
     // If a webp file contains a 29x32 image and it contains a color indexing transform with a 4-color palette, then the in-memory size of all images
     // after the color indexing transform assume a bitmap size of ceil_div(29, 4)x32 = 8x32.
     // That is, the sizes of transforms after the color indexing transform are computed relative to the size 8x32,
@@ -992,7 +992,10 @@ ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&
             break;
         case COLOR_INDEXING_TRANSFORM: {
             auto color_indexing_transform = TRY(ColorIndexingTransform::read(bit_stream, stored_size.width()));
+
+            // "After reading this transform, image_width is subsampled by width_bits. This affects the size of subsequent transforms."
             stored_size.set_width(ceil_div(stored_size.width(), color_indexing_transform->pixels_per_pixel()));
+
             TRY(transforms.try_append(move(color_indexing_transform)));
             break;
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -157,10 +157,7 @@ static ErrorOr<CanonicalCode> decode_webp_chunk_VP8L_prefix_code(LittleEndianInp
     // (...but webp uses 5 different prefix codes, while deflate doesn't.)
     int num_code_lengths = 4 + TRY(bit_stream.read_bits(4));
     dbgln_if(WEBP_DEBUG, "  num_code_lengths {}", num_code_lengths);
-
-    // "If num_code_lengths is > 19, the bit_stream is invalid. [AMENDED3]"
-    if (num_code_lengths > 19)
-        return Error::from_string_literal("WebPImageDecoderPlugin: invalid num_code_lengths");
+    VERIFY(num_code_lengths <= 19);
 
     constexpr int kCodeLengthCodes = 19;
     int kCodeLengthCodeOrder[kCodeLengthCodes] = { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -645,6 +645,8 @@ ErrorOr<NonnullRefPtr<Bitmap>> PredictorTransform::transform(NonnullRefPtr<Bitma
             u8 predictor = Color::from_argb(predictor_scanline[predictor_x]).green();
 
             ARGB32 predicted = TRY(predict(predictor, TL, T, TR, L));
+
+            // "The final pixel value is obtained by adding each channel of the predicted value to the encoded residual value."
             bitmap_scanline[x] = add_argb32(bitmap_scanline[x], predicted);
 
             TL = T;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -992,8 +992,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&
     auto format = vp8l_header.is_alpha_used ? BitmapFormat::BGRA8888 : BitmapFormat::BGRx8888;
     auto bitmap = TRY(decode_webp_chunk_VP8L_image(ImageKind::SpatiallyCoded, format, stored_size, bit_stream));
 
-    // Transforms have to be applied in the reverse order they appear in in the file.
-    // (As far as I can tell, this isn't mentioned in the spec.)
+    // "The inverse transforms are applied in the reverse order that they are read from the bitstream, that is, last one first."
     for (auto const& transform : transforms.in_reverse())
         bitmap = TRY(transform->transform(bitmap));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -940,7 +940,6 @@ ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&
     auto stored_size = IntSize { vp8l_header.width, vp8l_header.height };
 
     // optional-transform   =  (%b1 transform optional-transform) / %b0
-    // "Each transform is allowed to be used only once."
     u8 seen_transforms = 0;
     Vector<NonnullOwnPtr<Transform>, 4> transforms;
     while (TRY(bit_stream.read_bits(1))) {
@@ -964,7 +963,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&
         TransformType transform_type = static_cast<TransformType>(TRY(bit_stream.read_bits(2)));
         dbgln_if(WEBP_DEBUG, "transform type {}", (int)transform_type);
 
-        // Check that each transform is used only once.
+        // "Each transform is allowed to be used only once."
         u8 mask = 1 << (int)transform_type;
         if (seen_transforms & mask)
             return Error::from_string_literal("WebPImageDecoderPlugin: transform type used multiple times");

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -969,6 +969,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&
             return Error::from_string_literal("WebPImageDecoderPlugin: transform type used multiple times");
         seen_transforms |= mask;
 
+        // "Transform data contains the information required to apply the inverse transform and depends on the transform type."
         switch (transform_type) {
         case PREDICTOR_TRANSFORM:
             TRY(transforms.try_append(TRY(PredictorTransform::read(bit_stream, stored_size))));


### PR DESCRIPTION
When I wrote the webp lossless decoder, I left some feedback on the spec about things I found confusing or about things that were missing. Most of that actually got fixed! So update spec comments to match the current spec. Tweak some code in minor ways to look more like the spec, too.

No behavior change intended.