### PR TITLE
Meta: Use -std=c++2b on mac hosts in the GN build

### DIFF
--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -89,10 +89,15 @@ config("compiler_defaults") {
   if (use_lld) {
     ldflags += [ "-Wl,--color-diagnostics" ]
   }
-  cflags_cc += [
-    "-std=c++23",
-    "-fvisibility-inlines-hidden",
-  ]
+
+  if (current_os == "mac") {
+    # FIXME: Use -std=c++23 once Xcode's clang supports that.
+    cflags_cc += [ "-std=c++2b" ]
+  } else {
+    cflags_cc += [ "-std=c++23" ]
+  }
+
+  cflags_cc += [ "-fvisibility-inlines-hidden" ]
 
   # Warning setup.
   cflags += [

--- a/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
@@ -33,6 +33,7 @@ shared_library("LibJS") {
     "Bytecode/IdentifierTable.cpp",
     "Bytecode/Instruction.cpp",
     "Bytecode/Interpreter.cpp",
+    "Bytecode/Label.cpp",
     "Bytecode/RegexTable.cpp",
     "Bytecode/StringTable.cpp",
     "Console.cpp",


### PR DESCRIPTION
Xcode clang doesn't understand the -std=c++23 spelling yet, and this
is what CMake's `set(CMAKE_CXX_STANDARD 23)` translates to too.

Unbreaks building with Xcode clang on macOS.

---

Also port one change.