### PR TITLE
Ladybird: Ensure hamburger menu is placed within the browser window

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -46,6 +46,28 @@ static QIcon const& app_icon()
     return icon;
 }
 
+class HamburgerMenu : public QMenu {
+public:
+    using QMenu::QMenu;
+    virtual ~HamburgerMenu() override = default;
+
+    virtual void showEvent(QShowEvent*) override
+    {
+        if (!isVisible())
+            return;
+        auto* browser_window = verify_cast<BrowserWindow>(parentWidget());
+        if (!browser_window)
+            return;
+        auto* current_tab = browser_window->current_tab();
+        if (!current_tab)
+            return;
+        // Ensure the hamburger menu placed within the browser window.
+        auto* hamburger_button = current_tab->hamburger_button();
+        auto button_top_right = hamburger_button->mapToGlobal(hamburger_button->rect().bottomRight());
+        move(button_top_right - QPoint(rect().width(), 0));
+    }
+};
+
 BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path)
     : m_tabs_container(new TabWidget(this))
     , m_cookie_jar(cookie_jar)
@@ -72,7 +94,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
         });
     }
 
-    m_hamburger_menu = new QMenu(this);
+    m_hamburger_menu = new HamburgerMenu(this);
 
     if (!Settings::the()->show_menubar())
         menuBar()->hide();

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -93,6 +93,8 @@ public:
         return *m_inspect_dom_node_action;
     }
 
+    Tab* current_tab() const { return m_current_tab; }
+
 public slots:
     void device_pixel_ratio_changed(qreal dpi);
     void tab_title_changed(int index, QString const&);

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -58,6 +58,8 @@ public:
 
     void update_navigation_buttons_state();
 
+    QToolButton* hamburger_button() const { return m_hamburger_button; }
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/assets/11597044/f668ef52-5d71-46ff-a63a-d59cf9f4be19

Found the old behaviour a little odd (and knew how to hack around it). I saw this mentioned on Discord too (so if someone already has a patch WIP I'm happy to close this). 

cc @jamierocks 