### PR TITLE
LibJS: Mixed bag of optimizations

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -19,6 +19,7 @@
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Bytecode/Operand.h>
+#include <LibJS/Bytecode/ScopedOperand.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/ClassFieldDefinition.h>
@@ -55,7 +56,7 @@ public:
     // NOTE: This is here to stop ASAN complaining about mismatch between new/delete sizes in ASTNodeWithTailArray.
     void operator delete(void* ptr) { ::operator delete(ptr); }
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
     virtual void dump(int indent) const;
 
     [[nodiscard]] SourceRange source_range() const;
@@ -175,8 +176,8 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     DeprecatedFlyString const& label() const { return m_label; }
     DeprecatedFlyString& label() { return m_label; }
@@ -204,7 +205,7 @@ class IterationStatement : public Statement {
 public:
     using Statement::Statement;
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
 private:
     virtual bool is_iteration_statement() const final { return true; }
@@ -216,7 +217,7 @@ public:
         : Statement(move(source_range))
     {
     }
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 };
 
 class ErrorStatement final : public Statement {
@@ -236,7 +237,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     Expression const& expression() const { return m_expression; }
 
@@ -299,7 +300,7 @@ public:
 
     Vector<NonnullRefPtr<Statement const>> const& children() const { return m_children; }
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     void add_var_scoped_declaration(NonnullRefPtr<Declaration const> variables);
     void add_lexical_declaration(NonnullRefPtr<Declaration const> variables);
@@ -387,7 +388,7 @@ public:
 
     virtual void dump(int indent) const override;
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     bool has_bound_name(DeprecatedFlyString const& name) const;
     Vector<ImportEntry> const& entries() const { return m_entries; }
@@ -484,7 +485,7 @@ public:
 
     virtual void dump(int indent) const override;
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     bool has_export(DeprecatedFlyString const& export_name) const;
 
@@ -671,7 +672,7 @@ public:
     void set_is_global() { m_is_global = true; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     virtual bool is_identifier() const override { return true; }
@@ -761,7 +762,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
@@ -787,8 +788,8 @@ public:
 
     virtual void dump(int indent) const override;
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::Operand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     bool has_name() const { return !name().is_empty(); }
 
@@ -819,7 +820,7 @@ public:
     bool is_yield_from() const { return m_is_yield_from; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     RefPtr<Expression const> m_argument;
@@ -835,7 +836,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_argument;
@@ -852,7 +853,7 @@ public:
     Expression const* argument() const { return m_argument; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     RefPtr<Expression const> m_argument;
@@ -873,7 +874,7 @@ public:
     Statement const* alternate() const { return m_alternate; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_predicate;
@@ -894,8 +895,8 @@ public:
     Statement const& body() const { return *m_body; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_test;
@@ -915,8 +916,8 @@ public:
     Statement const& body() const { return *m_body; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_test;
@@ -936,7 +937,7 @@ public:
     Statement const& body() const { return *m_body; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_object;
@@ -960,8 +961,8 @@ public:
     Statement const& body() const { return *m_body; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     RefPtr<ASTNode const> m_init;
@@ -984,8 +985,8 @@ public:
     Expression const& rhs() const { return *m_rhs; }
     Statement const& body() const { return *m_body; }
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -1008,8 +1009,8 @@ public:
     Expression const& rhs() const { return *m_rhs; }
     Statement const& body() const { return *m_body; }
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -1028,8 +1029,8 @@ public:
     {
     }
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -1074,7 +1075,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     BinaryOp m_op;
@@ -1099,7 +1100,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     LogicalOp m_op;
@@ -1127,7 +1128,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     UnaryOp m_op;
@@ -1144,7 +1145,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     Vector<NonnullRefPtr<Expression const>> m_expressions;
@@ -1170,7 +1171,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     virtual Value value() const override { return Value(m_value); }
 
@@ -1187,7 +1188,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     virtual Value value() const override { return m_value; }
 
@@ -1206,7 +1207,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     ByteString m_value;
@@ -1221,7 +1222,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     ByteString const& value() const { return m_value; }
 
@@ -1239,7 +1240,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     virtual Value value() const override { return js_null(); }
 };
@@ -1257,7 +1258,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     regex::Parser::Result const& parsed_regex() const { return m_parsed_regex; }
     ByteString const& parsed_pattern() const { return m_parsed_pattern; }
@@ -1402,7 +1403,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     virtual bool is_super_expression() const override { return true; }
 };
@@ -1425,8 +1426,8 @@ public:
     RefPtr<FunctionExpression const> constructor() const { return m_constructor; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::Operand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     bool has_name() const { return m_name; }
 
@@ -1454,7 +1455,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
@@ -1482,7 +1483,7 @@ public:
     }
 
     virtual void dump(int) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_expression;
@@ -1498,7 +1499,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_target;
@@ -1511,7 +1512,7 @@ public:
     {
     }
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 };
 
 struct CallExpressionArgument {
@@ -1541,7 +1542,7 @@ public:
     static NonnullRefPtr<CallExpression> create(SourceRange, NonnullRefPtr<Expression const> callee, ReadonlySpan<Argument> arguments, InvocationStyleEnum invocation_style, InsideParenthesesEnum inside_parens);
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     Expression const& callee() const { return m_callee; }
 
@@ -1609,7 +1610,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     Vector<CallExpression::Argument> const m_arguments;
@@ -1654,7 +1655,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     AssignmentOp m_op;
@@ -1678,7 +1679,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     virtual bool is_update_expression() const override { return true; }
@@ -1738,7 +1739,7 @@ public:
     DeclarationKind declaration_kind() const { return m_declaration_kind; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     Vector<NonnullRefPtr<VariableDeclarator const>> const& declarations() const { return m_declarations; }
 
@@ -1824,7 +1825,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     virtual bool is_object_expression() const override { return true; }
@@ -1843,7 +1844,7 @@ public:
     Vector<RefPtr<Expression const>> const& elements() const { return m_elements; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     virtual bool is_array_expression() const override { return true; }
@@ -1867,7 +1868,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     Vector<NonnullRefPtr<Expression const>> const& expressions() const { return m_expressions; }
     Vector<NonnullRefPtr<Expression const>> const& raw_strings() const { return m_raw_strings; }
@@ -1887,7 +1888,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> const m_tag;
@@ -1905,7 +1906,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     bool is_computed() const { return m_computed; }
     Expression const& object() const { return *m_object; }
@@ -1957,7 +1958,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     Expression const& base() const { return *m_base; }
     Vector<Reference> const& references() const { return m_references; }
@@ -1981,7 +1982,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     Type m_type;
@@ -1997,7 +1998,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     virtual bool is_import_call() const override { return true; }
@@ -2017,7 +2018,7 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_test;
@@ -2066,7 +2067,7 @@ public:
     BlockStatement const* finalizer() const { return m_finalizer; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<BlockStatement const> m_block;
@@ -2085,7 +2086,7 @@ public:
     Expression const& argument() const { return m_argument; }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_argument;
@@ -2116,8 +2117,8 @@ public:
     }
 
     virtual void dump(int indent) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::Operand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     void add_case(NonnullRefPtr<SwitchCase const> switch_case) { m_cases.append(move(switch_case)); }
 
@@ -2135,7 +2136,7 @@ public:
     }
 
     Optional<DeprecatedFlyString> const& target_label() const { return m_target_label; }
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     Optional<DeprecatedFlyString> m_target_label;
@@ -2149,7 +2150,7 @@ public:
     {
     }
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     Optional<DeprecatedFlyString> const& target_label() const { return m_target_label; }
 
@@ -2164,7 +2165,7 @@ public:
     {
     }
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::Operand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 };
 
 class SyntheticReferenceExpression final : public Expression {

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -426,8 +426,7 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> AssignmentExpressio
                         // https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
                         // 1. Let env be GetThisEnvironment().
                         // 2. Let actualThis be ? env.GetThisBinding().
-                        this_value = Bytecode::Operand(generator.allocate_register());
-                        generator.emit<Bytecode::Op::ResolveThisBinding>(*this_value);
+                        this_value = generator.get_this();
 
                         // SuperProperty : super [ Expression ]
                         // 3. Let propertyNameReference be ? Evaluation of Expression.
@@ -1486,8 +1485,7 @@ static Bytecode::CodeGenerationErrorOr<BaseAndValue> get_base_and_value_from_mem
     if (is<SuperExpression>(member_expression.object())) {
         // 1. Let env be GetThisEnvironment().
         // 2. Let actualThis be ? env.GetThisBinding().
-        auto this_value = Bytecode::Operand(generator.allocate_register());
-        generator.emit<Bytecode::Op::ResolveThisBinding>(this_value);
+        auto this_value = generator.get_this();
 
         Optional<Bytecode::Operand> computed_property;
 
@@ -2718,9 +2716,7 @@ Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> SpreadExpression::g
 Bytecode::CodeGenerationErrorOr<Optional<Bytecode::Operand>> ThisExpression::generate_bytecode(Bytecode::Generator& generator, Optional<Bytecode::Operand> preferred_dst) const
 {
     Bytecode::Generator::SourceLocationScope scope(generator, *this);
-    auto dst = choose_dst(generator, preferred_dst);
-    generator.emit<Bytecode::Op::ResolveThisBinding>(dst);
-    return dst;
+    return generator.get_this(preferred_dst);
 }
 
 static Bytecode::Operand generate_await(

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -9,7 +9,7 @@
 #include <AK/Badge.h>
 #include <AK/String.h>
 #include <LibJS/Bytecode/Executable.h>
-#include <LibJS/Bytecode/Operand.h>
+#include <LibJS/Bytecode/ScopedOperand.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 
@@ -53,7 +53,7 @@ public:
     void add_source_map_entry(size_t bytecode_offset, SourceRecord const& source_record) { m_source_map.set(bytecode_offset, source_record); }
 
     auto const& this_() const { return m_this; }
-    void set_this(Operand operand) { m_this = operand; }
+    void set_this(ScopedOperand operand) { m_this = operand; }
 
 private:
     explicit BasicBlock(u32 index, String name);
@@ -67,7 +67,7 @@ private:
 
     HashMap<size_t, SourceRecord> m_source_map;
 
-    Optional<Operand> m_this;
+    Optional<ScopedOperand> m_this;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -9,6 +9,7 @@
 #include <AK/Badge.h>
 #include <AK/String.h>
 #include <LibJS/Bytecode/Executable.h>
+#include <LibJS/Bytecode/Operand.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 
@@ -51,6 +52,9 @@ public:
     auto const& source_map() const { return m_source_map; }
     void add_source_map_entry(size_t bytecode_offset, SourceRecord const& source_record) { m_source_map.set(bytecode_offset, source_record); }
 
+    auto const& this_() const { return m_this; }
+    void set_this(Operand operand) { m_this = operand; }
+
 private:
     explicit BasicBlock(u32 index, String name);
 
@@ -62,6 +66,8 @@ private:
     bool m_terminated { false };
 
     HashMap<size_t, SourceRecord> m_source_map;
+
+    Optional<Operand> m_this;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -168,7 +168,12 @@ inline ThrowCompletionOr<Value> get_by_value(VM& vm, Optional<DeprecatedFlyStrin
         // For "non-typed arrays":
         if (!object.may_interfere_with_indexed_property_access()
             && object_storage) {
-            auto maybe_value = object_storage->get(index);
+            auto maybe_value = [&] {
+                if (object_storage->is_simple_storage())
+                    return static_cast<SimpleIndexedPropertyStorage const*>(object_storage)->inline_get(index);
+                else
+                    return static_cast<GenericIndexedPropertyStorage const*>(object_storage)->get(index);
+            }();
             if (maybe_value.has_value()) {
                 auto value = maybe_value->value;
                 if (!value.is_accessor())

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -802,6 +802,10 @@ Operand Generator::get_this(Optional<Operand> preferred_dst)
 {
     if (m_current_basic_block->this_().has_value())
         return m_current_basic_block->this_().value();
+    if (m_root_basic_blocks[0]->this_().has_value()) {
+        m_current_basic_block->set_this(m_root_basic_blocks[0]->this_().value());
+        return m_root_basic_blocks[0]->this_().value();
+    }
     auto dst = preferred_dst.has_value() ? preferred_dst.value() : Operand(allocate_register());
     emit<Bytecode::Op::ResolveThisBinding>(dst);
     m_current_basic_block->set_this(dst);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -798,4 +798,14 @@ void Generator::set_local_initialized(u32 local_index)
     m_initialized_locals.set(local_index);
 }
 
+Operand Generator::get_this(Optional<Operand> preferred_dst)
+{
+    if (m_current_basic_block->this_().has_value())
+        return m_current_basic_block->this_().value();
+    auto dst = preferred_dst.has_value() ? preferred_dst.value() : Operand(allocate_register());
+    emit<Bytecode::Op::ResolveThisBinding>(dst);
+    m_current_basic_block->set_this(dst);
+    return dst;
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -220,18 +220,13 @@ void Generator::grow(size_t additional_size)
     m_current_basic_block->grow(additional_size);
 }
 
-ScopedOperand Generator::allocate_sequential_register()
-{
-    VERIFY(m_next_register != NumericLimits<u32>::max());
-    return ScopedOperand { *this, Operand { Register { m_next_register++ } } };
-}
-
 ScopedOperand Generator::allocate_register()
 {
     if (!m_free_registers.is_empty()) {
         return ScopedOperand { *this, Operand { m_free_registers.take_last() } };
     }
-    return allocate_sequential_register();
+    VERIFY(m_next_register != NumericLimits<u32>::max());
+    return ScopedOperand { *this, Operand { Register { m_next_register++ } } };
 }
 
 void Generator::free_register(Register reg)

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -257,6 +257,8 @@ public:
         m_boundaries.take_last();
     }
 
+    [[nodiscard]] Operand get_this(Optional<Operand> preferred_dst = {});
+
     void emit_get_by_id(Operand dst, Operand base, IdentifierTableIndex property_identifier, Optional<IdentifierTableIndex> base_identifier = {});
 
     void emit_get_by_id_with_this(Operand dst, Operand base, IdentifierTableIndex, Operand this_value);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -34,8 +34,6 @@ public:
     };
     static CodeGenerationErrorOr<NonnullGCPtr<Executable>> generate(VM&, ASTNode const&, ReadonlySpan<FunctionParameter> parameters, FunctionKind = FunctionKind::Normal);
 
-    [[nodiscard]] ScopedOperand allocate_sequential_register();
-
     [[nodiscard]] ScopedOperand allocate_register();
     [[nodiscard]] ScopedOperand local(u32 local_index);
     [[nodiscard]] ScopedOperand accumulator();

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -86,7 +86,7 @@ static ByteString format_operand_list(StringView name, ReadonlySpan<Operand> ope
 {
     StringBuilder builder;
     if (!name.is_empty())
-        builder.appendff(", \033[32m{}\033[0m:[", name);
+        builder.appendff("\033[32m{}\033[0m:[", name);
     for (size_t i = 0; i < operands.size(); ++i) {
         if (i != 0)
             builder.append(", "sv);
@@ -1095,8 +1095,7 @@ ThrowCompletionOr<void> NewArray::execute_impl(Bytecode::Interpreter& interprete
 {
     auto array = MUST(Array::create(interpreter.realm(), 0));
     for (size_t i = 0; i < m_element_count; i++) {
-        auto& value = interpreter.reg(Register(m_elements[0].index() + i));
-        array->indexed_properties().put(i, value, default_attributes);
+        array->indexed_properties().put(i, interpreter.get(m_elements[i]), default_attributes);
     }
     interpreter.set(dst(), array);
     return {};
@@ -1883,7 +1882,7 @@ ByteString NewArray::to_byte_string_impl(Bytecode::Executable const& executable)
     StringBuilder builder;
     builder.appendff("NewArray {}", format_operand("dst"sv, dst(), executable));
     if (m_element_count != 0) {
-        builder.appendff(", [{}-{}]", format_operand("from"sv, m_elements[0], executable), format_operand("to"sv, m_elements[1], executable));
+        builder.appendff(", {}", format_operand_list("args"sv, { m_elements, m_element_count }, executable));
     }
     return builder.to_byte_string();
 }
@@ -2169,7 +2168,7 @@ ByteString Call::to_byte_string_impl(Bytecode::Executable const& executable) con
     auto type = call_type_to_string(m_type);
 
     StringBuilder builder;
-    builder.appendff("Call{} {}, {}, {}"sv,
+    builder.appendff("Call{} {}, {}, {}, "sv,
         type,
         format_operand("dst"sv, m_dst, executable),
         format_operand("callee"sv, m_callee, executable),

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -254,13 +254,13 @@ public:
     {
     }
 
-    NewArray(Operand dst, AK::Array<Operand, 2> const& elements_range)
+    NewArray(Operand dst, ReadonlySpan<ScopedOperand> elements)
         : Instruction(Type::NewArray)
         , m_dst(dst)
-        , m_element_count(elements_range[1].index() - elements_range[0].index() + 1)
+        , m_element_count(elements.size())
     {
-        m_elements[0] = elements_range[0];
-        m_elements[1] = elements_range[1];
+        for (size_t i = 0; i < m_element_count; ++i)
+            m_elements[i] = elements[i];
     }
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
@@ -270,19 +270,7 @@ public:
 
     size_t length_impl() const
     {
-        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * (m_element_count == 0 ? 0 : 2));
-    }
-
-    Operand start() const
-    {
-        VERIFY(m_element_count);
-        return m_elements[0];
-    }
-
-    Operand end() const
-    {
-        VERIFY(m_element_count);
-        return m_elements[1];
+        return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_element_count);
     }
 
     size_t element_count() const { return m_element_count; }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -18,6 +18,7 @@
 #include <LibJS/Bytecode/Operand.h>
 #include <LibJS/Bytecode/RegexTable.h>
 #include <LibJS/Bytecode/Register.h>
+#include <LibJS/Bytecode/ScopedOperand.h>
 #include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Runtime/Environment.h>
@@ -211,7 +212,7 @@ class CopyObjectExcludingProperties final : public Instruction {
 public:
     static constexpr bool IsVariableLength = true;
 
-    CopyObjectExcludingProperties(Operand dst, Operand from_object, Vector<Operand> const& excluded_names)
+    CopyObjectExcludingProperties(Operand dst, Operand from_object, Vector<ScopedOperand> const& excluded_names)
         : Instruction(Type::CopyObjectExcludingProperties)
         , m_dst(dst)
         , m_from_object(from_object)
@@ -1238,7 +1239,7 @@ class Call final : public Instruction {
 public:
     static constexpr bool IsVariableLength = true;
 
-    Call(CallType type, Operand dst, Operand callee, Operand this_value, ReadonlySpan<Operand> arguments, Optional<StringTableIndex> expression_string = {}, Optional<Builtin> builtin = {})
+    Call(CallType type, Operand dst, Operand callee, Operand this_value, ReadonlySpan<ScopedOperand> arguments, Optional<StringTableIndex> expression_string = {}, Optional<Builtin> builtin = {})
         : Instruction(Type::Call)
         , m_dst(dst)
         , m_callee(callee)

--- a/Userland/Libraries/LibJS/Bytecode/Operand.h
+++ b/Userland/Libraries/LibJS/Bytecode/Operand.h
@@ -36,6 +36,8 @@ public:
     [[nodiscard]] Type type() const { return m_type; }
     [[nodiscard]] u32 index() const { return m_index; }
 
+    [[nodiscard]] Register as_register() const;
+
 private:
     Type m_type {};
     u32 m_index { 0 };

--- a/Userland/Libraries/LibJS/Bytecode/ScopedOperand.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ScopedOperand.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Bytecode/Generator.h>
+#include <LibJS/Bytecode/ScopedOperand.h>
+
+namespace JS::Bytecode {
+
+ScopedOperandImpl::~ScopedOperandImpl()
+{
+    if (!m_generator.is_finished() && m_operand.is_register() && m_operand.as_register().index() != 0)
+        m_generator.free_register(m_operand.as_register());
+}
+
+Register Operand::as_register() const
+{
+    return Register { m_index };
+}
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
+++ b/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <LibJS/Bytecode/Operand.h>
+
+namespace JS::Bytecode {
+
+class ScopedOperandImpl : public RefCounted<ScopedOperandImpl> {
+public:
+    ScopedOperandImpl(Generator& generator, Operand operand)
+        : m_generator(generator)
+        , m_operand(operand)
+    {
+    }
+
+    ~ScopedOperandImpl();
+
+    [[nodiscard]] Operand operand() const { return m_operand; }
+
+private:
+    Generator& m_generator;
+    Operand m_operand;
+};
+
+class ScopedOperand {
+public:
+    explicit ScopedOperand(Generator& generator, Operand operand)
+        : m_impl(adopt_ref(*new ScopedOperandImpl(generator, operand)))
+    {
+    }
+
+    [[nodiscard]] Operand operand() const { return m_impl->operand(); }
+    operator Operand() const { return operand(); }
+
+    [[nodiscard]] bool operator==(ScopedOperand const& other) const { return operand() == other.operand(); }
+
+private:
+    NonnullRefPtr<ScopedOperandImpl> m_impl;
+};
+
+}

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     Bytecode/Interpreter.cpp
     Bytecode/Label.cpp
     Bytecode/RegexTable.cpp
+    Bytecode/ScopedOperand.cpp
     Bytecode/StringTable.cpp
     Console.cpp
     Contrib/Test262/262Object.cpp

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -303,7 +303,13 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::parse_int)
     auto input_string = TRY(string.to_string(vm));
 
     // 2. Let S be ! TrimString(inputString, start).
-    auto trimmed_string = MUST(trim_string(vm, PrimitiveString::create(vm, move(input_string)), TrimMode::Left));
+    String trimmed_string;
+    // OPTIMIZATION: We can skip the trimming step when the value already starts with an alphanumeric ASCII character.
+    if (input_string.is_empty() || is_ascii_alphanumeric(input_string.bytes_as_string_view()[0])) {
+        trimmed_string = input_string;
+    } else {
+        trimmed_string = MUST(trim_string(vm, PrimitiveString::create(vm, move(input_string)), TrimMode::Left));
+    }
 
     // 3. Let sign be 1.
     auto sign = 1;

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -22,14 +22,12 @@ SimpleIndexedPropertyStorage::SimpleIndexedPropertyStorage(Vector<Value>&& initi
 
 bool SimpleIndexedPropertyStorage::has_index(u32 index) const
 {
-    return index < m_array_size && !m_packed_elements[index].is_empty();
+    return inline_has_index(index);
 }
 
 Optional<ValueAndAttributes> SimpleIndexedPropertyStorage::get(u32 index) const
 {
-    if (!has_index(index))
-        return {};
-    return ValueAndAttributes { m_packed_elements[index], default_attributes };
+    return inline_get(index);
 }
 
 void SimpleIndexedPropertyStorage::grow_storage_if_needed()

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -74,6 +74,18 @@ public:
 
     Vector<Value> const& elements() const { return m_packed_elements; }
 
+    [[nodiscard]] bool inline_has_index(u32 index) const
+    {
+        return index < m_array_size && !m_packed_elements.data()[index].is_empty();
+    }
+
+    [[nodiscard]] Optional<ValueAndAttributes> inline_get(u32 index) const
+    {
+        if (!inline_has_index(index))
+            return {};
+        return ValueAndAttributes { m_packed_elements.data()[index], default_attributes };
+    }
+
 private:
     friend GenericIndexedPropertyStorage;
 

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -735,6 +735,7 @@ struct Formatter<JS::Value> : Formatter<StringView> {
 template<>
 struct Traits<JS::Value> : DefaultTraits<JS::Value> {
     static unsigned hash(JS::Value value) { return Traits<u64>::hash(value.encoded()); }
+    static constexpr bool is_trivial() { return true; }
 };
 
 }


### PR DESCRIPTION
See individual commits.

Benchmark results before/after:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
Kraken      ai-astar.js                              0.998  2.905 ± 2.860 … 2.950        2.910 ± 2.900 … 2.920
Kraken      audio-beat-detection.js                  1.112  1.690 ± 1.690 … 1.690        1.520 ± 1.520 … 1.520
Kraken      audio-dft.js                             1.106  1.620 ± 1.620 … 1.620        1.465 ± 1.460 … 1.470
Kraken      audio-fft.js                             1.106  1.565 ± 1.540 … 1.590        1.415 ± 1.410 … 1.420
Kraken      audio-oscillator.js                      1.064  1.820 ± 1.810 … 1.830        1.710 ± 1.700 … 1.720
Kraken      imaging-darkroom.js                      0.977  2.505 ± 2.500 … 2.510        2.565 ± 2.560 … 2.570
Kraken      imaging-desaturate.js                    1.155  2.690 ± 2.670 … 2.710        2.330 ± 2.290 … 2.370
Kraken      imaging-gaussian-blur.js                 1.073  10.385 ± 10.360 … 10.410     9.680 ± 9.620 … 9.740
Kraken      json-parse-financial.js                  1      0.130 ± 0.130 … 0.130        0.130 ± 0.130 … 0.130
Kraken      json-stringify-tinderbox.js              1      0.170 ± 0.170 … 0.170        0.170 ± 0.170 … 0.170
Kraken      stanford-crypto-aes.js                   1.079  0.820 ± 0.820 … 0.820        0.760 ± 0.760 … 0.760
Kraken      stanford-crypto-ccm.js                   1.119  0.705 ± 0.700 … 0.710        0.630 ± 0.630 … 0.630
Kraken      stanford-crypto-pbkdf2.js                1.067  1.275 ± 1.270 … 1.280        1.195 ± 1.190 … 1.200
Kraken      stanford-crypto-sha256-iterative.js      1.061  0.520 ± 0.520 … 0.520        0.490 ± 0.490 … 0.490
Octane      box2d.js                                 1.026  3.385 ± 3.370 … 3.400        3.300 ± 3.290 … 3.310
Octane      code-load.js                             0.995  2.135 ± 2.130 … 2.140        2.145 ± 2.130 … 2.160
Octane      crypto.js                                1.022  7.395 ± 7.360 … 7.430        7.235 ± 7.190 … 7.280
Octane      deltablue.js                             0.801  2.035 ± 2.030 … 2.040        2.540 ± 2.030 … 3.050
Octane      earley-boyer.js                          1.006  20.635 ± 20.570 … 20.700     20.505 ± 20.440 … 20.570
Octane      gbemu.js                                 1.138  4.615 ± 4.610 … 4.620        4.055 ± 3.570 … 4.540
Octane      mandreel.js                              0.946  17.425 ± 17.190 … 17.660     18.415 ± 18.120 … 18.710
Octane      navier-stokes.js                         1.033  3.250 ± 3.230 … 3.270        3.145 ± 3.140 … 3.150
Octane      pdfjs.js                                 1.032  3.395 ± 3.380 … 3.410        3.290 ± 3.180 … 3.400
Octane      raytrace.js                              0.985  7.995 ± 7.990 … 8.000        8.120 ± 7.940 … 8.300
Octane      regexp.js                                0.992  23.470 ± 23.200 … 23.740     23.660 ± 23.200 … 24.120
Octane      richards.js                              1      2.020 ± 2.020 … 2.020        2.020 ± 2.020 … 2.020
Octane      splay.js                                 0.998  2.870 ± 2.860 … 2.880        2.875 ± 2.870 … 2.880
Octane      typescript.js                            1.049  46.535 ± 46.470 … 46.600     44.355 ± 43.320 … 45.390
Octane      zlib.js                                  1.049  113.820 ± 112.970 … 114.670  108.465 ± 105.660 … 111.270
Kraken      Total                                    1.068  28.800                       26.970
Octane      Total                                    1.027  260.980                      254.125
All Suites  Total                                    1.031  289.780                      281.095
```