### PR TITLE
Kernel/net: Add tracking of dropped packets per adapter 

### DIFF
--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.cpp
@@ -44,6 +44,7 @@ ErrorOr<void> SysFSNetworkAdaptersStats::try_generate(KBufferBuilder& builder)
         TRY(obj.add("link_speed"sv, adapter.link_speed()));
         TRY(obj.add("link_full_duplex"sv, adapter.link_full_duplex()));
         TRY(obj.add("mtu"sv, adapter.mtu()));
+        TRY(obj.add("packets_dropped"sv, adapter.packets_dropped()));
         TRY(obj.finish());
         return {};
     }));

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -76,7 +76,7 @@ void NetworkAdapter::did_receive(ReadonlyBytes payload)
     m_bytes_in += payload.size();
 
     if (m_packet_queue_size == max_packet_buffers) {
-        // FIXME: Keep track of the number of dropped packets
+        m_packets_dropped++;
         return;
     }
 

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -90,6 +90,7 @@ public:
     u32 bytes_in() const { return m_bytes_in; }
     u32 packets_out() const { return m_packets_out; }
     u32 bytes_out() const { return m_bytes_out; }
+    u32 packets_dropped() const { return m_packets_dropped; }
 
     RefPtr<PacketWithTimestamp> acquire_packet_buffer(size_t);
     void release_packet_buffer(PacketWithTimestamp&);
@@ -126,6 +127,7 @@ private:
     u32 m_packets_out { 0 };
     u32 m_bytes_out { 0 };
     u32 m_mtu { 1500 };
+    u32 m_packets_dropped { 0 };
 };
 
 }

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -69,6 +69,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_adapters_fields.empend("packets_out", "Pkt Out"_string, Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("bytes_in", "Bytes In"_string, Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("bytes_out", "Bytes Out"_string, Gfx::TextAlignment::CenterRight);
+        net_adapters_fields.empend("packets_dropped", "Packets Dropped"_string, Gfx::TextAlignment::CenterRight);
         m_adapter_model = GUI::JsonArrayModel::create("/sys/kernel/net/adapters", move(net_adapters_fields));
         m_adapter_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_adapter_model)));
         m_adapter_context_menu = GUI::Menu::construct();


### PR DESCRIPTION
The dropped packets status is shown in the last column of the network adapter column in the SystemMonitor app.