### PR TITLE
LibGfx+Utilities: Add animation utility, make it write animated webps

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -537,6 +537,7 @@ if (BUILD_LAGOM)
             lagom_utility(adjtime SOURCES ../../Userland/Utilities/adjtime.cpp LIBS LibMain)
         endif()
 
+        lagom_utility(animation SOURCES ../../Userland/Utilities/animation.cpp LIBS LibGfx LibMain)
         lagom_utility(base64 SOURCES ../../Userland/Utilities/base64.cpp LIBS LibMain)
 
         if (NOT EMSCRIPTEN)

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.h
@@ -7,12 +7,25 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Point.h>
 
 namespace Gfx {
 
 struct WebPEncoderOptions {
     Optional<ReadonlyBytes> icc_data;
+};
+
+class AnimationWriter {
+public:
+    virtual ~AnimationWriter() = default;
+
+    // Flushes the frame to disk.
+    // IntRect { at, at + bitmap.size() } must fit in the dimensions
+    // passed to `start_writing_animation()`.
+    // FIXME: Consider passing in disposal method and blend mode.
+    virtual ErrorOr<void> add_frame(Bitmap&, int duration_ms, IntPoint at = {}) = 0;
 };
 
 class WebPWriter {
@@ -21,6 +34,9 @@ public:
 
     // Always lossless at the moment.
     static ErrorOr<void> encode(Stream&, Bitmap const&, Options const& = {});
+
+    // Always lossless at the moment.
+    static ErrorOr<NonnullOwnPtr<AnimationWriter>> start_encoding_animation(SeekableStream&, IntSize dimensions, int loop_count = 0, Color background_color = Color::Black, Options const& = {});
 
 private:
     WebPWriter() = delete;

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -74,6 +74,7 @@ install(CODE "file(CREATE_LINK gunzip ${CMAKE_INSTALL_PREFIX}/bin/zcat SYMBOLIC)
 
 target_link_libraries(abench PRIVATE LibAudio LibFileSystem)
 target_link_libraries(aconv PRIVATE LibAudio LibFileSystem)
+target_link_libraries(animation PRIVATE LibGfx)
 target_link_libraries(aplay PRIVATE LibAudio LibFileSystem LibIPC)
 target_link_libraries(asctl PRIVATE LibAudio LibIPC)
 target_link_libraries(bt PRIVATE LibSymbolication LibURL)

--- a/Userland/Utilities/animation.cpp
+++ b/Userland/Utilities/animation.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/MappedFile.h>
+#include <LibGfx/ImageFormats/ImageDecoder.h>
+#include <LibGfx/ImageFormats/WebPWriter.h>
+
+struct Options {
+    StringView in_path;
+    StringView out_path;
+};
+
+static ErrorOr<Options> parse_options(Main::Arguments arguments)
+{
+    Options options;
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(options.in_path, "Path to input image file", "FILE");
+    args_parser.add_option(options.out_path, "Path to output image file", "output", 'o', "FILE");
+    args_parser.parse(arguments);
+
+    if (options.out_path.is_empty())
+        return Error::from_string_view("-o is required "sv);
+
+    return options;
+}
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    Options options = TRY(parse_options(arguments));
+
+    // FIXME: Allow multiple single frames as input too, and allow manually setting their duration.
+
+    auto file = TRY(Core::MappedFile::map(options.in_path));
+    auto decoder = TRY(Gfx::ImageDecoder::try_create_for_raw_bytes(file->bytes()));
+    if (!decoder)
+        return Error::from_string_view("Could not find decoder for input file"sv);
+
+    auto output_file = TRY(Core::File::open(options.out_path, Core::File::OpenMode::Write));
+    auto output_stream = TRY(Core::OutputBufferedFile::create(move(output_file)));
+
+    auto animation_writer = TRY(Gfx::WebPWriter::start_encoding_animation(*output_stream, decoder->size(), decoder->loop_count()));
+
+    for (size_t i = 0; i < decoder->frame_count(); ++i) {
+        auto frame = TRY(decoder->frame(i));
+        TRY(animation_writer->add_frame(*frame.image, frame.duration));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
The high-level design is that we have a static method on WebPWriter that
returns an AnimationWriter object. AnimationWriter has a virtual method
for writing individual frames. This allows streaming animations to disk,
without having to buffer up the entire animation in memory first.
The semantics of this function, add_frame(), are that data is flushed
to disk every time the function is called, so that no explicit `close()`
method is needed.

For some formats that store animation length at the start of the file,
including WebP, this means that this needs to write to a SeekableStream,
so that add_frame() can seek to the start and update the size when a
frame is written.

This design should work for GIF and APNG writing as well. We can move
AnimationWriter to a new header if we add writers for these.

Currently, `animation` can read any animated image format we can read
(apng, gif, webp) and convert it to an animated webp file.

The written animated webp file is not compressed whatsoever, so this
creates large output files at the moment.