### PR TITLE
LibWeb: Don't try to click a form image until it has loaded

### DIFF
--- a/Tests/LibWeb/Text/input/HTML/form-image-submission.html
+++ b/Tests/LibWeb/Text/input/HTML/form-image-submission.html
@@ -28,7 +28,9 @@
             done();
         });
 
-        const imageRect = image.getBoundingClientRect();
-        internals.click(imageRect.x + 10, imageRect.y + 20);
+        image.addEventListener("load", () => {
+            const imageRect = image.getBoundingClientRect();
+            internals.click(imageRect.x + 10, imageRect.y + 20);
+        });
     });
 </script>


### PR DESCRIPTION
We are often trying to click the image before it has finished loading. This results in us trying to click a 0x0 rect. Instead, wait until the image load event.

This fixes a flake with form-image-submission.html often seen on CI.