### PR TITLE
LibJS+LibCore: Some BSD Compatibility updates

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -357,7 +357,8 @@ add_serenity_subdirectory(Userland/Libraries/LibCore)
 target_link_libraries(LibCore PRIVATE Threads::Threads)
 if (${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
     # NetBSD has its shm_open and shm_unlink functions in librt so we need to link that
-    target_link_libraries(LibCore PRIVATE librt.so)
+    target_link_libraries(LibCore PRIVATE rt)
+    target_link_libraries(LibCoreMinimal PRIVATE rt)
 endif()
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries

--- a/Userland/Libraries/LibCore/Environment.cpp
+++ b/Userland/Libraries/LibCore/Environment.cpp
@@ -13,7 +13,7 @@
 #if defined(AK_OS_MACOS) || defined(AK_OS_IOS)
 #    include <crt_externs.h>
 #else
-extern char** environ;
+extern "C" char** environ;
 #endif
 
 namespace Core::Environment {
@@ -93,15 +93,16 @@ Optional<StringView> get(StringView name, [[maybe_unused]] SecureOnly secure)
     builder.append('\0');
     // Note the explicit null terminators above.
 
-#if defined(AK_OS_MACOS) || defined(AK_OS_ANDROID)
-    char* result = ::getenv(builder.string_view().characters_without_null_termination());
-#else
+    // FreeBSD < 14, Android, and generic BSDs do not support secure_getenv.
+#if (defined(__FreeBSD__) && __FreeBSD__ >= 14) || (!defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID))
     char* result;
     if (secure == SecureOnly::Yes) {
         result = ::secure_getenv(builder.string_view().characters_without_null_termination());
     } else {
         result = ::getenv(builder.string_view().characters_without_null_termination());
     }
+#else
+    char* result = ::getenv(builder.string_view().characters_without_null_termination());
 #endif
     if (result)
         return StringView { result, strlen(result) };
@@ -153,7 +154,9 @@ ErrorOr<void> put(StringView env)
 
 ErrorOr<void> clear()
 {
-#if defined(AK_OS_MACOS)
+#if (defined(__FreeBSD__) && __FreeBSD__ < 14)
+    environ = nullptr;
+#elif defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_FREEBSD)
     auto environment = raw_environ();
     for (size_t environ_size = 0; environment[environ_size]; ++environ_size) {
         environment[environ_size] = NULL;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -264,7 +264,11 @@ private:
     }
 
     struct AddrInfoDeleter {
-        void operator()(struct addrinfo* ptr) { ::freeaddrinfo(ptr); }
+        void operator()(struct addrinfo* ptr)
+        {
+            if (ptr)
+                ::freeaddrinfo(ptr);
+        }
     };
 
     Vector<struct addrinfo> m_addresses {};

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
@@ -55,9 +55,9 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
     }
 
 #ifdef AK_OS_SERENITY
-    auto* block = (HeapBlock*)serenity_mmap(nullptr, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_RANDOMIZED | MAP_PRIVATE, 0, 0, HeapBlock::block_size, name);
+    auto* block = (HeapBlock*)serenity_mmap(nullptr, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_RANDOMIZED | MAP_PRIVATE, -1, 0, HeapBlock::block_size, name);
 #else
-    auto* block = (HeapBlock*)mmap(nullptr, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
+    auto* block = (HeapBlock*)mmap(nullptr, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 #endif
     VERIFY(block != MAP_FAILED);
     LSAN_REGISTER_ROOT_REGION(block, HeapBlock::block_size);
@@ -74,7 +74,7 @@ void BlockAllocator::deallocate_block(void* block)
         perror("munmap");
         VERIFY_NOT_REACHED();
     }
-    if (mmap(block, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0) != block) {
+    if (mmap(block, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0) != block) {
         perror("mmap");
         VERIFY_NOT_REACHED();
     }


### PR DESCRIPTION
NetBSD and FreeBSD get upset when we don't set the fd to an invalid
value when using a non-shared mapping.

FreeBSD and NetBSD don't have secure_getenv(3), same as macOS.
FreeBSD 13 and lower also don't allow setting environ pointers to null.

Ref: #23375

cc @0-wiz-0
cc @clausecker
