### PR TITLE
LibChess: Fix crash when importing PGN 

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -708,7 +708,6 @@ ErrorOr<void, PGNParseError> ChessWidget::import_pgn(Core::File& file)
         switch (token.type) {
         case TokenType::Move:
             // FIXME: Add some move validation so the engine doesn't crash.
-            // FIXME: Engine crashes with pawn promotion notation (e.g. fxg8=Q).
             m_board.apply_move(Chess::Move::from_algebraic(token.value, turn, m_board));
             turn = Chess::opposing_color(turn);
             break;

--- a/Userland/Libraries/LibChess/Chess.cpp
+++ b/Userland/Libraries/LibChess/Chess.cpp
@@ -161,7 +161,7 @@ Move Move::from_algebraic(StringView algebraic, Color const turn, Board const& b
 
     Square::for_each([&](Square const& square) {
         if (!move_string.is_empty()) {
-            if (board.get_piece(square).type == move.piece.type && board.is_legal(Move(square, move.to), turn)) {
+            if (board.get_piece(square).type == move.piece.type && board.is_legal(Move(square, move.to, move.promote_to), turn)) {
                 if (move_string.length() >= 2) {
                     if (square == Square(move_string.substring_view(0, 2))) {
                         move.from = square;


### PR DESCRIPTION
Fix the incorrect parsing in `Chess::Move::from_algebraic` of moves with a capture and promotion (e.g. gxf8=Q) due to the promoted piece type not being passed through to the `Board::is_legal` method.