### PR TITLE
LibJS: Another big bag of optimizations

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -70,7 +70,6 @@ public:
         return *this;
     }
 
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     Optional(Optional const& other)
     requires(!IsCopyConstructible<T>)
     = delete;
@@ -93,12 +92,9 @@ public:
     requires(!IsDestructible<T>)
     = delete;
     ~Optional() = default;
-#endif
 
     ALWAYS_INLINE Optional(Optional const& other)
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!IsTriviallyCopyConstructible<T>)
-#endif
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
@@ -138,9 +134,7 @@ public:
     }
 
     ALWAYS_INLINE Optional& operator=(Optional const& other)
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
-#endif
     {
         if (this != &other) {
             clear();
@@ -177,9 +171,7 @@ public:
     }
 
     ALWAYS_INLINE ~Optional()
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!IsTriviallyDestructible<T>)
-#endif
     {
         clear();
     }

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -159,10 +159,6 @@
 #    define VALIDATE_IS_RISCV64() static_assert(false, "Trying to include riscv64 only header on non riscv64 platform");
 #endif
 
-#if !defined(AK_COMPILER_CLANG)
-#    define AK_HAS_CONDITIONALLY_TRIVIAL
-#endif
-
 // Apple Clang 14.0.3 (shipped in Xcode 14.3) has a bug that causes __builtin_subc{,l,ll}
 // to incorrectly return whether a borrow occurred on AArch64. See our writeup for the Qemu
 // issue also caused by it: https://gitlab.com/qemu-project/qemu/-/issues/1659#note_1408275831

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -267,7 +267,6 @@ public:
     {
     }
 
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     Variant(Variant const&)
     requires(!(IsCopyConstructible<Ts> && ...))
     = delete;
@@ -292,12 +291,9 @@ public:
     requires(!(IsMoveConstructible<Ts> && ...) || !(IsDestructible<Ts> && ...))
     = delete;
     Variant& operator=(Variant&&) = default;
-#endif
 
     ALWAYS_INLINE Variant(Variant const& old)
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!(IsTriviallyCopyConstructible<Ts> && ...))
-#endif
         : Detail::MergeAndDeduplicatePacks<Detail::VariantConstructors<Ts, Variant<Ts...>>...>()
         , m_data {}
         , m_index(old.m_index)
@@ -310,9 +306,7 @@ public:
     //       and if a variant with a nontrivial move ctor is moved from, it may or may not be valid
     //       but it will still contain the "moved-from" state of the object it previously contained.
     ALWAYS_INLINE Variant(Variant&& old)
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!(IsTriviallyMoveConstructible<Ts> && ...))
-#endif
         : Detail::MergeAndDeduplicatePacks<Detail::VariantConstructors<Ts, Variant<Ts...>>...>()
         , m_index(old.m_index)
     {
@@ -320,17 +314,13 @@ public:
     }
 
     ALWAYS_INLINE ~Variant()
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!(IsTriviallyDestructible<Ts> && ...))
-#endif
     {
         Helper::delete_(m_index, m_data);
     }
 
     ALWAYS_INLINE Variant& operator=(Variant const& other)
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!(IsTriviallyCopyConstructible<Ts> && ...) || !(IsTriviallyDestructible<Ts> && ...))
-#endif
     {
         if (this != &other) {
             if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {
@@ -343,9 +333,7 @@ public:
     }
 
     ALWAYS_INLINE Variant& operator=(Variant&& other)
-#ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     requires(!(IsTriviallyMoveConstructible<Ts> && ...) || !(IsTriviallyDestructible<Ts> && ...))
-#endif
     {
         if (this != &other) {
             if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -382,6 +382,10 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> Identifier::generate_by
         return local;
     }
 
+    if (is_global() && m_string == "undefined"sv) {
+        return generator.add_constant(js_undefined());
+    }
+
     auto dst = choose_dst(generator, preferred_dst);
     if (is_global()) {
         generator.emit<Bytecode::Op::GetGlobal>(dst, generator.intern_identifier(m_string), generator.next_global_variable_cache());

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -269,6 +269,14 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> LogicalExpression::gene
 Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> UnaryExpression::generate_bytecode(Bytecode::Generator& generator, Optional<ScopedOperand> preferred_dst) const
 {
     Bytecode::Generator::SourceLocationScope scope(generator, *this);
+
+    // OPTIMIZATION: Turn expressions like `-1` into a constant.
+    if (m_op == UnaryOp::Minus && is<NumericLiteral>(*m_lhs)) {
+        auto& numeric_literal = static_cast<NumericLiteral const&>(*m_lhs);
+        auto value = numeric_literal.value();
+        return generator.add_constant(Value(-value.as_double()));
+    }
+
     if (m_op == UnaryOp::Delete)
         return generator.emit_delete_reference(m_lhs);
 

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -36,6 +36,12 @@ public:
     u8 const* data() const { return m_buffer.data(); }
     size_t size() const { return m_buffer.size(); }
 
+    void rewind()
+    {
+        m_buffer.resize_and_keep_capacity(m_last_instruction_start_offset);
+        m_terminated = false;
+    }
+
     void grow(size_t additional_size);
 
     void terminate(Badge<Generator>) { m_terminated = true; }
@@ -55,6 +61,9 @@ public:
     auto const& this_() const { return m_this; }
     void set_this(ScopedOperand operand) { m_this = operand; }
 
+    [[nodiscard]] size_t last_instruction_start_offset() const { return m_last_instruction_start_offset; }
+    void set_last_instruction_start_offset(size_t offset) { m_last_instruction_start_offset = offset; }
+
 private:
     explicit BasicBlock(u32 index, String name);
 
@@ -68,6 +77,8 @@ private:
     HashMap<size_t, SourceRecord> m_source_map;
 
     Optional<ScopedOperand> m_this;
+
+    size_t m_last_instruction_start_offset { 0 };
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -22,7 +22,7 @@ namespace JS::Bytecode {
     O(MathRound, math_round, Math, round, 1) \
     O(MathSqrt, math_sqrt, Math, sqrt, 1)
 
-enum class Builtin {
+enum class Builtin : u8 {
 #define DEFINE_BUILTIN_ENUM(name, ...) name,
     JS_ENUMERATE_BUILTINS(DEFINE_BUILTIN_ENUM)
 #undef DEFINE_BUILTIN_ENUM

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -856,6 +856,18 @@ bool Generator::fuse_compare_and_jump(ScopedOperand const& condition, Label true
 
 void Generator::emit_jump_if(ScopedOperand const& condition, Label true_target, Label false_target)
 {
+    if (condition.operand().is_constant()) {
+        auto value = m_constants[condition.operand().index()];
+        if (value.is_boolean()) {
+            if (value.as_bool()) {
+                emit<Op::Jump>(true_target);
+            } else {
+                emit<Op::Jump>(false_target);
+            }
+            return;
+        }
+    }
+
     // NOTE: It's only safe to fuse compare-and-jump if the condition is a temporary with no other dependents.
     if (condition.operand().is_register()
         && condition.ref_count() == 1

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -528,7 +528,7 @@ CodeGenerationErrorOr<Optional<ScopedOperand>> Generator::emit_delete_reference(
         if (is<SuperExpression>(expression.object())) {
             auto super_reference = TRY(emit_super_reference(expression));
 
-            auto dst = Operand(allocate_register());
+            auto dst = allocate_register();
             if (super_reference.referenced_name.has_value()) {
                 emit<Bytecode::Op::DeleteByValueWithThis>(dst, *super_reference.base, *super_reference.this_value, *super_reference.referenced_name);
             } else {

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -70,8 +70,16 @@
     O(IteratorToArray)                 \
     O(Jump)                            \
     O(JumpFalse)                       \
+    O(JumpGreaterThan)                 \
+    O(JumpGreaterThanEquals)           \
     O(JumpIf)                          \
+    O(JumpLessThan)                    \
+    O(JumpLessThanEquals)              \
+    O(JumpLooselyEquals)               \
+    O(JumpLooselyInequals)             \
     O(JumpNullish)                     \
+    O(JumpStrictlyEquals)              \
+    O(JumpStrictlyInequals)            \
     O(JumpTrue)                        \
     O(JumpUndefined)                   \
     O(LeaveFinally)                    \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -148,7 +148,6 @@ public:
     Type type() const { return m_type; }
     size_t length() const;
     ByteString to_byte_string(Bytecode::Executable const&) const;
-    ThrowCompletionOr<void> execute(Bytecode::Interpreter&) const;
     void visit_labels(Function<void(Label&)> visitor);
     static void destroy(Instruction&);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -526,6 +526,14 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
         DISPATCH_NEXT(name);                                                                                                              \
     }
 
+#define HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(name)                                    \
+    handle_##name:                                                                          \
+    {                                                                                       \
+        auto& instruction = *reinterpret_cast<Op::name const*>(&bytecode[program_counter]); \
+        (void)instruction.execute_impl(*this);                                              \
+        DISPATCH_NEXT(name);                                                                \
+    }
+
             HANDLE_INSTRUCTION(Add);
             HANDLE_INSTRUCTION(ArrayAppend);
             HANDLE_INSTRUCTION(AsyncIteratorClose);
@@ -533,13 +541,13 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(BitwiseNot);
             HANDLE_INSTRUCTION(BitwiseOr);
             HANDLE_INSTRUCTION(BitwiseXor);
-            HANDLE_INSTRUCTION(BlockDeclarationInstantiation);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(BlockDeclarationInstantiation);
             HANDLE_INSTRUCTION(Call);
             HANDLE_INSTRUCTION(CallWithArgumentArray);
-            HANDLE_INSTRUCTION(Catch);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(Catch);
             HANDLE_INSTRUCTION(ConcatString);
             HANDLE_INSTRUCTION(CopyObjectExcludingProperties);
-            HANDLE_INSTRUCTION(CreateLexicalEnvironment);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(CreateLexicalEnvironment);
             HANDLE_INSTRUCTION(CreateVariable);
             HANDLE_INSTRUCTION(Decrement);
             HANDLE_INSTRUCTION(DeleteById);
@@ -548,7 +556,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(DeleteByValueWithThis);
             HANDLE_INSTRUCTION(DeleteVariable);
             HANDLE_INSTRUCTION(Div);
-            HANDLE_INSTRUCTION(Dump);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(Dump);
             HANDLE_INSTRUCTION(EnterObjectEnvironment);
             HANDLE_INSTRUCTION(Exp);
             HANDLE_INSTRUCTION(GetById);
@@ -557,10 +565,10 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(GetByValueWithThis);
             HANDLE_INSTRUCTION(GetCalleeAndThisFromEnvironment);
             HANDLE_INSTRUCTION(GetGlobal);
-            HANDLE_INSTRUCTION(GetImportMeta);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetImportMeta);
             HANDLE_INSTRUCTION(GetIterator);
             HANDLE_INSTRUCTION(GetMethod);
-            HANDLE_INSTRUCTION(GetNewTarget);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetNewTarget);
             HANDLE_INSTRUCTION(GetNextMethodFromIteratorRecord);
             HANDLE_INSTRUCTION(GetObjectFromIteratorRecord);
             HANDLE_INSTRUCTION(GetObjectPropertyIterator);
@@ -576,8 +584,8 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(IteratorClose);
             HANDLE_INSTRUCTION(IteratorNext);
             HANDLE_INSTRUCTION(IteratorToArray);
-            HANDLE_INSTRUCTION(LeaveFinally);
-            HANDLE_INSTRUCTION(LeaveLexicalEnvironment);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(LeaveFinally);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(LeaveLexicalEnvironment);
             HANDLE_INSTRUCTION(LeaveUnwindContext);
             HANDLE_INSTRUCTION(LeftShift);
             HANDLE_INSTRUCTION(LessThan);
@@ -586,13 +594,13 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(LooselyInequals);
             HANDLE_INSTRUCTION(Mod);
             HANDLE_INSTRUCTION(Mul);
-            HANDLE_INSTRUCTION(NewArray);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(NewArray);
             HANDLE_INSTRUCTION(NewClass);
-            HANDLE_INSTRUCTION(NewFunction);
-            HANDLE_INSTRUCTION(NewObject);
-            HANDLE_INSTRUCTION(NewPrimitiveArray);
-            HANDLE_INSTRUCTION(NewRegExp);
-            HANDLE_INSTRUCTION(NewTypeError);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(NewFunction);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(NewObject);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(NewPrimitiveArray);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(NewRegExp);
+            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(NewTypeError);
             HANDLE_INSTRUCTION(Not);
             HANDLE_INSTRUCTION(PostfixDecrement);
             HANDLE_INSTRUCTION(PostfixIncrement);

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1819,7 +1819,7 @@ ThrowCompletionOr<void> IteratorClose::execute_impl(Bytecode::Interpreter& inter
     auto& iterator = verify_cast<IteratorRecord>(interpreter.get(m_iterator_record).as_object());
 
     // FIXME: Return the value of the resulting completion. (Note that m_completion_value can be empty!)
-    TRY(iterator_close(vm, iterator, Completion { m_completion_type, m_completion_value, {} }));
+    TRY(iterator_close(vm, iterator, Completion { m_completion_type, m_completion_value }));
     return {};
 }
 
@@ -1829,7 +1829,7 @@ ThrowCompletionOr<void> AsyncIteratorClose::execute_impl(Bytecode::Interpreter& 
     auto& iterator = verify_cast<IteratorRecord>(interpreter.get(m_iterator_record).as_object());
 
     // FIXME: Return the value of the resulting completion. (Note that m_completion_value can be empty!)
-    TRY(async_iterator_close(vm, iterator, Completion { m_completion_type, m_completion_value, {} }));
+    TRY(async_iterator_close(vm, iterator, Completion { m_completion_type, m_completion_value }));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -441,21 +441,21 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             goto start;
         }
 
-#define HANDLE_COMPARISON_OP(op_TitleCase, op_snake_case)                                                                             \
-    handle_Jump##op_TitleCase:                                                                                                        \
-    {                                                                                                                                 \
-        auto& instruction = *reinterpret_cast<Op::Jump##op_TitleCase const*>(&bytecode[program_counter]);                             \
-        auto result = op_snake_case(vm(), get(instruction.lhs()), get(instruction.rhs()));                                            \
-        if (result.is_error()) {                                                                                                      \
-            if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable) \
-                return;                                                                                                               \
-            goto start;                                                                                                               \
-        }                                                                                                                             \
-        if (result.value().to_boolean())                                                                                              \
-            program_counter = instruction.true_target().address();                                                                    \
-        else                                                                                                                          \
-            program_counter = instruction.false_target().address();                                                                   \
-        goto start;                                                                                                                   \
+#define HANDLE_COMPARISON_OP(op_TitleCase, op_snake_case)                                                               \
+    handle_Jump##op_TitleCase:                                                                                          \
+    {                                                                                                                   \
+        auto& instruction = *reinterpret_cast<Op::Jump##op_TitleCase const*>(&bytecode[program_counter]);               \
+        auto result = op_snake_case(vm(), get(instruction.lhs()), get(instruction.rhs()));                              \
+        if (result.is_error()) {                                                                                        \
+            if (handle_exception(program_counter, result.error_value()) == HandleExceptionResponse::ExitFromExecutable) \
+                return;                                                                                                 \
+            goto start;                                                                                                 \
+        }                                                                                                               \
+        if (result.value().to_boolean())                                                                                \
+            program_counter = instruction.true_target().address();                                                      \
+        else                                                                                                            \
+            program_counter = instruction.false_target().address();                                                     \
+        goto start;                                                                                                     \
     }
 
             JS_ENUMERATE_COMPARISON_OPS(HANDLE_COMPARISON_OP)
@@ -510,19 +510,19 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             goto start;
         }
 
-#define HANDLE_INSTRUCTION(name)                                                                                                          \
-    handle_##name:                                                                                                                        \
-    {                                                                                                                                     \
-        auto& instruction = *reinterpret_cast<Op::name const*>(&bytecode[program_counter]);                                               \
-        {                                                                                                                                 \
-            auto result = instruction.execute_impl(*this);                                                                                \
-            if (result.is_error()) {                                                                                                      \
-                if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable) \
-                    return;                                                                                                               \
-                goto start;                                                                                                               \
-            }                                                                                                                             \
-        }                                                                                                                                 \
-        DISPATCH_NEXT(name);                                                                                                              \
+#define HANDLE_INSTRUCTION(name)                                                                                            \
+    handle_##name:                                                                                                          \
+    {                                                                                                                       \
+        auto& instruction = *reinterpret_cast<Op::name const*>(&bytecode[program_counter]);                                 \
+        {                                                                                                                   \
+            auto result = instruction.execute_impl(*this);                                                                  \
+            if (result.is_error()) {                                                                                        \
+                if (handle_exception(program_counter, result.error_value()) == HandleExceptionResponse::ExitFromExecutable) \
+                    return;                                                                                                 \
+                goto start;                                                                                                 \
+            }                                                                                                               \
+        }                                                                                                                   \
+        DISPATCH_NEXT(name);                                                                                                \
     }
 
 #define HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(name)                                    \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -630,7 +630,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 
         handle_Await: {
             auto& instruction = *reinterpret_cast<Op::Await const*>(&bytecode[program_counter]);
-            auto result = instruction.execute(*this);
+            auto result = instruction.execute_impl(*this);
 
             if (result.is_error()) {
                 if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable)
@@ -642,7 +642,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 
         handle_Return: {
             auto& instruction = *reinterpret_cast<Op::Return const*>(&bytecode[program_counter]);
-            auto result = instruction.execute(*this);
+            auto result = instruction.execute_impl(*this);
 
             if (result.is_error()) {
                 if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable)
@@ -654,7 +654,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 
         handle_Yield: {
             auto& instruction = *reinterpret_cast<Op::Yield const*>(&bytecode[program_counter]);
-            auto result = instruction.execute(*this);
+            auto result = instruction.execute_impl(*this);
 
             if (result.is_error()) {
                 if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable)

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -155,11 +155,11 @@ ALWAYS_INLINE Value Interpreter::get(Operand op) const
 {
     switch (op.type()) {
     case Operand::Type::Register:
-        return reg(Register { op.index() });
+        return m_registers.data()[op.index()];
     case Operand::Type::Local:
         return m_locals.data()[op.index()];
     case Operand::Type::Constant:
-        return current_executable().constants[op.index()];
+        return m_constants.data()[op.index()];
     }
     __builtin_unreachable();
 }
@@ -168,13 +168,13 @@ ALWAYS_INLINE void Interpreter::set(Operand op, Value value)
 {
     switch (op.type()) {
     case Operand::Type::Register:
-        reg(Register { op.index() }) = value;
+        m_registers.data()[op.index()] = value;
         return;
     case Operand::Type::Local:
         m_locals.data()[op.index()] = value;
         return;
     case Operand::Type::Constant:
-        VERIFY_NOT_REACHED();
+        break;
     }
     __builtin_unreachable();
 }
@@ -720,6 +720,7 @@ Interpreter::ResultAndReturnRegister Interpreter::run_executable(Executable& exe
 
     TemporaryChange restore_registers { m_registers, running_execution_context.registers.span() };
     TemporaryChange restore_locals { m_locals, running_execution_context.locals.span() };
+    TemporaryChange restore_constants { m_constants, executable.constants.span() };
 
     reg(Register::accumulator()) = initial_accumulator_value;
     reg(Register::return_value()) = {};

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -630,37 +630,19 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 
         handle_Await: {
             auto& instruction = *reinterpret_cast<Op::Await const*>(&bytecode[program_counter]);
-            auto result = instruction.execute_impl(*this);
-
-            if (result.is_error()) {
-                if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable)
-                    return;
-                goto start;
-            }
+            (void)instruction.execute_impl(*this);
             goto may_return;
         }
 
         handle_Return: {
             auto& instruction = *reinterpret_cast<Op::Return const*>(&bytecode[program_counter]);
-            auto result = instruction.execute_impl(*this);
-
-            if (result.is_error()) {
-                if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable)
-                    return;
-                goto start;
-            }
+            (void)instruction.execute_impl(*this);
             goto may_return;
         }
 
         handle_Yield: {
             auto& instruction = *reinterpret_cast<Op::Yield const*>(&bytecode[program_counter]);
-            auto result = instruction.execute_impl(*this);
-
-            if (result.is_error()) {
-                if (handle_exception(program_counter, *result.throw_completion().value()) == HandleExceptionResponse::ExitFromExecutable)
-                    return;
-                goto start;
-            }
+            (void)instruction.execute_impl(*this);
             goto may_return;
         }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -98,6 +98,7 @@ private:
     Optional<size_t&> m_program_counter;
     Span<Value> m_registers;
     Span<Value> m_locals;
+    Span<Value> m_constants;
 };
 
 extern bool g_dump_bytecode;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -2052,22 +2052,3 @@ private:
 };
 
 }
-
-namespace JS::Bytecode {
-
-ALWAYS_INLINE ThrowCompletionOr<void> Instruction::execute(Bytecode::Interpreter& interpreter) const
-{
-#define __BYTECODE_OP(op)       \
-    case Instruction::Type::op: \
-        return static_cast<Bytecode::Op::op const&>(*this).execute_impl(interpreter);
-
-    switch (type()) {
-        ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)
-    default:
-        VERIFY_NOT_REACHED();
-    }
-
-#undef __BYTECODE_OP
-}
-
-}

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1263,7 +1263,7 @@ private:
     Label m_false_target;
 };
 
-enum class CallType {
+enum class CallType : u8 {
     Call,
     Construct,
     DirectEval,
@@ -1280,8 +1280,8 @@ public:
         , m_this_value(this_value)
         , m_argument_count(arguments.size())
         , m_type(type)
-        , m_expression_string(expression_string)
         , m_builtin(builtin)
+        , m_expression_string(expression_string)
     {
         for (size_t i = 0; i < arguments.size(); ++i)
             m_arguments[i] = arguments[i];
@@ -1311,8 +1311,8 @@ private:
     Operand m_this_value;
     u32 m_argument_count { 0 };
     CallType m_type;
-    Optional<StringTableIndex> m_expression_string;
     Optional<Builtin> m_builtin;
+    Optional<StringTableIndex> m_expression_string;
     Operand m_arguments[];
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1157,6 +1157,52 @@ private:
     Label m_target;
 };
 
+#define JS_ENUMERATE_COMPARISON_OPS(X)        \
+    X(LessThan, less_than)                    \
+    X(LessThanEquals, less_than_equals)       \
+    X(GreaterThan, greater_than)              \
+    X(GreaterThanEquals, greater_than_equals) \
+    X(LooselyEquals, loosely_equals)          \
+    X(LooselyInequals, loosely_inequals)      \
+    X(StrictlyEquals, strict_equals)          \
+    X(StrictlyInequals, strict_inequals)
+
+#define DECLARE_COMPARISON_OP(op_TitleCase, op_snake_case)                                           \
+    class Jump##op_TitleCase final : public Instruction {                                            \
+    public:                                                                                          \
+        constexpr static bool IsTerminator = true;                                                   \
+                                                                                                     \
+        explicit Jump##op_TitleCase(Operand lhs, Operand rhs, Label true_target, Label false_target) \
+            : Instruction(Type::Jump##op_TitleCase)                                                  \
+            , m_lhs(lhs)                                                                             \
+            , m_rhs(rhs)                                                                             \
+            , m_true_target(true_target)                                                             \
+            , m_false_target(false_target)                                                           \
+        {                                                                                            \
+        }                                                                                            \
+                                                                                                     \
+        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;                          \
+        ByteString to_byte_string_impl(Bytecode::Executable const&) const;                           \
+        void visit_labels_impl(Function<void(Label&)> visitor)                                       \
+        {                                                                                            \
+            visitor(m_true_target);                                                                  \
+            visitor(m_false_target);                                                                 \
+        }                                                                                            \
+                                                                                                     \
+        Operand lhs() const { return m_lhs; }                                                        \
+        Operand rhs() const { return m_rhs; }                                                        \
+        auto& true_target() const { return m_true_target; }                                          \
+        auto& false_target() const { return m_false_target; }                                        \
+                                                                                                     \
+    private:                                                                                         \
+        Operand m_lhs;                                                                               \
+        Operand m_rhs;                                                                               \
+        Label m_true_target;                                                                         \
+        Label m_false_target;                                                                        \
+    };
+
+JS_ENUMERATE_COMPARISON_OPS(DECLARE_COMPARISON_OP)
+
 class JumpNullish final : public Instruction {
 public:
     constexpr static bool IsTerminator = true;

--- a/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
+++ b/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
@@ -40,6 +40,8 @@ public:
 
     [[nodiscard]] bool operator==(ScopedOperand const& other) const { return operand() == other.operand(); }
 
+    [[nodiscard]] size_t ref_count() const { return m_impl->ref_count(); }
+
 private:
     NonnullRefPtr<ScopedOperandImpl> m_impl;
 };

--- a/Userland/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Userland/Libraries/LibJS/Bytecode/StringTable.h
@@ -12,7 +12,7 @@
 
 namespace JS::Bytecode {
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, StringTableIndex, Comparison);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u32, StringTableIndex, Comparison);
 
 class StringTable {
     AK_MAKE_NONMOVABLE(StringTable);

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -315,7 +315,7 @@ class MarkedVector;
 
 namespace Bytecode {
 class BasicBlock;
-enum class Builtin;
+enum class Builtin : u8;
 class Executable;
 class Generator;
 class Instruction;

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -403,7 +403,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
                     TRY(array->set(vm.names.length, Value(k), Object::ShouldThrowExceptions::Yes));
 
                     // b. Return Completion Record { [[Type]]: return, [[Value]]: A, [[Target]]: empty }.
-                    return Completion { Completion::Type::Return, array, {} };
+                    return Completion { Completion::Type::Return, array };
                 }
 
                 // 8. Let nextValue be ? IteratorValue(nextResult).
@@ -508,7 +508,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
             TRY(array->set(vm.names.length, Value(length), Object::ShouldThrowExceptions::Yes));
 
             // ix. Return Completion Record { [[Type]]: return, [[Value]]: A, [[Target]]: empty }.
-            return Completion { Completion::Type::Return, array, {} };
+            return Completion { Completion::Type::Return, array };
         }
     };
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.cpp
@@ -119,7 +119,7 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncGeneratorPrototype::return_)
     auto generator = TRY_OR_REJECT(vm, promise_capability, async_generator_validate(vm, generator_this_value, OptionalNone {}));
 
     // 5. Let completion be Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
-    auto completion = Completion(Completion::Type::Return, vm.argument(0), {});
+    auto completion = Completion(Completion::Type::Return, vm.argument(0));
 
     // 6. Perform AsyncGeneratorEnqueue(generator, completion, promiseCapability).
     generator->async_generator_enqueue(completion, promise_capability);

--- a/Userland/Libraries/LibJS/Runtime/Completion.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Completion.cpp
@@ -144,7 +144,7 @@ Completion throw_completion(Value value)
         log_exception(value);
 
     // 1. Return Completion Record { [[Type]]: throw, [[Value]]: value, [[Target]]: empty }.
-    return { Completion::Type::Throw, value, {} };
+    return { Completion::Type::Throw, value };
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -315,6 +315,7 @@ public:
 
     [[nodiscard]] bool is_throw_completion() const { return m_value_or_error.template has<ErrorValue>(); }
     [[nodiscard]] Completion throw_completion() const { return error(); }
+    [[nodiscard]] Value error_value() const { return m_value_or_error.template get<ErrorValue>().error; }
 
     [[nodiscard]] bool has_value() const
     requires(!IsSame<ValueType, Empty>)

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -63,10 +63,9 @@ public:
         Throw,
     };
 
-    ALWAYS_INLINE Completion(Type type, Optional<Value> value, Optional<DeprecatedFlyString> target)
+    ALWAYS_INLINE Completion(Type type, Optional<Value> value)
         : m_type(type)
         , m_value(move(value))
-        , m_target(move(target))
     {
         VERIFY(type != Type::Empty);
         if (m_value.has_value())
@@ -78,12 +77,12 @@ public:
     // 5.2.3.1 Implicit Completion Values, https://tc39.es/ecma262/#sec-implicit-completion-values
     // Not `explicit` on purpose.
     ALWAYS_INLINE Completion(Value value)
-        : Completion(Type::Normal, value, {})
+        : Completion(Type::Normal, value)
     {
     }
 
     ALWAYS_INLINE Completion(Optional<Value> value)
-        : Completion(Type::Normal, move(value), {})
+        : Completion(Type::Normal, move(value))
     {
     }
 
@@ -104,8 +103,6 @@ public:
     }
     [[nodiscard]] Optional<Value>& value() { return m_value; }
     [[nodiscard]] Optional<Value> const& value() const { return m_value; }
-    [[nodiscard]] Optional<DeprecatedFlyString>& target() { return m_target; }
-    [[nodiscard]] Optional<DeprecatedFlyString> const& target() const { return m_target; }
 
     // "abrupt completion refers to any completion with a [[Type]] value other than normal"
     [[nodiscard]] bool is_abrupt() const { return m_type != Type::Normal; }
@@ -117,7 +114,7 @@ public:
     {
         VERIFY(is_error());
         VERIFY(m_value.has_value());
-        return { m_type, release_value(), move(m_target) };
+        return { m_type, release_value() };
     }
 
     // 6.2.3.4 UpdateEmpty ( completionRecord, value ), https://tc39.es/ecma262/#sec-updateempty
@@ -132,7 +129,7 @@ public:
             return *this;
 
         // 3. Return Completion Record { [[Type]]: completionRecord.[[Type]], [[Value]]: value, [[Target]]: completionRecord.[[Target]] }.
-        return { m_type, move(value), m_target };
+        return { m_type, move(value) };
     }
 
 private:
@@ -150,9 +147,9 @@ private:
         return m_type == Type::Empty;
     }
 
-    Type m_type { Type::Normal };           // [[Type]]
-    Optional<Value> m_value;                // [[Value]]
-    Optional<DeprecatedFlyString> m_target; // [[Target]]
+    Type m_type { Type::Normal }; // [[Type]]
+    Optional<Value> m_value;      // [[Value]]
+    // NOTE: We don't need the [[Target]] slot since control flow is handled in bytecode.
 };
 
 }
@@ -354,7 +351,7 @@ ThrowCompletionOr<Value> await(VM&, Value);
 inline Completion normal_completion(Optional<Value> value)
 {
     // 1. Return Completion Record { [[Type]]: normal, [[Value]]: value, [[Target]]: empty }.
-    return { Completion::Type::Normal, move(value), {} };
+    return { Completion::Type::Normal, move(value) };
 }
 
 // 6.2.4.2 ThrowCompletion ( value ), https://tc39.es/ecma262/#sec-throwcompletion

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -1247,7 +1247,7 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
         if (declaration_result.is_throw_completion()) {
             auto promise_capability = MUST(new_promise_capability(vm, realm.intrinsics().promise_constructor()));
             MUST(call(vm, *promise_capability->reject(), js_undefined(), *declaration_result.throw_completion().value()));
-            return Completion { Completion::Type::Return, promise_capability->promise(), {} };
+            return Completion { Completion::Type::Return, promise_capability->promise() };
         }
     }
 
@@ -1261,11 +1261,11 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
     // NOTE: Running the bytecode should eventually return a completion.
     // Until it does, we assume "return" and include the undefined fallback from the call site.
     if (m_kind == FunctionKind::Normal)
-        return { Completion::Type::Return, result.value_or(js_undefined()), {} };
+        return { Completion::Type::Return, result.value_or(js_undefined()) };
 
     if (m_kind == FunctionKind::AsyncGenerator) {
         auto async_generator_object = TRY(AsyncGenerator::create(realm, result, this, vm.running_execution_context().copy()));
-        return { Completion::Type::Return, async_generator_object, {} };
+        return { Completion::Type::Return, async_generator_object };
     }
 
     auto generator_object = TRY(GeneratorObject::create(realm, result, this, vm.running_execution_context().copy()));
@@ -1273,10 +1273,10 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
     // NOTE: Async functions are entirely transformed to generator functions, and wrapped in a custom driver that returns a promise
     //       See AwaitExpression::generate_bytecode() for the transformation.
     if (m_kind == FunctionKind::Async)
-        return { Completion::Type::Return, AsyncFunctionDriverWrapper::create(realm, generator_object), {} };
+        return { Completion::Type::Return, AsyncFunctionDriverWrapper::create(realm, generator_object) };
 
     VERIFY(m_kind == FunctionKind::Generator);
-    return { Completion::Type::Return, generator_object, {} };
+    return { Completion::Type::Return, generator_object };
 }
 
 void ECMAScriptFunctionObject::set_name(DeprecatedFlyString const& name)

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
@@ -44,7 +44,7 @@ JS_DEFINE_NATIVE_FUNCTION(GeneratorPrototype::return_)
     auto generator_object = TRY(typed_this_object(vm));
 
     // 2. Let C be Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
-    auto completion = Completion(Completion::Type::Return, vm.argument(0), {});
+    auto completion = Completion(Completion::Type::Return, vm.argument(0));
 
     // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
     return generator_object->resume_abrupt(vm, completion, {});

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelperPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelperPrototype.cpp
@@ -62,7 +62,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorHelperPrototype::return_)
     }
 
     // 5. Let C be Completion { [[Type]]: return, [[Value]]: undefined, [[Target]]: empty }.
-    Completion completion { Completion::Type::Return, js_undefined(), {} };
+    Completion completion { Completion::Type::Return, js_undefined() };
 
     // 6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
     return TRY(iterator->resume_abrupt(vm, move(completion), "Iterator Helper"sv));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -91,7 +91,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::En
 
     // 5. If script's error to rethrow is not null, then set evaluationStatus to Completion { [[Type]]: throw, [[Value]]: script's error to rethrow, [[Target]]: empty }.
     if (!error_to_rethrow().is_null()) {
-        evaluation_status = JS::Completion { JS::Completion::Type::Throw, error_to_rethrow(), {} };
+        evaluation_status = JS::Completion { JS::Completion::Type::Throw, error_to_rethrow() };
     } else {
         auto timer = Core::ElapsedTimer::start_new();
 


### PR DESCRIPTION
Lots of data structure shrinking + peephole optimizations today!

Some really nice benchmark progressions:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
Kraken      ai-astar.js                              1.066  2.910 ± 2.900 … 2.920        2.730 ± 2.700 … 2.760
Kraken      audio-beat-detection.js                  0.849  1.520 ± 1.520 … 1.520        1.790 ± 1.790 … 1.790
Kraken      audio-dft.js                             1.089  1.465 ± 1.460 … 1.470        1.345 ± 1.340 … 1.350
Kraken      audio-fft.js                             0.835  1.415 ± 1.410 … 1.420        1.695 ± 1.690 … 1.700
Kraken      audio-oscillator.js                      1.096  1.710 ± 1.700 … 1.720        1.560 ± 1.560 … 1.560
Kraken      imaging-darkroom.js                      1.123  2.565 ± 2.560 … 2.570        2.285 ± 2.280 … 2.290
Kraken      imaging-desaturate.js                    0.996  2.330 ± 2.290 … 2.370        2.340 ± 2.330 … 2.350
Kraken      imaging-gaussian-blur.js                 1.096  9.680 ± 9.620 … 9.740        8.830 ± 8.820 … 8.840
Kraken      json-parse-financial.js                  1      0.130 ± 0.130 … 0.130        0.130 ± 0.130 … 0.130
Kraken      json-stringify-tinderbox.js              0.68   0.170 ± 0.170 … 0.170        0.250 ± 0.250 … 0.250
Kraken      stanford-crypto-aes.js                   1.086  0.760 ± 0.760 … 0.760        0.700 ± 0.690 … 0.710
Kraken      stanford-crypto-ccm.js                   1.05   0.630 ± 0.630 … 0.630        0.600 ± 0.600 … 0.600
Kraken      stanford-crypto-pbkdf2.js                1.017  1.195 ± 1.190 … 1.200        1.175 ± 1.170 … 1.180
Kraken      stanford-crypto-sha256-iterative.js      1.032  0.490 ± 0.490 … 0.490        0.475 ± 0.470 … 0.480
Octane      box2d.js                                 1.294  3.300 ± 3.290 … 3.310        2.550 ± 2.540 … 2.560
Octane      code-load.js                             0.998  2.145 ± 2.130 … 2.160        2.150 ± 2.140 … 2.160
Octane      crypto.js                                0.99   7.235 ± 7.190 … 7.280        7.305 ± 7.240 … 7.370
Octane      deltablue.js                             1.248  2.540 ± 2.030 … 3.050        2.035 ± 2.030 … 2.040
Octane      earley-boyer.js                          1.101  20.505 ± 20.440 … 20.570     18.620 ± 18.620 … 18.620
Octane      gbemu.js                                 1.261  4.055 ± 3.570 … 4.540        3.215 ± 3.190 … 3.240
Octane      mandreel.js                              1.192  18.415 ± 18.120 … 18.710     15.450 ± 15.380 … 15.520
Octane      navier-stokes.js                         0.972  3.145 ± 3.140 … 3.150        3.235 ± 3.200 … 3.270
Octane      pdfjs.js                                 1.073  3.290 ± 3.180 … 3.400        3.065 ± 3.060 … 3.070
Octane      raytrace.js                              1.1    8.120 ± 7.940 … 8.300        7.385 ± 7.380 … 7.390
Octane      regexp.js                                1.049  23.660 ± 23.200 … 24.120     22.545 ± 22.430 … 22.660
Octane      richards.js                              1.005  2.020 ± 2.020 … 2.020        2.010 ± 2.010 … 2.010
Octane      splay.js                                 0.933  2.875 ± 2.870 … 2.880        3.080 ± 3.030 … 3.130
Octane      typescript.js                            1.146  44.355 ± 43.320 … 45.390     38.710 ± 38.680 … 38.740
Octane      zlib.js                                  0.969  108.465 ± 105.660 … 111.270  111.925 ± 111.760 … 112.090
Kraken      Total                                    1.041  26.970                       25.905
Octane      Total                                    1.045  254.125                      243.280
All Suites  Total                                    1.044  281.095                      269.185
```