### PR TITLE
LibJS/Bytecode: Make execute_impl() return void for non-throwing ops + Update docs to require Clang 17+

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -11,9 +11,9 @@ sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 
-#### GCC 12 or Clang 15
+#### GCC 12 or Clang 17
 
-A host compiler that supports C++23 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-15.
+A host compiler that supports C++23 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-17.
 
 On Ubuntu gcc-12 is available in the repositories of 22.04 (Jammy) and later.
 If you are running an older version, you will either need to upgrade, or find an alternative installation source.

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -2,7 +2,7 @@
 
 ## Build Prerequisites
 
-Qt6 development packages and a C++23 capable compiler are required. g++-12 or clang-15 are required at a minimum for c++23 support.
+Qt6 development packages and a C++23 capable compiler are required. g++-12 or clang-17 are required at a minimum for c++23 support.
 
 NOTE: In all of the below lists of packages, the Qt6 multimedia package is not needed if your Linux system supports PulseAudio.
 
@@ -69,7 +69,7 @@ On OpenIndiana:
 Note that OpenIndiana's latest GCC port (GCC 11) is too old to build Ladybird, so you need Clang, which is available in the repository.
 
 ```
-pfexec pkg install cmake ninja clang-15 libglvnd qt6
+pfexec pkg install cmake ninja clang-17 libglvnd qt6
 ```
 
 On Haiku:

--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -14,7 +14,7 @@ die() {
 
 pick_clang() {
     local BEST_VERSION=0
-    for CLANG_CANDIDATE in clang clang-15 clang-16 clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang ; do
+    for CLANG_CANDIDATE in clang clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang ; do
         if ! command -v $CLANG_CANDIDATE >/dev/null 2>&1; then
             continue
         fi

--- a/Meta/Lagom/Tools/LibJSGCVerifier/CMakeLists.txt
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/CMakeLists.txt
@@ -5,7 +5,7 @@ project(LibJSGCVerifier C CXX)
 set(LAGOM_BUILD OFF CACHE BOOL "Build without the serenity toolchain Clang")
 
 if (LAGOM_BUILD)
-    find_package(Clang 16 CONFIG REQUIRED)
+    find_package(Clang 17 CONFIG REQUIRED)
 else()
     find_package(Clang CONFIG REQUIRED HINTS "../../../../Toolchain/Local/clang")
 endif()

--- a/Meta/find_compiler.sh
+++ b/Meta/find_compiler.sh
@@ -56,7 +56,7 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler clang clang-15 clang-16 clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang
+    find_newest_compiler clang clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/clang/clang++}"
@@ -71,8 +71,8 @@ pick_host_compiler() {
     fi
 
     if [ "$(uname -s)" = "Darwin" ]; then
-        die "Please make sure that Xcode 14.3, Homebrew Clang 15, or higher is installed."
+        die "Please make sure that Xcode 14.3, Homebrew Clang 17, or higher is installed."
     else
-        die "Please make sure that GCC version 12, Clang version 15, or higher is installed."
+        die "Please make sure that GCC version 12, Clang version 17, or higher is installed."
     fi
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -145,7 +145,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -165,7 +165,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -183,25 +183,25 @@ private:
 #define JS_ENUMERATE_NEW_BUILTIN_ERROR_OPS(O) \
     O(TypeError)
 
-#define JS_DECLARE_NEW_BUILTIN_ERROR_OP(ErrorName)                          \
-    class New##ErrorName final : public Instruction {                       \
-    public:                                                                 \
-        New##ErrorName(Operand dst, StringTableIndex error_string)          \
-            : Instruction(Type::New##ErrorName)                             \
-            , m_dst(dst)                                                    \
-            , m_error_string(error_string)                                  \
-        {                                                                   \
-        }                                                                   \
-                                                                            \
-        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const; \
-        ByteString to_byte_string_impl(Bytecode::Executable const&) const;  \
-                                                                            \
-        Operand dst() const { return m_dst; }                               \
-        StringTableIndex error_string() const { return m_error_string; }    \
-                                                                            \
-    private:                                                                \
-        Operand m_dst;                                                      \
-        StringTableIndex m_error_string;                                    \
+#define JS_DECLARE_NEW_BUILTIN_ERROR_OP(ErrorName)                         \
+    class New##ErrorName final : public Instruction {                      \
+    public:                                                                \
+        New##ErrorName(Operand dst, StringTableIndex error_string)         \
+            : Instruction(Type::New##ErrorName)                            \
+            , m_dst(dst)                                                   \
+            , m_error_string(error_string)                                 \
+        {                                                                  \
+        }                                                                  \
+                                                                           \
+        void execute_impl(Bytecode::Interpreter&) const;                   \
+        ByteString to_byte_string_impl(Bytecode::Executable const&) const; \
+                                                                           \
+        Operand dst() const { return m_dst; }                              \
+        StringTableIndex error_string() const { return m_error_string; }   \
+                                                                           \
+    private:                                                               \
+        Operand m_dst;                                                     \
+        StringTableIndex m_error_string;                                   \
     };
 
 JS_ENUMERATE_NEW_BUILTIN_ERROR_OPS(JS_DECLARE_NEW_BUILTIN_ERROR_OP)
@@ -263,7 +263,7 @@ public:
             m_elements[i] = elements[i];
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -299,7 +299,7 @@ public:
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Value) * m_element_count);
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -409,7 +409,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -438,7 +438,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -454,7 +454,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -465,7 +465,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -1408,7 +1408,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -1431,7 +1431,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     ScopeNode const& scope_node() const { return m_scope_node; }
@@ -1450,7 +1450,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Optional<Operand> const& value() const { return m_value; }
@@ -1658,7 +1658,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -1669,7 +1669,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -1969,7 +1969,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -1986,7 +1986,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -2043,7 +2043,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
 private:


### PR DESCRIPTION
(Follow up to https://github.com/SerenityOS/serenity/pull/24276 which was merged prematurely)

Instructions now have a static `MayThrow` bool member that tells the
interpreter whether it needs to check exceptions after executing it.
Instructions that can't throw now return void from execute_impl(),
which lets us enforce the fact that nothing does get thrown.

Thanks Leon for suggesting this!