### PR TITLE
Kernel: Stop allocating physical pages for mapped MMIO regions

### DIFF
--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -109,13 +109,13 @@ UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 {
     // Adopt the page tables already set up by boot.S
     dmesgln("MM: boot_pml4t @ {}", boot_pml4t);
-    m_root_table = PhysicalPage::create(boot_pml4t, MayReturnToFreeList::No);
+    m_root_table = PhysicalRAMPage::create(boot_pml4t, MayReturnToFreeList::No);
     dmesgln("MM: boot_pdpt @ {}", boot_pdpt);
     dmesgln("MM: boot_pd0 @ {}", boot_pd0);
     dmesgln("MM: boot_pd_kernel @ {}", boot_pd_kernel);
-    m_directory_table = PhysicalPage::create(boot_pdpt, MayReturnToFreeList::No);
-    m_directory_pages[0] = PhysicalPage::create(boot_pd0, MayReturnToFreeList::No);
-    m_directory_pages[(kernel_mapping_base >> 30) & 0x1ff] = PhysicalPage::create(boot_pd_kernel, MayReturnToFreeList::No);
+    m_directory_table = PhysicalRAMPage::create(boot_pdpt, MayReturnToFreeList::No);
+    m_directory_pages[0] = PhysicalRAMPage::create(boot_pd0, MayReturnToFreeList::No);
+    m_directory_pages[(kernel_mapping_base >> 30) & 0x1ff] = PhysicalRAMPage::create(boot_pd_kernel, MayReturnToFreeList::No);
 }
 
 PageDirectory::~PageDirectory()

--- a/Kernel/Arch/aarch64/PageDirectory.h
+++ b/Kernel/Arch/aarch64/PageDirectory.h
@@ -17,7 +17,7 @@
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 
 namespace Kernel::Memory {
 
@@ -211,9 +211,9 @@ private:
     static void deregister_page_directory(PageDirectory* directory);
 
     Process* m_process { nullptr };
-    RefPtr<PhysicalPage> m_root_table;
-    RefPtr<PhysicalPage> m_directory_table;
-    RefPtr<PhysicalPage> m_directory_pages[512];
+    RefPtr<PhysicalRAMPage> m_root_table;
+    RefPtr<PhysicalRAMPage> m_directory_table;
+    RefPtr<PhysicalRAMPage> m_directory_pages[512];
     RecursiveSpinlock<LockRank::None> m_lock {};
 };
 

--- a/Kernel/Arch/riscv64/PageDirectory.cpp
+++ b/Kernel/Arch/riscv64/PageDirectory.cpp
@@ -99,8 +99,8 @@ UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 {
     dmesgln("MM: boot_pdpt @ {}", boot_pdpt);
     dmesgln("MM: boot_pd_kernel @ {}", boot_pd_kernel);
-    m_directory_table = PhysicalPage::create(boot_pdpt, MayReturnToFreeList::No);
-    m_directory_pages[(kernel_mapping_base >> VPN_2_OFFSET) & PAGE_TABLE_INDEX_MASK] = PhysicalPage::create(boot_pd_kernel, MayReturnToFreeList::No);
+    m_directory_table = PhysicalRAMPage::create(boot_pdpt, MayReturnToFreeList::No);
+    m_directory_pages[(kernel_mapping_base >> VPN_2_OFFSET) & PAGE_TABLE_INDEX_MASK] = PhysicalRAMPage::create(boot_pd_kernel, MayReturnToFreeList::No);
 }
 
 PageDirectory::~PageDirectory()

--- a/Kernel/Arch/riscv64/PageDirectory.h
+++ b/Kernel/Arch/riscv64/PageDirectory.h
@@ -13,7 +13,7 @@
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 
 #include <AK/Platform.h>
 VALIDATE_IS_RISCV64()
@@ -197,8 +197,8 @@ private:
     static void deregister_page_directory(PageDirectory* directory);
 
     Process* m_process { nullptr };
-    RefPtr<PhysicalPage> m_directory_table;
-    RefPtr<PhysicalPage> m_directory_pages[512];
+    RefPtr<PhysicalRAMPage> m_directory_table;
+    RefPtr<PhysicalRAMPage> m_directory_pages[512];
     RecursiveSpinlock<LockRank::None> m_lock {};
 };
 

--- a/Kernel/Arch/x86_64/Firmware/ACPI/StaticParsing.cpp
+++ b/Kernel/Arch/x86_64/Firmware/ACPI/StaticParsing.cpp
@@ -37,7 +37,7 @@ ErrorOr<Optional<PhysicalAddress>> find_rsdp_in_platform_specific_memory_locatio
         auto region_size_or_error = Memory::page_round_up(memory_range.length);
         if (region_size_or_error.is_error())
             return IterationDecision::Continue;
-        auto region_or_error = MM.allocate_kernel_region(memory_range.start, region_size_or_error.value(), {}, Memory::Region::Access::Read);
+        auto region_or_error = MM.allocate_mmio_kernel_region(memory_range.start, region_size_or_error.value(), {}, Memory::Region::Access::Read);
         if (region_or_error.is_error())
             return IterationDecision::Continue;
         mapping.region = region_or_error.release_value();

--- a/Kernel/Arch/x86_64/Firmware/PCBIOS/Mapper.cpp
+++ b/Kernel/Arch/x86_64/Firmware/PCBIOS/Mapper.cpp
@@ -17,7 +17,7 @@ ErrorOr<Memory::MappedROM> map_bios()
     mapping.size = 128 * KiB;
     mapping.paddr = PhysicalAddress(0xe0000);
     auto region_size = TRY(Memory::page_round_up(mapping.size));
-    mapping.region = TRY(MM.allocate_kernel_region(mapping.paddr, region_size, {}, Memory::Region::Access::Read));
+    mapping.region = TRY(MM.allocate_mmio_kernel_region(mapping.paddr, region_size, {}, Memory::Region::Access::Read));
     return mapping;
 }
 
@@ -31,7 +31,7 @@ ErrorOr<Memory::MappedROM> map_ebda()
 
     Memory::MappedROM mapping;
     auto region_size = TRY(Memory::page_round_up(ebda_size));
-    mapping.region = TRY(MM.allocate_kernel_region(ebda_paddr.page_base(), region_size, {}, Memory::Region::Access::Read));
+    mapping.region = TRY(MM.allocate_mmio_kernel_region(ebda_paddr.page_base(), region_size, {}, Memory::Region::Access::Read));
     mapping.offset = ebda_paddr.offset_in_page();
     mapping.size = ebda_size;
     mapping.paddr = ebda_paddr;

--- a/Kernel/Arch/x86_64/Interrupts/APIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.cpp
@@ -254,7 +254,7 @@ UNMAP_AFTER_INIT bool APIC::init_bsp()
     set_base(apic_base);
 
     if (!m_is_x2.was_set()) {
-        auto region_or_error = MM.allocate_kernel_region(apic_base.page_base(), PAGE_SIZE, {}, Memory::Region::Access::ReadWrite);
+        auto region_or_error = MM.allocate_mmio_kernel_region(apic_base.page_base(), PAGE_SIZE, {}, Memory::Region::Access::ReadWrite);
         if (region_or_error.is_error()) {
             dbgln("APIC: Failed to allocate memory for APIC base");
             return false;

--- a/Kernel/Arch/x86_64/PageDirectory.cpp
+++ b/Kernel/Arch/x86_64/PageDirectory.cpp
@@ -130,13 +130,13 @@ UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 {
     // Adopt the page tables already set up by boot.S
     dmesgln("MM: boot_pml4t @ {}", boot_pml4t);
-    m_pml4t = PhysicalPage::create(boot_pml4t, MayReturnToFreeList::No);
+    m_pml4t = PhysicalRAMPage::create(boot_pml4t, MayReturnToFreeList::No);
     dmesgln("MM: boot_pdpt @ {}", boot_pdpt);
     dmesgln("MM: boot_pd0 @ {}", boot_pd0);
     dmesgln("MM: boot_pd_kernel @ {}", boot_pd_kernel);
-    m_directory_table = PhysicalPage::create(boot_pdpt, MayReturnToFreeList::No);
-    m_directory_pages[0] = PhysicalPage::create(boot_pd0, MayReturnToFreeList::No);
-    m_directory_pages[(kernel_mapping_base >> 30) & 0x1ff] = PhysicalPage::create(boot_pd_kernel, MayReturnToFreeList::No);
+    m_directory_table = PhysicalRAMPage::create(boot_pdpt, MayReturnToFreeList::No);
+    m_directory_pages[0] = PhysicalRAMPage::create(boot_pd0, MayReturnToFreeList::No);
+    m_directory_pages[(kernel_mapping_base >> 30) & 0x1ff] = PhysicalRAMPage::create(boot_pd_kernel, MayReturnToFreeList::No);
 }
 
 PageDirectory::~PageDirectory()

--- a/Kernel/Arch/x86_64/PageDirectory.h
+++ b/Kernel/Arch/x86_64/PageDirectory.h
@@ -16,7 +16,7 @@
 #include <Kernel/Locking/LockRank.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 
 namespace Kernel::Memory {
 
@@ -193,9 +193,9 @@ private:
     static void deregister_page_directory(PageDirectory* directory);
 
     Process* m_process { nullptr };
-    RefPtr<PhysicalPage> m_pml4t;
-    RefPtr<PhysicalPage> m_directory_table;
-    RefPtr<PhysicalPage> m_directory_pages[512];
+    RefPtr<PhysicalRAMPage> m_pml4t;
+    RefPtr<PhysicalRAMPage> m_directory_table;
+    RefPtr<PhysicalRAMPage> m_directory_pages[512];
     RecursiveSpinlock<LockRank::None> m_lock {};
 };
 

--- a/Kernel/Arch/x86_64/Time/HPET.cpp
+++ b/Kernel/Arch/x86_64/Time/HPET.cpp
@@ -417,7 +417,7 @@ u64 HPET::ns_to_raw_counter_ticks(u64 ns) const
 UNMAP_AFTER_INIT HPET::HPET(PhysicalAddress acpi_hpet)
     : m_physical_acpi_hpet_table(acpi_hpet)
     , m_physical_acpi_hpet_registers(find_acpi_hpet_registers_block())
-    , m_hpet_mmio_region(MM.allocate_kernel_region(m_physical_acpi_hpet_registers.page_base(), PAGE_SIZE, "HPET MMIO"sv, Memory::Region::Access::ReadWrite).release_value())
+    , m_hpet_mmio_region(MM.allocate_mmio_kernel_region(m_physical_acpi_hpet_registers.page_base(), PAGE_SIZE, "HPET MMIO"sv, Memory::Region::Access::ReadWrite).release_value())
 {
     s_hpet = this; // Make available as soon as possible so that IRQs can use it
 

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -79,7 +79,7 @@ UNMAP_AFTER_INIT bool Access::find_and_register_pci_host_bridges_from_acpi_mcfg_
         dbgln("Failed to round up length of {} to pages", length);
         return false;
     }
-    auto mcfg_region_or_error = MM.allocate_kernel_region(mcfg_table.page_base(), region_size_or_error.value(), "PCI Parsing MCFG"sv, Memory::Region::Access::ReadWrite);
+    auto mcfg_region_or_error = MM.allocate_mmio_kernel_region(mcfg_table.page_base(), region_size_or_error.value(), "PCI Parsing MCFG"sv, Memory::Region::Access::ReadWrite);
     if (mcfg_region_or_error.is_error())
         return false;
     auto& mcfg = *(ACPI::Structures::MCFG*)mcfg_region_or_error.value()->vaddr().offset(mcfg_table.offset_in_page()).as_ptr();

--- a/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
+++ b/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
@@ -69,7 +69,7 @@ void MemoryBackedHostBridge::map_bus_region(BusNumber bus)
     if (m_mapped_bus == bus && m_mapped_bus_region)
         return;
     auto bus_base_address = determine_memory_mapped_bus_base_address(bus);
-    auto region_or_error = MM.allocate_kernel_region(bus_base_address, memory_range_per_bus, "PCI ECAM"sv, Memory::Region::Access::ReadWrite);
+    auto region_or_error = MM.allocate_mmio_kernel_region(bus_base_address, memory_range_per_bus, "PCI ECAM"sv, Memory::Region::Access::ReadWrite);
     // FIXME: Find a way to propagate error from here.
     if (region_or_error.is_error())
         VERIFY_NOT_REACHED();

--- a/Kernel/Bus/USB/EHCI/EHCIController.cpp
+++ b/Kernel/Bus/USB/EHCI/EHCIController.cpp
@@ -18,7 +18,7 @@ ErrorOr<NonnullLockRefPtr<EHCIController>> EHCIController::try_to_initialize(con
     auto pci_bar_space_size = PCI::get_BAR_space_size(pci_device_identifier, SpaceBaseAddressRegister);
 
     auto register_region_size = TRY(Memory::page_round_up(pci_bar_address.offset_in_page() + pci_bar_space_size));
-    auto register_region = TRY(MM.allocate_kernel_region(pci_bar_address.page_base(), register_region_size, {}, Memory::Region::Access::ReadWrite));
+    auto register_region = TRY(MM.allocate_mmio_kernel_region(pci_bar_address.page_base(), register_region_size, {}, Memory::Region::Access::ReadWrite));
 
     VirtualAddress register_base_address = register_region->vaddr().offset(pci_bar_address.offset_in_page());
 

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -12,7 +12,7 @@
 #include <Kernel/Bus/USB/USBPipe.h>
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Memory/Region.h>
 
 // TODO: Callback stuff in this class please!

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -238,7 +238,7 @@ set(KERNEL_SOURCES
     Memory/InodeVMObject.cpp
     Memory/MemoryManager.cpp
     Memory/MMIOVMObject.cpp
-    Memory/PhysicalPage.cpp
+    Memory/PhysicalRAMPage.cpp
     Memory/PhysicalRegion.cpp
     Memory/PhysicalZone.cpp
     Memory/PrivateInodeVMObject.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -237,6 +237,7 @@ set(KERNEL_SOURCES
     Memory/AnonymousVMObject.cpp
     Memory/InodeVMObject.cpp
     Memory/MemoryManager.cpp
+    Memory/MMIOVMObject.cpp
     Memory/PhysicalPage.cpp
     Memory/PhysicalRegion.cpp
     Memory/PhysicalZone.cpp

--- a/Kernel/Devices/GPU/Console/BootFramebufferConsole.cpp
+++ b/Kernel/Devices/GPU/Console/BootFramebufferConsole.cpp
@@ -15,7 +15,7 @@ BootFramebufferConsole::BootFramebufferConsole(PhysicalAddress framebuffer_addr,
 {
     // NOTE: We're very early in the boot process, memory allocations shouldn't really fail
     auto framebuffer_end = Memory::page_round_up(framebuffer_addr.offset(height * pitch).get()).release_value();
-    m_framebuffer = MM.allocate_kernel_region(framebuffer_addr.page_base(), framebuffer_end - framebuffer_addr.page_base().get(), "Boot Framebuffer"sv, Memory::Region::Access::ReadWrite).release_value();
+    m_framebuffer = MM.allocate_mmio_kernel_region(framebuffer_addr.page_base(), framebuffer_end - framebuffer_addr.page_base().get(), "Boot Framebuffer"sv, Memory::Region::Access::ReadWrite).release_value();
 
     [[maybe_unused]] auto result = m_framebuffer->set_write_combine(true);
     m_framebuffer_data = m_framebuffer->vaddr().offset(framebuffer_addr.offset_in_page()).as_ptr();

--- a/Kernel/Devices/GPU/Console/ContiguousFramebufferConsole.cpp
+++ b/Kernel/Devices/GPU/Console/ContiguousFramebufferConsole.cpp
@@ -29,7 +29,7 @@ void ContiguousFramebufferConsole::set_resolution(size_t width, size_t height, s
 
     size_t size = Memory::page_round_up(pitch * height).release_value_but_fixme_should_propagate_errors();
     dbgln("Framebuffer Console: taking {} bytes", size);
-    auto region_or_error = MM.allocate_kernel_region(m_framebuffer_address, size, "Framebuffer Console"sv, Memory::Region::Access::ReadWrite, Memory::Region::Cacheable::Yes);
+    auto region_or_error = MM.allocate_mmio_kernel_region(m_framebuffer_address, size, "Framebuffer Console"sv, Memory::Region::Access::ReadWrite, Memory::Region::Cacheable::Yes);
     VERIFY(!region_or_error.is_error());
     m_framebuffer_region = region_or_error.release_value();
 

--- a/Kernel/Devices/GPU/Console/VGATextModeConsole.cpp
+++ b/Kernel/Devices/GPU/Console/VGATextModeConsole.cpp
@@ -13,7 +13,7 @@ namespace Kernel::Graphics {
 NonnullLockRefPtr<VGATextModeConsole> VGATextModeConsole::initialize()
 {
     auto vga_window_size = MUST(Memory::page_round_up(0xc0000 - 0xa0000));
-    auto vga_window_region = MUST(MM.allocate_kernel_region(PhysicalAddress(0xa0000), vga_window_size, "VGA Display"sv, Memory::Region::Access::ReadWrite));
+    auto vga_window_region = MUST(MM.allocate_mmio_kernel_region(PhysicalAddress(0xa0000), vga_window_size, "VGA Display"sv, Memory::Region::Access::ReadWrite));
     return adopt_lock_ref(*new (nothrow) VGATextModeConsole(move(vga_window_region)));
 }
 

--- a/Kernel/Devices/GPU/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/DisplayConnector.cpp
@@ -80,7 +80,7 @@ ErrorOr<void> DisplayConnector::allocate_framebuffer_resources(size_t rounded_si
     if (!m_framebuffer_at_arbitrary_physical_range) {
         VERIFY(m_framebuffer_address.value().page_base() == m_framebuffer_address.value());
         m_shared_framebuffer_vmobject = TRY(Memory::SharedFramebufferVMObject::try_create_for_physical_range(m_framebuffer_address.value(), rounded_size));
-        m_framebuffer_region = TRY(MM.allocate_kernel_region(m_framebuffer_address.value().page_base(), rounded_size, "Framebuffer"sv, Memory::Region::Access::ReadWrite));
+        m_framebuffer_region = TRY(MM.allocate_mmio_kernel_region(m_framebuffer_address.value().page_base(), rounded_size, "Framebuffer"sv, Memory::Region::Access::ReadWrite));
     } else {
         m_shared_framebuffer_vmobject = TRY(Memory::SharedFramebufferVMObject::try_create_at_arbitrary_physical_range(rounded_size));
         m_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(m_shared_framebuffer_vmobject->real_writes_framebuffer_vmobject(), rounded_size, "Framebuffer"sv, Memory::Region::Access::ReadWrite));

--- a/Kernel/Devices/GPU/Intel/DisplayConnectorGroup.cpp
+++ b/Kernel/Devices/GPU/Intel/DisplayConnectorGroup.cpp
@@ -20,7 +20,7 @@ namespace Kernel {
 
 ErrorOr<NonnullLockRefPtr<IntelDisplayConnectorGroup>> IntelDisplayConnectorGroup::try_create(Badge<IntelNativeGraphicsAdapter>, IntelGraphics::Generation generation, MMIORegion const& first_region, MMIORegion const& second_region)
 {
-    auto registers_region = TRY(MM.allocate_kernel_region(first_region.pci_bar_paddr, first_region.pci_bar_space_length, "Intel Native Graphics Registers"sv, Memory::Region::Access::ReadWrite));
+    auto registers_region = TRY(MM.allocate_mmio_kernel_region(first_region.pci_bar_paddr, first_region.pci_bar_space_length, "Intel Native Graphics Registers"sv, Memory::Region::Access::ReadWrite));
     // NOTE: 0x5100 is the offset of the start of the GMBus registers
     auto gmbus_connector = TRY(GMBusConnector::create_with_physical_address(first_region.pci_bar_paddr.offset(0x5100)));
     auto connector_group = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) IntelDisplayConnectorGroup(generation, move(gmbus_connector), move(registers_region), first_region, second_region)));

--- a/Kernel/Devices/Storage/AHCI/InterruptHandler.h
+++ b/Kernel/Devices/Storage/AHCI/InterruptHandler.h
@@ -14,7 +14,7 @@
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Security/Random.h>
 #include <Kernel/Tasks/WaitQueue.h>

--- a/Kernel/Devices/Storage/AHCI/Port.cpp
+++ b/Kernel/Devices/Storage/AHCI/Port.cpp
@@ -54,7 +54,7 @@ ErrorOr<void> AHCIPort::allocate_resources_and_initialize_ports()
     return {};
 }
 
-UNMAP_AFTER_INIT AHCIPort::AHCIPort(AHCIController const& controller, NonnullRefPtr<Memory::PhysicalPage> identify_buffer_page, AHCI::HBADefinedCapabilities hba_capabilities, volatile AHCI::PortRegisters& registers, u32 port_index)
+UNMAP_AFTER_INIT AHCIPort::AHCIPort(AHCIController const& controller, NonnullRefPtr<Memory::PhysicalRAMPage> identify_buffer_page, AHCI::HBADefinedCapabilities hba_capabilities, volatile AHCI::PortRegisters& registers, u32 port_index)
     : m_port_index(port_index)
     , m_hba_capabilities(hba_capabilities)
     , m_identify_buffer_page(move(identify_buffer_page))
@@ -413,7 +413,7 @@ Optional<AsyncDeviceRequest::RequestResult> AHCIPort::prepare_and_set_scatter_li
     VERIFY(m_lock.is_locked());
     VERIFY(request.block_count() > 0);
 
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> allocated_dma_regions;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> allocated_dma_regions;
     for (size_t index = 0; index < calculate_descriptors_count(request.block_count()); index++) {
         allocated_dma_regions.append(m_dma_buffers.at(index));
     }

--- a/Kernel/Devices/Storage/AHCI/Port.cpp
+++ b/Kernel/Devices/Storage/AHCI/Port.cpp
@@ -507,7 +507,7 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
 
     dbgln_if(AHCI_DEBUG, "AHCI Port {}: CLE: ctba={:#08x}, ctbau={:#08x}, prdbc={:#08x}, prdtl={:#04x}, attributes={:#04x}", representative_port_index(), (u32)command_list_entries[unused_command_header.value()].ctba, (u32)command_list_entries[unused_command_header.value()].ctbau, (u32)command_list_entries[unused_command_header.value()].prdbc, (u16)command_list_entries[unused_command_header.value()].prdtl, (u16)command_list_entries[unused_command_header.value()].attributes);
 
-    auto command_table_region = MM.allocate_kernel_region(m_command_table_pages[unused_command_header.value()]->paddr().page_base(), Memory::page_round_up(sizeof(AHCI::CommandTable)).value(), "AHCI Command Table"sv, Memory::Region::Access::ReadWrite, Memory::Region::Cacheable::No).release_value();
+    auto command_table_region = MM.allocate_kernel_region_with_physical_pages({ &m_command_table_pages[unused_command_header.value()], 1 }, "AHCI Command Table"sv, Memory::Region::Access::ReadWrite, Memory::Region::Cacheable::No).release_value();
     auto& command_table = *(volatile AHCI::CommandTable*)command_table_region->vaddr().as_ptr();
 
     dbgln_if(AHCI_DEBUG, "AHCI Port {}: Allocated command table at {}", representative_port_index(), command_table_region->vaddr());
@@ -591,7 +591,7 @@ bool AHCIPort::identify_device()
     // QEMU doesn't care if we don't set the correct CFL field in this register, real hardware will set an handshake error bit in PxSERR register.
     command_list_entries[unused_command_header.value()].attributes = (size_t)FIS::DwordCount::RegisterHostToDevice | AHCI::CommandHeaderAttributes::P;
 
-    auto command_table_region = MM.allocate_kernel_region(m_command_table_pages[unused_command_header.value()]->paddr().page_base(), Memory::page_round_up(sizeof(AHCI::CommandTable)).value(), "AHCI Command Table"sv, Memory::Region::Access::ReadWrite).release_value();
+    auto command_table_region = MM.allocate_kernel_region_with_physical_pages({ &m_command_table_pages[unused_command_header.value()], 1 }, "AHCI Command Table"sv, Memory::Region::Access::ReadWrite).release_value();
     auto& command_table = *(volatile AHCI::CommandTable*)command_table_region->vaddr().as_ptr();
     memset(const_cast<u8*>(command_table.command_fis), 0, 64);
     command_table.descriptors[0].base_high = 0;

--- a/Kernel/Devices/Storage/AHCI/Port.h
+++ b/Kernel/Devices/Storage/AHCI/Port.h
@@ -19,7 +19,7 @@
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
 #include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Memory/ScatterGatherList.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Security/Random.h>
@@ -55,7 +55,7 @@ private:
     bool is_phy_enabled() const { return (m_port_registers.ssts & 0xf) == 3; }
     bool initialize();
 
-    AHCIPort(AHCIController const&, NonnullRefPtr<Memory::PhysicalPage> identify_buffer_page, AHCI::HBADefinedCapabilities, volatile AHCI::PortRegisters&, u32 port_index);
+    AHCIPort(AHCIController const&, NonnullRefPtr<Memory::PhysicalRAMPage> identify_buffer_page, AHCI::HBADefinedCapabilities, volatile AHCI::PortRegisters&, u32 port_index);
 
     ALWAYS_INLINE void clear_sata_error_register() const;
 
@@ -108,11 +108,11 @@ private:
 
     mutable bool m_wait_for_completion { false };
 
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> m_dma_buffers;
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> m_command_table_pages;
-    RefPtr<Memory::PhysicalPage> m_command_list_page;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> m_dma_buffers;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> m_command_table_pages;
+    RefPtr<Memory::PhysicalRAMPage> m_command_list_page;
     OwnPtr<Memory::Region> m_command_list_region;
-    RefPtr<Memory::PhysicalPage> m_fis_receive_page;
+    RefPtr<Memory::PhysicalRAMPage> m_fis_receive_page;
     LockRefPtr<ATADevice> m_connected_device;
 
     u32 m_port_index;
@@ -122,7 +122,7 @@ private:
     // it's probably better to just "cache" this here instead.
     AHCI::HBADefinedCapabilities const m_hba_capabilities;
 
-    NonnullRefPtr<Memory::PhysicalPage> const m_identify_buffer_page;
+    NonnullRefPtr<Memory::PhysicalRAMPage> const m_identify_buffer_page;
 
     volatile AHCI::PortRegisters& m_port_registers;
     NonnullRefPtr<AHCIController> const m_parent_controller;

--- a/Kernel/Devices/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeController.cpp
@@ -155,7 +155,7 @@ UNMAP_AFTER_INIT void NVMeController::set_admin_q_depth()
 UNMAP_AFTER_INIT ErrorOr<void> NVMeController::identify_and_init_namespaces()
 {
 
-    RefPtr<Memory::PhysicalPage> prp_dma_buffer;
+    RefPtr<Memory::PhysicalRAMPage> prp_dma_buffer;
     OwnPtr<Memory::Region> prp_dma_region;
     auto namespace_data_struct = TRY(ByteBuffer::create_zeroed(NVMe_IDENTIFY_SIZE));
     u32 active_namespace_list[NVMe_IDENTIFY_SIZE / sizeof(u32)];
@@ -219,7 +219,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::identify_and_init_namespaces()
 
 ErrorOr<void> NVMeController::identify_and_init_controller()
 {
-    RefPtr<Memory::PhysicalPage> prp_dma_buffer;
+    RefPtr<Memory::PhysicalRAMPage> prp_dma_buffer;
     OwnPtr<Memory::Region> prp_dma_region;
     IdentifyController ctrl {};
 
@@ -311,9 +311,9 @@ void NVMeController::complete_current_request([[maybe_unused]] AsyncDeviceReques
 UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_admin_queue(QueueType queue_type)
 {
     OwnPtr<Memory::Region> cq_dma_region;
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_pages;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> cq_dma_pages;
     OwnPtr<Memory::Region> sq_dma_region;
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_pages;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> sq_dma_pages;
     set_admin_q_depth();
     auto cq_size = round_up_to_power_of_two(CQ_SIZE(ADMIN_QUEUE_SIZE), 4096);
     auto sq_size = round_up_to_power_of_two(SQ_SIZE(ADMIN_QUEUE_SIZE), 4096);
@@ -364,9 +364,9 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_admin_queue(QueueType queu
 UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_io_queue(u8 qid, QueueType queue_type)
 {
     OwnPtr<Memory::Region> cq_dma_region;
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_pages;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> cq_dma_pages;
     OwnPtr<Memory::Region> sq_dma_region;
-    Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_pages;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> sq_dma_pages;
     auto cq_size = round_up_to_power_of_two(CQ_SIZE(IO_QUEUE_SIZE), 4096);
     auto sq_size = round_up_to_power_of_two(SQ_SIZE(IO_QUEUE_SIZE), 4096);
 

--- a/Kernel/Devices/Storage/NVMe/NVMeController.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeController.h
@@ -76,8 +76,8 @@ private:
     Vector<NonnullLockRefPtr<NVMeQueue>> m_queues;
     Vector<NonnullLockRefPtr<NVMeNameSpace>> m_namespaces;
     Memory::TypedMapping<ControllerRegister volatile> m_controller_regs;
-    RefPtr<Memory::PhysicalPage> m_dbbuf_shadow_page;
-    RefPtr<Memory::PhysicalPage> m_dbbuf_eventidx_page;
+    RefPtr<Memory::PhysicalRAMPage> m_dbbuf_shadow_page;
+    RefPtr<Memory::PhysicalRAMPage> m_dbbuf_eventidx_page;
     bool m_admin_queue_ready { false };
     size_t m_device_count { 0 };
     AK::Duration m_ready_timeout;

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -11,14 +11,14 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> NVMeInterruptQueue::try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
+ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> NVMeInterruptQueue::try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
 {
     auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMeInterruptQueue(device, move(rw_dma_region), rw_dma_page, qid, irq, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))));
     queue->initialize_interrupt_queue();
     return queue;
 }
 
-UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
+UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
     : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))
     , PCI::IRQHandler(device, irq)
 {

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
@@ -14,14 +14,14 @@ namespace Kernel {
 class NVMeInterruptQueue : public NVMeQueue
     , public PCI::IRQHandler {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
+    static ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
     virtual ~NVMeInterruptQueue() override {};
     virtual StringView purpose() const override { return "NVMe"sv; }
     void initialize_interrupt_queue();
 
 protected:
-    NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
+    NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
 
 private:
     virtual void complete_current_request(u16 cmdid, u16 status) override;

--- a/Kernel/Devices/Storage/NVMe/NVMePollQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMePollQueue.cpp
@@ -11,12 +11,12 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullLockRefPtr<NVMePollQueue>> NVMePollQueue::try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
+ErrorOr<NonnullLockRefPtr<NVMePollQueue>> NVMePollQueue::try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
 {
     return TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMePollQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))));
 }
 
-UNMAP_AFTER_INIT NVMePollQueue::NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
+UNMAP_AFTER_INIT NVMePollQueue::NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
     : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))
 {
 }

--- a/Kernel/Devices/Storage/NVMe/NVMePollQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMePollQueue.h
@@ -12,12 +12,12 @@ namespace Kernel {
 
 class NVMePollQueue : public NVMeQueue {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMePollQueue>> try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
+    static ErrorOr<NonnullLockRefPtr<NVMePollQueue>> try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
     virtual ~NVMePollQueue() override {};
 
 protected:
-    NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
+    NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
 
 private:
     Spinlock<LockRank::Interrupts> m_cq_lock {};

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(NVMeController& device, u16 qid, Optional<u8> irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs, QueueType queue_type)
 {
     // Note: Allocate DMA region for RW operation. For now the requests don't exceed more than 4096 bytes (Storage device takes care of it)
-    RefPtr<Memory::PhysicalPage> rw_dma_page;
+    RefPtr<Memory::PhysicalRAMPage> rw_dma_page;
     auto rw_dma_region = TRY(MM.allocate_dma_buffer_page("NVMe Queue Read/Write DMA"sv, Memory::Region::Access::ReadWrite, rw_dma_page));
 
     if (rw_dma_page.is_null())
@@ -30,7 +30,7 @@ ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(NVMeController& devi
     return queue;
 }
 
-UNMAP_AFTER_INIT NVMeQueue::NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
+UNMAP_AFTER_INIT NVMeQueue::NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalRAMPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
     : m_rw_dma_region(move(rw_dma_region))
     , m_qid(qid)
     , m_admin_queue(qid == 0)

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -83,7 +83,7 @@ protected:
             m_db_regs.mmio_reg->sq_tail = m_sq_tail;
     }
 
-    NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
+    NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalRAMPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
 
     [[nodiscard]] u32 get_request_cid()
     {
@@ -130,6 +130,6 @@ private:
     Span<NVMeCompletion> m_cqe_array;
     WaitQueue m_sync_wait_queue;
     Doorbell m_db_regs;
-    NonnullRefPtr<Memory::PhysicalPage const> const m_rw_dma_page;
+    NonnullRefPtr<Memory::PhysicalRAMPage const> const m_rw_dma_page;
 };
 }

--- a/Kernel/Devices/Storage/StorageController.h
+++ b/Kernel/Devices/Storage/StorageController.h
@@ -13,7 +13,7 @@
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Security/Random.h>
 #include <Kernel/Tasks/WaitQueue.h>
 

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -76,7 +76,7 @@ class InodeVMObject;
 class MappedROM;
 class MemoryManager;
 class PageDirectory;
-class PhysicalPage;
+class PhysicalRAMPage;
 class PhysicalRegion;
 class PrivateInodeVMObject;
 class Region;

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -20,12 +20,12 @@ public:
 
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_with_size(size_t, AllocationStrategy);
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_for_physical_range(PhysicalAddress paddr, size_t size);
-    static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalPage>>);
+    static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalRAMPage>>);
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_purgeable_with_size(size_t, AllocationStrategy);
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_physically_contiguous_with_size(size_t);
     virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override;
 
-    [[nodiscard]] NonnullRefPtr<PhysicalPage> allocate_committed_page(Badge<Region>);
+    [[nodiscard]] NonnullRefPtr<PhysicalRAMPage> allocate_committed_page(Badge<Region>);
     PageFaultResponse handle_cow_fault(size_t, VirtualAddress);
     size_t cow_pages() const;
     bool should_cow(size_t page_index, bool) const;
@@ -41,12 +41,12 @@ public:
 private:
     class SharedCommittedCowPages;
 
-    static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_with_shared_cow(AnonymousVMObject const&, NonnullLockRefPtr<SharedCommittedCowPages>, FixedArray<RefPtr<PhysicalPage>>&&);
+    static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_with_shared_cow(AnonymousVMObject const&, NonnullLockRefPtr<SharedCommittedCowPages>, FixedArray<RefPtr<PhysicalRAMPage>>&&);
 
-    explicit AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&&, AllocationStrategy, Optional<CommittedPhysicalPageSet>);
-    explicit AnonymousVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalPage>>&&);
-    explicit AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&&);
-    explicit AnonymousVMObject(LockWeakPtr<AnonymousVMObject>, NonnullLockRefPtr<SharedCommittedCowPages>, FixedArray<RefPtr<PhysicalPage>>&&);
+    explicit AnonymousVMObject(FixedArray<RefPtr<PhysicalRAMPage>>&&, AllocationStrategy, Optional<CommittedPhysicalPageSet>);
+    explicit AnonymousVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalRAMPage>>&&);
+    explicit AnonymousVMObject(FixedArray<RefPtr<PhysicalRAMPage>>&&);
+    explicit AnonymousVMObject(LockWeakPtr<AnonymousVMObject>, NonnullLockRefPtr<SharedCommittedCowPages>, FixedArray<RefPtr<PhysicalRAMPage>>&&);
 
     virtual StringView class_name() const override { return "AnonymousVMObject"sv; }
 
@@ -74,7 +74,7 @@ private:
 
         [[nodiscard]] bool is_empty() const { return m_committed_pages.is_empty(); }
 
-        [[nodiscard]] NonnullRefPtr<PhysicalPage> take_one();
+        [[nodiscard]] NonnullRefPtr<PhysicalRAMPage> take_one();
         void uncommit_one();
 
     private:

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -9,14 +9,14 @@
 
 namespace Kernel::Memory {
 
-InodeVMObject::InodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, Bitmap dirty_pages)
+InodeVMObject::InodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, Bitmap dirty_pages)
     : VMObject(move(new_physical_pages))
     , m_inode(inode)
     , m_dirty_pages(move(dirty_pages))
 {
 }
 
-InodeVMObject::InodeVMObject(InodeVMObject const& other, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, Bitmap dirty_pages)
+InodeVMObject::InodeVMObject(InodeVMObject const& other, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, Bitmap dirty_pages)
     : VMObject(move(new_physical_pages))
     , m_inode(other.m_inode)
     , m_dirty_pages(move(dirty_pages))

--- a/Kernel/Memory/InodeVMObject.h
+++ b/Kernel/Memory/InodeVMObject.h
@@ -28,8 +28,8 @@ public:
     u32 writable_mappings() const;
 
 protected:
-    explicit InodeVMObject(Inode&, FixedArray<RefPtr<PhysicalPage>>&&, Bitmap dirty_pages);
-    explicit InodeVMObject(InodeVMObject const&, FixedArray<RefPtr<PhysicalPage>>&&, Bitmap dirty_pages);
+    explicit InodeVMObject(Inode&, FixedArray<RefPtr<PhysicalRAMPage>>&&, Bitmap dirty_pages);
+    explicit InodeVMObject(InodeVMObject const&, FixedArray<RefPtr<PhysicalRAMPage>>&&, Bitmap dirty_pages);
 
     InodeVMObject& operator=(InodeVMObject const&) = delete;
     InodeVMObject& operator=(InodeVMObject&&) = delete;

--- a/Kernel/Memory/MMIOVMObject.cpp
+++ b/Kernel/Memory/MMIOVMObject.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Memory/MMIOVMObject.h>
+
+namespace Kernel::Memory {
+
+ErrorOr<NonnullLockRefPtr<MMIOVMObject>> MMIOVMObject::try_create_for_physical_range(PhysicalAddress paddr, size_t size)
+{
+    if (paddr.offset(size) < paddr) {
+        dbgln("Shenanigans! MMIOVMObject::try_create_for_physical_range({}, {}) would wrap around", paddr, size);
+        // Since we can't wrap around yet, let's pretend to OOM.
+        return ENOMEM;
+    }
+
+    // FIXME: We have to make this allocation because VMObject determines the size of the VMObject based on the physical pages array
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+
+    return adopt_nonnull_lock_ref_or_enomem(new (nothrow) MMIOVMObject(paddr, move(new_physical_pages)));
+}
+
+MMIOVMObject::MMIOVMObject(PhysicalAddress paddr, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : VMObject(move(new_physical_pages))
+{
+    VERIFY(paddr.page_base() == paddr);
+}
+
+}

--- a/Kernel/Memory/MMIOVMObject.cpp
+++ b/Kernel/Memory/MMIOVMObject.cpp
@@ -22,7 +22,7 @@ ErrorOr<NonnullLockRefPtr<MMIOVMObject>> MMIOVMObject::try_create_for_physical_r
     return adopt_nonnull_lock_ref_or_enomem(new (nothrow) MMIOVMObject(paddr, move(new_physical_pages)));
 }
 
-MMIOVMObject::MMIOVMObject(PhysicalAddress paddr, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+MMIOVMObject::MMIOVMObject(PhysicalAddress paddr, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages)
     : VMObject(move(new_physical_pages))
 {
     VERIFY(paddr.page_base() == paddr);

--- a/Kernel/Memory/MMIOVMObject.h
+++ b/Kernel/Memory/MMIOVMObject.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Memory/PhysicalAddress.h>
+#include <Kernel/Memory/VMObject.h>
+
+namespace Kernel::Memory {
+
+class MMIOVMObject final : public VMObject {
+public:
+    static ErrorOr<NonnullLockRefPtr<MMIOVMObject>> try_create_for_physical_range(PhysicalAddress paddr, size_t size);
+
+    virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return ENOTSUP; }
+
+private:
+    MMIOVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalPage>>&&);
+
+    virtual StringView class_name() const override { return "MMIOVMObject"sv; }
+};
+
+}

--- a/Kernel/Memory/MMIOVMObject.h
+++ b/Kernel/Memory/MMIOVMObject.h
@@ -18,7 +18,7 @@ public:
     virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return ENOTSUP; }
 
 private:
-    MMIOVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalPage>>&&);
+    MMIOVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalRAMPage>>&&);
 
     virtual StringView class_name() const override { return "MMIOVMObject"sv; }
 };

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -174,7 +174,8 @@ public:
     ErrorOr<NonnullOwnPtr<Memory::Region>> allocate_dma_buffer_pages(size_t size, StringView name, Memory::Region::Access access, Vector<NonnullRefPtr<Memory::PhysicalPage>>& dma_buffer_pages);
     ErrorOr<NonnullOwnPtr<Memory::Region>> allocate_dma_buffer_pages(size_t size, StringView name, Memory::Region::Access access);
     ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region(size_t, StringView name, Region::Access access, AllocationStrategy strategy = AllocationStrategy::Reserve, Region::Cacheable = Region::Cacheable::Yes);
-    ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region(PhysicalAddress, size_t, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
+    ErrorOr<NonnullOwnPtr<Region>> allocate_mmio_kernel_region(PhysicalAddress, size_t, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
+    ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region_with_physical_pages(Span<NonnullRefPtr<PhysicalPage>>, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
     ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region_with_vmobject(VMObject&, size_t, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
     ErrorOr<NonnullOwnPtr<Region>> allocate_unbacked_region_anywhere(size_t size, size_t alignment);
     ErrorOr<NonnullOwnPtr<Region>> create_identity_mapped_region(PhysicalAddress, size_t);

--- a/Kernel/Memory/PhysicalRAMPage.cpp
+++ b/Kernel/Memory/PhysicalRAMPage.cpp
@@ -6,37 +6,37 @@
 
 #include <Kernel/Heap/kmalloc.h>
 #include <Kernel/Memory/MemoryManager.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 
 namespace Kernel::Memory {
 
-NonnullRefPtr<PhysicalPage> PhysicalPage::create(PhysicalAddress paddr, MayReturnToFreeList may_return_to_freelist)
+NonnullRefPtr<PhysicalRAMPage> PhysicalRAMPage::create(PhysicalAddress paddr, MayReturnToFreeList may_return_to_freelist)
 {
     auto& physical_page_entry = MM.get_physical_page_entry(paddr);
-    return adopt_ref(*new (&physical_page_entry.allocated.physical_page) PhysicalPage(may_return_to_freelist));
+    return adopt_ref(*new (&physical_page_entry.allocated.physical_page) PhysicalRAMPage(may_return_to_freelist));
 }
 
-PhysicalPage::PhysicalPage(MayReturnToFreeList may_return_to_freelist)
+PhysicalRAMPage::PhysicalRAMPage(MayReturnToFreeList may_return_to_freelist)
     : m_may_return_to_freelist(may_return_to_freelist)
 {
 }
 
-PhysicalAddress PhysicalPage::paddr() const
+PhysicalAddress PhysicalRAMPage::paddr() const
 {
     return MM.get_physical_address(*this);
 }
 
-void PhysicalPage::free_this() const
+void PhysicalRAMPage::free_this() const
 {
     auto paddr = MM.get_physical_address(*this);
     if (m_may_return_to_freelist == MayReturnToFreeList::Yes) {
         auto& this_as_freelist_entry = MM.get_physical_page_entry(paddr).freelist;
-        this->~PhysicalPage(); // delete in place
+        this->~PhysicalRAMPage(); // delete in place
         this_as_freelist_entry.next_index = -1;
         this_as_freelist_entry.prev_index = -1;
         MM.deallocate_physical_page(paddr);
     } else {
-        this->~PhysicalPage(); // delete in place
+        this->~PhysicalRAMPage(); // delete in place
     }
 }
 

--- a/Kernel/Memory/PhysicalRAMPage.h
+++ b/Kernel/Memory/PhysicalRAMPage.h
@@ -16,9 +16,9 @@ enum class MayReturnToFreeList : bool {
     Yes
 };
 
-class PhysicalPage {
-    AK_MAKE_NONCOPYABLE(PhysicalPage);
-    AK_MAKE_NONMOVABLE(PhysicalPage);
+class PhysicalRAMPage {
+    AK_MAKE_NONCOPYABLE(PhysicalRAMPage);
+    AK_MAKE_NONMOVABLE(PhysicalRAMPage);
 
     friend class MemoryManager;
 
@@ -36,7 +36,7 @@ public:
             free_this();
     }
 
-    static NonnullRefPtr<PhysicalPage> create(PhysicalAddress, MayReturnToFreeList may_return_to_freelist = MayReturnToFreeList::Yes);
+    static NonnullRefPtr<PhysicalRAMPage> create(PhysicalAddress, MayReturnToFreeList may_return_to_freelist = MayReturnToFreeList::Yes);
 
     u32 ref_count() const { return m_ref_count.load(AK::memory_order_consume); }
 
@@ -44,8 +44,8 @@ public:
     bool is_lazy_committed_page() const;
 
 private:
-    explicit PhysicalPage(MayReturnToFreeList may_return_to_freelist);
-    ~PhysicalPage() = default;
+    explicit PhysicalRAMPage(MayReturnToFreeList may_return_to_freelist);
+    ~PhysicalRAMPage() = default;
 
     void free_this() const;
 
@@ -57,7 +57,7 @@ struct PhysicalPageEntry {
     union {
         // If it's a live PhysicalPage object:
         struct {
-            PhysicalPage physical_page;
+            PhysicalRAMPage physical_page;
         } allocated;
 
         // If it's an entry in a PhysicalZone::Bucket's freelist.

--- a/Kernel/Memory/PhysicalRegion.cpp
+++ b/Kernel/Memory/PhysicalRegion.cpp
@@ -74,7 +74,7 @@ OwnPtr<PhysicalRegion> PhysicalRegion::try_take_pages_from_beginning(size_t page
     return try_create(taken_lower, taken_upper);
 }
 
-Vector<NonnullRefPtr<PhysicalPage>> PhysicalRegion::take_contiguous_free_pages(size_t count)
+Vector<NonnullRefPtr<PhysicalRAMPage>> PhysicalRegion::take_contiguous_free_pages(size_t count)
 {
     auto rounded_page_count = next_power_of_two(count);
     auto order = count_trailing_zeroes(rounded_page_count);
@@ -94,15 +94,15 @@ Vector<NonnullRefPtr<PhysicalPage>> PhysicalRegion::take_contiguous_free_pages(s
     if (!page_base.has_value())
         return {};
 
-    Vector<NonnullRefPtr<PhysicalPage>> physical_pages;
+    Vector<NonnullRefPtr<PhysicalRAMPage>> physical_pages;
     physical_pages.ensure_capacity(count);
 
     for (size_t i = 0; i < count; ++i)
-        physical_pages.append(PhysicalPage::create(page_base.value().offset(i * PAGE_SIZE)));
+        physical_pages.append(PhysicalRAMPage::create(page_base.value().offset(i * PAGE_SIZE)));
     return physical_pages;
 }
 
-RefPtr<PhysicalPage> PhysicalRegion::take_free_page()
+RefPtr<PhysicalRAMPage> PhysicalRegion::take_free_page()
 {
     if (m_usable_zones.is_empty())
         return nullptr;
@@ -116,7 +116,7 @@ RefPtr<PhysicalPage> PhysicalRegion::take_free_page()
         m_full_zones.append(zone);
     }
 
-    return PhysicalPage::create(page.value());
+    return PhysicalRAMPage::create(page.value());
 }
 
 void PhysicalRegion::return_page(PhysicalAddress paddr)

--- a/Kernel/Memory/PhysicalRegion.h
+++ b/Kernel/Memory/PhysicalRegion.h
@@ -8,7 +8,7 @@
 
 #include <AK/OwnPtr.h>
 #include <AK/Vector.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Memory/PhysicalZone.h>
 
 namespace Kernel::Memory {
@@ -34,8 +34,8 @@ public:
 
     OwnPtr<PhysicalRegion> try_take_pages_from_beginning(size_t);
 
-    RefPtr<PhysicalPage> take_free_page();
-    Vector<NonnullRefPtr<PhysicalPage>> take_contiguous_free_pages(size_t count);
+    RefPtr<PhysicalRAMPage> take_free_page();
+    Vector<NonnullRefPtr<PhysicalRAMPage>> take_contiguous_free_pages(size_t count);
     void return_page(PhysicalAddress);
 
 private:

--- a/Kernel/Memory/PhysicalZone.cpp
+++ b/Kernel/Memory/PhysicalZone.cpp
@@ -7,7 +7,7 @@
 #include <AK/BuiltinWrappers.h>
 #include <AK/Format.h>
 #include <Kernel/Memory/MemoryManager.h>
-#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Memory/PhysicalZone.h>
 
 namespace Kernel::Memory {

--- a/Kernel/Memory/PrivateInodeVMObject.cpp
+++ b/Kernel/Memory/PrivateInodeVMObject.cpp
@@ -34,12 +34,12 @@ ErrorOr<NonnullLockRefPtr<VMObject>> PrivateInodeVMObject::try_clone()
     return adopt_nonnull_lock_ref_or_enomem<VMObject>(new (nothrow) PrivateInodeVMObject(*this, move(new_physical_pages), move(dirty_pages)));
 }
 
-PrivateInodeVMObject::PrivateInodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, Bitmap dirty_pages)
+PrivateInodeVMObject::PrivateInodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, Bitmap dirty_pages)
     : InodeVMObject(inode, move(new_physical_pages), move(dirty_pages))
 {
 }
 
-PrivateInodeVMObject::PrivateInodeVMObject(PrivateInodeVMObject const& other, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, Bitmap dirty_pages)
+PrivateInodeVMObject::PrivateInodeVMObject(PrivateInodeVMObject const& other, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, Bitmap dirty_pages)
     : InodeVMObject(other, move(new_physical_pages), move(dirty_pages))
 {
 }

--- a/Kernel/Memory/PrivateInodeVMObject.h
+++ b/Kernel/Memory/PrivateInodeVMObject.h
@@ -24,8 +24,8 @@ public:
 private:
     virtual bool is_private_inode() const override { return true; }
 
-    explicit PrivateInodeVMObject(Inode&, FixedArray<RefPtr<PhysicalPage>>&&, Bitmap dirty_pages);
-    explicit PrivateInodeVMObject(PrivateInodeVMObject const&, FixedArray<RefPtr<PhysicalPage>>&&, Bitmap dirty_pages);
+    explicit PrivateInodeVMObject(Inode&, FixedArray<RefPtr<PhysicalRAMPage>>&&, Bitmap dirty_pages);
+    explicit PrivateInodeVMObject(PrivateInodeVMObject const&, FixedArray<RefPtr<PhysicalRAMPage>>&&, Bitmap dirty_pages);
 
     virtual StringView class_name() const override { return "PrivateInodeVMObject"sv; }
 

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -210,7 +210,7 @@ ErrorOr<void> Region::set_should_cow(size_t page_index, bool cow)
     return {};
 }
 
-bool Region::map_individual_page_impl(size_t page_index, RefPtr<PhysicalPage> page)
+bool Region::map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage> page)
 {
     if (!page)
         return map_individual_page_impl(page_index, {}, false, false);
@@ -257,7 +257,7 @@ bool Region::map_individual_page_impl(size_t page_index, PhysicalAddress paddr, 
 
 bool Region::map_individual_page_impl(size_t page_index)
 {
-    RefPtr<PhysicalPage> page;
+    RefPtr<PhysicalRAMPage> page;
     {
         SpinlockLocker vmobject_locker(vmobject().m_lock);
         page = physical_page(page_index);
@@ -266,7 +266,7 @@ bool Region::map_individual_page_impl(size_t page_index)
     return map_individual_page_impl(page_index, page);
 }
 
-bool Region::remap_vmobject_page(size_t page_index, NonnullRefPtr<PhysicalPage> physical_page)
+bool Region::remap_vmobject_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage> physical_page)
 {
     SpinlockLocker page_lock(m_page_directory->get_lock());
 
@@ -487,7 +487,7 @@ PageFaultResponse Region::handle_fault(PageFault const& fault)
 #endif
 }
 
-PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region, PhysicalPage& page_in_slot_at_time_of_fault)
+PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region, PhysicalRAMPage& page_in_slot_at_time_of_fault)
 {
     VERIFY(vmobject().is_anonymous());
 
@@ -497,7 +497,7 @@ PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region, Physica
     if (current_thread != nullptr)
         current_thread->did_zero_fault();
 
-    RefPtr<PhysicalPage> new_physical_page;
+    RefPtr<PhysicalRAMPage> new_physical_page;
 
     if (page_in_slot_at_time_of_fault.is_lazy_committed_page()) {
         VERIFY(m_vmobject->is_anonymous());
@@ -636,14 +636,14 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region)
     return PageFaultResponse::Continue;
 }
 
-RefPtr<PhysicalPage> Region::physical_page(size_t index) const
+RefPtr<PhysicalRAMPage> Region::physical_page(size_t index) const
 {
     SpinlockLocker vmobject_locker(vmobject().m_lock);
     VERIFY(index < page_count());
     return vmobject().physical_pages()[first_page_index() + index];
 }
 
-RefPtr<PhysicalPage>& Region::physical_page_slot(size_t index)
+RefPtr<PhysicalRAMPage>& Region::physical_page_slot(size_t index)
 {
     VERIFY(vmobject().m_lock.is_locked_by_current_processor());
     VERIFY(index < page_count());

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -163,8 +163,8 @@ public:
         return size() / PAGE_SIZE;
     }
 
-    RefPtr<PhysicalPage> physical_page(size_t index) const;
-    RefPtr<PhysicalPage>& physical_page_slot(size_t index);
+    RefPtr<PhysicalRAMPage> physical_page(size_t index) const;
+    RefPtr<PhysicalRAMPage>& physical_page_slot(size_t index);
 
     [[nodiscard]] size_t offset_in_vmobject() const
     {
@@ -232,7 +232,7 @@ private:
     Region(NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString>, Region::Access access, Cacheable, bool shared);
     Region(VirtualRange const&, NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString>, Region::Access access, Cacheable, bool shared);
 
-    [[nodiscard]] bool remap_vmobject_page(size_t page_index, NonnullRefPtr<PhysicalPage>);
+    [[nodiscard]] bool remap_vmobject_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage>);
 
     void set_access_bit(Access access, bool b)
     {
@@ -244,10 +244,10 @@ private:
 
     [[nodiscard]] PageFaultResponse handle_cow_fault(size_t page_index);
     [[nodiscard]] PageFaultResponse handle_inode_fault(size_t page_index);
-    [[nodiscard]] PageFaultResponse handle_zero_fault(size_t page_index, PhysicalPage& page_in_slot_at_time_of_fault);
+    [[nodiscard]] PageFaultResponse handle_zero_fault(size_t page_index, PhysicalRAMPage& page_in_slot_at_time_of_fault);
 
     [[nodiscard]] bool map_individual_page_impl(size_t page_index);
-    [[nodiscard]] bool map_individual_page_impl(size_t page_index, RefPtr<PhysicalPage>);
+    [[nodiscard]] bool map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage>);
     [[nodiscard]] bool map_individual_page_impl(size_t page_index, PhysicalAddress);
     [[nodiscard]] bool map_individual_page_impl(size_t page_index, PhysicalAddress, bool readable, bool writeable);
 

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -208,6 +208,7 @@ public:
 
     void set_page_directory(PageDirectory&);
     ErrorOr<void> map(PageDirectory&, ShouldFlushTLB = ShouldFlushTLB::Yes);
+    ErrorOr<void> map(PageDirectory&, PhysicalAddress, ShouldFlushTLB = ShouldFlushTLB::Yes);
     void unmap(ShouldFlushTLB = ShouldFlushTLB::Yes);
     void unmap_with_locks_held(ShouldFlushTLB, SpinlockLocker<RecursiveSpinlock<LockRank::None>>& pd_locker);
 
@@ -247,6 +248,8 @@ private:
 
     [[nodiscard]] bool map_individual_page_impl(size_t page_index);
     [[nodiscard]] bool map_individual_page_impl(size_t page_index, RefPtr<PhysicalPage>);
+    [[nodiscard]] bool map_individual_page_impl(size_t page_index, PhysicalAddress);
+    [[nodiscard]] bool map_individual_page_impl(size_t page_index, PhysicalAddress, bool readable, bool writeable);
 
     LockRefPtr<PageDirectory> m_page_directory;
     VirtualRange m_range;

--- a/Kernel/Memory/ScatterGatherList.cpp
+++ b/Kernel/Memory/ScatterGatherList.cpp
@@ -8,7 +8,7 @@
 
 namespace Kernel::Memory {
 
-ErrorOr<LockRefPtr<ScatterGatherList>> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size, StringView region_name)
+ErrorOr<LockRefPtr<ScatterGatherList>> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalRAMPage>> allocated_pages, size_t device_block_size, StringView region_name)
 {
     auto vm_object = TRY(AnonymousVMObject::try_create_with_physical_pages(allocated_pages));
     auto size = TRY(page_round_up((request.block_count() * device_block_size)));

--- a/Kernel/Memory/ScatterGatherList.h
+++ b/Kernel/Memory/ScatterGatherList.h
@@ -19,7 +19,7 @@ namespace Kernel::Memory {
 
 class ScatterGatherList final : public AtomicRefCounted<ScatterGatherList> {
 public:
-    static ErrorOr<LockRefPtr<ScatterGatherList>> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size, StringView region_name);
+    static ErrorOr<LockRefPtr<ScatterGatherList>> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalRAMPage>> allocated_pages, size_t device_block_size, StringView region_name);
     VMObject const& vmobject() const { return m_vm_object; }
     VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
     size_t scatters_count() const { return m_vm_object->physical_pages().size(); }

--- a/Kernel/Memory/SharedFramebufferVMObject.cpp
+++ b/Kernel/Memory/SharedFramebufferVMObject.cpp
@@ -56,21 +56,21 @@ ErrorOr<void> SharedFramebufferVMObject::create_real_writes_framebuffer_vm_objec
     return {};
 }
 
-Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::real_framebuffer_physical_pages()
+Span<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::real_framebuffer_physical_pages()
 {
     return m_real_framebuffer_vmobject->physical_pages();
 }
-ReadonlySpan<RefPtr<PhysicalPage>> SharedFramebufferVMObject::real_framebuffer_physical_pages() const
+ReadonlySpan<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::real_framebuffer_physical_pages() const
 {
     return m_real_framebuffer_vmobject->physical_pages();
 }
 
-Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages()
+Span<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages()
 {
     return m_physical_pages.span();
 }
 
-ReadonlySpan<RefPtr<PhysicalPage>> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages() const
+ReadonlySpan<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages() const
 {
     return m_physical_pages.span();
 }
@@ -92,14 +92,14 @@ void SharedFramebufferVMObject::switch_to_real_framebuffer_writes(Badge<Kernel::
     });
 }
 
-ReadonlySpan<RefPtr<PhysicalPage>> SharedFramebufferVMObject::physical_pages() const
+ReadonlySpan<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::physical_pages() const
 {
     SpinlockLocker locker(m_writes_state_lock);
     if (m_writes_are_faked)
         return VMObject::physical_pages();
     return m_real_framebuffer_vmobject->physical_pages();
 }
-Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::physical_pages()
+Span<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::physical_pages()
 {
     SpinlockLocker locker(m_writes_state_lock);
     if (m_writes_are_faked)
@@ -107,7 +107,7 @@ Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::physical_pages()
     return m_real_framebuffer_vmobject->physical_pages();
 }
 
-SharedFramebufferVMObject::SharedFramebufferVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, CommittedPhysicalPageSet committed_pages, AnonymousVMObject& real_framebuffer_vmobject)
+SharedFramebufferVMObject::SharedFramebufferVMObject(FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, CommittedPhysicalPageSet committed_pages, AnonymousVMObject& real_framebuffer_vmobject)
     : VMObject(move(new_physical_pages))
     , m_real_framebuffer_vmobject(real_framebuffer_vmobject)
     , m_committed_pages(move(committed_pages))

--- a/Kernel/Memory/SharedFramebufferVMObject.h
+++ b/Kernel/Memory/SharedFramebufferVMObject.h
@@ -22,15 +22,15 @@ public:
         static ErrorOr<NonnullLockRefPtr<FakeWritesFramebufferVMObject>> try_create(Badge<SharedFramebufferVMObject>, SharedFramebufferVMObject const& parent_object);
 
     private:
-        FakeWritesFramebufferVMObject(SharedFramebufferVMObject const& parent_object, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+        FakeWritesFramebufferVMObject(SharedFramebufferVMObject const& parent_object, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages)
             : VMObject(move(new_physical_pages))
             , m_parent_object(parent_object)
         {
         }
         virtual StringView class_name() const override { return "FakeWritesFramebufferVMObject"sv; }
         virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
-        virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
-        virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        virtual ReadonlySpan<RefPtr<PhysicalRAMPage>> physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        virtual Span<RefPtr<PhysicalRAMPage>> physical_pages() override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
         NonnullLockRefPtr<SharedFramebufferVMObject> m_parent_object;
     };
 
@@ -39,15 +39,15 @@ public:
         static ErrorOr<NonnullLockRefPtr<RealWritesFramebufferVMObject>> try_create(Badge<SharedFramebufferVMObject>, SharedFramebufferVMObject const& parent_object);
 
     private:
-        RealWritesFramebufferVMObject(SharedFramebufferVMObject const& parent_object, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+        RealWritesFramebufferVMObject(SharedFramebufferVMObject const& parent_object, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages)
             : VMObject(move(new_physical_pages))
             , m_parent_object(parent_object)
         {
         }
         virtual StringView class_name() const override { return "RealWritesFramebufferVMObject"sv; }
         virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
-        virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
-        virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->real_framebuffer_physical_pages(); }
+        virtual ReadonlySpan<RefPtr<PhysicalRAMPage>> physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
+        virtual Span<RefPtr<PhysicalRAMPage>> physical_pages() override { return m_parent_object->real_framebuffer_physical_pages(); }
         NonnullLockRefPtr<SharedFramebufferVMObject> m_parent_object;
     };
 
@@ -60,14 +60,14 @@ public:
     void switch_to_fake_sink_framebuffer_writes(Badge<Kernel::DisplayConnector>);
     void switch_to_real_framebuffer_writes(Badge<Kernel::DisplayConnector>);
 
-    virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const override;
-    virtual Span<RefPtr<PhysicalPage>> physical_pages() override;
+    virtual ReadonlySpan<RefPtr<PhysicalRAMPage>> physical_pages() const override;
+    virtual Span<RefPtr<PhysicalRAMPage>> physical_pages() override;
 
-    Span<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages();
-    ReadonlySpan<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages() const;
+    Span<RefPtr<PhysicalRAMPage>> fake_sink_framebuffer_physical_pages();
+    ReadonlySpan<RefPtr<PhysicalRAMPage>> fake_sink_framebuffer_physical_pages() const;
 
-    Span<RefPtr<PhysicalPage>> real_framebuffer_physical_pages();
-    ReadonlySpan<RefPtr<PhysicalPage>> real_framebuffer_physical_pages() const;
+    Span<RefPtr<PhysicalRAMPage>> real_framebuffer_physical_pages();
+    ReadonlySpan<RefPtr<PhysicalRAMPage>> real_framebuffer_physical_pages() const;
 
     FakeWritesFramebufferVMObject const& fake_writes_framebuffer_vmobject() const { return *m_fake_writes_framebuffer_vmobject; }
     FakeWritesFramebufferVMObject& fake_writes_framebuffer_vmobject() { return *m_fake_writes_framebuffer_vmobject; }
@@ -76,7 +76,7 @@ public:
     RealWritesFramebufferVMObject& real_writes_framebuffer_vmobject() { return *m_real_writes_framebuffer_vmobject; }
 
 private:
-    SharedFramebufferVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, CommittedPhysicalPageSet, AnonymousVMObject& real_framebuffer_vmobject);
+    SharedFramebufferVMObject(FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, CommittedPhysicalPageSet, AnonymousVMObject& real_framebuffer_vmobject);
 
     virtual StringView class_name() const override { return "SharedFramebufferVMObject"sv; }
 

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -39,12 +39,12 @@ ErrorOr<NonnullLockRefPtr<VMObject>> SharedInodeVMObject::try_clone()
     return adopt_nonnull_lock_ref_or_enomem<VMObject>(new (nothrow) SharedInodeVMObject(*this, move(new_physical_pages), move(dirty_pages)));
 }
 
-SharedInodeVMObject::SharedInodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, Bitmap dirty_pages)
+SharedInodeVMObject::SharedInodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, Bitmap dirty_pages)
     : InodeVMObject(inode, move(new_physical_pages), move(dirty_pages))
 {
 }
 
-SharedInodeVMObject::SharedInodeVMObject(SharedInodeVMObject const& other, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, Bitmap dirty_pages)
+SharedInodeVMObject::SharedInodeVMObject(SharedInodeVMObject const& other, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages, Bitmap dirty_pages)
     : InodeVMObject(other, move(new_physical_pages), move(dirty_pages))
 {
 }

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -24,8 +24,8 @@ public:
 private:
     virtual bool is_shared_inode() const override { return true; }
 
-    explicit SharedInodeVMObject(Inode&, FixedArray<RefPtr<PhysicalPage>>&&, Bitmap dirty_pages);
-    explicit SharedInodeVMObject(SharedInodeVMObject const&, FixedArray<RefPtr<PhysicalPage>>&&, Bitmap dirty_pages);
+    explicit SharedInodeVMObject(Inode&, FixedArray<RefPtr<PhysicalRAMPage>>&&, Bitmap dirty_pages);
+    explicit SharedInodeVMObject(SharedInodeVMObject const&, FixedArray<RefPtr<PhysicalRAMPage>>&&, Bitmap dirty_pages);
 
     virtual StringView class_name() const override { return "SharedInodeVMObject"sv; }
 

--- a/Kernel/Memory/TypedMapping.h
+++ b/Kernel/Memory/TypedMapping.h
@@ -32,7 +32,7 @@ template<typename T>
 static ErrorOr<NonnullOwnPtr<TypedMapping<T>>> adopt_new_nonnull_own_typed_mapping(PhysicalAddress paddr, size_t length, Region::Access access = Region::Access::Read)
 {
     auto mapping_length = TRY(page_round_up(paddr.offset_in_page() + length));
-    auto region = TRY(MM.allocate_kernel_region(paddr.page_base(), mapping_length, {}, access));
+    auto region = TRY(MM.allocate_mmio_kernel_region(paddr.page_base(), mapping_length, {}, access));
     auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Memory::TypedMapping<T>()));
     table->region = move(region);
     table->offset = paddr.offset_in_page();
@@ -46,7 +46,7 @@ static ErrorOr<TypedMapping<T>> map_typed(PhysicalAddress paddr, size_t length, 
 {
     TypedMapping<T> table;
     auto mapping_length = TRY(page_round_up(paddr.offset_in_page() + length));
-    table.region = TRY(MM.allocate_kernel_region(paddr.page_base(), mapping_length, {}, access));
+    table.region = TRY(MM.allocate_mmio_kernel_region(paddr.page_base(), mapping_length, {}, access));
     table.offset = paddr.offset_in_page();
     table.paddr = paddr;
     table.length = length;

--- a/Kernel/Memory/VMObject.cpp
+++ b/Kernel/Memory/VMObject.cpp
@@ -17,17 +17,17 @@ SpinlockProtected<VMObject::AllInstancesList, LockRank::None>& VMObject::all_ins
     return s_all_instances;
 }
 
-ErrorOr<FixedArray<RefPtr<PhysicalPage>>> VMObject::try_clone_physical_pages() const
+ErrorOr<FixedArray<RefPtr<PhysicalRAMPage>>> VMObject::try_clone_physical_pages() const
 {
     return m_physical_pages.clone();
 }
 
-ErrorOr<FixedArray<RefPtr<PhysicalPage>>> VMObject::try_create_physical_pages(size_t size)
+ErrorOr<FixedArray<RefPtr<PhysicalRAMPage>>> VMObject::try_create_physical_pages(size_t size)
 {
-    return FixedArray<RefPtr<PhysicalPage>>::create(ceil_div(size, static_cast<size_t>(PAGE_SIZE)));
+    return FixedArray<RefPtr<PhysicalRAMPage>>::create(ceil_div(size, static_cast<size_t>(PAGE_SIZE)));
 }
 
-VMObject::VMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+VMObject::VMObject(FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages)
     : m_physical_pages(move(new_physical_pages))
 {
     all_instances().with([&](auto& list) { list.append(*this); });

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -35,8 +35,8 @@ public:
 
     size_t page_count() const { return m_physical_pages.size(); }
 
-    virtual ReadonlySpan<RefPtr<PhysicalPage>> physical_pages() const { return m_physical_pages.span(); }
-    virtual Span<RefPtr<PhysicalPage>> physical_pages() { return m_physical_pages.span(); }
+    virtual ReadonlySpan<RefPtr<PhysicalRAMPage>> physical_pages() const { return m_physical_pages.span(); }
+    virtual Span<RefPtr<PhysicalRAMPage>> physical_pages() { return m_physical_pages.span(); }
 
     size_t size() const { return m_physical_pages.size() * PAGE_SIZE; }
 
@@ -55,15 +55,15 @@ public:
     }
 
 protected:
-    static ErrorOr<FixedArray<RefPtr<PhysicalPage>>> try_create_physical_pages(size_t);
-    ErrorOr<FixedArray<RefPtr<PhysicalPage>>> try_clone_physical_pages() const;
-    explicit VMObject(FixedArray<RefPtr<PhysicalPage>>&&);
+    static ErrorOr<FixedArray<RefPtr<PhysicalRAMPage>>> try_create_physical_pages(size_t);
+    ErrorOr<FixedArray<RefPtr<PhysicalRAMPage>>> try_clone_physical_pages() const;
+    explicit VMObject(FixedArray<RefPtr<PhysicalRAMPage>>&&);
 
     template<typename Callback>
     void for_each_region(Callback);
 
     IntrusiveListNode<VMObject> m_list_node;
-    FixedArray<RefPtr<PhysicalPage>> m_physical_pages;
+    FixedArray<RefPtr<PhysicalRAMPage>> m_physical_pages;
 
     mutable RecursiveSpinlock<LockRank::None> m_lock {};
 


### PR DESCRIPTION
As MMIO is placed at fixed physical addresses, and does not need to be backed by real RAM physical pages, there's no need to use PhysicalPage instances to track their pages.
This results in slightly reduced allocations, but more importantly makes MMIO addresses which end up after the normal RAM ranges work, like 64-bit PCI BARs usually are.

Fixes #22720.
If this is merged after #24254, do not merge this until I add a commit to revert the commit in that PR that temporarily disables usage of 64-bit PCI MMIO addresses.