### PR TITLE
Kernel/FUSE: Allow buffering multiple requests

### DIFF
--- a/Kernel/Devices/FUSEDevice.h
+++ b/Kernel/Devices/FUSEDevice.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Atomic.h>
+#include <AK/HashMap.h>
 #include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Locking/SpinlockProtected.h>
@@ -17,7 +17,6 @@ struct FUSEInstance {
     OpenFileDescription const* fd = nullptr;
     NonnullOwnPtr<KBuffer> pending_request;
     NonnullOwnPtr<KBuffer> response;
-    bool drop_request = false;
     bool buffer_ready = false;
     bool response_ready = false;
     bool expecting_header = true;
@@ -47,7 +46,8 @@ private:
     virtual bool can_write(OpenFileDescription const&, u64) const override;
     virtual StringView class_name() const override { return "FUSEDevice"sv; }
 
-    SpinlockProtected<Vector<FUSEInstance>, LockRank::None> m_instances;
+    SpinlockProtected<HashMap<OpenFileDescription const*, Vector<FUSEInstance>>, LockRank::None> m_instances;
+    SpinlockProtected<Vector<OpenFileDescription const*>, LockRank::None> m_closing_instances;
 };
 
 }

--- a/Kernel/FileSystem/FUSE/Definitions.h
+++ b/Kernel/FileSystem/FUSE/Definitions.h
@@ -21,6 +21,11 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
+ *  This file is based on include/uapi/linux/fuse.h from Linux. That header
+ *  is dual-licensed under the GPLv2 and the above 2-Clause BSD license.
+ *  Consequentially, we are sublicensing this file under the latter license,
+ *  which is why we have to include it above verbatim.
  */
 
 #pragma once

--- a/Kernel/FileSystem/FUSE/FUSEConnection.h
+++ b/Kernel/FileSystem/FUSE/FUSEConnection.h
@@ -94,7 +94,7 @@ private:
 
         fuse_out_header* header = bit_cast<fuse_out_header*>(response.data());
         if (header->unique != unique) {
-            dmesgln("FUSE: Received a mismatched request");
+            dmesgln("FUSE: Received a mismatched request (expected #{}, received #{})", unique, header->unique);
             return Error::from_errno(EINVAL);
         }
 

--- a/Kernel/FileSystem/FUSE/FUSEConnection.h
+++ b/Kernel/FileSystem/FUSE/FUSEConnection.h
@@ -9,6 +9,7 @@
 #include <Kernel/FileSystem/FUSE/Definitions.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Library/KBuffer.h>
+#include <Kernel/Tasks/Process.h>
 
 namespace Kernel {
 
@@ -41,10 +42,10 @@ public:
         header->unique = unique;
         header->nodeid = nodeid;
 
-        // FIXME: Fill in proper values for these.
-        header->uid = 0;
-        header->gid = 0;
-        header->pid = 1;
+        auto current_process_credentials = Process::current().credentials();
+        header->uid = current_process_credentials->euid().value();
+        header->gid = current_process_credentials->egid().value();
+        header->pid = Process::current().pid().value();
 
         u8* payload = bit_cast<u8*>(request->data() + sizeof(fuse_in_header));
         memcpy(payload, request_body.data(), request_body.size());


### PR DESCRIPTION
Previously, it was assumed that only a single request can be pending for a FUSE instance, but we actually need to be able to send more requests even if there may be older requests pending response since requests can be blocked on other requests. In short, this means that recursively trying to list the mountpoint with the `passthrough` example from libfuse now works properly.

This also does some other cleanups, including clarifying the license of `Definitions.h`, doing a better job at filling out the request header, and improving debug output.