### PR TITLE
LibJS: Delete named_evaluation_if_anonymous_function()

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -452,26 +452,6 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
     return { class_constructor };
 }
 
-ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::class_definition_evaluation(VM& vm, Optional<DeprecatedFlyString> const& binding_name, DeprecatedFlyString const& class_name) const
-{
-    auto* environment = vm.lexical_environment();
-    VERIFY(environment);
-    auto class_environment = new_declarative_environment(*environment);
-
-    Value super_class;
-
-    if (binding_name.has_value())
-        MUST(class_environment->create_immutable_binding(vm, binding_name.value(), true));
-
-    if (!m_super_class.is_null()) {
-        vm.running_execution_context().lexical_environment = class_environment;
-        super_class = TRY(vm.execute_ast_node(*m_super_class));
-        vm.running_execution_context().lexical_environment = environment;
-    }
-
-    return create_class_constructor(vm, class_environment, environment, super_class, binding_name, class_name);
-}
-
 void ASTNode::dump(int indent) const
 {
     print_indent(indent);

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1446,7 +1446,6 @@ public:
 
     bool has_name() const { return m_name; }
 
-    ThrowCompletionOr<ECMAScriptFunctionObject*> class_definition_evaluation(VM&, Optional<DeprecatedFlyString> const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
     ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, Optional<DeprecatedFlyString> const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -219,25 +219,6 @@ void VM::gather_roots(HashMap<Cell*, HeapRoot>& roots)
         roots.set(job, HeapRoot { .type = HeapRoot::Type::VM });
 }
 
-ThrowCompletionOr<Value> VM::named_evaluation_if_anonymous_function(ASTNode const& expression, DeprecatedFlyString const& name)
-{
-    // 8.3.3 Static Semantics: IsAnonymousFunctionDefinition ( expr ), https://tc39.es/ecma262/#sec-isanonymousfunctiondefinition
-    // And 8.3.5 Runtime Semantics: NamedEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-namedevaluation
-    if (is<FunctionExpression>(expression)) {
-        auto& function = static_cast<FunctionExpression const&>(expression);
-        if (!function.has_name()) {
-            return function.instantiate_ordinary_function_expression(*this, name);
-        }
-    } else if (is<ClassExpression>(expression)) {
-        auto& class_expression = static_cast<ClassExpression const&>(expression);
-        if (!class_expression.has_name()) {
-            return TRY(class_expression.class_definition_evaluation(*this, {}, name));
-        }
-    }
-
-    return execute_ast_node(expression);
-}
-
 ThrowCompletionOr<Value> VM::execute_ast_node(ASTNode const& node)
 {
     // FIXME: This function should be gone once we will emit bytecode for everything before executing instructions.

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -226,8 +226,6 @@ public:
 
     CustomData* custom_data() { return m_custom_data; }
 
-    ThrowCompletionOr<Value> named_evaluation_if_anonymous_function(ASTNode const& expression, DeprecatedFlyString const& name);
-
     void save_execution_context_stack();
     void clear_execution_context_stack();
     void restore_execution_context_stack();


### PR DESCRIPTION
This code was a leftover from AST interpreter.