### PR TITLE
LibJS: Remove VM::execute_ast_node()

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -151,11 +151,9 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassMethod::class_element_evaluatio
 {
     auto property_key_or_private_name = TRY(class_key_to_property_name(vm, *m_key));
 
-    auto method_value = TRY(vm.execute_ast_node(*m_function));
+    auto& method_function = *ECMAScriptFunctionObject::create(*vm.current_realm(), m_function->name(), m_function->source_text(), m_function->body(), m_function->parameters(), m_function->function_length(), m_function->local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, m_function->kind(), m_function->is_strict_mode(), m_function->uses_this(), m_function->might_need_arguments_object(), m_function->contains_direct_call_to_eval(), m_function->is_arrow_function());
 
-    auto function_handle = make_handle(&method_value.as_function());
-
-    auto& method_function = static_cast<ECMAScriptFunctionObject&>(method_value.as_function());
+    auto method_value = Value(&method_function);
     method_function.make_method(target);
 
     auto set_function_name = [&](ByteString prefix = "") {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1326,7 +1326,7 @@ public:
 
     // We use the Completion also as a ClassStaticBlockDefinition Record.
     using ClassValue = Variant<ClassFieldDefinition, Completion, PrivateElement>;
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const = 0;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value) const = 0;
 
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const { return {}; }
 
@@ -1355,7 +1355,7 @@ public:
     virtual ElementKind class_element_kind() const override { return ElementKind::Method; }
 
     virtual void dump(int indent) const override;
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const override;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value property_key) const override;
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
 
 private:
@@ -1382,7 +1382,7 @@ public:
     virtual ElementKind class_element_kind() const override { return ElementKind::Field; }
 
     virtual void dump(int indent) const override;
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const override;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value property_key) const override;
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
 
 private:
@@ -1401,7 +1401,7 @@ public:
     }
 
     virtual ElementKind class_element_kind() const override { return ElementKind::StaticInitializer; }
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const override;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value property_key) const override;
 
     virtual void dump(int indent) const override;
 
@@ -1446,7 +1446,7 @@ public:
 
     bool has_name() const { return m_name; }
 
-    ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, Optional<DeprecatedFlyString> const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
+    ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, ReadonlySpan<Value> element_keys, Optional<DeprecatedFlyString> const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
 
 private:
     virtual bool is_class_expression() const override { return true; }

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -666,7 +666,7 @@ inline ThrowCompletionOr<void> create_variable(VM& vm, DeprecatedFlyString const
     return verify_cast<GlobalEnvironment>(vm.variable_environment())->create_global_var_binding(name, false);
 }
 
-inline ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM& vm, Value super_class, ClassExpression const& class_expression, Optional<IdentifierTableIndex> const& lhs_name)
+inline ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM& vm, Value super_class, ClassExpression const& class_expression, Optional<IdentifierTableIndex> const& lhs_name, ReadonlySpan<Value> element_keys)
 {
     auto& interpreter = vm.bytecode_interpreter();
     auto name = class_expression.name();
@@ -684,7 +684,7 @@ inline ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM& vm, Value supe
         class_name = name.is_null() ? ""sv : name;
     }
 
-    return TRY(class_expression.create_class_constructor(vm, class_environment, vm.lexical_environment(), super_class, binding_name, class_name));
+    return TRY(class_expression.create_class_constructor(vm, class_environment, vm.lexical_environment(), super_class, element_keys, binding_name, class_name));
 }
 
 // 13.3.7.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -15,6 +15,7 @@
 
 #define ENUMERATE_BYTECODE_OPS(O)      \
     O(Add)                             \
+    O(AddPrivateName)                  \
     O(ArrayAppend)                     \
     O(AsyncIteratorClose)              \
     O(Await)                           \
@@ -31,6 +32,7 @@
     O(CopyObjectExcludingProperties)   \
     O(CreateLexicalEnvironment)        \
     O(CreateVariableEnvironment)       \
+    O(CreatePrivateEnvironment)        \
     O(CreateVariable)                  \
     O(CreateRestParams)                \
     O(CreateArguments)                 \
@@ -88,6 +90,7 @@
     O(JumpUndefined)                   \
     O(LeaveFinally)                    \
     O(LeaveLexicalEnvironment)         \
+    O(LeavePrivateEnvironment)         \
     O(LeaveUnwindContext)              \
     O(LeftShift)                       \
     O(LessThan)                        \

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
@@ -34,7 +34,7 @@ PrivateName PrivateEnvironment::resolve_private_identifier(DeprecatedFlyString c
     return m_outer_environment->resolve_private_identifier(identifier);
 }
 
-void PrivateEnvironment::add_private_name(Badge<ClassExpression>, DeprecatedFlyString description)
+void PrivateEnvironment::add_private_name(DeprecatedFlyString description)
 {
     if (!find_private_name(description).is_end())
         return;

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -35,7 +35,10 @@ class PrivateEnvironment : public Cell {
 public:
     PrivateName resolve_private_identifier(DeprecatedFlyString const& identifier) const;
 
-    void add_private_name(Badge<ClassExpression>, DeprecatedFlyString description);
+    void add_private_name(DeprecatedFlyString description);
+
+    PrivateEnvironment* outer_environment() { return m_outer_environment; }
+    PrivateEnvironment const* outer_environment() const { return m_outer_environment; }
 
 private:
     explicit PrivateEnvironment(PrivateEnvironment* parent);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -258,10 +258,6 @@ public:
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
     Function<ThrowCompletionOr<HandledByHost>(ArrayBuffer&, size_t)> host_resize_array_buffer;
 
-    // Execute a specific AST node either in AST or BC interpreter, depending on which one is enabled by default.
-    // NOTE: This is meant as a temporary stopgap until everything is bytecode.
-    ThrowCompletionOr<Value> execute_ast_node(ASTNode const&);
-
     Vector<StackTraceElement> stack_trace() const;
 
 private:


### PR DESCRIPTION
```
Duration:
     -0.39s

Summary:
    Diff Tests:
        +20 ✅    -20 💥   

Diff Tests:
    test/language/expressions/class/accessor-name-inst-computed-yield-expr.js                                     💥 -> ✅
    test/language/expressions/class/accessor-name-static-computed-yield-expr.js                                   💥 -> ✅
    test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-await-expression.js      💥 -> ✅
    test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-yield-expression.js      💥 -> ✅
    test/language/expressions/class/cpn-class-expr-computed-property-name-from-await-expression.js                💥 -> ✅
    test/language/expressions/class/cpn-class-expr-computed-property-name-from-yield-expression.js                💥 -> ✅
    test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-await-expression.js         💥 -> ✅
    test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-yield-expression.js         💥 -> ✅
    test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-await-expression.js 💥 -> ✅
    test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-yield-expression.js 💥 -> ✅
    test/language/statements/class/accessor-name-inst-computed-yield-expr.js                                      💥 -> ✅
    test/language/statements/class/accessor-name-static-computed-yield-expr.js                                    💥 -> ✅
    test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-await-expression.js       💥 -> ✅
    test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-yield-expression.js       💥 -> ✅
    test/language/statements/class/cpn-class-decl-computed-property-name-from-await-expression.js                 💥 -> ✅
    test/language/statements/class/cpn-class-decl-computed-property-name-from-yield-expression.js                 💥 -> ✅
    test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-await-expression.js          💥 -> ✅
    test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-yield-expression.js          💥 -> ✅
    test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-await-expression.js  💥 -> ✅
    test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-yield-expression.js  💥 -> ✅

```