### PR TITLE
LibJS: Weekend optimization pack

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -231,7 +231,7 @@ inline ThrowCompletionOr<Value> get_by_value(VM& vm, Optional<DeprecatedFlyStrin
     return TRY(object->internal_get(property_key, base_value));
 }
 
-inline ThrowCompletionOr<Value> get_global(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& identifier, GlobalVariableCache& cache)
+inline ThrowCompletionOr<Value> get_global(Interpreter& interpreter, IdentifierTableIndex identifier_index, GlobalVariableCache& cache)
 {
     auto& vm = interpreter.vm();
     auto& binding_object = interpreter.global_object();
@@ -245,6 +245,8 @@ inline ThrowCompletionOr<Value> get_global(Bytecode::Interpreter& interpreter, D
     }
 
     cache.environment_serial_number = declarative_record.environment_serial_number();
+
+    auto& identifier = interpreter.current_executable().get_identifier(identifier_index);
 
     if (vm.running_execution_context().script_or_module.has<NonnullGCPtr<Module>>()) {
         // NOTE: GetGlobal is used to access variables stored in the module environment and global environment.

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -536,7 +536,7 @@ inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Byt
     Value this_value = js_undefined();
 
     if (cache.has_value()) {
-        auto const* environment = vm.running_execution_context().lexical_environment.ptr();
+        auto const* environment = interpreter.running_execution_context().lexical_environment.ptr();
         for (size_t i = 0; i < cache->hops; ++i)
             environment = environment->outer_environment();
         if (!environment->is_permanently_screwed_by_eval()) {

--- a/Userland/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.cpp
@@ -23,7 +23,6 @@ Executable::Executable(
     NonnullRefPtr<SourceCode const> source_code,
     size_t number_of_property_lookup_caches,
     size_t number_of_global_variable_caches,
-    size_t number_of_environment_variable_caches,
     size_t number_of_registers,
     bool is_strict_mode)
     : bytecode(move(bytecode))
@@ -37,7 +36,6 @@ Executable::Executable(
 {
     property_lookup_caches.resize(number_of_property_lookup_caches);
     global_variable_caches.resize(number_of_global_variable_caches);
-    environment_variable_caches.resize(number_of_environment_variable_caches);
 }
 
 Executable::~Executable() = default;

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -33,8 +33,6 @@ struct GlobalVariableCache : public PropertyLookupCache {
     u64 environment_serial_number { 0 };
 };
 
-using EnvironmentVariableCache = Optional<EnvironmentCoordinate>;
-
 struct SourceRecord {
     u32 source_start_offset {};
     u32 source_end_offset {};
@@ -54,7 +52,6 @@ public:
         NonnullRefPtr<SourceCode const>,
         size_t number_of_property_lookup_caches,
         size_t number_of_global_variable_caches,
-        size_t number_of_environment_variable_caches,
         size_t number_of_registers,
         bool is_strict_mode);
 
@@ -64,7 +61,6 @@ public:
     Vector<u8> bytecode;
     Vector<PropertyLookupCache> property_lookup_caches;
     Vector<GlobalVariableCache> global_variable_caches;
-    Vector<EnvironmentVariableCache> environment_variable_caches;
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<RegexTable> regex_table;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -38,7 +38,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
             auto id = intern_identifier(parameter_name.key);
             emit<Op::CreateVariable>(id, Op::EnvironmentMode::Lexical, false);
             if (function.m_has_duplicates) {
-                emit<Op::SetVariable>(id, add_constant(js_undefined()), next_environment_variable_cache(), Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Lexical);
+                emit<Op::SetVariable>(id, add_constant(js_undefined()), Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Lexical);
             }
         }
     }
@@ -90,7 +90,6 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
                 auto argument_reg = allocate_register();
                 emit<Op::GetArgument>(argument_reg.operand(), param_index);
                 emit<Op::SetVariable>(id, argument_reg.operand(),
-                    next_environment_variable_cache(),
                     init_mode,
                     Op::EnvironmentMode::Lexical);
             }
@@ -115,7 +114,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
                 } else {
                     auto intern_id = intern_identifier(id.string());
                     emit<Op::CreateVariable>(intern_id, Op::EnvironmentMode::Var, false);
-                    emit<Op::SetVariable>(intern_id, add_constant(js_undefined()), next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Var);
+                    emit<Op::SetVariable>(intern_id, add_constant(js_undefined()), Bytecode::Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Var);
                 }
             }
         }
@@ -132,7 +131,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
                     if (id.is_local()) {
                         emit<Op::Mov>(initial_value, local(id.local_variable_index()));
                     } else {
-                        emit<Op::GetVariable>(initial_value, intern_identifier(id.string()), next_environment_variable_cache());
+                        emit<Op::GetVariable>(initial_value, intern_identifier(id.string()));
                     }
                 }
 
@@ -141,7 +140,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
                 } else {
                     auto intern_id = intern_identifier(id.string());
                     emit<Op::CreateVariable>(intern_id, Op::EnvironmentMode::Var, false);
-                    emit<Op::SetVariable>(intern_id, initial_value, next_environment_variable_cache(), Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Var);
+                    emit<Op::SetVariable>(intern_id, initial_value, Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Var);
                 }
             }
         }
@@ -151,7 +150,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
         for (auto const& function_name : function.m_function_names_to_initialize_binding) {
             auto intern_id = intern_identifier(function_name);
             emit<Op::CreateVariable>(intern_id, Op::EnvironmentMode::Var, false);
-            emit<Op::SetVariable>(intern_id, add_constant(js_undefined()), next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Var);
+            emit<Op::SetVariable>(intern_id, add_constant(js_undefined()), Bytecode::Op::SetVariable::InitializationMode::Initialize, Op::EnvironmentMode::Var);
         }
     }
 
@@ -184,7 +183,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
         if (declaration.name_identifier()->is_local()) {
             emit<Op::Mov>(local(declaration.name_identifier()->local_variable_index()), function);
         } else {
-            emit<Op::SetVariable>(intern_identifier(declaration.name()), function, next_environment_variable_cache(), Op::SetVariable::InitializationMode::Set, Op::EnvironmentMode::Var);
+            emit<Op::SetVariable>(intern_identifier(declaration.name()), function, Op::SetVariable::InitializationMode::Set, Op::EnvironmentMode::Var);
         }
     }
 
@@ -355,7 +354,6 @@ CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::emit_function_body_by
         node.source_code(),
         generator.m_next_property_lookup_cache,
         generator.m_next_global_variable_cache,
-        generator.m_next_environment_variable_cache,
         generator.m_next_register,
         is_strict_mode);
 
@@ -776,7 +774,7 @@ void Generator::emit_set_variable(JS::Identifier const& identifier, ScopedOperan
         }
         emit<Bytecode::Op::SetLocal>(identifier.local_variable_index(), value);
     } else {
-        emit<Bytecode::Op::SetVariable>(intern_identifier(identifier.string()), value, next_environment_variable_cache(), initialization_mode, mode);
+        emit<Bytecode::Op::SetVariable>(intern_identifier(identifier.string()), value, initialization_mode, mode);
     }
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -280,7 +280,6 @@ public:
     void emit_iterator_complete(ScopedOperand dst, ScopedOperand result);
 
     [[nodiscard]] size_t next_global_variable_cache() { return m_next_global_variable_cache++; }
-    [[nodiscard]] size_t next_environment_variable_cache() { return m_next_environment_variable_cache++; }
     [[nodiscard]] size_t next_property_lookup_cache() { return m_next_property_lookup_cache++; }
 
     enum class DeduplicateConstant {
@@ -345,7 +344,6 @@ private:
     u32 m_next_block { 1 };
     u32 m_next_property_lookup_cache { 0 };
     u32 m_next_global_variable_cache { 0 };
-    u32 m_next_environment_variable_cache { 0 };
     FunctionKind m_enclosing_function_kind { FunctionKind::Normal };
     Vector<LabelableScope> m_continuable_scopes;
     Vector<LabelableScope> m_breakable_scopes;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1264,7 +1264,7 @@ ThrowCompletionOr<void> GetCalleeAndThisFromEnvironment::execute_impl(Bytecode::
 
 ThrowCompletionOr<void> GetGlobal::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.set(dst(), TRY(get_global(interpreter, interpreter.current_executable().get_identifier(m_identifier), interpreter.current_executable().global_variable_caches[m_cache_index])));
+    interpreter.set(dst(), TRY(get_global(interpreter, m_identifier, interpreter.current_executable().global_variable_caches[m_cache_index])));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -80,6 +80,8 @@ public:
     Vector<Value>& registers() { return vm().running_execution_context().registers; }
     Vector<Value> const& registers() const { return vm().running_execution_context().registers; }
 
+    ExecutionContext& running_execution_context() { return *m_running_execution_context; }
+
 private:
     void run_bytecode(size_t entry_point);
 
@@ -100,6 +102,7 @@ private:
     Span<Value> m_registers;
     Span<Value> m_locals;
     Span<Value> m_constants;
+    ExecutionContext* m_running_execution_context { nullptr };
 };
 
 extern bool g_dump_bytecode;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -588,13 +588,12 @@ public:
         Initialize,
         Set,
     };
-    explicit SetVariable(IdentifierTableIndex identifier, Operand src, u32 cache_index, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
+    explicit SetVariable(IdentifierTableIndex identifier, Operand src, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
         : Instruction(Type::SetVariable)
         , m_identifier(identifier)
         , m_src(src)
         , m_mode(mode)
         , m_initialization_mode(initialization_mode)
-        , m_cache_index(cache_index)
     {
     }
 
@@ -605,14 +604,13 @@ public:
     Operand src() const { return m_src; }
     EnvironmentMode mode() const { return m_mode; }
     InitializationMode initialization_mode() const { return m_initialization_mode; }
-    u32 cache_index() const { return m_cache_index; }
 
 private:
     IdentifierTableIndex m_identifier;
     Operand m_src;
     EnvironmentMode m_mode;
     InitializationMode m_initialization_mode { InitializationMode::Set };
-    u32 m_cache_index { 0 };
+    mutable EnvironmentCoordinate m_cache;
 };
 
 class SetLocal final : public Instruction {
@@ -678,12 +676,11 @@ private:
 
 class GetCalleeAndThisFromEnvironment final : public Instruction {
 public:
-    explicit GetCalleeAndThisFromEnvironment(Operand callee, Operand this_value, IdentifierTableIndex identifier, u32 cache_index)
+    explicit GetCalleeAndThisFromEnvironment(Operand callee, Operand this_value, IdentifierTableIndex identifier)
         : Instruction(Type::GetCalleeAndThisFromEnvironment)
         , m_identifier(identifier)
         , m_callee(callee)
         , m_this_value(this_value)
-        , m_cache_index(cache_index)
     {
     }
 
@@ -691,7 +688,6 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     IdentifierTableIndex identifier() const { return m_identifier; }
-    u32 cache_index() const { return m_cache_index; }
     Operand callee() const { return m_callee; }
     Operand this_() const { return m_this_value; }
 
@@ -699,16 +695,15 @@ private:
     IdentifierTableIndex m_identifier;
     Operand m_callee;
     Operand m_this_value;
-    u32 m_cache_index { 0 };
+    mutable EnvironmentCoordinate m_cache;
 };
 
 class GetVariable final : public Instruction {
 public:
-    explicit GetVariable(Operand dst, IdentifierTableIndex identifier, u32 cache_index)
+    explicit GetVariable(Operand dst, IdentifierTableIndex identifier)
         : Instruction(Type::GetVariable)
         , m_dst(dst)
         , m_identifier(identifier)
-        , m_cache_index(cache_index)
     {
     }
 
@@ -717,12 +712,11 @@ public:
 
     Operand dst() const { return m_dst; }
     IdentifierTableIndex identifier() const { return m_identifier; }
-    u32 cache_index() const { return m_cache_index; }
 
 private:
     Operand m_dst;
     IdentifierTableIndex m_identifier;
-    u32 m_cache_index { 0 };
+    mutable EnvironmentCoordinate m_cache;
 };
 
 class GetGlobal final : public Instruction {

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -182,29 +182,14 @@ ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding_direct(VM& v
 }
 
 // 9.1.1.1.6 GetBindingValue ( N, S ), https://tc39.es/ecma262/#sec-declarative-environment-records-getbindingvalue-n-s
-ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value(VM& vm, DeprecatedFlyString const& name, bool strict)
+ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value(VM& vm, DeprecatedFlyString const& name, [[maybe_unused]] bool strict)
 {
     // 1. Assert: envRec has a binding for N.
     auto binding_and_index = find_binding_and_index(name);
     VERIFY(binding_and_index.has_value());
 
     // 2-3. (extracted into a non-standard function below)
-    return get_binding_value_direct(vm, binding_and_index->binding(), strict);
-}
-
-ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value_direct(VM& vm, size_t index, bool strict)
-{
-    return get_binding_value_direct(vm, m_bindings[index], strict);
-}
-
-ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value_direct(VM&, Binding& binding, bool)
-{
-    // 2. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
-    if (!binding.initialized)
-        return vm().throw_completion<ReferenceError>(ErrorType::BindingNotInitialized, binding.name);
-
-    // 3. Return the value currently bound to N in envRec.
-    return binding.value;
+    return get_binding_value_direct(vm, binding_and_index->binding());
 }
 
 // 9.1.1.1.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
@@ -119,7 +119,7 @@ ThrowCompletionOr<Value> GlobalEnvironment::get_binding_value(VM& vm, Deprecated
     if (MUST(m_declarative_record->has_binding(name, &index))) {
         // a. Return ? DclRec.GetBindingValue(N, S).
         if (index.has_value())
-            return m_declarative_record->get_binding_value_direct(vm, index.value(), strict);
+            return m_declarative_record->get_binding_value_direct(vm, index.value());
         return m_declarative_record->get_binding_value(vm, name, strict);
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -142,7 +142,7 @@ ThrowCompletionOr<Value> Reference::get_value(VM& vm) const
 
     // c. Return ? base.GetBindingValue(V.[[ReferencedName]], V.[[Strict]]) (see 9.1).
     if (m_environment_coordinate.has_value())
-        return static_cast<DeclarativeEnvironment*>(m_base_environment)->get_binding_value_direct(vm, m_environment_coordinate->index, m_strict);
+        return static_cast<DeclarativeEnvironment*>(m_base_environment)->get_binding_value_direct(vm, m_environment_coordinate->index);
     return m_base_environment->get_binding_value(vm, m_name.as_string(), m_strict);
 }
 


### PR DESCRIPTION
Another batch of small optimizations.
Roughly 3% speed-up across all of Octane while Kraken looks neutral.

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  --------------------------
Kraken      ai-astar.js                              1.011  2.710 ± 2.700 … 2.720        2.680 ± 2.660 … 2.700
Kraken      audio-beat-detection.js                  0.994  1.770 ± 1.760 … 1.780        1.780 ± 1.780 … 1.780
Kraken      audio-dft.js                             1.008  1.340 ± 1.340 … 1.340        1.330 ± 1.310 … 1.350
Kraken      audio-fft.js                             0.997  1.670 ± 1.670 … 1.670        1.675 ± 1.670 … 1.680
Kraken      audio-oscillator.js                      0.984  1.570 ± 1.570 … 1.570        1.595 ± 1.590 … 1.600
Kraken      imaging-darkroom.js                      1.005  2.180 ± 2.180 … 2.180        2.170 ± 2.070 … 2.270
Kraken      imaging-desaturate.js                    0.934  2.345 ± 2.340 … 2.350        2.510 ± 2.500 … 2.520
Kraken      imaging-gaussian-blur.js                 1.006  8.965 ± 8.960 … 8.970        8.910 ± 8.570 … 9.250
Kraken      json-parse-financial.js                  1.04   0.130 ± 0.130 … 0.130        0.125 ± 0.120 … 0.130
Kraken      json-stringify-tinderbox.js              0.98   0.240 ± 0.240 … 0.240        0.245 ± 0.240 … 0.250
Kraken      stanford-crypto-aes.js                   1.022  0.705 ± 0.700 … 0.710        0.690 ± 0.680 … 0.700
Kraken      stanford-crypto-ccm.js                   1.009  0.590 ± 0.590 … 0.590        0.585 ± 0.580 … 0.590
Kraken      stanford-crypto-pbkdf2.js                0.996  1.165 ± 1.160 … 1.170        1.170 ± 1.150 … 1.190
Kraken      stanford-crypto-sha256-iterative.js      1.054  0.485 ± 0.480 … 0.490        0.460 ± 0.450 … 0.470
Octane      box2d.js                                 1.012  2.460 ± 2.450 … 2.470        2.430 ± 2.420 … 2.440
Octane      code-load.js                             0.995  2.155 ± 2.150 … 2.160        2.165 ± 2.160 … 2.170
Octane      crypto.js                                1.002  7.250 ± 7.230 … 7.270        7.235 ± 7.130 … 7.340
Octane      deltablue.js                             1      2.035 ± 2.010 … 2.060        2.035 ± 2.030 … 2.040
Octane      earley-boyer.js                          0.999  17.470 ± 17.280 … 17.660     17.480 ± 17.390 … 17.570
Octane      gbemu.js                                 1.032  3.220 ± 3.210 … 3.230        3.120 ± 3.090 … 3.150
Octane      mandreel.js                              1.022  15.030 ± 14.570 … 15.490     14.700 ± 14.490 … 14.910
Octane      navier-stokes.js                         1.03   3.215 ± 3.210 … 3.220        3.120 ± 3.110 … 3.130
Octane      pdfjs.js                                 1.002  3.005 ± 3.000 … 3.010        3.000 ± 2.990 … 3.010
Octane      raytrace.js                              1.072  7.125 ± 7.060 … 7.190        6.645 ± 6.500 … 6.790
Octane      regexp.js                                0.997  22.210 ± 22.140 … 22.280     22.285 ± 22.150 … 22.420
Octane      richards.js                              1.005  2.020 ± 2.020 … 2.020        2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.029  3.045 ± 3.040 … 3.050        2.960 ± 2.910 … 3.010
Octane      typescript.js                            0.984  37.695 ± 37.640 … 37.750     38.300 ± 38.180 … 38.420
Octane      zlib.js                                  1.066  106.620 ± 105.740 … 107.500  100.040 ± 99.850 … 100.230
Kraken      Total                                    0.998  25.865                       25.925
Octane      Total                                    1.031  234.555                      227.525
All Suites  Total                                    1.028  260.420                      253.450
```