### PR TITLE
Kernel: Run clang-format

### DIFF
--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -27,7 +27,7 @@ UNMAP_AFTER_INIT ErrorOr<void> Device::initialize_virtio_resources()
 }
 
 UNMAP_AFTER_INIT VirtIO::Device::Device(NonnullOwnPtr<TransportEntity> transport_entity)
-    : m_class_name(transport_entity -> determine_device_class_name())
+    : m_class_name(transport_entity->determine_device_class_name())
     , m_transport_entity(move(transport_entity))
 {
 }

--- a/Kernel/Devices/GPU/Console/VGATextModeConsole.cpp
+++ b/Kernel/Devices/GPU/Console/VGATextModeConsole.cpp
@@ -20,7 +20,7 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<VGATextModeConsole> VGATextModeConsole::initi
 UNMAP_AFTER_INIT VGATextModeConsole::VGATextModeConsole(NonnullOwnPtr<Memory::Region> vga_window_region)
     : Console(80, 25)
     , m_vga_window_region(move(vga_window_region))
-    , m_current_vga_window(m_vga_window_region -> vaddr().offset(0x18000).as_ptr())
+    , m_current_vga_window(m_vga_window_region->vaddr().offset(0x18000).as_ptr())
 {
     for (size_t index = 0; index < height(); index++) {
         clear_vga_row(index);


### PR DESCRIPTION
The following command was used to clang-format these files:

    clang-format-18 -i $(find . \
        -not \( -path "./\.*" -prune \) \
        -not \( -path "./Base/*" -prune \) \
        -not \( -path "./Build/*" -prune \) \
        -not \( -path "./Toolchain/*" -prune \) \
        -not \( -path "./Ports/*" -prune \) \
        -type f -name "*.cpp" -o -name "*.mm" -o -name "*.h")

There was a recent release of clang-format version 18.1.5 which fixes errant spaces around `->` in these files.