### PR TITLE
LibLocale: Move includes below `#pragma once` in generated headers

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -740,9 +740,9 @@ static ErrorOr<void> generate_unicode_locale_header(Core::InputBufferedFile& fil
     SourceGenerator generator { builder };
 
     generator.append(R"~~~(
-#include <AK/Types.h>
-
 #pragma once
+
+#include <AK/Types.h>
 
 namespace Locale {
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -431,9 +431,9 @@ static ErrorOr<void> generate_unicode_locale_header(Core::InputBufferedFile& fil
     SourceGenerator generator { builder };
 
     generator.append(R"~~~(
-#include <AK/Types.h>
-
 #pragma once
+
+#include <AK/Types.h>
 
 namespace Locale {
 )~~~");


### PR DESCRIPTION
When building `LibLocale`, I noticed a couple of the headers were putting includes before the `#pragma once` statement. Most of the generators were doing it correctly, but here is a fix for the remaining that weren't.

Before:
![locale_gen_before](https://github.com/SerenityOS/serenity/assets/11325341/5609db6f-806f-4cef-ba8b-e4b333adfab8)

After:
![locale_gen_after](https://github.com/SerenityOS/serenity/assets/11325341/439e4670-2a56-4029-9bb7-a2f0ea63244e)

