### PR TITLE
AK+LibHTTP+LibTest: Introduce more bugs in asynchronous code

### DIFF
--- a/AK/AsyncStream.h
+++ b/AK/AsyncStream.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/ByteBuffer.h>
+#include <AK/Coroutine.h>
+#include <AK/Error.h>
+#include <AK/ScopeGuard.h>
+
+namespace AK {
+
+// AsyncResource represents a generic resource (e. g. POSIX file descriptor, AsyncStream, HTTP
+// response body) with a failible and/or asynchronous destructor. Refer to AsynchronousDesign.md
+// documentation page for a description tailored for users of the asynchronous resources.
+//
+// In order to correctly implement methods of AsyncResource, you first have to define (not
+// necessarily in code) two abstract operations: Close and Reset. They should have the following
+// semantics:
+//
+//  * Close AO:
+//     1. Assert that nobody is awaiting on a resource.
+//     2. Ensure that further attempts to wait on a resource will assert.
+//     3. Shutdown (possibly asynchronously) the associated low-level resource. Shutdown must ensure
+//        that if the state of a resource is clean, it will remain so indefinitely. The "clean"
+//        state is resource-specific--for example, streams might define it as "no outstanding writes
+//        and no unread data".
+//     4. Check if the state of the resource is clean. If it is not, call Reset AO and return an
+//        error (preferably, EBUSY).
+//     5. Free (possibly asynchronously) the associated low-level resource.
+//     6. Return success.
+//
+//  * Reset AO:
+//     1. Schedule returning an error (preferably, ECANCELED) from the current resource awaiters.
+//     2. Ensure that further attempts to wait on a resource will assert.
+//     3. Free synchronously the associated low-level resource. Preferably, this should be done in a
+//        way that cleanly indicates an error for the event producer.
+//     4. Return synchronously.
+class AsyncResource {
+    AK_MAKE_NONCOPYABLE(AsyncResource);
+    AK_MAKE_NONMOVABLE(AsyncResource);
+
+public:
+    AsyncResource() = default;
+
+    // Destructor of an AsyncResource must perform the following steps when called:
+    // 1. Assert that nobody is awaiting on the resource.
+    // 2. If resource is open, perform Reset AO.
+    virtual ~AsyncResource() = default;
+
+    // reset() must perform the following steps when called:
+    // 1. Assert that the resource is open.
+    // 2. Perform Reset AO.
+    virtual void reset() = 0;
+
+    // close() must perform the following steps when called:
+    // 1. Assert that the object is fully constructed. For example, a socket might assert that it is
+    //    connected.
+    // 2. Assert that the resource is open.
+    // 3. Perform Close AO, await and return its result.
+    virtual Coroutine<ErrorOr<void>> close() = 0;
+
+    // Resource is said to be in an error state if either Reset AO was invoked or if an operation on
+    // a resource has failed and an implementation deemed the error unrecoverable. If a resource is
+    // being transitioned to an error state because of an internal error, Reset AO (or its
+    // equivalent) must be executed by an implementation. Resource is said to be open if it is not
+    // in a error state and Close AO has never been called on it.
+    virtual bool is_open() const = 0;
+};
+
+// AsyncInputStream is a base class for all asynchronous input streams. Refer to
+// AsynchronousDesign.md documentation page for a description tailored for users of the streams.
+//
+// In order to implement a brand new AsyncInputStream, you generally have to define a destructor and
+// overload six virtual functions: 3 from AsyncResource and 3 from AsyncInputStream. When
+// implementing the AsyncResource interface, please note that AsyncInputStream is considered clean
+// if there's no data left to be read.
+class AsyncInputStream : public virtual AsyncResource {
+public:
+    struct PeekOrEofResult {
+        ReadonlyBytes data;
+        bool is_eof;
+    };
+
+    AsyncInputStream() = default;
+
+    ReadonlyBytes buffered_data() const
+    {
+        VERIFY(is_open());
+        return buffered_data_unchecked({});
+    }
+
+    Coroutine<ErrorOr<PeekOrEofResult>> peek_or_eof()
+    {
+        VERIFY(is_open());
+        if (!m_is_reading_peek) {
+            m_is_reading_peek = true;
+            auto data = buffered_data_unchecked({});
+            if (!data.is_empty())
+                co_return PeekOrEofResult { data, false };
+        }
+        bool is_not_eof = CO_TRY(co_await enqueue_some({}));
+        co_return PeekOrEofResult { buffered_data_unchecked({}), !is_not_eof };
+    }
+
+    Coroutine<ErrorOr<ReadonlyBytes>> peek()
+    {
+        auto [data, is_eof] = CO_TRY(co_await peek_or_eof());
+        if (is_eof) {
+            reset();
+            co_return Error::from_errno(EIO);
+        }
+        co_return data;
+    }
+
+    Coroutine<ErrorOr<ReadonlyBytes>> read(size_t bytes)
+    {
+        m_is_reading_peek = false;
+
+        if (bytes) {
+            auto buffer = buffered_data();
+            while (buffer.size() < bytes) {
+                if (!CO_TRY(co_await enqueue_some({}))) {
+                    reset();
+                    co_return Error::from_errno(EIO);
+                }
+                buffer = buffered_data_unchecked({});
+            }
+            dequeue({}, bytes);
+            co_return buffer.slice(0, bytes);
+        } else {
+            co_return Bytes {};
+        }
+    }
+
+    template<typename T>
+    Coroutine<ErrorOr<T>> read_object()
+    {
+        auto bytes = CO_TRY(co_await read(sizeof(T)));
+        union {
+            T object;
+            char representation[sizeof(T)];
+        } reinterpreter = {};
+        memcpy(&reinterpreter, bytes.data(), sizeof(T));
+        co_return reinterpreter.object;
+    }
+
+    // If EOF has not been reached, `enqueue_some` should read at least one byte from the underlying
+    // stream to the internal buffer and return true. Otherwise, it must not change the buffer and
+    // return false. If read fails and, consequently, `enqueue_some` returns Error, it must
+    // perform Reset AO (or an equivalent of it). Therefore, all reading errors are considered fatal
+    // for AsyncInputStream. Additionally, implementation must assert if `enqueue_some` is called
+    // concurrently. This is the only method that can be interrupted by `reset`.
+    virtual Coroutine<ErrorOr<bool>> enqueue_some(Badge<AsyncInputStream>) = 0;
+
+    // `buffered_data_unchecked` should just return a view of the buffer. It must not invalidate
+    // previously returned views of the buffer.
+    virtual ReadonlyBytes buffered_data_unchecked(Badge<AsyncInputStream>) const = 0;
+
+    // `dequeue` should remove `bytes` bytes from the buffer. It is guaranteed that this amount of
+    // bytes will be present in the buffer at the point of the call. `dequeue` must not invalidate
+    // previously returned views of the buffer. There are some restrictions on `bytes` parameter
+    // originating from the length condition (see documentation), so if you just use
+    // AsyncStreamBuffer as the stream buffer, `dequeue` and `enqueue_some` will have amortized
+    // O(stream_length) complexity.
+    virtual void dequeue(Badge<AsyncInputStream>, size_t bytes) = 0;
+
+protected:
+    static Badge<AsyncInputStream> badge() { return {}; }
+
+    bool m_is_reading_peek { false };
+};
+
+class AsyncOutputStream : public virtual AsyncResource {
+public:
+    AsyncOutputStream() = default;
+
+    virtual Coroutine<ErrorOr<size_t>> write_some(ReadonlyBytes buffer) = 0;
+
+    virtual Coroutine<ErrorOr<void>> write(ReadonlySpan<ReadonlyBytes> buffers)
+    {
+        for (auto buffer : buffers) {
+            while (!buffer.is_empty()) {
+                auto nwritten = CO_TRY(co_await write_some(buffer));
+                buffer = buffer.slice(nwritten);
+            }
+        }
+        co_return {};
+    }
+};
+
+class AsyncStream
+    : public AsyncInputStream
+    , public AsyncOutputStream {
+public:
+    AsyncStream() = default;
+};
+
+template<typename T>
+class StreamWrapper : public virtual AsyncResource {
+public:
+    StreamWrapper(NonnullOwnPtr<T>&& stream)
+        : m_stream(move(stream))
+    {
+    }
+
+    void reset() override { return m_stream->reset(); }
+    Coroutine<ErrorOr<void>> close() override { return m_stream->close(); }
+    bool is_open() const override { return m_stream->is_open(); }
+
+protected:
+    NonnullOwnPtr<T> m_stream;
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::AsyncInputStream;
+using AK::AsyncOutputStream;
+using AK::AsyncResource;
+using AK::AsyncStream;
+using AK::StreamWrapper;
+#endif

--- a/AK/AsyncStreamBuffer.h
+++ b/AK/AsyncStreamBuffer.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Coroutine.h>
+#include <AK/Error.h>
+
+namespace AK {
+
+class AsyncStreamBuffer {
+    AK_MAKE_NONCOPYABLE(AsyncStreamBuffer);
+
+public:
+    AsyncStreamBuffer()
+    {
+        m_capacity = min_capacity;
+        m_data = reinterpret_cast<u8*>(kmalloc(m_capacity));
+    }
+
+    AsyncStreamBuffer(AsyncStreamBuffer&& other)
+        : m_read_head(exchange(other.m_read_head, 0))
+        , m_peek_head(exchange(other.m_peek_head, 0))
+        , m_capacity(exchange(other.m_capacity, 0))
+        , m_data(exchange(other.m_data, nullptr))
+    {
+    }
+
+    AsyncStreamBuffer& operator=(AsyncStreamBuffer&& buffer)
+    {
+        if (this != &buffer) {
+            this->~AsyncStreamBuffer();
+            new (this) AsyncStreamBuffer(move(buffer));
+        }
+        return *this;
+    }
+
+    ~AsyncStreamBuffer()
+    {
+        if (m_data)
+            kfree_sized(m_data, m_capacity);
+    }
+
+    bool is_empty() const
+    {
+        return m_read_head == m_peek_head;
+    }
+
+    ReadonlyBytes data() const
+    {
+        return { m_data + m_read_head, m_peek_head - m_read_head };
+    }
+
+    void dequeue(size_t bytes)
+    {
+        m_read_head += bytes;
+    }
+
+    template<typename Func>
+    Coroutine<ErrorOr<size_t>> enqueue(size_t preferred_capacity_for_writing, Func&& func)
+    {
+        allocate_enough_space_for(preferred_capacity_for_writing);
+        size_t nread = CO_TRY(co_await func(Bytes { m_data + m_peek_head, m_capacity - m_peek_head }));
+        m_peek_head += nread;
+        co_return nread;
+    }
+
+    void append(ReadonlyBytes bytes)
+    {
+        if (m_peek_head + bytes.size() > m_capacity)
+            allocate_enough_space_for(bytes.size());
+        memcpy(m_data + m_peek_head, bytes.data(), bytes.size());
+        m_peek_head += bytes.size();
+    }
+
+    void append(u8 byte)
+    {
+        if (m_peek_head == m_capacity)
+            allocate_enough_space_for(1);
+        m_data[m_peek_head++] = byte;
+    }
+
+    Bytes get_bytes_for_writing(size_t length)
+    {
+        if (m_peek_head + length > m_capacity)
+            allocate_enough_space_for(length);
+        m_peek_head += length;
+        return { m_data + m_peek_head - length, length };
+    }
+
+private:
+    static constexpr size_t min_capacity = 32;
+
+    void allocate_enough_space_for(size_t length)
+    {
+        if (m_read_head != 0) {
+            if (m_capacity - (m_peek_head - m_read_head) >= length) {
+                memmove(m_data, m_data + m_read_head, m_peek_head - m_read_head);
+                m_peek_head -= m_read_head;
+                m_read_head = 0;
+                return;
+            }
+        }
+
+        VERIFY(m_capacity < NumericLimits<size_t>::max() / 3);
+        size_t new_capacity = max(m_capacity * 3 / 2, m_capacity + length);
+
+        u8* new_data = (u8*)kmalloc(new_capacity);
+        memcpy(new_data, m_data + m_read_head, m_peek_head - m_read_head);
+        kfree_sized(m_data, m_capacity);
+
+        m_data = new_data;
+        m_capacity = new_capacity;
+        m_peek_head -= m_read_head;
+        m_read_head = 0;
+    }
+
+    size_t m_read_head { 0 };
+    size_t m_peek_head { 0 };
+    size_t m_capacity { 0 };
+    u8* m_data { nullptr };
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::AsyncStreamBuffer;
+#endif

--- a/AK/AsyncStreamHelpers.h
+++ b/AK/AsyncStreamHelpers.h
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AsyncStream.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StringUtils.h>
+
+namespace AK {
+
+struct AsyncStreamHelpers {
+    static Coroutine<ErrorOr<ReadonlyBytes>> consume_until(AsyncInputStream& stream, StringView delimiter)
+    {
+        size_t start_position = 0;
+        while (true) {
+            auto buffer = CO_TRY(co_await stream.peek());
+            auto position = StringUtils::find(StringView { buffer }, delimiter, start_position);
+            if (position.has_value())
+                co_return must_sync(stream.read(*position + delimiter.length()));
+            start_position = max(buffer.size(), delimiter.length() - 1) - delimiter.length() + 1;
+        }
+    }
+};
+
+class AsyncInputStreamSlice final : public AsyncInputStream {
+public:
+    AsyncInputStreamSlice(AsyncInputStream& stream, size_t length)
+        : m_stream(stream)
+        , m_length(length)
+        , m_encountered_eof(stream.buffered_data().size() >= m_length)
+    {
+    }
+
+    ~AsyncInputStreamSlice()
+    {
+        if (is_open())
+            reset();
+    }
+
+    void reset() override
+    {
+        VERIFY(is_open());
+        m_stream.reset();
+        m_is_open = false;
+    }
+
+    Coroutine<ErrorOr<void>> close() override
+    {
+        VERIFY(is_open());
+        if (m_length != 0) {
+            reset();
+            co_return Error::from_errno(EBUSY);
+        }
+        m_is_open = false;
+        co_return {};
+    }
+
+    bool is_open() const override
+    {
+        return m_is_open;
+    }
+
+    Coroutine<ErrorOr<bool>> enqueue_some(Badge<AsyncInputStream>) override
+    {
+        if (m_encountered_eof)
+            co_return false;
+        auto eof_or_error = co_await m_stream.enqueue_some(badge());
+        if (eof_or_error.is_error()) {
+            m_is_open = false;
+            co_return eof_or_error.release_error();
+        } else if (!eof_or_error.release_value()) {
+            reset();
+            co_return Error::from_errno(EIO);
+        }
+        if (m_stream.buffered_data_unchecked(badge()).size() >= m_length)
+            m_encountered_eof = true;
+        co_return true;
+    }
+
+    ReadonlyBytes buffered_data_unchecked(Badge<AsyncInputStream>) const override
+    {
+        auto data = m_stream.buffered_data_unchecked(badge());
+        return data.slice(0, min(data.size(), m_length));
+    }
+
+    void dequeue(Badge<AsyncInputStream>, size_t bytes) override
+    {
+        m_stream.dequeue(badge(), bytes);
+        m_length -= bytes;
+    }
+
+private:
+    AsyncInputStream& m_stream;
+    size_t m_length { 0 };
+    bool m_encountered_eof { false };
+    bool m_is_open { true };
+};
+
+class AsyncStreamPair final : public AsyncStream {
+public:
+    AsyncStreamPair(NonnullOwnPtr<AsyncInputStream>&& input_stream, NonnullOwnPtr<AsyncOutputStream>&& output_stream)
+        : m_input_stream(move(input_stream))
+        , m_output_stream(move(output_stream))
+    {
+    }
+
+    ~AsyncStreamPair()
+    {
+        if (is_open())
+            reset();
+    }
+
+    void reset() override
+    {
+        VERIFY(is_open());
+        m_input_stream->reset();
+        m_output_stream->reset();
+        m_is_open = false;
+    }
+
+    Coroutine<ErrorOr<void>> close() override
+    {
+        VERIFY(is_open());
+        m_is_open = false;
+
+        auto result = co_await m_input_stream->close();
+        if (result.is_error()) {
+            m_output_stream->reset();
+            co_return result;
+        }
+        CO_TRY(co_await m_output_stream->close());
+        co_return {};
+    }
+
+    bool is_open() const override
+    {
+        return m_is_open;
+    }
+
+    Coroutine<ErrorOr<bool>> enqueue_some(Badge<AsyncInputStream>) override
+    {
+        auto result = co_await m_input_stream->enqueue_some(badge());
+        if (result.is_error()) {
+            m_is_open = false;
+            m_output_stream->reset();
+        }
+        co_return result;
+    }
+
+    ReadonlyBytes buffered_data_unchecked(Badge<AsyncInputStream>) const override
+    {
+        return m_input_stream->buffered_data_unchecked(badge());
+    }
+
+    void dequeue(Badge<AsyncInputStream>, size_t bytes) override
+    {
+        m_input_stream->dequeue(badge(), bytes);
+    }
+
+    Coroutine<ErrorOr<size_t>> write_some(ReadonlyBytes buffer) override
+    {
+        auto result = co_await m_output_stream->write_some(buffer);
+        if (result.is_error()) {
+            m_is_open = false;
+            m_input_stream->reset();
+        }
+        co_return result;
+    }
+
+    Coroutine<ErrorOr<void>> write(ReadonlySpan<ReadonlyBytes> buffers) override
+    {
+        auto result = co_await m_output_stream->write(buffers);
+        if (result.is_error()) {
+            m_is_open = false;
+            m_input_stream->reset();
+        }
+        co_return result;
+    }
+
+private:
+    NonnullOwnPtr<AsyncInputStream> m_input_stream;
+    NonnullOwnPtr<AsyncOutputStream> m_output_stream;
+    bool m_is_open { true };
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::AsyncInputStreamSlice;
+using AK::AsyncStreamHelpers;
+using AK::AsyncStreamPair;
+#endif

--- a/AK/AsyncStreamTransform.h
+++ b/AK/AsyncStreamTransform.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AsyncStream.h>
+#include <AK/Generator.h>
+#include <AK/MaybeOwned.h>
+#include <AK/TemporaryChange.h>
+
+namespace AK {
+
+template<typename T>
+class AsyncStreamTransform : public AsyncInputStream {
+public:
+    AsyncStreamTransform(MaybeOwned<T>&& stream, AK::Generator<Empty, ErrorOr<void>>&& generator)
+        : m_stream(move(stream))
+        , m_generator(move(generator))
+    {
+    }
+
+    ~AsyncStreamTransform()
+    {
+        // 1. Assert that nobody is awaiting on the resource.
+        VERIFY(!m_generator_has_awaiters);
+
+        // 2. If resource is open, perform Reset AO.
+        if (is_open())
+            reset();
+    }
+
+    void reset() override
+    {
+        VERIFY(is_open());
+        m_stream->reset();
+        if (!m_generator_has_awaiters)
+            m_generator.destroy();
+        m_is_open = false;
+    }
+
+    Coroutine<ErrorOr<void>> close() override
+    {
+        VERIFY(is_open());
+        TemporaryChange await_guard(m_generator_has_awaiters, true);
+
+        if (!m_generator.is_done()) {
+            Variant<Empty, ErrorOr<void>> chunk_or_eof = co_await m_generator.next();
+            if (chunk_or_eof.has<Empty>()) {
+                reset();
+                co_return Error::from_errno(EBUSY);
+            } else {
+                m_is_open = false;
+                auto& error_or_eof = chunk_or_eof.get<ErrorOr<void>>();
+                if (error_or_eof.is_error()) {
+                    co_return error_or_eof.release_error();
+                } else {
+                    if (m_stream.is_owned())
+                        CO_TRY(co_await m_stream->close());
+                    co_return {};
+                }
+            }
+        } else {
+            m_is_open = false;
+            if (m_stream.is_owned())
+                CO_TRY(co_await m_stream->close());
+            co_return {};
+        }
+    }
+
+    bool is_open() const override
+    {
+        return m_is_open;
+    }
+
+    Coroutine<ErrorOr<bool>> enqueue_some(Badge<AsyncInputStream>) override
+    {
+        VERIFY(is_open());
+        TemporaryChange await_guard(m_generator_has_awaiters, true);
+
+        if (m_generator.is_done())
+            co_return false;
+
+        Variant<Empty, ErrorOr<void>> chunk_or_eof = co_await m_generator.next();
+        if (chunk_or_eof.has<Empty>()) {
+            co_return true;
+        } else {
+            auto& error_or_eof = chunk_or_eof.get<ErrorOr<void>>();
+            if (error_or_eof.is_error()) {
+                m_is_open = false;
+                co_return error_or_eof.release_error();
+            } else {
+                co_return false;
+            }
+        }
+    }
+
+protected:
+    using Generator = AK::Generator<Empty, ErrorOr<void>>;
+
+    MaybeOwned<T> m_stream;
+
+private:
+    Generator m_generator;
+    bool m_is_open { true };
+    bool m_generator_has_awaiters { false };
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::AsyncStreamTransform;
+#endif

--- a/AK/Badge.h
+++ b/AK/Badge.h
@@ -15,15 +15,15 @@ class Badge {
 public:
     using Type = T;
 
+    Badge(Badge&&) = default;
+    Badge& operator=(Badge&&) = default;
+
 private:
     friend T;
     constexpr Badge() = default;
 
     Badge(Badge const&) = delete;
     Badge& operator=(Badge const&) = delete;
-
-    Badge(Badge&&) = delete;
-    Badge& operator=(Badge&&) = delete;
 };
 
 }

--- a/AK/Coroutine.h
+++ b/AK/Coroutine.h
@@ -31,6 +31,12 @@ struct SuspendNever {
     void await_resume() const noexcept { }
 };
 
+struct SuspendAlways {
+    bool await_ready() const noexcept { return false; }
+    void await_suspend(std::coroutine_handle<>) const noexcept { }
+    void await_resume() const noexcept { }
+};
+
 struct SymmetricControlTransfer {
     SymmetricControlTransfer(std::coroutine_handle<> handle)
         : m_handle(handle ? handle : std::noop_coroutine())

--- a/AK/Coroutine.h
+++ b/AK/Coroutine.h
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Noncopyable.h>
+#include <coroutine>
+
+namespace AK {
+
+namespace Detail {
+struct SuspendNever {
+    // Even though we set -fno-exceptions, Clang really wants these to be noexcept.
+    bool await_ready() const noexcept { return true; }
+    void await_suspend(std::coroutine_handle<>) const noexcept { }
+    void await_resume() const noexcept { }
+};
+
+struct SymmetricControlTransfer {
+    SymmetricControlTransfer(std::coroutine_handle<> handle)
+        : m_handle(handle ? handle : std::noop_coroutine())
+    {
+    }
+
+    bool await_ready() const noexcept { return false; }
+    auto await_suspend(std::coroutine_handle<>) const noexcept { return m_handle; }
+    void await_resume() const noexcept { }
+
+    std::coroutine_handle<> m_handle;
+};
+
+template<typename T>
+struct TryAwaiter;
+
+template<typename T>
+struct ValueHolder {
+    alignas(T) u8 m_return_value[sizeof(T)];
+};
+
+template<>
+struct ValueHolder<void> { };
+}
+
+template<typename T>
+class [[nodiscard]] Coroutine : private Detail::ValueHolder<T> {
+    struct CoroutinePromiseVoid;
+    struct CoroutinePromiseValue;
+
+    AK_MAKE_NONCOPYABLE(Coroutine);
+
+public:
+    using ReturnType = T;
+    using promise_type = Conditional<SameAs<T, void>, CoroutinePromiseVoid, CoroutinePromiseValue>;
+
+    ~Coroutine()
+    {
+        VERIFY(await_ready());
+        if constexpr (!SameAs<T, void>)
+            return_value()->~T();
+        if (m_handle)
+            m_handle.destroy();
+    }
+
+    Coroutine(Coroutine&& other)
+    {
+        m_handle = AK::exchange(other.m_handle, {});
+        if (!await_ready())
+            m_handle.promise().m_coroutine = this;
+        else if constexpr (!IsVoid<T>)
+            new (return_value()) T(move(*other.return_value()));
+    }
+
+    Coroutine& operator=(Coroutine&& other)
+    {
+        if (this != &other) {
+            this->~Coroutine();
+            new (this) Coroutine(move(other));
+        }
+        return *this;
+    }
+
+    bool await_ready() const
+    {
+        return !m_handle || m_handle.done();
+    }
+
+    void await_suspend(std::coroutine_handle<> awaiter)
+    {
+        m_handle.promise().m_awaiter = awaiter;
+    }
+
+    // Do NOT bind the result of await_resume() on a temporary coroutine (or the result of CO_TRY) to auto&&!
+    [[nodiscard]] decltype(auto) await_resume()
+    {
+        if constexpr (SameAs<T, void>)
+            return;
+        else
+            return static_cast<T&&>(*return_value());
+    }
+
+private:
+    template<typename U>
+    friend struct Detail::TryAwaiter;
+
+    // You cannot just have return_value and return_void defined in the same promise type because C++.
+    struct CoroutinePromiseBase {
+        CoroutinePromiseBase() = default;
+
+        Coroutine get_return_object()
+        {
+            return { std::coroutine_handle<promise_type>::from_promise(*static_cast<promise_type*>(this)) };
+        }
+
+        Detail::SuspendNever initial_suspend() { return {}; }
+
+        Detail::SymmetricControlTransfer final_suspend() noexcept
+        {
+            return { m_awaiter };
+        }
+
+        std::coroutine_handle<> m_awaiter;
+        Coroutine* m_coroutine { nullptr };
+    };
+
+    struct CoroutinePromiseValue : CoroutinePromiseBase {
+        template<typename U>
+        requires requires { { T(forward<U>(declval<U>())) }; }
+        void return_value(U&& returned_object)
+        {
+            new (this->m_coroutine->return_value()) T(forward<U>(returned_object));
+        }
+
+        void return_value(T&& returned_object)
+        {
+            new (this->m_coroutine->return_value()) T(move(returned_object));
+        }
+    };
+
+    struct CoroutinePromiseVoid : CoroutinePromiseBase {
+        void return_void() { }
+    };
+
+    Coroutine(std::coroutine_handle<promise_type>&& handle)
+        : m_handle(move(handle))
+    {
+        m_handle.promise().m_coroutine = this;
+    }
+
+    T* return_value()
+    {
+        return reinterpret_cast<T*>(this->m_return_value);
+    }
+
+    std::coroutine_handle<promise_type> m_handle;
+};
+
+template<typename T>
+T must_sync(Coroutine<ErrorOr<T>>&& coroutine)
+{
+    VERIFY(coroutine.await_ready());
+    auto&& object = coroutine.await_resume();
+    VERIFY(!object.is_error());
+    return object.release_value();
+}
+
+namespace Detail {
+template<typename T>
+struct TryAwaiter {
+    TryAwaiter(T& expression)
+    requires(!IsSpecializationOf<T, Coroutine>)
+        : m_expression(&expression)
+    {
+    }
+
+    TryAwaiter(T&& expression)
+    requires(!IsSpecializationOf<T, Coroutine>)
+        : m_expression(&expression)
+    {
+    }
+
+    bool await_ready() { return false; }
+
+    template<typename U>
+    requires IsSpecializationOf<T, ErrorOr>
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<U> handle)
+    {
+        if (!m_expression->is_error()) {
+            return handle;
+        } else {
+            auto awaiter = handle.promise().m_awaiter;
+            auto* coroutine = handle.promise().m_coroutine;
+            using ReturnType = RemoveReference<decltype(*coroutine)>::ReturnType;
+            static_assert(IsSpecializationOf<ReturnType, ErrorOr>,
+                "CO_TRY can only be used inside functions returning a specialization of ErrorOr");
+
+            // Move error to the user-visible AK::Coroutine
+            new (coroutine->return_value()) ReturnType(m_expression->release_error());
+            // ... and tell it that there's a result available.
+            coroutine->m_handle = {};
+
+            // Run destructors for locals in the coroutine that failed.
+            handle.destroy();
+
+            // Lastly, transfer control to the parent (or nothing, if parent is not yet suspended).
+            if (awaiter)
+                return awaiter;
+            return std::noop_coroutine();
+        }
+    }
+
+    decltype(auto) await_resume()
+    {
+        return m_expression->release_value();
+    }
+
+    T* m_expression { nullptr };
+};
+}
+
+#ifdef AK_COMPILER_CLANG
+#    define CO_TRY(expression) (co_await ::AK::Detail::TryAwaiter { (expression) })
+#else
+// GCC cannot handle CO_TRY(...CO_TRY(...)...), this hack ensures that it always has the right type information available.
+// FIXME: Remove this once GCC can correctly infer the result type of `co_await TryAwaiter { ... }`.
+#    define CO_TRY(expression) static_cast<decltype(AK::Detail::declval_coro_result(expression).release_value())>(co_await ::AK::Detail::TryAwaiter { (expression) })
+
+namespace Detail {
+template<typename T>
+auto declval_coro_result(Coroutine<T>&&) -> T;
+template<typename T>
+auto declval_coro_result(T&&) -> T;
+}
+
+#endif
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::Coroutine;
+#endif

--- a/AK/Coroutine.h
+++ b/AK/Coroutine.h
@@ -13,6 +13,17 @@
 namespace AK {
 
 namespace Detail {
+
+// FIXME: GCC ICEs when a simpler implementation of CO_TRY_OR_FAIL is used. See also LibTest/AsyncTestCase.h.
+#ifdef AK_COMPILER_GCC
+namespace Test {
+
+template<typename T>
+struct TryOrFailAwaiter;
+
+}
+#endif
+
 struct SuspendNever {
     // Even though we set -fno-exceptions, Clang really wants these to be noexcept.
     bool await_ready() const noexcept { return true; }
@@ -105,6 +116,11 @@ public:
 private:
     template<typename U>
     friend struct Detail::TryAwaiter;
+
+#ifdef AK_COMPILER_GCC
+    template<typename U>
+    friend struct AK::Detail::Test::TryOrFailAwaiter;
+#endif
 
     // You cannot just have return_value and return_void defined in the same promise type because C++.
     struct CoroutinePromiseBase {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -20,6 +20,9 @@ class ByteBuffer;
 
 enum class TrailingCodePointTransformation : u8;
 
+class AsyncInputStream;
+class AsyncOutputStream;
+class AsyncStream;
 class BigEndianInputBitStream;
 class BigEndianOutputBitStream;
 class Bitmap;
@@ -154,6 +157,9 @@ class [[nodiscard]] ErrorOr;
 
 #if USING_AK_GLOBALLY
 using AK::Array;
+using AK::AsyncInputStream;
+using AK::AsyncOutputStream;
+using AK::AsyncStream;
 using AK::Atomic;
 using AK::Badge;
 using AK::BigEndianInputBitStream;

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -26,6 +26,8 @@ class Bitmap;
 using ByteBuffer = Detail::ByteBuffer<32>;
 class CircularBuffer;
 class ConstrainedStream;
+template<typename T>
+class Coroutine;
 class CountingStream;
 class DeprecatedFlyString;
 class ByteString;
@@ -163,6 +165,7 @@ using AK::ByteString;
 using AK::CircularBuffer;
 using AK::CircularQueue;
 using AK::ConstrainedStream;
+using AK::Coroutine;
 using AK::CountingStream;
 using AK::DeprecatedFlyString;
 using AK::DeprecatedStringCodePointIterator;

--- a/AK/Generator.h
+++ b/AK/Generator.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Coroutine.h>
+#include <AK/Variant.h>
+
+namespace AK {
+
+namespace Detail {
+class YieldAwaiter {
+public:
+    YieldAwaiter(std::coroutine_handle<> control_transfer, std::coroutine_handle<>& awaiter)
+        : m_control_transfer(control_transfer)
+        , m_awaiter(awaiter)
+    {
+    }
+
+    bool await_ready() const { return false; }
+
+    auto await_suspend(std::coroutine_handle<> handle)
+    {
+        m_awaiter = handle;
+        return m_control_transfer;
+    }
+
+    void await_resume() { }
+
+private:
+    std::coroutine_handle<> m_control_transfer;
+    std::coroutine_handle<>& m_awaiter;
+};
+}
+
+template<typename Y, typename R>
+class [[nodiscard]] Generator {
+    struct GeneratorPromiseType;
+
+    AK_MAKE_NONCOPYABLE(Generator);
+
+public:
+    using YieldType = Y;
+    using ReturnType = R;
+    using promise_type = GeneratorPromiseType;
+
+    ~Generator()
+    {
+        destroy_stored_object();
+        if (m_handle)
+            m_handle.destroy();
+    }
+
+    Generator(Generator&& other)
+    {
+        m_handle = AK::exchange(other.m_handle, {});
+        m_read_returned_object = exchange(other.m_read_returned_object, false);
+
+        m_currently_stored_type = other.m_currently_stored_type;
+        if (m_currently_stored_type == CurrentlyStoredType::Yield) {
+            new (m_data) YieldType(move(*reinterpret_cast<YieldType*>(other.m_data)));
+        } else if (m_currently_stored_type == CurrentlyStoredType::Return) {
+            new (m_data) ReturnType(move(*reinterpret_cast<ReturnType*>(other.m_data)));
+        }
+        other.destroy_stored_object();
+
+        if (m_handle)
+            m_handle.promise().m_coroutine = this;
+    }
+
+    Generator& operator=(Generator&& other)
+    {
+        if (this != &other) {
+            this->~Generator();
+            new (this) Generator(move(other));
+        }
+        return *this;
+    }
+
+    bool is_done() const { return !m_handle || m_handle.done(); }
+
+    void destroy()
+    {
+        VERIFY(m_handle && !m_handle.promise().m_awaiter);
+        destroy_stored_object();
+        m_handle.destroy();
+        m_handle = {};
+    }
+
+    Coroutine<Variant<Y, R>> next()
+    {
+        if (!is_done()) {
+            VERIFY(m_currently_stored_type != CurrentlyStoredType::Return);
+            co_await Detail::YieldAwaiter { m_handle, m_handle.promise().m_awaiter };
+            if (m_handle)
+                m_handle.promise().m_awaiter = {};
+        }
+
+        if (is_done()) {
+            VERIFY(m_currently_stored_type == CurrentlyStoredType::Return && !m_read_returned_object);
+            m_read_returned_object = true;
+            co_return move(*reinterpret_cast<ReturnType*>(m_data));
+        } else {
+            VERIFY(m_currently_stored_type == CurrentlyStoredType::Yield);
+            co_return move(*reinterpret_cast<YieldType*>(m_data));
+        }
+    }
+
+private:
+    template<typename U>
+    friend struct Detail::TryAwaiter;
+
+    struct GeneratorPromiseType {
+        Generator get_return_object()
+        {
+            return { std::coroutine_handle<promise_type>::from_promise(*this) };
+        }
+
+        Detail::SuspendAlways initial_suspend() { return {}; }
+
+        Detail::SymmetricControlTransfer final_suspend() noexcept
+        {
+            VERIFY(m_awaiter);
+            return { m_awaiter };
+        }
+
+        template<typename U>
+        requires requires { { T(forward<U>(declval<U>())) }; }
+        void return_value(U&& returned_object)
+        {
+            m_coroutine->place_returned_object(forward<U>(returned_object));
+        }
+
+        void return_value(ReturnType&& returned_object)
+        {
+            m_coroutine->place_returned_object(move(returned_object));
+        }
+
+        Detail::SymmetricControlTransfer yield_value(YieldType&& yield_value)
+        {
+            m_coroutine->place_yield_object(move(yield_value));
+            VERIFY(m_awaiter);
+            return { m_awaiter };
+        }
+
+        std::coroutine_handle<> m_awaiter;
+        Generator* m_coroutine { nullptr }; // Must be named `m_coroutine` for CO_TRY to work
+    };
+
+    Generator(std::coroutine_handle<promise_type>&& handle)
+        : m_handle(move(handle))
+    {
+        m_handle.promise().m_coroutine = this;
+    }
+
+    void destroy_stored_object()
+    {
+        switch (m_currently_stored_type) {
+        case CurrentlyStoredType::Empty:
+            break;
+        case CurrentlyStoredType::Yield:
+            reinterpret_cast<YieldType*>(m_data)->~YieldType();
+            break;
+        case CurrentlyStoredType::Return:
+            reinterpret_cast<ReturnType*>(m_data)->~ReturnType();
+            break;
+        }
+        m_currently_stored_type = CurrentlyStoredType::Empty;
+    }
+
+    template<typename... Args>
+    YieldType* place_yield_object(Args&&... args)
+    {
+        destroy_stored_object();
+        m_currently_stored_type = CurrentlyStoredType::Yield;
+        return new (m_data) YieldType(forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    ReturnType* place_returned_object(Args&&... args)
+    {
+        destroy_stored_object();
+        m_currently_stored_type = CurrentlyStoredType::Return;
+        return new (m_data) ReturnType(forward<Args>(args)...);
+    }
+
+    ReturnType* return_value() // Must be defined for CO_TRY.
+    {
+        destroy_stored_object();
+        m_currently_stored_type = CurrentlyStoredType::Return;
+        return reinterpret_cast<ReturnType*>(m_data);
+    }
+
+    std::coroutine_handle<promise_type> m_handle;
+
+    enum class CurrentlyStoredType {
+        Empty,
+        Yield,
+        Return,
+    } m_currently_stored_type
+        = CurrentlyStoredType::Empty;
+    bool m_read_returned_object { false };
+    alignas(max(alignof(YieldType), alignof(ReturnType))) u8 m_data[max(sizeof(YieldType), sizeof(ReturnType))];
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::Generator;
+#endif

--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -209,6 +209,9 @@ template ErrorOr<u32> GenericLexer::consume_decimal_integer<u32>();
 template ErrorOr<i32> GenericLexer::consume_decimal_integer<i32>();
 template ErrorOr<u64> GenericLexer::consume_decimal_integer<u64>();
 template ErrorOr<i64> GenericLexer::consume_decimal_integer<i64>();
+#ifdef AK_OS_MACOS
+template ErrorOr<size_t> GenericLexer::consume_decimal_integer<size_t>();
+#endif
 
 #ifndef KERNEL
 Optional<ByteString> GenericLexer::consume_and_unescape_string(char escape_char)

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -143,7 +143,7 @@ template<typename T, typename U = T>
 constexpr T exchange(T& slot, U&& value)
 {
     T old_value = move(slot);
-    slot = forward<U>(value);
+    slot = AK::forward<U>(value);
     return old_value;
 }
 

--- a/Documentation/AsynchronousDesign.md
+++ b/Documentation/AsynchronousDesign.md
@@ -1,0 +1,111 @@
+# Coroutines and asynchronous streams
+
+## Asynchronous resources
+
+`AK::AsyncResource` class represents a generic resource (e. g. POSIX file descriptor, AsyncStream, HTTP response body) with a failible and/or asynchronous destructor. As an example of such destructor, an asynchronous socket might want to wait for all outstanding transfers to complete and want to notify the calling code if the server acknowledged all buffered writes.
+
+When working with AsyncResource, the only thing you should pay attention to is not leaving the resource open when you are done with it. This is important both for consistency and for not signaling spurious end-of-data errors to the other party. This close/reset hygiene is not hard to achieve in practice: every AsyncResource is automatically reset during destruction and some resources reset on any error returned by any of their interfaces.
+
+The above means that the following snippet is correct:
+```cpp
+Coroutine<ErrorOr<void>> do_very_meaningful_work()
+{
+    Core::AsyncTCPSocket socket = make_me_a_socket();
+    // Core::AsyncTCPSocket is AK::AsyncStream (which is itself an AsyncResource, obviously), which
+    // exhibits reset-on-error behavior.
+    auto object = CO_TRY(co_await socket.read_object<VeryImportantObject>());
+    auto response = CO_TRY(process_object(object));
+    CO_TRY(co_await socket.write(response));
+    CO_TRY(co_await socket.close());
+}
+```
+and will send a TCP RST if any of the functions (including `process_object`) fails and will close the socket gracefully if everything goes well.
+
+Of course, automatic-reset-on-destruction does not always get rid of explicit resets. If asynchronous resource is not local to a fallible function, you will have to call reset manually in case of errors, i. e.
+```cpp
+Coroutine<ErrorOr<void>> do_very_meaningful_work_second_time(AsyncStream& stream)
+{
+    auto object = CO_TRY(co_await stream.read_object<VeryImportantObject>());
+    auto response_or_error = process_object(object);
+    if (response_or_error.is_error()) {
+        stream.reset();
+        co_return response_or_error.release_error();
+    }
+    CO_TRY(co_await stream.write(response_or_error.release_value()));
+}
+```
+
+It might be tempting to just do nothing with a stream in this situation. However, this will leave the  stream in an unknown state if the function fails, which would necessitate `stream->is_open()` checks later on in the caller (because doing pretty much anything with a closed stream asserts).
+
+As mentioned in the previous paragraph, in addition to `close` and `reset` methods, resources have an `is_open` method which checks if the resource has already been closed or reset (either explicitly or implicitly by a failed method). `is_open` state cannot change by itself with time (i. e. if a server sends RST when nobody is listening the socket)&mdash;one has to call a method on a resource for `open` state to change.
+
+## Input streams
+
+`AK::AsyncInputStream` is a base class for all asynchronous input streams.
+
+Every AsyncInputStream is effectively buffered by design. This means that all input streams have an internal read buffer to which data is read and references to which are returned from `peek` and `read` in the form of ReadonlyBytes.
+
+Typical workflow with AsyncInputStream consists of a number of peeks (until the caller finds what they are looking for in the stream) followed by a read that removes just-peeked object from the buffer.
+
+The following example reads an object of an unknown size from the stream:
+```cpp
+Coroutine<ErrorOr<VeryImportantObject>> read_some_very_important_object(AsyncInputStream& stream)
+{
+    size_t byte_size;
+    while (true) {
+        auto bytes = CO_TRY(co_await stream.peek());
+        Optional<size_t> maybe_size = figure_out_size_from_prefix(bytes);
+        if (maybe_size.has_value()) {
+            // Yay! We read enough to figure out how long the object is.
+            byte_size = maybe_size.value();
+            break;
+        }
+    }
+
+    auto bytes = CO_TRY(co_await stream.read(byte_size));
+    auto object_or_error = parse_object_from_data(bytes);
+    if (object_or_error.is_error()) {
+        stream.reset();
+        co_return object_or_error.release_error();
+    }
+    co_return object_or_error.release_value();
+}
+```
+
+Of course, if we know size upfront, reading stuff from a stream is as easy as `stream->read(size)`.
+
+> [!IMPORTANT]
+> Note that you should never peek more than is absolutely necessary.
+
+More formally, you should ensure the following: at the time of `read`, let $(s_1, s_2, ..., s_n)$ be a sequence of lengths of ReadonlyBytes views returned from `peek` or `peek_or_eof` since the last read (or since the creation of the stream, if there were no previous reads). If $n \le 1$, then any length is allowed. Otherwise, if $n > 1$, $s_{n - 1}$ MUST NOT be greater than `bytes` parameter. Moreover, if the stream data does not have sub-byte structure and EOF has not been reached, `bytes` SHOULD be greater than $s_{n - 1}$. While the said condition might seem arbitrary, violation of it almost always indicates a bug in the caller's code. The asynchronous streams framework doesn't guarantee linear asymptotic runtime complexity in the case of length condition violation.
+
+It is not hard to fulfill the condition in practice. For example, in the `read_some_very_important_object` example, the condition just requires `figure_out_size_from_prefix` to figure out size if the object is already fully inside `bytes` parameter.
+
+Note that `read` always returns exactly `bytes` bytes. If `bytes` is larger than $s_n$ or $n$ is 0, `read` will return more data than previously peeked (by reading the stream, obviously).
+
+If your use-case doesn't require the knowledge of EOF location (i. e. you know how much to read upfront without relying on EOF), then just use `peek`, `read`, and `close` in the end (if you own the stream, of course). `peek` or `read` will reset the stream and error out if input ended prematurely because of EOF. Likewise, `close` will error out if the data is left after the stream supposedly should have been fully read. EIO is returned for the unexpected stream end and EBUSY&mdash;for not reading the whole stream.
+
+For the EOF-aware applications, AsyncInputStream provides `peek_or_eof`. In contrast to `peek`, `peek_or_eof` returns an additional flag indicating if EOF has been reached. Note that the EOF detection is similar to POSIX streams: first, `peek_or_eof` returns data up to EOF without `is_eof` flag being set, and then, on the next call, it returns the same data with `is_eof` flag set.
+
+As an example, let us abuse the said functionality of `peek_or_eof` to implement a completely reliable `is_eof` for an asynchronous stream:
+```cpp
+Coroutine<ErrorOr<bool>> accurate_is_eof(AsyncInputStream& stream) {
+    auto [_, is_eof] = CO_TRY(co_await stream.peek_or_eof());
+    must_sync(stream.read(0));
+    co_return is_eof;
+}
+```
+
+You might notice a seemingly useless read of 0 bytes here. Why do we need it? Well, let us remove it and consider the case when we have a stream with an empty buffer and a single byte left overall. `peek_or_eof` will return that byte without `is_eof` flag set, so `accurate_is_eof` returns false. Next, someone tries to peek that byte with a plain `peek` that will in turn call `peek_or_eof`, which now _will_ set the `is_eof` flag. The flag will then be checked by `peek` and the stream will error out with EIO.
+
+Therefore,
+> [!IMPORTANT]
+> If you peek something from a stream, you should read it.
+
+What follows is a more formal specification of `peek`, `peek_or_eof`, and `read` behavior. The implementation of them might seem simple but it has a lot of conceptual complexity packed into it.
+
+Each `peek_or_eof` call is classified as either reading or non-reading peek. Reading peeks always read new data, while non-reading peeks only do so when there's no data available in the buffer. In the former case, non-reading peek is called a no-op peek and, in the later case, peek is called a promoted peek. Peek occurring after another peek is always a reading peek while a peek occurring just after `read` call is non-reading. Note that this gives rise to the aforementioned length condition: peek, in some way, is always a request for new unseen data, and an unnecessary peek can, for example, unintentionally read EOF and error out.
+
+Promoted and reading peeks read data from the underlying stream and check if EOF has been encountered (i. e. read returned 0 new bytes). If it was not, peek adds read data to the buffer. Finally, regardless of its type, peek returns a view to the buffer.
+
+Calling `peek` when the EOF has been reached as well as calling `read` that tries to read past EOF is a protocol violation and results in EIO error. Note that EIO (just like any other error) causes the stream to reset, so if one attempts to continue reading from the stream, it will assert. Next, calling read operations concurrently asserts since it is a logic error. And finally, calling `peek`, `peek_or_eof`, or `read` on a stream that isn't open is a logic error as well and asserts too.

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -34,6 +34,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     add_compile_options(-Wno-implicit-const-int-float-conversion)
     add_compile_options(-Wno-user-defined-literals)
     add_compile_options(-Wno-vla-cxx-extension)
+    add_compile_options(-Wno-coroutine-missing-unhandled-exception)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
     add_compile_options(-Wno-expansion-to-defined)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -637,6 +637,7 @@ if (BUILD_LAGOM)
             LibCompress
             LibGL
             LibGfx
+            LibHTTP
             LibIMAP
             LibLocale
             LibMarkdown

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -35,6 +35,7 @@ set(AK_TEST_SOURCES
     TestFlyString.cpp
     TestFormat.cpp
     TestFuzzyMatch.cpp
+    TestGeneratorAK.cpp
     TestGenericLexer.cpp
     TestHashFunctions.cpp
     TestHashMap.cpp

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -20,6 +20,7 @@ set(AK_TEST_SOURCES
     TestCircularDeque.cpp
     TestCircularQueue.cpp
     TestComplex.cpp
+    TestCoroutine.cpp
     TestDisjointChunks.cpp
     TestDistinctNumeric.cpp
     TestDoublyLinkedList.cpp

--- a/Tests/AK/TestCoroutine.cpp
+++ b/Tests/AK/TestCoroutine.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Coroutine.h>
+#include <LibCore/EventLoop.h>
+#include <LibTest/TestCase.h>
+
+namespace {
+Coroutine<int> id(int a)
+{
+    co_return a;
+}
+
+Coroutine<int> sum(int a, int b)
+{
+    int c = co_await id(a);
+    int d = co_await id(b);
+    co_return c + d;
+}
+}
+
+TEST_CASE(no_spin)
+{
+    auto coro = sum(2, 3);
+    EXPECT(coro.await_ready());
+    EXPECT_EQ(coro.await_resume(), 5);
+}
+
+namespace {
+struct LoopSpinner {
+    bool await_ready() const { return false; }
+    void await_suspend(std::coroutine_handle<> awaiter)
+    {
+        Core::deferred_invoke([awaiter] {
+            awaiter.resume();
+        });
+    }
+    void await_resume() { }
+};
+
+Coroutine<int> loop_spinner()
+{
+    co_await LoopSpinner {};
+    co_return 42;
+}
+
+Coroutine<ErrorOr<int>> failing_loop_spinner()
+{
+    co_await LoopSpinner {};
+    co_return Error::from_errno(ENOMEM);
+}
+
+Coroutine<int> two_level_loop_spinner()
+{
+    EXPECT_EQ(co_await loop_spinner(), 42);
+    co_return 43;
+}
+}
+
+TEST_CASE(loop_spinners)
+{
+    EXPECT_EQ(Core::run_async_in_new_event_loop(loop_spinner), 42);
+    EXPECT_EQ(Core::run_async_in_new_event_loop(failing_loop_spinner).error().code(), ENOMEM);
+    EXPECT_EQ(Core::run_async_in_new_event_loop(two_level_loop_spinner), 43);
+}
+
+namespace {
+Coroutine<int> spinner1(Vector<int>& result)
+{
+    result.append(1);
+    co_await LoopSpinner {};
+    result.append(2);
+    co_return 3;
+}
+
+Coroutine<int> spinner2(Vector<int>& result)
+{
+    result.append(4);
+    co_await LoopSpinner {};
+    result.append(5);
+    co_return 6;
+}
+
+Coroutine<Vector<int>> interleaved()
+{
+    Vector<int> result;
+
+    result.append(7);
+    auto coro1 = spinner1(result);
+    result.append(8);
+    auto coro2 = spinner2(result);
+    result.append(9);
+
+    result.append(co_await coro2);
+    result.append(co_await coro1);
+
+    co_return result;
+}
+}
+
+TEST_CASE(interleaved_coroutines)
+{
+    EXPECT_EQ(Core::run_async_in_new_event_loop(interleaved), (Vector { 7, 1, 8, 4, 9, 2, 5, 6, 3 }));
+}
+
+namespace {
+Coroutine<void> void_coro(int& result)
+{
+    result = 45;
+    co_return;
+}
+}
+
+TEST_CASE(void_coro)
+{
+    int result = 0;
+    auto coro = void_coro(result);
+    EXPECT(coro.await_ready());
+    EXPECT_EQ(result, 45);
+}
+
+namespace {
+Coroutine<void> destructors_inner(Vector<int>& order)
+{
+    ScopeGuard guard = [&] {
+        order.append(1);
+    };
+    co_await LoopSpinner {};
+    order.append(2);
+    co_return;
+}
+
+Coroutine<Vector<int>> destructors_outer()
+{
+    Vector<int> order;
+    order.append(3);
+    co_await destructors_inner(order);
+    order.append(4);
+    co_return order;
+}
+}
+
+TEST_CASE(destructors_order)
+{
+    EXPECT_EQ(Core::run_async_in_new_event_loop(destructors_outer), (Vector { 3, 2, 1, 4 }));
+}
+
+namespace {
+class Class {
+    AK_MAKE_NONCOPYABLE(Class);
+
+public:
+    Class()
+        : m_cookie(1)
+    {
+    }
+
+    ~Class()
+    {
+        VERIFY(m_cookie >= 0);
+        m_cookie = -1;
+        AK::taint_for_optimizer(m_cookie);
+    }
+
+    Class(Class&& other)
+    {
+        VERIFY(other.m_cookie >= 0);
+        m_cookie = exchange(other.m_cookie, 0) + 1;
+        AK::taint_for_optimizer(m_cookie);
+    }
+
+    Class& operator=(Class&& other) = delete;
+
+    int cookie() { return m_cookie; }
+
+private:
+    int m_cookie;
+};
+
+Coroutine<Class> return_class_1()
+{
+    co_await LoopSpinner {};
+    co_return {};
+}
+
+Coroutine<Class> return_class_2()
+{
+    co_await LoopSpinner {};
+    Class c;
+    co_return c;
+}
+
+Coroutine<ErrorOr<Class>> return_class_3()
+{
+    co_await LoopSpinner {};
+    co_return Class {};
+}
+
+Coroutine<void> move_count()
+{
+    {
+        auto c = co_await return_class_1();
+        // 1. Construct temporary as an argument for return_value.
+        // 2. Move this temporary into Coroutine.
+        // 3. Move class from Coroutine to local variable.
+        EXPECT_EQ(c.cookie(), 3);
+    }
+
+    {
+        auto c = co_await return_class_2();
+        // 1. Construct new class and store it as a local variable.
+        // 2. Move this temporary into Coroutine.
+        // 3. Move class from Coroutine to local variable.
+        EXPECT_EQ(c.cookie(), 3);
+    }
+
+    {
+        auto c_or_error = co_await return_class_3();
+        auto c = c_or_error.release_value();
+        // 1. Construct temporary as an argument for the constructor of a temporary ErrorOr<Class>.
+        // 2. Move temporary ErrorOr<Class> into Coroutine.
+        // 3. Move ErrorOr<Class> from Coroutine to c_or_error.
+        // 4. Move Class from c_or_error to c.
+        EXPECT_EQ(c.cookie(), 4);
+    }
+}
+}
+
+TEST_CASE(move_count)
+{
+    Core::run_async_in_new_event_loop(move_count);
+}
+
+namespace {
+Coroutine<ErrorOr<void>> co_try_success()
+{
+    auto c = CO_TRY(co_await return_class_3());
+    // 1. Construct temporary as an argument for the constructor of a temporary ErrorOr<Class>.
+    // 2. Move temporary ErrorOr<Class> into Coroutine.
+    // -. Some magic is done in TryAwaiter.
+    // 3. Move Class from ErrorOr<Class> inside Coroutine to c.
+    EXPECT_EQ(c.cookie(), 3);
+    co_return {};
+}
+
+Coroutine<ErrorOr<void>> co_try_fail()
+{
+    ErrorOr<void> error = Error::from_string_literal("ERROR!");
+    CO_TRY(error);
+    co_return {};
+}
+
+Coroutine<ErrorOr<void>> co_try_fail_inner()
+{
+    co_await LoopSpinner {};
+    co_return Error::from_string_literal("ERROR!");
+}
+
+Coroutine<ErrorOr<void>> co_try_fail_async()
+{
+    CO_TRY(co_await co_try_fail_inner());
+    co_return {};
+}
+}
+
+TEST_CASE(co_try)
+{
+    {
+        auto result = Core::run_async_in_new_event_loop(co_try_success);
+        EXPECT(!result.is_error());
+    }
+
+    {
+        auto result = Core::run_async_in_new_event_loop(co_try_fail);
+        EXPECT(result.is_error());
+    }
+
+    {
+        auto result = Core::run_async_in_new_event_loop(co_try_fail_async);
+        EXPECT(result.is_error());
+    }
+}
+
+namespace {
+Coroutine<void> nothing() { co_return; }
+}
+
+TEST_CASE(move_void_coroutine)
+{
+    auto void_coro = nothing();
+    auto moved = move(void_coro);
+    EXPECT(moved.await_ready());
+}

--- a/Tests/AK/TestGeneratorAK.cpp
+++ b/Tests/AK/TestGeneratorAK.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Generator.h>
+#include <LibTest/AsyncTestCase.h>
+
+namespace {
+
+Generator<int, Empty> generate_sync(Vector<int>& order)
+{
+    ScopeGuard guard = [&] {
+        order.append(7);
+    };
+
+    order.append(2);
+    co_yield 1;
+    order.append(4);
+    co_yield 2;
+    order.append(6);
+    co_return {};
+}
+
+}
+
+ASYNC_TEST_CASE(sync_order)
+{
+    Vector<int> order;
+
+    auto gen = generate_sync(order);
+    EXPECT(!gen.is_done());
+
+    order.append(1);
+
+    auto result1 = gen.next();
+    order.append(3);
+    EXPECT(result1.await_ready());
+    EXPECT_EQ(result1.await_resume(), 1);
+
+    auto result2 = gen.next();
+    order.append(5);
+    EXPECT(result2.await_ready());
+    EXPECT_EQ(result2.await_resume(), 2);
+
+    auto end = gen.next();
+    order.append(8);
+    EXPECT(end.await_ready());
+    EXPECT_EQ(end.await_resume(), Empty {});
+
+    EXPECT_EQ(order, (Vector<int> { 1, 2, 3, 4, 5, 6, 7, 8 }));
+    co_return;
+}

--- a/Tests/LibHTTP/CMakeLists.txt
+++ b/Tests/LibHTTP/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(TEST_SOURCES
+    TestHttp11Connection.cpp
+)
+
+foreach(source IN LISTS TEST_SOURCES)
+    serenity_test("${source}" LibHTTP LIBS LibHTTP)
+endforeach()

--- a/Tests/LibHTTP/TestHttp11Connection.cpp
+++ b/Tests/LibHTTP/TestHttp11Connection.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/AsyncStreamHelpers.h>
+#include <LibHTTP/Http11Connection.h>
+#include <LibTest/AsyncTestCase.h>
+#include <LibTest/AsyncTestStreams.h>
+
+struct HTTPUnitTest {
+    StringView name;
+    HTTP::Method method;
+    StringView url;
+    Vector<HTTP::Header> headers;
+    StringView response;
+
+    StringView request_expectation;
+    StringView body_expectation;
+};
+
+Vector<HTTPUnitTest> const http_unit_tests = {
+    {
+        .name = "Basic"sv,
+        .method = HTTP::Method::GET,
+        .url = "/"sv,
+        .headers = {
+            { "Host", "localhost" },
+        },
+        .response = "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 16\r\n"
+                    "\r\n"
+                    "0123456789abcdef"sv,
+        .request_expectation = "GET / HTTP/1.1\r\n"
+                               "Host: localhost\r\n"
+                               "\r\n"sv,
+        .body_expectation = "0123456789abcdef"sv,
+    },
+};
+
+ASYNC_TEST_CASE(unit_tests_single)
+{
+    for (auto const& test : http_unit_tests) {
+        outln("Running '{}'...", test.name);
+
+        auto response_partitioning = Test::randomly_partition_input(1, AK::get_random_uniform(50) + 1, test.response.length());
+        outln("Input partitioning: {}", response_partitioning);
+        auto input = make<Test::AsyncMemoryInputStream>(test.response, Test::StreamCloseExpectation::Close, move(response_partitioning));
+        auto output = make<Test::AsyncMemoryOutputStream>(Test::StreamCloseExpectation::Close);
+
+        auto output_ref = output.ptr();
+
+        auto stream_pair = make<AsyncStreamPair>(move(input), move(output));
+        auto connection = make<HTTP::Http11Connection>(move(stream_pair));
+
+        CO_TRY_OR_FAIL(co_await connection->request(
+            {
+                .method = test.method,
+                .url = test.url,
+                .headers = test.headers,
+            },
+            [&](HTTP::Http11Response& response) -> Coroutine<ErrorOr<void>> {
+                auto body = CO_TRY(co_await Test::read_until_eof(response.body()));
+                EXPECT_EQ(StringView { body }, test.body_expectation);
+                co_return {};
+            }));
+
+        CO_TRY_OR_FAIL(co_await connection->close());
+
+        EXPECT_EQ(StringView { output_ref->view() }, test.request_expectation);
+    }
+}

--- a/Tests/LibHTTP/TestHttp11Connection.cpp
+++ b/Tests/LibHTTP/TestHttp11Connection.cpp
@@ -37,6 +37,27 @@ Vector<HTTPUnitTest> const http_unit_tests = {
                                "\r\n"sv,
         .body_expectation = "0123456789abcdef"sv,
     },
+    {
+        .name = "Chunked"sv,
+        .method = HTTP::Method::GET,
+        .url = "/"sv,
+        .headers = {
+            { "Host", "localhost" },
+        },
+        .response = "HTTP/1.1 200 OK\r\n"
+                    "Transfer-Encoding: chunked\r\n"
+                    "\r\n"
+                    "18\r\n"
+                    "0123456789abcdef\r\n\r\n"
+                    "19\r\n"
+                    "Well hello friends!\r\n"
+                    "0\r\n"
+                    "\r\n"sv,
+        .request_expectation = "GET / HTTP/1.1\r\n"
+                               "Host: localhost\r\n"
+                               "\r\n"sv,
+        .body_expectation = "0123456789abcdef\r\nWell hello friends!"sv,
+    },
 };
 
 ASYNC_TEST_CASE(unit_tests_single)

--- a/Tests/LibTest/CMakeLists.txt
+++ b/Tests/LibTest/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestAsyncTestStreams.cpp
     TestNoCrash.cpp
     TestGenerator.cpp
 )

--- a/Tests/LibTest/TestAsyncTestStreams.cpp
+++ b/Tests/LibTest/TestAsyncTestStreams.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/AsyncTestCase.h>
+#include <LibTest/AsyncTestStreams.h>
+
+ASYNC_TEST_CASE(input_basic)
+{
+    Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Close, { 1, 2, 2 });
+
+    auto first_letter_coro = stream.read(1);
+    EXPECT(first_letter_coro.await_ready());
+
+    auto first_letter_view = CO_TRY_OR_FAIL(co_await first_letter_coro);
+    EXPECT_EQ(StringView { first_letter_view }, "h"sv);
+
+    auto next_letters_coro = stream.read(3);
+    EXPECT(!next_letters_coro.await_ready());
+
+    auto next_letters_view = CO_TRY_OR_FAIL(co_await next_letters_coro);
+    EXPECT_EQ(StringView { next_letters_view }, "ell"sv);
+
+    auto last_letter_coro = stream.peek_or_eof();
+    EXPECT(last_letter_coro.await_ready());
+
+    auto [last_letter_view, is_eof_1] = CO_TRY_OR_FAIL(co_await last_letter_coro);
+    EXPECT_EQ(StringView { last_letter_view }, "o"sv);
+    EXPECT(!is_eof_1);
+
+    auto o_again = CO_TRY_OR_FAIL(co_await stream.read(1));
+    EXPECT_EQ(StringView { o_again }, "o"sv);
+
+    auto [empty_view, is_eof_2] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+    EXPECT(empty_view.is_empty());
+    EXPECT(is_eof_2);
+
+    CO_TRY_OR_FAIL(co_await stream.close());
+}
+
+ASYNC_TEST_CASE(input_eof_read)
+{
+    Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Close, { 5 });
+
+    auto [hello, is_eof_1] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+    EXPECT_EQ(StringView { hello }, "hello"sv);
+    EXPECT(!is_eof_1);
+
+    auto [also_hello, is_eof_2] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+    EXPECT_EQ(StringView { also_hello }, "hello"sv);
+    EXPECT(is_eof_2);
+
+    auto [hello_one_more_time, is_eof_3] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+    EXPECT_EQ(StringView { hello_one_more_time }, "hello"sv);
+    EXPECT(is_eof_3);
+
+    auto hello_for_the_final_time = CO_TRY_OR_FAIL(co_await stream.read(5));
+    EXPECT_EQ(StringView { hello_for_the_final_time }, "hello"sv);
+
+    CO_TRY_OR_FAIL(co_await stream.close());
+}
+
+ASYNC_TEST_CASE(input_eof_read_2)
+{
+    Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Close, { 0, 5 });
+
+    auto [hello, is_eof_1] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+    EXPECT_EQ(StringView { hello }, "hello"sv);
+    EXPECT(!is_eof_1);
+
+    auto hello_again = must_sync(stream.read(5));
+    EXPECT_EQ(StringView { hello_again }, "hello"sv);
+
+    auto [not_hello, is_eof_2] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+    EXPECT(not_hello.is_empty());
+    EXPECT(is_eof_2);
+
+    must_sync(stream.read(0));
+
+    for (int i = 0; i < 2; ++i) {
+        auto [not_hello_2, is_eof_3] = CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+        EXPECT(not_hello_2.is_empty());
+        EXPECT(is_eof_3);
+    }
+
+    CO_TRY_OR_FAIL(co_await stream.close());
+}
+
+// FIXME: Maybe add some kind of intentionally failing tests?
+ASYNC_TEST_CASE(input_unexpected_operations)
+{
+    {
+        Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Close, { 5 });
+    }
+    VERIFY(Test::current_test_result() == Test::TestResult::Failed);
+    Test::set_current_test_result(Test::TestResult::NotRun);
+
+    {
+        Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 5 });
+    }
+    VERIFY(Test::current_test_result() == Test::TestResult::NotRun);
+
+    {
+        Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Close, { 1, 1, 1, 1, 1 });
+        auto view = CO_TRY_OR_FAIL(co_await stream.read(5));
+        EXPECT_EQ(StringView { view }, "hello"sv);
+        CO_TRY_OR_FAIL(co_await stream.close());
+    }
+    VERIFY(Test::current_test_result() == Test::TestResult::NotRun);
+
+    {
+        Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Close, { 1, 1, 1, 1, 1 });
+        (void)co_await stream.close();
+    }
+    VERIFY(Test::current_test_result() == Test::TestResult::Failed);
+    Test::set_current_test_result(Test::TestResult::NotRun);
+
+    {
+        Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 1, 1, 1, 1, 1 });
+        stream.reset();
+    }
+    VERIFY(Test::current_test_result() == Test::TestResult::NotRun);
+}
+
+ASYNC_TEST_CASE(input_reset_during_wait)
+{
+    Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 0, 5 });
+
+    auto read_coro = stream.read(5);
+    EXPECT(!read_coro.await_ready());
+
+    stream.reset();
+
+    auto error = co_await read_coro;
+    EXPECT_EQ(error.error().code(), ECANCELED);
+}
+
+TEST_CASE(input_crash)
+{
+    EXPECT_CRASH("input_concurrent_reads", [] -> Test::Crash::Failure {
+        Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 0, 5 });
+
+        auto read_coro1 = stream.read(2);
+        if (read_coro1.await_ready()) {
+            // NOTE: Intentionally don't run destructors.
+            _exit(0);
+        }
+
+        auto read_coro2 = stream.read(3);
+        _exit(0);
+    });
+
+    EXPECT_CRASH("input_peek_read_condition_violation", [] {
+        auto coro = [] -> Coroutine<void> {
+            Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 2, 1, 1, 1 });
+
+            auto peek_view_1 = CO_TRY_OR_FAIL(co_await stream.peek());
+            if (peek_view_1.size() != 2)
+                co_return;
+
+            auto peek_view_2 = CO_TRY_OR_FAIL(co_await stream.peek());
+            if (peek_view_2.size() != 3)
+                co_return;
+
+            auto peek_view_3 = CO_TRY_OR_FAIL(co_await stream.peek());
+            if (peek_view_3.size() != 4)
+                co_return;
+
+            (void)co_await stream.read(2);
+        };
+        Core::run_async_in_new_event_loop(coro);
+        return Test::Crash::Failure::DidNotCrash;
+    });
+
+    EXPECT_CRASH("one_less_than_eof", ([] {
+        auto coro = [] -> Coroutine<void> {
+            Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 5 });
+
+            CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+            CO_TRY_OR_FAIL(co_await stream.peek_or_eof());
+            CO_TRY_OR_FAIL(co_await stream.read(4));
+            _exit(0);
+        };
+        Core::run_async_in_new_event_loop(coro);
+        return Test::Crash::Failure::DidNotCrash;
+    }));
+}
+
+ASYNC_TEST_CASE(input_close_ebusy)
+{
+    Test::AsyncMemoryInputStream stream("hello"sv, Test::StreamCloseExpectation::Reset, { 5 });
+    auto error = co_await stream.close();
+    EXPECT_EQ(error.error().code(), EBUSY);
+}
+
+ASYNC_TEST_CASE(output_basic)
+{
+    Test::AsyncMemoryOutputStream stream(Test::StreamCloseExpectation::Close);
+
+    CO_TRY_OR_FAIL(co_await stream.write({ {
+        "Consider a non-trivial loop $\\alpha$ in $\\R P^2$ "sv.bytes(),
+        "and $f \\circ \\alpha$. $[f \\circ \\alpha]$ maps to some integer "sv.bytes(),
+    } }));
+
+    size_t nwritten = CO_TRY_OR_FAIL(co_await stream.write_some("$n$ from a fundamental group $\\pi_1(S^1)$."sv.bytes()));
+    EXPECT_EQ(nwritten, 42uz);
+
+    auto sentence = "Consider a non-trivial loop $\\alpha$ in $\\R P^2$ and $f \\circ \\alpha$. $[f \\circ \\alpha]$ maps to some integer $n$ from a fundamental group $\\pi_1(S^1)$."sv;
+    EXPECT_EQ(sentence, StringView { stream.view() });
+
+    CO_TRY_OR_FAIL(co_await stream.close());
+}

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Forward.h>
 #include <AK/Function.h>
 #include <AK/Noncopyable.h>
@@ -102,5 +103,17 @@ private:
 };
 
 void deferred_invoke(ESCAPING Function<void()>);
+
+template<typename T>
+requires(IsSpecializationOf<InvokeResult<T&>, Coroutine>)
+auto run_async_in_new_event_loop(T&& function)
+{
+    Core::EventLoop loop;
+    auto coro = function();
+    loop.spin_until([&] {
+        return coro.await_ready();
+    });
+    return coro.await_resume();
+}
 
 }

--- a/Userland/Libraries/LibHTTP/CMakeLists.txt
+++ b/Userland/Libraries/LibHTTP/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    Http11Connection.cpp
     HttpRequest.cpp
     HttpResponse.cpp
     HttpsJob.cpp

--- a/Userland/Libraries/LibHTTP/Http11Connection.cpp
+++ b/Userland/Libraries/LibHTTP/Http11Connection.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/AsyncStreamHelpers.h>
+#include <AK/GenericLexer.h>
+#include <LibHTTP/Http11Connection.h>
+
+namespace HTTP {
+
+namespace {
+StringView method_name(Method method)
+{
+    switch (method) {
+#define CASE(x)     \
+    case Method::x: \
+        return #x##sv;
+        ENUMERATE_METHODS(CASE)
+#undef CASE
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+ByteBuffer format_request(RequestData const& data)
+{
+    StringBuilder builder;
+
+    builder.append(method_name(data.method));
+    builder.append(' ');
+    builder.append(data.url);
+    builder.append(" HTTP/1.1\r\n"sv);
+
+    for (auto const& [name, value] : data.headers) {
+        builder.append(name);
+        builder.append(": "sv);
+        builder.append(value);
+        builder.append("\r\n"sv);
+    }
+    builder.append("\r\n"sv);
+
+    return MUST(builder.to_byte_buffer());
+}
+
+struct StatusCodeAndHeaders {
+    u16 status_code;
+    Vector<Header> headers;
+};
+
+Coroutine<ErrorOr<StatusCodeAndHeaders>> receive_response_headers(AsyncStream& stream)
+{
+    auto status_line = CO_TRY(co_await AsyncStreamHelpers::consume_until(stream, "\r\n"sv));
+
+    GenericLexer status_lexer { StringView { status_line } };
+    if (!status_lexer.next_is("HTTP/1.1 ")) {
+        stream.reset();
+        co_return Error::from_string_literal("HTTP-version must be 'HTTP/1.1'");
+    }
+    status_lexer.consume(9);
+
+    auto status_code = status_lexer.consume_decimal_integer<u16>();
+    if (status_code.is_error()) {
+        stream.reset();
+        co_return Error::from_string_literal("Invalid HTTP status code");
+    }
+
+    Vector<Header> headers;
+    while (true) {
+        auto header = StringView { CO_TRY(co_await AsyncStreamHelpers::consume_until(stream, "\r\n"sv)) };
+        if (header == "\r\n"sv)
+            break;
+
+        auto colon_position = header.find(':');
+        if (!colon_position.has_value()) {
+            stream.reset();
+            co_return Error::from_string_literal("':' must be present in a header line");
+        }
+
+        headers.append({
+            .header = header.substring_view(0, colon_position.value()),
+            .value = header.substring_view(colon_position.value() + 1).trim_whitespace(),
+        });
+    }
+
+    co_return StatusCodeAndHeaders {
+        .status_code = status_code.value(),
+        .headers = headers,
+    };
+}
+}
+
+Coroutine<ErrorOr<NonnullOwnPtr<Http11Response>>> Http11Response::create(Badge<Http11Connection>, RequestData&& data, AsyncStream& stream)
+{
+    auto header = format_request(data);
+
+    if (data.body.has<Empty>()) {
+        CO_TRY(co_await stream.write({ { header } }));
+    } else if (data.body.has<RequestData::PlainBody>()) {
+        auto& body = data.body.get<RequestData::PlainBody>().data;
+        CO_TRY(co_await stream.write({ { header, body.bytes() } }));
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+
+    auto [status_code, headers] = CO_TRY(co_await receive_response_headers(stream));
+
+    Optional<size_t> content_length;
+    for (auto const& header : headers) {
+        if (header.header.equals_ignoring_ascii_case("Content-Length"sv)) {
+            content_length = header.value.to_number<size_t>();
+        }
+    }
+
+    if (!content_length.has_value()) {
+        stream.reset();
+        co_return Error::from_string_literal("'Content-Length' must be provided");
+    }
+
+    auto body = make<AsyncInputStreamSlice>(stream, content_length.value());
+
+    co_return adopt_own(*new (nothrow) Http11Response(move(body), status_code, move(headers)));
+}
+
+}

--- a/Userland/Libraries/LibHTTP/Http11Connection.h
+++ b/Userland/Libraries/LibHTTP/Http11Connection.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AsyncStream.h>
+#include <AK/ByteString.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/TemporaryChange.h>
+#include <AK/Vector.h>
+
+namespace HTTP {
+
+class Http11Connection;
+class Http11Response;
+
+#define ENUMERATE_METHODS(F) \
+    F(Invalid)               \
+    F(HEAD)                  \
+    F(GET)                   \
+    F(POST)                  \
+    F(DELETE)                \
+    F(PATCH)                 \
+    F(OPTIONS)               \
+    F(TRACE)                 \
+    F(CONNECT)               \
+    F(PUT)
+
+enum class Method {
+#define ID(x) x,
+    ENUMERATE_METHODS(ID)
+#undef ID
+};
+
+struct Header {
+    ByteString header;
+    ByteString value;
+};
+
+struct RequestData {
+    struct PlainBody {
+        StringView data;
+    };
+
+    Method method;
+    StringView url;
+    Vector<Header> headers;
+    Variant<Empty, PlainBody> body = Empty {};
+};
+
+class Http11Response final : public StreamWrapper<AsyncInputStream> {
+public:
+    static Coroutine<ErrorOr<NonnullOwnPtr<Http11Response>>> create(Badge<Http11Connection>, RequestData&& data, AsyncStream& stream);
+
+    u16 status_code() const { return m_status_code; }
+    Vector<Header> const& headers() const { return m_headers; }
+
+    AsyncInputStream& body() { return *m_stream; }
+
+private:
+    Http11Response(NonnullOwnPtr<AsyncInputStream>&& body, u16 status_code, Vector<Header>&& headers)
+        : StreamWrapper(move(body))
+        , m_status_code(status_code)
+        , m_headers(move(headers))
+    {
+    }
+
+    u16 m_status_code { 0 };
+    Vector<Header> m_headers;
+};
+
+class Http11Connection final : public StreamWrapper<AsyncStream> {
+public:
+    using StreamWrapper::StreamWrapper;
+
+    template<
+        typename Func,
+        typename T = InvokeResult<Func, Http11Response&>::ReturnType::ResultType>
+    Coroutine<ErrorOr<T>> request(RequestData&& data, Func&& func)
+    {
+        VERIFY(!m_request_in_flight);
+        TemporaryChange request_in_flight { m_request_in_flight, true };
+
+        auto response = CO_TRY(co_await Http11Response::create({}, move(data), *m_stream));
+        auto result = co_await func(*response);
+        if (response->is_open()) {
+            auto close_result = co_await response->close();
+            if (!result.is_error()) // Preserve callback error in case it has failed.
+                CO_TRY(close_result);
+        }
+        co_return result;
+    }
+
+private:
+    bool m_request_in_flight { false };
+};
+
+}

--- a/Userland/Libraries/LibTest/AsyncTestCase.h
+++ b/Userland/Libraries/LibTest/AsyncTestCase.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Coroutine.h>
+#include <LibCore/EventLoop.h>
+#include <LibTest/TestCase.h>
+
+#ifdef AK_COMPILER_GCC
+namespace AK::Detail::Test {
+
+// FIXME: Straight-forward way to implement CO_TRY_OR_FAIL we use for Clang causes GCC to ICE.
+template<typename T>
+struct TryOrFailAwaiter {
+    TryOrFailAwaiter(T& expression)
+        : m_expression(&expression)
+    {
+    }
+
+    TryOrFailAwaiter(T&& expression)
+        : m_expression(&expression)
+    {
+    }
+
+    TryOrFailAwaiter(Coroutine<T>&&)
+    {
+        static_assert(DependentFalse<T>, "Despite the CO_ prefix in CO_TRY_OR_FAIL, you should co_await the argument of it.");
+    }
+
+    bool await_ready() { return false; }
+
+    template<typename U>
+    requires IsSpecializationOf<T, ErrorOr>
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<U> handle)
+    {
+        if (!m_expression->is_error()) {
+            return handle;
+        } else {
+            auto awaiter = handle.promise().m_awaiter;
+            auto* coroutine = handle.promise().m_coroutine;
+            using ReturnType = RemoveReference<decltype(*coroutine)>::ReturnType;
+            static_assert(SameAs<ReturnType, void>,
+                "CO_TRY_OR_FAIL can only be used inside ASYNC_TEST_CASE functions");
+
+            // Fail the current test.
+            FAIL(m_expression->release_error());
+
+            // Forcefully stop coroutine.
+            coroutine->m_handle = {};
+
+            // Run destructors for locals in the coroutine that failed.
+            handle.destroy();
+
+            // Lastly, transfer control to the parent (or nothing, if parent is not yet suspended).
+            if (awaiter)
+                return awaiter;
+            return std::noop_coroutine();
+        }
+    }
+
+    decltype(auto) await_resume()
+    {
+        return m_expression->release_value();
+    }
+
+    T* m_expression { nullptr };
+};
+
+}
+#endif
+
+namespace Test {
+
+#define __ASYNC_TESTCASE_FUNC(x) __async_test_##x
+
+#define ASYNC_TEST_CASE(x)                                                                           \
+    static Coroutine<void> __ASYNC_TESTCASE_FUNC(x)();                                               \
+                                                                                                     \
+    static void __TESTCASE_FUNC(x)()                                                                 \
+    {                                                                                                \
+        Core::run_async_in_new_event_loop(__ASYNC_TESTCASE_FUNC(x));                                 \
+    }                                                                                                \
+                                                                                                     \
+    struct __TESTCASE_TYPE(x) {                                                                      \
+        __TESTCASE_TYPE(x)                                                                           \
+        ()                                                                                           \
+        {                                                                                            \
+            add_test_case_to_suite(adopt_ref(*new ::Test::TestCase(#x, __TESTCASE_FUNC(x), false))); \
+        }                                                                                            \
+    };                                                                                               \
+    static struct __TESTCASE_TYPE(x) __TESTCASE_TYPE(x);                                             \
+    static Coroutine<void> __ASYNC_TESTCASE_FUNC(x)()
+
+#ifdef AK_COMPILER_GCC
+#    define CO_TRY_OR_FAIL(expression) (co_await ::AK::Detail::Test::TryOrFailAwaiter { (expression) })
+#else
+#    define CO_TRY_OR_FAIL(expression)                                                                   \
+        ({                                                                                               \
+            /* Ignore -Wshadow to allow nesting the macro. */                                            \
+            AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
+                auto _temporary_result = (expression));                                                  \
+            static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+                "Do not return a reference from a fallible expression");                                 \
+            if (_temporary_result.is_error()) [[unlikely]] {                                             \
+                FAIL(_temporary_result.release_error());                                                 \
+                co_return;                                                                               \
+            }                                                                                            \
+            _temporary_result.release_value();                                                           \
+        })
+#endif
+
+}

--- a/Userland/Libraries/LibTest/AsyncTestStreams.cpp
+++ b/Userland/Libraries/LibTest/AsyncTestStreams.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Random.h>
+#include <LibTest/AsyncTestStreams.h>
+
+namespace Test {
+
+static auto s_deferred_context = Core::DeferredInvocationContext::construct();
+
+struct Spinner {
+    Spinner(std::coroutine_handle<>& awaiter)
+        : m_awaiter(awaiter)
+    {
+        VERIFY(!m_awaiter);
+    }
+
+    bool await_ready() const { return false; }
+
+    void await_suspend(std::coroutine_handle<> awaiter)
+    {
+        m_awaiter = awaiter;
+        Core::ThreadEventQueue::current().post_event(
+            s_deferred_context,
+            make<Core::DeferredInvocationEvent>(s_deferred_context, [&] {
+                m_awaiter.resume();
+            }));
+    }
+
+    void await_resume() { m_awaiter = {}; }
+
+    std::coroutine_handle<>& m_awaiter;
+};
+
+AsyncMemoryInputStream::AsyncMemoryInputStream(StringView data, StreamCloseExpectation expectation, Vector<size_t>&& chunks)
+    : m_data(data)
+    , m_expectation(expectation)
+    , m_chunks(move(chunks))
+    , m_peek_head(m_chunks[0])
+{
+    size_t accumulator = 0;
+    for (auto& value : m_chunks) {
+        accumulator += value;
+        value = accumulator;
+    }
+    VERIFY(accumulator == m_data.length());
+}
+
+AsyncMemoryInputStream::~AsyncMemoryInputStream()
+{
+    // 1. Assert that nobody is awaiting on the resource.
+    VERIFY(!m_awaiter);
+
+    // 2. If resource is open, perform Reset AO.
+    if (is_open())
+        reset();
+
+    if (m_expectation == StreamCloseExpectation::Reset) {
+        EXPECT(m_is_reset);
+    } else if (m_expectation == StreamCloseExpectation::Close) {
+        EXPECT(m_is_closed);
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void AsyncMemoryInputStream::reset()
+{
+    // 1. Assert that the resource is open.
+    VERIFY(is_open());
+
+    // 2. Perform Reset AO.
+    //     1. Schedule returning an error (preferably, ECANCELED) from the current resource awaiters.
+    //     2. Ensure that further attempts to wait on a resource will assert.
+    m_is_reset = true;
+
+    //     3. Free synchronously the associated low-level resource.
+
+    //     4. Return synchronously.
+}
+
+Coroutine<ErrorOr<void>> AsyncMemoryInputStream::close()
+{
+    // 1. Assert that the object is fully constructed.
+    // 2. Assert that the resource is open.
+    VERIFY(is_open());
+
+    // 3. Perform Close AO, await and return its result.
+    //     1. Assert that nobody is awaiting on a resource.
+    VERIFY(!m_awaiter);
+
+    //     3. Shutdown (possibly asynchronously) the associated low-level resource.
+
+    //     4. Check if the state of the resource is clean. If it is not, call Reset AO and return an
+    //        error (preferably, EBUSY).
+    if (m_read_head != m_data.length()) {
+        reset();
+        co_return Error::from_errno(EBUSY);
+    }
+
+    //     2. Ensure that further attempts to wait on a resource will assert.
+    m_is_closed = true;
+
+    //     5. Free (possibly asynchronously) the associated low-level resource.
+    //     6. Return success.
+    co_return {};
+}
+
+bool AsyncMemoryInputStream::is_open() const
+{
+    return !m_is_closed && !m_is_reset;
+}
+
+Coroutine<ErrorOr<bool>> AsyncMemoryInputStream::enqueue_some(Badge<AsyncInputStream>)
+{
+    if (m_next_chunk_index == m_chunks.size()) {
+        m_last_enqueue = m_peek_head;
+        co_return false;
+    }
+
+    co_await Spinner { m_awaiter };
+    if (m_is_reset)
+        co_return Error::from_errno(ECANCELED);
+
+    m_last_enqueue = m_peek_head;
+    m_peek_head = m_chunks[m_next_chunk_index++];
+    co_return true;
+}
+
+ReadonlyBytes AsyncMemoryInputStream::buffered_data_unchecked(Badge<AsyncInputStream>) const
+{
+    return m_data.bytes().slice(m_read_head, m_peek_head - m_read_head);
+}
+
+void AsyncMemoryInputStream::dequeue(Badge<AsyncInputStream>, size_t bytes)
+{
+    m_read_head += bytes;
+    VERIFY(m_last_enqueue <= m_read_head && m_read_head <= m_peek_head);
+}
+
+AsyncMemoryOutputStream::AsyncMemoryOutputStream(StreamCloseExpectation expectation)
+    : m_expectation(expectation)
+{
+}
+
+AsyncMemoryOutputStream::~AsyncMemoryOutputStream()
+{
+    if (is_open())
+        reset();
+
+    if (m_expectation == StreamCloseExpectation::Reset) {
+        EXPECT(m_is_reset);
+    } else if (m_expectation == StreamCloseExpectation::Close) {
+        EXPECT(m_is_closed);
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void AsyncMemoryOutputStream::reset()
+{
+    VERIFY(is_open());
+    m_is_reset = true;
+}
+
+Coroutine<ErrorOr<void>> AsyncMemoryOutputStream::close()
+{
+    VERIFY(is_open());
+    m_is_closed = true;
+    co_return {};
+}
+
+bool AsyncMemoryOutputStream::is_open() const
+{
+    return !m_is_closed && !m_is_reset;
+}
+
+Coroutine<ErrorOr<size_t>> AsyncMemoryOutputStream::write_some(ReadonlyBytes data)
+{
+    VERIFY(is_open());
+    m_buffer.append(data);
+    co_return data.size();
+}
+
+Coroutine<ErrorOr<ReadonlyBytes>> read_until_eof(AsyncInputStream& stream)
+{
+    size_t previously_returned_size = 0;
+    while (true) {
+        auto [data, is_eof] = CO_TRY(co_await stream.peek_or_eof());
+
+        EXPECT(is_eof || previously_returned_size < data.size());
+        previously_returned_size = data.size();
+
+        if (is_eof) {
+            auto result = must_sync(stream.read(data.size()));
+
+            // Poke stream one more time just to be sure :^)
+            auto [empty_data, set_eof_flag] = CO_TRY(co_await stream.peek_or_eof());
+            EXPECT(empty_data.is_empty());
+            EXPECT(set_eof_flag);
+
+            co_return result;
+        }
+    }
+}
+
+Vector<size_t> randomly_partition_input(u32 partition_probability_numerator, u32 partition_probability_denominator, size_t length)
+{
+    Vector<size_t> result { 0 };
+    for (size_t i = 0; i < length; ++i) {
+        if (AK::get_random_uniform(partition_probability_denominator) < partition_probability_numerator) {
+            result.append(1);
+        } else {
+            ++result.last();
+        }
+    }
+    return result;
+}
+
+}

--- a/Userland/Libraries/LibTest/AsyncTestStreams.h
+++ b/Userland/Libraries/LibTest/AsyncTestStreams.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AsyncStream.h>
+#include <LibCore/Event.h>
+#include <LibCore/ThreadEventQueue.h>
+#include <LibTest/Macros.h>
+
+namespace Test {
+
+enum class StreamCloseExpectation {
+    Reset,
+    Close,
+};
+
+class AsyncMemoryInputStream final : public AsyncInputStream {
+public:
+    AsyncMemoryInputStream(StringView data, StreamCloseExpectation expectation, Vector<size_t>&& chunks);
+    ~AsyncMemoryInputStream();
+
+    void reset() override;
+    Coroutine<ErrorOr<void>> close() override;
+    bool is_open() const override;
+
+    Coroutine<ErrorOr<bool>> enqueue_some(Badge<AsyncInputStream>) override;
+    ReadonlyBytes buffered_data_unchecked(Badge<AsyncInputStream>) const override;
+    void dequeue(Badge<AsyncInputStream>, size_t bytes) override;
+
+private:
+    StringView m_data;
+    StreamCloseExpectation m_expectation;
+    Vector<size_t> m_chunks;
+
+    bool m_is_closed { false };
+    bool m_is_reset { false };
+
+    bool m_encountered_eof { false };
+    size_t m_read_head { 0 };
+    size_t m_peek_head { 0 };
+    size_t m_next_chunk_index { 1 };
+
+    size_t m_last_enqueue { 0 };
+
+    std::coroutine_handle<> m_awaiter;
+};
+
+class AsyncMemoryOutputStream final : public AsyncOutputStream {
+public:
+    // FIXME: Support artificial atomic write limits similar to `chunks` parameter in
+    //        AsyncMemoryInputStream.
+    AsyncMemoryOutputStream(StreamCloseExpectation expectation);
+    ~AsyncMemoryOutputStream();
+
+    void reset() override;
+    Coroutine<ErrorOr<void>> close() override;
+    bool is_open() const override;
+
+    Coroutine<ErrorOr<size_t>> write_some(ReadonlyBytes data) override;
+
+    ReadonlyBytes view() const { return m_buffer; }
+
+private:
+    StreamCloseExpectation m_expectation;
+
+    bool m_is_closed { false };
+    bool m_is_reset { false };
+
+    ByteBuffer m_buffer;
+};
+
+Coroutine<ErrorOr<ReadonlyBytes>> read_until_eof(AsyncInputStream& stream);
+Vector<size_t> randomly_partition_input(u32 partition_probability_numerator, u32 partition_probability_denominator, size_t length);
+
+}

--- a/Userland/Libraries/LibTest/CMakeLists.txt
+++ b/Userland/Libraries/LibTest/CMakeLists.txt
@@ -1,11 +1,13 @@
 serenity_install_sources("Userland/Libraries/LibTest")
 
 set(SOURCES
+    AsyncTestStreams.cpp
     TestSuite.cpp
     CrashTest.cpp
 )
 
 serenity_lib(LibTest test)
+target_link_libraries(LibTest PRIVATE LibCore)
 
 add_library(LibTestMain OBJECT TestMain.cpp)
 add_library(JavaScriptTestRunnerMain OBJECT JavaScriptTestRunnerMain.cpp)


### PR DESCRIPTION
You thought you mastered idiosyncrasies of AK::Stream? This PR gets you covered by adding a similar but completely unrelated way of doing datastreams.

You thought you figured out how to write event-driven asynchronous code in Serenity? This PR gets you covered by adding a similar but subtly different way for dealing with asynchronousness.

You thought you knew how and when lifetimes are ended? This PR gets you covered by complicating things so much you would start to question your C++ skills.

You thought you knew how to read backtraces in GDB? This PR gets you covered by converting backtraces into an unreadable mess ~~going both in call-stack and reverse call-stack directions while~~ interleaving actual calls with visual clutter.

You thought you knew what I would upstream first? This PR gets you covered by choosing a different subset of features to contribute.

------

As much as I would like to leave only the first 5 sentences in the PR description, I guess I have to properly explain some things here. So, I think coroutines are ready to be experimented on in tree. Thus, this PR implements `AK::Coroutine`, defines and gives an extremely detailed description of `AK::Async{Input,Output,}Stream`s interfaces, and implements a very bare-bones fully asynchronous HTTP/1.1 client.

In order to prove that the architecture I chose for asynchronous streams is adequate, I've implemented a variety of streams, stream adapters, and stream wrappers, including but not limiting to `AK::AsyncLexingAdapter` for consuming data until a predefined delimiter, `AK::AsyncInputStreamSlice` for treating a prefix of the stream with some predefined length as a stream by itself, `Test::AsyncMemory{Input,Output}Stream` for treating memory locations as streams, `HTTP::(anonymous namespace)::ChunkedBodyStream` for treating a `Transfer-Encoding: chunked`-encoded HTTP response body as a stream, and (not present in this PR) `AK::AsyncInputStreamLegacyTransform` for treating an asynchronous stream transformed by legacy `AK::Stream` as asynchronous stream. All of these classes have a very simple and (after you spend dozens of hours using `AK::Coroutine`) intuitive implementations. Therefore, I don't expect the fundamental design of streams to change much anymore.

I know, however, that there are a few minor deficiencies in the current asynchronous framework. ~~Namely, asynchronous input streams are basically asynchronous generators and it would be very inconvenient and error-prone to write more complicated transformations as hand-unrolled state machines (you can see what I mean by looking at ChunkedBodyStream and comment just above its `enqueue_some`). Additionally, current lockless design of `AsyncOutputStream::write` won't work for HTTP/2. However, these two problems can be dealt with later without significant changes to the code I add in this PR.~~ Generated streams have been implemented. However, I now think that AsyncOutputStream design is just plain wrong, but again, it can be improved later.

Note that this PR doesn't contain asynchronous TCP socket as it requires a bit more work in general and Serenity lacks necessary runtime functions to support it. This doesn't mean that the code here can't be tested -- Test::Async{Input,Output}Stream combined using `AK::AsyncStreamPair` work well as a replacement for socket in tests (and actually allow proper unit testing of HTTP code).