### PR TITLE
Utilities: Support reading arbitrarily long lines

### DIFF
--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -130,7 +130,7 @@ static bool expand_list(ByteString& list, Vector<Range>& ranges)
 static void process_line_bytes(StringView line, Vector<Range> const& ranges)
 {
     for (auto& i : ranges) {
-        if (i.m_from >= line.length())
+        if (i.m_from > line.length())
             continue;
 
         auto to = min(i.m_to, line.length());
@@ -143,7 +143,7 @@ static void process_line_bytes(StringView line, Vector<Range> const& ranges)
 static void process_line_characters(StringView line, Vector<Range> const& ranges)
 {
     for (auto const& range : ranges) {
-        if (range.m_from >= line.length())
+        if (range.m_from > line.length())
             continue;
 
         auto s = String::from_utf8(line).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -271,10 +271,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         auto file = TRY(Core::InputBufferedFile::create(maybe_file.release_value()));
 
-        Array<u8, PAGE_SIZE> buffer;
-        while (TRY(file->can_read_line())) {
-            auto line = TRY(file->read_line(buffer));
-            if (line == "\n" && TRY(file->can_read_line()))
+        auto buffer = TRY(ByteBuffer::create_uninitialized(PAGE_SIZE));
+        while (!file->is_eof()) {
+            auto line = TRY(file->read_line_with_resize(buffer));
+            if (line.is_empty() && file->is_eof())
                 break;
 
             if (selected_bytes) {


### PR DESCRIPTION
This PR adds support for reading arbitrarily long lines in the `comm`, `cut`, `grep` and `sed` utilities.

Previously, these utilities wouldn't behave correctly when working with input containing lines longer than 4KiB.

I've also included a drive-by commit to fix an off-by-one error in `cut`, which led to the last character on each line being skipped when the `-b` or `-c` option was used.