### PR TITLE
LibWeb: Implement Document.dir

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Document-dir.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-dir.txt
@@ -1,0 +1,6 @@
+String
+document.dir = ''
+document.dir = 'ltr'
+document.dir = 'rtl'
+document.dir = 'auto'
+document.dir = ''

--- a/Tests/LibWeb/Text/input/DOM/Document-dir.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-dir.html
@@ -1,0 +1,15 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(document.dir.constructor.name);
+        println(`document.dir = '${document.dir}'`);
+        document.dir = 'ltr';
+        println(`document.dir = '${document.dir}'`);
+        document.dir = 'rtl';
+        println(`document.dir = '${document.dir}'`);
+        document.dir = 'auto';
+        println(`document.dir = '${document.dir}'`);
+        document.dir = 'unknown';
+        println(`document.dir = '${document.dir}'`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -760,6 +760,28 @@ JS::GCPtr<HTML::HTMLTitleElement> Document::title_element()
     return title_element;
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#dom-document-dir
+StringView Document::dir() const
+{
+    // The dir IDL attribute on Document objects must reflect the dir content attribute of the html
+    // element, if any, limited to only known values. If there is no such element, then the
+    // attribute must return the empty string and do nothing on setting.
+    if (auto html = html_element())
+        return html->dir();
+
+    return ""sv;
+}
+
+// https://html.spec.whatwg.org/multipage/dom.html#dom-document-dir
+void Document::set_dir(String const& dir)
+{
+    // The dir IDL attribute on Document objects must reflect the dir content attribute of the html
+    // element, if any, limited to only known values. If there is no such element, then the
+    // attribute must return the empty string and do nothing on setting.
+    if (auto html = html_element())
+        html->set_dir(dir);
+}
+
 HTML::HTMLElement* Document::body()
 {
     auto* html = html_element();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -175,6 +175,10 @@ public:
     HTML::HTMLHtmlElement* html_element();
     HTML::HTMLHeadElement* head();
     JS::GCPtr<HTML::HTMLTitleElement> title_element();
+
+    StringView dir() const;
+    void set_dir(String const&);
+
     HTML::HTMLElement* body();
 
     HTML::HTMLHtmlElement const* html_element() const

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -111,6 +111,7 @@ interface Document : Node {
     readonly attribute DocumentType? doctype;
 
     readonly attribute Element? documentElement;
+    [CEReactions] attribute DOMString dir;
     [CEReactions] attribute HTMLElement? body;
     readonly attribute HTMLHeadElement? head;
     readonly attribute HTMLScriptElement? currentScript;


### PR DESCRIPTION
This was seen getting called on stuff.co.nz and resulting in an exception getting thrown due to no String being returned (before ladybird crashes later on due to an unrelated navigation bug) https://github.com/SerenityOS/serenity/issues/24198