### PR TITLE
LibJS: Join locals, constants and registers into single vector

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1624,7 +1624,10 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
 
             // iii. Perform ! env.InitializeBinding(fn, fo). NOTE: This step is replaced in section B.3.2.6.
             if (function_declaration.name_identifier()->is_local()) {
-                vm.running_execution_context().local(function_declaration.name_identifier()->local_variable_index()) = function;
+                auto& running_execution_context = vm.running_execution_context();
+                auto number_of_registers = running_execution_context.executable->number_of_registers;
+                auto number_of_constants = running_execution_context.executable->constants.size();
+                running_execution_context.local(function_declaration.name_identifier()->local_variable_index() + number_of_registers + number_of_constants) = function;
             } else {
                 VERIFY(is<DeclarativeEnvironment>(*environment));
                 static_cast<DeclarativeEnvironment&>(*environment).initialize_or_set_mutable_binding({}, vm, function_declaration.name(), function);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -42,6 +42,22 @@ void Instruction::visit_labels(Function<void(JS::Bytecode::Label&)> visitor)
 #undef __BYTECODE_OP
 }
 
+void Instruction::visit_operands(Function<void(JS::Bytecode::Operand&)> visitor)
+{
+#define __BYTECODE_OP(op)                                               \
+    case Type::op:                                                      \
+        static_cast<Op::op&>(*this).visit_operands_impl(move(visitor)); \
+        return;
+
+    switch (type()) {
+        ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+#undef __BYTECODE_OP
+}
+
 template<typename Op>
 concept HasVariableLength = Op::IsVariableLength;
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -157,6 +157,7 @@ public:
     size_t length() const;
     ByteString to_byte_string(Bytecode::Executable const&) const;
     void visit_labels(Function<void(Label&)> visitor);
+    void visit_operands(Function<void(Operand&)> visitor);
     static void destroy(Instruction&);
 
 protected:
@@ -166,6 +167,7 @@ protected:
     }
 
     void visit_labels_impl(Function<void(Label&)>) { }
+    void visit_operands_impl(Function<void(Operand&)>) { }
 
 private:
     Type m_type {};

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -49,11 +49,11 @@ public:
     ALWAYS_INLINE Value& saved_return_value() { return reg(Register::saved_return_value()); }
     Value& reg(Register const& r)
     {
-        return m_registers.data()[r.index()];
+        return m_registers_and_constants_and_locals.data()[r.index()];
     }
     Value reg(Register const& r) const
     {
-        return m_registers.data()[r.index()];
+        return m_registers_and_constants_and_locals.data()[r.index()];
     }
 
     [[nodiscard]] Value get(Operand) const;
@@ -77,9 +77,6 @@ public:
     Executable const& current_executable() const { return *m_current_executable; }
     Optional<size_t> program_counter() const { return m_program_counter; }
 
-    Vector<Value>& registers() { return vm().running_execution_context().registers; }
-    Vector<Value> const& registers() const { return vm().running_execution_context().registers; }
-
     ExecutionContext& running_execution_context() { return *m_running_execution_context; }
 
 private:
@@ -99,9 +96,7 @@ private:
     GCPtr<DeclarativeEnvironment> m_global_declarative_environment { nullptr };
     Optional<size_t&> m_program_counter;
     Span<Value> m_arguments;
-    Span<Value> m_registers;
-    Span<Value> m_locals;
-    Span<Value> m_constants;
+    Span<Value> m_registers_and_constants_and_locals;
     ExecutionContext* m_running_execution_context { nullptr };
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -43,6 +43,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
 private:
     Operand m_dst;
@@ -82,6 +86,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_src);
+    }
 
     Operand dst() const { return m_dst; }
     Operand src() const { return m_src; }
@@ -130,6 +139,12 @@ private:
                                                                             \
         ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const; \
         ByteString to_byte_string_impl(Bytecode::Executable const&) const;  \
+        void visit_operands_impl(Function<void(Operand&)> visitor)          \
+        {                                                                   \
+            visitor(m_dst);                                                 \
+            visitor(m_lhs);                                                 \
+            visitor(m_rhs);                                                 \
+        }                                                                   \
                                                                             \
         Operand dst() const { return m_dst; }                               \
         Operand lhs() const { return m_lhs; }                               \
@@ -164,6 +179,11 @@ JS_ENUMERATE_COMMON_BINARY_OPS_WITH_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
                                                                             \
         ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const; \
         ByteString to_byte_string_impl(Bytecode::Executable const&) const;  \
+        void visit_operands_impl(Function<void(Operand&)> visitor)          \
+        {                                                                   \
+            visitor(m_dst);                                                 \
+            visitor(m_src);                                                 \
+        }                                                                   \
                                                                             \
         Operand dst() const { return m_dst; }                               \
         Operand src() const { return m_src; }                               \
@@ -186,6 +206,10 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -206,6 +230,10 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
     StringTableIndex source_index() const { return m_source_index; }
@@ -234,6 +262,10 @@ private:
                                                                            \
         void execute_impl(Bytecode::Interpreter&) const;                   \
         ByteString to_byte_string_impl(Bytecode::Executable const&) const; \
+        void visit_operands_impl(Function<void(Operand&)> visitor)         \
+        {                                                                  \
+            visitor(m_dst);                                                \
+        }                                                                  \
                                                                            \
         Operand dst() const { return m_dst; }                              \
         StringTableIndex error_string() const { return m_error_string; }   \
@@ -263,6 +295,13 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_from_object);
+        for (size_t i = 0; i < m_excluded_names_count; i++)
+            visitor(m_excluded_names[i]);
+    }
 
     size_t length_impl() const
     {
@@ -304,6 +343,12 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        for (size_t i = 0; i < m_element_count; i++)
+            visitor(m_elements[i]);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -340,6 +385,10 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
     ReadonlySpan<Value> elements() const { return { m_elements, m_element_count }; }
@@ -377,6 +426,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_src);
+    }
 
     Operand dst() const { return m_dst; }
     Operand src() const { return m_src; }
@@ -400,6 +454,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_specifier);
+        visitor(m_options);
+    }
 
     Operand dst() const { return m_dst; }
     Operand specifier() const { return m_specifier; }
@@ -426,6 +486,12 @@ public:
     Operand dst() const { return m_dst; }
     Operand iterator() const { return m_iterator; }
 
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_iterator);
+    }
+
 private:
     Operand m_dst;
     Operand m_iterator;
@@ -445,6 +511,12 @@ public:
 
     Operand dst() const { return m_dst; }
     Operand src() const { return m_src; }
+
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_src);
+    }
 
 private:
     Operand m_dst;
@@ -510,6 +582,11 @@ public:
 
     Operand object() const { return m_object; }
 
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_object);
+    }
+
 private:
     Operand m_object;
 };
@@ -526,6 +603,11 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
+
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
 private:
     Operand m_dst;
@@ -599,6 +681,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
 
     IdentifierTableIndex identifier() const { return m_identifier; }
     Operand src() const { return m_src; }
@@ -617,20 +703,25 @@ class SetLocal final : public Instruction {
 public:
     SetLocal(size_t index, Operand src)
         : Instruction(Type::SetLocal)
-        , m_index(index)
+        , m_dst(Operand(Operand::Type::Local, index))
         , m_src(src)
     {
     }
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_src);
+    }
 
-    u32 index() const { return m_index; }
-    Operand dst() const { return Operand(Operand::Type::Local, m_index); }
+    u32 index() const { return m_dst.index(); }
+    Operand dst() const { return m_dst; }
     Operand src() const { return m_src; }
 
 private:
-    u32 m_index;
+    Operand m_dst;
     Operand m_src;
 };
 
@@ -645,6 +736,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
 
     size_t index() const { return m_index; }
     Operand src() const { return m_src; }
@@ -665,6 +760,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     u32 index() const { return m_index; }
     Operand dst() const { return m_dst; }
@@ -686,6 +785,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_callee);
+        visitor(m_this_value);
+    }
 
     IdentifierTableIndex identifier() const { return m_identifier; }
     Operand callee() const { return m_callee; }
@@ -713,6 +817,11 @@ public:
     Operand dst() const { return m_dst; }
     IdentifierTableIndex identifier() const { return m_identifier; }
 
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
+
 private:
     Operand m_dst;
     IdentifierTableIndex m_identifier;
@@ -736,6 +845,11 @@ public:
     IdentifierTableIndex identifier() const { return m_identifier; }
     u32 cache_index() const { return m_cache_index; }
 
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
+
 private:
     Operand m_dst;
     IdentifierTableIndex m_identifier;
@@ -757,6 +871,11 @@ public:
     Operand dst() const { return m_dst; }
     IdentifierTableIndex identifier() const { return m_identifier; }
 
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
+
 private:
     Operand m_dst;
     IdentifierTableIndex m_identifier;
@@ -776,6 +895,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -804,6 +928,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_this_value);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -831,6 +961,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -854,6 +989,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -889,6 +1029,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_base);
+        visitor(m_src);
+    }
 
     Operand base() const { return m_base; }
     IdentifierTableIndex property() const { return m_property; }
@@ -920,6 +1065,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_base);
+        visitor(m_this_value);
+        visitor(m_src);
+    }
 
     Operand base() const { return m_base; }
     Operand this_value() const { return m_this_value; }
@@ -950,6 +1101,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_base);
+        visitor(m_src);
+    }
 
     Operand base() const { return m_base; }
     IdentifierTableIndex property() const { return m_property; }
@@ -974,6 +1130,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -998,6 +1159,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_this_value);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -1024,6 +1191,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_property);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -1051,6 +1224,13 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_property);
+        visitor(m_this_value);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -1078,6 +1258,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_base);
+        visitor(m_property);
+        visitor(m_src);
+    }
 
     Operand base() const { return m_base; }
     Operand property() const { return m_property; }
@@ -1106,6 +1292,13 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_base);
+        visitor(m_property);
+        visitor(m_this_value);
+        visitor(m_src);
+    }
 
     Operand base() const { return m_base; }
     Operand property() const { return m_property; }
@@ -1133,6 +1326,12 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_property);
+    }
 
     Operand dst() const { return m_dst; }
     Operand base() const { return m_base; }
@@ -1162,6 +1361,13 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_this_value);
+        visitor(m_property);
+    }
 
 private:
     Operand m_dst;
@@ -1212,6 +1418,10 @@ public:
         visitor(m_true_target);
         visitor(m_false_target);
     }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_condition);
+    }
 
     Operand condition() const { return m_condition; }
     auto& true_target() const { return m_true_target; }
@@ -1240,6 +1450,10 @@ public:
     {
         visitor(m_target);
     }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_condition);
+    }
 
     Operand condition() const { return m_condition; }
     auto& target() const { return m_target; }
@@ -1265,6 +1479,10 @@ public:
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
         visitor(m_target);
+    }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_condition);
     }
 
     Operand condition() const { return m_condition; }
@@ -1306,6 +1524,11 @@ private:
             visitor(m_true_target);                                                                  \
             visitor(m_false_target);                                                                 \
         }                                                                                            \
+        void visit_operands_impl(Function<void(Operand&)> visitor)                                   \
+        {                                                                                            \
+            visitor(m_lhs);                                                                          \
+            visitor(m_rhs);                                                                          \
+        }                                                                                            \
                                                                                                      \
         Operand lhs() const { return m_lhs; }                                                        \
         Operand rhs() const { return m_rhs; }                                                        \
@@ -1340,6 +1563,10 @@ public:
         visitor(m_true_target);
         visitor(m_false_target);
     }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_condition);
+    }
 
     Operand condition() const { return m_condition; }
     auto& true_target() const { return m_true_target; }
@@ -1369,6 +1596,10 @@ public:
     {
         visitor(m_true_target);
         visitor(m_false_target);
+    }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_condition);
     }
 
     Operand condition() const { return m_condition; }
@@ -1422,6 +1653,14 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_callee);
+        visitor(m_this_value);
+        for (size_t i = 0; i < m_argument_count; i++)
+            visitor(m_arguments[i]);
+    }
 
 private:
     Operand m_dst;
@@ -1456,6 +1695,13 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_callee);
+        visitor(m_this_value);
+        visitor(m_arguments);
+    }
 
 private:
     Operand m_dst;
@@ -1478,6 +1724,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_arguments);
+    }
 
     Operand dst() const { return m_dst; }
     Operand arguments() const { return m_arguments; }
@@ -1514,6 +1765,16 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        if (m_super_class.has_value())
+            visitor(m_super_class.value());
+        for (size_t i = 0; i < m_element_keys_count; i++) {
+            if (m_element_keys[i].has_value())
+                visitor(m_element_keys[i].value());
+        }
+    }
 
     Operand dst() const { return m_dst; }
     Optional<Operand> const& super_class() const { return m_super_class; }
@@ -1542,6 +1803,12 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        if (m_home_object.has_value())
+            visitor(m_home_object.value());
+    }
 
     Operand dst() const { return m_dst; }
     FunctionNode const& function_node() const { return m_function_node; }
@@ -1584,6 +1851,11 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        if (m_value.has_value())
+            visitor(m_value.value());
+    }
 
     Optional<Operand> const& value() const { return m_value; }
 
@@ -1601,6 +1873,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -1619,6 +1895,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_src);
+    }
 
     Operand dst() const { return m_dst; }
     Operand src() const { return m_src; }
@@ -1638,6 +1919,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -1656,6 +1941,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_src);
+    }
 
     Operand dst() const { return m_dst; }
     Operand src() const { return m_src; }
@@ -1677,6 +1967,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
 
     Operand src() const { return m_src; }
 
@@ -1694,6 +1988,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
 
     Operand src() const { return m_src; }
 
@@ -1711,6 +2009,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
 
     Operand src() const { return m_src; }
 
@@ -1728,6 +2030,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
 
     Operand src() const { return m_src; }
 
@@ -1863,6 +2169,10 @@ public:
         if (m_continuation_label.has_value())
             visitor(m_continuation_label.value());
     }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_value);
+    }
 
     auto& continuation() const { return m_continuation_label; }
     Operand value() const { return m_value; }
@@ -1889,6 +2199,10 @@ public:
     {
         visitor(m_continuation_label);
     }
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_argument);
+    }
 
     auto& continuation() const { return m_continuation_label; }
     Operand argument() const { return m_argument; }
@@ -1910,6 +2224,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_iterable);
+    }
 
     Operand dst() const { return m_dst; }
     Operand iterable() const { return m_iterable; }
@@ -1932,6 +2251,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_object);
+        visitor(m_iterator_record);
+    }
 
     Operand object() const { return m_object; }
     Operand iterator_record() const { return m_iterator_record; }
@@ -1952,6 +2276,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_next_method);
+        visitor(m_iterator_record);
+    }
 
     Operand next_method() const { return m_next_method; }
     Operand iterator_record() const { return m_iterator_record; }
@@ -1973,6 +2302,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_object);
+    }
 
     Operand dst() const { return m_dst; }
     Operand object() const { return m_object; }
@@ -1995,6 +2329,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_object);
+    }
 
     Operand dst() const { return m_dst; }
     Operand object() const { return m_object; }
@@ -2016,6 +2355,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_iterator_record);
+    }
 
     Operand iterator_record() const { return m_iterator_record; }
     Completion::Type completion_type() const { return m_completion_type; }
@@ -2039,6 +2382,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_iterator_record);
+    }
 
     Operand iterator_record() const { return m_iterator_record; }
     Completion::Type completion_type() const { return m_completion_type; }
@@ -2061,6 +2408,11 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_iterator_record);
+    }
 
     Operand dst() const { return m_dst; }
     Operand iterator_record() const { return m_iterator_record; }
@@ -2080,6 +2432,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -2097,6 +2453,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -2114,6 +2474,10 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -2131,6 +2495,10 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
 
@@ -2149,6 +2517,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
 
     Operand dst() const { return m_dst; }
     IdentifierTableIndex identifier() const { return m_identifier; }
@@ -2170,6 +2542,10 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_value);
+    }
 
     Operand value() const { return m_value; }
 
@@ -2188,6 +2564,10 @@ public:
 
     void execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_value);
+    }
 
 private:
     StringView m_text;

--- a/Userland/Libraries/LibJS/Bytecode/Operand.h
+++ b/Userland/Libraries/LibJS/Bytecode/Operand.h
@@ -38,6 +38,8 @@ public:
 
     [[nodiscard]] Register as_register() const;
 
+    void offset_index_by(u32 offset) { m_index += offset; }
+
 private:
     Type m_type {};
     u32 m_index { 0 };

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -380,8 +380,6 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 
     auto callee_context = ExecutionContext::create(heap());
 
-    callee_context->locals.resize(m_local_variables_names.size());
-
     // Non-standard
     callee_context->arguments.ensure_capacity(max(arguments_list.size(), m_formal_parameters.size()));
     callee_context->arguments.append(arguments_list.data(), arguments_list.size());
@@ -456,8 +454,6 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
     }
 
     auto callee_context = ExecutionContext::create(heap());
-
-    callee_context->locals.resize(m_local_variables_names.size());
 
     // Non-standard
     callee_context->arguments.ensure_capacity(max(arguments_list.size(), m_formal_parameters.size()));
@@ -840,6 +836,8 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
         }
         m_bytecode_executable = m_ecmascript_code->bytecode_executable();
     }
+
+    vm.running_execution_context().registers_and_constants_and_locals.resize(m_local_variables_names.size() + m_bytecode_executable->number_of_registers + m_bytecode_executable->constants.size());
 
     auto result_and_frame = vm.bytecode_interpreter().run_executable(*m_bytecode_executable, {});
 

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -43,8 +43,7 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
     copy->executable = executable;
     copy->arguments = arguments;
     copy->passed_argument_count = passed_argument_count;
-    copy->locals = locals;
-    copy->registers = registers;
+    copy->registers_and_constants_and_locals = registers_and_constants_and_locals;
     copy->unwind_contexts = unwind_contexts;
     copy->saved_lexical_environments = saved_lexical_environments;
     copy->previously_scheduled_jumps = previously_scheduled_jumps;
@@ -63,8 +62,7 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(executable);
     visitor.visit(function_name);
     visitor.visit(arguments);
-    visitor.visit(locals);
-    visitor.visit(registers);
+    visitor.visit(registers_and_constants_and_locals);
     for (auto& context : unwind_contexts) {
         visitor.visit(context.lexical_environment);
     }

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -70,14 +70,13 @@ public:
 
     Value& local(size_t index)
     {
-        return locals[index];
+        return registers_and_constants_and_locals[index];
     }
 
     u32 passed_argument_count { 0 };
 
     Vector<Value> arguments;
-    Vector<Value> locals;
-    Vector<Value> registers;
+    Vector<Value> registers_and_constants_and_locals;
     Vector<Bytecode::UnwindInfo> unwind_contexts;
     Vector<Optional<size_t>> previously_scheduled_jumps;
     Vector<GCPtr<Environment>> saved_lexical_environments;


### PR DESCRIPTION
Merging registers, constants and locals into single vector means:
- Better data locality
- No need to check type in Interpreter::get() and Interpreter::set() which are very hot functions

Performance improvement is visible in almost all Octane and Kraken tests.

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.047  1.660 ± 1.580 … 1.740     1.585 ± 1.580 … 1.590
Kraken      audio-beat-detection.js                  1.06   1.240 ± 1.240 … 1.240     1.170 ± 1.170 … 1.170
Kraken      audio-dft.js                             1.057  0.920 ± 0.890 … 0.950     0.870 ± 0.870 … 0.870
Kraken      audio-fft.js                             1.078  1.100 ± 1.080 … 1.120     1.020 ± 1.000 … 1.040
Kraken      audio-oscillator.js                      1.035  1.170 ± 1.160 … 1.180     1.130 ± 1.120 … 1.140
Kraken      imaging-darkroom.js                      1.116  1.590 ± 1.570 … 1.610     1.425 ± 1.420 … 1.430
Kraken      imaging-desaturate.js                    1.067  1.590 ± 1.590 … 1.590     1.490 ± 1.490 … 1.490
Kraken      imaging-gaussian-blur.js                 1.161  7.105 ± 6.470 … 7.740     6.120 ± 6.040 … 6.200
Kraken      json-parse-financial.js                  0.95   0.095 ± 0.090 … 0.100     0.100 ± 0.100 … 0.100
Kraken      json-stringify-tinderbox.js              1.05   0.210 ± 0.210 … 0.210     0.200 ± 0.200 … 0.200
Kraken      stanford-crypto-aes.js                   1.098  0.505 ± 0.500 … 0.510     0.460 ± 0.460 … 0.460
Kraken      stanford-crypto-ccm.js                   1.025  0.410 ± 0.400 … 0.420     0.400 ± 0.400 … 0.400
Kraken      stanford-crypto-pbkdf2.js                1.118  0.855 ± 0.850 … 0.860     0.765 ± 0.760 … 0.770
Kraken      stanford-crypto-sha256-iterative.js      1.045  0.350 ± 0.350 … 0.350     0.335 ± 0.320 … 0.350
Octane      box2d.js                                 1.039  2.240 ± 2.210 … 2.270     2.155 ± 2.140 … 2.170
Octane      code-load.js                             1.007  2.170 ± 2.170 … 2.170     2.155 ± 2.150 … 2.160
Octane      crypto.js                                0.989  6.100 ± 6.080 … 6.120     6.165 ± 6.160 … 6.170
Octane      deltablue.js                             1.002  2.025 ± 2.020 … 2.030     2.020 ± 2.020 … 2.020
Octane      earley-boyer.js                          1.055  13.810 ± 13.160 … 14.460  13.085 ± 13.050 … 13.120
Octane      gbemu.js                                 0.937  2.250 ± 2.200 … 2.300     2.400 ± 2.160 … 2.640
Octane      mandreel.js                              1.064  10.415 ± 10.390 … 10.440  9.790 ± 9.560 … 10.020
Octane      navier-stokes.js                         1.014  2.110 ± 2.100 … 2.120     2.080 ± 2.080 … 2.080
Octane      pdfjs.js                                 0.893  2.250 ± 2.250 … 2.250     2.520 ± 2.290 … 2.750
Octane      raytrace.js                              1.011  5.395 ± 5.280 … 5.510     5.335 ± 5.310 … 5.360
Octane      regexp.js                                1.022  18.415 ± 17.800 … 19.030  18.025 ± 17.920 … 18.130
Octane      richards.js                              1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.004  2.670 ± 2.660 … 2.680     2.660 ± 2.660 … 2.660
Octane      typescript.js                            1.059  28.740 ± 28.660 … 28.820  27.145 ± 27.070 … 27.220
Octane      zlib.js                                  1.152  73.495 ± 72.850 … 74.140  63.815 ± 62.220 … 65.410
Kraken      Total                                    1.101  18.800                    17.070
Octane      Total                                    1.079  174.095                   161.360
All Suites  Total                                    1.081  192.895                   178.430
```