### PR TITLE
LibWeb: Specify the correct argument type in IDL for AbortSignal::any()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -147,25 +147,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::timeout(JS::VM& 
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-any
-WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::any(JS::VM& vm, JS::Value signals)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::any(JS::VM& vm, Vector<JS::Handle<AbortSignal>> const& signals)
 {
-    Vector<JS::Handle<AbortSignal>> signals_list;
-    auto iterator_record = TRY(get_iterator(vm, signals, JS::IteratorHint::Sync));
-    while (true) {
-        auto next = TRY(iterator_step_value(vm, iterator_record));
-        if (!next.has_value())
-            break;
-
-        auto value = next.release_value();
-        if (!value.is_object() || !is<AbortSignal>(value.as_object()))
-            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "AbortSignal");
-
-        auto& signal = static_cast<AbortSignal&>(value.as_object());
-        signals_list.append(JS::make_handle(signal));
-    }
-
     // The static any(signals) method steps are to return the result of creating a dependent abort signal from signals using AbortSignal and the current realm.
-    return create_dependent_abort_signal(*vm.current_realm(), signals_list);
+    return create_dependent_abort_signal(*vm.current_realm(), signals);
 }
 
 // https://dom.spec.whatwg.org/#create-a-dependent-abort-signal

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -45,7 +45,7 @@ public:
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> abort(JS::VM&, JS::Value reason);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> timeout(JS::VM&, Web::WebIDL::UnsignedLongLong milliseconds);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> any(JS::VM&, JS::Value signals);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> any(JS::VM&, Vector<JS::Handle<AbortSignal>> const&);
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> create_dependent_abort_signal(JS::Realm&, Vector<JS::Handle<AbortSignal>> const&);
 

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
@@ -6,8 +6,7 @@
 interface AbortSignal : EventTarget {
     [NewObject] static AbortSignal abort(optional any reason);
     [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
-    // FIXME: Argument should be of type: sequence<AbortSignal>.
-    [NewObject] static AbortSignal _any(any signals);
+    [NewObject] static AbortSignal _any(sequence<AbortSignal> signals);
 
     readonly attribute boolean aborted;
     readonly attribute any reason;


### PR DESCRIPTION
This allows some boilerplate code to be generated automatically.

I'm not sure why this didn't work when I first implemented this method, but it works now :shrug: 