### PR TITLE
AK: Fix off by one error in integral ceil_log2()

### DIFF
--- a/AK/IntegralMath.h
+++ b/AK/IntegralMath.h
@@ -27,12 +27,10 @@ constexpr T log2(T x)
 template<Integral T>
 constexpr T ceil_log2(T x)
 {
-    if (!x)
+    if (x <= 1)
         return 0;
 
-    T log = AK::log2(x);
-    log += (x & ((((T)1) << (log - 1)) - 1)) != 0;
-    return log;
+    return AK::log2(x - 1) + 1;
 }
 
 template<Integral I>

--- a/Tests/AK/TestIntegerMath.cpp
+++ b/Tests/AK/TestIntegerMath.cpp
@@ -64,3 +64,37 @@ TEST_CASE(exp2)
     EXPECT_EQ(AK::exp2<i64>(62), 4611686018427387904);
     EXPECT_EQ(AK::exp2<u64>(63), 9223372036854775808ull);
 }
+
+TEST_CASE(ceil_log2)
+{
+    EXPECT_EQ(AK::ceil_log2<u64>(0), 0ull);
+    EXPECT_EQ(AK::ceil_log2<u64>(1), 0ull);
+    EXPECT_EQ(AK::ceil_log2<u8>(2), 1);
+    EXPECT_EQ(AK::ceil_log2<u8>(3), 2);
+    EXPECT_EQ(AK::ceil_log2<u8>(6), 3);
+    EXPECT_EQ(AK::ceil_log2<i8>(96), 7);
+    EXPECT_EQ(AK::ceil_log2<i8>(127), 7);
+    EXPECT_EQ(AK::ceil_log2<u8>(128), 7);
+    EXPECT_EQ(AK::ceil_log2<u8>(255), 8);
+    EXPECT_EQ(AK::ceil_log2<i16>(256), 8);
+    EXPECT_EQ(AK::ceil_log2<i16>(257), 9);
+    EXPECT_EQ(AK::ceil_log2<i16>(384), 9);
+    EXPECT_EQ(AK::ceil_log2<i16>(24576), 15);
+    EXPECT_EQ(AK::ceil_log2<i16>(32767), 15);
+    EXPECT_EQ(AK::ceil_log2<i32>(32768), 15);
+    EXPECT_EQ(AK::ceil_log2<i32>(32769), 16);
+    EXPECT_EQ(AK::ceil_log2<i32>(98304), 17);
+    EXPECT_EQ(AK::ceil_log2<i32>(1610612736), 31);
+    EXPECT_EQ(AK::ceil_log2<i32>(2147483647), 31);
+    EXPECT_EQ(AK::ceil_log2<u32>(2147483648), 31u);
+    EXPECT_EQ(AK::ceil_log2<u32>(2147483649), 32u);
+    EXPECT_EQ(AK::ceil_log2<u32>(3221225472), 32u);
+    EXPECT_EQ(AK::ceil_log2<u32>(4294967295), 32u);
+    EXPECT_EQ(AK::ceil_log2<i64>(4294967296), 32);
+    EXPECT_EQ(AK::ceil_log2<i64>(4294967297), 33);
+    EXPECT_EQ(AK::ceil_log2<i64>(9223372036854775807), 63ll);
+    EXPECT_EQ(AK::ceil_log2<u64>(9223372036854775808ull), 63ull);
+    EXPECT_EQ(AK::ceil_log2<u64>(9223372036854775809ull), 64ull);
+    EXPECT_EQ(AK::ceil_log2<u64>(13835058055282163712ull), 64ull);
+    EXPECT_EQ(AK::ceil_log2<u64>(18446744073709551615ull), 64ull);
+}

--- a/Tests/AK/TestIntegerMath.cpp
+++ b/Tests/AK/TestIntegerMath.cpp
@@ -65,6 +65,24 @@ TEST_CASE(exp2)
     EXPECT_EQ(AK::exp2<u64>(63), 9223372036854775808ull);
 }
 
+TEST_CASE(log2)
+{
+    EXPECT_EQ(AK::log2<u64>(0), 0ull);
+    EXPECT_EQ(AK::log2<u64>(1), 0ull);
+    EXPECT_EQ(AK::log2<i8>(64), 6);
+    EXPECT_EQ(AK::log2<u8>(128), 7);
+    EXPECT_EQ(AK::log2<u16>(512), 9);
+    EXPECT_EQ(AK::log2<i16>(16384), 14);
+    EXPECT_EQ(AK::log2<u16>(32768), 15);
+    EXPECT_EQ(AK::log2<i32>(131072), 17);
+    EXPECT_EQ(AK::log2<i32>(1073741824), 30);
+    EXPECT_EQ(AK::log2<u32>(2147483648), 31u);
+    EXPECT_EQ(AK::log2<i64>(4294967296), 32);
+    EXPECT_EQ(AK::log2<i64>(8589934592), 33);
+    EXPECT_EQ(AK::log2<i64>(4611686018427387904), 62);
+    EXPECT_EQ(AK::log2<u64>(9223372036854775808ull), 63ull);
+}
+
 TEST_CASE(ceil_log2)
 {
     EXPECT_EQ(AK::ceil_log2<u64>(0), 0ull);


### PR DESCRIPTION
Previously, certain values of `ceil_log2(x)` would be 1 smaller than `ceil(log2(x))`.

In addition to the test cases I've included in this PR, I also tested `ceil_log2()` exhaustively (for all `u32`) with the following test case: 

```c++
TEST_CASE(ceil_log2_exhaustive)
{
    for (u32 i = 1; i < NumericLimits<u32>::max(); i++)
    {
        if (AK::ceil_log2(i) != ceil(log2(i)))
            FAIL(MUST(String::formatted("AK::ceil_log2(i) != ceil(log2(i) for i = {}, LHS = {}, RHS = {}", i, AK::ceil_log2(i), ceil(log2(i)))));
    }
}
```

Before this PR, the above test generated the following output:

```
Running test 'ceil_log2_exhaustive'.
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 1, LHS = 1, RHS = 0
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 3, LHS = 1, RHS = 2
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 6, LHS = 2, RHS = 3
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 12, LHS = 3, RHS = 4
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 24, LHS = 4, RHS = 5
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 48, LHS = 5, RHS = 6
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 96, LHS = 6, RHS = 7
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 192, LHS = 7, RHS = 8
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 384, LHS = 8, RHS = 9
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 768, LHS = 9, RHS = 10
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 1536, LHS = 10, RHS = 11
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 3072, LHS = 11, RHS = 12
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 6144, LHS = 12, RHS = 13
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 12288, LHS = 13, RHS = 14
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 24576, LHS = 14, RHS = 15
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 49152, LHS = 15, RHS = 16
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 98304, LHS = 16, RHS = 17
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 196608, LHS = 17, RHS = 18
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 393216, LHS = 18, RHS = 19
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 786432, LHS = 19, RHS = 20
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 1572864, LHS = 20, RHS = 21
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 3145728, LHS = 21, RHS = 22
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 6291456, LHS = 22, RHS = 23
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 12582912, LHS = 23, RHS = 24
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 25165824, LHS = 24, RHS = 25
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 50331648, LHS = 25, RHS = 26
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 100663296, LHS = 26, RHS = 27
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 201326592, LHS = 27, RHS = 28
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 402653184, LHS = 28, RHS = 29
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 805306368, LHS = 29, RHS = 30
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 1610612736, LHS = 30, RHS = 31
FAIL: /home/tim/repos/serenity/Tests/AK/TestIntegerMath.cpp:82: AK::ceil_log2(i) != ceil(log2(i) for i = 3221225472, LHS = 31, RHS = 32
```