### PR TITLE
LibWeb: Stub out FontFaceSet.status and .ready attributes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -17,7 +17,8 @@ JS_DEFINE_ALLOCATOR(FontFaceSet);
 
 JS::NonnullGCPtr<FontFaceSet> FontFaceSet::construct_impl(JS::Realm& realm, Vector<JS::Handle<FontFace>> initial_faces)
 {
-    return realm.heap().allocate<FontFaceSet>(realm, realm, move(initial_faces));
+    auto promise = WebIDL::create_promise(realm);
+    return realm.heap().allocate<FontFaceSet>(realm, realm, promise, move(initial_faces));
 }
 
 JS::NonnullGCPtr<FontFaceSet> FontFaceSet::create(JS::Realm& realm)
@@ -25,9 +26,14 @@ JS::NonnullGCPtr<FontFaceSet> FontFaceSet::create(JS::Realm& realm)
     return construct_impl(realm, {});
 }
 
-FontFaceSet::FontFaceSet(JS::Realm& realm, Vector<JS::Handle<FontFace>>)
+FontFaceSet::FontFaceSet(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::Promise> ready_promise, Vector<JS::Handle<FontFace>>)
     : Bindings::PlatformObject(realm)
+    , m_ready_promise(ready_promise)
 {
+    // FIXME: Only set this after all the initial faces have been loaded
+    m_status = Bindings::FontFaceSetLoadStatus::Loaded;
+    // FIXME: Only resolve the promise after all the initial faces have been loaded
+    WebIDL::resolve_promise(realm, *m_ready_promise);
 }
 
 void FontFaceSet::initialize(JS::Realm& realm)
@@ -35,6 +41,12 @@ void FontFaceSet::initialize(JS::Realm& realm)
     Base::initialize(realm);
 
     WEB_SET_PROTOTYPE_FOR_INTERFACE(FontFaceSet);
+}
+
+void FontFaceSet::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_ready_promise);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-add
@@ -50,6 +62,12 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> FontFaceSet::load(String co
     // FIXME: Do the steps
     auto promise = WebIDL::create_rejected_promise(realm(), WebIDL::NotSupportedError::create(realm(), "FontFaceSet::load is not yet implemented"_fly_string));
     return verify_cast<JS::Promise>(*promise->promise());
+}
+
+// https://drafts.csswg.org/css-font-loading/#font-face-set-ready
+JS::NonnullGCPtr<JS::Promise> FontFaceSet::ready() const
+{
+    return verify_cast<JS::Promise>(*m_ready_promise->promise());
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <LibWeb/Bindings/FontFaceSetPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/FontFace.h>
 
 namespace Web::CSS {
 
 class FontFaceSet final : public Bindings::PlatformObject {
-    WEB_PLATFORM_OBJECT(FontFace, Bindings::PlatformObject);
+    WEB_PLATFORM_OBJECT(FontFaceSet, Bindings::PlatformObject);
     JS_DECLARE_ALLOCATOR(FontFaceSet);
 
 public:
@@ -23,10 +24,17 @@ public:
     JS::NonnullGCPtr<FontFaceSet> add(JS::Handle<FontFace> face);
     JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> load(String const& font, String const& text);
 
+    JS::NonnullGCPtr<JS::Promise> ready() const;
+    Bindings::FontFaceSetLoadStatus status() const { return m_status; }
+
 private:
-    FontFaceSet(JS::Realm&, Vector<JS::Handle<FontFace>> initial_faces);
+    FontFaceSet(JS::Realm&, JS::NonnullGCPtr<WebIDL::Promise> ready_promise, Vector<JS::Handle<FontFace>> initial_faces);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    JS::GCPtr<WebIDL::Promise> m_ready_promise; // [[ReadyPromise]]
+    Bindings::FontFaceSetLoadStatus m_status { Bindings::FontFaceSetLoadStatus::Loading };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.idl
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.idl
@@ -38,10 +38,10 @@ interface FontFaceSet : EventTarget {
     // FIXME: boolean check(CSSOMString font, optional CSSOMString text = " ");
 
     // async notification that font loading and layout operations are done
-    // FIXME: readonly attribute Promise<FontFaceSet> ready;
+    readonly attribute Promise<FontFaceSet> ready;
 
     // loading state, "loading" while one or more fonts loading, "loaded" otherwise
-    // FIXME: readonly attribute FontFaceSetLoadStatus status;
+    readonly attribute FontFaceSetLoadStatus status;
 };
 
 interface mixin FontFaceSource {


### PR DESCRIPTION
WPT wants to check these properties before running ref tests. This fixes a ton of crashes in our CI WPT runs.

Output from ./Tests/LibWeb/run.sh:

This PR:
```
Ran 120 tests finished in 22.7 seconds.
  • 109 ran as expected. 0 tests skipped.
  • 8 tests failed unexpectedly
  • 1 tests passed unexpectedly
  • 2 tests had unexpected subtest results
```

Current master:
```
Ran 120 tests finished in 139.7 seconds.
  • 13 ran as expected. 0 tests skipped.
  • 105 tests crashed unexpectedly
  • 2 tests had unexpected subtest results
```