### PR TITLE
LibJS/Bytecode: Add environment coordinate caching to SetVariable

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1386,6 +1386,25 @@ ThrowCompletionOr<void> CreateArguments::execute_impl(Bytecode::Interpreter& int
 ThrowCompletionOr<void> SetVariable::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
+
+    if (m_cache.is_valid()) {
+        auto* environment = m_mode == EnvironmentMode::Lexical
+            ? interpreter.running_execution_context().lexical_environment.ptr()
+            : interpreter.running_execution_context().variable_environment.ptr();
+        for (size_t i = 0; i < m_cache.hops; ++i)
+            environment = environment->outer_environment();
+        if (!environment->is_permanently_screwed_by_eval()) {
+            auto value = interpreter.get(src());
+            if (m_initialization_mode == InitializationMode::Initialize) {
+                TRY(static_cast<DeclarativeEnvironment&>(*environment).initialize_binding_direct(vm, m_cache.index, value, Environment::InitializeBindingHint::Normal));
+                return {};
+            }
+            TRY(static_cast<DeclarativeEnvironment&>(*environment).set_mutable_binding_direct(vm, m_cache.index, value, vm.in_strict_mode()));
+            return {};
+        }
+        m_cache = {};
+    }
+
     auto const& name = interpreter.current_executable().get_identifier(m_identifier);
     TRY(set_variable(vm,
         name,

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -110,9 +110,12 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, De
 // 4.1.1.1.1 InitializeBinding ( N, V, hint ), https://tc39.es/proposal-explicit-resource-management/#sec-declarative-environment-records
 ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding(VM& vm, DeprecatedFlyString const& name, Value value, Environment::InitializeBindingHint hint)
 {
-    auto binding_and_index = find_binding_and_index(name);
-    VERIFY(binding_and_index.has_value());
-    auto& binding = binding_and_index->binding();
+    return initialize_binding_direct(vm, find_binding_and_index(name)->index().value(), value, hint);
+}
+
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding_direct(VM& vm, size_t index, Value value, Environment::InitializeBindingHint hint)
+{
+    auto& binding = m_bindings.at(index);
 
     // 1. Assert: envRec must have an uninitialized binding for N.
     VERIFY(binding.initialized == false);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -56,6 +56,7 @@ public:
         return names;
     }
 
+    ThrowCompletionOr<void> initialize_binding_direct(VM&, size_t index, Value, InitializeBindingHint);
     ThrowCompletionOr<void> set_mutable_binding_direct(VM&, size_t index, Value, bool strict);
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, size_t index) const;
 


### PR DESCRIPTION
This means that `SetVariable` instructions will now remember which (relative) environment contains the targeted binding, letting it bypass the full binding resolution machinery on subsequent accesses.

Small but decent speed-ups across the board in Kraken and Octane:
```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.018  2.575 ± 2.550 … 2.600     2.530 ± 2.510 … 2.550
Kraken      audio-beat-detection.js                  1.042  1.505 ± 1.500 … 1.510     1.445 ± 1.440 … 1.450
Kraken      audio-dft.js                             1.004  1.235 ± 1.230 … 1.240     1.230 ± 1.220 … 1.240
Kraken      audio-fft.js                             1.029  1.430 ± 1.360 … 1.500     1.390 ± 1.330 … 1.450
Kraken      audio-oscillator.js                      1.024  1.500 ± 1.480 … 1.520     1.465 ± 1.450 … 1.480
Kraken      imaging-darkroom.js                      0.992  1.790 ± 1.770 … 1.810     1.805 ± 1.800 … 1.810
Kraken      imaging-desaturate.js                    1.012  2.080 ± 2.080 … 2.080     2.055 ± 2.050 … 2.060
Kraken      imaging-gaussian-blur.js                 1.048  8.040 ± 8.030 … 8.050     7.670 ± 7.640 … 7.700
Kraken      json-parse-financial.js                  1      0.130 ± 0.130 … 0.130     0.130 ± 0.130 … 0.130
Kraken      json-stringify-tinderbox.js              1      0.240 ± 0.240 … 0.240     0.240 ± 0.240 … 0.240
Kraken      stanford-crypto-aes.js                   1.008  0.670 ± 0.670 … 0.670     0.665 ± 0.660 … 0.670
Kraken      stanford-crypto-ccm.js                   1.026  0.585 ± 0.580 … 0.590     0.570 ± 0.570 … 0.570
Kraken      stanford-crypto-pbkdf2.js                0.991  1.090 ± 1.090 … 1.090     1.100 ± 1.090 … 1.110
Kraken      stanford-crypto-sha256-iterative.js      1      0.450 ± 0.450 … 0.450     0.450 ± 0.450 … 0.450
Octane      box2d.js                                 1.017  2.370 ± 2.370 … 2.370     2.330 ± 2.320 … 2.340
Octane      code-load.js                             0.998  2.140 ± 2.140 … 2.140     2.145 ± 2.140 … 2.150
Octane      crypto.js                                1.058  7.160 ± 7.130 … 7.190     6.765 ± 6.390 … 7.140
Octane      deltablue.js                             1.007  2.045 ± 2.040 … 2.050     2.030 ± 2.020 … 2.040
Octane      earley-boyer.js                          1.013  17.355 ± 17.020 … 17.690  17.125 ± 17.110 … 17.140
Octane      gbemu.js                                 1.038  3.020 ± 2.930 … 3.110     2.910 ± 2.900 … 2.920
Octane      mandreel.js                              1.022  13.415 ± 13.120 … 13.710  13.130 ± 12.890 … 13.370
Octane      navier-stokes.js                         1      3.110 ± 3.040 … 3.180     3.110 ± 3.100 … 3.120
Octane      pdfjs.js                                 1.033  2.960 ± 2.950 … 2.970     2.865 ± 2.840 … 2.890
Octane      raytrace.js                              1.02   7.015 ± 6.880 … 7.150     6.880 ± 6.790 … 6.970
Octane      regexp.js                                1.014  22.585 ± 22.060 … 23.110  22.265 ± 22.230 … 22.300
Octane      richards.js                              1.005  2.020 ± 2.020 … 2.020     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.007  2.980 ± 2.960 … 3.000     2.960 ± 2.940 … 2.980
Octane      typescript.js                            1.017  37.175 ± 36.310 … 38.040  36.545 ± 36.270 … 36.820
Octane      zlib.js                                  1.012  80.230 ± 80.040 … 80.420  79.275 ± 79.090 … 79.460
Kraken      Total                                    1.025  23.320                    22.745
Octane      Total                                    1.016  205.580                   202.345
All Suites  Total                                    1.017  228.900                   225.090
```