### PR TITLE
CI+CMake: Enable Clang plugins for Serenity Clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,13 @@ if (HACKSTUDIO_BUILD)
     return()
 endif()
 
+add_library(GenericClangPlugin INTERFACE)
+add_library(JSClangPlugin INTERFACE)
+if (ENABLE_CLANG_PLUGINS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    target_link_libraries(GenericClangPlugin INTERFACE Lagom::GenericClangPlugin)
+    target_link_libraries(JSClangPlugin INTERFACE Lagom::JSClangPlugin)
+endif()
+
 add_subdirectory(AK)
 add_subdirectory(Kernel)
 
@@ -264,6 +271,3 @@ if (ENABLE_USB_IDS_DOWNLOAD AND NOT EXISTS "${USB_IDS_INSTALL_PATH}/${USB_IDS_FI
     download_file("${USB_IDS_URL}" "${USB_IDS_DOWNLOAD_PATH}")
     install(FILES "${USB_IDS_DOWNLOAD_PATH}" DESTINATION "${USB_IDS_INSTALL_PATH}")
 endif()
-
-add_library(GenericClangPlugin INTERFACE)
-add_library(JSClangPlugin INTERFACE)

--- a/Meta/CMake/clang_development.cmake
+++ b/Meta/CMake/clang_development.cmake
@@ -1,0 +1,12 @@
+#
+# Finds clang and llvm development packages that match the current clang version
+#
+
+if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    return()
+endif()
+
+set(DESIRED_CLANG_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+
+find_package(Clang "${DESIRED_CLANG_VERSION}" QUIET REQUIRED CONFIG)
+find_package(LLVM "${DESIRED_CLANG_VERSION}" QUIET REQUIRED CONFIG)

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -237,3 +237,22 @@ function(extract_path dest_dir zip_path source_path dest_path)
         file(ARCHIVE_EXTRACT INPUT "${zip_path}" DESTINATION "${dest_dir}" PATTERNS "${source_path}")
     endif()
 endfunction()
+
+function(add_lagom_library_install_rules target_name)
+    cmake_parse_arguments(PARSE_ARGV 1 LAGOM_INSTALL_RULES "" "ALIAS_NAME" "")
+    if (NOT LAGOM_INSTALL_RULES_ALIAS_NAME)
+        set(LAGOM_INSTALL_RULES_ALIAS_NAME ${target_name})
+    endif()
+     # Don't make alias when we're going to import a previous build for Tools
+    # FIXME: Is there a better way to write this?
+    if (NOT ENABLE_FUZZERS AND NOT CMAKE_CROSSCOMPILING)
+        # alias for parity with exports
+        add_library(Lagom::${LAGOM_INSTALL_RULES_ALIAS_NAME} ALIAS ${target_name})
+    endif()
+    install(TARGETS ${target_name} EXPORT LagomTargets
+        RUNTIME COMPONENT Lagom_Runtime
+        LIBRARY COMPONENT Lagom_Runtime NAMELINK_COMPONENT Lagom_Development
+        ARCHIVE COMPONENT Lagom_Development
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endfunction()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -137,8 +137,6 @@ CHECK_INCLUDE_FILE(pulse/pulseaudio.h HAVE_PULSEAUDIO)
 
 add_library(JSClangPlugin INTERFACE)
 add_library(GenericClangPlugin INTERFACE)
-# These need to be installed to avoid CMake complaining about them not being in the export set
-install(TARGETS GenericClangPlugin JSClangPlugin EXPORT LagomTargets)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     add_compile_options(-Wno-overloaded-virtual)
@@ -152,7 +150,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")
     endif()
 
-    if (ENABLE_CLANG_PLUGINS)
+    # Vanilla host builds only for building the clang plugins
+    if (ENABLE_CLANG_PLUGINS AND NOT CROSS_COMPILING AND NOT ENABLE_FUZZERS AND NOT ENABLE_COMPILER_EXPLORER_BUILD)
         add_subdirectory(ClangPlugins)
         depend_on_clang_plugin(JSClangPlugin LibJSGCClangPlugin)
         depend_on_clang_plugin(GenericClangPlugin LambdaCaptureClangPlugin)
@@ -219,13 +218,6 @@ function(lagom_lib target_name fs_name)
         set(LAGOM_LIBRARY_LIBRARY_TYPE "")
     endif()
     add_library(${target_name} ${LAGOM_LIBRARY_LIBRARY_TYPE} ${LAGOM_LIBRARY_SOURCES})
-    # Don't make alias when we're going to import a previous build for Tools
-    # FIXME: Is there a better way to write this?
-    if (NOT ENABLE_FUZZERS AND NOT CMAKE_CROSSCOMPILING)
-        # alias for parity with exports
-        add_library(Lagom::${library} ALIAS ${target_name})
-    endif()
-
     set_target_properties(
         ${target_name} PROPERTIES
         VERSION "${PROJECT_VERSION}"
@@ -246,19 +238,7 @@ function(lagom_lib target_name fs_name)
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Userland/Libraries>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Userland/Services>
     )
-    install(
-        TARGETS ${target_name}
-        EXPORT LagomTargets
-        RUNTIME #
-            COMPONENT Lagom_Runtime
-        LIBRARY #
-            COMPONENT Lagom_Runtime
-            NAMELINK_COMPONENT Lagom_Development
-        ARCHIVE #
-            COMPONENT Lagom_Development
-        INCLUDES #
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
+    add_lagom_library_install_rules(${target_name} ALIAS_NAME ${library})
     # FIXME: Move this to serenity_install_headers
     install(
         DIRECTORY "${SERENITY_PROJECT_ROOT}/Userland/Libraries/Lib${library}"
@@ -339,6 +319,10 @@ if (NOT TARGET all_generated)
     # Meta target to run all code-gen steps in the build.
     add_custom_target(all_generated)
 endif()
+
+# Plugins need to be installed in order to be used by non-lagom builds
+add_lagom_library_install_rules(GenericClangPlugin)
+add_lagom_library_install_rules(JSClangPlugin)
 
 # Create mostly empty targets for system libraries we don't need to build for Lagom
 add_library(LibC INTERFACE)

--- a/Meta/Lagom/ClangPlugins/CMakeLists.txt
+++ b/Meta/Lagom/ClangPlugins/CMakeLists.txt
@@ -1,9 +1,8 @@
-find_package(Clang 17 CONFIG REQUIRED)
+include(clang_development)
 
 function(clang_plugin target_name)
     cmake_parse_arguments(CLANG_PLUGIN "" "" "SOURCES" ${ARGN})
     add_library(${target_name} ${CLANG_PLUGIN_SOURCES})
-    install(TARGETS ${target_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     target_include_directories(${target_name} SYSTEM PRIVATE ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
     target_compile_features(${target_name} PRIVATE cxx_std_20)
     target_compile_options(${target_name} PRIVATE -Wall -Wextra -Werror -Wno-unused -fno-rtti)
@@ -11,12 +10,16 @@ function(clang_plugin target_name)
     add_custom_target(${target_name}Target DEPENDS ${target_name})
 
     set_property(GLOBAL APPEND PROPERTY CLANG_PLUGINS_ALL_COMPILE_OPTIONS -fplugin=${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${target_name}.so)
+
+    add_lagom_library_install_rules(${target_name})
+endfunction()
+
+function(depend_on_clang_plugin target_name plugin_name)
+    if (TARGET ${plugin_name}Target)
+        add_dependencies(${target_name} ${plugin_name}Target)
+    endif()
+    target_compile_options(${target_name} INTERFACE -fplugin=$<TARGET_FILE:Lagom::${plugin_name}>)
 endfunction()
 
 clang_plugin(LambdaCaptureClangPlugin SOURCES LambdaCapturePluginAction.cpp)
 clang_plugin(LibJSGCClangPlugin SOURCES LibJSGCPluginAction.cpp)
-
-function(depend_on_clang_plugin target_name plugin_name)
-    add_dependencies(${target_name} ${plugin_name}Target)
-    target_compile_options(${target_name} INTERFACE -fplugin=$<TARGET_FILE:${plugin_name}>)
-endfunction()

--- a/Tests/ClangPlugins/CMakeLists.txt
+++ b/Tests/ClangPlugins/CMakeLists.txt
@@ -1,5 +1,4 @@
-find_package(Clang 17 CONFIG REQUIRED)
-find_package(LLVM 17 CONFIG REQUIRED)
+include(clang_development)
 include(AddLLVM)
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)


### PR DESCRIPTION
:partying_face: 

As a note, the Lambda capture one is *very* noisy.

And the warnings from these plugins don't seem to respect -Werror which is... good(?)