### PR TITLE
LibJS: Replace SetLocal instruction usage with Mov

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -814,7 +814,7 @@ void Generator::emit_set_variable(JS::Identifier const& identifier, ScopedOperan
             // Moving a local to itself is a no-op.
             return;
         }
-        emit<Bytecode::Op::SetLocal>(identifier.local_variable_index(), value);
+        emit<Bytecode::Op::Mov>(local(identifier.local_variable_index()), value);
     } else {
         emit<Bytecode::Op::SetVariable>(intern_identifier(identifier.string()), value, initialization_mode, mode);
     }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -123,7 +123,6 @@
     O(ScheduleJump)                    \
     O(SetArgument)                     \
     O(SetVariable)                     \
-    O(SetLocal)                        \
     O(StrictlyEquals)                  \
     O(StrictlyInequals)                \
     O(Sub)                             \

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -699,32 +699,6 @@ private:
     mutable EnvironmentCoordinate m_cache;
 };
 
-class SetLocal final : public Instruction {
-public:
-    SetLocal(size_t index, Operand src)
-        : Instruction(Type::SetLocal)
-        , m_dst(Operand(Operand::Type::Local, index))
-        , m_src(src)
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-    void visit_operands_impl(Function<void(Operand&)> visitor)
-    {
-        visitor(m_dst);
-        visitor(m_src);
-    }
-
-    u32 index() const { return m_dst.index(); }
-    Operand dst() const { return m_dst; }
-    Operand src() const { return m_src; }
-
-private:
-    Operand m_dst;
-    Operand m_src;
-};
-
 class SetArgument final : public Instruction {
 public:
     SetArgument(size_t index, Operand src)


### PR DESCRIPTION
No need for separate instuction to set a local.