### PR TITLE
LibJS: Another day, another pack of optimizations

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -647,7 +647,7 @@ struct BindingPattern : RefCounted<BindingPattern> {
 
     bool contains_expression() const;
 
-    Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&, Bytecode::Op::SetVariable::InitializationMode initialization_mode, Bytecode::ScopedOperand const& object, bool create_variables) const;
+    Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&, Bytecode::Op::BindingInitializationMode initialization_mode, Bytecode::ScopedOperand const& object, bool create_variables) const;
 
     Vector<BindingEntry> entries;
     Kind kind { Kind::Object };

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -642,7 +642,12 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> AssignmentExpression::g
         return TRY(m_rhs->generate_bytecode(generator)).value();
     }());
 
-    auto dst = choose_dst(generator, preferred_dst);
+    // OPTIMIZATION: If LHS is a local, we can write the result directly into it.
+    auto dst = [&] {
+        if (lhs.operand().is_local())
+            return lhs;
+        return choose_dst(generator, preferred_dst);
+    }();
 
     switch (m_op) {
     case AssignmentOp::AdditionAssignment:

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -397,7 +397,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> Identifier::generate_by
     if (is_global()) {
         generator.emit<Bytecode::Op::GetGlobal>(dst, generator.intern_identifier(m_string), generator.next_global_variable_cache());
     } else {
-        generator.emit<Bytecode::Op::GetVariable>(dst, generator.intern_identifier(m_string));
+        generator.emit<Bytecode::Op::GetBinding>(dst, generator.intern_identifier(m_string));
     }
     return dst;
 }
@@ -520,7 +520,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> AssignmentExpression::g
                         generator.emit<Bytecode::Op::ResolveSuperBase>(*base);
                     }
                 } else if (is<Identifier>(*lhs)) {
-                    // NOTE: For Identifiers, we cannot perform GetVariable and then write into the reference it retrieves, only SetVariable can do this.
+                    // NOTE: For Identifiers, we cannot perform GetBinding and then write into the reference it retrieves, only SetVariable can do this.
                     // FIXME: However, this breaks spec as we are doing variable lookup after evaluating the RHS. This is observable in an object environment, where we visibly perform HasOwnProperty and Get(@@unscopables) on the binded object.
                 } else {
                     (void)TRY(lhs->generate_bytecode(generator));
@@ -1150,7 +1150,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> FunctionDeclaration::ge
         Bytecode::Generator::SourceLocationScope scope(generator, *this);
         auto index = generator.intern_identifier(name());
         auto value = generator.allocate_register();
-        generator.emit<Bytecode::Op::GetVariable>(value, index);
+        generator.emit<Bytecode::Op::GetBinding>(value, index);
         generator.emit<Bytecode::Op::SetVariableBinding>(index, value);
     }
     return Optional<ScopedOperand> {};

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -399,29 +399,6 @@ inline ThrowCompletionOr<Value> typeof_variable(VM& vm, DeprecatedFlyString cons
     return PrimitiveString::create(vm, value.typeof());
 }
 
-inline ThrowCompletionOr<void> set_variable(
-    VM& vm,
-    DeprecatedFlyString const& name,
-    Value value,
-    Op::EnvironmentMode mode,
-    Op::SetVariable::InitializationMode initialization_mode,
-    EnvironmentCoordinate& cache)
-{
-    auto environment = mode == Op::EnvironmentMode::Lexical ? vm.running_execution_context().lexical_environment : vm.running_execution_context().variable_environment;
-    auto reference = TRY(vm.resolve_binding(name, environment));
-    if (reference.environment_coordinate().has_value())
-        cache = reference.environment_coordinate().value();
-    switch (initialization_mode) {
-    case Op::SetVariable::InitializationMode::Initialize:
-        TRY(reference.initialize_referenced_binding(vm, value));
-        break;
-    case Op::SetVariable::InitializationMode::Set:
-        TRY(reference.put_value(vm, value));
-        break;
-    }
-    return {};
-}
-
 inline Value new_function(VM& vm, FunctionNode const& function_node, Optional<IdentifierTableIndex> const& lhs_name, Optional<Operand> const& home_object)
 {
     Value value;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -133,7 +133,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
                     if (id.is_local()) {
                         emit<Op::Mov>(initial_value, local(id.local_variable_index()));
                     } else {
-                        emit<Op::GetVariable>(initial_value, intern_identifier(id.string()));
+                        emit<Op::GetBinding>(initial_value, intern_identifier(id.string()));
                     }
                 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -144,7 +144,7 @@ public:
 
     CodeGenerationErrorOr<ReferenceOperands> emit_super_reference(MemberExpression const&);
 
-    void emit_set_variable(JS::Identifier const& identifier, ScopedOperand value, Bytecode::Op::SetVariable::InitializationMode initialization_mode = Bytecode::Op::SetVariable::InitializationMode::Set, Bytecode::Op::EnvironmentMode mode = Bytecode::Op::EnvironmentMode::Lexical);
+    void emit_set_variable(JS::Identifier const& identifier, ScopedOperand value, Bytecode::Op::BindingInitializationMode initialization_mode = Bytecode::Op::BindingInitializationMode::Set, Bytecode::Op::EnvironmentMode mode = Bytecode::Op::EnvironmentMode::Lexical);
 
     void push_home_object(ScopedOperand);
     void pop_home_object();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -33,6 +33,11 @@ public:
         Block,
     };
 
+    enum class MustPropagateCompletion {
+        No,
+        Yes,
+    };
+
     static CodeGenerationErrorOr<NonnullGCPtr<Executable>> generate_from_ast_node(VM&, ASTNode const&, FunctionKind = FunctionKind::Normal);
     static CodeGenerationErrorOr<NonnullGCPtr<Executable>> generate_from_function(VM&, ECMAScriptFunctionObject const& function);
 
@@ -302,10 +307,12 @@ public:
 
     [[nodiscard]] bool is_finished() const { return m_finished; }
 
+    [[nodiscard]] bool must_propagate_completion() const { return m_must_propagate_completion; }
+
 private:
     VM& m_vm;
 
-    static CodeGenerationErrorOr<NonnullGCPtr<Executable>> emit_function_body_bytecode(VM&, ASTNode const&, FunctionKind, GCPtr<ECMAScriptFunctionObject const>);
+    static CodeGenerationErrorOr<NonnullGCPtr<Executable>> emit_function_body_bytecode(VM&, ASTNode const&, FunctionKind, GCPtr<ECMAScriptFunctionObject const>, MustPropagateCompletion = MustPropagateCompletion::Yes);
 
     enum class JumpType {
         Continue,
@@ -314,7 +321,7 @@ private:
     void generate_scoped_jump(JumpType);
     void generate_labelled_jump(JumpType, DeprecatedFlyString const& label);
 
-    explicit Generator(VM&);
+    Generator(VM&, MustPropagateCompletion);
     ~Generator() = default;
 
     void grow(size_t);
@@ -353,6 +360,7 @@ private:
     HashTable<u32> m_initialized_locals;
 
     bool m_finished { false };
+    bool m_must_propagate_completion { true };
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -70,6 +70,8 @@
     O(ImportCall)                      \
     O(In)                              \
     O(Increment)                       \
+    O(InitializeLexicalBinding)        \
+    O(InitializeVariableBinding)       \
     O(InstanceOf)                      \
     O(IteratorClose)                   \
     O(IteratorNext)                    \
@@ -122,7 +124,8 @@
     O(RightShift)                      \
     O(ScheduleJump)                    \
     O(SetArgument)                     \
-    O(SetVariable)                     \
+    O(SetLexicalBinding)               \
+    O(SetVariableBinding)              \
     O(StrictlyEquals)                  \
     O(StrictlyInequals)                \
     O(Sub)                             \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -63,7 +63,7 @@
     O(GetObjectFromIteratorRecord)     \
     O(GetObjectPropertyIterator)       \
     O(GetPrivateById)                  \
-    O(GetVariable)                     \
+    O(GetBinding)                      \
     O(GreaterThan)                     \
     O(GreaterThanEquals)               \
     O(HasPrivateId)                    \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -30,12 +30,12 @@
     O(ConcatString)                    \
     O(ContinuePendingUnwind)           \
     O(CopyObjectExcludingProperties)   \
-    O(CreateLexicalEnvironment)        \
-    O(CreateVariableEnvironment)       \
-    O(CreatePrivateEnvironment)        \
-    O(CreateVariable)                  \
-    O(CreateRestParams)                \
     O(CreateArguments)                 \
+    O(CreateLexicalEnvironment)        \
+    O(CreatePrivateEnvironment)        \
+    O(CreateRestParams)                \
+    O(CreateVariable)                  \
+    O(CreateVariableEnvironment)       \
     O(Decrement)                       \
     O(DeleteById)                      \
     O(DeleteByIdWithThis)              \
@@ -54,16 +54,16 @@
     O(GetByValue)                      \
     O(GetByValueWithThis)              \
     O(GetCalleeAndThisFromEnvironment) \
+    O(GetGlobal)                       \
+    O(GetImportMeta)                   \
     O(GetIterator)                     \
     O(GetMethod)                       \
     O(GetNewTarget)                    \
     O(GetNextMethodFromIteratorRecord) \
     O(GetObjectFromIteratorRecord)     \
-    O(GetImportMeta)                   \
     O(GetObjectPropertyIterator)       \
     O(GetPrivateById)                  \
     O(GetVariable)                     \
-    O(GetGlobal)                       \
     O(GreaterThan)                     \
     O(GreaterThanEquals)               \
     O(HasPrivateId)                    \
@@ -115,8 +115,8 @@
     O(PutByValue)                      \
     O(PutByValueWithThis)              \
     O(PutPrivateById)                  \
-    O(ResolveThisBinding)              \
     O(ResolveSuperBase)                \
+    O(ResolveThisBinding)              \
     O(RestoreScheduledJump)            \
     O(Return)                          \
     O(RightShift)                      \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -866,12 +866,6 @@ void Dump::execute_impl(Bytecode::Interpreter& interpreter) const
     }
 }
 
-ThrowCompletionOr<void> End::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
 #define JS_DEFINE_EXECUTE_FOR_COMMON_BINARY_OP(OpTitleCase, op_snake_case)                      \
     ThrowCompletionOr<void> OpTitleCase::execute_impl(Bytecode::Interpreter& interpreter) const \
     {                                                                                           \
@@ -1433,18 +1427,6 @@ ThrowCompletionOr<void> SetVariableBinding::execute_impl(Bytecode::Interpreter& 
     return initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Set>(interpreter, m_identifier, interpreter.get(m_src), m_cache);
 }
 
-ThrowCompletionOr<void> SetArgument::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> GetArgument::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
 ThrowCompletionOr<void> GetById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto base_identifier = interpreter.current_executable().get_identifier(m_base_identifier);
@@ -1543,12 +1525,6 @@ ThrowCompletionOr<void> DeleteByIdWithThis::execute_impl(Bytecode::Interpreter& 
     return {};
 }
 
-ThrowCompletionOr<void> Jump::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
 ThrowCompletionOr<void> ResolveThisBinding::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& cached_this_value = interpreter.reg(Register::this_value());
@@ -1587,42 +1563,6 @@ void GetNewTarget::execute_impl(Bytecode::Interpreter& interpreter) const
 void GetImportMeta::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     interpreter.set(dst(), interpreter.vm().get_import_meta());
-}
-
-ThrowCompletionOr<void> JumpIf::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> JumpTrue::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> JumpFalse::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> JumpUndefined::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> JumpNullish::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> Mov::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
 }
 
 static ThrowCompletionOr<Value> dispatch_builtin_call(Bytecode::Interpreter& interpreter, Bytecode::Builtin builtin, ReadonlySpan<Operand> arguments)
@@ -1811,18 +1751,6 @@ ThrowCompletionOr<void> ThrowIfTDZ::execute_impl(Bytecode::Interpreter& interpre
     return {};
 }
 
-ThrowCompletionOr<void> EnterUnwindContext::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
-ThrowCompletionOr<void> ScheduleJump::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
-}
-
 void LeaveLexicalEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& running_execution_context = interpreter.running_execution_context();
@@ -1838,12 +1766,6 @@ void LeavePrivateEnvironment::execute_impl(Bytecode::Interpreter& interpreter) c
 void LeaveUnwindContext::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     interpreter.leave_unwind_context();
-}
-
-ThrowCompletionOr<void> ContinuePendingUnwind::execute_impl(Bytecode::Interpreter&) const
-{
-    // Handled in the interpreter loop.
-    __builtin_unreachable();
 }
 
 ThrowCompletionOr<void> Yield::execute_impl(Bytecode::Interpreter& interpreter) const

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -577,7 +577,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(GetObjectFromIteratorRecord);
             HANDLE_INSTRUCTION(GetObjectPropertyIterator);
             HANDLE_INSTRUCTION(GetPrivateById);
-            HANDLE_INSTRUCTION(GetVariable);
+            HANDLE_INSTRUCTION(GetBinding);
             HANDLE_INSTRUCTION(GreaterThan);
             HANDLE_INSTRUCTION(GreaterThanEquals);
             HANDLE_INSTRUCTION(HasPrivateId);
@@ -1237,7 +1237,7 @@ ThrowCompletionOr<void> ConcatString::execute_impl(Bytecode::Interpreter& interp
     return {};
 }
 
-ThrowCompletionOr<void> GetVariable::execute_impl(Bytecode::Interpreter& interpreter) const
+ThrowCompletionOr<void> GetBinding::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
     auto& executable = interpreter.current_executable();
@@ -2122,9 +2122,9 @@ ByteString GetCalleeAndThisFromEnvironment::to_byte_string_impl(Bytecode::Execut
         executable.identifier_table->get(m_identifier));
 }
 
-ByteString GetVariable::to_byte_string_impl(Bytecode::Executable const& executable) const
+ByteString GetBinding::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
-    return ByteString::formatted("GetVariable {}, {}",
+    return ByteString::formatted("GetBinding {}, {}",
         format_operand("dst"sv, dst(), executable),
         executable.identifier_table->get(m_identifier));
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -846,10 +846,10 @@ private:
     mutable EnvironmentCoordinate m_cache;
 };
 
-class GetVariable final : public Instruction {
+class GetBinding final : public Instruction {
 public:
-    explicit GetVariable(Operand dst, IdentifierTableIndex identifier)
-        : Instruction(Type::GetVariable)
+    explicit GetBinding(Operand dst, IdentifierTableIndex identifier)
+        : Instruction(Type::GetBinding)
         , m_dst(dst)
         , m_identifier(identifier)
     {

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -84,7 +84,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -778,7 +777,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -802,7 +800,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1430,7 +1427,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -1455,7 +1451,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -1488,7 +1483,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -1518,7 +1512,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -1600,7 +1593,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -1634,7 +1626,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -2095,7 +2086,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -2122,7 +2112,6 @@ public:
 
     Label target() const { return m_target; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -2176,7 +2165,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -2584,7 +2572,6 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -528,6 +528,11 @@ enum class EnvironmentMode {
     Var,
 };
 
+enum class BindingInitializationMode {
+    Initialize,
+    Set,
+};
+
 class CreateLexicalEnvironment final : public Instruction {
 public:
     explicit CreateLexicalEnvironment(u32 capacity = 0)
@@ -664,18 +669,12 @@ private:
     bool m_is_strict { false };
 };
 
-class SetVariable final : public Instruction {
+class InitializeLexicalBinding final : public Instruction {
 public:
-    enum class InitializationMode {
-        Initialize,
-        Set,
-    };
-    explicit SetVariable(IdentifierTableIndex identifier, Operand src, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
-        : Instruction(Type::SetVariable)
+    explicit InitializeLexicalBinding(IdentifierTableIndex identifier, Operand src)
+        : Instruction(Type::InitializeLexicalBinding)
         , m_identifier(identifier)
         , m_src(src)
-        , m_mode(mode)
-        , m_initialization_mode(initialization_mode)
     {
     }
 
@@ -688,14 +687,85 @@ public:
 
     IdentifierTableIndex identifier() const { return m_identifier; }
     Operand src() const { return m_src; }
-    EnvironmentMode mode() const { return m_mode; }
-    InitializationMode initialization_mode() const { return m_initialization_mode; }
 
 private:
     IdentifierTableIndex m_identifier;
     Operand m_src;
-    EnvironmentMode m_mode;
-    InitializationMode m_initialization_mode { InitializationMode::Set };
+    mutable EnvironmentCoordinate m_cache;
+};
+
+class InitializeVariableBinding final : public Instruction {
+public:
+    explicit InitializeVariableBinding(IdentifierTableIndex identifier, Operand src)
+        : Instruction(Type::InitializeVariableBinding)
+        , m_identifier(identifier)
+        , m_src(src)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
+
+    IdentifierTableIndex identifier() const { return m_identifier; }
+    Operand src() const { return m_src; }
+
+private:
+    IdentifierTableIndex m_identifier;
+    Operand m_src;
+    mutable EnvironmentCoordinate m_cache;
+};
+
+class SetLexicalBinding final : public Instruction {
+public:
+    explicit SetLexicalBinding(IdentifierTableIndex identifier, Operand src)
+        : Instruction(Type::SetLexicalBinding)
+        , m_identifier(identifier)
+        , m_src(src)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
+
+    IdentifierTableIndex identifier() const { return m_identifier; }
+    Operand src() const { return m_src; }
+
+private:
+    IdentifierTableIndex m_identifier;
+    Operand m_src;
+    mutable EnvironmentCoordinate m_cache;
+};
+
+class SetVariableBinding final : public Instruction {
+public:
+    explicit SetVariableBinding(IdentifierTableIndex identifier, Operand src)
+        : Instruction(Type::SetVariableBinding)
+        , m_identifier(identifier)
+        , m_src(src)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
+
+    IdentifierTableIndex identifier() const { return m_identifier; }
+    Operand src() const { return m_src; }
+
+private:
+    IdentifierTableIndex m_identifier;
+    Operand m_src;
     mutable EnvironmentCoordinate m_cache;
 };
 


### PR DESCRIPTION
More work towards going fast. See individual commits.

Benchmarks move in the right direction :^)

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.053  2.575 ± 2.570 … 2.580     2.445 ± 2.430 … 2.460
Kraken      audio-beat-detection.js                  1.017  1.455 ± 1.440 … 1.470     1.430 ± 1.430 … 1.430
Kraken      audio-dft.js                             1.034  1.225 ± 1.210 … 1.240     1.185 ± 1.170 … 1.200
Kraken      audio-fft.js                             0.975  1.355 ± 1.350 … 1.360     1.390 ± 1.390 … 1.390
Kraken      audio-oscillator.js                      0.935  1.440 ± 1.440 … 1.440     1.540 ± 1.540 … 1.540
Kraken      imaging-darkroom.js                      0.927  1.830 ± 1.810 … 1.850     1.975 ± 1.960 … 1.990
Kraken      imaging-desaturate.js                    1.224  2.760 ± 2.750 … 2.770     2.255 ± 2.240 … 2.270
Kraken      imaging-gaussian-blur.js                 0.998  7.785 ± 7.780 … 7.790     7.800 ± 7.740 … 7.860
Kraken      json-parse-financial.js                  1      0.125 ± 0.120 … 0.130     0.125 ± 0.120 … 0.130
Kraken      json-stringify-tinderbox.js              0.96   0.240 ± 0.240 … 0.240     0.250 ± 0.250 … 0.250
Kraken      stanford-crypto-aes.js                   1.015  0.685 ± 0.670 … 0.700     0.675 ± 0.660 … 0.690
Kraken      stanford-crypto-ccm.js                   0.957  0.555 ± 0.550 … 0.560     0.580 ± 0.580 … 0.580
Kraken      stanford-crypto-pbkdf2.js                0.977  1.055 ± 1.050 … 1.060     1.080 ± 1.080 … 1.080
Kraken      stanford-crypto-sha256-iterative.js      0.989  0.435 ± 0.430 … 0.440     0.440 ± 0.430 … 0.450
Octane      box2d.js                                 1.011  2.320 ± 2.310 … 2.330     2.295 ± 2.250 … 2.340
Octane      code-load.js                             0.993  2.150 ± 2.150 … 2.150     2.165 ± 2.160 … 2.170
Octane      crypto.js                                1.033  7.370 ± 7.280 … 7.460     7.135 ± 7.110 … 7.160
Octane      deltablue.js                             0.995  2.015 ± 2.010 … 2.020     2.025 ± 2.010 … 2.040
Octane      earley-boyer.js                          1.004  16.925 ± 16.810 … 17.040  16.855 ± 16.780 … 16.930
Octane      gbemu.js                                 0.995  2.885 ± 2.870 … 2.900     2.900 ± 2.890 … 2.910
Octane      mandreel.js                              0.999  13.160 ± 12.950 … 13.370  13.175 ± 13.130 … 13.220
Octane      navier-stokes.js                         1.037  3.190 ± 3.170 … 3.210     3.075 ± 3.070 … 3.080
Octane      pdfjs.js                                 1.002  2.845 ± 2.830 … 2.860     2.840 ± 2.810 … 2.870
Octane      raytrace.js                              1.019  6.880 ± 6.860 … 6.900     6.755 ± 6.720 … 6.790
Octane      regexp.js                                0.981  22.270 ± 22.050 … 22.490  22.705 ± 22.270 … 23.140
Octane      richards.js                              1      2.015 ± 2.010 … 2.020     2.015 ± 2.010 … 2.020
Octane      splay.js                                 0.988  2.935 ± 2.920 … 2.950     2.970 ± 2.970 … 2.970
Octane      typescript.js                            0.995  36.045 ± 35.720 … 36.370  36.215 ± 36.060 … 36.370
Octane      zlib.js                                  1.062  81.165 ± 79.820 … 82.510  76.395 ± 74.860 … 77.930
Kraken      Total                                    1.015  23.520                    23.170
Octane      Total                                    1.023  204.170                   199.520
All Suites  Total                                    1.022  227.690                   222.690
```