### PR TITLE
Ports/file: Build host version to ensure we can properly cross compile

### DIFF
--- a/Ports/file/package.sh
+++ b/Ports/file/package.sh
@@ -6,3 +6,18 @@ use_fresh_config_sub='true'
 files=(
     "http://ftp.astron.com/pub/file/file-${version}.tar.gz#fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82"
 )
+
+function pre_configure() {
+    host_env
+    mkdir -p "host-build"
+    (
+        cd host-build
+        "../${workdir}/configure"
+        make
+    )
+}
+
+function build() {
+    export PATH="${PORT_BUILD_DIR}/host-build/src/.libs/:$PATH"
+    run make
+}


### PR DESCRIPTION
We should build file natively as well so it can be used to compile the target build (for serenity). The Makefile doesn't do this automatically so to ensure it will not fail due to version mismatch between the host version and target version, we ensure we always have a native binary at hand.

Some funny backstory - I looked on the Internet something related to bashisms and dash, and was interested to see the state of the `dash` port, and (surprise surprise) I saw it did the `host_env` trickery @timschumi suggested to do and simply copied the procedures and changed it a bit to work according to the `README.DEVELOPER` guidelines in the port.

Closes #18415.