### PR TITLE
Chess: Port application to GML

### DIFF
--- a/Userland/Games/Chess/CMakeLists.txt
+++ b/Userland/Games/Chess/CMakeLists.txt
@@ -5,11 +5,16 @@ serenity_component(
     DEPENDS ChessEngine
 )
 
+compile_gml(Chess.gml ChessGML.cpp chess_gml)
+compile_gml(PromotionWidget.gml PromotionWidgetGML.cpp promotionWidget_gml)
+
 set(SOURCES
     main.cpp
     ChessWidget.cpp
     PromotionDialog.cpp
     Engine.cpp
+    ChessGML.cpp
+    PromotionWidgetGML.cpp
 )
 
 serenity_app(Chess ICON app-chess)

--- a/Userland/Games/Chess/Chess.gml
+++ b/Userland/Games/Chess/Chess.gml
@@ -1,0 +1,8 @@
+@Chess::MainWidget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {}
+
+    @Chess::ChessWidget {
+        name: "chess_widget"
+    }
+}

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -289,7 +289,7 @@ void ChessWidget::mouseup_event(GUI::MouseEvent& event)
 
     Chess::Move move = { m_moving_square, target_square.release_value() };
     if (board().is_promotion_move(move)) {
-        auto promotion_dialog = PromotionDialog::construct(*this);
+        auto promotion_dialog = MUST(PromotionDialog::try_create(*this));
         if (promotion_dialog->exec() == PromotionDialog::ExecResult::OK)
             move.promote_to = promotion_dialog->selected_piece();
     }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -24,6 +24,8 @@
 #include <LibGfx/Path.h>
 #include <unistd.h>
 
+namespace Chess {
+
 ErrorOr<NonnullRefPtr<ChessWidget>> ChessWidget::try_create()
 {
     auto widget = TRY(AK::adopt_nonnull_ref_or_enomem(new (nothrow) ChessWidget));
@@ -43,7 +45,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    painter.fill_rect(frame_inner_rect(), Color::Black);
+    painter.fill_rect(frame_inner_rect(), Gfx::Color::Black);
 
     painter.translate(frame_thickness() + widget_offset_x, frame_thickness() + widget_offset_y);
 
@@ -74,8 +76,8 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
             auto const piece = active_board.get_piece(sq);
             if (m_highlight_checks && last_move.is_check && piece.type == Chess::Type::King && piece.color == active_board.turn()) {
                 Array<Gfx::ColorStop, 2> colors = {
-                    Gfx::ColorStop { .color = Color::Red, .position = 0.16f },
-                    Gfx::ColorStop { .color = Color::Transparent, .position = .66f }
+                    Gfx::ColorStop { .color = Gfx::Color::Red, .position = 0.16f },
+                    Gfx::ColorStop { .color = Gfx::Color::Transparent, .position = .66f }
                 };
 
                 painter.fill_rect_with_radial_gradient(tile_rect, colors, tile_rect.center() - tile_rect.top_left(), tile_rect.size());
@@ -445,11 +447,11 @@ void ChessWidget::set_board_theme(StringView name)
     // FIXME: Add some kind of themes.json
     // The following Colors have been taken from lichess.org, but i'm pretty sure they took them from chess.com.
     if (name == "Beige") {
-        m_board_theme = { "Beige"sv, Color::from_rgb(0xb58863), Color::from_rgb(0xf0d9b5) };
+        m_board_theme = { "Beige"sv, Gfx::Color::from_rgb(0xb58863), Gfx::Color::from_rgb(0xf0d9b5) };
     } else if (name == "Green") {
-        m_board_theme = { "Green"sv, Color::from_rgb(0x86a666), Color::from_rgb(0xffffdd) };
+        m_board_theme = { "Green"sv, Gfx::Color::from_rgb(0x86a666), Gfx::Color::from_rgb(0xffffdd) };
     } else if (name == "Blue") {
-        m_board_theme = { "Blue"sv, Color::from_rgb(0x8ca2ad), Color::from_rgb(0xdee3e6) };
+        m_board_theme = { "Blue"sv, Gfx::Color::from_rgb(0x8ca2ad), Gfx::Color::from_rgb(0xdee3e6) };
     } else {
         set_board_theme("Beige"sv);
     }
@@ -892,4 +894,6 @@ void ChessWidget::config_bool_did_change(StringView domain, StringView group, St
         set_highlight_checks(value);
         update();
     }
+}
+
 }

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -18,6 +18,8 @@
 #include <LibGUI/Frame.h>
 #include <LibGfx/Bitmap.h>
 
+namespace Chess {
+
 class PGNParseError {
 public:
     PGNParseError() = default;
@@ -86,8 +88,8 @@ public:
 
     struct BoardTheme {
         StringView name;
-        Color dark_square_color;
-        Color light_square_color;
+        Gfx::Color dark_square_color;
+        Gfx::Color light_square_color;
     };
 
     BoardTheme const& board_theme() const { return m_board_theme; }
@@ -155,11 +157,11 @@ private:
     size_t m_playback_move_number { 0 };
     BoardMarking m_current_marking;
     Vector<BoardMarking> m_board_markings;
-    BoardTheme m_board_theme { "Beige"sv, Color::from_rgb(0xb58863), Color::from_rgb(0xf0d9b5) };
-    Color m_move_highlight_color { Color::from_argb(0x66ccee00) };
-    Color m_marking_primary_color { Color::from_argb(0x66ff0000) };
-    Color m_marking_alternate_color { Color::from_argb(0x66ffaa00) };
-    Color m_marking_secondary_color { Color::from_argb(0x6655dd55) };
+    BoardTheme m_board_theme { "Beige"sv, Gfx::Color::from_rgb(0xb58863), Gfx::Color::from_rgb(0xf0d9b5) };
+    Gfx::Color m_move_highlight_color { Gfx::Color::from_argb(0x66ccee00) };
+    Gfx::Color m_marking_primary_color { Gfx::Color::from_argb(0x66ff0000) };
+    Gfx::Color m_marking_alternate_color { Gfx::Color::from_argb(0x66ffaa00) };
+    Gfx::Color m_marking_secondary_color { Gfx::Color::from_argb(0x6655dd55) };
     Chess::Color m_side { Chess::Color::White };
     HashMap<Chess::Piece, RefPtr<Gfx::Bitmap const>> m_pieces;
     bool m_any_piece_images_are_missing { false };
@@ -173,3 +175,5 @@ private:
     bool m_coordinates { true };
     bool m_highlight_checks { true };
 };
+
+}

--- a/Userland/Games/Chess/MainWidget.h
+++ b/Userland/Games/Chess/MainWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace Chess {
+
+class MainWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(MainWidget)
+public:
+    static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
+    virtual ~MainWidget() override = default;
+
+private:
+    MainWidget() = default;
+};
+
+}

--- a/Userland/Games/Chess/PromotionDialog.cpp
+++ b/Userland/Games/Chess/PromotionDialog.cpp
@@ -11,28 +11,34 @@
 
 namespace Chess {
 
-PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
+ErrorOr<NonnullRefPtr<PromotionDialog>> PromotionDialog::try_create(ChessWidget& chess_widget)
+{
+    auto promotion_widget = TRY(Chess::PromotionWidget::try_create());
+    auto promotion_dialog = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PromotionDialog(move(promotion_widget), chess_widget)));
+    return promotion_dialog;
+}
+
+PromotionDialog::PromotionDialog(NonnullRefPtr<Chess::PromotionWidget> promotion_widget, ChessWidget& chess_widget)
     : Dialog(chess_widget.window())
     , m_selected_piece(Chess::Type::None)
 {
     set_title("Choose piece to promote to");
     set_icon(chess_widget.window()->icon());
-    resize(70 * 4, 70);
+    set_main_widget(promotion_widget);
 
-    auto main_widget = set_main_widget<GUI::Frame>();
-    main_widget->set_frame_style(Gfx::FrameStyle::SunkenContainer);
-    main_widget->set_fill_with_background_color(true);
-    main_widget->set_layout<GUI::HorizontalBoxLayout>();
-
-    for (auto const& type : { Chess::Type::Queen, Chess::Type::Knight, Chess::Type::Rook, Chess::Type::Bishop }) {
-        auto& button = main_widget->add<GUI::Button>();
-        button.set_fixed_height(70);
-        button.set_icon(chess_widget.get_piece_graphic({ chess_widget.board().turn(), type }));
-        button.on_click = [this, type](auto) {
-            m_selected_piece = type;
+    auto initialize_promotion_button = [&](StringView button_name, Chess::Type piece) {
+        auto button = promotion_widget->find_descendant_of_type_named<GUI::Button>(button_name);
+        button->set_icon(chess_widget.get_piece_graphic({ chess_widget.board().turn(), piece }));
+        button->on_click = [this, piece](auto) {
+            m_selected_piece = piece;
             done(ExecResult::OK);
         };
-    }
+    };
+
+    initialize_promotion_button("queen_button"sv, Type::Queen);
+    initialize_promotion_button("knight_button"sv, Type::Knight);
+    initialize_promotion_button("rook_button"sv, Type::Rook);
+    initialize_promotion_button("bishop_button"sv, Type::Bishop);
 }
 
 void PromotionDialog::event(Core::Event& event)

--- a/Userland/Games/Chess/PromotionDialog.cpp
+++ b/Userland/Games/Chess/PromotionDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2024, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +8,8 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Frame.h>
+
+namespace Chess {
 
 PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
     : Dialog(chess_widget.window())
@@ -36,4 +38,6 @@ PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
 void PromotionDialog::event(Core::Event& event)
 {
     Dialog::event(event);
+}
+
 }

--- a/Userland/Games/Chess/PromotionDialog.h
+++ b/Userland/Games/Chess/PromotionDialog.h
@@ -7,17 +7,19 @@
 #pragma once
 
 #include "ChessWidget.h"
+#include "PromotionWidget.h"
 #include <LibGUI/Dialog.h>
 
 namespace Chess {
 
 class PromotionDialog final : public GUI::Dialog {
-    C_OBJECT(PromotionDialog)
+    C_OBJECT_ABSTRACT(PromotionDialog)
 public:
+    static ErrorOr<NonnullRefPtr<PromotionDialog>> try_create(ChessWidget& chess_widget);
     Chess::Type selected_piece() const { return m_selected_piece; }
 
 private:
-    explicit PromotionDialog(ChessWidget& chess_widget);
+    PromotionDialog(NonnullRefPtr<Chess::PromotionWidget> promotion_widget, ChessWidget& chess_widget);
     virtual void event(Core::Event&) override;
 
     Chess::Type m_selected_piece;

--- a/Userland/Games/Chess/PromotionDialog.h
+++ b/Userland/Games/Chess/PromotionDialog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2024, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +8,8 @@
 
 #include "ChessWidget.h"
 #include <LibGUI/Dialog.h>
+
+namespace Chess {
 
 class PromotionDialog final : public GUI::Dialog {
     C_OBJECT(PromotionDialog)
@@ -20,3 +22,5 @@ private:
 
     Chess::Type m_selected_piece;
 };
+
+}

--- a/Userland/Games/Chess/PromotionWidget.gml
+++ b/Userland/Games/Chess/PromotionWidget.gml
@@ -1,0 +1,29 @@
+@Chess::PromotionWidget {
+    fixed_height: 70
+    fill_with_background_color: true
+    layout: @GUI::HorizontalBoxLayout {}
+
+    @GUI::Button {
+        fixed_width: 70
+        fixed_height: 70
+        name: "queen_button"
+    }
+
+    @GUI::Button {
+        fixed_width: 70
+        fixed_height: 70
+        name: "knight_button"
+    }
+
+    @GUI::Button {
+        fixed_width: 70
+        fixed_height: 70
+        name: "rook_button"
+    }
+
+    @GUI::Button {
+        fixed_width: 70
+        fixed_height: 70
+        name: "bishop_button"
+    }
+}

--- a/Userland/Games/Chess/PromotionWidget.h
+++ b/Userland/Games/Chess/PromotionWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace Chess {
+
+class PromotionWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(PromotionWidget)
+public:
+    static ErrorOr<NonnullRefPtr<PromotionWidget>> try_create();
+    virtual ~PromotionWidget() override = default;
+
+private:
+    PromotionWidget() = default;
+};
+
+}

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -64,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-chess"sv));
 
     auto window = GUI::Window::construct();
-    auto widget = TRY(ChessWidget::try_create());
+    auto widget = TRY(Chess::ChessWidget::try_create());
     window->set_main_widget(widget);
 
     auto engines = TRY(available_engines());


### PR DESCRIPTION
This PR adds the chess application to the `Chess` namespaces and then ports the 
chess application to GML in order to facilitate the addition of widgets in the future.