### PR TITLE
LibGUI: Don't crash when rendering a collapsible toolbar with no items

### DIFF
--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -165,7 +165,7 @@ ErrorOr<void> Toolbar::create_overflow_objects()
 
 ErrorOr<void> Toolbar::update_overflow_menu()
 {
-    if (!m_collapsible)
+    if (!m_collapsible || m_items.is_empty())
         return {};
 
     Optional<size_t> marginal_index {};


### PR DESCRIPTION
This prevents a crash in GML Playground that would occur when previewing a GUI with a collapsible toolbar.

Fixes #24303