### PR TITLE
Toolchain: Set cpu_family in meson cross files to SERENITY_ARCH

### DIFF
--- a/Toolchain/CMake/meson-cross-file-Clang.txt.in
+++ b/Toolchain/CMake/meson-cross-file-Clang.txt.in
@@ -11,6 +11,6 @@ needs_exe_wrapper = true
 
 [host_machine]
 system = 'serenity'
-cpu_family = 'x86'
+cpu_family = '@SERENITY_ARCH@'
 cpu = '@SERENITY_ARCH@'
 endian = 'little'

--- a/Toolchain/CMake/meson-cross-file-GNU.txt.in
+++ b/Toolchain/CMake/meson-cross-file-GNU.txt.in
@@ -11,6 +11,6 @@ needs_exe_wrapper = true
 
 [host_machine]
 system = 'serenity'
-cpu_family = 'x86'
+cpu_family = '@SERENITY_ARCH@'
 cpu = '@SERENITY_ARCH@'
 endian = 'little'


### PR DESCRIPTION
Noticed these were still set to `x86` while playing around with enabling the dynamic core on our `dosbox-staging` port.

EDIT:
Switching to the environment variable `SERENITY_ARCH` instead of the hardcoded value for `cpu_family`. Seems that both `cpu_family` and `cpu` is supposed have the value `x86_64 in our case`: https://mesonbuild.com/Cross-compilation.html#cross-compilation