### PR TITLE
Toolchain+CI: Remove unused TRY_USE_LOCAL_TOOLCHAIN parameter

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,10 +23,14 @@ runs:
 
         set -e
         sudo apt-get purge -y clang-13 clang-14 clang-15 gcc-10 gcc-11 gcc-12
+
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+
         sudo apt-get update
-        sudo apt-get install ccache clang-18 clang++-18 lld-18 clang-format-18 ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
+        sudo apt-get install ccache clang-18 clang++-18 clang-format-18 lld-18 gcc-13 g++-13 libstdc++-13-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
@@ -55,8 +59,12 @@ runs:
       shell: bash
       run: |
         set -e
+
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+
         sudo apt-get update
         sudo apt-get install clang-format-18 ccache e2fsprogs gcc-13 g++-13 libstdc++-13-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja libegl1-mesa-dev
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,7 +22,6 @@ runs:
         # Packages below aren't.
 
         set -e
-        sudo apt-get purge -y clang-13 clang-14 clang-15 gcc-10 gcc-11 gcc-12
 
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -115,8 +115,8 @@ jobs:
             -DENABLE_FUZZERS_LIBFUZZER=ON \
             -DENABLE_ADDRESS_SANITIZER=ON \
             -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
+            -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \
             -DCMAKE_PREFIX_PATH=tool-install
 
       # === BUILD ===

--- a/.github/workflows/serenity-template.yml
+++ b/.github/workflows/serenity-template.yml
@@ -83,7 +83,6 @@ jobs:
         env:
           ARCH: ${{ inputs.arch}}
           CCACHE_DIR: ${{ env.TOOLCHAIN_CCACHE_DIR }}
-          TRY_USE_LOCAL_TOOLCHAIN: 'y'
 
       - name: Build AArch64 Qemu
         if: ${{ inputs.arch == 'aarch64' && !steps.cache-restore.outputs.qemu_cache_hit }}

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -19,6 +19,7 @@ moc_qt_objects("generate_moc") {
     "Qt/EventLoopImplementationQtEventTarget.h",
     "Qt/InspectorWidget.h",
     "Qt/LocationEdit.h",
+    "Qt/Settings.h",
     "Qt/SettingsDialog.h",
     "Qt/Tab.h",
     "Qt/TabBar.h",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/WebAudio/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/WebAudio/BUILD.gn
@@ -16,6 +16,8 @@ source_set("WebAudio") {
     "AudioScheduledSourceNode.h",
     "BaseAudioContext.cpp",
     "BaseAudioContext.h",
+    "DynamicsCompressorNode.cpp",
+    "DynamicsCompressorNode.h",
     "OfflineAudioContext.cpp",
     "OfflineAudioContext.h",
     "OscillatorNode.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/idl_files.gni
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/idl_files.gni
@@ -314,6 +314,7 @@ standard_idl_files = [
   "//Userland/Libraries/LibWeb/WebAudio/AudioParam.idl",
   "//Userland/Libraries/LibWeb/WebAudio/AudioScheduledSourceNode.idl",
   "//Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.idl",
+  "//Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.idl",
   "//Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.idl",
   "//Userland/Libraries/LibWeb/WebAudio/OscillatorNode.idl",
   "//Userland/Libraries/LibWeb/WebAudio/PeriodicWave.idl",

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -159,43 +159,6 @@ else
     buildstep setup echo "Using user-provided CFLAGS/CXXFLAGS."
 fi
 
-# === CHECK CACHE AND REUSE ===
-
-pushd "$DIR"
-    if [ "$TRY_USE_LOCAL_TOOLCHAIN" = "y" ]; then
-        mkdir -p Cache
-        echo "Cache (before):"
-        ls -l Cache
-        CACHED_TOOLCHAIN_ARCHIVE="Cache/ToolchainBinariesGithubActions.tar.gz"
-        if [ -r "${CACHED_TOOLCHAIN_ARCHIVE}" ] ; then
-            echo "Cache at ${CACHED_TOOLCHAIN_ARCHIVE} exists!"
-            echo "Extracting toolchain from cache:"
-            if tar xzf "${CACHED_TOOLCHAIN_ARCHIVE}" ; then
-                 echo "Done 'building' the toolchain."
-                 echo "Cache unchanged."
-                 exit 0
-            else
-                echo
-                echo
-                echo
-                echo "Could not extract cached toolchain archive."
-                echo "This means the cache is broken and *should be removed*!"
-                echo "As Github Actions cannot update a cache, this will unnecessarily"
-                echo "slow down all future builds for this hash, until someone"
-                echo "resets the cache."
-                echo
-                echo
-                echo
-                rm -f "${CACHED_TOOLCHAIN_ARCHIVE}"
-            fi
-        else
-            echo "Cache at ${CACHED_TOOLCHAIN_ARCHIVE} does not exist."
-            echo "Will rebuild toolchain from scratch, and save the result."
-        fi
-    fi
-    echo "::group::Actually building Toolchain"
-popd
-
 # === DOWNLOAD AND PATCH ===
 
 pushd "$DIR/Tarballs"
@@ -309,21 +272,4 @@ pushd "$DIR/Local/clang/bin/"
         ln -s llvm-nm "$arch"-pc-serenity-nm
         echo "--sysroot=$BUILD/${arch}clang/Root" > "$arch"-pc-serenity.cfg
     done
-popd
-
-# === SAVE TO CACHE ===
-
-pushd "$DIR"
-    if [ "$TRY_USE_LOCAL_TOOLCHAIN" = "y" ]; then
-        echo "::endgroup::"
-        echo "Building cache tar:"
-
-        echo "Building cache tar:"
-
-        rm -f "${CACHED_TOOLCHAIN_ARCHIVE}"  # Just in case
-
-        tar czf "${CACHED_TOOLCHAIN_ARCHIVE}" Local/
-        echo "Cache (after):"
-        ls -l Cache
-    fi
 popd


### PR DESCRIPTION
This was used to create a .tar of the built Clang toolchain, but now we
just upload the built toolchain artifacts (same as the GNU toolchain).

Ref https://github.com/SerenityOS/serenity/pull/24263#discussion_r1594302549