### PR TITLE
LibWeb: Use correct type for `MessageEventInit.ports`

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -888,7 +888,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
                 } else {
                     sequence_generator.append(R"~~~(
-    @sequence.storage_type@ @cpp_name@ { global_object.heap() };
+    @sequence.storage_type@<@sequence.type@> @cpp_name@ { vm.heap() };
 )~~~");
                 }
             }

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MessageEventPrototype.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 
 namespace Web::HTML {
 
@@ -31,9 +32,9 @@ MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, Messag
     , m_source(event_init.source)
 {
     m_ports.ensure_capacity(event_init.ports.size());
-    for (auto& port : event_init.ports) {
+    for (auto const& port : event_init.ports) {
         VERIFY(port);
-        m_ports.unchecked_append(*port);
+        m_ports.unchecked_append(static_cast<JS::Object&>(*port));
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -20,7 +20,7 @@ struct MessageEventInit : public DOM::EventInit {
     String origin {};
     String last_event_id {};
     Optional<MessageEventSource> source;
-    Vector<JS::Handle<JS::Object>> ports;
+    Vector<JS::Handle<MessagePort>> ports;
 };
 
 class MessageEvent : public DOM::Event {

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.idl
@@ -22,6 +22,5 @@ dictionary MessageEventInit : EventInit {
     USVString origin = "";
     DOMString lastEventId = "";
     MessageEventSource? source = null;
-    // FIXME: sequence<MessagePort> ports = [];
-    sequence<object> ports = [];
+    sequence<MessagePort> ports = [];
 };

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -372,10 +372,10 @@ void MessagePort::post_message_task_steps(SerializedTransferRecord& serialize_wi
 
     // 5. Let newPorts be a new frozen array consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]], if any, maintaining their relative order.
     // FIXME: Use a FrozenArray
-    Vector<JS::Handle<JS::Object>> new_ports;
+    Vector<JS::Handle<MessagePort>> new_ports;
     for (auto const& object : deserialize_record.transferred_values) {
         if (is<HTML::MessagePort>(*object)) {
-            new_ports.append(object);
+            new_ports.append(verify_cast<MessagePort>(*object));
         }
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1160,10 +1160,10 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         // 6. Let newPorts be a new frozen array consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]],
         //    if any, maintaining their relative order.
         // FIXME: Use a FrozenArray
-        Vector<JS::Handle<JS::Object>> new_ports;
+        Vector<JS::Handle<MessagePort>> new_ports;
         for (auto const& object : deserialize_record.transferred_values) {
             if (is<HTML::MessagePort>(*object)) {
-                new_ports.append(object);
+                new_ports.append(verify_cast<MessagePort>(*object));
             }
         }
 


### PR DESCRIPTION
This didn't work previously because the IDL generator used the incorrect type for some types of sequences within dictionaries.