### PR TITLE
LibWeb: Implement the `relList` attribute

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
@@ -1,0 +1,6 @@
+a.relList initial length: 0
+a.relList always returns the same value: true
+a.relList for after setting rel to "whatever": whatever
+a.relList for after setting rel to "prefetch": prefetch
+a.relList contains "prefetch": true
+a.relList contains "whatever": false

--- a/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
@@ -10,3 +10,9 @@ area.relList for after setting rel to "whatever": whatever
 area.relList for after setting rel to "prefetch": prefetch
 area.relList contains "prefetch": true
 area.relList contains "whatever": false
+form.relList initial length: 0
+form.relList always returns the same value: true
+form.relList for after setting rel to "whatever": whatever
+form.relList for after setting rel to "prefetch": prefetch
+form.relList contains "prefetch": true
+form.relList contains "whatever": false

--- a/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
@@ -4,3 +4,9 @@ a.relList for after setting rel to "whatever": whatever
 a.relList for after setting rel to "prefetch": prefetch
 a.relList contains "prefetch": true
 a.relList contains "whatever": false
+area.relList initial length: 0
+area.relList always returns the same value: true
+area.relList for after setting rel to "whatever": whatever
+area.relList for after setting rel to "prefetch": prefetch
+area.relList contains "prefetch": true
+area.relList contains "whatever": false

--- a/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/relList-attribute.txt
@@ -16,3 +16,9 @@ form.relList for after setting rel to "whatever": whatever
 form.relList for after setting rel to "prefetch": prefetch
 form.relList contains "prefetch": true
 form.relList contains "whatever": false
+link.relList initial length: 0
+link.relList always returns the same value: true
+link.relList for after setting rel to "whatever": whatever
+link.relList for after setting rel to "prefetch": prefetch
+link.relList contains "prefetch": true
+link.relList contains "whatever": false

--- a/Tests/LibWeb/Text/input/HTML/relList-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/relList-attribute.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function relListTest(tagName) {
+        const element = document.createElement(tagName);
+        const relList = element.relList;
+        println(`${tagName}.relList initial length: ${relList.length}`);
+        println(`${tagName}.relList always returns the same value: ${relList === element.relList}`);
+        element.rel = "whatever";
+        println(`${tagName}.relList for after setting rel to "whatever": ${relList}`);
+        element.relList = "prefetch";
+        println(`${tagName}.relList for after setting rel to "prefetch": ${relList}`);
+        println(`${tagName}.relList contains "prefetch": ${relList.contains("prefetch")}`);
+        println(`${tagName}.relList contains "whatever": ${relList.contains("whatever")}`);        
+    }
+
+    test(() => {
+        const tagNamesToTest = [
+            "a",
+        ];
+
+        for (const tagName of tagNamesToTest) {
+            relListTest(tagName);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/relList-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/relList-attribute.html
@@ -18,6 +18,7 @@
         const tagNamesToTest = [
             "a",
             "area",
+            "form",
         ];
 
         for (const tagName of tagNamesToTest) {

--- a/Tests/LibWeb/Text/input/HTML/relList-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/relList-attribute.html
@@ -17,6 +17,7 @@
     test(() => {
         const tagNamesToTest = [
             "a",
+            "area",
         ];
 
         for (const tagName of tagNamesToTest) {

--- a/Tests/LibWeb/Text/input/HTML/relList-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/relList-attribute.html
@@ -19,6 +19,7 @@
             "a",
             "area",
             "form",
+            "link",
         ];
 
         for (const tagName of tagNamesToTest) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -7,6 +7,7 @@
 
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/HTMLAnchorElementPrototype.h>
+#include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
@@ -38,6 +39,9 @@ void HTMLAnchorElement::attribute_changed(FlyString const& name, Optional<String
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
         set_the_url();
+    } else if (name == HTML::AttributeNames::rel) {
+        if (m_rel_list)
+            m_rel_list->associated_attribute_changed(value.value_or(String {}));
     }
 }
 
@@ -121,6 +125,15 @@ Optional<ARIA::Role> HTMLAnchorElement::default_role() const
         return ARIA::Role::link;
     // https://www.w3.org/TR/html-aria/#el-a
     return ARIA::Role::generic;
+}
+
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-rellist
+JS::GCPtr<DOM::DOMTokenList> HTMLAnchorElement::rel_list()
+{
+    // The IDL attribute relList must reflect the rel content attribute.
+    if (!m_rel_list)
+        m_rel_list = DOM::DOMTokenList::create(*this, HTML::AttributeNames::rel);
+    return m_rel_list;
 }
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-text

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -24,6 +24,8 @@ public:
     String target() const { return get_attribute_value(HTML::AttributeNames::target); }
     String download() const { return get_attribute_value(HTML::AttributeNames::download); }
 
+    JS::GCPtr<DOM::DOMTokenList> rel_list();
+
     String text() const;
     void set_text(String const&);
 
@@ -68,6 +70,8 @@ private:
     }
 
     virtual Optional<ARIA::Role> default_role() const override;
+
+    JS::GCPtr<DOM::DOMTokenList> m_rel_list;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -11,7 +11,7 @@ interface HTMLAnchorElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString download;
     [CEReactions, Reflect] attribute DOMString ping;
     [CEReactions, Reflect] attribute DOMString rel;
-    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
     [CEReactions, Reflect] attribute DOMString hreflang;
     [CEReactions, Reflect] attribute DOMString type;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/HTMLAreaElementPrototype.h>
+#include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/Window.h>
 
@@ -31,7 +32,19 @@ void HTMLAreaElement::attribute_changed(FlyString const& name, Optional<String> 
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
         set_the_url();
+    } else if (name == HTML::AttributeNames::rel) {
+        if (m_rel_list)
+            m_rel_list->associated_attribute_changed(value.value_or(String {}));
     }
+}
+
+// https://html.spec.whatwg.org/multipage/image-maps.html#dom-area-rellist
+JS::GCPtr<DOM::DOMTokenList> HTMLAreaElement::rel_list()
+{
+    // The IDL attribute relList must reflect the rel content attribute.
+    if (!m_rel_list)
+        m_rel_list = DOM::DOMTokenList::create(*this, HTML::AttributeNames::rel);
+    return m_rel_list;
 }
 
 Optional<String> HTMLAreaElement::hyperlink_element_utils_href() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -20,6 +20,7 @@ class HTMLAreaElement final
 
 public:
     virtual ~HTMLAreaElement() override;
+    JS::GCPtr<DOM::DOMTokenList> rel_list();
 
 private:
     HTMLAreaElement(DOM::Document&, DOM::QualifiedName);
@@ -50,6 +51,8 @@ private:
     }
 
     virtual Optional<ARIA::Role> default_role() const override;
+
+    JS::GCPtr<DOM::DOMTokenList> m_rel_list;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.idl
@@ -14,7 +14,7 @@ interface HTMLAreaElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString download;
     [CEReactions, Reflect] attribute USVString ping;
     [CEReactions, Reflect] attribute DOMString rel;
-    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
     // FIXME: [CEReactions] attribute DOMString referrerPolicy;
 
     // Obsolete

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -11,6 +11,7 @@
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLFormElementPrototype.h>
+#include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/HTMLFormControlsCollection.h>
@@ -584,6 +585,15 @@ StringView HTMLFormElement::method() const
     VERIFY_NOT_REACHED();
 }
 
+// https://html.spec.whatwg.org/multipage/forms.html#dom-form-rellist
+JS::GCPtr<DOM::DOMTokenList> HTMLFormElement::rel_list()
+{
+    // The relList IDL attribute must reflect the rel content attribute.
+    if (!m_rel_list)
+        m_rel_list = DOM::DOMTokenList::create(*this, HTML::AttributeNames::rel);
+    return m_rel_list;
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-method
 WebIDL::ExceptionOr<void> HTMLFormElement::set_method(String const& method)
 {
@@ -609,6 +619,15 @@ String HTMLFormElement::action() const
 WebIDL::ExceptionOr<void> HTMLFormElement::set_action(String const& value)
 {
     return set_attribute(AttributeNames::action, value);
+}
+
+void HTMLFormElement::attribute_changed(FlyString const& name, Optional<String> const& value)
+{
+    HTMLElement::attribute_changed(name, value);
+    if (name == HTML::AttributeNames::rel) {
+        if (m_rel_list)
+            m_rel_list->associated_attribute_changed(value.value_or(String {}));
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#picking-an-encoding-for-the-form

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -92,6 +92,8 @@ public:
     StringView method() const;
     WebIDL::ExceptionOr<void> set_method(String const&);
 
+    JS::GCPtr<DOM::DOMTokenList> rel_list();
+
     String action() const;
     WebIDL::ExceptionOr<void> set_action(String const&);
 
@@ -108,6 +110,8 @@ private:
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual Vector<FlyString> supported_property_names() const override;
     virtual bool is_supported_property_index(u32) const override;
+
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     ErrorOr<String> pick_an_encoding() const;
 
@@ -143,6 +147,8 @@ private:
     // Each form element has a planned navigation, which is either null or a task; when the form is first created,
     // its planned navigation must be set to null.
     JS::GCPtr<Task const> m_planned_navigation;
+
+    JS::GCPtr<DOM::DOMTokenList> m_rel_list;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -17,7 +17,7 @@ interface HTMLFormElement : HTMLElement {
     [CEReactions, Reflect=novalidate] attribute boolean noValidate;
     [CEReactions, Reflect] attribute DOMString target;
     [CEReactions, Reflect] attribute DOMString rel;
-    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
 
     [SameObject] readonly attribute HTMLFormControlsCollection elements;
     readonly attribute unsigned long length;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -13,6 +13,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/HTMLLinkElementPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -89,6 +90,15 @@ void HTMLLinkElement::inserted()
     }
 }
 
+// https://html.spec.whatwg.org/multipage/semantics.html#dom-link-rellist
+JS::GCPtr<DOM::DOMTokenList> HTMLLinkElement::rel_list()
+{
+    // The relList IDL attribute must reflect the rel content attribute.
+    if (!m_rel_list)
+        m_rel_list = DOM::DOMTokenList::create(*this, HTML::AttributeNames::rel);
+    return m_rel_list;
+}
+
 bool HTMLLinkElement::has_loaded_icon() const
 {
     return m_relationship & Relationship::Icon && resource() && resource()->is_loaded() && resource()->has_encoded_data();
@@ -121,6 +131,9 @@ void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> 
             else if (part == "icon"sv)
                 m_relationship |= Relationship::Icon;
         }
+
+        if (m_rel_list)
+            m_rel_list->associated_attribute_changed(value.value_or(String {}));
     }
 
     // https://html.spec.whatwg.org/multipage/semantics.html#the-link-element:explicitly-enabled

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -34,6 +34,8 @@ public:
     String type() const { return get_attribute_value(HTML::AttributeNames::type); }
     String href() const { return get_attribute_value(HTML::AttributeNames::href); }
 
+    JS::GCPtr<DOM::DOMTokenList> rel_list();
+
     bool has_loaded_icon() const;
     bool load_favicon_and_use_if_window_is_active();
 
@@ -43,7 +45,7 @@ private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    void attribute_changed(FlyString const&, Optional<String> const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<String> const&) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;
@@ -133,6 +135,7 @@ private:
     JS::GCPtr<CSS::CSSStyleSheet> m_loaded_style_sheet;
 
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
+    JS::GCPtr<DOM::DOMTokenList> m_rel_list;
     unsigned m_relationship { 0 };
     // https://html.spec.whatwg.org/multipage/semantics.html#explicitly-enabled
     bool m_explicitly_enabled { false };

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -11,7 +11,7 @@ interface HTMLLinkElement : HTMLElement {
     // FIXME: [CEReactions] attribute DOMString? crossOrigin;
     [CEReactions, Reflect] attribute DOMString rel;
     // FIXME: [CEReactions] attribute DOMString as;
-    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
     [CEReactions, Reflect] attribute DOMString media;
     [CEReactions, Reflect] attribute DOMString integrity;
     [CEReactions, Reflect] attribute DOMString hreflang;


### PR DESCRIPTION
This PR implements the `relList` attribute for the `<a>`, `<area>`, `<link>` and `<form>` elements.

This returns a DOMTokenList that reflects the `rel` attribute.