### PR TITLE
LibWeb: Implement the `form` attribute for `<label>` and `<object>` elements

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLLabelElement-form.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLLabelElement-form.txt
@@ -1,0 +1,12 @@
+              Form for #label-no-for is null
+Control for #label-no-for is null: true
+Form for #parent-of-input2: #form2
+label.form is the same as label.control.form for #parent-of-input2: true
+Form for #label-for-input2: #form2
+label.form is the same as label.control.form for #label-for-input2: true
+Form for #label-for-input1: #form1
+label.form is the same as label.control.form for #label-for-input1: true
+Form for #label-for-non-labelable-element is null
+Control for #label-for-non-labelable-element is null: true
+Form for #label-for-nonexistent-element is null
+Control for #label-for-nonexistent-element is null: true

--- a/Tests/LibWeb/Text/expected/HTML/HTMLObjectElement-form.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLObjectElement-form.txt
@@ -1,0 +1,3 @@
+objectElement.form initial value is null: true
+objectElement.form.id after appending to #form1: form1
+objectElement.form value after removing from #form1 is null: true

--- a/Tests/LibWeb/Text/input/HTML/HTMLLabelElement-form.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLLabelElement-form.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<label id="label-no-for"></label>
+<span id="non-labelable"></span>
+<form id="form1">
+    <input id="input1">
+</form>
+<form id="form2">
+    <label id="parent-of-input2"><input id="input2" ></label>    
+    <label id="label-for-input2" for="input2"></label>
+    <label id="label-for-input1" for="input1"></label>
+    <label id="label-for-non-labelable-element" for="non-labelable"></label>
+    <label id="label-for-nonexistent-element" for="invalid"></label>
+</form>
+</form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (const labelElement of document.querySelectorAll("label")) {
+            if (labelElement.form) {
+                println(`Form for #${labelElement.id}: #${labelElement.form.id}`);
+                println(`label.form is the same as label.control.form for #${labelElement.id}: ${labelElement.form === labelElement.control.form}`);
+            } else {
+                println(`Form for #${labelElement.id} is null`);
+                println(`Control for #${labelElement.id} is null: ${labelElement.control === null}`);
+            }
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-form.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-form.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const objectElement = document.createElement("object");
+        println(`objectElement.form initial value is null: ${objectElement.form === null}`);
+
+        const formElement = document.createElement("form");
+        formElement.id = "form1";
+        formElement.appendChild(objectElement);
+        println(`objectElement.form.id after appending to #form1: ${objectElement.form.id}`);
+        formElement.removeChild(objectElement);
+        println(`objectElement.form value after removing from #form1 is null: ${objectElement.form === null}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -43,7 +43,7 @@ JS::GCPtr<HTMLElement> HTMLLabelElement::control() const
     // and the first such element in tree order is a labelable element, then that element is the
     // label element's labeled control.
     if (for_().has_value()) {
-        for_each_in_inclusive_subtree_of_type<HTMLElement>([&](auto& element) {
+        root().for_each_in_inclusive_subtree_of_type<HTMLElement>([&](auto& element) {
             if (element.id() == *for_() && element.is_labelable()) {
                 control = &const_cast<HTMLElement&>(element);
                 return TraversalDecision::Break;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/HTMLLabelElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLLabelElement.h>
 #include <LibWeb/Layout/Label.h>
 
@@ -64,6 +65,23 @@ JS::GCPtr<HTMLElement> HTMLLabelElement::control() const
     });
 
     return control;
+}
+
+// https://html.spec.whatwg.org/multipage/forms.html#dom-label-form
+JS::GCPtr<HTMLFormElement> HTMLLabelElement::form() const
+{
+    auto labeled_control = control();
+
+    // 1. If the label element has no labeled control, then return null.
+    if (!labeled_control)
+        return {};
+
+    // 2. If the label element's labeled control is not a form-associated element, then return null.
+    if (!is<FormAssociatedElement>(*labeled_control))
+        return {};
+
+    // 3. Return the label element's labeled control's form owner (which can still be null).
+    return dynamic_cast<FormAssociatedElement*>(labeled_control.ptr())->form();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
@@ -22,6 +22,7 @@ public:
     Optional<String> for_() const { return attribute(HTML::AttributeNames::for_); }
 
     JS::GCPtr<HTMLElement> control() const;
+    JS::GCPtr<HTMLFormElement> form() const;
 
 private:
     HTMLLabelElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.idl
@@ -6,7 +6,7 @@ interface HTMLLabelElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    // FIXME: readonly attribute HTMLFormElement? form;
+    readonly attribute HTMLFormElement? form;
     [CEReactions, Reflect=for] attribute DOMString htmlFor;
     readonly attribute HTMLElement? control;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -10,7 +10,7 @@ interface HTMLObjectElement : HTMLElement {
     [CEReactions] attribute DOMString data;
     [CEReactions, Reflect] attribute DOMString type;
     [CEReactions, Reflect] attribute DOMString name;
-    // FIXME: readonly attribute HTMLFormElement? form;
+    readonly attribute HTMLFormElement? form;
     [CEReactions, Reflect] attribute DOMString width;
     [CEReactions, Reflect] attribute DOMString height;
     readonly attribute Document? contentDocument;


### PR DESCRIPTION
This PR adds the `form` attribute to the `<label>` and `<object>` elements. In the case of `<object>` we are simply exposing functionality that already exists in `FormAssociatedElement`.  

With these changes we now pass the following WPT test:  http://wpt.live/html/semantics/forms/form-control-infrastructure/form.html

