### PR TITLE
Documentation: Update minimum GCC version to 13

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -13,9 +13,9 @@ Optional: `fuse2fs` for [building images without root](https://github.com/Sereni
 
 #### GCC 12 or Clang 17
 
-A host compiler that supports C++23 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-17.
+A host compiler that supports C++23 features is required for building host tools, the newer the better. Tested versions include gcc-13 and clang-17.
 
-On Ubuntu gcc-12 is available in the repositories of 22.04 (Jammy) and later.
+On Ubuntu gcc-13 is available in the repositories of 22.04 (Jammy) and later.
 If you are running an older version, you will either need to upgrade, or find an alternative installation source.
 
 Next, update your local package information from this repository:
@@ -24,10 +24,10 @@ Next, update your local package information from this repository:
 sudo apt update
 ```
 
-Now on Ubuntu or Debian you can install gcc-12 with apt like this:
+Now on Ubuntu or Debian you can install gcc-13 with apt like this:
 
 ```console
-sudo apt install gcc-12 g++-12
+sudo apt install gcc-13 g++-13
 ```
 
 #### QEMU 6.2 or later


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/pull/24169 upgraded the compiler to use C++23 standard, and recently (not sure if it was related to the C++23 upgrade or not) if you have a GCC-12 compiler (in my case GCC 12.3) you get the following error when attempting to build ladybird:

```
> ./Meta/serenity.sh run lagom ladybird
-- Configuring done (1.9s)
-- Generating done (0.6s)
-- Build files have been written to: ./serenityos/Build/lagom
ninja: Entering directory `./serenityos/Build/lagom'
[0/2] Re-checking globbed directories...
[7/2394] Building CXX object CMakeFiles/LibGUI.d.../serenityos/Userland/Libraries/LibGUI/Icon.cpp.o
FAILED: CMakeFiles/LibGUI.dir./serenityos/Userland/Libraries/LibGUI/Icon.cpp.o 
In file included from ./serenityos/Meta/Lagom/../../Userland/Libraries/LibGfx/Bitmap.h:15,
                 from ./serenityos/Meta/Lagom/../../Userland/Libraries/LibGUI/Icon.h:14,
                 from ./serenityos/Userland/Libraries/LibGUI/Icon.cpp:9:
./serenityos/Meta/Lagom/../../Userland/Libraries/LibGfx/Color.h: In member function ‘constexpr u8 Gfx::Color::luminosity() const’:
./serenityos/Meta/Lagom/../../Userland/Libraries/LibGfx/Color.h:319:28: error: call to non-‘constexpr’ function ‘I AK::Rounding::round_to(float) [with I = unsigned char]’
  319 |         return round_to<u8>(red() * 0.2126f + green() * 0.7152f + blue() * 0.0722f);
      |                ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./serenityos/Meta/Lagom/../../Userland/Libraries/LibGfx/Color.h:12:
./serenityos/Meta/Lagom/../../AK/Math.h:258:17: note: ‘I AK::Rounding::round_to(float) [with I = unsigned char]’ declared here
  258 | ALWAYS_INLINE I round_to(float value)
      |                 ^~~~~~~~
[...]
cc1plus: note: unrecognized command-line option ‘-Wno-shorten-64-to-32’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-dangling-reference’ may have been intended to silence earlier diagnostics
[...]
ninja: build stopped: subcommand failed.
```

When I upgraded to GCC 13.1, the build error was fixed. So the doc should be updated to reflect the new minimum required version