### PR TITLE
LibWeb: Implement AudioParams for DynamicsCompressorNode

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAudio/DynamicsCompressorNode.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/DynamicsCompressorNode.txt
@@ -7,3 +7,4 @@ Object
 [object AudioParam] current: 12, default: 12, min: 1, max: 20, rate: k-rate
 [object AudioParam] current: 0.003000000026077032, default: 0.003000000026077032, min: 0, max: 1, rate: k-rate
 [object AudioParam] current: 0.25, default: 0.25, min: 0, max: 1, rate: k-rate
+reduction: 0

--- a/Tests/LibWeb/Text/expected/WebAudio/DynamicsCompressorNode.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/DynamicsCompressorNode.txt
@@ -2,3 +2,8 @@ DynamicsCompressorNode
 AudioNode
 EventTarget
 Object
+[object AudioParam] current: -24, default: -24, min: -100, max: 0, rate: k-rate
+[object AudioParam] current: 30, default: 30, min: 0, max: 40, rate: k-rate
+[object AudioParam] current: 12, default: 12, min: 1, max: 20, rate: k-rate
+[object AudioParam] current: 0.003000000026077032, default: 0.003000000026077032, min: 0, max: 1, rate: k-rate
+[object AudioParam] current: 0.25, default: 0.25, min: 0, max: 1, rate: k-rate

--- a/Tests/LibWeb/Text/input/WebAudio/DynamicsCompressorNode.html
+++ b/Tests/LibWeb/Text/input/WebAudio/DynamicsCompressorNode.html
@@ -23,5 +23,8 @@
         dumpAudioParam(compressor.ratio);
         dumpAudioParam(compressor.attack);
         dumpAudioParam(compressor.release);
+
+        // Default reduction
+        println(`reduction: ${compressor.reduction}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/WebAudio/DynamicsCompressorNode.html
+++ b/Tests/LibWeb/Text/input/WebAudio/DynamicsCompressorNode.html
@@ -1,5 +1,9 @@
 <script src="../include.js"></script>
 <script>
+    function dumpAudioParam(param) {
+        println(`${param} current: ${param.value}, default: ${param.defaultValue}, min: ${param.minValue}, max: ${param.maxValue}, rate: ${param.automationRate}`);
+    }
+
     test(() => {
         const audioContext = new OfflineAudioContext(1, 5000, 44100);
 
@@ -12,5 +16,12 @@
             println(prototype.constructor.name);
             prototype = Object.getPrototypeOf(prototype);
         }
+
+        // Audio Params
+        dumpAudioParam(compressor.threshold);
+        dumpAudioParam(compressor.knee);
+        dumpAudioParam(compressor.ratio);
+        dumpAudioParam(compressor.attack);
+        dumpAudioParam(compressor.release);
     });
 </script>

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/DynamicsCompressorNodePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/WebAudio/AudioParam.h>
 #include <LibWeb/WebAudio/DynamicsCompressorNode.h>
 
 namespace Web::WebAudio {
@@ -26,8 +27,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DynamicsCompressorNode>> DynamicsCompressor
     return realm.vm().heap().allocate<DynamicsCompressorNode>(realm, realm, context, options);
 }
 
-DynamicsCompressorNode::DynamicsCompressorNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, DynamicsCompressorOptions const&)
+DynamicsCompressorNode::DynamicsCompressorNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, DynamicsCompressorOptions const& options)
     : AudioNode(realm, context)
+    , m_threshold(AudioParam::create(realm, options.threshold, -100, 0, Bindings::AutomationRate::KRate))
+    , m_knee(AudioParam::create(realm, options.knee, 0, 40, Bindings::AutomationRate::KRate))
+    , m_ratio(AudioParam::create(realm, options.ratio, 1, 20, Bindings::AutomationRate::KRate))
+    , m_attack(AudioParam::create(realm, options.attack, 0, 1, Bindings::AutomationRate::KRate))
+    , m_release(AudioParam::create(realm, options.release, 0, 1, Bindings::AutomationRate::KRate))
 {
 }
 
@@ -40,6 +46,11 @@ void DynamicsCompressorNode::initialize(JS::Realm& realm)
 void DynamicsCompressorNode::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_threshold);
+    visitor.visit(m_knee);
+    visitor.visit(m_ratio);
+    visitor.visit(m_attack);
+    visitor.visit(m_release);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
@@ -35,6 +35,7 @@ public:
     JS::NonnullGCPtr<AudioParam const> ratio() const { return m_ratio; }
     JS::NonnullGCPtr<AudioParam const> attack() const { return m_attack; }
     JS::NonnullGCPtr<AudioParam const> release() const { return m_release; }
+    float reduction() const { return m_reduction; }
 
 protected:
     DynamicsCompressorNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, DynamicsCompressorOptions const& = {});
@@ -57,6 +58,9 @@ private:
 
     // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-release
     JS::NonnullGCPtr<AudioParam> m_release;
+
+    // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-internal-reduction-slot
+    float m_reduction { 0 }; // [[internal reduction]]
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
@@ -30,11 +30,33 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<DynamicsCompressorNode>> create(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, DynamicsCompressorOptions const& = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<DynamicsCompressorNode>> construct_impl(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, DynamicsCompressorOptions const& = {});
 
+    JS::NonnullGCPtr<AudioParam const> threshold() const { return m_threshold; }
+    JS::NonnullGCPtr<AudioParam const> knee() const { return m_knee; }
+    JS::NonnullGCPtr<AudioParam const> ratio() const { return m_ratio; }
+    JS::NonnullGCPtr<AudioParam const> attack() const { return m_attack; }
+    JS::NonnullGCPtr<AudioParam const> release() const { return m_release; }
+
 protected:
     DynamicsCompressorNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, DynamicsCompressorOptions const& = {});
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+
+private:
+    // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-threshold
+    JS::NonnullGCPtr<AudioParam> m_threshold;
+
+    // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-knee
+    JS::NonnullGCPtr<AudioParam> m_knee;
+
+    // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-ratio
+    JS::NonnullGCPtr<AudioParam> m_ratio;
+
+    // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-attack
+    JS::NonnullGCPtr<AudioParam> m_attack;
+
+    // https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-release
+    JS::NonnullGCPtr<AudioParam> m_release;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.idl
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.idl
@@ -16,10 +16,10 @@ dictionary DynamicsCompressorOptions : AudioNodeOptions {
 interface DynamicsCompressorNode : AudioNode {
     constructor(BaseAudioContext context,
                 optional DynamicsCompressorOptions options = {});
-    // FIXME: readonly attribute AudioParam threshold;
-    // FIXME: readonly attribute AudioParam knee;
-    // FIXME: readonly attribute AudioParam ratio;
+    readonly attribute AudioParam threshold;
+    readonly attribute AudioParam knee;
+    readonly attribute AudioParam ratio;
     // FIXME: readonly attribute float reduction;
-    // FIXME: readonly attribute AudioParam attack;
-    // FIXME: readonly attribute AudioParam release;
+    readonly attribute AudioParam attack;
+    readonly attribute AudioParam release;
 };

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.idl
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.idl
@@ -19,7 +19,7 @@ interface DynamicsCompressorNode : AudioNode {
     readonly attribute AudioParam threshold;
     readonly attribute AudioParam knee;
     readonly attribute AudioParam ratio;
-    // FIXME: readonly attribute float reduction;
+    readonly attribute float reduction;
     readonly attribute AudioParam attack;
     readonly attribute AudioParam release;
 };


### PR DESCRIPTION
This gets us up to the AudioNode::connect in the testcase for https://github.com/SerenityOS/serenity/issues/22902, also further progress towards: https://github.com/SerenityOS/serenity/issues/23632