### PR TITLE
LibGfx/WebP(+LibCompress): Add CanonicalCode::write_symbol(), use it in writer

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
@@ -97,6 +97,7 @@ shared_library("LibGfx") {
     "ImageFormats/WebPLoader.cpp",
     "ImageFormats/WebPLoaderLossless.cpp",
     "ImageFormats/WebPLoaderLossy.cpp",
+    "ImageFormats/WebPSharedLossless.cpp",
     "ImageFormats/WebPWriter.cpp",
     "ImageFormats/WebPWriterLossless.cpp",
     "ImmutableBitmap.cpp",

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -9,7 +9,6 @@
 #include <AK/Assertions.h>
 #include <AK/BinaryHeap.h>
 #include <AK/BinarySearch.h>
-#include <AK/BitStream.h>
 #include <AK/MemoryStream.h>
 #include <string.h>
 
@@ -164,14 +163,6 @@ ErrorOr<u32> CanonicalCode::read_symbol(LittleEndianInputBitStream& stream) cons
     }
 
     return Error::from_string_literal("Symbol exceeds maximum symbol number");
-}
-
-ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& stream, u32 symbol) const
-{
-    auto code = symbol < m_bit_codes.size() ? m_bit_codes[symbol] : 0u;
-    auto length = symbol < m_bit_code_lengths.size() ? m_bit_code_lengths[symbol] : 0u;
-    TRY(stream.write_bits(code, length));
-    return {};
 }
 
 DeflateDecompressor::CompressedBlock::CompressedBlock(DeflateDecompressor& decompressor, CanonicalCode literal_codes, Optional<CanonicalCode> distance_codes)

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/BitStream.h>
 #include <AK/ByteBuffer.h>
 #include <AK/CircularBuffer.h>
 #include <AK/Endian.h>
@@ -50,6 +51,14 @@ private:
     Vector<u16, 288> m_bit_codes {};
     Vector<u16, 288> m_bit_code_lengths {};
 };
+
+ALWAYS_INLINE ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& stream, u32 symbol) const
+{
+    auto code = symbol < m_bit_codes.size() ? m_bit_codes[symbol] : 0u;
+    auto length = symbol < m_bit_code_lengths.size() ? m_bit_code_lengths[symbol] : 0u;
+    TRY(stream.write_bits(code, length));
+    return {};
+}
 
 class DeflateDecompressor final : public Stream {
 private:

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     ImageFormats/WebPLoader.cpp
     ImageFormats/WebPLoaderLossless.cpp
     ImageFormats/WebPLoaderLossy.cpp
+    ImageFormats/WebPSharedLossless.cpp
     ImageFormats/WebPWriter.cpp
     ImageFormats/WebPWriterLossless.cpp
     ImmutableBitmap.cpp

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ImageFormats/WebPSharedLossless.h>
+
+namespace Gfx {
+
+ErrorOr<CanonicalCode> CanonicalCode::from_bytes(ReadonlyBytes bytes)
+{
+    auto non_zero_symbol_count = 0;
+    auto last_non_zero_symbol = -1;
+    for (size_t i = 0; i < bytes.size(); i++) {
+        if (bytes[i] != 0) {
+            non_zero_symbol_count++;
+            last_non_zero_symbol = i;
+        }
+    }
+
+    if (non_zero_symbol_count == 1)
+        return CanonicalCode(last_non_zero_symbol);
+
+    return CanonicalCode(TRY(Compress::CanonicalCode::from_bytes(bytes)));
+}
+
+ErrorOr<u32> CanonicalCode::read_symbol(LittleEndianInputBitStream& bit_stream) const
+{
+    return TRY(m_code.visit(
+        [](u32 single_code) -> ErrorOr<u32> { return single_code; },
+        [&bit_stream](Compress::CanonicalCode const& code) { return code.read_symbol(bit_stream); }));
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.cpp
@@ -32,4 +32,12 @@ ErrorOr<u32> CanonicalCode::read_symbol(LittleEndianInputBitStream& bit_stream) 
         [&bit_stream](Compress::CanonicalCode const& code) { return code.read_symbol(bit_stream); }));
 }
 
+ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& bit_stream, u32 symbol) const
+{
+    TRY(m_code.visit(
+        [&](u32 single_code) -> ErrorOr<void> { VERIFY(symbol == single_code); return {};},
+        [&](Compress::CanonicalCode const& code) { return code.write_symbol(bit_stream, symbol); }));
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.cpp
@@ -32,12 +32,4 @@ ErrorOr<u32> CanonicalCode::read_symbol(LittleEndianInputBitStream& bit_stream) 
         [&bit_stream](Compress::CanonicalCode const& code) { return code.read_symbol(bit_stream); }));
 }
 
-ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& bit_stream, u32 symbol) const
-{
-    TRY(m_code.visit(
-        [&](u32 single_code) -> ErrorOr<void> { VERIFY(symbol == single_code); return {};},
-        [&](Compress::CanonicalCode const& code) { return code.write_symbol(bit_stream, symbol); }));
-    return {};
-}
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCompress/Deflate.h>
+
+namespace Gfx {
+
+// WebP-lossless's CanonicalCodes are almost identical to deflate's.
+// One difference is that codes with a single element in webp-lossless consume 0 bits to produce that single element,
+// while they consume 1 bit in Compress::CanonicalCode. This class wraps Compress::CanonicalCode to handle the case
+// where the codes contain just a single element, and dispatches to Compress::CanonicalCode else.
+class CanonicalCode {
+public:
+    CanonicalCode()
+        : m_code(0)
+    {
+    }
+
+    static ErrorOr<CanonicalCode> from_bytes(ReadonlyBytes);
+    ErrorOr<u32> read_symbol(LittleEndianInputBitStream&) const;
+
+private:
+    explicit CanonicalCode(u32 single_symbol)
+        : m_code(single_symbol)
+    {
+    }
+
+    explicit CanonicalCode(Compress::CanonicalCode code)
+        : m_code(move(code))
+    {
+    }
+
+    Variant<u32, Compress::CanonicalCode> m_code;
+};
+
+// https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#61_overview
+// "From here on, we refer to this set as a prefix code group."
+class PrefixCodeGroup {
+public:
+    PrefixCodeGroup() = default;
+    PrefixCodeGroup(PrefixCodeGroup&&) = default;
+    PrefixCodeGroup(PrefixCodeGroup const&) = delete;
+
+    CanonicalCode& operator[](int i) { return m_codes[i]; }
+    CanonicalCode const& operator[](int i) const { return m_codes[i]; }
+
+private:
+    Array<CanonicalCode, 5> m_codes;
+};
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -23,6 +23,7 @@ public:
 
     static ErrorOr<CanonicalCode> from_bytes(ReadonlyBytes);
     ErrorOr<u32> read_symbol(LittleEndianInputBitStream&) const;
+    ErrorOr<void> write_symbol(LittleEndianOutputBitStream&, u32) const;
 
 private:
     explicit CanonicalCode(u32 single_symbol)

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -39,6 +39,14 @@ private:
     Variant<u32, Compress::CanonicalCode> m_code;
 };
 
+ALWAYS_INLINE ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& bit_stream, u32 symbol) const
+{
+    TRY(m_code.visit(
+        [&](u32 single_code) __attribute__((always_inline))->ErrorOr<void> { VERIFY(symbol == single_code); return {}; },
+        [&](Compress::CanonicalCode const& code) __attribute__((always_inline)) { return code.write_symbol(bit_stream, symbol); }));
+    return {};
+}
+
 // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#61_overview
 // "From here on, we refer to this set as a prefix code group."
 class PrefixCodeGroup {

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -16,10 +16,7 @@ namespace Gfx {
 // where the codes contain just a single element, and dispatches to Compress::CanonicalCode else.
 class CanonicalCode {
 public:
-    CanonicalCode()
-        : m_code(0)
-    {
-    }
+    CanonicalCode() = default;
 
     static ErrorOr<CanonicalCode> from_bytes(ReadonlyBytes);
     ErrorOr<u32> read_symbol(LittleEndianInputBitStream&) const;
@@ -36,7 +33,7 @@ private:
     {
     }
 
-    Variant<u32, Compress::CanonicalCode> m_code;
+    Variant<u32, Compress::CanonicalCode> m_code { 0 };
 };
 
 ALWAYS_INLINE ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& bit_stream, u32 symbol) const

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
@@ -22,15 +22,15 @@ namespace Gfx {
 static ErrorOr<void> write_webp_header(Stream& stream, unsigned data_size)
 {
     TRY(stream.write_until_depleted("RIFF"sv));
-    TRY(stream.write_value<LittleEndian<u32>>(4 + data_size)); // Including size of "WEBP" and the data size itself.
+    TRY(stream.write_value<LittleEndian<u32>>("WEBP"sv.length() + data_size));
     TRY(stream.write_until_depleted("WEBP"sv));
     return {};
 }
 
-static ErrorOr<void> write_chunk_header(Stream& stream, StringView chunk_fourcc, unsigned vp8l_data_size)
+static ErrorOr<void> write_chunk_header(Stream& stream, StringView chunk_fourcc, unsigned data_size)
 {
     TRY(stream.write_until_depleted(chunk_fourcc));
-    TRY(stream.write_value<LittleEndian<u32>>(vp8l_data_size));
+    TRY(stream.write_value<LittleEndian<u32>>(data_size));
     return {};
 }
 


### PR DESCRIPTION
We still construct the code length codes manually, and now we also
construct a PrefixCodeGroup manually that assigns 8 bits to all
symbols (except for fully-opaque alpha channels, and for the
unused distance codes, like before). But now we use the CanonicalCodes
from that PrefixCodeGroup for writing.

No behavior change at all, the output is bit-for-bit identical to
before. But this is a step towards actually huffman-coding symbols.

I thought this would be a nice and easy patch, but it regressed
perf quite a bit! I mitigated this a bit, so in total it's "only"
a 7-12% regression for exactly the same output. But a local
branch that builds actual data-dependent optimal huffman
trees is perf-neutral and adds at least some compression.
(I still haven't implemented backrefs.)

`hyperfine 'image -o test.webp test.bmp'`:
* Before:          23.7 ms ± 0.7 ms (116 runs)
* Naive commit: 33.2 ms ± 0.8 ms (82 runs)
* Final commit:     25.5 ms ± 0.7 ms (102 runs)

`hyperfine 'animation -o wow.webp giphy.gif'`:
* Before:           85.5 ms ± 2.0 ms (34 runs)
* Naive commit: 127.7 ms ± 4.4 ms (22 runs)
* Final commit:      95.3 ms ± 2.1 ms (31 runs)

`hyperfine 'animation -o wow.webp 7z7c.gif'`:
* Before:          12.6 ms ± 0.6 ms (198 runs)
* Naive commit: 16.5 ms ± 0.9 ms (153 runs)
* Final commit:     13.5 ms ± 0.6 ms (186 runs)