### PR TITLE
LibWeb: Generate binding for `HTMLObjectElement.contentWindow` attribute

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLObjectElement-contentWindow.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLObjectElement-contentWindow.txt
@@ -1,0 +1,2 @@
+object.contentWindow initial value should be null: true
+contentWindow.name should be the same as object.name PASS

--- a/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-contentWindow.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-contentWindow.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {        
+        const objectElement = document.createElement("object");
+        println(`object.contentWindow initial value should be null: ${objectElement.contentWindow === null}`);
+        objectElement.type = "text/html";
+        objectElement.name = "PASS"
+        // FIXME: about:srcdoc is being used here as a convenient way to load a blank document. This isn't cross browser compatible.
+        objectElement.data = "about:srcdoc";
+        objectElement.onload = () => {
+            println(`contentWindow.name should be the same as object.name ${objectElement.contentWindow.name}`);
+            document.body.removeChild(objectElement);
+            done();     
+        };
+
+        document.body.appendChild(objectElement);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -14,7 +14,7 @@ interface HTMLObjectElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString width;
     [CEReactions, Reflect] attribute DOMString height;
     readonly attribute Document? contentDocument;
-    // FIXME: readonly attribute WindowProxy? contentWindow;
+    readonly attribute WindowProxy? contentWindow;
     Document? getSVGDocument();
 
     // FIXME: readonly attribute boolean willValidate;


### PR DESCRIPTION
This only required adding the appropriate definition to the IDL file, as `NavigableContainer` already implements the logic that we need.