### PR TITLE
LibWeb: Implement the `labels` attribute for all labelable elements

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLElement-labels.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLElement-labels.txt
@@ -1,0 +1,21 @@
+input.labels.length: 1
+input.labels[0] === label: true
+input.labels always returns the same object: true
+meter.labels.length: 1
+meter.labels[0] === label: true
+meter.labels always returns the same object: true
+output.labels.length: 1
+output.labels[0] === label: true
+output.labels always returns the same object: true
+progress.labels.length: 1
+progress.labels[0] === label: true
+progress.labels always returns the same object: true
+select.labels.length: 1
+select.labels[0] === label: true
+select.labels always returns the same object: true
+textarea.labels.length: 1
+textarea.labels[0] === label: true
+textarea.labels always returns the same object: true
+input.labels returns null if input type is hidden: true
+input.labels.length after input type is changed from hidden: 1
+input.labels[0] === label after input type is changed from hidden: true

--- a/Tests/LibWeb/Text/input/HTML/HTMLElement-labels.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLElement-labels.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const labelableElements = ["input", "meter", "output", "progress", "select", "textarea"];
+        for (const tagName of labelableElements) {
+            const element = document.createElement(tagName);
+            element.id = `${tagName}Id`;
+            const label = document.createElement("label")
+            label.htmlFor = `${tagName}Id`;
+            document.body.appendChild(label);
+            document.body.appendChild(element);
+            const labels = element.labels;
+            println(`${tagName}.labels.length: ${labels.length}`);
+            println(`${tagName}.labels[0] === label: ${labels[0] === label}`);
+            println(`${tagName}.labels always returns the same object: ${labels === element.labels}`);
+            document.body.removeChild(label);
+            document.body.removeChild(element);
+        }
+
+        const inputElement = document.createElement("input");
+        inputElement.type = "hidden";
+        inputElement.id = "inputId"
+        const label = document.createElement("label")
+        label.htmlFor = 'inputId';
+        document.body.appendChild(label);
+        document.body.appendChild(inputElement);
+        println(`input.labels returns null if input type is hidden: ${inputElement.labels === null}`);
+        inputElement.type = "text";
+        const labels = inputElement.labels;
+        println(`input.labels.length after input type is changed from hidden: ${labels.length}`);
+        println(`input.labels[0] === label after input type is changed from hidden: ${labels[0] === label}`);
+        document.body.removeChild(label);
+        document.body.removeChild(inputElement);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -31,6 +31,6 @@ interface HTMLButtonElement : HTMLElement {
     // FIXME: boolean reportValidity();
     // FIXME: undefined setCustomValidity(DOMString error);
 
-    // FIXME: readonly attribute NodeList labels;
+    readonly attribute NodeList labels;
 };
 // FIXME: HTMLButtonElement includes PopoverInvokerElement;

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -68,6 +68,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const { return false; }
 
+    JS::GCPtr<DOM::NodeList> labels();
+
     virtual Optional<ARIA::Role> default_role() const override;
 
     String get_an_elements_target() const;
@@ -92,6 +94,8 @@ private:
     [[nodiscard]] String get_the_text_steps();
 
     JS::GCPtr<DOMStringMap> m_dataset;
+
+    JS::GCPtr<DOM::NodeList> m_labels;
 
     enum class ContentEditableState {
         True,

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -54,7 +54,7 @@ interface HTMLInputElement : HTMLElement {
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    // FIXME: readonly attribute NodeList? labels;
+    readonly attribute NodeList? labels;
 
     undefined select();
     // FIXME: attribute unsigned long? selectionStart;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.idl
@@ -11,5 +11,5 @@ interface HTMLMeterElement : HTMLElement {
     [CEReactions] attribute double low;
     [CEReactions] attribute double high;
     [CEReactions] attribute double optimum;
-    // FIXME: readonly attribute NodeList labels;
+    readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.idl
@@ -21,5 +21,5 @@ interface HTMLOutputElement : HTMLElement {
     // FIXME: boolean reportValidity();
     // FIXME: undefined setCustomValidity(DOMString error);
 
-    // FIXME: readonly attribute NodeList labels;
+    readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.idl
@@ -8,5 +8,5 @@ interface HTMLProgressElement : HTMLElement {
     [CEReactions] attribute double value;
     [CEReactions] attribute double max;
     readonly attribute double position;
-    // FIXME: readonly attribute NodeList labels;
+    readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -37,5 +37,5 @@ interface HTMLSelectElement : HTMLElement {
     // FIXME: boolean reportValidity();
     // FIXME: undefined setCustomValidity(DOMString error);
 
-    // FIXME: readonly attribute NodeList labels;
+    readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -32,7 +32,7 @@ interface HTMLTextAreaElement : HTMLElement {
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    // FIXME: readonly attribute NodeList labels;
+    readonly attribute NodeList labels;
 
     // FIXME: undefined select();
     attribute unsigned long selectionStart;


### PR DESCRIPTION
This returns a `NodeList` of all the labels associated with the given element.

With this change we now pass this WPT test: http://wpt.live/html/semantics/forms/the-label-element/labelable-elements.html