### PR TITLE
LibWeb: Add missing visit to `m_labels` in HTMLElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -59,6 +59,7 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_dataset);
+    visitor.visit(m_labels);
 }
 
 JS::NonnullGCPtr<DOMStringMap> HTMLElement::dataset()


### PR DESCRIPTION
#24359 was merged just as I pushed the fix for this :sweat_smile: 