### PR TITLE
Chess: Add display widget for moves

### DIFF
--- a/Userland/Games/Chess/Chess.gml
+++ b/Userland/Games/Chess/Chess.gml
@@ -2,7 +2,34 @@
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {}
 
-    @Chess::ChessWidget {
-        name: "chess_widget"
+    @GUI::HorizontalSplitter {
+        @GUI::Frame {
+            name: "chess_widget_frame"
+            min_width: 508
+            min_height: 508
+            layout: @GUI::HorizontalBoxLayout {}
+
+            @Chess::ChessWidget {
+                name: "chess_widget"
+            }
+        }
+
+        @GUI::Frame {
+            layout: @GUI::VerticalBoxLayout {}
+
+            @GUI::Label {
+                text: "Moves"
+                text_alignment: "Center"
+                font_weight: "Bold"
+                fixed_height: 24
+                name: "moves_display_widget_label"
+            }
+
+            @GUI::TextEditor {
+                name: "move_display_widget"
+                mode: "DisplayOnly"
+                focus_policy: "NoFocus"
+            }
+        }
     }
 }

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -16,6 +16,7 @@
 #include <LibChess/Chess.h>
 #include <LibConfig/Listener.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/TextEditor.h>
 #include <LibGfx/Bitmap.h>
 
 namespace Chess {
@@ -81,6 +82,7 @@ public:
     ErrorOr<String> get_fen() const;
     ErrorOr<void, PGNParseError> import_pgn(Core::File&);
     ErrorOr<void> export_pgn(Core::File&) const;
+    void update_move_display_widget(Chess::Board&);
 
     int resign();
     void flip_board();
@@ -106,6 +108,7 @@ public:
     void playback_move(PlaybackDirection);
 
     void set_engine(RefPtr<Engine> engine) { m_engine = engine; }
+    void set_move_display_widget(RefPtr<GUI::TextEditor> move_display_widget) { m_move_display_widget = move_display_widget; }
 
     void input_engine_move();
     bool want_engine_move();
@@ -174,6 +177,7 @@ private:
     RefPtr<Engine> m_engine;
     bool m_coordinates { true };
     bool m_highlight_checks { true };
+    RefPtr<GUI::TextEditor> m_move_display_widget;
 };
 
 }

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -66,7 +66,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     auto main_widget = TRY(Chess::MainWidget::try_create());
+
     auto& chess_widget = *main_widget->find_descendant_of_type_named<Chess::ChessWidget>("chess_widget");
+    auto& move_display_widget = *main_widget->find_descendant_of_type_named<GUI::TextEditor>("move_display_widget");
+    chess_widget.set_move_display_widget(move(move_display_widget));
 
     window->set_main_widget(main_widget);
     window->set_focused_widget(&chess_widget);
@@ -85,7 +88,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Chess");
     window->set_base_size({ 4, 4 });
     window->set_size_increment({ 8, 8 });
-    window->resize(508, 508);
+    window->resize(668, 508);
 
     window->set_icon(app_icon.bitmap_for_size(16));
 


### PR DESCRIPTION
Adds a TextEditor widget to the chess application to display move
history. It is updated whenever Board::apply_move is called to reflect
the current board state.