### PR TITLE
LibWeb: Fix division by zero on a zero-width viewport SVG image

### DIFF
--- a/Tests/LibWeb/Layout/expected/zero-height-viewport-svg-image.txt
+++ b/Tests/LibWeb/Layout/expected/zero-height-viewport-svg-image.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x150 children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+      ImageBox <img> at (8,8) content-size 300x150 children: not-inline
+        (SVG-as-image isolated context)
+        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: inline
+          SVGSVGBox <svg> at (0,0) content-size 300x150 [SVG] children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      ImagePaintable (ImageBox<IMG>) [8,8 300x150]

--- a/Tests/LibWeb/Layout/expected/zero-width-viewport-svg-image.txt
+++ b/Tests/LibWeb/Layout/expected/zero-width-viewport-svg-image.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x150 children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+      ImageBox <img> at (8,8) content-size 300x150 children: not-inline
+        (SVG-as-image isolated context)
+        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: inline
+          SVGSVGBox <svg> at (0,0) content-size 300x150 [SVG] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      ImagePaintable (ImageBox<IMG>) [8,8 300x150]

--- a/Tests/LibWeb/Layout/input/zero-height-viewport-svg-image.html
+++ b/Tests/LibWeb/Layout/input/zero-height-viewport-svg-image.html
@@ -1,0 +1,1 @@
+<img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2040%200'%3E%3C/svg%3E">

--- a/Tests/LibWeb/Layout/input/zero-width-viewport-svg-image.html
+++ b/Tests/LibWeb/Layout/input/zero-width-viewport-svg-image.html
@@ -1,0 +1,1 @@
+<img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%2040'%3E%3C/svg%3E">

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -162,6 +162,8 @@ Optional<CSSPixelFraction> SVGDecodedImageData::intrinsic_aspect_ratio() const
             return {};
 
         auto viewbox_height = CSSPixels::nearest_value_for(viewbox->height);
+        if (viewbox_height == 0)
+            return {};
 
         return viewbox_width / viewbox_height;
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -155,9 +155,16 @@ Optional<CSSPixelFraction> SVGDecodedImageData::intrinsic_aspect_ratio() const
     if (width.has_value() && height.has_value())
         return *width / *height;
 
-    if (auto const& viewbox = m_root_element->view_box(); viewbox.has_value())
-        return CSSPixels::nearest_value_for(viewbox->width) / CSSPixels::nearest_value_for(viewbox->height);
+    if (auto const& viewbox = m_root_element->view_box(); viewbox.has_value()) {
+        auto viewbox_width = CSSPixels::nearest_value_for(viewbox->width);
 
+        if (viewbox_width == 0)
+            return {};
+
+        auto viewbox_height = CSSPixels::nearest_value_for(viewbox->height);
+
+        return viewbox_width / viewbox_height;
+    }
     return {};
 }
 


### PR DESCRIPTION
We were previously crashing by a division by zero due to an aspect ratio of zero on https://comicbookshop.co.nz/