### PR TITLE
LibGfx/GIF+animation: Support animated GIFs

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/GIFWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFWriter.cpp
@@ -21,15 +21,15 @@ ErrorOr<void> write_header(Stream& stream)
     return {};
 }
 
-ErrorOr<void> write_logical_descriptor(BigEndianOutputBitStream& stream, Bitmap const& bitmap)
+ErrorOr<void> write_logical_descriptor(BigEndianOutputBitStream& stream, IntSize size)
 {
     // 18. Logical Screen Descriptor
 
-    if (bitmap.width() > NumericLimits<u16>::max() || bitmap.height() > NumericLimits<u16>::max())
+    if (size.width() > NumericLimits<u16>::max() || size.height() > NumericLimits<u16>::max())
         return Error::from_string_literal("Bitmap size is too big for a GIF");
 
-    TRY(stream.write_value<u16>(bitmap.width()));
-    TRY(stream.write_value<u16>(bitmap.height()));
+    TRY(stream.write_value<u16>(size.width()));
+    TRY(stream.write_value<u16>(size.height()));
 
     // Global Color Table Flag
     TRY(stream.write_bits(false, 1));
@@ -135,7 +135,7 @@ ErrorOr<void> GIFWriter::encode(Stream& stream, Bitmap const& bitmap)
     TRY(write_header(stream));
 
     BigEndianOutputBitStream bit_stream { MaybeOwned<Stream> { stream } };
-    TRY(write_logical_descriptor(bit_stream, bitmap));
+    TRY(write_logical_descriptor(bit_stream, bitmap.size()));
 
     // Write a Table-Based Image
     TRY(write_image_descriptor(bit_stream, bitmap));

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFWriter.h
@@ -8,6 +8,7 @@
 
 #include <AK/Error.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImageFormats/AnimationWriter.h>
 
 namespace Gfx {
 
@@ -16,6 +17,7 @@ namespace Gfx {
 class GIFWriter {
 public:
     static ErrorOr<void> encode(Stream&, Bitmap const&);
+    static ErrorOr<NonnullOwnPtr<AnimationWriter>> start_encoding_animation(SeekableStream&, IntSize dimensions);
 };
 
 }


### PR DESCRIPTION
We are not writing any control block for frame duration or loop count, so the resulting image is not the best for a demonstration :sweat_smile:

But still here it is (loop count is 1, so you need to reload the page to see the animation again):

![reencoded](https://github.com/SerenityOS/serenity/assets/26030965/bd59f174-08ee-4a9c-8cf8-96988973371b)
