### PR TITLE
LibJS/Bytecode: Add dedicated instruction for getting `length` property

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1037,11 +1037,19 @@ CodeGenerationErrorOr<Optional<ScopedOperand>> Generator::emit_named_evaluation_
 
 void Generator::emit_get_by_id(ScopedOperand dst, ScopedOperand base, IdentifierTableIndex property_identifier, Optional<IdentifierTableIndex> base_identifier)
 {
+    if (m_identifier_table->get(property_identifier) == "length"sv) {
+        emit<Op::GetLength>(dst, base, move(base_identifier), m_next_property_lookup_cache++);
+        return;
+    }
     emit<Op::GetById>(dst, base, property_identifier, move(base_identifier), m_next_property_lookup_cache++);
 }
 
 void Generator::emit_get_by_id_with_this(ScopedOperand dst, ScopedOperand base, IdentifierTableIndex id, ScopedOperand this_value)
 {
+    if (m_identifier_table->get(id) == "length"sv) {
+        emit<Op::GetLengthWithThis>(dst, base, this_value, m_next_property_lookup_cache++);
+        return;
+    }
     emit<Op::GetByIdWithThis>(dst, base, id, this_value, m_next_property_lookup_cache++);
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -57,6 +57,8 @@
     O(GetGlobal)                       \
     O(GetImportMeta)                   \
     O(GetIterator)                     \
+    O(GetLength)                       \
+    O(GetLengthWithThis)               \
     O(GetMethod)                       \
     O(GetNewTarget)                    \
     O(GetNextMethodFromIteratorRecord) \

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -990,6 +990,68 @@ private:
     u32 m_cache_index { 0 };
 };
 
+class GetLength final : public Instruction {
+public:
+    GetLength(Operand dst, Operand base, Optional<IdentifierTableIndex> base_identifier, u32 cache_index)
+        : Instruction(Type::GetLength)
+        , m_dst(dst)
+        , m_base(base)
+        , m_base_identifier(move(base_identifier))
+        , m_cache_index(cache_index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+    }
+
+    Operand dst() const { return m_dst; }
+    Operand base() const { return m_base; }
+    u32 cache_index() const { return m_cache_index; }
+
+private:
+    Operand m_dst;
+    Operand m_base;
+    Optional<IdentifierTableIndex> m_base_identifier;
+    u32 m_cache_index { 0 };
+};
+
+class GetLengthWithThis final : public Instruction {
+public:
+    GetLengthWithThis(Operand dst, Operand base, Operand this_value, u32 cache_index)
+        : Instruction(Type::GetLengthWithThis)
+        , m_dst(dst)
+        , m_base(base)
+        , m_this_value(this_value)
+        , m_cache_index(cache_index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+        visitor(m_base);
+        visitor(m_this_value);
+    }
+
+    Operand dst() const { return m_dst; }
+    Operand base() const { return m_base; }
+    Operand this_value() const { return m_this_value; }
+    u32 cache_index() const { return m_cache_index; }
+
+private:
+    Operand m_dst;
+    Operand m_base;
+    Operand m_this_value;
+    u32 m_cache_index { 0 };
+};
+
 class GetPrivateById final : public Instruction {
 public:
     explicit GetPrivateById(Operand dst, Operand base, IdentifierTableIndex property)


### PR DESCRIPTION
By doing this, we can remove all the special-case checks for `length` from the generic GetById and GetByIdWithThis code paths, making every other property lookup a bit faster.

Small progressions on most benchmarks, and some larger progressions:

- 12% on Octane/crypto.js
- 6% on Kraken/ai-astar.js

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.065  2.450 ± 2.450 … 2.450     2.300 ± 2.290 … 2.310
Kraken      audio-beat-detection.js                  1.014  1.455 ± 1.450 … 1.460     1.435 ± 1.420 … 1.450
Kraken      audio-dft.js                             1.013  1.195 ± 1.190 … 1.200     1.180 ± 1.170 … 1.190
Kraken      audio-fft.js                             1.011  1.340 ± 1.340 … 1.340     1.325 ± 1.320 … 1.330
Kraken      audio-oscillator.js                      1.046  1.480 ± 1.480 … 1.480     1.415 ± 1.410 … 1.420
Kraken      imaging-darkroom.js                      0.983  1.750 ± 1.750 … 1.750     1.780 ± 1.770 … 1.790
Kraken      imaging-desaturate.js                    0.975  2.385 ± 2.380 … 2.390     2.445 ± 2.440 … 2.450
Kraken      imaging-gaussian-blur.js                 1.007  7.570 ± 7.460 … 7.680     7.520 ± 7.510 … 7.530
Kraken      json-parse-financial.js                  1      0.130 ± 0.130 … 0.130     0.130 ± 0.130 … 0.130
Kraken      json-stringify-tinderbox.js              1.082  0.265 ± 0.260 … 0.270     0.245 ± 0.240 … 0.250
Kraken      stanford-crypto-aes.js                   0.992  0.625 ± 0.620 … 0.630     0.630 ± 0.630 … 0.630
Kraken      stanford-crypto-ccm.js                   0.982  0.550 ± 0.550 … 0.550     0.560 ± 0.560 … 0.560
Kraken      stanford-crypto-pbkdf2.js                1      1.030 ± 1.030 … 1.030     1.030 ± 1.030 … 1.030
Kraken      stanford-crypto-sha256-iterative.js      1      0.420 ± 0.420 … 0.420     0.420 ± 0.420 … 0.420
Octane      box2d.js                                 1.018  2.290 ± 2.290 … 2.290     2.250 ± 2.230 … 2.270
Octane      code-load.js                             0.998  2.145 ± 2.140 … 2.150     2.150 ± 2.150 … 2.150
Octane      crypto.js                                1.128  7.115 ± 7.080 … 7.150     6.310 ± 6.310 … 6.310
Octane      deltablue.js                             0.995  2.020 ± 2.010 … 2.030     2.030 ± 2.020 … 2.040
Octane      earley-boyer.js                          1.004  16.715 ± 16.620 … 16.810  16.645 ± 16.640 … 16.650
Octane      gbemu.js                                 0.991  2.825 ± 2.770 … 2.880     2.850 ± 2.840 … 2.860
Octane      mandreel.js                              0.983  12.750 ± 12.630 … 12.870  12.975 ± 12.970 … 12.980
Octane      navier-stokes.js                         0.99   3.110 ± 3.100 … 3.120     3.140 ± 3.110 … 3.170
Octane      pdfjs.js                                 0.996  2.840 ± 2.830 … 2.850     2.850 ± 2.840 … 2.860
Octane      raytrace.js                              0.995  6.860 ± 6.820 … 6.900     6.895 ± 6.880 … 6.910
Octane      regexp.js                                1.007  22.195 ± 21.980 … 22.410  22.035 ± 21.860 … 22.210
Octane      richards.js                              1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      splay.js                                 0.998  2.940 ± 2.930 … 2.950     2.945 ± 2.910 … 2.980
Octane      typescript.js                            0.992  36.265 ± 36.210 … 36.320  36.570 ± 36.310 … 36.830
Octane      zlib.js                                  1.008  75.885 ± 75.370 … 76.400  75.265 ± 74.710 … 75.820
Kraken      Total                                    1.01   22.645                    22.415
Octane      Total                                    1.005  197.965                   196.920
All Suites  Total                                    1.006  220.610                   219.335
```