### PR TITLE
RequestServer: Account for null sockets in recreate_socket_if_needed()

### DIFF
--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -188,7 +188,7 @@ ErrorOr<void> recreate_socket_if_needed(T& connection, URL::URL const& url)
     using SocketType = typename T::SocketType;
     using SocketStorageType = typename T::StorageType;
 
-    if (!connection.socket->is_open() || connection.socket->is_eof()) {
+    if (!connection.socket || !connection.socket->is_open() || connection.socket->is_eof()) {
         connection.socket = nullptr;
         // Create another socket for the connection.
         auto set_socket = [&](NonnullOwnPtr<SocketStorageType>&& socket) -> ErrorOr<void> {


### PR DESCRIPTION
A connection's socket is allowed to be null if it's being recreated after a failed connect(), this was handled correctly in request_did_finish but not in recreate_socket_if_needed; this commit fixes this oversight.