### PR TITLE
LibThreading: Remove extra spammy log message upon starting a thread

### DIFF
--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -108,7 +108,6 @@ void Thread::start()
         VERIFY(rc == 0);
     }
 #endif
-    dbgln("Started {}", *this);
 }
 
 void Thread::detach()


### PR DESCRIPTION
I get 64 of these guys starting the browser, which is a bit much when e.g. running a single test in headless-browser