### PR TITLE
Meta: Fix detection of default compiler versions

### DIFF
--- a/Meta/find_compiler.sh
+++ b/Meta/find_compiler.sh
@@ -50,7 +50,7 @@ find_newest_compiler() {
 
 pick_host_compiler() {
     CC=${CC:-"cc"}
-    CXX=${CXX:-"cxx"}
+    CXX=${CXX:-"c++"}
 
     if is_supported_compiler "$CC" && is_supported_compiler "$CXX"; then
         return

--- a/Meta/gn/README.md
+++ b/Meta/gn/README.md
@@ -40,7 +40,7 @@ If you modify `args.gn` outside of `gn args`, be sure to run `gn gen` again to r
 
 On macOS, the default args should work out of the box. For compiling Ladybird there won't be any tailoring needed if you have Qt6 installed via homebrew and the Xcode tools installed.
 
-On Ubuntu, it's likely that the default ``cc`` and ``cxx`` will not be able to compile the project. For compiling Ladybird, a typical ``args.gn`` might look like the below:
+On Ubuntu, it's likely that the default ``cc`` and ``c++`` will not be able to compile the project. For compiling Ladybird, a typical ``args.gn`` might look like the below:
 
 args.gn
 ```gn


### PR DESCRIPTION
The logic in this script was *intended* to use the system's default compiler if it was sufficiently new, and only start searching for the latest installed if the default was not suitable.

However, the `cxx` program does not exist on Unixes, so the version check always failed. We should be using the standard `c++` program name instead.

After this change, the `CC` and `CXX` environment variables will have to be used if someone wants to force a newer compiler version.