### PR TITLE
LibGfx/WebPWriter: Use huffman compression

### DIFF
--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -7,12 +7,12 @@
 
 #include <AK/Array.h>
 #include <AK/Assertions.h>
-#include <AK/BinaryHeap.h>
 #include <AK/BinarySearch.h>
 #include <AK/MemoryStream.h>
 #include <string.h>
 
 #include <LibCompress/Deflate.h>
+#include <LibCompress/Huffman.h>
 
 namespace Compress {
 
@@ -591,78 +591,6 @@ size_t DeflateCompressor::find_back_match(size_t start, u16 hash, size_t previou
 ALWAYS_INLINE u8 DeflateCompressor::distance_to_base(u16 distance)
 {
     return (distance <= 256) ? distance_to_base_lo[distance - 1] : distance_to_base_hi[(distance - 1) >> 7];
-}
-
-template<size_t Size>
-void DeflateCompressor::generate_huffman_lengths(Array<u8, Size>& lengths, Array<u16, Size> const& frequencies, size_t max_bit_length, u16 frequency_cap)
-{
-    VERIFY((1u << max_bit_length) >= Size);
-    u16 heap_keys[Size]; // Used for O(n) heap construction
-    u16 heap_values[Size];
-
-    u16 huffman_links[Size * 2] = { 0 };
-    size_t non_zero_freqs = 0;
-    for (size_t i = 0; i < Size; i++) {
-        auto frequency = frequencies[i];
-        if (frequency == 0)
-            continue;
-
-        if (frequency > frequency_cap) {
-            frequency = frequency_cap;
-        }
-
-        heap_keys[non_zero_freqs] = frequency;               // sort symbols by frequency
-        heap_values[non_zero_freqs] = Size + non_zero_freqs; // huffman_links "links"
-        non_zero_freqs++;
-    }
-
-    // special case for only 1 used symbol
-    if (non_zero_freqs < 2) {
-        for (size_t i = 0; i < Size; i++)
-            lengths[i] = (frequencies[i] == 0) ? 0 : 1;
-        return;
-    }
-
-    BinaryHeap<u16, u16, Size> heap { heap_keys, heap_values, non_zero_freqs };
-
-    // build the huffman tree - binary heap is used for efficient frequency comparisons
-    while (heap.size() > 1) {
-        u16 lowest_frequency = heap.peek_min_key();
-        u16 lowest_link = heap.pop_min();
-        u16 second_lowest_frequency = heap.peek_min_key();
-        u16 second_lowest_link = heap.pop_min();
-
-        u16 new_link = heap.size() + 1;
-
-        heap.insert(lowest_frequency + second_lowest_frequency, new_link);
-
-        huffman_links[lowest_link] = new_link;
-        huffman_links[second_lowest_link] = new_link;
-    }
-
-    non_zero_freqs = 0;
-    for (size_t i = 0; i < Size; i++) {
-        if (frequencies[i] == 0) {
-            lengths[i] = 0;
-            continue;
-        }
-
-        u16 link = huffman_links[Size + non_zero_freqs];
-        non_zero_freqs++;
-
-        size_t bit_length = 1;
-        while (link != 1) {
-            bit_length++;
-            link = huffman_links[link];
-        }
-
-        if (bit_length > max_bit_length) {
-            VERIFY(frequency_cap != 1);
-            return generate_huffman_lengths(lengths, frequencies, max_bit_length, frequency_cap / 2);
-        }
-
-        lengths[i] = bit_length;
-    }
 }
 
 void DeflateCompressor::lz77_compress_block()

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -815,15 +815,12 @@ size_t DeflateCompressor::encode_block_lengths(Array<u8, max_huffman_literals> c
         distance_code_count--;
 
     Array<u8, max_huffman_literals + max_huffman_distances> all_lengths {};
-    size_t lengths_count = 0;
-    for (size_t i = 0; i < literal_code_count; i++) {
-        all_lengths[lengths_count++] = literal_bit_lengths[i];
-    }
-    for (size_t i = 0; i < distance_code_count; i++) {
-        all_lengths[lengths_count++] = distance_bit_lengths[i];
-    }
+    for (size_t i = 0; i < literal_code_count; i++)
+        all_lengths[i] = literal_bit_lengths[i];
+    for (size_t i = 0; i < distance_code_count; i++)
+        all_lengths[literal_code_count + i] = distance_bit_lengths[i];
 
-    return encode_huffman_lengths(all_lengths, lengths_count, encoded_lengths);
+    return encode_huffman_lengths(all_lengths, literal_code_count + distance_code_count, encoded_lengths);
 }
 
 ErrorOr<void> DeflateCompressor::write_dynamic_huffman(CanonicalCode const& literal_code, size_t literal_code_count, Optional<CanonicalCode> const& distance_code, size_t distance_code_count, Array<u8, 19> const& code_lengths_bit_lengths, size_t code_length_count, Array<code_length_symbol, max_huffman_literals + max_huffman_distances> const& encoded_lengths, size_t encoded_lengths_count)

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -193,8 +193,6 @@ private:
         u8 count; // used for special symbols 16-18
     };
     static u8 distance_to_base(u16 distance);
-    template<size_t Size>
-    static void generate_huffman_lengths(Array<u8, Size>& lengths, Array<u16, Size> const& frequencies, size_t max_bit_length, u16 frequency_cap = UINT16_MAX);
     size_t huffman_block_length(Array<u8, max_huffman_literals> const& literal_bit_lengths, Array<u8, max_huffman_distances> const& distance_bit_lengths);
     ErrorOr<void> write_huffman(CanonicalCode const& literal_code, Optional<CanonicalCode> const& distance_code);
     static size_t encode_huffman_lengths(Array<u8, max_huffman_literals + max_huffman_distances> const& lengths, size_t lengths_count, Array<code_length_symbol, max_huffman_literals + max_huffman_distances>& encoded_lengths);

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -195,7 +195,7 @@ private:
     static u8 distance_to_base(u16 distance);
     size_t huffman_block_length(Array<u8, max_huffman_literals> const& literal_bit_lengths, Array<u8, max_huffman_distances> const& distance_bit_lengths);
     ErrorOr<void> write_huffman(CanonicalCode const& literal_code, Optional<CanonicalCode> const& distance_code);
-    static size_t encode_huffman_lengths(Array<u8, max_huffman_literals + max_huffman_distances> const& lengths, size_t lengths_count, Array<code_length_symbol, max_huffman_literals + max_huffman_distances>& encoded_lengths);
+    static size_t encode_huffman_lengths(ReadonlyBytes lengths, Array<code_length_symbol, max_huffman_literals + max_huffman_distances>& encoded_lengths);
     size_t encode_block_lengths(Array<u8, max_huffman_literals> const& literal_bit_lengths, Array<u8, max_huffman_distances> const& distance_bit_lengths, Array<code_length_symbol, max_huffman_literals + max_huffman_distances>& encoded_lengths, size_t& literal_code_count, size_t& distance_code_count);
     ErrorOr<void> write_dynamic_huffman(CanonicalCode const& literal_code, size_t literal_code_count, Optional<CanonicalCode> const& distance_code, size_t distance_code_count, Array<u8, 19> const& code_lengths_bit_lengths, size_t code_length_count, Array<code_length_symbol, max_huffman_literals + max_huffman_distances> const& encoded_lengths, size_t encoded_lengths_count);
 

--- a/Userland/Libraries/LibCompress/Huffman.h
+++ b/Userland/Libraries/LibCompress/Huffman.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/BinaryHeap.h>
+
+namespace Compress {
+
+template<size_t Size>
+void generate_huffman_lengths(Array<u8, Size>& lengths, Array<u16, Size> const& frequencies, size_t max_bit_length, u16 frequency_cap = UINT16_MAX)
+{
+    VERIFY((1u << max_bit_length) >= Size);
+    u16 heap_keys[Size]; // Used for O(n) heap construction
+    u16 heap_values[Size];
+
+    u16 huffman_links[Size * 2] = { 0 };
+    size_t non_zero_freqs = 0;
+    for (size_t i = 0; i < Size; i++) {
+        auto frequency = frequencies[i];
+        if (frequency == 0)
+            continue;
+
+        if (frequency > frequency_cap) {
+            frequency = frequency_cap;
+        }
+
+        heap_keys[non_zero_freqs] = frequency;               // sort symbols by frequency
+        heap_values[non_zero_freqs] = Size + non_zero_freqs; // huffman_links "links"
+        non_zero_freqs++;
+    }
+
+    // special case for only 1 used symbol
+    if (non_zero_freqs < 2) {
+        for (size_t i = 0; i < Size; i++)
+            lengths[i] = (frequencies[i] == 0) ? 0 : 1;
+        return;
+    }
+
+    BinaryHeap<u16, u16, Size> heap { heap_keys, heap_values, non_zero_freqs };
+
+    // build the huffman tree - binary heap is used for efficient frequency comparisons
+    while (heap.size() > 1) {
+        u16 lowest_frequency = heap.peek_min_key();
+        u16 lowest_link = heap.pop_min();
+        u16 second_lowest_frequency = heap.peek_min_key();
+        u16 second_lowest_link = heap.pop_min();
+
+        u16 new_link = heap.size() + 1;
+
+        heap.insert(lowest_frequency + second_lowest_frequency, new_link);
+
+        huffman_links[lowest_link] = new_link;
+        huffman_links[second_lowest_link] = new_link;
+    }
+
+    non_zero_freqs = 0;
+    for (size_t i = 0; i < Size; i++) {
+        if (frequencies[i] == 0) {
+            lengths[i] = 0;
+            continue;
+        }
+
+        u16 link = huffman_links[Size + non_zero_freqs];
+        non_zero_freqs++;
+
+        size_t bit_length = 1;
+        while (link != 1) {
+            bit_length++;
+            link = huffman_links[link];
+        }
+
+        if (bit_length > max_bit_length) {
+            VERIFY(frequency_cap != 1);
+            return generate_huffman_lengths(lengths, frequencies, max_bit_length, frequency_cap / 2);
+        }
+
+        lengths[i] = bit_length;
+    }
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -89,9 +89,7 @@ static ErrorOr<CanonicalCode> decode_webp_chunk_VP8L_prefix_code(LittleEndianInp
     dbgln_if(WEBP_DEBUG, "  num_code_lengths {}", num_code_lengths);
     VERIFY(num_code_lengths <= 19);
 
-    constexpr int kCodeLengthCodes = 19;
-    int kCodeLengthCodeOrder[kCodeLengthCodes] = { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-    u8 code_length_code_lengths[kCodeLengthCodes] = { 0 }; // "All zeros" [sic]
+    u8 code_length_code_lengths[kCodeLengthCodeOrder.size()] = { 0 }; // "All zeros" [sic]
     for (int i = 0; i < num_code_lengths; ++i)
         code_length_code_lengths[kCodeLengthCodeOrder[i]] = TRY(bit_stream.read_bits(3));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -10,6 +10,8 @@
 
 namespace Gfx {
 
+constexpr Array kCodeLengthCodeOrder = { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
 // WebP-lossless's CanonicalCodes are almost identical to deflate's.
 // One difference is that codes with a single element in webp-lossless consume 0 bits to produce that single element,
 // while they consume 1 bit in Compress::CanonicalCode. This class wraps Compress::CanonicalCode to handle the case


### PR DESCRIPTION
This implements some of the basic webp compression: Huffman coding.
(The other parts of the basics are backreferences, and color cache
entries; and after that there are the four transforms -- predictor,
subtract green, color indexing, color.)

How much huffman coding helps depends on the input's entropy.
Constant-color channels are now encoded in constant space, but
otherwise a huffman code always needs at least one bit per symbol.
This means just huffman coding can at the very best reduce output
size to 1/8th of input size.

For three test input files:

sunset-retro.png (876K): 2.25M -> 2.02M
(helps fairly little; from 2.6x as big as the png input to 2.36x)

giphy.gif (184k): 11M -> 4.9M
(pretty decent, from 61x as big as the gif input to 27x as big)

7z7c.gif (11K): 775K -> 118K
(almost as good as possible an improvement for just huffman coding,
from 70x as big as the gif input to 10.7x as big)

No measurable encoding perf impact for encoding.

The code is pretty similar to Deflate.cpp in LibCompress, with just
enough differences that sharing code doesn't look like it's worth
it to me. I left comments outlining similarities.

---

Also some cleanup commits in LibCompress in code I read for this.