### PR TITLE
Ladybird+SQLServer: Migrate server launch to Core::IPCProcess::spawn

### DIFF
--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -84,19 +84,6 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_generic_server_process(
     });
 }
 
-template<typename ClientType, typename... ClientArguments>
-static ErrorOr<NonnullRefPtr<ClientType>> launch_singleton_server_process(
-    StringView server_name,
-    ReadonlySpan<ByteString> candidate_server_paths,
-    Vector<ByteString> arguments,
-    RegisterWithProcessManager register_with_process_manager,
-    ClientArguments&&... client_arguments)
-{
-    return launch_server_process_impl<ClientType>(server_name, candidate_server_paths, move(arguments), register_with_process_manager, Ladybird::EnableCallgrindProfiling::No, [&](auto options) {
-        return Core::IPCProcess::spawn_singleton<ClientType>(move(options), forward<ClientArguments>(client_arguments)...);
-    });
-}
-
 ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     WebView::ViewImplementation& view,
     ReadonlySpan<ByteString> candidate_web_content_paths,
@@ -182,7 +169,7 @@ ErrorOr<NonnullRefPtr<SQL::SQLClient>> launch_sql_server_process(ReadonlySpan<By
         arguments.append(server.value());
     }
 
-    return launch_singleton_server_process<SQL::SQLClient>("SQLServer"sv, candidate_sql_server_paths, arguments, RegisterWithProcessManager::Yes);
+    return launch_generic_server_process<SQL::SQLClient>("SQLServer"sv, candidate_sql_server_paths, move(arguments), RegisterWithProcessManager::Yes, Ladybird::EnableCallgrindProfiling::No);
 }
 
 ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient& client)

--- a/Ladybird/SQLServer/main.cpp
+++ b/Ladybird/SQLServer/main.cpp
@@ -9,7 +9,7 @@
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/StandardPaths.h>
-#include <LibIPC/MultiServer.h>
+#include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 #include <SQLServer/ConnectionFromClient.h>
 
@@ -21,15 +21,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     AK::set_rich_debug_enabled(true);
 
-    StringView pid_file;
     StringView mach_server_name;
 
     Core::ArgsParser args_parser;
-    args_parser.add_option(pid_file, "Path to the PID file for the SQLServer singleton process", "pid-file", 'p', "pid_file");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
     args_parser.parse(arguments);
-
-    VERIFY(!pid_file.is_empty());
 
     auto database_path = ByteString::formatted("{}/Ladybird", Core::StandardPaths::data_directory());
     TRY(Core::Directory::create(database_path, Core::Directory::CreateDirectories::Yes));
@@ -41,20 +37,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         Core::Platform::register_with_mach_server(mach_server_name);
 #endif
 
-    auto server = TRY(IPC::MultiServer<SQLServer::ConnectionFromClient>::try_create());
-    u64 connection_count { 0 };
-
-    server->on_new_client = [&](auto& client) {
-        client.set_database_path(database_path);
-        ++connection_count;
-
-        client.on_disconnect = [&]() {
-            if (--connection_count == 0) {
-                MUST(Core::System::unlink(pid_file));
-                loop.quit(0);
-            }
-        };
-    };
+    auto client = TRY(IPC::take_over_accepted_client_from_system_server<SQLServer::ConnectionFromClient>());
+    client->set_database_path(database_path);
 
     return loop.exec();
 }

--- a/Userland/Services/SQLServer/ConnectionFromClient.h
+++ b/Userland/Services/SQLServer/ConnectionFromClient.h
@@ -32,7 +32,7 @@ public:
     Function<void()> on_disconnect;
 
 private:
-    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>, int client_id);
+    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
 
     virtual Messages::SQLServer::ConnectResponse connect(ByteString const&) override;
     virtual Messages::SQLServer::PrepareStatementResponse prepare_statement(SQL::ConnectionID, ByteString const&) override;

--- a/Userland/Services/SQLServer/main.cpp
+++ b/Userland/Services/SQLServer/main.cpp
@@ -8,7 +8,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
-#include <LibIPC/MultiServer.h>
+#include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 #include <SQLServer/ConnectionFromClient.h>
 
@@ -24,6 +24,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     Core::EventLoop event_loop;
 
-    auto server = TRY(IPC::MultiServer<SQLServer::ConnectionFromClient>::try_create());
+    auto client = TRY(IPC::take_over_accepted_client_from_system_server<SQLServer::ConnectionFromClient>());
     return event_loop.exec();
 }


### PR DESCRIPTION
Just saw an inconsistency in how SQLServer and RequestServer were being spawned, and since they are both singleton processes they should be able to be launched the same way. The newer strategy also allowed for some cleanup in how SQLServer handles client connections.



https://github.com/SerenityOS/serenity/assets/11325341/5ca7b7d7-ee16-402c-9ba7-7480a66bb539


