### PR TITLE
LibJS: Use a local variable for arguments object when possible

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -45,10 +45,15 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
     }
 
     if (function.m_arguments_object_needed) {
+        Optional<Operand> dst;
+        auto local_var_index = function.m_local_variables_names.find_first_index("arguments"sv);
+        if (local_var_index.has_value())
+            dst = local(local_var_index.value());
+
         if (function.m_strict || !function.has_simple_parameter_list()) {
-            emit<Op::CreateArguments>(Op::CreateArguments::Kind::Unmapped, function.m_strict);
+            emit<Op::CreateArguments>(dst, Op::CreateArguments::Kind::Unmapped, function.m_strict);
         } else {
-            emit<Op::CreateArguments>(Op::CreateArguments::Kind::Mapped, function.m_strict);
+            emit<Op::CreateArguments>(dst, Op::CreateArguments::Kind::Mapped, function.m_strict);
         }
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1373,6 +1373,11 @@ ThrowCompletionOr<void> CreateArguments::execute_impl(Bytecode::Interpreter& int
         arguments_object = create_unmapped_arguments_object(interpreter.vm(), passed_arguments);
     }
 
+    if (m_dst.has_value()) {
+        interpreter.set(*m_dst, arguments_object);
+        return {};
+    }
+
     if (m_is_immutable) {
         MUST(environment->create_immutable_binding(interpreter.vm(), interpreter.vm().names.arguments.as_string(), false));
     } else {
@@ -2110,9 +2115,14 @@ ByteString CreateRestParams::to_byte_string_impl(Bytecode::Executable const& exe
     return ByteString::formatted("CreateRestParams {}, rest_index:{}", format_operand("dst"sv, m_dst, executable), m_rest_index);
 }
 
-ByteString CreateArguments::to_byte_string_impl(Bytecode::Executable const&) const
+ByteString CreateArguments::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
-    return ByteString::formatted("CreateArguments {} immutable:{}", m_kind == Kind::Mapped ? "mapped"sv : "unmapped"sv, m_is_immutable);
+    StringBuilder builder;
+    builder.appendff("CreateArguments");
+    if (m_dst.has_value())
+        builder.appendff(" {}", format_operand("dst"sv, *m_dst, executable));
+    builder.appendff(" {} immutable:{}", m_kind == Kind::Mapped ? "mapped"sv : "unmapped"sv, m_is_immutable);
+    return builder.to_byte_string();
 }
 
 ByteString EnterObjectEnvironment::to_byte_string_impl(Executable const& executable) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -60,8 +60,9 @@ public:
         Unmapped,
     };
 
-    CreateArguments(Kind kind, bool is_immutable)
+    CreateArguments(Optional<Operand> dst, Kind kind, bool is_immutable)
         : Instruction(Type::CreateArguments)
+        , m_dst(dst)
         , m_kind(kind)
         , m_is_immutable(is_immutable)
     {
@@ -69,8 +70,14 @@ public:
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        if (m_dst.has_value())
+            visitor(m_dst.value());
+    }
 
 private:
+    Optional<Operand> m_dst;
     Kind m_kind;
     bool m_is_immutable { false };
 };

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -328,7 +328,8 @@ ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, Byt
         }));
     }
 
-    m_function_environment_needed = m_arguments_object_needed || m_function_environment_bindings_count > 0 || m_var_environment_bindings_count > 0 || m_lex_environment_bindings_count > 0 || uses_this == UsesThis::Yes || m_contains_direct_call_to_eval;
+    auto arguments_object_needs_binding = m_arguments_object_needed && !m_local_variables_names.contains_slow(vm().names.arguments.as_string());
+    m_function_environment_needed = arguments_object_needs_binding || m_function_environment_bindings_count > 0 || m_var_environment_bindings_count > 0 || m_lex_environment_bindings_count > 0 || uses_this == UsesThis::Yes || m_contains_direct_call_to_eval;
 }
 
 void ECMAScriptFunctionObject::initialize(Realm& realm)


### PR DESCRIPTION
This allows us to skip allocating a function environment in cases where it was previously impossible because the arguments object needed a binding.

This change does not bring visible improvement in Kraken or Octane benchmarks but seems useful to have anyway.