### PR TITLE
AK: Enable format string checking in Clang builds

### DIFF
--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -12,14 +12,6 @@
 #include <AK/StringView.h>
 
 #ifdef ENABLE_COMPILETIME_FORMAT_CHECK
-// FIXME: Seems like clang doesn't like calling 'consteval' functions inside 'consteval' functions quite the same way as GCC does,
-//        it seems to entirely forget that it accepted that parameters to a 'consteval' function to begin with.
-#    if defined(AK_COMPILER_CLANG)
-#        undef ENABLE_COMPILETIME_FORMAT_CHECK
-#    endif
-#endif
-
-#ifdef ENABLE_COMPILETIME_FORMAT_CHECK
 namespace AK::Format::Detail {
 
 // We have to define a local "purely constexpr" Array that doesn't lead back to us (via e.g. VERIFY)

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -26,7 +26,8 @@
 class SQLRepl {
 public:
     explicit SQLRepl(Core::EventLoop& loop, ByteString const& database_name, NonnullRefPtr<SQL::SQLClient> sql_client)
-        : m_sql_client(move(sql_client))
+        : m_history_path(ByteString::formatted("{}/.sql-history", Core::StandardPaths::home_directory()))
+        , m_sql_client(move(sql_client))
         , m_loop(loop)
     {
         m_editor = Line::Editor::construct();
@@ -147,7 +148,7 @@ public:
     }
 
 private:
-    ByteString m_history_path { ByteString::formatted("{}/.sql-history", Core::StandardPaths::home_directory()) };
+    ByteString m_history_path;
     RefPtr<Line::Editor> m_editor { nullptr };
     int m_repl_line_level { 0 };
     bool m_keep_running { true };


### PR DESCRIPTION
Format string checking was disabled in Clang-based builds due to a compiler bug: https://github.com/llvm/llvm-project/issues/51182. Now that the requirement has been raised to Clang 17, that is no longer necessary.

This has been tested to work correctly with Apple Clang 15.0.0 (which is the *least modern* supported compiler), as well as CLion 2024.1's bundled Clangd.