### PR TITLE
LibWeb: Add some missing `[FIXME]` IDL attributes

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3194,7 +3194,7 @@ void @class_name@::initialize(JS::Realm& realm)
 
     if (!interface.attributes.is_empty() || !interface.functions.is_empty() || interface.has_stringifier) {
         generator.append(R"~~~(
-static JS::ThrowCompletionOr<@fully_qualified_name@*> impl_from(JS::VM& vm)
+[[maybe_unused]] static JS::ThrowCompletionOr<@fully_qualified_name@*> impl_from(JS::VM& vm)
 {
     auto this_value = vm.this_value();
     JS::Object* this_object = nullptr;

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.idl
@@ -2,5 +2,5 @@
 [Exposed=(Window,Worker)]
 interface CanvasPattern {
     // opaque object
-    // FIXME: undefined setTransform(optional DOMMatrix2DInit transform = {});
+    [FIXME] undefined setTransform(optional DOMMatrix2DInit transform = {});
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -28,7 +28,7 @@ interface HTMLElement : Element {
     [LegacyNullToEmptyString, CEReactions] attribute DOMString innerText;
     [LegacyNullToEmptyString, CEReactions] attribute DOMString outerText;
 
-    // FIXME: ElementInternals attachInternals();
+    [FIXME] ElementInternals attachInternals();
 
     // The popover API
     [FIXME] undefined showPopover();

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -46,7 +46,7 @@ interface HTMLMediaElement : HTMLElement {
     attribute double currentTime;
     undefined fastSeek(double time);
     readonly attribute unrestricted double duration;
-    // FIXME: object getStartDate();
+    [FIXME] object getStartDate();
     readonly attribute boolean paused;
     [FIXME] attribute double defaultPlaybackRate;
     [FIXME] attribute double playbackRate;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -34,7 +34,7 @@ interface HTMLTextAreaElement : HTMLElement {
 
     readonly attribute NodeList labels;
 
-    // FIXME: undefined select();
+    [FIXME] undefined select();
     attribute unsigned long selectionStart;
     attribute unsigned long selectionEnd;
     [FIXME] attribute DOMString selectionDirection;


### PR DESCRIPTION
This PR adds `[FIXME]` attributes to some unimplemented methods that were previously missing them.

As far as I'm aware the only methods that aren't now covered by `[FIXME]` attributes are those with overload resolution issues.