### PR TITLE
Revert "LibCore: Add Core::deferred_invoke_if(F, Condition)"

### DIFF
--- a/Userland/Libraries/LibCore/DeferredInvocationContext.h
+++ b/Userland/Libraries/LibCore/DeferredInvocationContext.h
@@ -13,21 +13,8 @@ namespace Core {
 
 class DeferredInvocationContext final : public Core::EventReceiver {
     C_OBJECT(DeferredInvocationContext)
-public:
-    bool should_invoke() const { return m_condition(); }
-
 private:
-    DeferredInvocationContext()
-        : m_condition([] { return true; })
-    {
-    }
-
-    DeferredInvocationContext(Function<bool()> condition)
-        : m_condition(move(condition))
-    {
-    }
-
-    Function<bool()> m_condition;
+    DeferredInvocationContext() = default;
 };
 
 }

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -156,20 +156,9 @@ void EventLoop::deferred_invoke(Function<void()> invokee)
     post_event(context, make<Core::DeferredInvocationEvent>(context, move(invokee)));
 }
 
-void EventLoop::deferred_invoke_if(Function<void()> invokee, Function<bool()> condition)
-{
-    auto context = DeferredInvocationContext::construct(move(condition));
-    post_event(context, make<Core::DeferredInvocationEvent>(context, move(invokee)));
-}
-
 void deferred_invoke(Function<void()> invokee)
 {
     EventLoop::current().deferred_invoke(move(invokee));
-}
-
-void deferred_invoke_if(Function<void()> invokee, Function<bool()> condition)
-{
-    EventLoop::current().deferred_invoke_if(move(invokee), move(condition));
 }
 
 bool EventLoop::was_exit_requested() const

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -68,7 +68,6 @@ public:
     void add_job(NonnullRefPtr<Promise<NonnullRefPtr<EventReceiver>>> job_promise);
 
     void deferred_invoke(Function<void()>);
-    void deferred_invoke_if(Function<void()>, Function<bool()>);
 
     void wake();
 
@@ -103,5 +102,5 @@ private:
 };
 
 void deferred_invoke(Function<void()>);
-void deferred_invoke_if(Function<void()>, Function<bool()>);
+
 }

--- a/Userland/Libraries/LibCore/ThreadEventQueue.cpp
+++ b/Userland/Libraries/LibCore/ThreadEventQueue.cpp
@@ -84,7 +84,6 @@ void ThreadEventQueue::cancel_all_pending_jobs()
 size_t ThreadEventQueue::process()
 {
     decltype(m_private->queued_events) events;
-    decltype(m_private->queued_events) future_events;
     {
         Threading::MutexLocker locker(m_private->mutex);
         events = move(m_private->queued_events);
@@ -106,10 +105,7 @@ size_t ThreadEventQueue::process()
                 break;
             }
         } else if (event.type() == Event::Type::DeferredInvoke) {
-            if (static_cast<DeferredInvocationContext&>(*receiver).should_invoke())
-                static_cast<DeferredInvocationEvent&>(event).m_invokee();
-            else
-                future_events.append(move(queued_event));
+            static_cast<DeferredInvocationEvent&>(event).m_invokee();
         } else {
             NonnullRefPtr<EventReceiver> protector(*receiver);
             receiver->dispatch_event(event);
@@ -119,8 +115,6 @@ size_t ThreadEventQueue::process()
 
     {
         Threading::MutexLocker locker(m_private->mutex);
-        if (!future_events.is_empty())
-            m_private->queued_events.extend(move(future_events));
         if (m_private->pending_promises.size() > 30 && !m_private->warned_promise_count) {
             m_private->warned_promise_count = true;
             dbgln("ThreadEventQueue::process: Job queue wasn't designed for this load ({} promises)", m_private->pending_promises.size());


### PR DESCRIPTION
This reverts commit a362c37c8b3d2c8f0d5e23276bfe81cb1c24d384.

The commit tried to add an unused function that continued our tradition of not properly waiting for things but instead flooding event loop with condition checks that delay firing of the event. I think this is a fundamentally flawed approach. See also checks for `fire_when_not_visible` in LibCore/EventLoopImplementationUnix.cpp.