### PR TITLE
LibJS: Skip ordinary_call_bind_this() when possible

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -242,6 +242,7 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
         auto function_code = create_ast_node<ClassFieldInitializerStatement>(m_initializer->source_range(), copy_initializer.release_nonnull(), name);
         FunctionParsingInsights parsing_insights;
         parsing_insights.uses_this_from_environment = true;
+        parsing_insights.uses_this = true;
         initializer = make_handle(*ECMAScriptFunctionObject::create(realm, "field", ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, parsing_insights, false, property_key_or_private_name));
         initializer->make_method(target);
     }
@@ -288,6 +289,7 @@ ThrowCompletionOr<ClassElement::ClassValue> StaticInitializer::class_element_eva
     // Note: The function bodyFunction is never directly accessible to ECMAScript code.
     FunctionParsingInsights parsing_insights;
     parsing_insights.uses_this_from_environment = true;
+    parsing_insights.uses_this = true;
     auto body_function = ECMAScriptFunctionObject::create(realm, ByteString::empty(), ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, parsing_insights, false);
 
     // 6. Perform MakeMethod(bodyFunction, homeObject).
@@ -337,6 +339,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
     auto const& constructor = *m_constructor;
     auto parsing_insights = constructor.parsing_insights();
     parsing_insights.uses_this_from_environment = true;
+    parsing_insights.uses_this = true;
     auto class_constructor = ECMAScriptFunctionObject::create(
         realm,
         constructor.name(),

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -107,7 +107,7 @@ Value FunctionExpression::instantiate_ordinary_function_expression(VM& vm, Depre
     auto private_environment = vm.running_execution_context().private_environment;
 
     auto closure = ECMAScriptFunctionObject::create(realm, used_name, source_text(), body(), parameters(), function_length(), local_variables_names(), environment, private_environment, kind(), is_strict_mode(),
-        uses_this_from_environment(), might_need_arguments_object(), contains_direct_call_to_eval(), is_arrow_function());
+        parsing_insights(), is_arrow_function());
 
     // FIXME: 6. Perform SetFunctionName(closure, name).
     // FIXME: 7. Perform MakeConstructor(closure).
@@ -153,7 +153,7 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassMethod::class_element_evaluatio
     auto property_key_or_private_name = TRY(class_key_to_property_name(vm, *m_key, property_key));
 
     auto& method_function = *ECMAScriptFunctionObject::create(*vm.current_realm(), m_function->name(), m_function->source_text(), m_function->body(), m_function->parameters(), m_function->function_length(), m_function->local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, m_function->kind(), m_function->is_strict_mode(),
-        m_function->uses_this_from_environment(), m_function->might_need_arguments_object(), m_function->contains_direct_call_to_eval(), m_function->is_arrow_function());
+        m_function->parsing_insights(), m_function->is_arrow_function());
 
     auto method_value = Value(&method_function);
     method_function.make_method(target);
@@ -240,7 +240,9 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
 
         // FIXME: A potential optimization is not creating the functions here since these are never directly accessible.
         auto function_code = create_ast_node<ClassFieldInitializerStatement>(m_initializer->source_range(), copy_initializer.release_nonnull(), name);
-        initializer = make_handle(*ECMAScriptFunctionObject::create(realm, "field", ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, UsesThisFromEnvironment::Yes, false, m_contains_direct_call_to_eval, false, property_key_or_private_name));
+        FunctionParsingInsights parsing_insights;
+        parsing_insights.uses_this_from_environment = true;
+        initializer = make_handle(*ECMAScriptFunctionObject::create(realm, "field", ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, parsing_insights, false, property_key_or_private_name));
         initializer->make_method(target);
     }
 
@@ -284,7 +286,9 @@ ThrowCompletionOr<ClassElement::ClassValue> StaticInitializer::class_element_eva
     // 4. Let formalParameters be an instance of the production FormalParameters : [empty] .
     // 5. Let bodyFunction be OrdinaryFunctionCreate(%Function.prototype%, sourceText, formalParameters, ClassStaticBlockBody, non-lexical-this, lex, privateEnv).
     // Note: The function bodyFunction is never directly accessible to ECMAScript code.
-    auto body_function = ECMAScriptFunctionObject::create(realm, ByteString::empty(), ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, UsesThisFromEnvironment::Yes, false, m_contains_direct_call_to_eval, false);
+    FunctionParsingInsights parsing_insights;
+    parsing_insights.uses_this_from_environment = true;
+    auto body_function = ECMAScriptFunctionObject::create(realm, ByteString::empty(), ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, parsing_insights, false);
 
     // 6. Perform MakeMethod(bodyFunction, homeObject).
     body_function->make_method(home_object);
@@ -331,6 +335,8 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
 
     // FIXME: Step 14.a is done in the parser. By using a synthetic super(...args) which does not call @@iterator of %Array.prototype%
     auto const& constructor = *m_constructor;
+    auto parsing_insights = constructor.parsing_insights();
+    parsing_insights.uses_this_from_environment = true;
     auto class_constructor = ECMAScriptFunctionObject::create(
         realm,
         constructor.name(),
@@ -343,9 +349,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
         vm.running_execution_context().private_environment,
         constructor.kind(),
         constructor.is_strict_mode(),
-        UsesThisFromEnvironment::Yes,
-        constructor.might_need_arguments_object(),
-        constructor.contains_direct_call_to_eval(),
+        parsing_insights,
         constructor.is_arrow_function());
 
     class_constructor->set_name(class_name);
@@ -824,7 +828,7 @@ void FunctionNode::dump(int indent, ByteString const& class_name) const
     auto is_async = m_kind == FunctionKind::Async || m_kind == FunctionKind::AsyncGenerator;
     auto is_generator = m_kind == FunctionKind::Generator || m_kind == FunctionKind::AsyncGenerator;
     outln("{}{}{} '{}'", class_name, is_async ? " async" : "", is_generator ? "*" : "", name());
-    if (m_contains_direct_call_to_eval) {
+    if (m_parsing_insights.contains_direct_call_to_eval) {
         print_indent(indent + 1);
         outln("\033[31;1m(direct eval)\033[0m");
     }
@@ -1623,7 +1627,7 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
 
             // ii. Let fo be InstantiateFunctionObject of d with arguments env and privateEnv.
             auto function = ECMAScriptFunctionObject::create(realm, function_declaration.name(), function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(),
-                function_declaration.uses_this_from_environment(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
+                function_declaration.parsing_insights());
 
             // iii. Perform ! env.InitializeBinding(fn, fo). NOTE: This step is replaced in section B.3.2.6.
             if (function_declaration.name_identifier()->is_local()) {
@@ -1831,7 +1835,7 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments env and privateEnv.
         auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), &global_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
-            declaration.uses_this_from_environment(), declaration.might_need_arguments_object(), declaration.contains_direct_call_to_eval());
+            declaration.parsing_insights());
 
         // c. Perform ? env.CreateGlobalFunctionBinding(fn, fo, false).
         TRY(global_environment.create_global_function_binding(declaration.name(), function, false));

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -694,6 +694,7 @@ struct FunctionParameter {
 };
 
 struct FunctionParsingInsights {
+    bool uses_this { false };
     bool uses_this_from_environment { false };
     bool contains_direct_call_to_eval { false };
     bool might_need_arguments_object { false };

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -418,7 +418,7 @@ inline Value new_function(VM& vm, FunctionNode const& function_node, Optional<Id
         value = function_node.instantiate_ordinary_function_expression(vm, name);
     } else {
         value = ECMAScriptFunctionObject::create(*vm.current_realm(), function_node.name(), function_node.source_text(), function_node.body(), function_node.parameters(), function_node.function_length(), function_node.local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, function_node.kind(), function_node.is_strict_mode(),
-            function_node.uses_this_from_environment(), function_node.might_need_arguments_object(), function_node.contains_direct_call_to_eval(), function_node.is_arrow_function());
+            function_node.parsing_insights(), function_node.is_arrow_function());
     }
 
     if (home_object.has_value()) {

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -87,7 +87,7 @@ public:
 
     NonnullRefPtr<Statement const> parse_statement(AllowLabelledFunction allow_labelled_function = AllowLabelledFunction::No);
     NonnullRefPtr<BlockStatement const> parse_block_statement();
-    NonnullRefPtr<FunctionBody const> parse_function_body(Vector<FunctionParameter> const& parameters, FunctionKind function_kind, bool& contains_direct_call_to_eval, bool& uses_this);
+    NonnullRefPtr<FunctionBody const> parse_function_body(Vector<FunctionParameter> const& parameters, FunctionKind function_kind, FunctionParsingInsights&);
     NonnullRefPtr<ReturnStatement const> parse_return_statement();
 
     enum class IsForLoopVariableDeclaration {
@@ -211,7 +211,7 @@ public:
     // Needs to mess with m_state, and we're not going to expose a non-const getter for that :^)
     friend ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic_function(VM&, FunctionObject&, FunctionObject*, FunctionKind, MarkedVector<Value> const&);
 
-    static Parser parse_function_body_from_string(ByteString const& body_string, u16 parse_options, Vector<FunctionParameter> const& parameters, FunctionKind kind, bool& contains_direct_call_to_eval, bool& uses_this_from_environment);
+    static Parser parse_function_body_from_string(ByteString const& body_string, u16 parse_options, Vector<FunctionParameter> const& parameters, FunctionKind kind, FunctionParsingInsights&);
 
 private:
     friend class ScopePusher;

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -973,7 +973,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
         auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
-            declaration.uses_this_from_environment(), declaration.might_need_arguments_object());
+            declaration.parsing_insights());
 
         // c. If varEnv is a global Environment Record, then
         if (global_var_environment) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -332,6 +332,7 @@ ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, Byt
     }
 
     m_function_environment_needed = arguments_object_needs_binding || m_function_environment_bindings_count > 0 || m_var_environment_bindings_count > 0 || m_lex_environment_bindings_count > 0 || parsing_insights.uses_this_from_environment || m_contains_direct_call_to_eval;
+    m_uses_this = parsing_insights.uses_this;
 }
 
 void ECMAScriptFunctionObject::initialize(Realm& realm)
@@ -414,7 +415,8 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
     }
 
     // 5. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
-    ordinary_call_bind_this(*callee_context, this_argument);
+    if (m_uses_this)
+        ordinary_call_bind_this(*callee_context, this_argument);
 
     // 6. Let result be Completion(OrdinaryCallEvaluateBody(F, argumentsList)).
     auto result = ordinary_call_evaluate_body();
@@ -477,7 +479,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
     // 6. If kind is base, then
     if (kind == ConstructorKind::Base) {
         // a. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
-        ordinary_call_bind_this(*callee_context, this_argument);
+        if (m_uses_this)
+            ordinary_call_bind_this(*callee_context, this_argument);
 
         // b. Let initializeResult be Completion(InitializeInstanceElements(thisArgument, F)).
         auto initialize_result = this_argument->initialize_instance_elements(*this);

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -164,6 +164,7 @@ private:
     bool m_arguments_object_needed { false };
     bool m_is_module_wrapper { false };
     bool m_function_environment_needed { false };
+    bool m_uses_this { false };
     Vector<VariableNameToInitialize> m_var_names_to_initialize_binding;
     Vector<DeprecatedFlyString> m_function_names_to_initialize_binding;
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -39,8 +39,8 @@ public:
         Global,
     };
 
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, UsesThisFromEnvironment, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, UsesThisFromEnvironment, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
 
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
@@ -109,7 +109,7 @@ protected:
     virtual Completion ordinary_call_evaluate_body();
 
 private:
-    ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, UsesThisFromEnvironment, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
+    ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
 
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -182,9 +182,8 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     }
 
     // 18. Let body be ParseText(StringToCodePoints(bodyString), bodySym).
-    bool contains_direct_call_to_eval = false;
-    bool uses_this_from_environment = false;
-    auto body_parser = Parser::parse_function_body_from_string(body_string, parse_options, parameters, kind, contains_direct_call_to_eval, uses_this_from_environment);
+    FunctionParsingInsights parsing_insights;
+    auto body_parser = Parser::parse_function_body_from_string(body_string, parse_options, parameters, kind, parsing_insights);
 
     // 19. If body is a List of errors, throw a SyntaxError exception.
     if (body_parser.has_errors()) {
@@ -219,7 +218,8 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     PrivateEnvironment* private_environment = nullptr;
 
     // 28. Let F be OrdinaryFunctionCreate(proto, sourceText, parameters, body, non-lexical-this, env, privateEnv).
-    auto function = ECMAScriptFunctionObject::create(realm, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), uses_this_from_environment ? UsesThisFromEnvironment::Yes : UsesThisFromEnvironment::No, expr->might_need_arguments_object(), contains_direct_call_to_eval);
+    parsing_insights.might_need_arguments_object = true;
+    auto function = ECMAScriptFunctionObject::create(realm, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), parsing_insights);
 
     // FIXME: Remove the name argument from create() and do this instead.
     // 29. Perform SetFunctionName(F, "anonymous").

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -760,6 +760,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
 
         FunctionParsingInsights parsing_insights;
         parsing_insights.uses_this_from_environment = true;
+        parsing_insights.uses_this = true;
         auto module_wrapper_function = ECMAScriptFunctionObject::create(
             realm(), "module code with top-level await", StringView {}, this->m_ecmascript_code,
             {}, 0, {}, environment(), nullptr, FunctionKind::Async, true, parsing_insights);

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -499,7 +499,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
                 if (function_name == ExportStatement::local_name_for_default)
                     function_name = "default"sv;
                 auto function = ECMAScriptFunctionObject::create(realm(), function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(),
-                    function_declaration.uses_this_from_environment(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
+                    function_declaration.parsing_insights());
 
                 // 2. Perform ! env.InitializeBinding(dn, fo, normal).
                 MUST(environment->initialize_binding(vm, name, function, Environment::InitializeBindingHint::Normal));
@@ -758,9 +758,11 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
         //         the top-level module code.
         // FIXME: Improve this situation, so we can match the spec better.
 
+        FunctionParsingInsights parsing_insights;
+        parsing_insights.uses_this_from_environment = true;
         auto module_wrapper_function = ECMAScriptFunctionObject::create(
             realm(), "module code with top-level await", StringView {}, this->m_ecmascript_code,
-            {}, 0, {}, environment(), nullptr, FunctionKind::Async, true, UsesThisFromEnvironment::Yes, false, false);
+            {}, 0, {}, environment(), nullptr, FunctionKind::Async, true, parsing_insights);
         module_wrapper_function->set_is_module_wrapper(true);
 
         // AD-HOC: We push/pop the moduleContext around the call to ensure that the async execution context

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -486,7 +486,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
         //  6. Return scope. (NOTE: Not necessary)
 
         auto function = JS::ECMAScriptFunctionObject::create(realm, name.to_deprecated_fly_string(), builder.to_byte_string(), program->body(), program->parameters(), program->function_length(), program->local_variables_names(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(),
-            program->uses_this_from_environment(), program->might_need_arguments_object(), is_arrow_function);
+            program->parsing_insights(), is_arrow_function);
 
         // 10. Remove settings object's realm execution context from the JavaScript execution context stack.
         VERIFY(vm.execution_context_stack().last() == &settings_object.realm_execution_context());

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -237,7 +237,6 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(Web::Page& page,
 
     auto& realm = window->realm();
 
-    bool contains_direct_call_to_eval = false;
     auto source_text = ByteString::formatted("function() {{ {} }}", body);
     auto parser = JS::Parser { JS::Lexer { source_text } };
     auto function_expression = parser.parse_function_node<JS::FunctionExpression>();
@@ -266,8 +265,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(Web::Page& page,
     //    The result of parsing global scope above.
     // strict
     //    The result of parsing strict above.
-    auto function = JS::ECMAScriptFunctionObject::create(realm, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(),
-        function_expression->uses_this_from_environment(), function_expression->might_need_arguments_object(), contains_direct_call_to_eval);
+    auto function = JS::ECMAScriptFunctionObject::create(realm, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->parsing_insights());
 
     // 9. Let completion be Function.[[Call]](window, parameters) with function as the this value.
     // NOTE: This is not entirely clear, but I don't think they mean actually passing `function` as


### PR DESCRIPTION
If during parsing it was found that function won't use `this` then
there is no need to initialise `this_value` during call.

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1      1.855 ± 1.850 … 1.860     1.855 ± 1.840 … 1.870
Kraken      audio-beat-detection.js                  1.014  1.440 ± 1.440 … 1.440     1.420 ± 1.410 … 1.430
Kraken      audio-dft.js                             1.063  1.270 ± 1.260 … 1.280     1.195 ± 1.190 … 1.200
Kraken      audio-fft.js                             1.023  1.335 ± 1.330 … 1.340     1.305 ± 1.300 … 1.310
Kraken      audio-oscillator.js                      1.021  1.480 ± 1.480 … 1.480     1.450 ± 1.450 … 1.450
Kraken      imaging-darkroom.js                      1.02   2.535 ± 2.510 … 2.560     2.485 ± 2.480 … 2.490
Kraken      imaging-desaturate.js                    1.027  2.075 ± 2.070 … 2.080     2.020 ± 2.010 … 2.030
Kraken      imaging-gaussian-blur.js                 1.025  7.720 ± 7.710 … 7.730     7.535 ± 7.530 … 7.540
Kraken      json-parse-financial.js                  1.071  0.150 ± 0.150 … 0.150     0.140 ± 0.140 … 0.140
Kraken      json-stringify-tinderbox.js              1.042  0.250 ± 0.250 … 0.250     0.240 ± 0.240 … 0.240
Kraken      stanford-crypto-aes.js                   1.032  0.650 ± 0.650 … 0.650     0.630 ± 0.630 … 0.630
Kraken      stanford-crypto-ccm.js                   1.036  0.570 ± 0.570 … 0.570     0.550 ± 0.550 … 0.550
Kraken      stanford-crypto-pbkdf2.js                1.023  1.135 ± 1.130 … 1.140     1.110 ± 1.110 … 1.110
Kraken      stanford-crypto-sha256-iterative.js      0.989  0.460 ± 0.460 … 0.460     0.465 ± 0.460 … 0.470
Octane      box2d.js                                 1.002  2.105 ± 2.100 … 2.110     2.100 ± 2.100 … 2.100
Octane      code-load.js                             1.005  2.080 ± 2.080 … 2.080     2.070 ± 2.070 … 2.070
Octane      crypto.js                                0.973  6.100 ± 6.100 … 6.100     6.270 ± 6.200 … 6.340
Octane      deltablue.js                             0.998  2.030 ± 2.030 … 2.030     2.035 ± 2.020 … 2.050
Octane      earley-boyer.js                          1.011  17.620 ± 17.360 … 17.880  17.430 ± 17.300 … 17.560
Octane      gbemu.js                                 1.014  2.975 ± 2.970 … 2.980     2.935 ± 2.920 … 2.950
Octane      mandreel.js                              0.997  13.955 ± 13.870 … 14.040  13.995 ± 13.940 … 14.050
Octane      navier-stokes.js                         0.998  3.170 ± 3.150 … 3.190     3.175 ± 3.150 … 3.200
Octane      pdfjs.js                                 1.005  2.925 ± 2.920 … 2.930     2.910 ± 2.900 … 2.920
Octane      raytrace.js                              0.997  5.565 ± 5.530 … 5.600     5.580 ± 5.570 … 5.590
Octane      regexp.js                                0.977  22.850 ± 22.850 … 22.850  23.385 ± 23.240 … 23.530
Octane      richards.js                              0.998  2.010 ± 2.010 … 2.010     2.015 ± 2.010 … 2.020
Octane      splay.js                                 0.974  2.615 ± 2.610 … 2.620     2.685 ± 2.670 … 2.700
Octane      typescript.js                            0.991  25.975 ± 25.690 … 26.260  26.220 ± 25.990 … 26.450
Octane      zlib.js                                  1.016  73.110 ± 72.260 … 73.960  71.970 ± 71.910 … 72.030
Kraken      Total                                    1.023  22.925                    22.400
Octane      Total                                    1.002  185.085                   184.775
All Suites  Total                                    1.004  208.010                   207.175
```