### PR TITLE
IDLGenerators: Use spec-compliant algorithm to parse integer values

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3440,7 +3440,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     i32 retval = 0;
     auto content_attribute_value = impl->get_attribute(HTML::AttributeNames::@attribute.reflect_name@);
     if (content_attribute_value.has_value()) {
-        auto maybe_parsed_value = content_attribute_value->to_number<i32>();
+        auto maybe_parsed_value = Web::HTML::parse_integer(*content_attribute_value);
         if (maybe_parsed_value.has_value())
             retval = *maybe_parsed_value;
     }
@@ -3467,7 +3467,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     u32 minimum = 0;
     u32 maximum = 2147483647;
     if (content_attribute_value.has_value()) {
-        auto parsed_value = content_attribute_value->to_number<u32>();
+        auto parsed_value = Web::HTML::parse_non_negative_integer(*content_attribute_value);
         if (parsed_value.has_value()) {
             if (*parsed_value >= minimum && *parsed_value <= maximum) {
                 retval = *parsed_value;
@@ -4338,6 +4338,7 @@ void generate_prototype_implementation(IDL::Interface const& interface, StringBu
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOM/NodeFilter.h>
 #include <LibWeb/DOM/Range.h>
+#include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>

--- a/Tests/LibWeb/Text/expected/HTML/reflected-integer-attributes.txt
+++ b/Tests/LibWeb/Text/expected/HTML/reflected-integer-attributes.txt
@@ -1,30 +1,40 @@
 img.hspace after setting to -1: 0
 img.hspace after setting to 20: 20
 img.hspace after setting to 2147483648: 0
+img.hspace after setting to 50 with a leading vertical tab: 0
 img.vspace after setting to -1: 0
 img.vspace after setting to 20: 20
 img.vspace after setting to 2147483648: 0
+img.vspace after setting to 50 with a leading vertical tab: 0
 marquee.hspace after setting to -1: 0
 marquee.hspace after setting to 20: 20
 marquee.hspace after setting to 2147483648: 0
+marquee.hspace after setting to 50 with a leading vertical tab: 0
 marquee.vspace after setting to -1: 0
 marquee.vspace after setting to 20: 20
 marquee.vspace after setting to 2147483648: 0
+marquee.vspace after setting to 50 with a leading vertical tab: 0
 object.hspace after setting to -1: 0
 object.hspace after setting to 20: 20
 object.hspace after setting to 2147483648: 0
+object.hspace after setting to 50 with a leading vertical tab: 0
 object.vspace after setting to -1: 0
 object.vspace after setting to 20: 20
 object.vspace after setting to 2147483648: 0
+object.vspace after setting to 50 with a leading vertical tab: 0
 source.width after setting to -1: 0
 source.width after setting to 20: 20
 source.width after setting to 2147483648: 0
+source.width after setting to 50 with a leading vertical tab: 0
 source.height after setting to -1: 0
 source.height after setting to 20: 20
 source.height after setting to 2147483648: 0
+source.height after setting to 50 with a leading vertical tab: 0
 video.width after setting to -1: 0
 video.width after setting to 20: 20
 video.width after setting to 2147483648: 0
+video.width after setting to 50 with a leading vertical tab: 0
 video.height after setting to -1: 0
 video.height after setting to 20: 20
 video.height after setting to 2147483648: 0
+video.height after setting to 50 with a leading vertical tab: 0

--- a/Tests/LibWeb/Text/input/HTML/reflected-integer-attributes.html
+++ b/Tests/LibWeb/Text/input/HTML/reflected-integer-attributes.html
@@ -11,6 +11,10 @@
         setPropertyAndDumpValue(tagName, property, -1);
         setPropertyAndDumpValue(tagName, property, 20);
         setPropertyAndDumpValue(tagName, property, 2147483648);
+        
+        const element = document.createElement(tagName);
+        element.setAttribute(property, "\v50");
+        println(`${tagName}.${property} after setting to 50 with a leading vertical tab: ${element[property]}`);
     }
 
     test(() => {


### PR DESCRIPTION
This fixes an oversight from #24402.