### PR TITLE
LibWeb: Enable callbacks in chunk steps for ReadableStreamDefaultTee

### DIFF
--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -401,7 +401,7 @@ public:
     {
         // 1. Queue a microtask to perform the following steps:
         HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk]() {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm) };
+            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             auto controller1 = m_params->branch1->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>();
             auto controller2 = m_params->branch2->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>();


### PR DESCRIPTION
We enqueue a microtask for this readable stream AO, and the methods that we call from the chunk steps manipulate promises. As such, we need to enable callbacks for the entire microtask's temporary execution context.

Fixes #24419

Now the nytimes website spins on something instead of crashing outright :) 