### PR TITLE
LibJS: Add fast ExecutionContext allocator

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -31,11 +31,15 @@ struct ExecutionContext {
     void visit_edges(Cell::Visitor&);
 
 private:
+    friend class ExecutionContextAllocator;
+
     ExecutionContext(Heap&);
 
     IntrusiveListNode<ExecutionContext> m_list_node;
 
 public:
+    void operator delete(void* ptr);
+
     Heap& m_heap;
 
     using List = IntrusiveList<&ExecutionContext::m_list_node>;


### PR DESCRIPTION
...that maintains a list of allocated execution contexts so malloc() does not have to be called every time we need to get a new one.

20% improvement in Octane/typescript.js
16% improvement in Kraken/imaging-darkroom.js

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.006  1.800 ± 1.790 … 1.810     1.790 ± 1.790 … 1.790
Kraken      audio-beat-detection.js                  1      1.410 ± 1.410 … 1.410     1.410 ± 1.410 … 1.410
Kraken      audio-dft.js                             1.018  1.155 ± 1.150 … 1.160     1.135 ± 1.130 … 1.140
Kraken      audio-fft.js                             0.992  1.300 ± 1.300 … 1.300     1.310 ± 1.310 … 1.310
Kraken      audio-oscillator.js                      1      1.445 ± 1.440 … 1.450     1.445 ± 1.440 … 1.450
Kraken      imaging-darkroom.js                      1.163  2.395 ± 2.380 … 2.410     2.060 ± 2.060 … 2.060
Kraken      imaging-desaturate.js                    1      2.015 ± 2.010 … 2.020     2.015 ± 2.010 … 2.020
Kraken      imaging-gaussian-blur.js                 1.01   7.545 ± 7.510 … 7.580     7.470 ± 7.470 … 7.470
Kraken      json-parse-financial.js                  1      0.140 ± 0.140 … 0.140     0.140 ± 0.140 … 0.140
Kraken      json-stringify-tinderbox.js              1      0.240 ± 0.240 … 0.240     0.240 ± 0.240 … 0.240
Kraken      stanford-crypto-aes.js                   1.033  0.630 ± 0.630 … 0.630     0.610 ± 0.610 … 0.610
Kraken      stanford-crypto-ccm.js                   1.09   0.545 ± 0.540 … 0.550     0.500 ± 0.500 … 0.500
Kraken      stanford-crypto-pbkdf2.js                1.078  1.110 ± 1.110 … 1.110     1.030 ± 1.030 … 1.030
Kraken      stanford-crypto-sha256-iterative.js      1.095  0.460 ± 0.460 … 0.460     0.420 ± 0.420 … 0.420
Octane      box2d.js                                 0.908  2.085 ± 2.080 … 2.090     2.295 ± 2.290 … 2.300
Octane      code-load.js                             1.002  2.090 ± 2.090 … 2.090     2.085 ± 2.080 … 2.090
Octane      crypto.js                                1.009  6.305 ± 6.260 … 6.350     6.250 ± 6.180 … 6.320
Octane      deltablue.js                             1.007  2.035 ± 2.030 … 2.040     2.020 ± 2.010 … 2.030
Octane      earley-boyer.js                          1.125  17.355 ± 17.310 … 17.400  15.425 ± 15.420 … 15.430
Octane      gbemu.js                                 1.154  3.005 ± 3.000 … 3.010     2.605 ± 2.600 … 2.610
Octane      mandreel.js                              1.089  13.820 ± 13.810 … 13.830  12.690 ± 12.630 … 12.750
Octane      navier-stokes.js                         0.983  3.185 ± 3.140 … 3.230     3.240 ± 3.240 … 3.240
Octane      pdfjs.js                                 1.139  3.025 ± 3.020 … 3.030     2.655 ± 2.640 … 2.670
Octane      raytrace.js                              1.141  6.220 ± 6.170 … 6.270     5.450 ± 5.430 … 5.470
Octane      regexp.js                                1.088  23.475 ± 23.370 … 23.580  21.580 ± 21.550 … 21.610
Octane      richards.js                              1.002  2.015 ± 2.010 … 2.020     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.039  2.675 ± 2.670 … 2.680     2.575 ± 2.570 … 2.580
Octane      typescript.js                            1.2    25.835 ± 25.680 … 25.990  21.525 ± 21.520 … 21.530
Octane      zlib.js                                  1.002  73.110 ± 72.060 … 74.160  72.980 ± 72.850 … 73.110
Kraken      Total                                    1.029  22.190                    21.575
Octane      Total                                    1.062  186.235                   175.385
All Suites  Total                                    1.058  208.425                   196.960
```