### PR TITLE
Kernel: Ignore dirfd if absolute path is given in VFS-related syscalls

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -135,6 +135,7 @@ set(KERNEL_SOURCES
     FileSystem/AnonymousFile.cpp
     FileSystem/BlockBasedFileSystem.cpp
     FileSystem/Custody.cpp
+    FileSystem/CustodyBase.cpp
     FileSystem/DevLoopFS/FileSystem.cpp
     FileSystem/DevLoopFS/Inode.cpp
     FileSystem/DevPtsFS/FileSystem.cpp

--- a/Kernel/FileSystem/CustodyBase.cpp
+++ b/Kernel/FileSystem/CustodyBase.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/CustodyBase.h>
+#include <Kernel/FileSystem/VirtualFileSystem.h>
+#include <Kernel/Library/KLexicalPath.h>
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<NonnullRefPtr<Custody>> CustodyBase::resolve() const
+{
+    if (m_base)
+        return *m_base;
+    if (KLexicalPath::is_absolute(m_path))
+        return VirtualFileSystem::the().root_custody();
+    return Process::current().custody_for_dirfd({}, m_dirfd);
+}
+
+}

--- a/Kernel/FileSystem/CustodyBase.h
+++ b/Kernel/FileSystem/CustodyBase.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/RefPtr.h>
+#include <AK/StringView.h>
+#include <Kernel/FileSystem/Custody.h>
+
+namespace Kernel {
+
+class CustodyBase {
+public:
+    CustodyBase(int dirfd, StringView path)
+        : m_path(path)
+        , m_dirfd(dirfd)
+    {
+    }
+
+    CustodyBase(NonnullRefPtr<Custody> base)
+        : m_base(base)
+    {
+    }
+
+    CustodyBase(Custody& base)
+        : m_base(base)
+    {
+    }
+
+    CustodyBase(Custody const& base)
+        : m_base(base)
+    {
+    }
+
+    ErrorOr<NonnullRefPtr<Custody>> resolve() const;
+
+private:
+    RefPtr<Custody> const m_base;
+    StringView m_path;
+    int m_dirfd { -1 };
+};
+
+}

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -52,7 +52,7 @@ void Inode::sync()
     }
 }
 
-ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Credentials const& credentials, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const
+ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Credentials const& credentials, CustodyBase const& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const
 {
     // The default implementation simply treats the stored
     // contents as a path and resolves that. That is, it

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -11,6 +11,7 @@
 #include <AK/Function.h>
 #include <AK/HashTable.h>
 #include <AK/IntrusiveList.h>
+#include <Kernel/FileSystem/CustodyBase.h>
 #include <Kernel/FileSystem/FIFO.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
@@ -72,7 +73,7 @@ public:
     virtual ErrorOr<void> chmod(mode_t) = 0;
     virtual ErrorOr<void> chown(UserID, GroupID) = 0;
 
-    ErrorOr<NonnullRefPtr<Custody>> resolve_as_link(Credentials const&, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const;
+    ErrorOr<NonnullRefPtr<Custody>> resolve_as_link(Credentials const&, CustodyBase const& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const;
 
     virtual ErrorOr<int> get_block_address(int) { return ENOTSUP; }
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -12,6 +12,7 @@
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
+#include <Kernel/FileSystem/CustodyBase.h>
 #include <Kernel/FileSystem/FileBackedFileSystem.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/Initializer.h>
@@ -64,27 +65,27 @@ public:
     ErrorOr<void> unmount(Custody& mount_point);
     ErrorOr<void> unmount(Inode& guest_inode, StringView custody_path);
 
-    ErrorOr<NonnullRefPtr<OpenFileDescription>> open(Credentials const&, StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
-    ErrorOr<NonnullRefPtr<OpenFileDescription>> open(Process const&, Credentials const&, StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
+    ErrorOr<NonnullRefPtr<OpenFileDescription>> open(Credentials const&, StringView path, int options, mode_t mode, CustodyBase const& base, Optional<UidAndGid> = {});
+    ErrorOr<NonnullRefPtr<OpenFileDescription>> open(Process const&, Credentials const&, StringView path, int options, mode_t mode, CustodyBase const& base, Optional<UidAndGid> = {});
     ErrorOr<NonnullRefPtr<OpenFileDescription>> create(Credentials const&, StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
     ErrorOr<NonnullRefPtr<OpenFileDescription>> create(Process const&, Credentials const&, StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
-    ErrorOr<void> mkdir(Credentials const&, StringView path, mode_t mode, Custody& base);
-    ErrorOr<void> link(Credentials const&, StringView old_path, StringView new_path, Custody& base);
-    ErrorOr<void> unlink(Credentials const&, StringView path, Custody& base);
-    ErrorOr<void> symlink(Credentials const&, StringView target, StringView linkpath, Custody& base);
-    ErrorOr<void> rmdir(Credentials const&, StringView path, Custody& base);
-    ErrorOr<void> chmod(Credentials const&, StringView path, mode_t, Custody& base, int options = 0);
+    ErrorOr<void> mkdir(Credentials const&, StringView path, mode_t mode, CustodyBase const& base);
+    ErrorOr<void> link(Credentials const&, StringView old_path, StringView new_path, CustodyBase const& base);
+    ErrorOr<void> unlink(Credentials const&, StringView path, CustodyBase const& base);
+    ErrorOr<void> symlink(Credentials const&, StringView target, StringView linkpath, CustodyBase const& base);
+    ErrorOr<void> rmdir(Credentials const&, StringView path, CustodyBase const& base);
+    ErrorOr<void> chmod(Credentials const&, StringView path, mode_t, CustodyBase const& base, int options = 0);
     ErrorOr<void> chmod(Credentials const&, Custody&, mode_t);
-    ErrorOr<void> chown(Credentials const&, StringView path, UserID, GroupID, Custody& base, int options);
+    ErrorOr<void> chown(Credentials const&, StringView path, UserID, GroupID, CustodyBase const& base, int options);
     ErrorOr<void> chown(Credentials const&, Custody&, UserID, GroupID);
-    ErrorOr<void> access(Credentials const&, StringView path, int mode, Custody& base, AccessFlags);
-    ErrorOr<InodeMetadata> lookup_metadata(Credentials const&, StringView path, Custody& base, int options = 0);
-    ErrorOr<void> utime(Credentials const&, StringView path, Custody& base, time_t atime, time_t mtime);
-    ErrorOr<void> utimensat(Credentials const&, StringView path, Custody& base, timespec const& atime, timespec const& mtime, int options = 0);
+    ErrorOr<void> access(Credentials const&, StringView path, int mode, CustodyBase const& base, AccessFlags);
+    ErrorOr<InodeMetadata> lookup_metadata(Credentials const&, StringView path, CustodyBase const& base, int options = 0);
+    ErrorOr<void> utime(Credentials const&, StringView path, CustodyBase const& base, time_t atime, time_t mtime);
+    ErrorOr<void> utimensat(Credentials const&, StringView path, CustodyBase const& base, timespec const& atime, timespec const& mtime, int options = 0);
     ErrorOr<void> do_utimens(Credentials const& credentials, Custody& custody, timespec const& atime, timespec const& mtime);
-    ErrorOr<void> rename(Credentials const&, Custody& old_base, StringView oldpath, Custody& new_base, StringView newpath);
-    ErrorOr<void> mknod(Credentials const&, StringView path, mode_t, dev_t, Custody& base);
-    ErrorOr<NonnullRefPtr<Custody>> open_directory(Credentials const&, StringView path, Custody& base);
+    ErrorOr<void> rename(Credentials const&, CustodyBase const& old_base, StringView oldpath, CustodyBase const& new_base, StringView newpath);
+    ErrorOr<void> mknod(Credentials const&, StringView path, mode_t, dev_t, CustodyBase const& base);
+    ErrorOr<NonnullRefPtr<Custody>> open_directory(Credentials const&, StringView path, CustodyBase const& base);
 
     ErrorOr<void> for_each_mount(Function<ErrorOr<void>(Mount const&)>) const;
 
@@ -94,8 +95,8 @@ public:
     static void sync();
 
     NonnullRefPtr<Custody> root_custody();
-    ErrorOr<NonnullRefPtr<Custody>> resolve_path(Credentials const&, StringView path, NonnullRefPtr<Custody> base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
-    ErrorOr<NonnullRefPtr<Custody>> resolve_path(Process const&, Credentials const&, StringView path, NonnullRefPtr<Custody> base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
+    ErrorOr<NonnullRefPtr<Custody>> resolve_path(Credentials const&, StringView path, CustodyBase const& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
+    ErrorOr<NonnullRefPtr<Custody>> resolve_path(Process const&, Credentials const&, StringView path, CustodyBase const& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
     ErrorOr<NonnullRefPtr<Custody>> resolve_path_without_veil(Credentials const&, StringView path, NonnullRefPtr<Custody> base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
 
 private:

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -17,6 +17,7 @@ class BlockDevice;
 class CharacterDevice;
 class Coredump;
 class Credentials;
+class CustodyBase;
 class Custody;
 class Device;
 class DeviceControlDevice;

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -16,10 +16,8 @@ ErrorOr<FlatPtr> Process::sys$chdir(Userspace<char const*> user_path, size_t pat
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::rpath));
     auto path = TRY(get_syscall_path_argument(user_path, path_length));
-    auto current_directory = m_current_directory.with([](auto& current_directory) -> NonnullRefPtr<Custody> {
-        return *current_directory;
-    });
-    RefPtr<Custody> new_directory = TRY(VirtualFileSystem::the().open_directory(credentials(), path->view(), *current_directory));
+
+    RefPtr<Custody> new_directory = TRY(VirtualFileSystem::the().open_directory(credentials(), path->view(), current_directory()));
     m_current_directory.with([&](auto& current_directory) {
         // NOTE: We use swap() here to avoid manipulating the ref counts while holding the lock.
         swap(current_directory, new_directory);

--- a/Kernel/Syscalls/chmod.cpp
+++ b/Kernel/Syscalls/chmod.cpp
@@ -17,8 +17,8 @@ ErrorOr<FlatPtr> Process::sys$chmod(Userspace<Syscall::SC_chmod_params const*> u
     TRY(require_promise(Pledge::fattr));
     auto params = TRY(copy_typed_from_user(user_params));
     auto path = TRY(get_syscall_path_argument(params.path));
-    auto base = TRY(custody_for_dirfd(params.dirfd));
-    TRY(VirtualFileSystem::the().chmod(credentials(), path->view(), params.mode, *base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR));
+    CustodyBase base(params.dirfd, path->view());
+    TRY(VirtualFileSystem::the().chmod(credentials(), path->view(), params.mode, base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR));
     return 0;
 }
 

--- a/Kernel/Syscalls/chown.cpp
+++ b/Kernel/Syscalls/chown.cpp
@@ -27,8 +27,8 @@ ErrorOr<FlatPtr> Process::sys$chown(Userspace<Syscall::SC_chown_params const*> u
     TRY(require_promise(Pledge::chown));
     auto params = TRY(copy_typed_from_user(user_params));
     auto path = TRY(get_syscall_path_argument(params.path));
-    auto base = TRY(custody_for_dirfd(params.dirfd));
-    TRY(VirtualFileSystem::the().chown(credentials(), path->view(), params.uid, params.gid, *base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR));
+    CustodyBase base(params.dirfd, path->view());
+    TRY(VirtualFileSystem::the().chown(credentials(), path->view(), params.uid, params.gid, base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR));
     return 0;
 }
 

--- a/Kernel/Syscalls/faccessat.cpp
+++ b/Kernel/Syscalls/faccessat.cpp
@@ -26,7 +26,8 @@ ErrorOr<FlatPtr> Process::sys$faccessat(Userspace<Syscall::SC_faccessat_params c
     if (params.flags & AT_EACCESS)
         flags |= AccessFlags::EffectiveAccess;
 
-    TRY(VirtualFileSystem::the().access(credentials(), pathname->view(), params.mode, TRY(custody_for_dirfd(params.dirfd)), flags));
+    CustodyBase base(params.dirfd, pathname->view());
+    TRY(VirtualFileSystem::the().access(credentials(), pathname->view(), params.mode, base, flags));
     return 0;
 }
 

--- a/Kernel/Syscalls/link.cpp
+++ b/Kernel/Syscalls/link.cpp
@@ -17,6 +17,7 @@ ErrorOr<FlatPtr> Process::sys$link(Userspace<Syscall::SC_link_params const*> use
     auto params = TRY(copy_typed_from_user(user_params));
     auto old_path = TRY(try_copy_kstring_from_user(params.old_path));
     auto new_path = TRY(try_copy_kstring_from_user(params.new_path));
+
     TRY(VirtualFileSystem::the().link(credentials(), old_path->view(), new_path->view(), current_directory()));
     return 0;
 }
@@ -29,7 +30,8 @@ ErrorOr<FlatPtr> Process::sys$symlink(Userspace<Syscall::SC_symlink_params const
 
     auto target = TRY(get_syscall_path_argument(params.target));
     auto linkpath = TRY(get_syscall_path_argument(params.linkpath));
-    TRY(VirtualFileSystem::the().symlink(credentials(), target->view(), linkpath->view(), TRY(custody_for_dirfd(params.dirfd))));
+    CustodyBase base(params.dirfd, target->view());
+    TRY(VirtualFileSystem::the().symlink(credentials(), target->view(), linkpath->view(), base));
     return 0;
 }
 

--- a/Kernel/Syscalls/mkdir.cpp
+++ b/Kernel/Syscalls/mkdir.cpp
@@ -15,7 +15,9 @@ ErrorOr<FlatPtr> Process::sys$mkdir(int dirfd, Userspace<char const*> user_path,
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::cpath));
     auto path = TRY(get_syscall_path_argument(user_path, path_length));
-    TRY(VirtualFileSystem::the().mkdir(credentials(), path->view(), mode & ~umask(), TRY(custody_for_dirfd(dirfd))));
+
+    CustodyBase base(dirfd, path->view());
+    TRY(VirtualFileSystem::the().mkdir(credentials(), path->view(), mode & ~umask(), base));
     return 0;
 }
 }

--- a/Kernel/Syscalls/mknod.cpp
+++ b/Kernel/Syscalls/mknod.cpp
@@ -20,7 +20,9 @@ ErrorOr<FlatPtr> Process::sys$mknod(Userspace<Syscall::SC_mknod_params const*> u
     if (!credentials->is_superuser() && !is_regular_file(params.mode) && !is_fifo(params.mode) && !is_socket(params.mode))
         return EPERM;
     auto path = TRY(get_syscall_path_argument(params.path));
-    TRY(VirtualFileSystem::the().mknod(credentials, path->view(), params.mode & ~umask(), params.dev, TRY(custody_for_dirfd(params.dirfd))));
+
+    CustodyBase base(params.dirfd, path->view());
+    TRY(VirtualFileSystem::the().mknod(credentials, path->view(), params.mode & ~umask(), params.dev, base));
     return 0;
 }
 

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -55,8 +55,8 @@ ErrorOr<FlatPtr> Process::open_impl(Userspace<Syscall::SC_open_params const*> us
     dbgln_if(IO_DEBUG, "sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path->view(), options, mode);
 
     auto fd_allocation = TRY(allocate_fd());
-    auto base = TRY(custody_for_dirfd(dirfd));
-    auto description = TRY(VirtualFileSystem::the().open(credentials(), path->view(), options, mode & ~umask(), *base));
+    CustodyBase base(dirfd, path->view());
+    auto description = TRY(VirtualFileSystem::the().open(credentials(), path->view(), options, mode & ~umask(), base));
 
     if (description->inode() && description->inode()->bound_socket())
         return ENXIO;

--- a/Kernel/Syscalls/rename.cpp
+++ b/Kernel/Syscalls/rename.cpp
@@ -17,7 +17,9 @@ ErrorOr<FlatPtr> Process::sys$rename(Userspace<Syscall::SC_rename_params const*>
     auto params = TRY(copy_typed_from_user(user_params));
     auto old_path = TRY(get_syscall_path_argument(params.old_path));
     auto new_path = TRY(get_syscall_path_argument(params.new_path));
-    TRY(VirtualFileSystem::the().rename(credentials(), TRY(custody_for_dirfd(params.olddirfd)), old_path->view(), TRY(custody_for_dirfd(params.newdirfd)), new_path->view()));
+    CustodyBase old_base(params.olddirfd, old_path->view());
+    CustodyBase new_base(params.newdirfd, new_path->view());
+    TRY(VirtualFileSystem::the().rename(credentials(), old_base, old_path->view(), new_base, new_path->view()));
     return 0;
 }
 

--- a/Kernel/Syscalls/stat.cpp
+++ b/Kernel/Syscalls/stat.cpp
@@ -28,8 +28,9 @@ ErrorOr<FlatPtr> Process::sys$stat(Userspace<Syscall::SC_stat_params const*> use
     auto params = TRY(copy_typed_from_user(user_params));
 
     auto path = TRY(get_syscall_path_argument(params.path));
-    auto base = TRY(custody_for_dirfd(params.dirfd));
-    auto metadata = TRY(VirtualFileSystem::the().lookup_metadata(credentials(), path->view(), *base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR));
+
+    CustodyBase base(params.dirfd, path->view());
+    auto metadata = TRY(VirtualFileSystem::the().lookup_metadata(credentials(), path->view(), base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR));
     auto statbuf = TRY(metadata.stat());
     TRY(copy_to_user(params.statbuf, &statbuf));
     return 0;

--- a/Kernel/Syscalls/unlink.cpp
+++ b/Kernel/Syscalls/unlink.cpp
@@ -19,12 +19,12 @@ ErrorOr<FlatPtr> Process::sys$unlink(int dirfd, Userspace<char const*> user_path
     if (flags & ~AT_REMOVEDIR)
         return Error::from_errno(EINVAL);
 
-    auto base = TRY(custody_for_dirfd(dirfd));
+    CustodyBase base(dirfd, path->view());
 
     if (flags & AT_REMOVEDIR)
-        TRY(VirtualFileSystem::the().rmdir(credentials(), path->view(), *base));
+        TRY(VirtualFileSystem::the().rmdir(credentials(), path->view(), base));
     else
-        TRY(VirtualFileSystem::the().unlink(credentials(), path->view(), *base));
+        TRY(VirtualFileSystem::the().unlink(credentials(), path->view(), base));
     return 0;
 }
 

--- a/Kernel/Tasks/Coredump.cpp
+++ b/Kernel/Tasks/Coredump.cpp
@@ -109,7 +109,7 @@ ErrorOr<NonnullRefPtr<OpenFileDescription>> Coredump::try_create_target_file(Pro
         KLexicalPath::basename(output_path),
         O_CREAT | O_WRONLY | O_EXCL,
         S_IFREG, // We will enable reading from userspace when we finish generating the coredump file
-        *dump_directory,
+        dump_directory,
         UidAndGid { process_credentials->uid(), process_credentials->gid() }));
 }
 

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -1195,6 +1195,11 @@ RefPtr<Custody const> Process::executable() const
     return m_executable.with([](auto& executable) { return executable; });
 }
 
+ErrorOr<NonnullRefPtr<Custody>> Process::custody_for_dirfd(Badge<CustodyBase>, int dirfd)
+{
+    return custody_for_dirfd(dirfd);
+}
+
 ErrorOr<NonnullRefPtr<Custody>> Process::custody_for_dirfd(int dirfd)
 {
     if (dirfd == AT_FDCWD)

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -919,6 +919,8 @@ public:
         return m_fds.with_exclusive([](auto& fds) { return fds.allocate(); });
     }
 
+    ErrorOr<NonnullRefPtr<Custody>> custody_for_dirfd(Badge<CustodyBase>, int dirfd);
+
 private:
     ErrorOr<NonnullRefPtr<Custody>> custody_for_dirfd(int dirfd);
 


### PR DESCRIPTION
To be able to do this, we add a new class called CustodyBase, which can be resolved on-demand internally in the VirtualFileSystem resolving path code.

When being resolved, CustodyBase will return a known custody if it was constructed with such, if that's not the case it will provide the root custody if the original path is absolute.
Lastly, if that's not the case as well, it will resolve the given dirfd to provide a Custody object.

Fixes #24328.