### PR TITLE
LibWeb: Save time for animationcancel event before transitioning to idle

### DIFF
--- a/Tests/LibWeb/Text/expected/css/sending-animationcancel-event-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/sending-animationcancel-event-crash.txt
@@ -1,0 +1,1 @@
+   PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/css/sending-animationcancel-event-crash.html
+++ b/Tests/LibWeb/Text/input/css/sending-animationcancel-event-crash.html
@@ -1,0 +1,27 @@
+<!-- https://github.com/SerenityOS/serenity/issues/24424 -->
+<style>
+    @keyframes anim {
+        to {
+            width: 200px;
+        }
+    }
+
+    div {
+        animation: anim 1s;
+    }
+</style>
+<div id="foo"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const foo = document.getElementById("foo");
+        const anim = foo.getAnimations()[0];
+        foo.addEventListener("animationcancel", () => {
+            println("PASS! (Didn't crash)");
+            done();
+        });
+        requestAnimationFrame(() => {
+            anim.cancel();
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -470,6 +470,10 @@ void Animation::cancel(ShouldInvalidate should_invalidate)
     // 3. Make animation’s start time unresolved.
     m_start_time = {};
 
+    // This time is needed for dispatching the animationcancel DOM event
+    if (auto effect = m_effect)
+        m_saved_cancel_time = effect->active_time_using_fill(Bindings::FillMode::Both);
+
     if (should_invalidate == ShouldInvalidate::Yes)
         invalidate_effect();
 }

--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -108,6 +108,8 @@ public:
 
     unsigned int global_animation_list_order() const { return m_global_animation_list_order; }
 
+    auto release_saved_cancel_time() { return move(m_saved_cancel_time); }
+
 protected:
     Animation(JS::Realm&);
 
@@ -194,6 +196,7 @@ private:
 
     Optional<double> m_saved_play_time;
     Optional<double> m_saved_pause_time;
+    Optional<double> m_saved_cancel_time;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2103,8 +2103,9 @@ void Document::dispatch_events_for_animation_if_necessary(JS::NonnullGCPtr<Anima
         }
 
         if (current_phase == Animations::AnimationEffect::Phase::Idle && previous_phase != Animations::AnimationEffect::Phase::Idle && previous_phase != Animations::AnimationEffect::Phase::After) {
-            // FIXME: Use the active time "at the moment it was cancelled"
-            dispatch_event(HTML::EventNames::animationcancel, effect->active_time_using_fill(Bindings::FillMode::Both).value());
+            // FIXME: Calculate a non-zero time when the animation is cancelled by means other than calling cancel()
+            auto cancel_time = animation->release_saved_cancel_time().value_or(0.0);
+            dispatch_event(HTML::EventNames::animationcancel, cancel_time);
         }
     }
     effect->set_previous_phase(current_phase);


### PR DESCRIPTION
The if statement in the dispatch implies we are in the idle state, so of course the active time will always be undefined. If this was cancelled via a call to cancel(), we can save the time at that point. Otherwise, just send 0.

I'm not sure if the FIXME is totally necessary. It does seem wrong to just send zero, but this matches what WebKit seems to do, so at least it can't be _that_ wrong. Calculating the time if `cancel()` wasn't called is quite a bit harder, as deriving the current state happens when we invoke `phase()`. At that point, the phase is already idle; there's no telling when the switch from the previous state happened.

Fixes #24424 