### PR TITLE
Prekernel: Make the prekernel stage more elegant and debuggable

### DIFF
--- a/AK/FixedStringBuffer.h
+++ b/AK/FixedStringBuffer.h
@@ -12,7 +12,7 @@
 #include <AK/TypedTransfer.h>
 #include <AK/Userspace.h>
 
-#ifdef KERNEL
+#if defined(KERNEL) && !defined(PREKERNEL)
 #    include <Kernel/Arch/SafeMem.h>
 #    include <Kernel/Arch/SmapDisabler.h>
 #    include <Kernel/Memory/MemorySections.h>
@@ -64,7 +64,7 @@ public:
             m_storage[index] = '\0';
     }
 
-#ifdef KERNEL
+#if defined(KERNEL) && !defined(PREKERNEL)
     ErrorOr<void> copy_characters_from_user(Userspace<char const*> user_str, size_t user_str_size)
     {
         if (user_str_size > Size)

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -16,7 +16,8 @@
 #    include <serenity.h>
 #endif
 
-#ifdef KERNEL
+#if defined(PREKERNEL)
+#elif defined(KERNEL)
 #    include <Kernel/Tasks/Process.h>
 #    include <Kernel/Tasks/Thread.h>
 #    include <Kernel/Time/TimeManagement.h>
@@ -1152,7 +1153,9 @@ void vdbg(StringView fmtstr, TypeErasedFormatParams& params, bool newline)
     StringBuilder builder;
 
     if (is_rich_debug_enabled) {
-#ifdef KERNEL
+#if defined(PREKERNEL)
+        ;
+#elif defined(KERNEL)
         if (Kernel::Processor::is_initialized() && TimeManagement::is_initialized()) {
             auto time = TimeManagement::the().monotonic_time(TimePrecision::Coarse);
             if (Kernel::Thread::current()) {
@@ -1195,7 +1198,7 @@ void vdbg(StringView fmtstr, TypeErasedFormatParams& params, bool newline)
     auto const string = builder.string_view();
 
 #ifdef AK_OS_SERENITY
-#    ifdef KERNEL
+#    if defined(KERNEL) && !defined(PREKERNEL)
     if (!Kernel::Processor::is_initialized()) {
         kernelearlyputstr(string.characters_without_null_termination(), string.length());
         return;
@@ -1205,7 +1208,7 @@ void vdbg(StringView fmtstr, TypeErasedFormatParams& params, bool newline)
     dbgputstr(string.characters_without_null_termination(), string.length());
 }
 
-#ifdef KERNEL
+#if defined(KERNEL) && !defined(PREKERNEL)
 void vdmesgln(StringView fmtstr, TypeErasedFormatParams& params)
 {
     StringBuilder builder;

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -14,7 +14,9 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 
-#ifdef KERNEL
+#if defined(PREKERNEL)
+#    include <Kernel/Library/MiniStdLib.h>
+#elif defined(KERNEL)
 #    include <Kernel/Library/StdLib.h>
 #else
 #    include <AK/ByteString.h>

--- a/Kernel/Arch/x86_64/DebugOutput.cpp
+++ b/Kernel/Arch/x86_64/DebugOutput.cpp
@@ -5,9 +5,12 @@
  */
 
 #include <Kernel/Arch/DebugOutput.h>
-#include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/x86_64/BochsDebugOutput.h>
 #include <Kernel/Arch/x86_64/IO.h>
+
+#if !defined(PREKERNEL)
+#    include <Kernel/Arch/Processor.h>
+#endif
 
 namespace Kernel {
 
@@ -35,8 +38,13 @@ void debug_output(char ch)
         serial_ready = true;
     }
 
-    while ((IO::in8(serial_com1_io_port + 5) & 0x20) == 0)
+    while ((IO::in8(serial_com1_io_port + 5) & 0x20) == 0) {
+#if !defined(PREKERNEL)
         Processor::wait_check();
+#else
+        ;
+#endif
+    }
 
     if (ch == '\n' && !was_cr)
         IO::out8(serial_com1_io_port, '\r');

--- a/Kernel/Library/MiniStdLib.h
+++ b/Kernel/Library/MiniStdLib.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/UnixTypes.h>
+#include <stddef.h>
+
+extern "C" {
+
+void* memcpy(void*, void const*, size_t);
+[[nodiscard]] int strncmp(char const* s1, char const* s2, size_t n);
+[[nodiscard]] char* strstr(char const* haystack, char const* needle);
+[[nodiscard]] int strcmp(char const*, char const*);
+[[nodiscard]] size_t strlen(char const*);
+[[nodiscard]] size_t strnlen(char const*, size_t);
+void* memset(void*, int, size_t);
+[[nodiscard]] int memcmp(void const*, void const*, size_t);
+void* memmove(void* dest, void const* src, size_t n);
+void const* memmem(void const* haystack, size_t, void const* needle, size_t);
+
+[[nodiscard]] inline u16 ntohs(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
+[[nodiscard]] inline u16 htons(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
+}

--- a/Kernel/Library/StdLib.h
+++ b/Kernel/Library/StdLib.h
@@ -14,6 +14,7 @@
 #include <AK/Time.h>
 #include <AK/Userspace.h>
 #include <Kernel/Library/KString.h>
+#include <Kernel/Library/MiniStdLib.h>
 #include <Kernel/UnixTypes.h>
 #include <stddef.h>
 
@@ -55,23 +56,6 @@ ErrorOr<Duration> copy_time_from_user(Userspace<T*>);
 ErrorOr<void> copy_to_user(void*, void const*, size_t);
 ErrorOr<void> copy_from_user(void*, void const*, size_t);
 ErrorOr<void> memset_user(void*, int, size_t);
-
-extern "C" {
-
-void* memcpy(void*, void const*, size_t);
-[[nodiscard]] int strncmp(char const* s1, char const* s2, size_t n);
-[[nodiscard]] char* strstr(char const* haystack, char const* needle);
-[[nodiscard]] int strcmp(char const*, char const*);
-[[nodiscard]] size_t strlen(char const*);
-[[nodiscard]] size_t strnlen(char const*, size_t);
-void* memset(void*, int, size_t);
-[[nodiscard]] int memcmp(void const*, void const*, size_t);
-void* memmove(void* dest, void const* src, size_t n);
-void const* memmem(void const* haystack, size_t, void const* needle, size_t);
-
-[[nodiscard]] inline u16 ntohs(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
-[[nodiscard]] inline u16 htons(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
-}
 
 template<typename T>
 [[nodiscard]] inline ErrorOr<void> copy_from_user(T* dest, T const* src)

--- a/Kernel/Prekernel/Assertions.cpp
+++ b/Kernel/Prekernel/Assertions.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Prekernel/DebugOutput.h>
+
+void __assertion_failed(char const* msg, char const* file, unsigned line, char const* func)
+{
+    write_debug_output("ASSERTION FAILED: {}\n", msg);
+    write_debug_output("{}:{} in {}\n", file, line, func);
+    halt();
+}

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     DebugOutput.cpp
     kmalloc.cpp
     Runtime.cpp
+    Random.cpp
     ../../Userland/Libraries/LibELF/Relocation.cpp
     )
 

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -4,6 +4,8 @@ set(SOURCES
     boot.S
     multiboot.S
     init.cpp
+    kmalloc.cpp
+    Runtime.cpp
     ../../Userland/Libraries/LibELF/Relocation.cpp
     )
 

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -1,13 +1,25 @@
 set(SOURCES
+    ../../AK/StringBuilder.cpp
+    ../../AK/StringUtils.cpp
+    ../../AK/StringView.cpp
+    ../../AK/Format.cpp
     UBSanitizer.cpp
     ../Library/MiniStdLib.cpp
+    Assertions.cpp
     boot.S
     multiboot.S
     init.cpp
+    DebugOutput.cpp
     kmalloc.cpp
     Runtime.cpp
     ../../Userland/Libraries/LibELF/Relocation.cpp
     )
+
+if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+    set(SOURCES
+        ${SOURCES}
+        ../Arch/x86_64/DebugOutput.cpp)
+endif()
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(PREKERNEL_TARGET kernel_x86-64)
@@ -22,6 +34,8 @@ add_library(KernelObject OBJECT IMPORTED)
 set_property(TARGET KernelObject PROPERTY
     IMPORTED_OBJECTS ${CMAKE_CURRENT_BINARY_DIR}/../Kernel.o
 )
+
+add_compile_definitions(PREKERNEL)
 
 add_executable(${PREKERNEL_TARGET} ${SOURCES} $<TARGET_OBJECTS:KernelObject>)
 add_dependencies(${PREKERNEL_TARGET} Kernel)

--- a/Kernel/Prekernel/DebugOutput.cpp
+++ b/Kernel/Prekernel/DebugOutput.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+#include <AK/kstdio.h>
+#include <Kernel/Arch/DebugOutput.h>
+#include <Kernel/Prekernel/DebugOutput.h>
+#if ARCH(X86_64)
+#    include <Kernel/Arch/x86_64/BochsDebugOutput.h>
+#endif
+
+void debug_write_string(StringView str)
+{
+    if (str.is_null())
+        return;
+    for (u8 ch : str.bytes()) {
+        Kernel::debug_output(ch);
+#if ARCH(X86_64)
+        Kernel::bochs_debug_output(ch);
+#endif
+    }
+}
+
+extern "C" void dbgputstr(char const* characters, size_t length)
+{
+    if (!characters)
+        return;
+    debug_write_string(StringView { characters, length });
+}

--- a/Kernel/Prekernel/DebugOutput.h
+++ b/Kernel/Prekernel/DebugOutput.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/CheckedFormatString.h>
+#include <AK/FixedStringBuffer.h>
+#include <AK/Format.h>
+#include <AK/kmalloc.h>
+#include <Kernel/Prekernel/Runtime.h>
+
+void debug_write_string(StringView str);
+
+template<typename... Parameters>
+void write_debug_output(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::No, Parameters...> variadic_format_parameters { parameters... };
+    auto message_buffer_or_error = FixedStringBuffer<128>::vformatted(fmtstr.view(), variadic_format_parameters);
+    if (message_buffer_or_error.is_error()) {
+        debug_write_string("PANIC: Failed to write message buffer:\n"sv);
+        debug_write_string(fmtstr.view());
+        halt();
+    }
+
+    auto message_buffer = message_buffer_or_error.release_value();
+    debug_write_string(message_buffer.representable_view());
+}

--- a/Kernel/Prekernel/Prekernel.h
+++ b/Kernel/Prekernel/Prekernel.h
@@ -20,6 +20,9 @@
 #define KERNEL_MAPPING_BASE 0x2000000000
 
 #ifdef __cplusplus
+
+extern "C" multiboot_info_t* multiboot_info_ptr;
+
 namespace Kernel {
 
 #    if ARCH(X86_64)

--- a/Kernel/Prekernel/Random.cpp
+++ b/Kernel/Prekernel/Random.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+#include <Kernel/Boot/Multiboot.h>
+#include <Kernel/Prekernel/Prekernel.h>
+#include <Kernel/Prekernel/Random.h>
+#if ARCH(X86_64)
+#    include <Kernel/Arch/x86_64/ASM_wrapper.h>
+#    include <Kernel/Arch/x86_64/CPUID.h>
+#endif
+
+u64 generate_secure_seed()
+{
+    u32 seed = 0xFEEBDAED;
+
+#if ARCH(X86_64)
+    Kernel::CPUID processor_info(0x1);
+    if (processor_info.edx() & (1 << 4)) // TSC
+        seed ^= Kernel::read_tsc();
+
+    if (processor_info.ecx() & (1 << 30)) // RDRAND
+        seed ^= Kernel::read_rdrand();
+
+    Kernel::CPUID extended_features(0x7);
+    if (extended_features.ebx() & (1 << 18)) // RDSEED
+        seed ^= Kernel::read_rdseed();
+#else
+#    warning No native randomness source available for this architecture
+#endif
+
+    seed ^= multiboot_info_ptr->mods_addr;
+    seed ^= multiboot_info_ptr->framebuffer_addr;
+
+    return seed;
+}

--- a/Kernel/Prekernel/Random.h
+++ b/Kernel/Prekernel/Random.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+u64 generate_secure_seed();

--- a/Kernel/Prekernel/Runtime.cpp
+++ b/Kernel/Prekernel/Runtime.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Prekernel/Runtime.h>
+
+void halt()
+{
+    asm volatile("hlt");
+    __builtin_unreachable();
+}

--- a/Kernel/Prekernel/Runtime.h
+++ b/Kernel/Prekernel/Runtime.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+[[noreturn]] void halt();

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -11,6 +11,7 @@
 #include <Kernel/Memory/PhysicalAddress.h>
 #include <Kernel/Memory/VirtualAddress.h>
 #include <Kernel/Prekernel/Prekernel.h>
+#include <Kernel/Prekernel/Runtime.h>
 #include <LibELF/ELFABI.h>
 #include <LibELF/Relocation.h>
 
@@ -46,12 +47,6 @@ extern "C" void reload_cr3();
 
 extern "C" {
 multiboot_info_t* multiboot_info_ptr;
-}
-
-[[noreturn]] static void halt()
-{
-    asm volatile("hlt");
-    __builtin_unreachable();
 }
 
 void __stack_chk_fail()

--- a/Kernel/Prekernel/kmalloc.cpp
+++ b/Kernel/Prekernel/kmalloc.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/kmalloc.h>
+#include <Kernel/Prekernel/Runtime.h>
+
+void kfree_sized(void*, size_t)
+{
+    halt();
+}
+
+void* kmalloc(size_t)
+{
+    halt();
+}
+
+size_t kmalloc_good_size(size_t)
+{
+    halt();
+}


### PR DESCRIPTION
I realized recently that we could use the `FixedStringBuffer` class to perform string formatting without doing any memory allocations, which suits the use-case of the prekernel stage quite elegantly.
Therefore, I add a way to print debug logs (to serial console currently, and to bochs serial debug as well), and by doing so, we can actually see now debug prints during assertion failed scenarios, which is very nice imho :)

cc @ADKaster @timschumi 