### PR TITLE
Kernel: Support re-mapping MMIOVMObject-backed regions

### DIFF
--- a/Kernel/Memory/MMIOVMObject.cpp
+++ b/Kernel/Memory/MMIOVMObject.cpp
@@ -24,6 +24,7 @@ ErrorOr<NonnullLockRefPtr<MMIOVMObject>> MMIOVMObject::try_create_for_physical_r
 
 MMIOVMObject::MMIOVMObject(PhysicalAddress paddr, FixedArray<RefPtr<PhysicalRAMPage>>&& new_physical_pages)
     : VMObject(move(new_physical_pages))
+    , m_base_address(paddr)
 {
     VERIFY(paddr.page_base() == paddr);
 }

--- a/Kernel/Memory/MMIOVMObject.h
+++ b/Kernel/Memory/MMIOVMObject.h
@@ -17,10 +17,15 @@ public:
 
     virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override { return ENOTSUP; }
 
+    PhysicalAddress base_address() const { return m_base_address; }
+
 private:
     MMIOVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalRAMPage>>&&);
 
     virtual StringView class_name() const override { return "MMIOVMObject"sv; }
+    virtual bool is_mmio() const override { return true; }
+
+    PhysicalAddress m_base_address;
 };
 
 }

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -12,6 +12,7 @@
 #include <Kernel/Interrupts/InterruptDisabler.h>
 #include <Kernel/Library/Panic.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
+#include <Kernel/Memory/MMIOVMObject.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/Region.h>
 #include <Kernel/Memory/SharedInodeVMObject.h>
@@ -355,7 +356,11 @@ ErrorOr<void> Region::map(PageDirectory& page_directory, PhysicalAddress paddr, 
 void Region::remap()
 {
     VERIFY(m_page_directory);
-    auto result = map(*m_page_directory);
+    ErrorOr<void> result;
+    if (m_vmobject->is_mmio())
+        result = map(*m_page_directory, static_cast<MMIOVMObject const&>(*m_vmobject).base_address());
+    else
+        result = map(*m_page_directory);
     if (result.is_error())
         TODO();
 }

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -32,6 +32,7 @@ public:
     virtual bool is_inode() const { return false; }
     virtual bool is_shared_inode() const { return false; }
     virtual bool is_private_inode() const { return false; }
+    virtual bool is_mmio() const { return false; }
 
     size_t page_count() const { return m_physical_pages.size(); }
 


### PR DESCRIPTION
This is required for example when write combine is enabled on a region after the initial mapping.