### PR TITLE
LibWasm: Properly read data section tags

### DIFF
--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -1552,7 +1552,7 @@ ParseResult<CodeSection> CodeSection::parse(Stream& stream)
 ParseResult<DataSection::Data> DataSection::Data::parse(Stream& stream)
 {
     ScopeLogger<WASM_BINPARSER_DEBUG> logger("Data"sv);
-    auto tag_or_error = stream.read_value<u8>();
+    auto tag_or_error = stream.read_value<LEB128<size_t>>();
     if (tag_or_error.is_error())
         return with_eof_check(stream, ParseError::ExpectedKindTag);
 


### PR DESCRIPTION
The previous version of the function read the tag as a u8. However, as per the spec, the tag of the data section should be a u32, LEB128 encoded. This fixes at least one spectest (binary-leb128_4).

https://webassembly.github.io/spec/core/binary/modules.html#data-section