### PR TITLE
Kernel: Add a minimal xHCI driver implementation

### DIFF
--- a/Kernel/Bus/USB/Drivers/HID/MouseDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/HID/MouseDriver.cpp
@@ -65,7 +65,7 @@ ErrorOr<void> MouseDriver::initialize_device(USB::Device& device, USBInterface c
         USB_REQUEST_SET_CONFIGURATION, configuration.configuration_id(), 0, 0, nullptr));
 
     auto const& endpoint_descriptor = interface.endpoints()[0];
-    auto interrupt_in_pipe = TRY(USB::InterruptInPipe::create(device.controller(), endpoint_descriptor.endpoint_address, endpoint_descriptor.max_packet_size, device.address(), 10));
+    auto interrupt_in_pipe = TRY(USB::InterruptInPipe::create(device.controller(), device, endpoint_descriptor.endpoint_address, endpoint_descriptor.max_packet_size, 10));
     auto mouse_device = TRY(USBMouseDevice::try_create_instance(device, endpoint_descriptor.max_packet_size, move(interrupt_in_pipe)));
     HIDManagement::the().attach_standalone_hid_device(*mouse_device);
     m_interfaces.append(mouse_device);

--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -128,8 +128,8 @@ ErrorOr<void> MassStorageDriver::initialise_bulk_only_device(USB::Device& device
         return ENOTSUP;
     }
 
-    auto in_pipe = TRY(BulkInPipe::create(device.controller(), in_pipe_address, in_max_packet_size, device.address()));
-    auto out_pipe = TRY(BulkOutPipe::create(device.controller(), out_pipe_address, out_max_packet_size, device.address()));
+    auto in_pipe = TRY(BulkInPipe::create(device.controller(), device, in_pipe_address, in_max_packet_size));
+    auto out_pipe = TRY(BulkOutPipe::create(device.controller(), device, out_pipe_address, out_max_packet_size));
 
     CommandBlockWrapper command_block {};
     command_block.set_command(SCSI::ReadCapacity10 {});

--- a/Kernel/Bus/USB/EHCI/EHCIController.h
+++ b/Kernel/Bus/USB/EHCI/EHCIController.h
@@ -35,6 +35,8 @@ public:
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer&) override { return ENOTSUP; }
     virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer>, u16) override { return ENOTSUP; }
 
+    virtual ErrorOr<void> initialize_device(USB::Device&) override { return ENOTSUP; }
+
 private:
     EHCIController(PCI::DeviceIdentifier const& pci_device_identifier, NonnullOwnPtr<Memory::Region> register_region, VirtualAddress register_base_address);
 

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -268,6 +268,98 @@ ErrorOr<void> UHCIController::start()
     return {};
 }
 
+u8 UHCIController::allocate_address()
+{
+    // FIXME: This can be smarter.
+    return m_next_device_index++;
+}
+
+ErrorOr<void> UHCIController::initialize_device(USB::Device& device)
+{
+    USBDeviceDescriptor dev_descriptor {};
+
+    // Send 8-bytes to get at least the `max_packet_size` from the device
+    constexpr u8 short_device_descriptor_length = 8;
+    auto transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, short_device_descriptor_length, &dev_descriptor));
+
+    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
+    if (transfer_length < short_device_descriptor_length) {
+        dbgln("USB Device: Not enough bytes for short device descriptor. Expected {}, got {}.", short_device_descriptor_length, transfer_length);
+        return EIO;
+    }
+
+    if constexpr (UHCI_DEBUG) {
+        dbgln("USB Short Device Descriptor:");
+        dbgln("Descriptor length: {}", dev_descriptor.descriptor_header.length);
+        dbgln("Descriptor type: {}", dev_descriptor.descriptor_header.descriptor_type);
+
+        dbgln("Device Class: {:02x}", dev_descriptor.device_class);
+        dbgln("Device Sub-Class: {:02x}", dev_descriptor.device_sub_class);
+        dbgln("Device Protocol: {:02x}", dev_descriptor.device_protocol);
+        dbgln("Max Packet Size: {:02x} bytes", dev_descriptor.max_packet_size);
+    }
+
+    // Ensure that this is actually a valid device descriptor...
+    VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
+    device.set_max_packet_size<UHCIController>({}, dev_descriptor.max_packet_size);
+
+    transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, sizeof(USBDeviceDescriptor), &dev_descriptor));
+
+    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
+    if (transfer_length < sizeof(USBDeviceDescriptor)) {
+        dbgln("USB Device: Unexpected device descriptor length. Expected {}, got {}.", sizeof(USBDeviceDescriptor), transfer_length);
+        return EIO;
+    }
+
+    // Ensure that this is actually a valid device descriptor...
+    VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
+
+    if constexpr (UHCI_DEBUG) {
+        dbgln("USB Device Descriptor for {:04x}:{:04x}", dev_descriptor.vendor_id, dev_descriptor.product_id);
+        dbgln("Device Class: {:02x}", dev_descriptor.device_class);
+        dbgln("Device Sub-Class: {:02x}", dev_descriptor.device_sub_class);
+        dbgln("Device Protocol: {:02x}", dev_descriptor.device_protocol);
+        dbgln("Max Packet Size: {:02x} bytes", dev_descriptor.max_packet_size);
+        dbgln("Number of configurations: {:02x}", dev_descriptor.num_configurations);
+    }
+
+    auto new_address = allocate_address();
+
+    // Attempt to set devices address on the bus
+    transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE, USB_REQUEST_SET_ADDRESS, new_address, 0, 0, nullptr));
+
+    // This has to be set after we send out the "Set Address" request because it might be sent to the root hub.
+    // The root hub uses the address to intercept requests to itself.
+    device.set_address<UHCIController>({}, new_address);
+
+    dbgln_if(USB_DEBUG, "USB Device: Set address to {}", new_address);
+
+    device.set_descriptor<UHCIController>({}, dev_descriptor);
+
+    // Fetch the configuration descriptors from the device
+    auto& configurations = device.configurations<UHCIController>({});
+    configurations.ensure_capacity(dev_descriptor.num_configurations);
+    for (auto configuration = 0u; configuration < dev_descriptor.num_configurations; configuration++) {
+        USBConfigurationDescriptor configuration_descriptor;
+        transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8u) | configuration, 0, sizeof(USBConfigurationDescriptor), &configuration_descriptor));
+
+        if constexpr (UHCI_DEBUG) {
+            dbgln("USB Configuration Descriptor {}", configuration);
+            dbgln("Total Length: {}", configuration_descriptor.total_length);
+            dbgln("Number of interfaces: {}", configuration_descriptor.number_of_interfaces);
+            dbgln("Configuration Value: {}", configuration_descriptor.configuration_value);
+            dbgln("Attributes Bitmap: {:08b}", configuration_descriptor.attributes_bitmap);
+            dbgln("Maximum Power: {}mA", configuration_descriptor.max_power_in_ma * 2u); // This value is in 2mA steps
+        }
+
+        USBConfiguration device_configuration(device, configuration_descriptor);
+        TRY(device_configuration.enumerate_interfaces());
+        configurations.append(device_configuration);
+    }
+
+    return {};
+}
+
 TransferDescriptor* UHCIController::create_transfer_descriptor(Pipe& pipe, PacketID direction, size_t data_len)
 {
     TransferDescriptor* td = allocate_transfer_descriptor();

--- a/Kernel/Bus/USB/UHCI/UHCIController.h
+++ b/Kernel/Bus/USB/UHCI/UHCIController.h
@@ -55,6 +55,8 @@ public:
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) override;
     virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) override;
 
+    virtual ErrorOr<void> initialize_device(USB::Device&) override;
+
     void get_port_status(Badge<UHCIRootHub>, u8, HubStatus&);
     ErrorOr<void> set_port_feature(Badge<UHCIRootHub>, u8, HubFeatureSelector);
     ErrorOr<void> clear_port_feature(Badge<UHCIRootHub>, u8, HubFeatureSelector);
@@ -99,6 +101,8 @@ private:
 
     void reset_port(u8);
 
+    u8 allocate_address();
+
     NonnullOwnPtr<IOWindow> m_registers_io_window;
 
     Spinlock<LockRank::None> m_async_lock {};
@@ -126,5 +130,7 @@ private:
 
     // Bitfield containing whether a given port should signal a change in suspend or not.
     u8 m_port_suspend_change_statuses { 0 };
+
+    u8 m_next_device_index { 1 };
 };
 }

--- a/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
@@ -78,7 +78,7 @@ static USBHubDescriptor uhci_root_hub_hub_descriptor = {
         DESCRIPTOR_TYPE_HUB,
     },
     UHCIController::NUMBER_OF_ROOT_PORTS, // 2 ports
-    0x0,                                  // Ganged power switching, not a compound device, global over-current protection.
+    { 0x0 },                              // Ganged power switching, not a compound device, global over-current protection.
     0x0,                                  // UHCI ports are always powered, so there's no time from power on to power good.
     0x0,                                  // Self-powered
 };

--- a/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
@@ -99,7 +99,7 @@ ErrorOr<void> UHCIRootHub::setup(Badge<UHCIController>)
 
     // NOTE: The root hub will be on the default address at this point.
     // The root hub must be the first device to be created, otherwise the HCD will intercept all default address transfers as though they're targeted at the root hub.
-    TRY(m_hub->enumerate_device());
+    TRY(m_uhci_controller->initialize_device(*m_hub));
 
     // NOTE: The root hub is no longer on the default address.
     TRY(m_hub->enumerate_and_power_on_hub());

--- a/Kernel/Bus/USB/USBController.cpp
+++ b/Kernel/Bus/USB/USBController.cpp
@@ -14,10 +14,4 @@ USBController::USBController()
 {
 }
 
-u8 USBController::allocate_address()
-{
-    // FIXME: This can be smarter.
-    return m_next_device_index++;
-}
-
 }

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -28,8 +28,9 @@ public:
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) = 0;
     virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) = 0;
 
+    virtual ErrorOr<void> initialize_device(Device&) = 0;
+
     u32 storage_controller_id() const { return m_storage_controller_id; }
-    u8 allocate_address();
 
 protected:
     USBController();
@@ -39,8 +40,6 @@ private:
     //       And do not follow a hardware_relative_controller_id for the controller class "USB",
     //       as we also have to follow the device id and its internal LUN, leaving no room for that
     u32 m_storage_controller_id { 0 };
-
-    u8 m_next_device_index { 1 };
 
     IntrusiveListNode<USBController, NonnullLockRefPtr<USBController>> m_controller_list_node;
 

--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -95,6 +95,24 @@ struct [[gnu::packed]] USBEndpointDescriptor {
     u8 poll_interval_in_frames;
 };
 
+struct [[gnu::packed]] USBSuperSpeedEndpointCompanionDescriptor {
+    USBDescriptorCommon descriptor_header;
+    u8 max_burst;
+    union {
+        u8 raw;
+        struct {
+            u8 max_streams : 5;
+            u8 reserved0 : 3;
+        } bulk;
+        struct {
+            u8 mult : 2;
+            u8 reserved0 : 5;
+            u8 super_speed_plus_companion : 1;
+        } isoch;
+    } endpoint_attributes_bitmap;
+    u16 bytes_per_interval;
+};
+
 //
 //  USB 1.1/2.0 Hub Descriptor
 //  ==============
@@ -102,7 +120,17 @@ struct [[gnu::packed]] USBEndpointDescriptor {
 struct [[gnu::packed]] USBHubDescriptor {
     USBDescriptorCommon descriptor_header;
     u8 number_of_downstream_ports;
-    u16 hub_characteristics;
+    union {
+        u16 raw;
+        struct {
+            u16 logical_power_switching_mode : 2;
+            u16 compound_device : 1;
+            u16 over_current_protection_mode : 2;
+            u16 transaction_translator_think_time : 2;
+            u16 port_indicators_supported : 1;
+            u16 reserved0 : 8;
+        } usb2;
+    } hub_characteristics;
     u8 power_on_to_power_good_time;
     u8 hub_controller_current;
     // NOTE: This does not contain DeviceRemovable or PortPwrCtrlMask because a struct cannot have two VLAs in a row.
@@ -128,5 +156,6 @@ static constexpr u8 DESCRIPTOR_TYPE_INTERFACE = 0x04;
 static constexpr u8 DESCRIPTOR_TYPE_ENDPOINT = 0x05;
 static constexpr u8 DESCRIPTOR_TYPE_DEVICE_QUALIFIER = 0x06;
 static constexpr u8 DESCRIPTOR_TYPE_HUB = 0x29;
+static constexpr u8 DESCRIPTOR_TYPE_USB_SUPERSPEED_ENDPOINT_COMPANION = 0x30;
 
 }

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -17,7 +17,7 @@
 
 namespace Kernel::USB {
 
-ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController const& controller, u8 port, DeviceSpeed speed)
+ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController& controller, u8 port, DeviceSpeed speed)
 {
     auto pipe = TRY(ControlPipe::create(controller, 0, 8, 0));
     auto device = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) Device(controller, port, speed, move(pipe))));
@@ -25,7 +25,7 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController const& contr
     device->m_sysfs_device_info_node.with([&](auto& node) {
         node = move(sysfs_node);
     });
-    TRY(device->enumerate_device());
+    TRY(controller.initialize_device(*device));
 
     // Attempt to find a driver for this device. If one is found, we call the driver's
     // "probe" function, which initialises the local state for the device driver.
@@ -76,92 +76,6 @@ Device::Device(Device const& device, NonnullOwnPtr<ControlPipe> default_pipe)
 }
 
 Device::~Device() = default;
-
-ErrorOr<void> Device::enumerate_device()
-{
-    USBDeviceDescriptor dev_descriptor {};
-
-    // Send 8-bytes to get at least the `max_packet_size` from the device
-    constexpr u8 short_device_descriptor_length = 8;
-    auto transfer_length = TRY(m_default_pipe->submit_control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, short_device_descriptor_length, &dev_descriptor));
-
-    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
-    if (transfer_length < short_device_descriptor_length) {
-        dbgln("USB Device: Not enough bytes for short device descriptor. Expected {}, got {}.", short_device_descriptor_length, transfer_length);
-        return EIO;
-    }
-
-    if constexpr (USB_DEBUG) {
-        dbgln("USB Short Device Descriptor:");
-        dbgln("Descriptor length: {}", dev_descriptor.descriptor_header.length);
-        dbgln("Descriptor type: {}", dev_descriptor.descriptor_header.descriptor_type);
-
-        dbgln("Device Class: {:02x}", dev_descriptor.device_class);
-        dbgln("Device Sub-Class: {:02x}", dev_descriptor.device_sub_class);
-        dbgln("Device Protocol: {:02x}", dev_descriptor.device_protocol);
-        dbgln("Max Packet Size: {:02x} bytes", dev_descriptor.max_packet_size);
-    }
-
-    // Ensure that this is actually a valid device descriptor...
-    VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
-    m_default_pipe->set_max_packet_size(dev_descriptor.max_packet_size);
-
-    transfer_length = TRY(m_default_pipe->submit_control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, sizeof(USBDeviceDescriptor), &dev_descriptor));
-
-    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
-    if (transfer_length < sizeof(USBDeviceDescriptor)) {
-        dbgln("USB Device: Unexpected device descriptor length. Expected {}, got {}.", sizeof(USBDeviceDescriptor), transfer_length);
-        return EIO;
-    }
-
-    // Ensure that this is actually a valid device descriptor...
-    VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
-
-    if constexpr (USB_DEBUG) {
-        dbgln("USB Device Descriptor for {:04x}:{:04x}", dev_descriptor.vendor_id, dev_descriptor.product_id);
-        dbgln("Device Class: {:02x}", dev_descriptor.device_class);
-        dbgln("Device Sub-Class: {:02x}", dev_descriptor.device_sub_class);
-        dbgln("Device Protocol: {:02x}", dev_descriptor.device_protocol);
-        dbgln("Max Packet Size: {:02x} bytes", dev_descriptor.max_packet_size);
-        dbgln("Number of configurations: {:02x}", dev_descriptor.num_configurations);
-    }
-
-    auto new_address = m_controller->allocate_address();
-
-    // Attempt to set devices address on the bus
-    transfer_length = TRY(m_default_pipe->submit_control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE, USB_REQUEST_SET_ADDRESS, new_address, 0, 0, nullptr));
-
-    // This has to be set after we send out the "Set Address" request because it might be sent to the root hub.
-    // The root hub uses the address to intercept requests to itself.
-    m_address = new_address;
-    m_default_pipe->set_device_address(new_address);
-
-    dbgln_if(USB_DEBUG, "USB Device: Set address to {}", m_address);
-
-    memcpy(&m_device_descriptor, &dev_descriptor, sizeof(USBDeviceDescriptor));
-
-    // Fetch the configuration descriptors from the device
-    m_configurations.ensure_capacity(m_device_descriptor.num_configurations);
-    for (auto configuration = 0u; configuration < m_device_descriptor.num_configurations; configuration++) {
-        USBConfigurationDescriptor configuration_descriptor;
-        transfer_length = TRY(m_default_pipe->submit_control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8u) | configuration, 0, sizeof(USBConfigurationDescriptor), &configuration_descriptor));
-
-        if constexpr (USB_DEBUG) {
-            dbgln("USB Configuration Descriptor {}", configuration);
-            dbgln("Total Length: {}", configuration_descriptor.total_length);
-            dbgln("Number of interfaces: {}", configuration_descriptor.number_of_interfaces);
-            dbgln("Configuration Value: {}", configuration_descriptor.configuration_value);
-            dbgln("Attributes Bitmap: {:08b}", configuration_descriptor.attributes_bitmap);
-            dbgln("Maximum Power: {}mA", configuration_descriptor.max_power_in_ma * 2u); // This value is in 2mA steps
-        }
-
-        USBConfiguration device_configuration(*this, configuration_descriptor);
-        TRY(device_configuration.enumerate_interfaces());
-        m_configurations.append(device_configuration);
-    }
-
-    return {};
-}
 
 ErrorOr<size_t> Device::control_transfer(u8 request_type, u8 request, u16 value, u16 index, u16 length, void* data)
 {

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -19,8 +19,8 @@ namespace Kernel::USB {
 
 ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController& controller, u8 port, DeviceSpeed speed)
 {
-    auto pipe = TRY(ControlPipe::create(controller, 0, 8, 0));
-    auto device = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) Device(controller, port, speed, move(pipe))));
+    auto device = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) Device(controller, port, speed)));
+    device->set_default_pipe(TRY(ControlPipe::create(controller, device, 0, 8)));
     auto sysfs_node = TRY(SysFSUSBDeviceInformation::create(*device));
     device->m_sysfs_device_info_node.with([&](auto& node) {
         node = move(sysfs_node);
@@ -46,36 +46,39 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController& controller,
     return device;
 }
 
-Device::Device(USBController const& controller, u8 port, DeviceSpeed speed, NonnullOwnPtr<ControlPipe> default_pipe)
+Device::Device(USBController const& controller, u8 port, DeviceSpeed speed)
     : m_device_port(port)
     , m_device_speed(speed)
     , m_address(0)
     , m_controller(controller)
-    , m_default_pipe(move(default_pipe))
 {
 }
 
-Device::Device(NonnullLockRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<ControlPipe> default_pipe)
+Device::Device(NonnullLockRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed)
     : m_device_port(port)
     , m_device_speed(speed)
     , m_address(address)
     , m_controller(move(controller))
-    , m_default_pipe(move(default_pipe))
 {
 }
 
-Device::Device(Device const& device, NonnullOwnPtr<ControlPipe> default_pipe)
+Device::Device(Device const& device)
     : m_device_port(device.port())
     , m_device_speed(device.speed())
     , m_address(device.address())
     , m_device_descriptor(device.device_descriptor())
     , m_configurations(device.configurations())
     , m_controller(device.controller())
-    , m_default_pipe(move(default_pipe))
 {
 }
 
 Device::~Device() = default;
+
+void Device::set_default_pipe(NonnullOwnPtr<ControlPipe> pipe)
+{
+    VERIFY(!m_default_pipe);
+    m_default_pipe = move(pipe);
+}
 
 ErrorOr<size_t> Device::control_transfer(u8 request_type, u8 request, u16 value, u16 index, u16 length, void* data)
 {

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -39,8 +39,8 @@ public:
 
     static ErrorOr<NonnullLockRefPtr<Device>> try_create(USBController&, u8, DeviceSpeed);
 
-    Device(USBController const&, u8, DeviceSpeed, NonnullOwnPtr<ControlPipe> default_pipe);
-    Device(Device const& device, NonnullOwnPtr<ControlPipe> default_pipe);
+    Device(USBController const&, u8, DeviceSpeed);
+    Device(Device const& device);
     virtual ~Device();
 
     u8 port() const { return m_device_port; }
@@ -77,7 +77,6 @@ public:
     {
         VERIFY(m_address == 0); // Device can only transition once
         m_address = address;
-        m_default_pipe->set_device_address(address);
     }
     template<DerivedFrom<USBController> Controller>
     void set_descriptor(Badge<Controller>, USBDeviceDescriptor const& descriptor)
@@ -88,7 +87,8 @@ public:
     Vector<USBConfiguration>& configurations(Badge<Controller>) { return m_configurations; }
 
 protected:
-    Device(NonnullLockRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<ControlPipe> default_pipe);
+    Device(NonnullLockRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed);
+    void set_default_pipe(NonnullOwnPtr<ControlPipe> pipe);
 
     u8 m_device_port { 0 };     // What port is this device attached to. NOTE: This is 1-based.
     DeviceSpeed m_device_speed; // What speed is this device running at
@@ -101,7 +101,7 @@ protected:
     Vector<USBConfiguration> m_configurations;  // Configurations for this device
 
     NonnullLockRefPtr<USBController> m_controller;
-    NonnullOwnPtr<ControlPipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration
+    OwnPtr<ControlPipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration
 
     LockRefPtr<Driver> m_driver;
 

--- a/Kernel/Bus/USB/USBHub.h
+++ b/Kernel/Bus/USB/USBHub.h
@@ -94,9 +94,9 @@ public:
 
 private:
     // Root Hub constructor
-    Hub(NonnullLockRefPtr<USBController>, DeviceSpeed, NonnullOwnPtr<ControlPipe> default_pipe);
+    Hub(NonnullLockRefPtr<USBController>, DeviceSpeed);
 
-    Hub(Device const&, NonnullOwnPtr<ControlPipe> default_pipe);
+    Hub(Device const&);
 
     USBHubDescriptor m_hub_descriptor {};
 

--- a/Kernel/Bus/USB/USBHub.h
+++ b/Kernel/Bus/USB/USBHub.h
@@ -44,6 +44,7 @@ enum HubFeatureSelector : u8 {
     C_PORT_RESET = 20,
     PORT_TEST = 21,
     PORT_INDICATOR = 22,
+    C_PORT_LINK_STATE = 25,
 };
 
 // USB 2.0 Specification Section 11.24.2.{6,7}
@@ -71,6 +72,8 @@ static constexpr u16 PORT_STATUS_HIGH_SPEED_DEVICE_ATTACHED = (1 << 10);
 static constexpr u16 PORT_STATUS_PORT_STATUS_MODE = (1 << 11);
 static constexpr u16 PORT_STATUS_PORT_INDICATOR_CONTROL = (1 << 12);
 
+static constexpr u16 SUPERSPEED_PORT_STATUS_POWER = (1 << 9);
+
 static constexpr u16 PORT_STATUS_CONNECT_STATUS_CHANGED = (1 << 0);
 static constexpr u16 PORT_STATUS_PORT_ENABLED_CHANGED = (1 << 1);
 static constexpr u16 PORT_STATUS_SUSPEND_CHANGED = (1 << 2);
@@ -80,6 +83,7 @@ static constexpr u16 PORT_STATUS_RESET_CHANGED = (1 << 4);
 class Hub : public Device {
 public:
     static ErrorOr<NonnullLockRefPtr<Hub>> try_create_root_hub(NonnullLockRefPtr<USBController>, DeviceSpeed);
+    static ErrorOr<NonnullLockRefPtr<Hub>> try_create_root_hub(NonnullLockRefPtr<USBController>, DeviceSpeed, u8 address, USBDeviceDescriptor const&);
     static ErrorOr<NonnullLockRefPtr<Hub>> try_create_from_device(Device const&);
 
     virtual ~Hub() override = default;
@@ -95,6 +99,7 @@ public:
 private:
     // Root Hub constructor
     Hub(NonnullLockRefPtr<USBController>, DeviceSpeed);
+    Hub(NonnullLockRefPtr<USBController>, DeviceSpeed, u8 address, USBDeviceDescriptor const&);
 
     Hub(Device const&);
 

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -12,6 +12,7 @@
 #include <Kernel/Bus/USB/EHCI/EHCIController.h>
 #include <Kernel/Bus/USB/UHCI/UHCIController.h>
 #include <Kernel/Bus/USB/USBManagement.h>
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.h>
 #include <Kernel/Sections.h>
 
@@ -53,9 +54,15 @@ UNMAP_AFTER_INIT void USBManagement::enumerate_controllers()
             if (auto ehci_controller_or_error = EHCI::EHCIController::try_to_initialize(device_identifier); !ehci_controller_or_error.is_error())
                 m_controllers.append(ehci_controller_or_error.release_value());
             return;
-        case xHCI:
-            dmesgln("USBManagement: xHCI controller found at {} is not currently supported.", device_identifier.address());
+        case xHCI: {
+            dmesgln("USBManagement: xHCI controller found at {}", device_identifier.address());
+            auto xhci_controller_or_error = xHCIController::try_to_initialize(device_identifier);
+            if (xhci_controller_or_error.is_error())
+                dmesgln("USBManagement: Failed initializing xHCI controller - {}", xhci_controller_or_error.error());
+            else
+                m_controllers.append(xhci_controller_or_error.release_value());
             return;
+        }
         case None:
             dmesgln("USBManagement: Non interface-able controller found at {} is not currently supported.", device_identifier.address());
             return;

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -13,11 +13,11 @@
 
 namespace Kernel::USB {
 
-Pipe::Pipe(USBController const& controller, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer)
+Pipe::Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
     : m_controller(controller)
+    , m_device(device)
     , m_type(type)
     , m_direction(direction)
-    , m_device_address(device_address)
     , m_endpoint_address(endpoint_address)
     , m_max_packet_size(max_packet_size)
     , m_data_toggle(false)
@@ -25,14 +25,14 @@ Pipe::Pipe(USBController const& controller, Type type, Direction direction, u8 e
 {
 }
 
-ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size)
 {
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB device DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) ControlPipe(controller, endpoint_address, max_packet_size, device_address, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) ControlPipe(controller, device, endpoint_address, max_packet_size, move(dma_buffer)));
 }
 
-ControlPipe::ControlPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, Type::Control, Direction::Bidirectional, endpoint_address, max_packet_size, device_address, move(dma_buffer))
+ControlPipe::ControlPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Control, Direction::Bidirectional, endpoint_address, max_packet_size, move(dma_buffer))
 {
 }
 
@@ -64,15 +64,15 @@ ErrorOr<size_t> ControlPipe::submit_control_transfer(u8 request_type, u8 request
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<BulkInPipe>> BulkInPipe::create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<BulkInPipe>> BulkInPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BulkInPipe(controller, endpoint_address, max_packet_size, device_address, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) BulkInPipe(controller, device, endpoint_address, max_packet_size, move(dma_buffer)));
 }
 
-BulkInPipe::BulkInPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, Pipe::Type::Bulk, Direction::In, endpoint_address, max_packet_size, device_address, move(dma_buffer))
+BulkInPipe::BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Pipe::Type::Bulk, Direction::In, endpoint_address, max_packet_size, move(dma_buffer))
 {
 }
 
@@ -110,15 +110,15 @@ ErrorOr<size_t> BulkInPipe::submit_bulk_in_transfer(size_t length, UserOrKernelB
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<BulkOutPipe>> BulkOutPipe::create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<BulkOutPipe>> BulkOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BulkOutPipe(controller, endpoint_address, max_packet_size, device_address, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) BulkOutPipe(controller, device, endpoint_address, max_packet_size, move(dma_buffer)));
 }
 
-BulkOutPipe::BulkOutPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, Type::Bulk, Direction::Out, endpoint_address, max_packet_size, device_address, move(dma_buffer))
+BulkOutPipe::BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Bulk, Direction::Out, endpoint_address, max_packet_size, move(dma_buffer))
 
 {
 }
@@ -156,15 +156,15 @@ ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, UserOrKerne
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<InterruptInPipe>> InterruptInPipe::create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, u16 poll_interval, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<InterruptInPipe>> InterruptInPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptInPipe(controller, endpoint_address, max_packet_size, device_address, poll_interval, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptInPipe(controller, device, endpoint_address, max_packet_size, poll_interval, move(dma_buffer)));
 }
 
-InterruptInPipe::InterruptInPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, Type::Interrupt, Direction::In, endpoint_address, max_packet_size, device_address, move(dma_buffer))
+InterruptInPipe::InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_address, max_packet_size, move(dma_buffer))
     , m_poll_interval(poll_interval)
 {
 }
@@ -179,15 +179,15 @@ ErrorOr<NonnullLockRefPtr<Transfer>> InterruptInPipe::submit_interrupt_in_transf
     return transfer;
 }
 
-ErrorOr<NonnullOwnPtr<InterruptOutPipe>> InterruptOutPipe::create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, u16 poll_interval, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<InterruptOutPipe>> InterruptOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptOutPipe(controller, endpoint_address, max_packet_size, device_address, poll_interval, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptOutPipe(controller, device, endpoint_address, max_packet_size, poll_interval, move(dma_buffer)));
 }
 
-InterruptOutPipe::InterruptOutPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, Type::Interrupt, Direction::In, endpoint_address, max_packet_size, device_address, move(dma_buffer))
+InterruptOutPipe::InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_address, max_packet_size, move(dma_buffer))
     , m_poll_interval(poll_interval)
 {
 }

--- a/Kernel/Bus/USB/xHCI/xHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIController.cpp
@@ -1,0 +1,1441 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Delay.h>
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/BarMapping.h>
+#include <Kernel/Bus/PCI/IDs.h>
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBHub.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+#include <Kernel/Bus/USB/xHCI/xHCIInterrupter.h>
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel::USB {
+
+ErrorOr<NonnullLockRefPtr<xHCIController>> xHCIController::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier)
+{
+    auto registers_mapping = TRY(PCI::map_bar<u8>(pci_device_identifier, PCI::HeaderType0BaseRegister::BAR0));
+    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) xHCIController(pci_device_identifier, move(registers_mapping))));
+    TRY(controller->initialize());
+    return controller;
+}
+
+UNMAP_AFTER_INIT xHCIController::xHCIController(PCI::DeviceIdentifier const& pci_device_identifier, Memory::TypedMapping<u8> registers_mapping)
+    : PCI::Device(pci_device_identifier)
+    , m_registers_mapping(move(registers_mapping))
+    , m_capability_registers(*reinterpret_cast<CapabilityRegisters volatile*>(m_registers_mapping.ptr()))
+    , m_operational_registers(*reinterpret_cast<OperationalRegisters volatile*>(m_registers_mapping.ptr() + m_capability_registers.capability_register_length))
+    , m_runtime_registers(*reinterpret_cast<RuntimeRegisters volatile*>(m_registers_mapping.ptr() + m_capability_registers.runtime_register_space_offset))
+    , m_doorbell_registers(*reinterpret_cast<DoorbellRegisters volatile*>(m_registers_mapping.ptr() + m_capability_registers.doorbell_offset))
+{
+}
+
+xHCIController::~xHCIController()
+{
+    if (m_process) {
+        m_process->die();
+        // Block until all threads exited to prevent UAF
+        ErrorOr<siginfo_t> result = siginfo_t {};
+        (void)Thread::current()->block<Thread::WaitBlocker>({}, WEXITED, m_process.release_nonnull(), result);
+    }
+}
+
+// 4.22.1 Pre-OS to OS Handoff Synchronization
+void xHCIController::take_exclusive_control_from_bios()
+{
+    if (m_capability_registers.capability_parameters_1.xHCI_extended_capabilities_pointer == 0)
+        return;
+    auto* extended_capabilities_pointer = m_registers_mapping.ptr() + (m_capability_registers.capability_parameters_1.xHCI_extended_capabilities_pointer << 2);
+
+    ExtendedCapability volatile* extended_capability = nullptr;
+    while (true) {
+        extended_capability = reinterpret_cast<ExtendedCapability volatile*>(extended_capabilities_pointer);
+        if (extended_capability->capability_id == ExtendedCapability::CapabilityID::USB_Legacy_Support)
+            break;
+        u32 const next_extended_capability_offset = extended_capability->next_xHCI_extended_capability_pointer << 2;
+        if (next_extended_capability_offset == 0)
+            return;
+        extended_capabilities_pointer += next_extended_capability_offset;
+    };
+
+    auto* usb_legacy_support_extended_capability = reinterpret_cast<USBLegacySupportExtendedCapability volatile*>(extended_capability);
+    if (!usb_legacy_support_extended_capability->usb_legacy_support_capability.host_controller_bios_owned_semaphore)
+        return;
+
+    dmesgln_pci(*this, "Controller is owned by BIOS - taking ownership");
+    usb_legacy_support_extended_capability->usb_legacy_support_capability.host_controller_os_owned_semaphore = 1;
+    for (auto attempts = 0; attempts < 20; ++attempts) {
+        if (!usb_legacy_support_extended_capability->usb_legacy_support_capability.host_controller_bios_owned_semaphore)
+            break;
+        microseconds_delay(50000); // The time that OS shall wait for BIOS to respond to the request for ownership should not exceed ‘1’ second.
+    }
+    if (usb_legacy_support_extended_capability->usb_legacy_support_capability.host_controller_bios_owned_semaphore)
+        dmesgln_pci(*this, "Bios refuses to transfer ownership - ignoring");
+    else if (usb_legacy_support_extended_capability->usb_legacy_support_capability.host_controller_os_owned_semaphore)
+        dmesgln_pci(*this, "Took ownership of controller successfully");
+    // Force disable BIOS control in case the BIOS is broken/non-responsive (disable their SMIs)
+    usb_legacy_support_extended_capability->usb_legacy_support_capability.host_controller_bios_owned_semaphore = 0;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.usb_smi_enable = 0;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_host_system_error_enable = 0;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_os_ownership_enable = 0;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_pci_command_enable = 0;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_bar_enable = 0;
+    // write '1' to clear bits
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_os_ownership_change = 1;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_pci_command = 1;
+    usb_legacy_support_extended_capability->usb_legacy_support_control_status.smi_on_bar = 1;
+
+    if (device_identifier().hardware_id().vendor_id == PCI::VendorID::Intel)
+        intel_quirk_enable_xhci_ports();
+}
+
+void xHCIController::intel_quirk_enable_xhci_ports()
+{
+    // Intel chipsets that include both xHCI and EHCI USB controllers default to configuring their USB ports to be attached to the EHCI controller,
+    // Attach them to the xHCI controller instead.
+    bool ehci_controller_found = false;
+    MUST(PCI::enumerate([&ehci_controller_found](PCI::DeviceIdentifier const& device_identifier) {
+        if (device_identifier.hardware_id().vendor_id != PCI::VendorID::Intel
+            || device_identifier.class_code() != PCI::ClassID::SerialBus
+            || device_identifier.subclass_code() != PCI::SerialBus::SubclassID::USB
+            || device_identifier.prog_if() != PCI::SerialBus::USBProgIf::EHCI)
+            return;
+        ehci_controller_found = true;
+    }));
+    if (!ehci_controller_found)
+        return;
+    dmesgln_pci(*this, "Switching Intel chipset USB ports to xHCI instead of EHCI");
+    SpinlockLocker const locker(device_identifier().operation_lock());
+    // Enable USB3 Ports
+    write32_locked(device_identifier(), intel_xhci_usb3_port_super_speed_enable_offset, read32_locked(device_identifier(), intel_xhci_usb3_port_routing_mask_offset));
+    // Enable USB2 Ports
+    write32_locked(device_identifier(), intel_xhci_usb2_port_routing_offset, read32_locked(device_identifier(), intel_xhci_usb2_port_routing_mask_offset));
+}
+
+ErrorOr<void> xHCIController::find_port_max_speeds()
+{
+    // At least one of these capability structures is required for all xHCI implementations.
+    if (m_capability_registers.capability_parameters_1.xHCI_extended_capabilities_pointer == 0)
+        return EINVAL;
+    auto* extended_capabilities_pointer = m_registers_mapping.ptr() + (m_capability_registers.capability_parameters_1.xHCI_extended_capabilities_pointer << 2);
+
+    ExtendedCapability volatile* extended_capability = nullptr;
+    Vector<SupportedProtocolExtendedCapability volatile*> supported_protocol_capabilities;
+    while (true) {
+        extended_capability = reinterpret_cast<ExtendedCapability volatile*>(extended_capabilities_pointer);
+        if (extended_capability->capability_id == ExtendedCapability::CapabilityID::Supported_Protocols)
+            TRY(supported_protocol_capabilities.try_append(reinterpret_cast<SupportedProtocolExtendedCapability volatile*>(extended_capability)));
+        u32 const next_extended_capability_offset = extended_capability->next_xHCI_extended_capability_pointer << 2;
+        if (next_extended_capability_offset == 0)
+            break;
+        extended_capabilities_pointer += next_extended_capability_offset;
+    };
+
+    if (supported_protocol_capabilities.is_empty())
+        return EINVAL;
+
+    for (auto* supported_protocol_capability : supported_protocol_capabilities) {
+        if (supported_protocol_capability->name_string != SupportedProtocolExtendedCapability::usb_name_string)
+            continue;
+        auto major_revision = supported_protocol_capability->major_revision;
+        if (major_revision < 0x02 || major_revision > 0x03)
+            continue;
+        auto minor_revision = supported_protocol_capability->minor_revision;
+        if (major_revision == 0x02 && minor_revision != 0x00)
+            continue;
+        if (major_revision == 0x03 && minor_revision > 0x20)
+            continue;
+        auto offset = supported_protocol_capability->compatible_port_offset;
+        if (offset < 1 || offset > m_port_max_speeds.size())
+            continue;
+        auto count = supported_protocol_capability->compatible_port_count;
+        if (count == 0 || count > (m_port_max_speeds.size() - offset + 1))
+            continue;
+        if (supported_protocol_capability->protocol_speed_id_count > 0) {
+            dmesgln_pci(*this, "Controller has explicit protocol speed ID definitions - this is not supported yet");
+            continue;
+        }
+        auto max_speed = major_revision == 0x03 ? USB::Device::DeviceSpeed::SuperSpeed : USB::Device::DeviceSpeed::HighSpeed;
+        for (auto i = offset - 1; i < count; ++i)
+            m_port_max_speeds[i] = max_speed;
+    }
+    return {};
+}
+
+ErrorOr<void> xHCIController::initialize()
+{
+    dmesgln_pci(*this, "Controller found {}", PCI::get_hardware_id(device_identifier()));
+    dmesgln_pci(*this, "Registers base: {}", m_registers_mapping.paddr);
+
+    auto interface_version = m_capability_registers.host_controller_interface_version_number;
+    if (interface_version < 0x0090 || interface_version > 0x0102) { // The Intel specification defines versions 0.9.0 up to 1.2.0
+        dmesgln_pci(*this, "Unsupported interface version: {}.{}.{}", interface_version >> 8, (interface_version >> 4) & 0xF, interface_version & 0xF);
+        return ENOTSUP;
+    }
+    dmesgln_pci(*this, "Interface version: {}.{}.{}", interface_version >> 8, (interface_version >> 4) & 0xF, interface_version & 0xF);
+    dbgln_if(XHCI_DEBUG, "xHCI: Using {}-bit addressing", m_capability_registers.capability_parameters_1._64bit_addressing_capability ? 64 : 32);
+
+    PCI::enable_bus_mastering(device_identifier());
+    PCI::enable_memory_space(device_identifier());
+
+#if ARCH(RISCV64)
+    constexpr bool use_msi = false;
+    dmesgln_pci(*this, "FIXME: Disabling MSI-based interrupts on RISC-V");
+#else
+    constexpr bool use_msi = true;
+#endif
+    auto interrupt_type = TRY(reserve_irqs(1, use_msi)); // TODO: Support more than one interrupter using MSI/MSI-X
+    m_using_message_signalled_interrupts = interrupt_type != PCI::InterruptType::PIN;
+
+    take_exclusive_control_from_bios();
+    TRY(find_port_max_speeds());
+
+    TRY(reset());
+
+    if ((m_operational_registers.page_size & 1) == 0) {
+        dmesgln_pci(*this, "Interface does not support 4K pages");
+        return ENOTSUP;
+    }
+
+    auto [process, event_handler_thread] = TRY(Process::create_kernel_process("xHCI Controller"sv, [this]() { event_handling_thread(); }));
+    event_handler_thread->set_name("xHCI Event Handling"sv);
+    (void)TRY(process->create_kernel_thread("xHCI Hot Plug"sv, [this]() { hot_plug_thread(); }));
+    m_process = move(process);
+
+    m_large_contexts = m_capability_registers.capability_parameters_1.context_size;
+    m_ports = m_capability_registers.structural_parameters.number_of_ports;
+    m_device_slots = min((u8)m_capability_registers.structural_parameters.number_of_device_slots, max_devices);
+    // 4.2 Host Controller Initialization
+    // 1. Program the Max Device Slots Enabled (MaxSlotsEn) field in the CONFIG register (5.4.7) to enable the device slots that system software is going to use.
+    m_operational_registers.configure.max_device_slots_enabled = m_device_slots;
+
+    // 2. Program the Device Context Base Address Array Pointer (DCBAAP) register (5.4.6) with a 64-bit address pointing to where the Device Context Base Address Array is located.
+    m_device_context_base_address_array_region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up((m_device_slots + 1) * sizeof(u64))), "xHCI Device Context Base Address Array"sv, Memory::Region::Access::ReadWrite));
+    dbgln_if(XHCI_DEBUG, "xHCI: Device Context Base Address Array - {} / {}", m_device_context_base_address_array_region->vaddr(), m_device_context_base_address_array_region->physical_page(0)->paddr());
+    m_device_context_base_address_array = reinterpret_cast<u64*>(m_device_context_base_address_array_region->vaddr().as_ptr());
+    auto requested_scratchpad_buffers = (m_capability_registers.structural_parameters.max_scratchpad_buffers_high << 5) | m_capability_registers.structural_parameters.max_scratchpad_buffers_low;
+    if (requested_scratchpad_buffers > 0) {
+        dbgln_if(XHCI_DEBUG, "xHCI: Allocating {} scratchpad buffers", requested_scratchpad_buffers);
+        m_scratchpad_buffers_array_region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up(requested_scratchpad_buffers * sizeof(u64))), "xHCI Scratchpad Buffers Array"sv, Memory::Region::Access::ReadWrite));
+        auto* scratchpad_buffers_array = reinterpret_cast<u64*>(m_scratchpad_buffers_array_region->vaddr().as_ptr());
+        for (auto i = 0; i < requested_scratchpad_buffers; ++i) {
+            auto page = TRY(MM.allocate_physical_page());
+            scratchpad_buffers_array[i] = page->paddr().get();
+            TRY(m_scratchpad_buffers.try_append(move(page)));
+        }
+        m_device_context_base_address_array[0] = m_scratchpad_buffers_array_region->physical_page(0)->paddr().get();
+    } else {
+        m_device_context_base_address_array[0] = 0;
+    }
+    auto device_context_base_address_array_pointer = m_device_context_base_address_array_region->physical_page(0)->paddr().get();
+    m_operational_registers.device_context_base_address_array_pointer.low = device_context_base_address_array_pointer;
+    m_operational_registers.device_context_base_address_array_pointer.high = device_context_base_address_array_pointer >> 32;
+
+    // 3. Define the Command Ring Dequeue Pointer by programming the Command Ring Control Register (5.4.5) with a 64-bit address pointing to the starting address of the first TRB of the Command Ring.
+    m_command_and_event_rings_region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up(sizeof(CommandAndEventRings))), "xHCI Command and Event Rings"sv, Memory::Region::Access::ReadWrite));
+    dbgln_if(XHCI_DEBUG, "xHCI: Command and Event Rings - {} / {}", m_command_and_event_rings_region->vaddr(), m_command_and_event_rings_region->physical_page(0)->paddr());
+    auto command_and_event_rings_region_virtual_address = m_command_and_event_rings_region->vaddr().get();
+    m_command_ring = reinterpret_cast<TransferRequestBlock*>(command_and_event_rings_region_virtual_address + __builtin_offsetof(CommandAndEventRings, command_ring));
+    m_command_ring[command_ring_size - 1].generic.transfer_request_block_type = TransferRequestBlock::TRBType::Link;
+    auto command_and_event_rings_region_physical_address = m_command_and_event_rings_region->physical_page(0)->paddr().get();
+    auto command_ring_pointer = command_and_event_rings_region_physical_address + __builtin_offsetof(CommandAndEventRings, command_ring);
+    m_command_ring[command_ring_size - 1].link.ring_segment_pointer_low = command_ring_pointer;
+    m_command_ring[command_ring_size - 1].link.ring_segment_pointer_high = command_ring_pointer >> 32;
+    m_command_ring[command_ring_size - 1].link.toggle_cycle = 1;
+
+    // Must be written as 2 whole 32-bit writes, since reads always return 0 (so RMW won't work)
+    CommandRingControlRegister command_ring_control_register;
+    command_ring_control_register.command_ring_pointer_low = command_ring_pointer >> 6;
+    command_ring_control_register.command_ring_pointer_high = command_ring_pointer >> 32;
+    command_ring_control_register.ring_cycle_state = 1;
+    m_operational_registers.command_ring_control.raw0 = command_ring_control_register.raw0;
+    m_operational_registers.command_ring_control.raw1 = command_ring_control_register.raw1;
+
+    // Clear interrupt conditions left-over from BIOS
+    m_operational_registers.usb_status.raw = m_operational_registers.usb_status.raw;
+
+    // TODO: Support more than one interrupter using MSI/MSI-X
+    // 4. Initialize each active interrupter by:
+    //   1. Defining the Event Ring: (refer to section 4.9.4 for a discussion of Event Ring Management.)
+    //     1. Allocate and initialize the Event Ring Segment(s).
+    m_event_ring_segment = reinterpret_cast<TransferRequestBlock*>(command_and_event_rings_region_virtual_address + __builtin_offsetof(CommandAndEventRings, event_ring_segment));
+    m_event_ring_segment_pointer = command_and_event_rings_region_physical_address + __builtin_offsetof(CommandAndEventRings, event_ring_segment);
+
+    //     2. Allocate the Event Ring Segment Table (ERST) (section 6.5).
+    //     Initialize ERST table entries to point to and to define the size (in TRBs) of the respective Event Ring Segment.
+    auto* event_ring_segment_table = reinterpret_cast<EventRingSegmentTableEntry*>(command_and_event_rings_region_virtual_address + __builtin_offsetof(CommandAndEventRings, event_ring_segment_table_entry));
+    event_ring_segment_table->ring_segment_base_address_low = m_event_ring_segment_pointer;
+    event_ring_segment_table->ring_segment_base_address_high = m_event_ring_segment_pointer >> 32;
+    event_ring_segment_table->ring_segment_size = event_ring_segment_size;
+
+    //     3. Program the Interrupter Event Ring Segment Table Size (ERSTSZ) register (5.5.2.3.1) with the number of segments described by the Event Ring Segment Table.
+    m_runtime_registers.interrupter_registers[0].even_ring_segment_table_size = 1;
+
+    //     4. Program the Interrupter Event Ring Dequeue Pointer (ERDP) register (5.5.2.3.3) with the starting address of the first segment described by the Event Ring Segment Table.
+    m_runtime_registers.interrupter_registers[0].event_ring_dequeue_pointer.event_ring_dequeue_pointer_low = m_event_ring_segment_pointer >> 4;
+    m_runtime_registers.interrupter_registers[0].event_ring_dequeue_pointer.event_ring_dequeue_pointer_high = m_event_ring_segment_pointer >> 32;
+
+    //     5. Program the Interrupter Event Ring Segment Table Base Address (ERSTBA) register (5.5.2.3.2) with a 64-bit address pointer to where the Event Ring Segment Table is located.
+    auto event_ring_segment_table_entry_address = command_and_event_rings_region_physical_address + __builtin_offsetof(CommandAndEventRings, event_ring_segment_table_entry);
+    m_runtime_registers.interrupter_registers[0].event_ring_segment_table_base_address.low = event_ring_segment_table_entry_address;
+    m_runtime_registers.interrupter_registers[0].event_ring_segment_table_base_address.high = event_ring_segment_table_entry_address >> 32;
+
+    //   2. Defining the interrupts:
+    //     1. Initializing the Interval field of the Interrupt Moderation register (5.5.2.2) with the target interrupt moderation rate.
+    m_runtime_registers.interrupter_registers[0].interrupter_moderation.interrupt_moderation_interval = 0x3F8; // max 4000 interrupts/sec
+
+    //     2. Enable system bus interrupt generation by writing a ‘1’ to the Interrupter Enable (INTE) flag of the USBCMD register (5.4.1).
+    m_operational_registers.usb_command.interrupter_enable = 1;
+    m_operational_registers.usb_command.host_system_error_enable = 1;
+
+    //     3. Enable the Interrupter by writing a ‘1’ to the Interrupt Enable (IE) field of the Interrupter Management register (5.5.2.1).
+    m_runtime_registers.interrupter_registers[0].interrupter_management.interrupt_enabled = 1;
+
+    m_interrupter = TRY(xHCIInterrupter::create(*this, 0));
+
+    return start();
+}
+
+ErrorOr<void> xHCIController::reset()
+{
+    dbgln_if(XHCI_DEBUG, "Resetting xHCI Controller");
+    TRY(stop());
+
+    m_operational_registers.usb_command.host_controller_reset = 1;
+    for (auto attempts = 0; attempts < 1000; ++attempts) {
+        microseconds_delay(1000);
+        if (!m_operational_registers.usb_command.host_controller_reset)
+            break;
+    }
+    if (m_operational_registers.usb_command.host_controller_reset) {
+        dmesgln_pci(*this, "Failed resetting controller - stuck in reset state");
+        return EBUSY;
+    }
+
+    // After Chip Hardware Reset wait until the Controller Not Ready (CNR) flag in the USBSTS is ‘0’ before writing any xHC Operational or Runtime/ registers.
+    for (auto attempts = 0; attempts < 1000; ++attempts) {
+        microseconds_delay(1000);
+        if (!m_operational_registers.usb_status.controller_not_ready)
+            return {};
+    }
+    dmesgln_pci(*this, "Failed resetting controller - stuck in not-ready state");
+    return EBUSY;
+}
+
+ErrorOr<void> xHCIController::start()
+{
+    m_operational_registers.usb_command.run_stop = 1;
+    for (auto attempts = 0; attempts < 1000; ++attempts) {
+        microseconds_delay(1000);
+        if (!m_operational_registers.usb_status.host_controller_halted)
+            break;
+    }
+    if (m_operational_registers.usb_status.host_controller_halted) {
+        dmesgln_pci(*this, "Failed starting controller");
+        return EBUSY;
+    }
+    dmesgln_pci(*this, "Finished starting controller");
+
+    m_root_hub = TRY(xHCIRootHub::try_create(*this));
+    TRY(m_root_hub->setup({}));
+    dmesgln_pci(*this, "Initialized root hub");
+    return {};
+}
+
+ErrorOr<void> xHCIController::stop()
+{
+    m_operational_registers.usb_command.run_stop = 0;
+    for (auto attempts = 0; attempts < 1000; ++attempts) {
+        microseconds_delay(1000);
+        if (m_operational_registers.usb_status.host_controller_halted)
+            return {};
+    }
+    dmesgln_pci(*this, "Failed stopping controller");
+    return EBUSY;
+}
+
+void xHCIController::ring_doorbell(u8 doorbell, u8 doorbell_target)
+{
+    DoorbellRegister const doorbell_value {
+        .doorbell_target = doorbell_target,
+        .reserved0 = 0,
+        .doorbell_stream_id = 0,
+    };
+    m_doorbell_registers.doorbells[doorbell] = doorbell_value.raw;
+    // Read-after-write to serialize PCI transactions
+    (void)m_doorbell_registers.doorbells[doorbell];
+}
+
+void xHCIController::enqueue_command(TransferRequestBlock& transfer_request_block)
+{
+    transfer_request_block.generic.cycle_bit = m_command_ring_producer_cycle_state;
+    m_command_ring[m_command_ring_enqueue_index] = transfer_request_block;
+
+    m_command_ring_enqueue_index++;
+
+    if (m_command_ring_enqueue_index == (command_ring_size - 1)) {
+        // Reached Link TRB, flip cycle bit and return to start
+        m_command_ring[m_command_ring_enqueue_index].link.cycle_bit = m_command_ring_producer_cycle_state;
+        m_command_ring_enqueue_index = 0;
+        m_command_ring_producer_cycle_state ^= 1;
+    }
+
+    atomic_thread_fence(MemoryOrder::memory_order_seq_cst);
+
+    ring_command_doorbell();
+}
+
+void xHCIController::execute_command(TransferRequestBlock& transfer_request_block)
+{
+    SpinlockLocker const locker(m_command_lock);
+    enqueue_command(transfer_request_block);
+    m_command_completion_queue.wait_forever();
+    transfer_request_block = m_command_result_transfer_request_block;
+}
+
+ErrorOr<u8> xHCIController::enable_slot()
+{
+    // 4.6.3 Enable Slot
+    // Insert an Enable Slot Command TRB on the Command Ring and initialize the following fields:
+    // * TRB Type = Enable Slot command (refer to Table 6-91).
+    // * Slot Type = value specified by the Protocol Slot Type field of the associated xHCI Supported Protocol Capability structure (refer to Table 7-9).
+    // 7.2.2.1.4 Protocol Slot Type Field
+    // The Protocol Slot Type field of a USB3 or USB2 xHCI Supported Protocol Capability shall be set to '0'
+    TransferRequestBlock transfer_request_block {};
+    transfer_request_block.enable_slot_command.transfer_request_block_type = TransferRequestBlock::TRBType::Enable_Slot_Command;
+    transfer_request_block.enable_slot_command.slot_type = 0;
+    execute_command(transfer_request_block);
+    // If a slot is available, the ID of a selected slot will be returned in the Slot ID field of a successful Command Completion Event on the Event Ring.
+    if (transfer_request_block.command_completion_event.completion_code == TransferRequestBlock::CompletionCode::Success) {
+        VERIFY(transfer_request_block.command_completion_event.slot_id != 0);
+        return (u8)transfer_request_block.command_completion_event.slot_id;
+    }
+    // If a Device Slot is not available, the Slot ID field shall be cleared to '0' and a No Slots Available Error shall be returned in the Command Completion Event.
+    dmesgln_pci(*this, "Enable Slot command failed with completion code: {}", enum_to_string(transfer_request_block.command_completion_event.completion_code));
+    return EINVAL;
+}
+
+ErrorOr<void> xHCIController::address_device(u8 slot, u64 input_context_address)
+{
+    // 4.6.5 Address Device
+    // Insert an Address Device Command on the Command Ring and initialize the following fields:
+    // * TRB Type = Address Device command (refer to Table 6-91).
+    // * Slot ID = ID of the target Device Slot.
+    // * Input Context Pointer = The base address of the Input Context data structure.
+    TransferRequestBlock transfer_request_block {};
+    transfer_request_block.address_device_command.transfer_request_block_type = TransferRequestBlock::TRBType::Address_Device_Command;
+    transfer_request_block.address_device_command.slot_id = slot;
+    transfer_request_block.address_device_command.input_context_pointer_low = input_context_address;
+    transfer_request_block.address_device_command.input_context_pointer_high = input_context_address >> 32;
+    transfer_request_block.address_device_command.block_set_address_request = 0;
+    execute_command(transfer_request_block);
+    if (transfer_request_block.command_completion_event.completion_code != TransferRequestBlock::CompletionCode::Success) {
+        dmesgln_pci(*this, "Address Device command failed with completion code: {}", enum_to_string(transfer_request_block.command_completion_event.completion_code));
+        return EINVAL;
+    }
+    return {};
+}
+
+ErrorOr<void> xHCIController::evaluate_context(u8 slot, u64 input_context_address)
+{
+    // 4.6.7 Evaluate Context
+    // Insert an Evaluate Context Command on the Command Ring and initialize the following fields:
+    // * TRB Type = Evaluate Context Command (refer to Table 6-91).
+    // * Slot ID = ID of the target Device Slot.
+    // * Input Context Pointer = The base address of the Input Context data structure.
+    TransferRequestBlock transfer_request_block {};
+    transfer_request_block.evaluate_context_command.transfer_request_block_type = TransferRequestBlock::TRBType::Evaluate_Context_Command;
+    transfer_request_block.evaluate_context_command.slot_id = slot;
+    transfer_request_block.evaluate_context_command.input_context_pointer_low = input_context_address;
+    transfer_request_block.evaluate_context_command.input_context_pointer_high = input_context_address >> 32;
+    execute_command(transfer_request_block);
+    if (transfer_request_block.command_completion_event.completion_code != TransferRequestBlock::CompletionCode::Success) {
+        dmesgln_pci(*this, "Evaluate Context command failed with completion code: {}", enum_to_string(transfer_request_block.command_completion_event.completion_code));
+        return EINVAL;
+    }
+    return {};
+}
+
+ErrorOr<void> xHCIController::configure_endpoint(u8 slot, u64 input_context_address)
+{
+    // 4.6.6 Configure Endpoint
+    // Insert a Configure Endpoint Command on the Command Ring and initialize the following fields:
+    // * TRB Type = Configure Endpoint Command (refer to Table 6-91).
+    // * Slot ID = ID of the target Device Slot.
+    // * Input Context Pointer = The base address of the Input Context data structure.
+    TransferRequestBlock transfer_request_block {};
+    transfer_request_block.configure_endpoint_command.transfer_request_block_type = TransferRequestBlock::TRBType::Configure_Endpoint_Command;
+    transfer_request_block.configure_endpoint_command.slot_id = slot;
+    transfer_request_block.configure_endpoint_command.input_context_pointer_low = input_context_address;
+    transfer_request_block.configure_endpoint_command.input_context_pointer_high = input_context_address >> 32;
+    transfer_request_block.configure_endpoint_command.deconfigure = 0;
+    execute_command(transfer_request_block);
+    if (transfer_request_block.command_completion_event.completion_code != TransferRequestBlock::CompletionCode::Success) {
+        dmesgln_pci(*this, "Configure Endpoint command failed with completion code: {}", enum_to_string(transfer_request_block.command_completion_event.completion_code));
+        return EINVAL;
+    }
+    return {};
+}
+
+ErrorOr<void> xHCIController::initialize_device(USB::Device& device)
+{
+    // 4. After the port successfully reaches the Enabled state, system software shall obtain a Device Slot for the newly attached device using an Enable Slot Command,
+    // as described in section 4.3.2.
+    auto slot = TRY(enable_slot());
+    VERIFY(slot > 0 && slot <= m_device_slots);
+    device.set_controller_identifier<xHCIController>({}, slot);
+
+    auto& slot_state = m_slots_state[slot - 1];
+    SpinlockLocker const locker(slot_state.lock);
+    VERIFY(!slot_state.input_context_region); // Prevent trying to initialize an already initialized device
+
+    // 5. After successfully obtaining a Device Slot, system software shall initialize the data structures associated with the slot as described in section 4.3.3.
+    //   1. Allocate an Input Context data structure (6.2.5) and initialize all fields to ‘0’.
+    slot_state.input_context_region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up(input_context_size())), "xHCI Input Context"sv, Memory::Region::ReadWrite));
+
+    //   2. Initialize the Input Control Context (6.2.5.1) of the Input Context by setting the A0 and A1 flags to ‘1’.
+    // These flags indicate that the Slot Context and the Endpoint 0 Context of the Input Context are affected by the command.
+    auto* control_context = input_control_context(slot);
+    control_context->drop_contexts = 0;
+    control_context->add_contexts = (1 << 0) | (1 << 1);
+
+    //   3. Initialize the Input Slot Context data structure (6.2.2).
+    auto* slot_context = input_slot_context(slot);
+    u8 parent_hub_port = device.port();
+    u32 device_route = 0;
+    for (auto const* hub = device.hub(); hub != &m_root_hub->hub(); hub = hub->hub()) {
+        device_route <<= 4;
+        device_route |= min(parent_hub_port, 15);
+        parent_hub_port = hub->port();
+    }
+    //   * Root Hub Port Number = Topology defined.
+    slot_context->root_hub_port_number = parent_hub_port;
+    //   * Route String = Topology defined. Refer to section 8.9 in the USB3 spec. Note that the Route String does not include the Root Hub Port Number.
+    slot_context->route_string = device_route;
+    //   * Context Entries = 1.
+    slot_context->context_entries = 1;
+    //   * Interrupter Target = System defined.
+    slot_context->interrupter_target = 0; // TODO: Support more than one interrupter using MSI/MSI-X
+    //   * Speed = Defined by downstream facing port attached to the device
+    USB::Device::DeviceSpeed speed = device.speed();
+    if (device_route == 0) { // If this is a root hub port, use the PORTSC Port Speed instead of relying on the fake hub reported speed
+        auto port_speed = m_operational_registers.port_registers[device.port() - 1].port_status_and_control.port_speed;
+        slot_context->speed = port_speed;
+        switch (port_speed) {
+        case 1:
+            speed = USB::Device::DeviceSpeed::FullSpeed;
+            break;
+        case 2:
+            speed = USB::Device::DeviceSpeed::LowSpeed;
+            break;
+        case 3:
+            speed = USB::Device::DeviceSpeed::HighSpeed;
+            break;
+        case 4:
+            speed = USB::Device::DeviceSpeed::SuperSpeed;
+            break;
+        default:
+            dmesgln_pci(*this, "Unknown port speed reported ({}), assuming SuperSpeed/USB3", port_speed);
+            speed = USB::Device::DeviceSpeed::SuperSpeed;
+            break;
+        }
+    } else {
+        switch (speed) {
+        case USB::Device::DeviceSpeed::LowSpeed:
+            slot_context->speed = 2;
+            break;
+        case USB::Device::DeviceSpeed::FullSpeed:
+            slot_context->speed = 1;
+            break;
+        case USB::Device::DeviceSpeed::HighSpeed:
+            slot_context->speed = 3;
+            break;
+        case USB::Device::DeviceSpeed::SuperSpeed:
+            slot_context->speed = 4;
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+    //   * If the device is a Low-/Full-speed function or hub accessed through a High-speed hub, then the following values are derived from the “parent” High-speed hub whose downstream facing port isolates the High-speed signaling environment from the Low-/Full-speed signaling environment:
+    if (device_route != 0 && (speed == USB::Device::DeviceSpeed::LowSpeed || speed == USB::Device::DeviceSpeed::FullSpeed) && device.hub()->speed() == USB::Device::DeviceSpeed::HighSpeed) {
+        // * MTT = '1' if the Multi-TT Interface of the hub has been enabled with a Set Interface request, otherwise '0'. Software shall issue a Set Interface request to select the Multi-TT interface of the hub prior to issuing any transactions to devices attached to the hub.
+        slot_context->multi_transaction_translator = 0;
+        // * Parent Port Number = The number of the downstream facing port in the parent High-speed hub that the device is accessed through.
+        slot_context->parent_port_number = device.port();
+        // * Parent Hub Slot ID = The Slot ID of the parent High-speed hub.
+        slot_context->parent_hub_slot_id = device.hub()->controller_identifier();
+    }
+
+    //   4.  Allocate and initialize the Transfer Ring for the Default Control Endpoint.
+    //   Refer to section 4.9 for TRB Ring initialization requirements and to section 6.4 for the formats of TRBs
+    slot_state.endpoint_rings[0].region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up(endpoint_ring_size * sizeof(TransferRequestBlock))), "xHCI Endpoint Rings"sv, Memory::Region::ReadWrite));
+    auto* endpoint_ring_memory = slot_state.endpoint_rings[0].ring_vaddr();
+    endpoint_ring_memory[endpoint_ring_size - 1].generic.transfer_request_block_type = TransferRequestBlock::TRBType::Link;
+    auto endpoint_ring_address = slot_state.endpoint_rings[0].ring_paddr();
+    endpoint_ring_memory[endpoint_ring_size - 1].link.ring_segment_pointer_low = endpoint_ring_address;
+    endpoint_ring_memory[endpoint_ring_size - 1].link.ring_segment_pointer_high = endpoint_ring_address >> 32;
+    endpoint_ring_memory[endpoint_ring_size - 1].link.toggle_cycle = 1;
+
+    //   5. Initialize the Input default control Endpoint 0 Context (6.2.3).
+    auto* endpoint_context = input_endpoint_context(slot, 0, Pipe::Direction::Bidirectional);
+    //   * EP Type = Control.
+    endpoint_context->endpoint_type = EndpointContext::EndpointType::Control_Bidirectional;
+    //   * Max Packet Size = The default maximum packet size for the Default Control Endpoint, as function of the PORTSC Port Speed field.
+    u16 default_max_packet_size;
+    switch (speed) {
+    case USB::Device::DeviceSpeed::LowSpeed:
+    case USB::Device::DeviceSpeed::FullSpeed:
+        default_max_packet_size = 8;
+        break;
+    case USB::Device::DeviceSpeed::HighSpeed:
+        default_max_packet_size = 64;
+        break;
+    case USB::Device::DeviceSpeed::SuperSpeed:
+        default_max_packet_size = 512;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+    endpoint_context->max_packet_size = default_max_packet_size;
+    //   * Max Burst Size = 0.
+    endpoint_context->max_burst_size = 0;
+    //   * TR Dequeue Pointer = Start address of first segment of the Default Control Endpoint Transfer Ring.
+    endpoint_context->transfer_ring_dequeue_pointer_low = endpoint_ring_address >> 4;
+    endpoint_context->transfer_ring_dequeue_pointer_high = endpoint_ring_address >> 32;
+    //   * Dequeue Cycle State (DCS) = 1. Reflects Cycle bit state for valid TRBs written by software.
+    endpoint_context->dequeue_cycle_state = 1;
+    //   * Interval = 0.
+    endpoint_context->interval = 0;
+    //   * Max Primary Streams (MaxPStreams) = 0.
+    endpoint_context->max_primary_streams = 0;
+    //   * Mult = 0.
+    endpoint_context->mult = 0;
+    //   * Error Count (CErr) = 3.
+    endpoint_context->error_count = 3;
+    //   "Reasonable initial values of Average TRB Length for Control endpoints would be 8B"
+    endpoint_context->average_transfer_request_block = 8;
+
+    //   6. Allocate the Output Device Context data structure (6.2.1) and initialize it to ‘0’.
+    slot_state.device_context_region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up(device_context_size())), "xHCI Device Context"sv, Memory::Region::ReadWrite));
+
+    //   7. Load the appropriate (Device Slot ID) entry in the Device Context Base Address Array (5.4.6) with a pointer to the Output Device Context data structure (6.2.1).
+    m_device_context_base_address_array[slot] = slot_state.device_context_region->physical_page(0)->paddr().get();
+
+    // 6. Once the slot related data structures are initialized, system software shall use an Address Device Command to assign an address to the device and enable its Default Control Endpoint,
+    // as described in section 4.3.4.
+    auto input_context_address = slot_state.input_context_region->physical_page(0)->paddr().get();
+    TRY(address_device(slot, input_context_address));
+    auto new_address = device_slot_context(slot)->usb_device_address + 1; // We add 1 to the address since we use 1 as the fake address for the root hub
+    device.set_address<xHCIController>({}, new_address);
+    dbgln_if(USB_DEBUG, "USB Device: Set address to {}", new_address);
+
+    // 7. For LS, HS, and SS devices; 8, 64, and 512 bytes, respectively, are the only packet sizes allowed for the Default Control Endpoint, so this step may be skipped.
+    // For FS devices, system software should initially read the first 8 bytes of the USB Device Descriptor to retrieve the value of the bMaxPacketSize0 field and determine the actual Max Packet Size for the Default Control Endpoint,
+    // by issuing a USB GET_DESCRIPTOR request to the device, update the Default Control Endpoint Context with the actual Max Packet Size and inform the xHC of the context change.
+    constexpr u8 short_device_descriptor_length = 8;
+    USBDeviceDescriptor dev_descriptor {};
+    auto transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, short_device_descriptor_length, &dev_descriptor));
+    if (transfer_length < short_device_descriptor_length) {
+        dmesgln_pci(*this, "USB Device did not return enough bytes for short device descriptor - Expected {} but got {}", short_device_descriptor_length, transfer_length);
+        return EIO;
+    }
+    VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
+    device.set_max_packet_size<xHCIController>({}, dev_descriptor.max_packet_size);
+    if (speed == USB::Device::DeviceSpeed::FullSpeed && dev_descriptor.max_packet_size != 8) {
+        control_context->drop_contexts = 0;
+        control_context->add_contexts = (1 << 1);
+        endpoint_context->max_packet_size = dev_descriptor.max_packet_size;
+        TRY(evaluate_context(slot, input_context_address));
+    }
+
+    // 8. Now that the Default Control Endpoint is fully operational, system software may read the complete USB Device Descriptor and possibly the Configuration Descriptors so that it can hand the device off to the appropriate Class Driver(s).
+    transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, sizeof(USBDeviceDescriptor), &dev_descriptor));
+    if (transfer_length < sizeof(USBDeviceDescriptor)) {
+        dmesgln_pci(*this, "USB Device did not return enough bytes for device descriptor - Expected {} but got {}", sizeof(USBDeviceDescriptor), transfer_length);
+        return EIO;
+    }
+    VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
+    device.set_descriptor<xHCIController>({}, dev_descriptor);
+
+    // If the device is a hub:
+    if (dev_descriptor.device_class == USB_CLASS_HUB) {
+        USBHubDescriptor hub_descriptor {};
+        transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST | USB_REQUEST_TYPE_CLASS, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_HUB << 8), 0, sizeof(USBHubDescriptor), &hub_descriptor));
+        if (transfer_length < sizeof(USBHubDescriptor)) {
+            dmesgln_pci(*this, "USB Device did not return enough bytes for hub descriptor - Expected {} but got {}", sizeof(USBHubDescriptor), transfer_length);
+            return EIO;
+        }
+        control_context->drop_contexts = 0;
+        control_context->add_contexts = (1 << 0);
+        // * Hub = ‘1’.
+        slot_context->hub = 1;
+        // * Number of Ports = bNbrPorts from the USB Hub Descriptor.
+        slot_context->number_of_ports = hub_descriptor.number_of_downstream_ports;
+        // * If the device Speed = High-Speed (‘3’):
+        if (speed == USB::Device::DeviceSpeed::HighSpeed) {
+            // * TT Think Time (TTT) = Value of the TT Think Time sub-field (USB2 spec, Table 11-13) in the Hub Descriptor:wHubCharacteristics field.
+            slot_context->transaction_translator_think_time = hub_descriptor.hub_characteristics.usb2.transaction_translator_think_time;
+            // * Multi-TT (MTT) = '1' if the Multi-TT Interface of the hub has been enabled with a Set Interface request, otherwise '0'.
+            slot_context->multi_transaction_translator = 0;
+        }
+        TRY(evaluate_context(slot, input_context_address));
+    }
+
+    // Fetch the configuration descriptors from the device
+    auto& configurations = device.configurations<xHCIController>({});
+    configurations.ensure_capacity(dev_descriptor.num_configurations);
+    for (auto configuration = 0u; configuration < dev_descriptor.num_configurations; configuration++) {
+        USBConfigurationDescriptor configuration_descriptor;
+        transfer_length = TRY(device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8u) | configuration, 0, sizeof(USBConfigurationDescriptor), &configuration_descriptor));
+        if (transfer_length < sizeof(USBConfigurationDescriptor)) {
+            dbgln_if(XHCI_DEBUG, "xHCI: Did not receive enough bytes for configuration descriptor - Expected {} but got {}", sizeof(USBConfigurationDescriptor), transfer_length);
+            continue;
+        }
+        USBConfiguration device_configuration(device, configuration_descriptor);
+        TRY(device_configuration.enumerate_interfaces());
+        configurations.append(device_configuration);
+    }
+
+    return {};
+}
+
+void xHCIController::cancel_async_transfer(NonnullLockRefPtr<Transfer>)
+{
+    TODO();
+}
+
+ErrorOr<void> xHCIController::enqueue_transfer(u8 slot, u8 endpoint, Pipe::Direction direction, Span<TransferRequestBlock> transfer_request_blocks, PendingTransfer& pending_transfer)
+{
+    VERIFY(transfer_request_blocks.size() > 0);
+    VERIFY(transfer_request_blocks.size() < endpoint_ring_size);
+    SpinlockLocker const locker(m_slots_state[slot - 1].lock);
+
+    auto& endpoint_ring = m_slots_state[slot - 1].endpoint_rings[endpoint_index(endpoint, direction) - 1];
+    VERIFY(endpoint_ring.region);
+    if (transfer_request_blocks.size() > endpoint_ring.free_transfer_request_blocks)
+        return ENOBUFS;
+    endpoint_ring.free_transfer_request_blocks -= transfer_request_blocks.size();
+
+    auto* ring_memory = endpoint_ring.ring_vaddr();
+    auto first_trb_index = endpoint_ring.enqueue_index;
+    auto last_trb_index = 0u;
+    for (auto i = 0u; i < transfer_request_blocks.size(); i++) {
+        transfer_request_blocks[i].generic.cycle_bit = endpoint_ring.producer_cycle_state ^ (i == 0);
+        ring_memory[endpoint_ring.enqueue_index] = transfer_request_blocks[i];
+
+        last_trb_index = endpoint_ring.enqueue_index;
+        endpoint_ring.enqueue_index++;
+
+        if (endpoint_ring.enqueue_index == (endpoint_ring_size - 1)) {
+            // Reached Link TRB, flip cycle bit and return to start
+            ring_memory[endpoint_ring.enqueue_index].link.chain_bit = transfer_request_blocks[i].generic.chain_bit; // Make sure we don't interrupt a multi-TRB chain
+            ring_memory[endpoint_ring.enqueue_index].link.cycle_bit = endpoint_ring.producer_cycle_state;
+            endpoint_ring.enqueue_index = 0;
+            endpoint_ring.producer_cycle_state ^= 1;
+        }
+    }
+
+    pending_transfer.start_index = first_trb_index;
+    pending_transfer.end_index = last_trb_index;
+    endpoint_ring.pending_transfers.append(pending_transfer);
+
+    atomic_thread_fence(MemoryOrder::memory_order_seq_cst);
+
+    ring_memory[first_trb_index].generic.cycle_bit ^= 1;
+
+    atomic_thread_fence(MemoryOrder::memory_order_seq_cst);
+
+    ring_endpoint_doorbell(slot, endpoint, direction);
+
+    return {};
+}
+
+ErrorOr<size_t> xHCIController::submit_control_transfer(Transfer& transfer)
+{
+    dbgln_if(XHCI_DEBUG, "xHCI: Received control transfer for address {}", transfer.pipe().device().address());
+
+    // Short-circuit the root hub.
+    if (transfer.pipe().device().address() == m_root_hub->device_address())
+        return m_root_hub->handle_control_transfer(transfer);
+
+    bool const direction_in = (transfer.request().request_type & USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST) == USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST;
+    auto const& device = transfer.pipe().device();
+    auto const slot = device.controller_identifier();
+
+    TransferRequestBlock transfer_request_blocks[3] {};
+    auto trb_index = 0u;
+
+    auto* setup_trb = &transfer_request_blocks[trb_index++];
+    memcpy(setup_trb, &transfer.request(), sizeof(USBRequestData));
+    setup_trb->setup_stage.transfer_request_block_transfer_length = 8; // Always 8.
+    setup_trb->setup_stage.interrupter_target = 0;
+    setup_trb->setup_stage.interrupt_on_completion = 0;
+    setup_trb->setup_stage.immediate_data = 1; // This bit shall be set to ‘1’ in a Setup Stage TRB
+    setup_trb->setup_stage.transfer_request_block_type = TransferRequestBlock::TRBType::Setup_Stage;
+    if (transfer.transfer_data_size() > 0)
+        setup_trb->setup_stage.transfer_type = direction_in ? TransferRequestBlock::TransferType::IN_Data_Stage : TransferRequestBlock::TransferType::OUT_Data_Stage;
+    else
+        setup_trb->setup_stage.transfer_type = TransferRequestBlock::TransferType::No_Data_Stage;
+
+    if (transfer.transfer_data_size() > 0) {
+        auto* data_trb = &transfer_request_blocks[trb_index++];
+        auto data_buffer_paddr = transfer.buffer_physical().get() + sizeof(USBRequestData); // FIXME: This is an ugly hack in the USB subsystem that works around a UHCI-specific issue, get rid of this
+        data_trb->data_stage.data_buffer_low = data_buffer_paddr;
+        data_trb->data_stage.data_buffer_high = data_buffer_paddr >> 32;
+        data_trb->data_stage.transfer_request_block_transfer_length = transfer.transfer_data_size();
+        data_trb->data_stage.transfer_descriptor_size = 0;
+        data_trb->data_stage.interrupter_target = 0;
+        data_trb->data_stage.chain_bit = 0;
+        data_trb->data_stage.interrupt_on_completion = 0;
+        data_trb->data_stage.immediate_data = 0;
+        data_trb->data_stage.transfer_request_block_type = TransferRequestBlock::TRBType::Data_Stage;
+        data_trb->data_stage.direction = direction_in;
+    }
+
+    auto* status_trb = &transfer_request_blocks[trb_index++];
+    status_trb->status_stage.interrupter_target = 0;
+    status_trb->status_stage.chain_bit = 0;
+    status_trb->status_stage.interrupt_on_completion = 1;
+    status_trb->status_stage.transfer_request_block_type = TransferRequestBlock::TRBType::Status_Stage;
+    status_trb->status_stage.direction = !direction_in || transfer.transfer_data_size() == 0;
+
+    SyncPendingTransfer pending_transfer;
+    TRY(enqueue_transfer(slot, 0, Pipe::Direction::Bidirectional, { transfer_request_blocks, trb_index }, pending_transfer));
+    pending_transfer.wait_queue.wait_forever();
+    VERIFY(!pending_transfer.endpoint_list_node.is_in_list());
+
+    if (pending_transfer.completion_code != TransferRequestBlock::CompletionCode::Success)
+        return EINVAL;
+
+    return transfer.transfer_data_size() - pending_transfer.remainder;
+}
+
+ErrorOr<size_t> xHCIController::submit_bulk_transfer(Transfer&)
+{
+    dmesgln_pci(*this, "TODO: Support submitting bulk transfers");
+    return ENOTIMPL;
+}
+
+ErrorOr<void> xHCIController::submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16)
+{
+    dbgln_if(XHCI_DEBUG, "xHCI: Received async interrupt transfer for address {}", transfer->pipe().device().address());
+
+    TRY(initialize_endpoint_if_needed(transfer->pipe()));
+
+    auto const& device = transfer->pipe().device();
+    auto const slot = device.controller_identifier();
+    u32 max_burst_payload = 0;
+    {
+        auto endpoint_id = endpoint_index(transfer->pipe().endpoint_address(), transfer->pipe().direction());
+        SpinlockLocker locker(m_slots_state[slot - 1].lock);
+        max_burst_payload = m_slots_state[slot - 1].endpoint_rings[endpoint_id - 1].max_burst_payload;
+    }
+    VERIFY(max_burst_payload > 0);
+    u32 total_transfer_size = transfer->transfer_data_size();
+    auto transfer_request_blocks_count = ceil_div(total_transfer_size, max_burst_payload);
+    Vector<TransferRequestBlock> transfer_request_blocks;
+    TRY(transfer_request_blocks.try_resize(transfer_request_blocks_count));
+    auto offset = 0u;
+    for (auto i = 0u; i < transfer_request_blocks_count; ++i) {
+        auto& transfer_request_block = transfer_request_blocks[i];
+        auto buffer_pointer = transfer->buffer_physical().get() + offset;
+        transfer_request_block.normal.data_buffer_pointer_low = buffer_pointer;
+        transfer_request_block.normal.data_buffer_pointer_high = buffer_pointer >> 32;
+        auto remaining = total_transfer_size - offset;
+        auto trb_transfer_length = remaining < max_burst_payload ? remaining : max_burst_payload;
+        transfer_request_block.normal.transfer_request_block_transfer_length = trb_transfer_length;
+        offset += trb_transfer_length;
+        transfer_request_block.normal.transfer_descriptor_size = min(ceil_div(remaining, (u32)transfer->pipe().max_packet_size()), 31);
+        transfer_request_block.normal.interrupter_target = 0;
+        if (i != (transfer_request_blocks_count - 1))
+            transfer_request_block.normal.chain_bit = 1;
+        else
+            transfer_request_block.normal.interrupt_on_completion = 1;
+        transfer_request_block.normal.transfer_request_block_type = TransferRequestBlock::TRBType::Normal;
+    }
+
+    NonnullOwnPtr<PeriodicPendingTransfer> pending_transfer = TRY(adopt_nonnull_own_or_enomem(new (nothrow) PeriodicPendingTransfer({}, move(transfer_request_blocks), move(transfer))));
+    TRY(enqueue_transfer(slot, pending_transfer->original_transfer->pipe().endpoint_address(), pending_transfer->original_transfer->pipe().direction(), pending_transfer->transfer_request_blocks, *pending_transfer));
+    TRY(m_active_periodic_transfers.try_append(move(pending_transfer)));
+
+    return {};
+}
+
+ErrorOr<void> xHCIController::initialize_endpoint_if_needed(Pipe const& pipe)
+{
+    VERIFY(pipe.endpoint_address() != 0); // Endpoint 0 is manually initialized during device initialization
+    auto const slot = pipe.device().controller_identifier();
+    auto& slot_state = m_slots_state[slot - 1];
+    SpinlockLocker locker(slot_state.lock);
+    VERIFY(slot_state.input_context_region);
+    auto endpoint_id = endpoint_index(pipe.endpoint_address(), pipe.direction());
+    auto& endpoint_ring = slot_state.endpoint_rings[endpoint_id - 1];
+    if (endpoint_ring.region)
+        return {}; // Already initialized
+
+    endpoint_ring.region = TRY(MM.allocate_dma_buffer_pages(MUST(Memory::page_round_up(endpoint_ring_size * sizeof(TransferRequestBlock))), "xHCI Endpoint Rings"sv, Memory::Region::ReadWrite));
+    auto* endpoint_ring_memory = endpoint_ring.ring_vaddr();
+    endpoint_ring_memory[endpoint_ring_size - 1].generic.transfer_request_block_type = TransferRequestBlock::TRBType::Link;
+    auto endpoint_ring_address = endpoint_ring.ring_paddr();
+    endpoint_ring_memory[endpoint_ring_size - 1].link.ring_segment_pointer_low = endpoint_ring_address;
+    endpoint_ring_memory[endpoint_ring_size - 1].link.ring_segment_pointer_high = endpoint_ring_address >> 32;
+    endpoint_ring_memory[endpoint_ring_size - 1].link.toggle_cycle = 1;
+
+    endpoint_ring.type = pipe.type();
+
+    auto input_context_address = slot_state.input_context_region->physical_page(0)->paddr().get();
+    auto* control_context = input_control_context(slot);
+    if (device_slot_context(slot)->context_entries < endpoint_id) {
+        control_context->drop_contexts = 0;
+        control_context->add_contexts = (1 << 0);
+        input_slot_context(slot)->context_entries = endpoint_id;
+        TRY(evaluate_context(slot, input_context_address));
+    }
+
+    control_context->drop_contexts = 0;
+    control_context->add_contexts = (1 << 0) | (1 << endpoint_id);
+
+    auto* endpoint_context = input_endpoint_context(slot, pipe.endpoint_address(), pipe.direction());
+    switch (pipe.type()) {
+    case Pipe::Type::Isochronous:
+        if (pipe.direction() == Pipe::Direction::In)
+            endpoint_context->endpoint_type = EndpointContext::EndpointType::Isoch_In;
+        else
+            endpoint_context->endpoint_type = EndpointContext::EndpointType::Isoch_Out;
+        break;
+    case Pipe::Type::Bulk:
+        if (pipe.direction() == Pipe::Direction::In)
+            endpoint_context->endpoint_type = EndpointContext::EndpointType::Bulk_In;
+        else
+            endpoint_context->endpoint_type = EndpointContext::EndpointType::Bulk_Out;
+        break;
+    case Pipe::Type::Interrupt:
+        if (pipe.direction() == Pipe::Direction::In)
+            endpoint_context->endpoint_type = EndpointContext::EndpointType::Interrupt_In;
+        else
+            endpoint_context->endpoint_type = EndpointContext::EndpointType::Interrupt_Out;
+        break;
+    case Pipe::Type::Control: // The control pipe is configured during device initialization
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    // FIXME: We should be all three of these somehow from the SuperSpeedEndpointCompanionDescriptor/SuperSpeedPlusEndpointCompanionDescriptor for SuperSpeed/SuperSpeedPlus devices
+    if (pipe.type() == Pipe::Type::Isochronous || pipe.type() == Pipe::Type::Interrupt) {
+        endpoint_context->max_packet_size = pipe.max_packet_size() & 0x7FF;
+        endpoint_context->max_burst_size = (pipe.max_packet_size() & 0x1800) >> 11;
+    } else {
+        endpoint_context->max_packet_size = pipe.max_packet_size();
+        endpoint_context->max_burst_size = 0;
+    }
+    // The Max Burst Payload (MBP) is the number of bytes moved by a maximum sized burst, i.e. (Max Burst Size + 1) * Max Packet Size bytes.
+    endpoint_ring.max_burst_payload = endpoint_context->max_packet_size * (endpoint_context->max_burst_size + 1);
+    if (pipe.type() == Pipe::Type::Isochronous || pipe.type() == Pipe::Type::Interrupt) {
+        endpoint_context->max_endpoint_service_time_interval_payload_low = endpoint_ring.max_burst_payload;
+        endpoint_context->max_endpoint_service_time_interval_payload_high = endpoint_ring.max_burst_payload >> 16;
+    }
+
+    endpoint_context->transfer_ring_dequeue_pointer_low = endpoint_ring_address >> 4;
+    endpoint_context->transfer_ring_dequeue_pointer_high = endpoint_ring_address >> 32;
+    endpoint_context->dequeue_cycle_state = 1;
+
+    if (pipe.type() == Pipe::Type::Bulk) {
+        endpoint_context->interval = 0;
+    } else {
+        u16 base_interval = 0;
+        if (pipe.type() == Pipe::Type::Isochronous) {
+            TODO(); // TODO: Fetch Isoch interval once we support Isoch pipes
+        } else if (pipe.type() == Pipe::Type::Interrupt) {
+            if (pipe.direction() == Pipe::Direction::In)
+                base_interval = static_cast<InterruptInPipe const&>(pipe).poll_interval();
+            else
+                base_interval = static_cast<InterruptOutPipe const&>(pipe).poll_interval();
+        }
+        // Table 6-12: Endpoint Type vs. Interval Calculation
+        switch (pipe.device().speed()) {
+        case USB::Device::DeviceSpeed::FullSpeed:
+            if (pipe.type() == Pipe::Type::Isochronous) {
+                endpoint_context->interval = min(max(base_interval, 1), 16) + 2;
+                break;
+            }
+            [[fallthrough]];
+        case USB::Device::DeviceSpeed::LowSpeed:
+            endpoint_context->interval = count_required_bits(min(max(base_interval, 1), 255)) + 2;
+            break;
+        case USB::Device::DeviceSpeed::HighSpeed:
+        case USB::Device::DeviceSpeed::SuperSpeed:
+            endpoint_context->interval = min(max(base_interval, 1), 16) - 1;
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    endpoint_context->max_primary_streams = 0;
+    if (pipe.type() == Pipe::Type::Isochronous) {
+        endpoint_context->mult = 0; // FIXME: We should be getting this somehow from the SuperSpeedEndpointCompanionDescriptor for SuperSpeed devices
+        endpoint_context->error_count = 0;
+    } else {
+        endpoint_context->mult = 0;
+        endpoint_context->error_count = 3;
+    }
+
+    // "Reasonable initial values of Average TRB Length for Control endpoints would be 8B, Interrupt endpoints 1KB, and Bulk and Isoch endpoints 3KB."
+    switch (pipe.type()) {
+    case Pipe::Type::Isochronous:
+    case Pipe::Type::Bulk:
+        endpoint_context->average_transfer_request_block = 3 * KiB;
+        break;
+    case Pipe::Type::Interrupt:
+        endpoint_context->average_transfer_request_block = 1 * KiB;
+        break;
+    case Pipe::Type::Control:
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    return configure_endpoint(slot, input_context_address);
+}
+
+ErrorOr<HubStatus> xHCIController::get_port_status(Badge<xHCIRootHub>, u8 port)
+{
+    dbgln_if(XHCI_DEBUG, "xHCI: get port status for port {}", port);
+    if (port >= m_ports)
+        return EINVAL;
+
+    PortStatusAndControl const port_status { .raw = m_operational_registers.port_registers[port].port_status_and_control.raw };
+    HubStatus hub_status {};
+    if (port_status.current_connect_status)
+        hub_status.status |= PORT_STATUS_CURRENT_CONNECT_STATUS;
+    if (port_status.connect_status_change)
+        hub_status.change |= PORT_STATUS_CONNECT_STATUS_CHANGED;
+    if (port_status.port_enabled_disabled)
+        hub_status.status |= PORT_STATUS_PORT_ENABLED;
+    if (port_status.port_enabled_disabled_change)
+        hub_status.change |= PORT_STATUS_PORT_ENABLED_CHANGED;
+    if (port_status.port_reset)
+        hub_status.status |= PORT_STATUS_RESET;
+    if (port_status.port_reset_change)
+        hub_status.change |= PORT_STATUS_RESET_CHANGED;
+    if (port_status.over_current_active)
+        hub_status.status |= PORT_STATUS_OVER_CURRENT;
+    if (port_status.over_current_change)
+        hub_status.change |= HUB_STATUS_OVER_CURRENT_CHANGED;
+    if (port_status.port_power) {
+        if (m_port_max_speeds[port] == USB::Device::DeviceSpeed::SuperSpeed)
+            hub_status.status |= SUPERSPEED_PORT_STATUS_POWER;
+        else
+            hub_status.status |= PORT_STATUS_PORT_POWER;
+    }
+    if (m_port_max_speeds[port] != USB::Device::DeviceSpeed::SuperSpeed) {
+        if (port_status.port_speed == 2)
+            hub_status.status |= PORT_STATUS_LOW_SPEED_DEVICE_ATTACHED;
+        else if (port_status.port_speed == 3)
+            hub_status.status |= PORT_STATUS_HIGH_SPEED_DEVICE_ATTACHED;
+    }
+    return hub_status;
+}
+
+ErrorOr<void> xHCIController::set_port_feature(Badge<xHCIRootHub>, u8 port, HubFeatureSelector feature)
+{
+    dbgln_if(XHCI_DEBUG, "xHCI: set port feature {} for port {}", (u8)feature, port);
+    if (port >= m_ports)
+        return EINVAL;
+
+    // The PORTSC must be read/written manually since it has RW1C/S fields which will change state given a normal read-modify-write sequence
+    PortStatusAndControl port_status { .raw = m_operational_registers.port_registers[port].port_status_and_control.raw };
+    // clear RW1C/S fields
+    port_status.port_enabled_disabled = 0;
+    port_status.port_reset = 0;
+    port_status.connect_status_change = 0;
+    port_status.port_enabled_disabled_change = 0;
+    port_status.warm_port_reset_change = 0;
+    port_status.over_current_change = 0;
+    port_status.port_reset_change = 0;
+    port_status.port_link_state_change = 0;
+    port_status.port_config_error_change = 0;
+    switch (feature) {
+    case HubFeatureSelector::PORT_POWER:
+        port_status.port_power = 1;
+        break;
+    case HubFeatureSelector::PORT_RESET:
+        port_status.port_reset = 1;
+        break;
+    case HubFeatureSelector::PORT_SUSPEND:
+        if (!m_operational_registers.port_registers[port].port_status_and_control.port_enabled_disabled     // Port disabled
+            || m_operational_registers.port_registers[port].port_status_and_control.port_reset              // Port resetting
+            || m_operational_registers.port_registers[port].port_status_and_control.port_link_state >= 3) { // Port is not in suspendable state
+            dmesgln_pci(*this, "Attempt to suspend port {} in non-suspendable state", port);
+            return EINVAL;
+        }
+        port_status.port_link_state_write_strobe = 1;
+        port_status.port_link_state = 3;
+        break;
+    default:
+        dmesgln_pci(*this, "Attempt to set unknown feature {} for port {}", (u8)feature, port);
+        return EINVAL;
+    }
+    m_operational_registers.port_registers[port].port_status_and_control.raw = port_status.raw;
+
+    return {};
+}
+
+ErrorOr<void> xHCIController::clear_port_feature(Badge<xHCIRootHub>, u8 port, HubFeatureSelector feature)
+{
+    dbgln_if(XHCI_DEBUG, "xHCI: clear port feature {} for port {}", (u8)feature, port);
+    if (port >= m_ports)
+        return EINVAL;
+
+    // The PORTSC must be read/written manually since it has RW1C/S fields which will change state given a normal read-modify-write sequence
+    PortStatusAndControl port_status { .raw = m_operational_registers.port_registers[port].port_status_and_control.raw };
+    // clear RW1C/S fields
+    port_status.port_enabled_disabled = 0;
+    port_status.port_reset = 0;
+    port_status.connect_status_change = 0;
+    port_status.port_enabled_disabled_change = 0;
+    port_status.warm_port_reset_change = 0;
+    port_status.over_current_change = 0;
+    port_status.port_reset_change = 0;
+    port_status.port_link_state_change = 0;
+    port_status.port_config_error_change = 0;
+    switch (feature) {
+    case HubFeatureSelector::PORT_ENABLE:
+        port_status.port_enabled_disabled = 1;
+        break;
+    case HubFeatureSelector::PORT_SUSPEND:
+        if (!m_operational_registers.port_registers[port].port_status_and_control.port_enabled_disabled     // Port disabled
+            || m_operational_registers.port_registers[port].port_status_and_control.port_reset              // Port resetting
+            || m_operational_registers.port_registers[port].port_status_and_control.port_link_state != 3) { // Port is not in suspended state
+            dmesgln_pci(*this, "Attempt to un-suspend port {} in non-suspended state", port);
+            return EINVAL;
+        }
+        port_status.port_link_state_write_strobe = 1;
+        port_status.port_link_state = 0;
+        break;
+    case HubFeatureSelector::PORT_POWER:
+        port_status.port_power = 0;
+        break;
+    case HubFeatureSelector::C_PORT_CONNECTION:
+        port_status.connect_status_change = 1;
+        break;
+    case HubFeatureSelector::C_PORT_RESET:
+        port_status.port_reset_change = 1;
+        break;
+    case HubFeatureSelector::C_PORT_ENABLE:
+        port_status.port_enabled_disabled_change = 1;
+        break;
+    case HubFeatureSelector::C_PORT_LINK_STATE:
+        port_status.port_link_state_change = 1;
+        break;
+    case HubFeatureSelector::C_PORT_OVER_CURRENT:
+        port_status.over_current_change = 1;
+        break;
+    default:
+        dmesgln_pci(*this, "Attempt to clear unknown feature {} for port {}", (u8)feature, port);
+        return EINVAL;
+    }
+    m_operational_registers.port_registers[port].port_status_and_control.raw = port_status.raw;
+
+    return {};
+}
+
+void xHCIController::handle_interrupt(Badge<xHCIInterrupter>, u16 interrupter_id)
+{
+    VERIFY(interrupter_id == 0);
+    // The USBSTS must be read/written manually since it has RW1C/S fields which will change state given a normal read-modify-write sequence
+    USBStatus usb_status { .raw = m_operational_registers.usb_status.raw };
+    m_operational_registers.usb_status.raw = usb_status.raw; // Clear pending status bits
+
+    if (!m_using_message_signalled_interrupts) // MSI/MSI-X automatically clears the interrupt pending flag, otherwise, clear it manually
+        m_runtime_registers.interrupter_registers[0].interrupter_management.interrupt_pending = 1;
+
+    if (usb_status.host_controller_halted) {
+        dmesgln_pci(*this, "Host controller halted unexpectedly");
+        return;
+    }
+    if (usb_status.host_system_error) {
+        dmesgln_pci(*this, "Host system error");
+        return;
+    }
+    if (usb_status.host_controller_error) {
+        dmesgln_pci(*this, "Host controller error");
+        return;
+    }
+    if (usb_status.event_interrupt) {
+        m_event_queue.wake_all();
+        return;
+    }
+}
+
+StringView xHCIController::enum_to_string(TransferRequestBlock::CompletionCode completion_code)
+{
+    switch (completion_code) {
+    case TransferRequestBlock::CompletionCode::Invalid:
+        return "Invalid"sv;
+    case TransferRequestBlock::CompletionCode::Success:
+        return "Success"sv;
+    case TransferRequestBlock::CompletionCode::Data_Buffer_Error:
+        return "Data Buffer Error"sv;
+    case TransferRequestBlock::CompletionCode::Babble_Detected_Error:
+        return "Babble Detected Error"sv;
+    case TransferRequestBlock::CompletionCode::USB_Transaction_Error:
+        return "USB Transaction Error"sv;
+    case TransferRequestBlock::CompletionCode::TRB_Error:
+        return "TRB Error"sv;
+    case TransferRequestBlock::CompletionCode::Stall_Error:
+        return "Stall Error"sv;
+    case TransferRequestBlock::CompletionCode::Resource_Error:
+        return "Resource Error"sv;
+    case TransferRequestBlock::CompletionCode::Bandwidth_Error:
+        return "Bandwidth Error"sv;
+    case TransferRequestBlock::CompletionCode::No_Slots_Available_Error:
+        return "No Slots Available Error"sv;
+    case TransferRequestBlock::CompletionCode::Invalid_Stream_Type_Error:
+        return "Invalid Stream Type Error"sv;
+    case TransferRequestBlock::CompletionCode::Slot_Not_Enabled_Error:
+        return "Slot Not Enabled Error"sv;
+    case TransferRequestBlock::CompletionCode::Endpoint_Not_Enabled_Error:
+        return "Endpoint Not Enabled Error"sv;
+    case TransferRequestBlock::CompletionCode::Short_Packet:
+        return "Short Packet"sv;
+    case TransferRequestBlock::CompletionCode::Ring_Underrun:
+        return "Ring Underrun"sv;
+    case TransferRequestBlock::CompletionCode::Ring_Overrun:
+        return "Ring Overrun"sv;
+    case TransferRequestBlock::CompletionCode::VF_Event_Ring_Full_Error:
+        return "VF Event Ring Full Error"sv;
+    case TransferRequestBlock::CompletionCode::Parameter_Error:
+        return "Parameter Error"sv;
+    case TransferRequestBlock::CompletionCode::Bandwidth_Overrun_Error:
+        return "Bandwidth Overrun Error"sv;
+    case TransferRequestBlock::CompletionCode::Context_State_Error:
+        return "Context State Error"sv;
+    case TransferRequestBlock::CompletionCode::No_Ping_Response_Error:
+        return "No Ping Response Error"sv;
+    case TransferRequestBlock::CompletionCode::Event_Ring_Full_Error:
+        return "Event Ring Full Error"sv;
+    case TransferRequestBlock::CompletionCode::Incompatible_Device_Error:
+        return "Incompatible Device Error"sv;
+    case TransferRequestBlock::CompletionCode::Missed_Service_Error:
+        return "Missed Service Error"sv;
+    case TransferRequestBlock::CompletionCode::Command_Ring_Stopped:
+        return "Command Ring Stopped"sv;
+    case TransferRequestBlock::CompletionCode::Command_Aborted:
+        return "Command Aborted"sv;
+    case TransferRequestBlock::CompletionCode::Stopped:
+        return "Stopped"sv;
+    case TransferRequestBlock::CompletionCode::Stopped_Length_Invalid:
+        return "Stopped Length Invalid"sv;
+    case TransferRequestBlock::CompletionCode::Stopped_Short_Packet:
+        return "Stopped Short Packet"sv;
+    case TransferRequestBlock::CompletionCode::Max_Exit_Latency_Too_Large_Error:
+        return "Max Exit Latency Too Large Error"sv;
+    case TransferRequestBlock::CompletionCode::Isoch_Buffer_Overrun:
+        return "Isoch Buffer Overrun"sv;
+    case TransferRequestBlock::CompletionCode::Event_Lost_Error:
+        return "Event Lost Error"sv;
+    case TransferRequestBlock::CompletionCode::Undefined_Error:
+        return "Undefined Error"sv;
+    case TransferRequestBlock::CompletionCode::Invalid_Stream_ID_Error:
+        return "Invalid Stream ID Error"sv;
+    case TransferRequestBlock::CompletionCode::Secondary_Bandwidth_Error:
+        return "Secondary Bandwidth Error"sv;
+    case TransferRequestBlock::CompletionCode::Split_Transaction_Error:
+        return "Split Transaction Error"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+StringView xHCIController::enum_to_string(TransferRequestBlock::TRBType trb_type)
+{
+    switch (trb_type) {
+    case TransferRequestBlock::TRBType::Normal:
+        return "Normal"sv;
+    case TransferRequestBlock::TRBType::Setup_Stage:
+        return "Setup Stage"sv;
+    case TransferRequestBlock::TRBType::Data_Stage:
+        return "Data Stage"sv;
+    case TransferRequestBlock::TRBType::Status_Stage:
+        return "Status Stage"sv;
+    case TransferRequestBlock::TRBType::Isoch:
+        return "Isoch"sv;
+    case TransferRequestBlock::TRBType::Link:
+        return "Link"sv;
+    case TransferRequestBlock::TRBType::Event_Data:
+        return "Event Data"sv;
+    case TransferRequestBlock::TRBType::No_Op:
+        return "No Op"sv;
+    case TransferRequestBlock::TRBType::Enable_Slot_Command:
+        return "Enable Slot Command"sv;
+    case TransferRequestBlock::TRBType::Disable_Slot_Command:
+        return "Disable Slot Command"sv;
+    case TransferRequestBlock::TRBType::Address_Device_Command:
+        return "Address Device Command"sv;
+    case TransferRequestBlock::TRBType::Configure_Endpoint_Command:
+        return "Configure Endpoint Command"sv;
+    case TransferRequestBlock::TRBType::Evaluate_Context_Command:
+        return "Evaluate Context Command"sv;
+    case TransferRequestBlock::TRBType::Reset_Endpoint_Command:
+        return "Reset Endpoint Command"sv;
+    case TransferRequestBlock::TRBType::Stop_Endpoint_Command:
+        return "Stop Endpoint Command"sv;
+    case TransferRequestBlock::TRBType::Set_TR_Dequeue_Pointer_Command:
+        return "Set TR Dequeue Pointer Command"sv;
+    case TransferRequestBlock::TRBType::Reset_Device_Command:
+        return "Reset Device Command"sv;
+    case TransferRequestBlock::TRBType::Force_Event_Command:
+        return "Force Event Command"sv;
+    case TransferRequestBlock::TRBType::Negotiate_Bandwidth_Command:
+        return "Negotiate Bandwidth Command"sv;
+    case TransferRequestBlock::TRBType::Set_Latency_Tolerance_Value_Command:
+        return "Set Latency Tolerance Value Command"sv;
+    case TransferRequestBlock::TRBType::Get_Port_Bandwidth_Command:
+        return "Get Port Bandwidth Command"sv;
+    case TransferRequestBlock::TRBType::Force_Header_Command:
+        return "Force Header Command"sv;
+    case TransferRequestBlock::TRBType::No_Op_Command:
+        return "No Op Command"sv;
+    case TransferRequestBlock::TRBType::Get_Extended_Property_Command:
+        return "Get Extended Property Command"sv;
+    case TransferRequestBlock::TRBType::Set_Extended_Property_Command:
+        return "Set Extended Property Command"sv;
+    case TransferRequestBlock::TRBType::Transfer_Event:
+        return "Transfer Event"sv;
+    case TransferRequestBlock::TRBType::Command_Completion_Event:
+        return "Command Completion Event"sv;
+    case TransferRequestBlock::TRBType::Port_Status_Change_Event:
+        return "Port Status Change Event"sv;
+    case TransferRequestBlock::TRBType::Bandwidth_Request_Event:
+        return "Bandwidth Request Event"sv;
+    case TransferRequestBlock::TRBType::Doorbell_Event:
+        return "Doorbell Event"sv;
+    case TransferRequestBlock::TRBType::Host_Controller_Event:
+        return "Host Controller Event"sv;
+    case TransferRequestBlock::TRBType::Device_Notification_Event:
+        return "Device Notification Event"sv;
+    case TransferRequestBlock::TRBType::Microframe_Index_Wrap_Event:
+        return "Microframe Index Wrap Event"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void xHCIController::handle_transfer_event(TransferRequestBlock const& transfer_request_block)
+{
+    auto slot = transfer_request_block.transfer_event.slot_id;
+    VERIFY(slot > 0 && slot <= m_device_slots);
+    auto& slot_state = m_slots_state[slot - 1];
+    SpinlockLocker const locker(slot_state.lock);
+
+    auto endpoint = transfer_request_block.transfer_event.endpoint_id;
+    VERIFY(endpoint > 0 && endpoint <= max_endpoints);
+    auto& endpoint_ring = slot_state.endpoint_rings[endpoint - 1];
+    VERIFY(endpoint_ring.region);
+
+    if (transfer_request_block.transfer_event.completion_code != TransferRequestBlock::CompletionCode::Success)
+        dmesgln_pci(*this, "Transfer error on slot {} endpoint {}: {}", slot, endpoint, enum_to_string(transfer_request_block.transfer_event.completion_code));
+
+    VERIFY(transfer_request_block.transfer_event.event_data == 0); // The Pointer points to the interrupting TRB
+    auto transfer_request_block_pointer = ((u64)transfer_request_block.transfer_event.transfer_request_block_pointer_high << 32) | transfer_request_block.transfer_event.transfer_request_block_pointer_low;
+    VERIFY(transfer_request_block_pointer % sizeof(TransferRequestBlock) == 0);
+    if (transfer_request_block_pointer < endpoint_ring.ring_paddr() || (transfer_request_block_pointer - endpoint_ring.ring_paddr()) > (endpoint_ring_size * sizeof(TransferRequestBlock))) {
+        dmesgln_pci(*this, "Transfer event on slot {} endpoint {} points to unknown TRB", slot, endpoint);
+        return;
+    }
+    auto transfer_request_block_index = (transfer_request_block_pointer - endpoint_ring.ring_paddr()) / sizeof(TransferRequestBlock);
+    for (auto& pending_transfer : endpoint_ring.pending_transfers) {
+        auto freed_transfer_request_blocks = 0;
+        if (pending_transfer.start_index <= pending_transfer.end_index) {
+            if (pending_transfer.start_index > transfer_request_block_index || transfer_request_block_index > pending_transfer.end_index)
+                continue;
+            freed_transfer_request_blocks = pending_transfer.end_index - pending_transfer.start_index + 1;
+        } else {
+            if (pending_transfer.start_index > transfer_request_block_index && transfer_request_block_index > pending_transfer.end_index)
+                continue;
+            freed_transfer_request_blocks = (endpoint_ring_size - pending_transfer.start_index) + pending_transfer.end_index;
+        }
+        endpoint_ring.free_transfer_request_blocks += freed_transfer_request_blocks;
+        pending_transfer.endpoint_list_node.remove();
+        if (endpoint_ring.type == Pipe::Type::Control || endpoint_ring.type == Pipe::Type::Bulk) {
+            auto& sync_pending_transfer = static_cast<SyncPendingTransfer&>(pending_transfer);
+            sync_pending_transfer.completion_code = transfer_request_block.transfer_event.completion_code;
+            sync_pending_transfer.remainder = transfer_request_block.transfer_event.transfer_request_block_transfer_length;
+            atomic_thread_fence(MemoryOrder::memory_order_seq_cst);
+            sync_pending_transfer.wait_queue.wake_all();
+        } else {
+            auto& periodic_pending_transfer = static_cast<PeriodicPendingTransfer&>(pending_transfer);
+            periodic_pending_transfer.original_transfer->invoke_async_callback();
+            // Reschedule the periodic transfer (NOTE: We MUST() here since a re-enqueue should never fail)
+            MUST(enqueue_transfer(slot, periodic_pending_transfer.original_transfer->pipe().endpoint_address(), periodic_pending_transfer.original_transfer->pipe().direction(), periodic_pending_transfer.transfer_request_blocks, periodic_pending_transfer));
+        }
+        return;
+    }
+    dmesgln_pci(*this, "Transfer event on slot {} endpoint {} points to unowned TRB", slot, endpoint);
+}
+
+void xHCIController::event_handling_thread()
+{
+    while (!Process::current().is_dying()) {
+        m_event_queue.wait_forever(device_name());
+        // Handle up to ring-size events each time
+        for (auto i = 0u; i < event_ring_segment_size; ++i) {
+            // If the Cycle bit of the Event TRB pointed to by the Event Ring Dequeue Pointer equals CCS, then the Event TRB is a valid event,
+            // software processes it and advances the Event Ring Dequeue Pointer.
+            if (m_event_ring_segment[m_event_ring_dequeue_index].generic.cycle_bit != m_event_ring_consumer_cycle_state)
+                break;
+
+            auto event_type = m_event_ring_segment[m_event_ring_dequeue_index].generic.transfer_request_block_type;
+            switch (event_type) {
+            case TransferRequestBlock::TRBType::Transfer_Event:
+                handle_transfer_event(m_event_ring_segment[m_event_ring_dequeue_index]);
+                break;
+            case TransferRequestBlock::TRBType::Command_Completion_Event:
+                // We only process a single command at a time (and the caller holds the m_command_lock throughout), so we only ever have a single
+                // active command result.
+                m_command_result_transfer_request_block = m_event_ring_segment[m_event_ring_dequeue_index];
+                atomic_thread_fence(MemoryOrder::memory_order_seq_cst);
+                m_command_completion_queue.wake_all();
+                break;
+            case TransferRequestBlock::TRBType::Port_Status_Change_Event:
+                dbgln_if(XHCI_DEBUG, "Port status change detected by controller");
+                break;
+            default:
+                dmesgln_pci(*this, "Received unknown event type {} from controller", enum_to_string(event_type));
+                break;
+            }
+
+            m_event_ring_dequeue_index++;
+
+            if (m_event_ring_dequeue_index == event_ring_segment_size) {
+                m_event_ring_dequeue_index = 0;
+                m_event_ring_consumer_cycle_state ^= 1;
+            }
+        }
+        auto new_event_ring_dequeue_pointer = m_event_ring_segment_pointer + (sizeof(TransferRequestBlock) * m_event_ring_dequeue_index);
+        m_runtime_registers.interrupter_registers[0].event_ring_dequeue_pointer.event_ring_dequeue_pointer_low = new_event_ring_dequeue_pointer >> 4;
+        m_runtime_registers.interrupter_registers[0].event_ring_dequeue_pointer.event_ring_dequeue_pointer_high = new_event_ring_dequeue_pointer >> 32;
+    }
+    Thread::current()->exit();
+    VERIFY_NOT_REACHED();
+}
+
+void xHCIController::hot_plug_thread()
+{
+    while (!Process::current().is_dying()) {
+        if (m_root_hub)
+            m_root_hub->check_for_port_updates();
+
+        (void)Thread::current()->sleep(Duration::from_seconds(1));
+    }
+    Thread::current()->exit();
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -1,0 +1,1191 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Bus/USB/xHCI/xHCIRootHub.h>
+#include <Kernel/Memory/TypedMapping.h>
+
+namespace Kernel::USB {
+
+class xHCIInterrupter;
+
+class xHCIController final
+    : public USBController
+    , public PCI::Device {
+public:
+    static ErrorOr<NonnullLockRefPtr<xHCIController>> try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier);
+    virtual ~xHCIController() override;
+
+    virtual StringView device_name() const override { return "xHCI"sv; }
+
+    virtual ErrorOr<void> initialize() override;
+    virtual ErrorOr<void> reset() override;
+    virtual ErrorOr<void> stop() override;
+    virtual ErrorOr<void> start() override;
+
+    virtual void cancel_async_transfer(NonnullLockRefPtr<Transfer> transfer) override;
+    virtual ErrorOr<size_t> submit_control_transfer(Transfer& transfer) override;
+    virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) override;
+    virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) override;
+
+    virtual ErrorOr<void> initialize_device(USB::Device&) override;
+
+    ErrorOr<void> initialize_endpoint_if_needed(Pipe const&);
+
+    u8 ports() const { return m_ports; }
+
+    ErrorOr<HubStatus> get_port_status(Badge<xHCIRootHub>, u8 port);
+    ErrorOr<void> set_port_feature(Badge<xHCIRootHub>, u8 port, HubFeatureSelector);
+    ErrorOr<void> clear_port_feature(Badge<xHCIRootHub>, u8 port, HubFeatureSelector);
+
+    void handle_interrupt(Badge<xHCIInterrupter>, u16 interrupter_id);
+
+private:
+    xHCIController(PCI::DeviceIdentifier const& pci_device_identifier, Memory::TypedMapping<u8> registers_io_window);
+
+    void take_exclusive_control_from_bios();
+    void intel_quirk_enable_xhci_ports();
+    ErrorOr<void> find_port_max_speeds();
+
+    void event_handling_thread();
+    void hot_plug_thread();
+
+    // Arbitrarily chosen to decrease allocation sizes, can be increased up to 256 if we reach this limit
+    static constexpr size_t max_devices = 64;
+
+    static constexpr PCI::RegisterOffset intel_xhci_usb2_port_routing_offset = static_cast<PCI::RegisterOffset>(0xD0);
+    static constexpr PCI::RegisterOffset intel_xhci_usb2_port_routing_mask_offset = static_cast<PCI::RegisterOffset>(0xD4);
+    static constexpr PCI::RegisterOffset intel_xhci_usb3_port_super_speed_enable_offset = static_cast<PCI::RegisterOffset>(0xD8);
+    static constexpr PCI::RegisterOffset intel_xhci_usb3_port_routing_mask_offset = static_cast<PCI::RegisterOffset>(0xDC);
+
+    // 5.3 Host Controller Capability Registers
+    struct CapabilityRegisters {
+        u32 capability_register_length : 8; // CAPLENGTH
+
+        u32 reserved0 : 8; // Rsvd
+
+        u32 host_controller_interface_version_number : 16; // HCIVERSION
+
+        struct {
+            // HCSPARAMS1
+            u32 number_of_device_slots : 8;  // MaxSlots
+            u32 number_of_interrupters : 11; // MaxIntrs
+            u32 reserved0 : 5;               // Rsvd
+            u32 number_of_ports : 8;         // MaxPorts
+            // HCSPARAMS2
+            u32 isochronous_scheduling_threshold : 4; // IST
+            u32 event_ring_segment_table_max : 4;     // ERST Max
+            u32 reserved1 : 13;                       // Rsvd
+            u32 max_scratchpad_buffers_high : 5;      // Max Scratchpad Bufs Hi
+            u32 scratchpad_restore : 1;               // SPR
+            u32 max_scratchpad_buffers_low : 5;       // Max Scratchpad Bufs Lo
+            // HCSPARAMS3
+            u32 U1_device_exit_latency : 8;  // U1 Device Exit Latency
+            u32 reserved2 : 8;               // Rsvd
+            u32 U2_device_exit_latency : 16; // U2 Device Exit Latency
+        } structural_parameters;
+
+        struct {
+            u32 _64bit_addressing_capability : 1;           // AC64
+            u32 bandwidth_negotiation_capability : 1;       // BNC
+            u32 context_size : 1;                           // CSZ
+            u32 port_power_control : 1;                     // PPC
+            u32 port_indicators : 1;                        // PIND
+            u32 light_host_controller_reset_capability : 1; // LHRC
+            u32 latency_tolerance_messaging_capability : 1; // LTC
+            u32 no_secondary_stream_id_support : 1;         // NSS
+            u32 parse_all_event_data : 1;                   // PAE
+            u32 stopped_short_packet_capability : 1;        // SPC
+            u32 stopped_EDTLA_capability : 1;               // SEC
+            u32 contiguous_frame_id_capability : 1;         // CFC
+            u32 maximum_primary_stream_array_size : 4;      // MaxPSASize
+            u32 xHCI_extended_capabilities_pointer : 16;    // xECP
+        } capability_parameters_1;                          // HCCPARAMS1
+
+        u32 doorbell_offset; // DBOFF
+
+        u32 runtime_register_space_offset; // RTSOFF
+
+        struct {
+            u32 U3_entry_capability : 1;                                              // U3C
+            u32 configure_endpoint_command_max_exit_latency_too_large_capability : 1; // CMC
+            u32 force_save_context_capability : 1;                                    // FSC
+            u32 compliance_transition_capability : 1;                                 // CTC
+            u32 large_ESIT_payload_capability : 1;                                    // LEC
+            u32 configuration_information_capability : 1;                             // CIC
+            u32 extended_TBC_capability : 1;                                          // ETC
+            u32 extended_TBC_TRB_status_capability : 1;                               // ETC_TSC
+            u32 get_set_extended_property_capability : 1;                             // GSC
+            u32 virtualization_based_trusted_io_capability : 1;                       // VTC
+            u32 reserved0 : 22;                                                       // Reserved
+        } capability_parameters_2;                                                    // HCCPARAMS2
+    };
+    static_assert(AssertSize<CapabilityRegisters, 0x20>());
+
+    union PortStatusAndControl {
+        struct {
+            u32 current_connect_status : 1;       // CCS
+            u32 port_enabled_disabled : 1;        // PED
+            u32 reserved0 : 1;                    // RsvdZ
+            u32 over_current_active : 1;          // OCA
+            u32 port_reset : 1;                   // PR
+            u32 port_link_state : 4;              // PLS
+            u32 port_power : 1;                   // PP
+            u32 port_speed : 4;                   // Port Speed
+            u32 port_indicator_control : 2;       // PIC
+            u32 port_link_state_write_strobe : 1; // LWS
+            u32 connect_status_change : 1;        // CSC
+            u32 port_enabled_disabled_change : 1; // PEC
+            u32 warm_port_reset_change : 1;       // WRC
+            u32 over_current_change : 1;          // OCC
+            u32 port_reset_change : 1;            // PRC
+            u32 port_link_state_change : 1;       // PLC
+            u32 port_config_error_change : 1;     // CEC
+            u32 cold_attach_status : 1;           // CAS
+            u32 wake_on_connect_enable : 1;       // WCE
+            u32 wake_on_disconnect_enable : 1;    // WDE
+            u32 wake_on_over_current_enable : 1;  // WOE
+            u32 reserved1 : 2;                    // RsvdZ
+            u32 device_removable : 1;             // DR
+            u32 warm_port_reset : 1;              // WPR
+        };
+        u32 raw { 0 }; // RW1CS fields
+    };
+    static_assert(AssertSize<PortStatusAndControl, 0x4>());
+
+    struct PortRegisters {
+        PortStatusAndControl port_status_and_control; // PORTSC
+
+        union {
+            struct {
+                u32 U1_timeout : 8;                         // U1 Timeout
+                u32 U2_timeout : 8;                         // U2 Timeout
+                u32 force_link_power_management_accept : 1; // FLA
+                u32 reserved0 : 15;                         // RsvdP
+            } usb3;
+            struct {
+                u32 l1_status : 3;                             // L1S
+                u32 remote_wake_enable : 1;                    // RWE
+                u32 best_effort_service_latency : 4;           // BESL
+                u32 l1_device_slot : 8;                        // L1 Device Slot
+                u32 hardware_link_power_management_enable : 1; // HLE
+                u32 reserved0 : 11;                            // RsvdP
+                u32 port_test_control : 4;                     // Test Mode
+            } usb2;
+        } port_power_management_status_and_control; // PORTPMSC
+
+        union {
+            struct {
+                u32 link_error_count : 16; // Link Error Count
+                u32 rx_lane_count : 4;     // RLC
+                u32 tx_lane_count : 4;     // TLC
+                u32 reserved0 : 8;         // RsvdP
+            } usb3;
+            struct {
+                u32 reserved0;
+            } usb2;
+        } port_link_info; // PORTLI
+
+        union {
+            struct {
+                u32 reserved0;
+            } usb3;
+            struct {
+                u32 host_initiated_resume_duration_mode : 2; // HIRDM
+                u32 l1_timeout : 8;                          // L1 Timeout
+                u32 best_effort_service_latency_deep : 4;    // BESLD
+                u32 reserved0 : 18;                          // RsvdP
+            } usb2;
+        } port_hardware_link_power_management_control; // PORTHLPMC
+    };
+    static_assert(AssertSize<PortRegisters, 0x10>());
+
+    union USBStatus {
+        struct {
+            u32 host_controller_halted : 1; // HCH
+            u32 reserved0 : 1;              // RsvdZ
+            u32 host_system_error : 1;      // HSE
+            u32 event_interrupt : 1;        // EINT
+            u32 port_change_detect : 1;     // PCD
+            u32 reserved1 : 3;              // RsvdZ
+            u32 save_state_status : 1;      // SSS
+            u32 restore_status_status : 1;  // RSS
+            u32 save_restore_error : 1;     // SRE
+            u32 controller_not_ready : 1;   // CNR
+            u32 host_controller_error : 1;  // HCE
+            u32 reserved2 : 19;             // RsvdZ
+        };
+        u32 raw { 0 }; // RW1CS fields
+    };
+    static_assert(AssertSize<USBStatus, 0x4>());
+
+    union CommandRingControlRegister {
+        struct {
+            u32 ring_cycle_state : 1;           // RCS
+            u32 command_stop : 1;               // CS
+            u32 command_abort : 1;              // CA
+            u32 command_ring_running : 1;       // CRR
+            u32 reserved0 : 2;                  // RsvdP
+            u32 command_ring_pointer_low : 26;  // Command Ring Pointer Lo
+            u32 command_ring_pointer_high : 32; // Command Ring Pointer Hi
+        };
+        struct {
+            u32 raw0 { 0 };
+            u32 raw1 { 0 };
+        }; // RW1CS fields
+    };
+    static_assert(AssertSize<CommandRingControlRegister, 0x8>());
+
+    // 5.4 Host Controller Operational Registers
+    struct OperationalRegisters {
+        struct {
+            u32 run_stop : 1;                             // R/S
+            u32 host_controller_reset : 1;                // HCRST
+            u32 interrupter_enable : 1;                   // INTE
+            u32 host_system_error_enable : 1;             // HSEE
+            u32 reserved0 : 3;                            // RsvdP
+            u32 light_host_controller_reset : 1;          // LHCRST
+            u32 controller_save_state : 1;                // CSS
+            u32 controller_restore_state : 1;             // CRS
+            u32 enable_wrap_event : 1;                    // EWE
+            u32 enable_U3_microframe_index_stop : 1;      // EU3S
+            u32 reserved1 : 1;                            // RsvdP
+            u32 CEM_enable : 1;                           // CME
+            u32 extended_transfer_burst_count_enable : 1; // ETE
+            u32 extended_TBC_TRB_status_enable : 1;       // TSB_EN
+            u32 VTIO_enable : 1;                          // VTIOE
+            u32 reserved2 : 15;                           // RsvdP
+        } usb_command;                                    // USBCMD
+
+        USBStatus usb_status; // USBSTS
+
+        u32 page_size; // PAGESIZE
+
+        u32 reserved0[2]; // RsvdZ
+
+        struct {
+            u32 notification_enable_0 : 1;  // N0
+            u32 notification_enable_1 : 1;  // N1
+            u32 notification_enable_2 : 1;  // N2
+            u32 notification_enable_3 : 1;  // N3
+            u32 notification_enable_4 : 1;  // N4
+            u32 notification_enable_5 : 1;  // N5
+            u32 notification_enable_6 : 1;  // N6
+            u32 notification_enable_7 : 1;  // N7
+            u32 notification_enable_8 : 1;  // N8
+            u32 notification_enable_9 : 1;  // N9
+            u32 notification_enable_10 : 1; // N10
+            u32 notification_enable_11 : 1; // N11
+            u32 notification_enable_12 : 1; // N12
+            u32 notification_enable_13 : 1; // N13
+            u32 notification_enable_14 : 1; // N14
+            u32 notification_enable_15 : 1; // N15
+            u32 reserved0 : 16;             // RsvdP
+        } device_notification_control;      // DNCTRL
+
+        CommandRingControlRegister command_ring_control; // CRCR
+
+        u32 reserved1[4]; // RsvdZ
+
+        struct {
+            u32 low;
+            u32 high;
+        } device_context_base_address_array_pointer; // DCBAAP
+
+        struct {
+            u32 max_device_slots_enabled : 8;         // MaxSlotsEn
+            u32 U3_entry_enable : 1;                  // U3E
+            u32 configuration_information_enable : 1; // CIE
+            u32 reserved0 : 22;                       // RsvdP
+        } configure;                                  // CONFIG
+
+        u32 reserved2[241]; // RsvdZ
+
+        PortRegisters port_registers[0x100];
+    };
+    static_assert(AssertSize<OperationalRegisters, 0x1400>());
+
+    struct InterrupterRegisters {
+        struct {
+            u32 interrupt_pending : 1; // IP
+            u32 interrupt_enabled : 1; // IE
+            u32 reserved0 : 30;        // RsvdP
+        } interrupter_management;      // IMAN
+
+        struct {
+            u32 interrupt_moderation_interval : 16; // IMODI
+            u32 interrupt_moderation_counter : 16;  // IMODC
+        } interrupter_moderation;                   // IMOD
+
+        u32 even_ring_segment_table_size; // ERSTSZ
+
+        u32 reserved0; // RsvdP
+
+        struct {
+            u32 low;
+            u32 high;
+        } event_ring_segment_table_base_address; // ERSTBA
+
+        struct {
+            u32 dequeue_ERST_segment_index : 3;       // DESI
+            u32 event_handler_busy : 1;               // EHB
+            u32 event_ring_dequeue_pointer_low : 28;  // ERDP Lo
+            u32 event_ring_dequeue_pointer_high : 32; // ERDP Hi
+        } event_ring_dequeue_pointer;                 // ERDP
+    };
+    static_assert(AssertSize<InterrupterRegisters, 0x20>());
+
+    // 5.5 Host Controller Runtime Registers
+    struct RuntimeRegisters {
+        u32 microframe_index; // MFINDEX
+
+        u32 reserved0[7]; // RsvdZ
+
+        InterrupterRegisters interrupter_registers[0x400];
+    };
+    static_assert(AssertSize<RuntimeRegisters, 0x8020>());
+
+    // 5.6 Doorbell Registers
+    union DoorbellRegister {
+        struct {
+            u32 doorbell_target : 8;     // DB Target
+            u32 reserved0 : 8;           // RsvdZ
+            u32 doorbell_stream_id : 16; // DB Stream ID
+        };
+        u32 raw; // All fields must be modified at once
+    };
+    static_assert(AssertSize<DoorbellRegister, 0x4>());
+    struct DoorbellRegisters {
+        u32 doorbells[256];
+    };
+    static_assert(AssertSize<DoorbellRegisters, 0x400>());
+
+    struct ExtendedCapability {
+        enum class CapabilityID : u32 {
+            USB_Legacy_Support = 1,
+            Supported_Protocols = 2,
+            Extended_Power_Management = 3,
+            IO_Virtualization = 4,
+            Message_Interrupt = 5,
+            USB_Debug_Capability = 10,
+            Extended_Message_Interrupt = 17,
+        };
+        CapabilityID capability_id : 8;
+        u32 next_xHCI_extended_capability_pointer : 8;
+        u32 capability_specific : 16;
+    };
+    static_assert(AssertSize<ExtendedCapability, 0x4>());
+
+    struct USBLegacySupportExtendedCapability {
+        struct {
+            ExtendedCapability::CapabilityID capability_id : 8;
+            u32 next_xHCI_extended_capability_pointer : 8;
+            u32 host_controller_bios_owned_semaphore : 1;
+            u32 reserved0 : 7;
+            u32 host_controller_os_owned_semaphore : 1;
+            u32 reserved1 : 7;
+        } usb_legacy_support_capability; // USBLEGSUP
+
+        struct {
+            u32 usb_smi_enable : 1;
+            u32 reserved0 : 3;
+            u32 smi_on_host_system_error_enable : 1;
+            u32 reserved1 : 8;
+            u32 smi_on_os_ownership_enable : 1;
+            u32 smi_on_pci_command_enable : 1;
+            u32 smi_on_bar_enable : 1;
+            u32 smi_on_event_interrupt : 1;
+            u32 reserved2 : 3;
+            u32 smi_on_host_system_error : 1;
+            u32 reserved3 : 8;
+            u32 smi_on_os_ownership_change : 1;
+            u32 smi_on_pci_command : 1;
+            u32 smi_on_bar : 1;
+        } usb_legacy_support_control_status; // USBLEGCTLSTS
+    };
+    static_assert(AssertSize<USBLegacySupportExtendedCapability, 0x8>());
+
+    struct ProtocolSpeedID {
+        u32 protocol_speed_id_value : 4;       // PSIV
+        u32 protocol_speed_id_exponent : 2;    // PSIE
+        u32 protocol_speed_id_type : 2;        // PLT
+        u32 protocol_speed_id_full_duplex : 1; // PFD
+        u32 reserved0 : 5;                     // RsvdP
+        u32 link_protocol : 2;                 // LP
+        u32 protocol_speed_id_mantissa : 16;   // PSIM
+    };
+    static_assert(AssertSize<ProtocolSpeedID, 0x4>());
+
+    struct SupportedProtocolExtendedCapability {
+        static constexpr u32 usb_name_string = AK::convert_between_host_and_little_endian(0x20425355);
+        ExtendedCapability::CapabilityID capability_id : 8;
+        u32 next_xHCI_extended_capability_pointer : 8;
+        u32 minor_revision : 8;
+        u32 major_revision : 8;
+        u32 name_string : 32;
+        u32 compatible_port_offset : 8;
+        u32 compatible_port_count : 8;
+        u32 protocol_defined : 12;
+        u32 protocol_speed_id_count : 4; // PSIC
+        u32 protocol_slot_type : 5;
+        u32 reserved0 : 27;
+        ProtocolSpeedID protocol_speed_ids[16];
+    };
+    static_assert(AssertSize<SupportedProtocolExtendedCapability, 0x50>());
+
+    struct EventRingSegmentTableEntry {
+        u32 ring_segment_base_address_low : 32;
+        u32 ring_segment_base_address_high : 32;
+        u32 ring_segment_size : 16;
+        u32 reserved0 : 16;
+        u32 reserved1 : 32;
+    };
+    static_assert(AssertSize<EventRingSegmentTableEntry, 0x10>());
+
+    union TransferRequestBlock {
+        enum class TRBType : u32 {
+            Normal = 1,
+            Setup_Stage = 2,
+            Data_Stage = 3,
+            Status_Stage = 4,
+            Isoch = 5,
+            Link = 6,
+            Event_Data = 7,
+            No_Op = 8,
+            Enable_Slot_Command = 9,
+            Disable_Slot_Command = 10,
+            Address_Device_Command = 11,
+            Configure_Endpoint_Command = 12,
+            Evaluate_Context_Command = 13,
+            Reset_Endpoint_Command = 14,
+            Stop_Endpoint_Command = 15,
+            Set_TR_Dequeue_Pointer_Command = 16,
+            Reset_Device_Command = 17,
+            Force_Event_Command = 18,
+            Negotiate_Bandwidth_Command = 19,
+            Set_Latency_Tolerance_Value_Command = 20,
+            Get_Port_Bandwidth_Command = 21,
+            Force_Header_Command = 22,
+            No_Op_Command = 23,
+            Get_Extended_Property_Command = 24,
+            Set_Extended_Property_Command = 25,
+            Transfer_Event = 32,
+            Command_Completion_Event = 33,
+            Port_Status_Change_Event = 34,
+            Bandwidth_Request_Event = 35,
+            Doorbell_Event = 36,
+            Host_Controller_Event = 37,
+            Device_Notification_Event = 38,
+            Microframe_Index_Wrap_Event = 39,
+        };
+        enum class CompletionCode : u32 {
+            Invalid = 0,
+            Success = 1,
+            Data_Buffer_Error = 2,
+            Babble_Detected_Error = 3,
+            USB_Transaction_Error = 4,
+            TRB_Error = 5,
+            Stall_Error = 6,
+            Resource_Error = 7,
+            Bandwidth_Error = 8,
+            No_Slots_Available_Error = 9,
+            Invalid_Stream_Type_Error = 10,
+            Slot_Not_Enabled_Error = 11,
+            Endpoint_Not_Enabled_Error = 12,
+            Short_Packet = 13,
+            Ring_Underrun = 14,
+            Ring_Overrun = 15,
+            VF_Event_Ring_Full_Error = 16,
+            Parameter_Error = 17,
+            Bandwidth_Overrun_Error = 18,
+            Context_State_Error = 19,
+            No_Ping_Response_Error = 20,
+            Event_Ring_Full_Error = 21,
+            Incompatible_Device_Error = 22,
+            Missed_Service_Error = 23,
+            Command_Ring_Stopped = 24,
+            Command_Aborted = 25,
+            Stopped = 26,
+            Stopped_Length_Invalid = 27,
+            Stopped_Short_Packet = 28,
+            Max_Exit_Latency_Too_Large_Error = 29,
+            Isoch_Buffer_Overrun = 31,
+            Event_Lost_Error = 32,
+            Undefined_Error = 33,
+            Invalid_Stream_ID_Error = 34,
+            Secondary_Bandwidth_Error = 35,
+            Split_Transaction_Error = 36,
+        };
+        enum class TransferType : u32 {
+            No_Data_Stage = 0,
+            Reserved = 1,
+            OUT_Data_Stage = 2,
+            IN_Data_Stage = 3,
+        };
+        struct {
+            u32 parameter0 : 32;
+            u32 parameter1 : 32;
+            u32 status : 32;
+            u32 cycle_bit : 1;                            // C
+            u32 evaluate_next_transfer_request_block : 1; // ENT
+            u32 reserved0 : 2;
+            u32 chain_bit : 1; // CH
+            u32 reserved1 : 5;
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 control : 16;
+        } generic;
+        struct {
+            u32 data_buffer_pointer_low : 32;
+            u32 data_buffer_pointer_high : 32;
+            u32 transfer_request_block_transfer_length : 17;
+            u32 transfer_descriptor_size : 5;
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;                            // C
+            u32 evaluate_next_transfer_request_block : 1; // ENT
+            u32 interrupt_on_short_packet : 1;            // ISP
+            u32 no_snoop : 1;                             // NS
+            u32 chain_bit : 1;                            // CH
+            u32 interrupt_on_completion : 1;              // IOC
+            u32 immediate_data : 1;                       // IDT
+            u32 reserved0 : 2;                            // RsvdZ
+            u32 block_event_interrupt : 1;                // BEI
+            TRBType transfer_request_block_type : 6;      // TRB Type
+            u32 reserved1 : 16;
+        } normal;
+        struct {
+            u32 request_type : 8;                            // bmRequestType
+            u32 request : 8;                                 // bRequest
+            u32 value : 16;                                  // wValue
+            u32 index : 16;                                  // wIndex
+            u32 length : 16;                                 // wLength
+            u32 transfer_request_block_transfer_length : 17; // TRB Transfer Length
+            u32 reserved0 : 5;                               // RsvdZ
+            u32 interrupter_target : 10;                     // Interrupter Target
+            u32 cycle_bit : 1;                               // C
+            u32 reserved1 : 4;                               // RsvdZ
+            u32 interrupt_on_completion : 1;                 // IOC
+            u32 immediate_data : 1;                          // IDT
+            u32 reserved2 : 3;                               // RsvdZ
+            TRBType transfer_request_block_type : 6;         // TRB Type
+            TransferType transfer_type : 2;                  // TRT
+            u32 reserved3 : 14;                              // RsvdZ
+        } setup_stage;
+        struct {
+            u32 data_buffer_low : 32;
+            u32 data_buffer_high : 32;
+            u32 transfer_request_block_transfer_length : 17; // TRB Transfer Length
+            u32 transfer_descriptor_size : 5;
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;                            // C
+            u32 evaluate_next_transfer_request_block : 1; // ENT
+            u32 interrupt_on_short_packet : 1;            // ISP
+            u32 no_snoop : 1;                             // NS
+            u32 chain_bit : 1;                            // CH
+            u32 interrupt_on_completion : 1;              // IOC
+            u32 immediate_data : 1;                       // IDT
+            u32 reserved0 : 3;                            // RsvdZ
+            TRBType transfer_request_block_type : 6;      // TRB Type
+            u32 direction : 1;                            // DIR
+            u32 reserved1 : 15;                           // RsvdZ
+        } data_stage;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 22;
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;                            // C
+            u32 evaluate_next_transfer_request_block : 1; // ENT
+            u32 reserved3 : 2;                            // RsvdZ
+            u32 chain_bit : 1;                            // CH
+            u32 interrupt_on_completion : 1;              // IOC
+            u32 reserved4 : 4;
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 direction : 1;                       // DIR
+            u32 reserved5 : 15;                      // RsvdZ
+        } status_stage;
+        struct {
+            u32 data_buffer_pointer_low : 32;
+            u32 data_buffer_pointer_high : 32;
+            u32 transfer_request_block_transfer_length : 17;
+            u32 transfer_descriptor_size_OR_transfer_burst_count : 5; // TD Size/TBC
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;                                                          // C
+            u32 evaluate_next_transfer_request_block : 1;                               // ENT
+            u32 interrupt_on_short_packet : 1;                                          // ISP
+            u32 no_snoop : 1;                                                           // NS
+            u32 chain_bit : 1;                                                          // CH
+            u32 interrupt_on_completion : 1;                                            // IOC
+            u32 immediate_data : 1;                                                     // IDT
+            u32 transfer_burst_count_OR_transfer_request_block_status_OR_reserved0 : 2; // TBC/TRBSts/RsvdZ
+            u32 block_event_interrupt : 1;                                              // BEI
+            TRBType transfer_request_block_type : 6;                                    // TRB Type
+            u32 transfer_last_burst_packet_count : 4;                                   // TLBPC
+            u32 frame_id : 11;
+            u32 start_isoch_as_soon_as_possible : 1; // SIA
+        } isoch;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 22;
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;                            // C
+            u32 evaluate_next_transfer_request_block : 1; // ENT
+            u32 reserved3 : 2;                            // RsvdZ
+            u32 chain_bit : 1;                            // CH
+            u32 interrupt_on_completion : 1;              // IOC
+            u32 reserved4 : 4;                            // RsvdZ
+            TRBType transfer_request_block_type : 6;      // TRB Type
+            u32 reserved5 : 16;                           // RsvdZ
+        } no_op;
+        struct {
+            u32 transfer_request_block_pointer_low : 32;
+            u32 transfer_request_block_pointer_high : 32;
+            u32 transfer_request_block_transfer_length : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;  // C
+            u32 reserved0 : 1;  // RsvdZ
+            u32 event_data : 1; // ED
+            u32 reserved1 : 7;
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 endpoint_id : 5;
+            u32 reserved2 : 3;
+            u32 slot_id : 8;
+        } transfer_event;
+        struct {
+            u32 command_transfer_request_block_pointer_low : 32;
+            u32 command_transfer_request_block_pointer_high : 32;
+            u32 command_completion_parameter : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved0 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 vf_id : 8;
+            u32 slot_id : 8;
+        } command_completion_event;
+        struct {
+            u32 reserved0 : 24;
+            u32 port_id : 8;
+            u32 reserved1 : 32;
+            u32 reserved2 : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 16;
+        } port_status_change_event;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 8;
+            u32 slot_id : 8;
+        } bandwidth_request_event;
+        struct {
+            u32 doorbell_reason : 5;
+            u32 reserved0 : 27;
+            u32 reserved1 : 32;
+            u32 reserved2 : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 vf_id : 8;
+            u32 slot_id : 8;
+        } doorbell_event;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 16;
+        } host_controller_event;
+        struct {
+            u32 reserved0 : 4;
+            u32 notification_type : 4;
+            u32 device_notification_data_low : 24;
+            u32 device_notification_data_high : 32;
+            u32 reserved1 : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved2 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved3 : 8;
+            u32 slot_id : 8;
+        } device_notification_event;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 24;
+            CompletionCode completion_code : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 16;
+        } microframe_index_wrap_event;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 16;
+        } no_op_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 slot_type : 5;
+            u32 reserved4 : 11;
+        } enable_slot_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 8;
+            u32 slot_id : 8;
+        } disable_slot_command;
+        struct {
+            u32 input_context_pointer_low : 32;
+            u32 input_context_pointer_high : 32;
+            u32 reserved0 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 8;                       // RsvdZ
+            u32 block_set_address_request : 1;       // BSR
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved2 : 8;
+            u32 slot_id : 8;
+        } address_device_command;
+        struct {
+            u32 input_context_pointer_low : 32;
+            u32 input_context_pointer_high : 32;
+            u32 reserved0 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 8;                       // RsvdZ
+            u32 deconfigure : 1;                     // DC
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved2 : 8;
+            u32 slot_id : 8;
+        } configure_endpoint_command;
+        struct {
+            u32 input_context_pointer_low : 32;
+            u32 input_context_pointer_high : 32;
+            u32 reserved0 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved2 : 8;
+            u32 slot_id : 8;
+        } evaluate_context_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 8;                       // RsvdZ
+            u32 transfer_state_preserve : 1;         // TSP
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 endpoint_id : 5;
+            u32 reserved4 : 3;
+            u32 slot_id : 8;
+        } reset_endpoint_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 endpoint_id : 5;
+            u32 reserved4 : 2;
+            u32 suspend : 1; // SP
+            u32 slot_id : 8;
+        } stop_endpoint_command;
+        struct {
+            u32 dequeue_cycle_state : 1; // DCS
+            u32 stream_context_type : 3; // SCT
+            u32 new_tr_dequeue_pointer_low : 28;
+            u32 new_tr_dequeue_pointer_high : 32;
+            u32 reserved0 : 16;
+            u32 stream_id : 16;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 endpoint_id : 5;
+            u32 reserved2 : 3;
+            u32 slot_id : 8;
+        } set_tr_dequeue_pointer_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 8;
+            u32 slot_id : 8;
+        } reset_device_command;
+        struct {
+            u32 event_transfer_request_block_pointer_low : 32;
+            u32 event_transfer_request_block_pointer_high : 32;
+            u32 reserved0 : 22;
+            u32 vf_interrupter_target : 10;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 vf_id : 8;
+            u32 reserved4 : 8;
+        } force_event_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved4 : 8;
+            u32 slot_id : 8;
+        } negotiate_bandwidth_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 reserved2 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 best_effort_latency_tolerance_value : 12;
+            u32 reserved4 : 4;
+        } set_latency_tolerance_value_command;
+        struct {
+            u32 port_bandwidth_context_pointer_low : 32;
+            u32 port_bandwidth_context_pointer_high : 32;
+            u32 reserved0 : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 device_speed : 4;
+            u32 reserved2 : 4;
+            u32 hub_slot_id : 8;
+        } get_port_bandwidth_command;
+        struct {
+            u32 packet_type : 5;
+            u32 header_info_low : 27;
+            u32 header_info_middle : 32;
+            u32 header_info_high : 32;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved0 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved1 : 8;
+            u32 root_hub_port_number : 8;
+        } force_header_command;
+        struct {
+            u32 extended_property_context_pointer_low : 32;
+            u32 extended_property_context_pointer_high : 32;
+            u32 extended_capability_identifier : 16; // ECI
+            u32 reserved0 : 16;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved1 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 command_sub_type : 3;
+            u32 endpoint_id : 5;
+            u32 slot_id : 8;
+        } get_extended_property_command;
+        struct {
+            u32 reserved0 : 32;
+            u32 reserved1 : 32;
+            u32 extended_capability_identifier : 16; // ECI
+            u32 capability_parameter : 8;
+            u32 reserved2 : 8;
+            u32 cycle_bit : 1;                       // C
+            u32 reserved3 : 9;                       // RsvdZ
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 command_sub_type : 3;
+            u32 endpoint_id : 5;
+            u32 slot_id : 8;
+        } set_extended_property_command;
+        struct {
+            u32 ring_segment_pointer_low : 32;
+            u32 ring_segment_pointer_high : 32;
+            u32 reserved0 : 22;
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;               // C
+            u32 toggle_cycle : 1;            // TC
+            u32 reserved1 : 2;               // RsvdZ
+            u32 chain_bit : 1;               // CH
+            u32 interrupt_on_completion : 1; // IOC
+            u32 reserved2 : 4;
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved3 : 16;
+        } link;
+        struct {
+            u32 event_data_low : 32;
+            u32 event_data_high : 32;
+            u32 reserved0 : 22;
+            u32 interrupter_target : 10;
+            u32 cycle_bit : 1;                            // C
+            u32 evaluate_next_transfer_request_block : 1; // ENT
+            u32 reserved1 : 2;
+            u32 chain_bit : 1;                       // CH
+            u32 interrupt_on_completion : 1;         // IOC
+            u32 reserved2 : 3;                       // RsvdZ
+            u32 block_event_interrupt : 1;           // BEI
+            TRBType transfer_request_block_type : 6; // TRB Type
+            u32 reserved3 : 16;
+        } event_data;
+    };
+    static_assert(AssertSize<TransferRequestBlock, 0x10>());
+
+    static StringView enum_to_string(TransferRequestBlock::TRBType);
+    static StringView enum_to_string(TransferRequestBlock::CompletionCode);
+
+    static constexpr size_t command_ring_size = 16;
+    // Use up all the space left in the page
+    static constexpr size_t event_ring_segment_size = ((PAGE_SIZE - (sizeof(EventRingSegmentTableEntry) + sizeof(TransferRequestBlock) * command_ring_size)) & ~0x3F) / sizeof(TransferRequestBlock);
+    // System software is responsible for ensuring the Size of every ERST entry (Event Ring segment) is at least 16.
+    static_assert(event_ring_segment_size >= 16);
+    // System software shall allocate a buffer for the Event Ring Segment Table that rounds up its size to the nearest 64B boundary to allow full cache-line accesses.
+    static_assert((event_ring_segment_size * sizeof(TransferRequestBlock)) % 64 == 0);
+    // The command ring and event ring (ERST and the segment itself) are combined to not take 3 pages for something that fits in 1)
+    struct CommandAndEventRings {
+        TransferRequestBlock command_ring[command_ring_size];
+        TransferRequestBlock event_ring_segment[event_ring_segment_size];
+        // Software shall allocate a buffer for the Event Ring Segment Table that rounds up its size to the nearest 64B boundary to allow full cache-line accesses.
+        [[gnu::aligned(64)]] EventRingSegmentTableEntry event_ring_segment_table_entry;
+    };
+    static_assert(sizeof(CommandAndEventRings) <= 0x1000);
+    // System software shall allocate a buffer for the Event Ring Segment that rounds up its size to the nearest 64B boundary to allow full cache-line accesses
+    static_assert(__builtin_offsetof(CommandAndEventRings, command_ring) % 64 == 0);
+    static_assert(__builtin_offsetof(CommandAndEventRings, event_ring_segment) % 64 == 0);
+
+    struct InputControlContext {
+        u32 reserved0 : 2;
+        u32 drop_contexts : 30;
+        u32 add_contexts : 32;
+        u32 reserved1 : 32;
+        u32 reserved2 : 32;
+        u32 reserved3 : 32;
+        u32 reserved4 : 32;
+        u32 reserved5 : 32;
+        u32 configuration_value : 8;
+        u32 interface_number : 8;
+        u32 alternate_setting : 8;
+        u32 reserved6 : 8;
+    };
+    static_assert(AssertSize<InputControlContext, 0x20>());
+    struct SlotContext {
+        u32 route_string : 20;
+        u32 speed : 4;
+        u32 reserved0 : 1;
+        u32 multi_transaction_translator : 1; // MTT
+        u32 hub : 1;
+        u32 context_entries : 5;
+        u32 max_exit_latency : 16;
+        u32 root_hub_port_number : 8;
+        u32 number_of_ports : 8;
+        u32 parent_hub_slot_id : 8;
+        u32 parent_port_number : 8;
+        u32 transaction_translator_think_time : 2; // TTT
+        u32 reserved1 : 4;
+        u32 interrupter_target : 10;
+        u32 usb_device_address : 8;
+        u32 reserved2 : 19;
+        u32 slot_state : 5;
+        u32 reserved3 : 32;
+        u32 reserved4 : 32;
+        u32 reserved5 : 32;
+        u32 reserved6 : 32;
+    };
+    static_assert(AssertSize<SlotContext, 0x20>());
+    struct EndpointContext {
+        enum class EndpointType : u32 {
+            Not_Valid = 0,
+            Isoch_Out = 1,
+            Bulk_Out = 2,
+            Interrupt_Out = 3,
+            Control_Bidirectional = 4,
+            Isoch_In = 5,
+            Bulk_In = 6,
+            Interrupt_In = 7
+        };
+        u32 endpoint_state : 3;
+        u32 reserved0 : 5;
+        u32 mult : 2;
+        u32 max_primary_streams : 5; // MaxPStreams
+        u32 linear_stream_array : 1; // LSA
+        u32 interval : 8;
+        u32 max_endpoint_service_time_interval_payload_high : 8; // Max ESIT Payload Hi
+        u32 reserved1 : 1;
+        u32 error_count : 2; // CErr
+        EndpointType endpoint_type : 3;
+        u32 reserved2 : 1;
+        u32 host_initiate_disable : 1; // HID
+        u32 max_burst_size : 8;
+        u32 max_packet_size : 16;
+        u32 dequeue_cycle_state : 1;
+        u32 reserved3 : 3;
+        u32 transfer_ring_dequeue_pointer_low : 28;
+        u32 transfer_ring_dequeue_pointer_high : 32;
+        u32 average_transfer_request_block : 16;
+        u32 max_endpoint_service_time_interval_payload_low : 16; // Max ESIT Payload Lo
+        u32 reserved4 : 32;
+        u32 reserved5 : 32;
+        u32 reserved6 : 32;
+    };
+    static_assert(AssertSize<EndpointContext, 0x20>());
+
+    struct PendingTransfer {
+        IntrusiveListNode<PendingTransfer> endpoint_list_node;
+        u32 start_index { 0 };
+        u32 end_index { 0 };
+    };
+    struct SyncPendingTransfer : public PendingTransfer {
+        WaitQueue wait_queue;
+        TransferRequestBlock::CompletionCode completion_code { TransferRequestBlock::CompletionCode::Invalid };
+        u32 remainder { 0 };
+    };
+    struct PeriodicPendingTransfer : public PendingTransfer {
+        Vector<TransferRequestBlock> transfer_request_blocks;
+        NonnullLockRefPtr<Transfer> original_transfer;
+    };
+
+    struct EndpointRing {
+        OwnPtr<Memory::Region> region;
+        u32 enqueue_index { 0 };
+        u32 free_transfer_request_blocks { endpoint_ring_size - 1 }; // One less, since we use up the last one for the link TRB
+        u32 max_burst_payload { 0 };
+        Pipe::Type type { Pipe::Type::Control };
+        u8 producer_cycle_state { 1 };
+        IntrusiveList<&PendingTransfer::endpoint_list_node> pending_transfers;
+        TransferRequestBlock* ring_vaddr() const { return reinterpret_cast<TransferRequestBlock*>(region->vaddr().as_ptr()); }
+        PhysicalPtr ring_paddr() const { return region->physical_page(0)->paddr().get(); }
+    };
+    static constexpr size_t max_endpoints = 31;
+    static constexpr size_t endpoint_ring_size = PAGE_SIZE / sizeof(TransferRequestBlock);
+    struct SlotState {
+        RecursiveSpinlock<LockRank::None> lock;
+        OwnPtr<Memory::Region> input_context_region;
+        OwnPtr<Memory::Region> device_context_region;
+        Array<EndpointRing, max_endpoints> endpoint_rings;
+    };
+
+    static u8 endpoint_index(u8 endpoint, Pipe::Direction direction)
+    {
+        if (direction == Pipe::Direction::Bidirectional) {
+            VERIFY(endpoint == 0);
+            direction = Pipe::Direction::In;
+        }
+        return endpoint * 2 + to_underlying(direction);
+    }
+
+    size_t context_entry_size() const { return m_large_contexts ? 64 : 32; }
+    size_t input_context_size() const { return context_entry_size() * 33; }
+    u8* input_context(u8 slot, u8 index) const
+    {
+        auto* base = m_slots_state[slot - 1].input_context_region->vaddr().as_ptr();
+        return base + (context_entry_size() * index);
+    }
+    InputControlContext* input_control_context(u8 slot) const
+    {
+        return reinterpret_cast<InputControlContext*>(input_context(slot, 0));
+    }
+    SlotContext* input_slot_context(u8 slot) const
+    {
+        return reinterpret_cast<SlotContext*>(input_context(slot, 1));
+    }
+    EndpointContext* input_endpoint_context(u8 slot, u8 endpoint, Pipe::Direction direction) const
+    {
+        return reinterpret_cast<EndpointContext*>(input_context(slot, endpoint_index(endpoint, direction) + 1));
+    }
+    size_t device_context_size() const { return context_entry_size() * 32; }
+    u8* device_context(u8 slot, u8 index) const
+    {
+        auto* base = m_slots_state[slot - 1].device_context_region->vaddr().as_ptr();
+        return base + (context_entry_size() * index);
+    }
+    SlotContext* device_slot_context(u8 slot) const
+    {
+        return reinterpret_cast<SlotContext*>(device_context(slot, 0));
+    }
+    EndpointContext* device_endpoint_context(u8 slot, u8 endpoint, Pipe::Direction direction) const
+    {
+        return reinterpret_cast<EndpointContext*>(device_context(slot, endpoint_index(endpoint, direction)));
+    }
+
+    void ring_doorbell(u8 doorbell, u8 doorbell_target);
+    void ring_endpoint_doorbell(u8 slot, u8 endpoint, Pipe::Direction direction)
+    {
+        VERIFY(slot > 0);
+        ring_doorbell(slot, endpoint_index(endpoint, direction));
+    }
+    void ring_command_doorbell() { ring_doorbell(0, 0); }
+    void enqueue_command(TransferRequestBlock&);
+    void execute_command(TransferRequestBlock&);
+
+    ErrorOr<u8> enable_slot();
+    ErrorOr<void> address_device(u8 slot, u64 input_context_address);
+    ErrorOr<void> evaluate_context(u8 slot, u64 input_context_address);
+    ErrorOr<void> configure_endpoint(u8 slot, u64 input_context_address);
+
+    ErrorOr<void> enqueue_transfer(u8 slot, u8 endpoint, Pipe::Direction direction, Span<TransferRequestBlock>, PendingTransfer&);
+    void handle_transfer_event(TransferRequestBlock const&);
+
+    Memory::TypedMapping<u8> m_registers_mapping;
+    CapabilityRegisters const volatile& m_capability_registers;
+    OperationalRegisters volatile& m_operational_registers;
+    RuntimeRegisters volatile& m_runtime_registers;
+    DoorbellRegisters volatile& m_doorbell_registers;
+
+    RefPtr<Process> m_process;
+    WaitQueue m_event_queue;
+
+    bool m_using_message_signalled_interrupts { false };
+    bool m_large_contexts { false };
+    u8 m_device_slots { 0 };
+    Array<SlotState, max_devices> m_slots_state;
+    u8 m_ports { 0 };
+    Array<USB::Device::DeviceSpeed, 255> m_port_max_speeds {};
+
+    Vector<NonnullOwnPtr<PeriodicPendingTransfer>> m_active_periodic_transfers;
+
+    Spinlock<LockRank::None> m_command_lock;
+    WaitQueue m_command_completion_queue;
+    TransferRequestBlock m_command_result_transfer_request_block {};
+    u32 m_command_ring_enqueue_index { 0 };
+    u8 m_command_ring_producer_cycle_state { 1 };
+    u32 m_event_ring_dequeue_index { 0 };
+    u8 m_event_ring_consumer_cycle_state { 1 };
+
+    OwnPtr<Memory::Region> m_device_context_base_address_array_region;
+    u64* m_device_context_base_address_array { nullptr };
+    OwnPtr<Memory::Region> m_scratchpad_buffers_array_region;
+    Vector<NonnullRefPtr<Memory::PhysicalRAMPage>> m_scratchpad_buffers;
+    OwnPtr<Memory::Region> m_command_and_event_rings_region;
+    TransferRequestBlock* m_command_ring { nullptr };
+    TransferRequestBlock* m_event_ring_segment { nullptr };
+    PhysicalPtr m_event_ring_segment_pointer { 0 };
+
+    OwnPtr<xHCIInterrupter> m_interrupter;
+    OwnPtr<xHCIRootHub> m_root_hub;
+};
+
+}

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/USB/xHCI/xHCIInterrupter.h>
+
+namespace Kernel::USB {
+
+ErrorOr<NonnullOwnPtr<xHCIInterrupter>> xHCIInterrupter::create(xHCIController& controller, u16 interrupter_id)
+{
+    auto irq = TRY(controller.allocate_irq(0));
+    return TRY(adopt_nonnull_own_or_enomem(new (nothrow) xHCIInterrupter(controller, interrupter_id, irq)));
+}
+
+xHCIInterrupter::xHCIInterrupter(xHCIController& controller, u16 interrupter_id, u16 irq)
+    : PCI::IRQHandler(controller, irq)
+    , m_controller(controller)
+    , m_interrupter_id(interrupter_id)
+{
+    enable_irq();
+}
+
+bool xHCIInterrupter::handle_irq(RegisterState const&)
+{
+    m_controller.handle_interrupt({}, m_interrupter_id);
+    return true;
+}
+
+}

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+#include <Kernel/Interrupts/PCIIRQHandler.h>
+
+namespace Kernel::USB {
+
+class xHCIInterrupter final : public PCI::IRQHandler {
+public:
+    static ErrorOr<NonnullOwnPtr<xHCIInterrupter>> create(xHCIController&, u16 interrupter_id);
+
+    virtual StringView purpose() const override { return "xHCI Interrupter"sv; }
+
+private:
+    xHCIInterrupter(xHCIController& controller, u16 interrupter_id, u16 irq);
+
+    virtual bool handle_irq(RegisterState const&) override;
+
+    xHCIController& m_controller;
+    u16 m_interrupter_id { 0 };
+};
+
+}

--- a/Kernel/Bus/USB/xHCI/xHCIRootHub.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIRootHub.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBConstants.h>
+#include <Kernel/Bus/USB/USBEndpoint.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+
+namespace Kernel::USB {
+
+static USBDeviceDescriptor xhci_root_hub_device_descriptor = {
+    {
+        sizeof(USBDeviceDescriptor), // 18 bytes long
+        DESCRIPTOR_TYPE_DEVICE,
+    },
+    0x0300, // USB 3.0
+    (u8)USB_CLASS_HUB,
+    0,      // Hubs use subclass 0
+    3,      // Super Speed Hub
+    9,      // Max packet size
+    0x0,    // Vendor ID
+    0x0,    // Product ID
+    0x0300, // Product version (can be anything, currently matching usb_spec_compliance_bcd)
+    0,      // Index of manufacturer string.
+    0,      // Index of product string.
+    0,      // Index of serial string.
+    1,      // One configuration descriptor
+};
+
+struct USBRootHubDescriptorChain {
+    USBConfigurationDescriptor configuration_descriptor;
+    USBInterfaceDescriptor interface_descriptor;
+    USBEndpointDescriptor endpoint_descriptor;
+    USBSuperSpeedEndpointCompanionDescriptor speed_endpoint_companion_descriptor;
+    USBHubDescriptor hub_descriptor;
+};
+
+static USBConfigurationDescriptor xhci_root_hub_configuration_descriptor = {
+    {
+        sizeof(USBConfigurationDescriptor), // 9 bytes long
+        DESCRIPTOR_TYPE_CONFIGURATION,
+    },
+    sizeof(USBRootHubDescriptorChain), // Combined length of configuration, interface, endpoint, endpoint companion and hub descriptors.
+    1,                                 // One interface descriptor
+    1,                                 // Configuration #1
+    0,                                 // Index of configuration string.
+    (1 << 6),                          // Bit 6 is set to indicate that the root hub is self powered.
+    0,                                 // 0 mA required from the bus (self-powered)
+};
+
+static USBInterfaceDescriptor xhci_root_hub_interface_descriptor = {
+    {
+        sizeof(USBInterfaceDescriptor), // 9 bytes long
+        DESCRIPTOR_TYPE_INTERFACE,
+    },
+    0, // Interface #0
+    0, // Alternate setting
+    1, // One endpoint
+    (u8)USB_CLASS_HUB,
+    0, // Hubs use subclass 0
+    0, // Root hub
+    0, // Index of interface string.
+};
+
+static USBEndpointDescriptor xhci_root_hub_endpoint_descriptor = {
+    {
+        sizeof(USBEndpointDescriptor), // 7 bytes long
+        DESCRIPTOR_TYPE_ENDPOINT,
+    },
+    USBEndpoint::ENDPOINT_ADDRESS_DIRECTION_IN | 1,           // IN Endpoint #1
+    USBEndpoint::ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_INTERRUPT, // Interrupt endpoint
+    2,                                                        // Max Packet Size
+    0xFF,                                                     // Max possible interval
+};
+
+static USBSuperSpeedEndpointCompanionDescriptor xhci_root_hub_superspeed_endpoint_companion_descriptor = {
+    {
+        sizeof(USBSuperSpeedEndpointCompanionDescriptor), // 5 bytes long
+        DESCRIPTOR_TYPE_USB_SUPERSPEED_ENDPOINT_COMPANION,
+    },
+    0,
+    { 0 },
+    0,
+
+};
+
+static USBHubDescriptor xhci_root_hub_hub_descriptor = {
+    {
+        sizeof(USBHubDescriptor), // 7 bytes long.
+        DESCRIPTOR_TYPE_HUB,
+    },
+    0x0,     // number of root ports (set dynamically by xHCI controller)
+    { 0x0 }, // Ganged power switching, not a compound device, global over-current protection.
+    0x0,     // xHCI ports are always powered, so there's no time from power on to power good.
+    0x0,     // Self-powered
+};
+
+USBRootHubDescriptorChain xhci_root_hub_descriptor_chain {
+    xhci_root_hub_configuration_descriptor,
+    xhci_root_hub_interface_descriptor,
+    xhci_root_hub_endpoint_descriptor,
+    xhci_root_hub_superspeed_endpoint_companion_descriptor,
+    xhci_root_hub_hub_descriptor,
+};
+
+ErrorOr<NonnullOwnPtr<xHCIRootHub>> xHCIRootHub::try_create(NonnullLockRefPtr<xHCIController> controller)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) xHCIRootHub(move(controller)));
+}
+
+xHCIRootHub::xHCIRootHub(NonnullLockRefPtr<xHCIController> controller)
+    : m_controller(move(controller))
+{
+}
+
+ErrorOr<void> xHCIRootHub::setup(Badge<xHCIController>)
+{
+    m_hub = TRY(Hub::try_create_root_hub(m_controller, Device::DeviceSpeed::SuperSpeed, 1 /* Address 1 */, xhci_root_hub_device_descriptor));
+    return m_hub->enumerate_and_power_on_hub();
+}
+
+ErrorOr<size_t> xHCIRootHub::handle_control_transfer(Transfer& transfer)
+{
+    auto const& request = transfer.request();
+    auto* request_data = transfer.buffer().as_ptr() + sizeof(USBRequestData);
+
+    if constexpr (XHCI_DEBUG) {
+        dbgln("xHCIRootHub: Received control transfer.");
+        dbgln("xHCIRootHub: Request Type: {:#02x}", request.request_type);
+        dbgln("xHCIRootHub: Request: {:#02x}", request.request);
+        dbgln("xHCIRootHub: Value: {:#04x}", request.value);
+        dbgln("xHCIRootHub: Index: {:#04x}", request.index);
+        dbgln("xHCIRootHub: Length: {:#04x}", request.length);
+    }
+
+    size_t length = 0;
+
+    switch (request.request) {
+    case HubRequest::GET_STATUS: {
+        length = min(transfer.transfer_data_size(), sizeof(HubStatus));
+        VERIFY(length <= sizeof(HubStatus));
+
+        if (request.index == 0) {
+            // If index == 0, the actual request is Get Hub Status
+            // xHCI does not provide "Local Power Source" or "Over-current" and their corresponding change flags.
+            memset(request_data, 0, length);
+            break;
+        }
+
+        // If index != 0, the actual request is Get Port Status
+        auto status = m_controller->get_port_status({}, request.index - 1);
+        memcpy(request_data, &status, length);
+        break;
+    }
+    case HubRequest::GET_DESCRIPTOR: {
+        u8 descriptor_type = request.value >> 8;
+        switch (descriptor_type) {
+        case DESCRIPTOR_TYPE_DEVICE:
+            length = min(transfer.transfer_data_size(), sizeof(USBDeviceDescriptor));
+            VERIFY(length <= sizeof(USBDeviceDescriptor));
+            memcpy(request_data, &xhci_root_hub_device_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_CONFIGURATION: {
+            length = min(transfer.transfer_data_size(), sizeof(USBRootHubDescriptorChain));
+            VERIFY(length <= sizeof(USBRootHubDescriptorChain));
+            memcpy(request_data, &xhci_root_hub_descriptor_chain, length);
+            auto constexpr ports_offset = __builtin_offsetof(USBRootHubDescriptorChain, hub_descriptor.number_of_downstream_ports);
+            if (ports_offset < length)
+                *(request_data + ports_offset) = m_controller->ports();
+            break;
+        }
+        case DESCRIPTOR_TYPE_INTERFACE:
+            length = min(transfer.transfer_data_size(), sizeof(USBInterfaceDescriptor));
+            VERIFY(length <= sizeof(USBInterfaceDescriptor));
+            memcpy(request_data, &xhci_root_hub_interface_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_ENDPOINT:
+            length = min(transfer.transfer_data_size(), sizeof(USBEndpointDescriptor));
+            VERIFY(length <= sizeof(USBEndpointDescriptor));
+            memcpy(request_data, &xhci_root_hub_endpoint_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_USB_SUPERSPEED_ENDPOINT_COMPANION:
+            length = min(transfer.transfer_data_size(), sizeof(USBSuperSpeedEndpointCompanionDescriptor));
+            VERIFY(length <= sizeof(USBSuperSpeedEndpointCompanionDescriptor));
+            memcpy(request_data, &xhci_root_hub_superspeed_endpoint_companion_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_HUB: {
+            length = min(transfer.transfer_data_size(), sizeof(USBHubDescriptor));
+            VERIFY(length <= sizeof(USBHubDescriptor));
+            memcpy(request_data, &xhci_root_hub_hub_descriptor, length);
+            auto constexpr ports_offset = __builtin_offsetof(USBHubDescriptor, number_of_downstream_ports);
+            if (ports_offset < length)
+                *(request_data + ports_offset) = m_controller->ports();
+            break;
+        }
+        default:
+            return EINVAL;
+        }
+        break;
+    }
+    case USB_REQUEST_SET_ADDRESS:
+        dbgln_if(XHCI_DEBUG, "xHCIRootHub: Attempt to set address to {}, ignoring.", request.value);
+        if (request.value > USB_MAX_ADDRESS)
+            return EINVAL;
+        // Ignore SET_ADDRESS requests. USBDevice sets its internal address to the new allocated address that it just sent to us.
+        // The internal address is used to check if the request is directed at the root hub or not.
+        break;
+    case HubRequest::SET_FEATURE: {
+        if (request.index == 0) {
+            // If index == 0, the actual request is Set Hub Feature.
+            // xHCI does not provide "Local Power Source" or "Over-current" and their corresponding change flags.
+            // Therefore, ignore the request, but return an error if the value is not "Local Power Source" or "Over-current"
+            switch (request.value) {
+            case HubFeatureSelector::C_HUB_LOCAL_POWER:
+            case HubFeatureSelector::C_HUB_OVER_CURRENT:
+                break;
+            default:
+                return EINVAL;
+            }
+
+            break;
+        }
+
+        // If index != 0, the actual request is Set Port Feature.
+
+        auto feature_selector = (HubFeatureSelector)request.value;
+        TRY(m_controller->set_port_feature({}, request.index - 1, feature_selector));
+        break;
+    }
+    case HubRequest::CLEAR_FEATURE: {
+        if (request.index == 0) {
+            // If index == 0, the actual request is Clear Hub Feature.
+            // xHCI does not provide "Local Power Source" or "Over-current" and their corresponding change flags.
+            // Therefore, ignore the request, but return an error if the value is not "Local Power Source" or "Over-current"
+            switch (request.value) {
+            case HubFeatureSelector::C_HUB_LOCAL_POWER:
+            case HubFeatureSelector::C_HUB_OVER_CURRENT:
+                break;
+            default:
+                return EINVAL;
+            }
+
+            break;
+        }
+
+        // If index != 0, the actual request is Clear Port Feature.
+        auto feature_selector = (HubFeatureSelector)request.value;
+        TRY(m_controller->clear_port_feature({}, request.index - 1, feature_selector));
+        break;
+    }
+    default:
+        return EINVAL;
+    }
+
+    transfer.set_complete();
+    return length;
+}
+
+}

--- a/Kernel/Bus/USB/xHCI/xHCIRootHub.h
+++ b/Kernel/Bus/USB/xHCI/xHCIRootHub.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <Kernel/Bus/USB/USBHub.h>
+#include <Kernel/Bus/USB/USBTransfer.h>
+#include <Kernel/Library/NonnullLockRefPtr.h>
+
+namespace Kernel::USB {
+
+class xHCIController;
+
+class xHCIRootHub {
+public:
+    static ErrorOr<NonnullOwnPtr<xHCIRootHub>> try_create(NonnullLockRefPtr<xHCIController>);
+
+    xHCIRootHub(NonnullLockRefPtr<xHCIController>);
+    ~xHCIRootHub() = default;
+
+    ErrorOr<void> setup(Badge<xHCIController>);
+
+    u8 device_address() const { return m_hub->address(); }
+
+    ErrorOr<size_t> handle_control_transfer(Transfer& transfer);
+
+    void check_for_port_updates() { m_hub->check_for_port_updates(); }
+
+    Hub const& hub() const { return *m_hub; }
+
+private:
+    NonnullLockRefPtr<xHCIController> m_controller;
+    LockRefPtr<Hub> m_hub;
+};
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -34,6 +34,9 @@ set(KERNEL_SOURCES
     Bus/USB/EHCI/EHCIController.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
+    Bus/USB/xHCI/xHCIController.cpp
+    Bus/USB/xHCI/xHCIInterrupter.cpp
+    Bus/USB/xHCI/xHCIRootHub.cpp
     Bus/USB/Drivers/HID/MouseDriver.cpp
     Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
     Bus/USB/USBConfiguration.cpp
@@ -677,6 +680,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Prevent naively implemented string functions (like strlen) from being "optimized" into a call to themselves.
     set_source_files_properties(Library/MiniStdLib.cpp
         PROPERTIES COMPILE_FLAGS "-fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")
+
+    # Prevent volatile bitfield accesses from being optimized into smaller load/stores
+    set_source_files_properties(Bus/USB/xHCI/xHCIController.cpp PROPERTIES COMPILE_FLAGS "-fstrict-volatile-bitfields")
 
     if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         # The BFD linker only supports RELR relocations on x86 and POWER.

--- a/Kernel/Debug.h.in
+++ b/Kernel/Debug.h.in
@@ -354,3 +354,7 @@
 #ifndef WAITQUEUE_DEBUG
 #cmakedefine01 WAITQUEUE_DEBUG
 #endif
+
+#ifndef XHCI_DEBUG
+#cmakedefine01 XHCI_DEBUG
+#endif

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -1043,9 +1043,7 @@ ErrorOr<NonnullRefPtr<Thread>> Process::create_kernel_thread(void (*entry)(void*
     if (!joinable)
         thread->detach();
 
-    auto& regs = thread->regs();
-    regs.set_ip((FlatPtr)entry);
-    regs.set_sp((FlatPtr)entry_data); // entry function argument is expected to be in the SP register
+    thread->regs().set_entry_function((FlatPtr)entry, (FlatPtr)entry_data);
 
     SpinlockLocker lock(g_scheduler_lock);
     thread->set_state(Thread::State::Runnable);

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -223,6 +223,12 @@ public:
 
     virtual void remove_from_secondary_lists();
 
+    template<typename EntryFunction>
+    ErrorOr<NonnullRefPtr<Thread>> create_kernel_thread(StringView name, EntryFunction entry, u32 priority = THREAD_PRIORITY_NORMAL, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true)
+    {
+        auto* entry_func = new EntryFunction(move(entry));
+        return create_kernel_thread(&Process::kernel_process_trampoline<EntryFunction>, entry_func, priority, name, affinity, joinable);
+    }
     ErrorOr<NonnullRefPtr<Thread>> create_kernel_thread(void (*entry)(void*), void* entry_data, u32 priority, StringView name, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true);
 
     bool is_profiling() const { return m_profiling; }

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -228,6 +228,7 @@ set(WINDOWMANAGER_DEBUG ON)
 set(WORKER_THREAD_DEBUG ON)
 set(WSMESSAGELOOP_DEBUG ON)
 set(WSSCREEN_DEBUG ON)
+set(XHCI_DEBUG ON)
 set(XML_PARSER_DEBUG ON)
 
 # False positive: DEBUG is a flag but it works differently.

--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -41,14 +41,17 @@ fi
 if [ "$SERENITY_ARCH" = "x86_64" ]; then
     gdb_arch=i386:x86-64
     prekernel_image=Prekernel64
+    kernel_image=Kernel_shared_object
     kernel_base=0x2000200000
 elif [ "$SERENITY_ARCH" = "aarch64" ]; then
     gdb_arch=aarch64:armv8-r
     prekernel_image=Prekernel
+    kernel_image=Kernel
     kernel_base=0x0
 elif [ "$SERENITY_ARCH" = "riscv64" ]; then
     gdb_arch=riscv:rv64
     prekernel_image=Prekernel
+    kernel_image=Kernel
     kernel_base=0x0
 fi
 
@@ -64,7 +67,7 @@ exec $SERENITY_KERNEL_DEBUGGER \
     -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
     -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/" \
-    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/Kernel_shared_object -o $kernel_base" \
+    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-x86_64}$toolchain_suffix/Kernel/$kernel_image -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
     -ex "set print frame-arguments none" \

--- a/Meta/gn/secondary/Kernel/BUILD.gn
+++ b/Meta/gn/secondary/Kernel/BUILD.gn
@@ -106,6 +106,7 @@ write_cmake_config("kernel_debug_gen") {
     "VIRTUAL_CONSOLE_DEBUG=",
     "WAITBLOCK_DEBUG=",
     "WAITQUEUE_DEBUG=",
+    "XHCI_DEBUG=",
   ]
 }
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -500,7 +500,7 @@ elif [ "$CMD" = "__tmux_cmd" ]; then
             export SERENITY_KERNEL_CMDLINE="${CMD_ARGS[0]}"
         fi
         # We need to make sure qemu doesn't start until we continue in gdb
-        export SERENITY_EXTRA_QEMU_ARGS="${SERENITY_EXTRA_QEMU_ARGS} -d int -no-reboot -no-shutdown -S"
+        export SERENITY_EXTRA_QEMU_ARGS="${SERENITY_EXTRA_QEMU_ARGS} -no-reboot -no-shutdown -S"
         # We need to disable kaslr to let gdb map the kernel symbols correctly
         export SERENITY_KERNEL_CMDLINE="${SERENITY_KERNEL_CMDLINE} disable_kaslr"
         set_tmux_title 'qemu'


### PR DESCRIPTION
This adds a minimal (that is, just enough to make USB mouse/keyboard work) implementation of an xHCI driver, to let us use serenity on modern baremetal machines.