### PR TITLE
LibWeb: Support interpolation of mixed percentage dimension units

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAnimations/misc/animate-with-mixed-percentages.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/misc/animate-with-mixed-percentages.txt
@@ -1,0 +1,1 @@
+    box is moving in the correct direction: true

--- a/Tests/LibWeb/Text/input/WebAnimations/misc/animate-with-mixed-percentages.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/misc/animate-with-mixed-percentages.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+    div {
+        position: absolute;
+        animation: moveRight 2s linear;
+    }
+
+    @keyframes moveRight {
+        from {
+            left: 0;
+        }
+        to {
+            left: 100%;
+            transform: translateX(-100%);
+        }
+    }
+</style>
+<body>
+<div id="foo"></div>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const foo = document.getElementById("foo");
+        const timeline = internals.createInternalAnimationTimeline();
+        const anim = foo.getAnimations()[0];
+        anim.timeline = timeline;
+        timeline.setTime(1000);
+
+        await animationFrame();
+        const bounds = foo.getBoundingClientRect();
+        println(`box is moving in the correct direction: ${bounds.left > 0}`);
+    });
+</script>
+</body>


### PR DESCRIPTION
This is much simpler than the previous solution I came up with for this, which was to introduce a new `StyleValue` type that then somehow had to propagate through all of the `CalculatedOr`/`PercentageOr` stuff. 

Fixes #23543