### PR TITLE
LibJS: Remove non-spec compliant code from internal_construct

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -506,15 +506,6 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
 
     // 10. If result.[[Type]] is return, then
     if (result.type() == Completion::Type::Return) {
-        // FIXME: This is leftover from untangling the call/construct mess - doesn't belong here in any way, but removing it breaks derived classes.
-        // Likely fixed by making ClassDefinitionEvaluation fully spec compliant.
-        if (kind == ConstructorKind::Derived && result.value()->is_object()) {
-            auto prototype = TRY(new_target.get(vm.names.prototype));
-            if (prototype.is_object())
-                TRY(result.value()->as_object().internal_set_prototype_of(&prototype.as_object()));
-        }
-        // EOF (End of FIXME)
-
         // a. If Type(result.[[Value]]) is Object, return result.[[Value]].
         if (result.value()->is_object())
             return result.value()->as_object();

--- a/Userland/Libraries/LibJS/Tests/classes/class-inheritance.js
+++ b/Userland/Libraries/LibJS/Tests/classes/class-inheritance.js
@@ -506,3 +506,29 @@ test("When no constructor on deriving class @@iterator of %Array.prototype% is n
 
     expect(calls).toBe(1);
 });
+
+test("constructor return value overrides inheritance and property initialization", () => {
+    let calls = 0;
+    class Base {
+        constructor() {
+            this.prop = 1;
+            calls++;
+        }
+    }
+
+    class Derived extends Base {
+        constructor() {
+            super();
+
+            // Return an empty object instead of Derived/Base object
+            return {};
+        }
+    }
+
+    let object = new Derived();
+
+    expect(calls).toBe(1);
+    expect(typeof object.prop).toBe("undefined");
+    expect(object instanceof Derived).toBe(false);
+    expect(object instanceof Base).toBe(false);
+});


### PR DESCRIPTION
Happened to stumble across this when trying to make another fix (for strict mode).

It seems that we are now spec compliant enough to be able to remove this code block :^)

Diff Tests:
    +2 ✅    -2 ❌