### PR TITLE
LibWeb: Fix clip box calculation in PaintableWithLines

### DIFF
--- a/Tests/LibWeb/Ref/paintablewithlines-corner-clip-in-scroll-container.html
+++ b/Tests/LibWeb/Ref/paintablewithlines-corner-clip-in-scroll-container.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/paintablewithlines-corner-clip-in-scroll-container-ref.html" />
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  * {
+    scrollbar-width: none;
+  }
+
+  #container {
+    height: 500px;
+    overflow: scroll;
+    border: 1px solid black;
+  }
+
+  #padding {
+    height: 300px;
+  }
+
+  #rounded-corners-mask {
+    width: 300px;
+    height: 300px;
+    border-radius: 50%;
+    overflow: hidden;
+    overflow: scroll;
+    font-size: 40px;
+    background-color: orangered;
+  }
+</style>
+<div id="container">
+  <div id="padding"></div>
+  <div id="rounded-corners-mask">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ultrices neque
+    eu nisi facilisis viverra. Integer lacinia, lacus vel condimentum suscipit,
+    lacus felis porta nulla, eget lacinia sem neque ut neque. In sagittis, eros
+    vel interdum porta, quam ex rhoncus lectus, vitae suscipit risus orci sit
+    amet velit. Praesent imperdiet condimentum rutrum. Cras vitae nisl sapien.
+    Curabitur ligula diam, tincidunt congue tincidunt nec, sodales nec orci.
+    Vestibulum tincidunt non elit in vehicula. Etiam malesuada neque eu porta
+    rhoncus. Curabitur vel nunc finibus ligula posuere venenatis.
+  </div>
+  <div id="padding"></div>
+</div>
+<script>
+    const scrollContainer = document.getElementById("container");
+    scrollContainer.scrollTop = 300;
+</script>

--- a/Tests/LibWeb/Ref/reference/paintablewithlines-corner-clip-in-scroll-container-ref.html
+++ b/Tests/LibWeb/Ref/reference/paintablewithlines-corner-clip-in-scroll-container-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  * {
+    scrollbar-width: none;
+  }
+
+  #container {
+    height: 500px;
+    overflow: scroll;
+    border: 1px solid black;
+  }
+
+  #padding {
+    height: 300px;
+  }
+
+  #rounded-corners-mask {
+    width: 300px;
+    height: 300px;
+    border-radius: 50%;
+    overflow: hidden;
+    overflow: scroll;
+    font-size: 40px;
+    background-color: orangered;
+  }
+</style>
+<div id="container">
+  <div id="rounded-corners-mask">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ultrices neque
+    eu nisi facilisis viverra. Integer lacinia, lacus vel condimentum suscipit,
+    lacus felis porta nulla, eget lacinia sem neque ut neque. In sagittis, eros
+    vel interdum porta, quam ex rhoncus lectus, vitae suscipit risus orci sit
+    amet velit. Praesent imperdiet condimentum rutrum. Cras vitae nisl sapien.
+    Curabitur ligula diam, tincidunt congue tincidunt nec, sodales nec orci.
+    Vestibulum tincidunt non elit in vehicula. Etiam malesuada neque eu porta
+    rhoncus. Curabitur vel nunc finibus ligula posuere venenatis.
+  </div>
+</div>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -692,6 +692,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             context.recording_painter().sample_under_corners(*corner_clip_id, corner_radii, context.rounded_device_rect(clip_box).to_type<int>(), CornerClip::Outside);
         }
 
+        context.recording_painter().save();
         auto scroll_offset = context.rounded_device_point(this->scroll_offset());
         context.recording_painter().translate(-scroll_offset.to_type<int>());
     }
@@ -725,6 +726,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             context.recording_painter().blit_corner_clipping(*corner_clip_id, clip_box.to_type<int>());
             corner_clip_id = {};
         }
+        context.recording_painter().restore();
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -723,7 +723,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     if (should_clip_overflow) {
         context.recording_painter().restore();
         if (corner_clip_id.has_value()) {
-            context.recording_painter().blit_corner_clipping(*corner_clip_id, clip_box.to_type<int>());
+            context.recording_painter().blit_corner_clipping(*corner_clip_id, context.rounded_device_rect(clip_box).to_type<int>());
             corner_clip_id = {};
         }
         context.recording_painter().restore();

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -673,12 +673,13 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
         clip_box.intersect(get_clip_rect().value());
         should_clip_overflow = true;
     }
-    if (enclosing_scroll_frame_offset().has_value())
-        clip_box.translate_by(enclosing_scroll_frame_offset().value());
     if (should_clip_overflow) {
         context.recording_painter().save();
         // FIXME: Handle overflow-x and overflow-y being different values.
-        context.recording_painter().add_clip_rect(context.rounded_device_rect(clip_box).to_type<int>());
+        auto clip_box_with_enclosing_scroll_frame_offset = clip_box;
+        if (enclosing_scroll_frame_offset().has_value())
+            clip_box_with_enclosing_scroll_frame_offset.translate_by(enclosing_scroll_frame_offset().value());
+        context.recording_painter().add_clip_rect(context.rounded_device_rect(clip_box_with_enclosing_scroll_frame_offset).to_type<int>());
 
         auto border_radii = normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
         CornerRadii corner_radii {


### PR DESCRIPTION
Before:
<img width="352" alt="Screenshot 2024-05-26 at 11 21 06" src="https://github.com/SerenityOS/serenity/assets/45686940/e270c218-88eb-42ad-9614-fafca211b0b8">

After:
<img width="347" alt="Screenshot 2024-05-26 at 11 21 24" src="https://github.com/SerenityOS/serenity/assets/45686940/361e3713-cd40-40ca-9705-537079ece892">
