### PR TITLE
LibCore+LibJS: Consider millisecond in Date constructor parsing, validate ranges

### DIFF
--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -25,12 +25,14 @@ public:
     unsigned hour() const { return m_hour; }
     unsigned minute() const { return m_minute; }
     unsigned second() const { return m_second; }
+    unsigned microsecond() const { return m_microsecond; }
+
     unsigned weekday() const;
     unsigned days_in_month() const;
     unsigned day_of_year() const;
     bool is_leap_year() const;
 
-    void set_time(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
+    void set_time(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0, unsigned microsecond = 0);
     void set_time_only(int hour, int minute, Optional<int> second = {});
     void set_date(Core::DateTime const& other);
 
@@ -42,7 +44,7 @@ public:
     ErrorOr<String> to_string(StringView format = "%Y-%m-%d %H:%M:%S"sv, LocalTime = LocalTime::Yes) const;
     ByteString to_byte_string(StringView format = "%Y-%m-%d %H:%M:%S"sv, LocalTime = LocalTime::Yes) const;
 
-    static DateTime create(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
+    static DateTime create(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0, unsigned microsecond = 0);
     static DateTime now();
     static DateTime from_timestamp(time_t);
     static Optional<DateTime> parse(StringView format, StringView string);
@@ -61,6 +63,8 @@ private:
     int m_hour { 0 };
     int m_minute { 0 };
     int m_second { 0 };
+    // NOTE: microseconds not part of the timestamp - only present if %f given
+    unsigned m_microsecond { 0 };
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -26,7 +26,7 @@ namespace JS {
 JS_DEFINE_ALLOCATOR(DateConstructor);
 
 // 21.4.3.2 Date.parse ( string ), https://tc39.es/ecma262/#sec-date.parse
-static double parse_simplified_iso8601(ByteString const& iso_8601)
+static double parse_simplified_iso8601(StringView iso_8601)
 {
     // 21.4.1.15 Date Time String Format, https://tc39.es/ecma262/#sec-date-time-string-format
     GenericLexer lexer(iso_8601);
@@ -150,7 +150,7 @@ static double parse_simplified_iso8601(ByteString const& iso_8601)
     return time_clip(time_ms);
 }
 
-static double parse_date_string(ByteString const& date_string)
+static double parse_date_string(StringView date_string)
 {
     auto value = parse_simplified_iso8601(date_string);
     if (isfinite(value))

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -28,7 +28,7 @@ test("basic functionality", () => {
     expect(Date.parse("2024-01-15 00:00:01")).toBe(1705298401000);
     expect(Date.parse("Tue Nov 07 2023 10:05:55  UTC")).toBe(1699351555000);
     expect(Date.parse("Wed Apr 17 23:08:53 2019")).toBe(1555560533000);
-    expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011000); // FIXME: support sub-second precision
+    expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011306);
     expect(Date.parse("1/27/2024, 9:28:30 AM")).toBe(1706369310000);
 
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -203,3 +203,23 @@ test("Round trip Date.prototype.to*String", () => {
     expect(Date.parse(epoch.toISOString())).toBe(epoch.valueOf());
     expect(Date.parse(epoch.toUTCString())).toBe(epoch.valueOf());
 });
+
+test("Date parsing of minimum and maximum values", () => {
+    const minDateStr = "-271821-04-20T00:00:00.000Z";
+    const minDate = new Date(-8640000000000000);
+
+    expect(minDate.toISOString()).toBe(minDateStr);
+    expect(Date.parse(minDateStr)).toBe(minDate.valueOf());
+
+    const maxDateStr = "+275760-09-13T00:00:00.000Z";
+    const maxDate = new Date(8640000000000000);
+
+    expect(maxDate.toISOString()).toBe(maxDateStr);
+    expect(Date.parse(maxDateStr)).toBe(maxDate.valueOf());
+
+    const belowRange = "-271821-04-19T23:59:59.999Z";
+    const aboveRange = "+275760-09-13T00:00:00.001Z";
+
+    expect(Date.parse(belowRange)).toBe(NaN);
+    expect(Date.parse(aboveRange)).toBe(NaN);
+});


### PR DESCRIPTION
Diff Tests:
    +1 ✅    -1 ❌