### PR TITLE
LibWeb: Use stack to represent blit/sample corners commands state

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -63,7 +63,7 @@ public:
 
         inline operator bool() const
         {
-            return horizontal_radius > 0 || vertical_radius > 0;
+            return horizontal_radius > 0 && vertical_radius > 0;
         }
 
         Gfx::IntRect as_rect() const

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
@@ -21,7 +21,7 @@ struct BorderRadiusData {
 
     inline operator bool() const
     {
-        return horizontal_radius > 0 || vertical_radius > 0;
+        return horizontal_radius > 0 && vertical_radius > 0;
     }
 
     inline void shrink(CSSPixels horizontal, CSSPixels vertical)

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -135,7 +135,7 @@ ScopedCornerRadiusClip::~ScopedCornerRadiusClip()
 {
     if (!m_has_radius)
         return;
-    m_context.recording_painter().blit_corner_clipping(m_id, m_border_rect);
+    m_context.recording_painter().blit_corner_clipping(m_id);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -459,10 +459,6 @@ CommandResult CommandExecutorCPU::sample_under_corners(u32 id, CornerRadii const
         m_corner_clippers.resize(id + 1);
 
     auto clipper = BorderRadiusCornerClipper::create(corner_radii, border_rect.to_type<DevicePixels>(), corner_clip);
-    if (clipper.is_error()) {
-        m_corner_clippers[id] = nullptr;
-        return CommandResult::Continue;
-    }
     m_corner_clippers[id] = clipper.release_value();
     m_corner_clippers[id]->sample_under_corners(painter());
     return CommandResult::Continue;
@@ -470,9 +466,6 @@ CommandResult CommandExecutorCPU::sample_under_corners(u32 id, CornerRadii const
 
 CommandResult CommandExecutorCPU::blit_corner_clipping(u32 id)
 {
-    if (!m_corner_clippers[id])
-        return CommandResult::Continue;
-
     m_corner_clippers[id]->blit_corner_clipping(painter());
     m_corner_clippers[id] = nullptr;
     return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
@@ -49,6 +49,8 @@ public:
     bool needs_prepare_glyphs_texture() const override { return false; }
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override {};
 
+    virtual void prepare_to_execute(size_t corner_clip_max_depth) override;
+
     bool needs_update_immutable_bitmap_texture_cache() const override { return false; }
     void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override {};
 
@@ -56,7 +58,7 @@ public:
 
 private:
     Gfx::Bitmap& m_target_bitmap;
-    Vector<RefPtr<BorderRadiusCornerClipper>> m_corner_clippers;
+    Vector<RefPtr<BorderRadiusCornerClipper>> m_corner_clippers_stack;
 
     struct StackingContext {
         MaybeOwned<Gfx::Painter> painter;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
@@ -429,7 +429,7 @@ void CommandExecutorGPU::prepare_glyph_texture(HashMap<Gfx::Font const*, HashTab
     AccelGfx::GlyphAtlas::the().update(unique_glyphs);
 }
 
-void CommandExecutorGPU::prepare_to_execute()
+void CommandExecutorGPU::prepare_to_execute([[maybe_unused]] size_t corner_clip_max_depth)
 {
     m_context.activate();
 }

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
@@ -50,7 +50,7 @@ public:
     virtual bool needs_prepare_glyphs_texture() const override { return true; }
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override;
 
-    virtual void prepare_to_execute() override;
+    virtual void prepare_to_execute(size_t corner_clip_max_depth) override;
 
     bool needs_update_immutable_bitmap_texture_cache() const override { return true; }
     void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override;

--- a/Userland/Libraries/LibWeb/Painting/CommandList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.cpp
@@ -78,7 +78,7 @@ void CommandList::mark_unnecessary_commands()
 
 void CommandList::execute(CommandExecutor& executor)
 {
-    executor.prepare_to_execute();
+    executor.prepare_to_execute(m_corner_clip_max_depth);
 
     if (executor.needs_prepare_glyphs_texture()) {
         HashMap<Gfx::Font const*, HashTable<u32>> unique_glyphs;

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -86,7 +86,7 @@ public:
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
     virtual bool needs_prepare_glyphs_texture() const { return false; }
     virtual void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs) = 0;
-    virtual void prepare_to_execute() { }
+    virtual void prepare_to_execute([[maybe_unused]] size_t corner_clip_max_depth) { }
     virtual bool needs_update_immutable_bitmap_texture_cache() const = 0;
     virtual void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) = 0;
 };
@@ -99,6 +99,9 @@ public:
     void mark_unnecessary_commands();
     void execute(CommandExecutor&);
 
+    size_t corner_clip_max_depth() const { return m_corner_clip_max_depth; }
+    void set_corner_clip_max_depth(size_t depth) { m_corner_clip_max_depth = depth; }
+
 private:
     struct CommandListItem {
         Optional<i32> scroll_frame_id;
@@ -106,6 +109,7 @@ private:
         bool skip { false };
     };
 
+    size_t m_corner_clip_max_depth { 0 };
     AK::SegmentedVector<CommandListItem, 512> m_commands;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -501,7 +501,7 @@ void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase ph
         m_clipping_overflow = false;
         auto const& combined_transform = combined_css_transform();
         auto const& border_radii_clips = this->border_radii_clips();
-        for (size_t corner_clip_index = 0; corner_clip_index < border_radii_clips.size(); ++corner_clip_index) {
+        for (int corner_clip_index = border_radii_clips.size() - 1; corner_clip_index >= 0; --corner_clip_index) {
             auto const& corner_clip = border_radii_clips[corner_clip_index];
             auto corners = corner_clip.radii.as_corners(context);
             if (!corners.has_any_radius())

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -499,7 +499,6 @@ void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase ph
 
     if (m_clipping_overflow) {
         m_clipping_overflow = false;
-        auto const& combined_transform = combined_css_transform();
         auto const& border_radii_clips = this->border_radii_clips();
         for (int corner_clip_index = border_radii_clips.size() - 1; corner_clip_index >= 0; --corner_clip_index) {
             auto const& corner_clip = border_radii_clips[corner_clip_index];
@@ -508,8 +507,7 @@ void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase ph
                 continue;
             auto corner_clipper_id = m_corner_clipper_ids[corner_clip_index];
             m_corner_clipper_ids[corner_clip_index] = corner_clipper_id;
-            auto rect = corner_clip.rect.translated(-combined_transform.translation().to_type<CSSPixels>());
-            context.recording_painter().blit_corner_clipping(corner_clipper_id, context.rounded_device_rect(rect).to_type<int>());
+            context.recording_painter().blit_corner_clipping(corner_clipper_id);
         }
         context.recording_painter().restore();
     }
@@ -724,7 +722,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     if (should_clip_overflow) {
         context.recording_painter().restore();
         if (corner_clip_id.has_value()) {
-            context.recording_painter().blit_corner_clipping(*corner_clip_id, context.rounded_device_rect(clip_box).to_type<int>());
+            context.recording_painter().blit_corner_clipping(*corner_clip_id);
             corner_clip_id = {};
         }
         context.recording_painter().restore();

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -28,6 +28,8 @@ void RecordingPainter::append(Command&& command)
 void RecordingPainter::sample_under_corners(u32 id, CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip)
 {
     m_corner_clip_state_stack.append({ id, border_rect });
+    if (m_corner_clip_state_stack.size() > commands_list().corner_clip_max_depth())
+        commands_list().set_corner_clip_max_depth(m_corner_clip_state_stack.size());
     append(SampleUnderCorners {
         id,
         corner_radii,

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -127,7 +127,7 @@ public:
     void pop_stacking_context();
 
     void sample_under_corners(u32 id, CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip);
-    void blit_corner_clipping(u32 id, Gfx::IntRect border_rect);
+    void blit_corner_clipping(u32 id);
 
     void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, CSS::ResolvedBackdropFilter const& backdrop_filter);
 
@@ -144,6 +144,7 @@ public:
     void paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data);
 
     RecordingPainter(CommandList& commands_list);
+    ~RecordingPainter();
 
     CommandList& commands_list() { return m_command_list; }
 
@@ -157,6 +158,12 @@ private:
     };
     State& state() { return m_state_stack.last(); }
     State const& state() const { return m_state_stack.last(); }
+
+    struct CornerClipState {
+        u32 id;
+        Gfx::IntRect rect;
+    };
+    Vector<CornerClipState> m_corner_clip_state_stack;
 
     Vector<State> m_state_stack;
     CommandList& m_command_list;


### PR DESCRIPTION
...instead of allocating separate BorderRadiusCornerClipper for each executed sample/blit commands pair.

With this change a vector of BorderRadiusCornerClipper has far fewer items. For example on twitter profile page its size goes down from ~3000 to ~3 items.