### PR TITLE
Tests/LibWeb: Initialize 'arrayBuffer' to an UInt8Array

### DIFF
--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-object-primitives.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-object-primitives.html
@@ -24,18 +24,14 @@
         println(result === result["b"]);
 
         {
-            let arrayBuffer = new ArrayBuffer(6);
-            for (let i = 0; i < arrayBuffer.byteLength; ++i) {
-                arrayBuffer[i] = i;
-            }
+            let arrayBuffer = new Uint8Array([1, 2, 3, 4, 5, 6 ]);
             let arrayClone = structuredClone(arrayBuffer);
             for (let i = 0; i < arrayBuffer.byteLength; ++i) {
-                if (arrayBuffer[i] !== arrayBuffer[i]) {
+                if (arrayClone[i] !== arrayBuffer[i]) {
                     println("FAILED");
                 }
             }
-            // FIXME: This should print something like ArrayBuffer { byteLength: 6 }
-            println(arrayClone);
+            println(arrayClone.buffer);
         }
 
         try {


### PR DESCRIPTION
This initializes 'arrayBuffer' to an UInt8Array so that we can manipulate the contents of 'arrayBuffer'. The test verifies that the internal buffer is an ArrayBuffer.

Also:
* Correct comparison in test so that we compare arrayBuffer to arrayClone, not to itself.
* Remove FIXME, this outputs [object ArrayBuffer] in Firefox and Chrome too.