### PR TITLE
LibWasm: Implement parsing all element variants

### DIFF
--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -797,44 +797,6 @@ public:
     struct Passive {
     };
 
-    struct SegmentType0 {
-        static ParseResult<SegmentType0> parse(Stream& stream);
-
-        Vector<FunctionIndex> function_indices;
-        Active mode;
-    };
-    struct SegmentType1 {
-        static ParseResult<SegmentType1> parse(Stream& stream);
-
-        Vector<FunctionIndex> function_indices;
-    };
-    struct SegmentType2 {
-        // FIXME: Implement me!
-        static ParseResult<SegmentType2> parse(Stream& stream);
-    };
-    struct SegmentType3 {
-        // FIXME: Implement me!
-        static ParseResult<SegmentType3> parse(Stream& stream);
-    };
-    struct SegmentType4 {
-        static ParseResult<SegmentType4> parse(Stream& stream);
-
-        Active mode;
-        Vector<Expression> initializer;
-    };
-    struct SegmentType5 {
-        // FIXME: Implement me!
-        static ParseResult<SegmentType5> parse(Stream& stream);
-    };
-    struct SegmentType6 {
-        // FIXME: Implement me!
-        static ParseResult<SegmentType6> parse(Stream& stream);
-    };
-    struct SegmentType7 {
-        // FIXME: Implement me!
-        static ParseResult<SegmentType7> parse(Stream& stream);
-    };
-
     struct Element {
         static ParseResult<Element> parse(Stream&);
 


### PR DESCRIPTION
Implemented the rest of the element parsing variants. Previously, the implementation had 7 cases for each element type, and had three of the seven finished. I changed the implementation to use the semantic meaning of each part of the tag. Is that okay implementation-wise? It definitely cuts down on the amount of code, but I'm not sure if this approach was ruled out for a different reason. The control flow is uh... well... I can try to find ways to simplify it if needed.

This PR isn't ready to be merged yet because I still need to delete the old code (for the 7 cases thing). I wanted to wait for the okay for this implementation before I did that. Anyway, some more spec tests pass now, and a lot more spec tests get past the parsing stage (but fail in the validator)!