### PR TITLE
LibWasm: Use TRY macro when possible

### DIFF
--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -557,10 +557,8 @@ public:
         template<typename T>
         static ParseResult<Import> parse_with_type(auto&& stream, auto&& module, auto&& name)
         {
-            auto result = T::parse(stream);
-            if (result.is_error())
-                return result.error();
-            return Import { module.release_value(), name.release_value(), result.release_value() };
+            auto result = TRY(T::parse(stream));
+            return Import { module, name, result };
         }
 
         ByteString m_module;


### PR DESCRIPTION
This removes a lot of the error handling boilerplate, and is more consistent with the rest of the codebase. Hopefully I'm not just being an idiot with this PR if there was a reason TRY isn't supposed to be used in these cases...