### PR TITLE
LibWeb: Pass whole command by reference into painting command executor

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
@@ -13,36 +13,36 @@ namespace Web::Painting {
 
 class CommandExecutorCPU : public CommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation, double scale) override;
-    CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
-    CommandResult fill_rect(Gfx::IntRect const& rect, Color const&, Vector<Gfx::Path> const& clip_paths) override;
-    CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
-    CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
-    CommandResult clear_clip_rect() override;
-    CommandResult push_stacking_context(float opacity, bool is_fixed_position, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask) override;
-    CommandResult pop_stacking_context() override;
-    CommandResult paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult paint_outer_box_shadow(PaintOuterBoxShadowParams const&) override;
-    CommandResult paint_inner_box_shadow(PaintOuterBoxShadowParams const&) override;
-    CommandResult paint_text_shadow(int blur_radius, Gfx::IntRect const& shadow_bounding_rect, Gfx::IntRect const& text_rect, Span<Gfx::DrawGlyphOrEmoji const>, Color const&, int fragment_baseline, Gfx::IntPoint const& draw_location) override;
-    CommandResult fill_rect_with_rounded_corners(Gfx::IntRect const&, Color const&, Gfx::AntiAliasingPainter::CornerRadius const& top_left_radius, Gfx::AntiAliasingPainter::CornerRadius const& top_right_radius, Gfx::AntiAliasingPainter::CornerRadius const& bottom_left_radius, Gfx::AntiAliasingPainter::CornerRadius const& bottom_right_radius, Vector<Gfx::Path> const& clip_paths) override;
-    CommandResult fill_path_using_color(Gfx::Path const&, Color const&, Gfx::Painter::WindingRule winding_rule, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult fill_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const& paint_style, Gfx::Painter::WindingRule winding_rule, float opacity, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult stroke_path_using_color(Gfx::Path const&, Color const& color, float thickness, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult stroke_path_using_paint_style(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, float thickness, float opacity, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult draw_ellipse(Gfx::IntRect const& rect, Color const& color, int thickness) override;
-    CommandResult fill_ellipse(Gfx::IntRect const& rect, Color const& color) override;
-    CommandResult draw_line(Color const&, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle style, Color const& alternate_color) override;
-    CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const& sdf, float smoothing) override;
-    CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) override;
-    CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) override;
-    CommandResult paint_radial_gradient(Gfx::IntRect const& rect, Web::Painting::RadialGradientData const& radial_gradient_data, Gfx::IntPoint const& center, Gfx::IntSize const& size, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult paint_conic_gradient(Gfx::IntRect const& rect, Web::Painting::ConicGradientData const& conic_gradient_data, Gfx::IntPoint const& position, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const&, int amplitude, int thickness) override;
-    CommandResult sample_under_corners(u32 id, CornerRadii const&, Gfx::IntRect const&, CornerClip) override;
-    CommandResult blit_corner_clipping(u32 id) override;
-    CommandResult paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data) override;
+    CommandResult draw_glyph_run(DrawGlyphRun const&) override;
+    CommandResult draw_text(DrawText const&) override;
+    CommandResult fill_rect(FillRect const&) override;
+    CommandResult draw_scaled_bitmap(DrawScaledBitmap const&) override;
+    CommandResult draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const&) override;
+    CommandResult set_clip_rect(SetClipRect const&) override;
+    CommandResult clear_clip_rect(ClearClipRect const&) override;
+    CommandResult push_stacking_context(PushStackingContext const&) override;
+    CommandResult pop_stacking_context(PopStackingContext const&) override;
+    CommandResult paint_linear_gradient(PaintLinearGradient const&) override;
+    CommandResult paint_outer_box_shadow(PaintOuterBoxShadow const&) override;
+    CommandResult paint_inner_box_shadow(PaintInnerBoxShadow const&) override;
+    CommandResult paint_text_shadow(PaintTextShadow const&) override;
+    CommandResult fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) override;
+    CommandResult fill_path_using_color(FillPathUsingColor const&) override;
+    CommandResult fill_path_using_paint_style(FillPathUsingPaintStyle const&) override;
+    CommandResult stroke_path_using_color(StrokePathUsingColor const&) override;
+    CommandResult stroke_path_using_paint_style(StrokePathUsingPaintStyle const&) override;
+    CommandResult draw_ellipse(DrawEllipse const&) override;
+    CommandResult fill_ellipse(FillEllipse const&) override;
+    CommandResult draw_line(DrawLine const&) override;
+    CommandResult draw_signed_distance_field(DrawSignedDistanceField const&) override;
+    CommandResult apply_backdrop_filter(ApplyBackdropFilter const&) override;
+    CommandResult draw_rect(DrawRect const&) override;
+    CommandResult paint_radial_gradient(PaintRadialGradient const&) override;
+    CommandResult paint_conic_gradient(PaintConicGradient const&) override;
+    CommandResult draw_triangle_wave(DrawTriangleWave const&) override;
+    CommandResult sample_under_corners(SampleUnderCorners const&) override;
+    CommandResult blit_corner_clipping(BlitCornerClipping const&) override;
+    CommandResult paint_borders(PaintBorders const&) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.h
@@ -14,36 +14,36 @@ namespace Web::Painting {
 
 class CommandExecutorGPU : public CommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation, double scale) override;
-    CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
-    CommandResult fill_rect(Gfx::IntRect const& rect, Color const&, Vector<Gfx::Path> const& clip_paths) override;
-    CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
-    CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
-    CommandResult clear_clip_rect() override;
-    CommandResult push_stacking_context(float opacity, bool, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask) override;
-    CommandResult pop_stacking_context() override;
-    CommandResult paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult paint_outer_box_shadow(PaintOuterBoxShadowParams const&) override;
-    CommandResult paint_inner_box_shadow(PaintOuterBoxShadowParams const&) override;
-    CommandResult paint_text_shadow(int blur_radius, Gfx::IntRect const& shadow_bounding_rect, Gfx::IntRect const& text_rect, Span<Gfx::DrawGlyphOrEmoji const>, Color const&, int fragment_baseline, Gfx::IntPoint const& draw_location) override;
-    CommandResult fill_rect_with_rounded_corners(Gfx::IntRect const&, Color const&, Gfx::AntiAliasingPainter::CornerRadius const& top_left_radius, Gfx::AntiAliasingPainter::CornerRadius const& top_right_radius, Gfx::AntiAliasingPainter::CornerRadius const& bottom_left_radius, Gfx::AntiAliasingPainter::CornerRadius const& bottom_right_radius, Vector<Gfx::Path> const& clip_paths) override;
-    CommandResult fill_path_using_color(Gfx::Path const&, Color const&, Gfx::Painter::WindingRule winding_rule, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult fill_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const& paint_style, Gfx::Painter::WindingRule winding_rule, float opacity, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult stroke_path_using_color(Gfx::Path const&, Color const& color, float thickness, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult stroke_path_using_paint_style(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, float thickness, float opacity, Gfx::FloatPoint const& aa_translation) override;
-    CommandResult draw_ellipse(Gfx::IntRect const& rect, Color const& color, int thickness) override;
-    CommandResult fill_ellipse(Gfx::IntRect const& rect, Color const& color) override;
-    CommandResult draw_line(Color const&, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle style, Color const& alternate_color) override;
-    CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const& sdf, float smoothing) override;
-    CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) override;
-    CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) override;
-    CommandResult paint_radial_gradient(Gfx::IntRect const& rect, Web::Painting::RadialGradientData const& radial_gradient_data, Gfx::IntPoint const& center, Gfx::IntSize const& size, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult paint_conic_gradient(Gfx::IntRect const& rect, Web::Painting::ConicGradientData const& conic_gradient_data, Gfx::IntPoint const& position, Vector<Gfx::Path> const& clip_paths = {}) override;
-    CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const&, int amplitude, int thickness) override;
-    CommandResult sample_under_corners(u32 id, CornerRadii const&, Gfx::IntRect const&, CornerClip) override;
-    CommandResult blit_corner_clipping(u32) override;
-    CommandResult paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data) override;
+    CommandResult draw_glyph_run(DrawGlyphRun const&) override;
+    CommandResult draw_text(DrawText const&) override;
+    CommandResult fill_rect(FillRect const&) override;
+    CommandResult draw_scaled_bitmap(DrawScaledBitmap const&) override;
+    CommandResult draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const&) override;
+    CommandResult set_clip_rect(SetClipRect const&) override;
+    CommandResult clear_clip_rect(ClearClipRect const&) override;
+    CommandResult push_stacking_context(PushStackingContext const&) override;
+    CommandResult pop_stacking_context(PopStackingContext const&) override;
+    CommandResult paint_linear_gradient(PaintLinearGradient const&) override;
+    CommandResult paint_outer_box_shadow(PaintOuterBoxShadow const&) override;
+    CommandResult paint_inner_box_shadow(PaintInnerBoxShadow const&) override;
+    CommandResult paint_text_shadow(PaintTextShadow const&) override;
+    CommandResult fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) override;
+    CommandResult fill_path_using_color(FillPathUsingColor const&) override;
+    CommandResult fill_path_using_paint_style(FillPathUsingPaintStyle const&) override;
+    CommandResult stroke_path_using_color(StrokePathUsingColor const&) override;
+    CommandResult stroke_path_using_paint_style(StrokePathUsingPaintStyle const&) override;
+    CommandResult draw_ellipse(DrawEllipse const&) override;
+    CommandResult fill_ellipse(FillEllipse const&) override;
+    CommandResult draw_line(DrawLine const&) override;
+    CommandResult draw_signed_distance_field(DrawSignedDistanceField const&) override;
+    CommandResult apply_backdrop_filter(ApplyBackdropFilter const&) override;
+    CommandResult draw_rect(DrawRect const&) override;
+    CommandResult paint_radial_gradient(PaintRadialGradient const&) override;
+    CommandResult paint_conic_gradient(PaintConicGradient const&) override;
+    CommandResult draw_triangle_wave(DrawTriangleWave const&) override;
+    CommandResult sample_under_corners(SampleUnderCorners const&) override;
+    CommandResult blit_corner_clipping(BlitCornerClipping const&) override;
+    CommandResult paint_borders(PaintBorders const&) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 

--- a/Userland/Libraries/LibWeb/Painting/CommandList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.cpp
@@ -130,113 +130,88 @@ void CommandList::execute(CommandExecutor& executor)
 
         auto result = command.visit(
             [&](DrawGlyphRun const& command) {
-                return executor.draw_glyph_run(command.glyph_run->glyphs(), command.color, command.translation, command.scale);
+                return executor.draw_glyph_run(command);
             },
             [&](DrawText const& command) {
-                return executor.draw_text(command.rect, command.raw_text, command.alignment, command.color,
-                    command.elision, command.wrapping, command.font);
+                return executor.draw_text(command);
             },
             [&](FillRect const& command) {
-                return executor.fill_rect(command.rect, command.color, command.clip_paths);
+                return executor.fill_rect(command);
             },
             [&](DrawScaledBitmap const& command) {
-                return executor.draw_scaled_bitmap(command.dst_rect, command.bitmap, command.src_rect,
-                    command.scaling_mode);
+                return executor.draw_scaled_bitmap(command);
             },
             [&](DrawScaledImmutableBitmap const& command) {
-                return executor.draw_scaled_immutable_bitmap(command.dst_rect, command.bitmap, command.src_rect,
-                    command.scaling_mode, command.clip_paths);
+                return executor.draw_scaled_immutable_bitmap(command);
             },
             [&](SetClipRect const& command) {
-                return executor.set_clip_rect(command.rect);
+                return executor.set_clip_rect(command);
             },
-            [&](ClearClipRect const&) {
-                return executor.clear_clip_rect();
+            [&](ClearClipRect const& command) {
+                return executor.clear_clip_rect(command);
             },
             [&](PushStackingContext const& command) {
-                return executor.push_stacking_context(command.opacity, command.is_fixed_position,
-                    command.source_paintable_rect,
-                    command.post_transform_translation,
-                    command.image_rendering, command.transform, command.mask);
+                return executor.push_stacking_context(command);
             },
-            [&](PopStackingContext const&) {
-                return executor.pop_stacking_context();
+            [&](PopStackingContext const& command) {
+                return executor.pop_stacking_context(command);
             },
             [&](PaintLinearGradient const& command) {
-                return executor.paint_linear_gradient(command.gradient_rect, command.linear_gradient_data, command.clip_paths);
+                return executor.paint_linear_gradient(command);
             },
             [&](PaintRadialGradient const& command) {
-                return executor.paint_radial_gradient(command.rect, command.radial_gradient_data,
-                    command.center, command.size, command.clip_paths);
+                return executor.paint_radial_gradient(command);
             },
             [&](PaintConicGradient const& command) {
-                return executor.paint_conic_gradient(command.rect, command.conic_gradient_data,
-                    command.position, command.clip_paths);
+                return executor.paint_conic_gradient(command);
             },
             [&](PaintOuterBoxShadow const& command) {
-                return executor.paint_outer_box_shadow(command.outer_box_shadow_params);
+                return executor.paint_outer_box_shadow(command);
             },
             [&](PaintInnerBoxShadow const& command) {
-                return executor.paint_inner_box_shadow(command.outer_box_shadow_params);
+                return executor.paint_inner_box_shadow(command);
             },
             [&](PaintTextShadow const& command) {
-                return executor.paint_text_shadow(command.blur_radius, command.shadow_bounding_rect,
-                    command.text_rect, command.glyph_run, command.color,
-                    command.fragment_baseline, command.draw_location);
+                return executor.paint_text_shadow(command);
             },
             [&](FillRectWithRoundedCorners const& command) {
-                return executor.fill_rect_with_rounded_corners(command.rect, command.color,
-                    command.top_left_radius,
-                    command.top_right_radius,
-                    command.bottom_left_radius,
-                    command.bottom_right_radius,
-                    command.clip_paths);
+                return executor.fill_rect_with_rounded_corners(command);
             },
             [&](FillPathUsingColor const& command) {
-                return executor.fill_path_using_color(command.path, command.color, command.winding_rule,
-                    command.aa_translation);
+                return executor.fill_path_using_color(command);
             },
             [&](FillPathUsingPaintStyle const& command) {
-                return executor.fill_path_using_paint_style(command.path, command.paint_style,
-                    command.winding_rule, command.opacity,
-                    command.aa_translation);
+                return executor.fill_path_using_paint_style(command);
             },
             [&](StrokePathUsingColor const& command) {
-                return executor.stroke_path_using_color(command.path, command.color, command.thickness,
-                    command.aa_translation);
+                return executor.stroke_path_using_color(command);
             },
             [&](StrokePathUsingPaintStyle const& command) {
-                return executor.stroke_path_using_paint_style(command.path, command.paint_style,
-                    command.thickness, command.opacity,
-                    command.aa_translation);
+                return executor.stroke_path_using_paint_style(command);
             },
             [&](DrawEllipse const& command) {
-                return executor.draw_ellipse(command.rect, command.color, command.thickness);
+                return executor.draw_ellipse(command);
             },
             [&](FillEllipse const& command) {
-                return executor.fill_ellipse(command.rect, command.color);
+                return executor.fill_ellipse(command);
             },
             [&](DrawLine const& command) {
-                return executor.draw_line(command.color, command.from, command.to, command.thickness,
-                    command.style, command.alternate_color);
+                return executor.draw_line(command);
             },
             [&](DrawSignedDistanceField const& command) {
-                return executor.draw_signed_distance_field(command.rect, command.color, command.sdf,
-                    command.smoothing);
+                return executor.draw_signed_distance_field(command);
             },
             [&](ApplyBackdropFilter const& command) {
-                return executor.apply_backdrop_filter(command.backdrop_region, command.backdrop_filter);
+                return executor.apply_backdrop_filter(command);
             },
             [&](DrawRect const& command) {
-                return executor.draw_rect(command.rect, command.color, command.rough);
+                return executor.draw_rect(command);
             },
             [&](DrawTriangleWave const& command) {
-                return executor.draw_triangle_wave(command.p1, command.p2, command.color, command.amplitude,
-                    command.thickness);
+                return executor.draw_triangle_wave(command);
             },
             [&](SampleUnderCorners const& command) {
-                return executor.sample_under_corners(command.id, command.corner_radii, command.border_rect,
-                    command.corner_clip);
+                return executor.sample_under_corners(command);
             },
             [&](BlitCornerClipping const& command) {
                 if (skipped_sample_corner_commands.contains(command.id)) {
@@ -247,10 +222,10 @@ void CommandList::execute(CommandExecutor& executor)
                     dbgln("Skipping blit_corner_clipping command because the sample_under_corners command was skipped.");
                     return CommandResult::Continue;
                 }
-                return executor.blit_corner_clipping(command.id);
+                return executor.blit_corner_clipping(command);
             },
             [&](PaintBorders const& command) {
-                return executor.paint_borders(command.border_rect, command.corner_radii, command.borders_data);
+                return executor.paint_borders(command);
             });
 
         if (result == CommandResult::SkipStackingContext) {

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -47,42 +47,36 @@ class CommandExecutor {
 public:
     virtual ~CommandExecutor() = default;
 
-    virtual CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&, Gfx::FloatPoint translation, double scale) = 0;
-    virtual CommandResult draw_text(Gfx::IntRect const&, String const&, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) = 0;
-    virtual CommandResult fill_rect(Gfx::IntRect const&, Color const&, Vector<Gfx::Path> const& clip_paths) = 0;
-    virtual CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;
-    virtual CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode, Vector<Gfx::Path> const& clip_paths = {}) = 0;
-    virtual CommandResult set_clip_rect(Gfx::IntRect const& rect) = 0;
-    virtual CommandResult clear_clip_rect() = 0;
-    virtual CommandResult push_stacking_context(float opacity, bool is_fixed_position, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering image_rendering, StackingContextTransform transform, Optional<StackingContextMask> mask) = 0;
-    virtual CommandResult pop_stacking_context() = 0;
-    virtual CommandResult paint_linear_gradient(Gfx::IntRect const&, LinearGradientData const&, Vector<Gfx::Path> const& clip_paths = {}) = 0;
-    virtual CommandResult paint_radial_gradient(Gfx::IntRect const& rect, RadialGradientData const&, Gfx::IntPoint const& center, Gfx::IntSize const& size, Vector<Gfx::Path> const& clip_paths = {}) = 0;
-    virtual CommandResult paint_conic_gradient(Gfx::IntRect const& rect, ConicGradientData const&, Gfx::IntPoint const& position, Vector<Gfx::Path> const& clip_paths = {}) = 0;
-    virtual CommandResult paint_outer_box_shadow(PaintOuterBoxShadowParams const&) = 0;
-    virtual CommandResult paint_inner_box_shadow(PaintOuterBoxShadowParams const&) = 0;
-    virtual CommandResult paint_text_shadow(int blur_radius, Gfx::IntRect const& shadow_bounding_rect, Gfx::IntRect const& text_rect, Span<Gfx::DrawGlyphOrEmoji const>, Color const&, int fragment_baseline, Gfx::IntPoint const& draw_location) = 0;
-    virtual CommandResult fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color const& color,
-        Gfx::AntiAliasingPainter::CornerRadius const& top_left_radius,
-        Gfx::AntiAliasingPainter::CornerRadius const& top_right_radius,
-        Gfx::AntiAliasingPainter::CornerRadius const& bottom_left_radius,
-        Gfx::AntiAliasingPainter::CornerRadius const& bottom_right_radius,
-        Vector<Gfx::Path> const& clip_paths = {})
-        = 0;
-    virtual CommandResult fill_path_using_color(Gfx::Path const&, Color const& color, Gfx::Painter::WindingRule, Gfx::FloatPoint const& aa_translation) = 0;
-    virtual CommandResult fill_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const& paint_style, Gfx::Painter::WindingRule winding_rule, float opacity, Gfx::FloatPoint const& aa_translation) = 0;
-    virtual CommandResult stroke_path_using_color(Gfx::Path const&, Color const& color, float thickness, Gfx::FloatPoint const& aa_translation) = 0;
-    virtual CommandResult stroke_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const& paint_style, float thickness, float opacity, Gfx::FloatPoint const& aa_translation) = 0;
-    virtual CommandResult draw_ellipse(Gfx::IntRect const&, Color const&, int thickness) = 0;
-    virtual CommandResult fill_ellipse(Gfx::IntRect const&, Color const&) = 0;
-    virtual CommandResult draw_line(Color const& color, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle, Color const& alternate_color) = 0;
-    virtual CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const&, float smoothing) = 0;
-    virtual CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) = 0;
-    virtual CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) = 0;
-    virtual CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const& color, int amplitude, int thickness) = 0;
-    virtual CommandResult sample_under_corners(u32 id, CornerRadii const&, Gfx::IntRect const&, CornerClip) = 0;
-    virtual CommandResult blit_corner_clipping(u32 id) = 0;
-    virtual CommandResult paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data) = 0;
+    virtual CommandResult draw_glyph_run(DrawGlyphRun const&) = 0;
+    virtual CommandResult draw_text(DrawText const&) = 0;
+    virtual CommandResult fill_rect(FillRect const&) = 0;
+    virtual CommandResult draw_scaled_bitmap(DrawScaledBitmap const&) = 0;
+    virtual CommandResult draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const&) = 0;
+    virtual CommandResult set_clip_rect(SetClipRect const&) = 0;
+    virtual CommandResult clear_clip_rect(ClearClipRect const&) = 0;
+    virtual CommandResult push_stacking_context(PushStackingContext const&) = 0;
+    virtual CommandResult pop_stacking_context(PopStackingContext const&) = 0;
+    virtual CommandResult paint_linear_gradient(PaintLinearGradient const&) = 0;
+    virtual CommandResult paint_radial_gradient(PaintRadialGradient const&) = 0;
+    virtual CommandResult paint_conic_gradient(PaintConicGradient const&) = 0;
+    virtual CommandResult paint_outer_box_shadow(PaintOuterBoxShadow const&) = 0;
+    virtual CommandResult paint_inner_box_shadow(PaintInnerBoxShadow const&) = 0;
+    virtual CommandResult paint_text_shadow(PaintTextShadow const&) = 0;
+    virtual CommandResult fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) = 0;
+    virtual CommandResult fill_path_using_color(FillPathUsingColor const&) = 0;
+    virtual CommandResult fill_path_using_paint_style(FillPathUsingPaintStyle const&) = 0;
+    virtual CommandResult stroke_path_using_color(StrokePathUsingColor const&) = 0;
+    virtual CommandResult stroke_path_using_paint_style(StrokePathUsingPaintStyle const&) = 0;
+    virtual CommandResult draw_ellipse(DrawEllipse const&) = 0;
+    virtual CommandResult fill_ellipse(FillEllipse const&) = 0;
+    virtual CommandResult draw_line(DrawLine const&) = 0;
+    virtual CommandResult draw_signed_distance_field(DrawSignedDistanceField const&) = 0;
+    virtual CommandResult apply_backdrop_filter(ApplyBackdropFilter const&) = 0;
+    virtual CommandResult draw_rect(DrawRect const&) = 0;
+    virtual CommandResult draw_triangle_wave(DrawTriangleWave const&) = 0;
+    virtual CommandResult sample_under_corners(SampleUnderCorners const&) = 0;
+    virtual CommandResult blit_corner_clipping(BlitCornerClipping const&) = 0;
+    virtual CommandResult paint_borders(PaintBorders const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
     virtual bool needs_prepare_glyphs_texture() const { return false; }
     virtual void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs) = 0;


### PR DESCRIPTION
Now after making a change in a painting command we could avoid updating method's parameters list across 3 classes.