### PR TITLE
LibAudio: Replace DeprecatedFlyString with FlyString

### DIFF
--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -66,7 +66,7 @@ ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::create_plugin(NonnullO
         TRY(stream->seek(0, SeekMode::SetPosition));
     }
 
-    return LoaderError { "No loader plugin available" };
+    return LoaderError { "No loader plugin available"_fly_string };
 }
 
 LoaderSamples Loader::get_more_samples(size_t samples_to_read_from_input)

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -8,6 +8,7 @@
 
 #include <AK/DeprecatedFlyString.h>
 #include <AK/Error.h>
+#include <AK/FlyString.h>
 #include <errno.h>
 
 namespace Audio {
@@ -28,20 +29,20 @@ struct LoaderError {
     Category category { Category::Unknown };
     // Binary index: where in the file the error occurred.
     size_t index { 0 };
-    DeprecatedFlyString description { ByteString::empty() };
+    FlyString description { ""_fly_string };
 
     constexpr LoaderError() = default;
-    LoaderError(Category category, size_t index, DeprecatedFlyString description)
+    LoaderError(Category category, size_t index, FlyString description)
         : category(category)
         , index(index)
         , description(move(description))
     {
     }
-    LoaderError(DeprecatedFlyString description)
+    LoaderError(FlyString description)
         : description(move(description))
     {
     }
-    LoaderError(Category category, DeprecatedFlyString description)
+    LoaderError(Category category, FlyString description)
         : category(category)
         , description(move(description))
     {
@@ -54,11 +55,11 @@ struct LoaderError {
     {
         if (error.is_errno()) {
             auto code = error.code();
-            description = ByteString::formatted("{} ({})", strerror(code), code);
+            description = String::formatted("{} ({})", strerror(code), code).release_value_but_fixme_should_propagate_errors();
             if (code == EBADF || code == EBUSY || code == EEXIST || code == EIO || code == EISDIR || code == ENOENT || code == ENOMEM || code == EPIPE)
                 category = Category::IO;
         } else {
-            description = error.string_literal();
+            description = FlyString::from_utf8(error.string_literal()).release_value_but_fixme_should_propagate_errors();
         }
     }
 };

--- a/Userland/Libraries/LibAudio/QOALoader.cpp
+++ b/Userland/Libraries/LibAudio/QOALoader.cpp
@@ -48,7 +48,7 @@ MaybeLoaderError QOALoaderPlugin::parse_header()
 {
     u32 header_magic = TRY(m_stream->read_value<BigEndian<u32>>());
     if (header_magic != QOA::magic)
-        return LoaderError { LoaderError::Category::Format, 0, "QOA header: Magic number must be 'qoaf'" };
+        return LoaderError { LoaderError::Category::Format, 0, "QOA header: Magic number must be 'qoaf'"_fly_string };
 
     m_total_samples = TRY(m_stream->read_value<BigEndian<u32>>());
 
@@ -62,9 +62,9 @@ MaybeLoaderError QOALoaderPlugin::load_one_frame(Span<Sample>& target, IsFirstFr
     if (header.num_channels > 8)
         dbgln("QOALoader: Warning: QOA frame at {} has more than 8 channels ({}), this is not supported by the reference implementation.", TRY(m_stream->tell()) - sizeof(QOA::FrameHeader), header.num_channels);
     if (header.num_channels == 0)
-        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "QOA frame: Number of channels must be greater than 0" };
+        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "QOA frame: Number of channels must be greater than 0"_fly_string };
     if (header.sample_count > QOA::max_frame_samples)
-        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "QOA frame: Too many samples in frame" };
+        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "QOA frame: Too many samples in frame"_fly_string };
 
     // We weren't given a large enough buffer; signal that we didn't write anything and return.
     if (header.sample_count > target.size()) {
@@ -105,7 +105,7 @@ MaybeLoaderError QOALoaderPlugin::load_one_frame(Span<Sample>& target, IsFirstFr
         m_sample_rate = header.sample_rate;
     } else {
         if (m_sample_rate != header.sample_rate)
-            return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), "QOA: Differing sample rate in non-initial frame" };
+            return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), "QOA: Differing sample rate in non-initial frame"_fly_string };
         if (m_num_channels != header.num_channels)
             m_has_uniform_channel_count = false;
     }
@@ -189,7 +189,7 @@ MaybeLoaderError QOALoaderPlugin::seek(int sample_index)
     // A QOA file consists of 8 bytes header followed by a number of usually fixed-size frames.
     // This fixed bitrate allows us to seek in constant time.
     if (!m_has_uniform_channel_count)
-        return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), "QOA with non-uniform channel count is currently not seekable"sv };
+        return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), "QOA with non-uniform channel count is currently not seekable"_fly_string };
     /// FIXME: Change the Loader API to use size_t.
     VERIFY(sample_index >= 0);
     // We seek to the frame "before"; i.e. the frame that contains that sample.

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -165,7 +165,7 @@ MaybeLoaderError WavLoaderPlugin::seek(int sample_index)
 {
     dbgln_if(AWAVLOADER_DEBUG, "seek sample_index {}", sample_index);
     if (sample_index < 0 || sample_index >= static_cast<int>(m_total_samples))
-        return LoaderError { LoaderError::Category::Internal, m_loaded_samples, "Seek outside the sample range" };
+        return LoaderError { LoaderError::Category::Internal, m_loaded_samples, "Seek outside the sample range"_fly_string };
 
     size_t sample_offset = m_byte_offset_of_data_samples + static_cast<size_t>(sample_index * m_num_channels * (pcm_bits_per_sample(m_sample_format) / 8));
 
@@ -178,11 +178,11 @@ MaybeLoaderError WavLoaderPlugin::seek(int sample_index)
 // Specification reference: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
 MaybeLoaderError WavLoaderPlugin::parse_header()
 {
-#define CHECK(check, category, msg)                                                                                                    \
-    do {                                                                                                                               \
-        if (!(check)) {                                                                                                                \
-            return LoaderError { category, static_cast<size_t>(TRY(m_stream->tell())), ByteString::formatted("WAV header: {}", msg) }; \
-        }                                                                                                                              \
+#define CHECK(check, category, msg)                                                                                                     \
+    do {                                                                                                                                \
+        if (!(check)) {                                                                                                                 \
+            return LoaderError { category, static_cast<size_t>(TRY(m_stream->tell())), TRY(String::formatted("WAV header: {}", msg)) }; \
+        }                                                                                                                               \
     } while (0)
 
     auto file_header = TRY(m_stream->read_value<RIFF::FileHeader>());


### PR DESCRIPTION
This addresses part of #22447 by replacing a `DeprecatedFlyString` with a `FlyString` in LibAudio's `LoaderError`.