### PR TITLE
Chess: Add time controls

### DIFF
--- a/Userland/Games/Chess/CMakeLists.txt
+++ b/Userland/Games/Chess/CMakeLists.txt
@@ -7,14 +7,17 @@ serenity_component(
 
 compile_gml(Chess.gml ChessGML.cpp chess_gml)
 compile_gml(PromotionWidget.gml PromotionWidgetGML.cpp promotionWidget_gml)
+compile_gml(NewGameWidget.gml NewGameWidgetGML.cpp newGameWidget_gml)
 
 set(SOURCES
     main.cpp
     ChessWidget.cpp
     PromotionDialog.cpp
+    NewGameDialog.cpp
     Engine.cpp
     ChessGML.cpp
     PromotionWidgetGML.cpp
+    NewGameWidgetGML.cpp
 )
 
 serenity_app(Chess ICON app-chess)

--- a/Userland/Games/Chess/Chess.gml
+++ b/Userland/Games/Chess/Chess.gml
@@ -30,6 +30,20 @@
                 mode: "DisplayOnly"
                 focus_policy: "NoFocus"
             }
+
+            @GUI::Label {
+                text_alignment: "CenterLeft"
+                font_weight: "Bold"
+                autosize: true
+                name: "white_time_label"
+            }
+
+            @GUI::Label {
+                text_alignment: "CenterLeft"
+                font_weight: "Bold"
+                autosize: true
+                name: "black_time_label"
+            }
         }
     }
 }

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -16,6 +16,7 @@
 #include <LibChess/Chess.h>
 #include <LibConfig/Listener.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/Label.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGfx/Bitmap.h>
 
@@ -109,6 +110,8 @@ public:
 
     void set_engine(RefPtr<Engine> engine) { m_engine = engine; }
     void set_move_display_widget(RefPtr<GUI::TextEditor> move_display_widget) { m_move_display_widget = move_display_widget; }
+    void set_white_time_label(RefPtr<GUI::Label> time_label) { m_white_time_label = time_label; }
+    void set_black_time_label(RefPtr<GUI::Label> time_label) { m_black_time_label = time_label; }
 
     void input_engine_move();
     bool want_engine_move();
@@ -118,6 +121,18 @@ public:
 
     void set_highlight_checks(bool highlight_checks) { m_highlight_checks = highlight_checks; }
     bool highlight_checks() const { return m_highlight_checks; }
+
+    void set_unlimited_time_control(bool unlimited) { m_unlimited_time_control = unlimited; }
+    bool unlimited_time_control() const { return m_unlimited_time_control; }
+
+    void set_time_control_seconds(i32 seconds) { m_time_control_seconds = seconds; }
+    i32 time_control_seconds() const { return m_time_control_seconds; }
+
+    void set_time_control_increment(i32 seconds) { m_time_control_increment = seconds; }
+    i32 time_control_increment() const { return m_time_control_increment; }
+
+    void initialize_timer();
+    void update_time_labels(u32 white_time, u32 black_time);
 
     struct BoardMarking {
         Chess::Square from { 50, 50 };
@@ -153,6 +168,8 @@ private:
     virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value) override;
 
     bool check_game_over(ClaimDrawBehavior);
+    void check_resign_on_time(StringView msg);
+    void apply_increment(Chess::Move move);
 
     Chess::Board m_board;
     Chess::Board m_board_playback;
@@ -178,6 +195,14 @@ private:
     bool m_coordinates { true };
     bool m_highlight_checks { true };
     RefPtr<GUI::TextEditor> m_move_display_widget;
+    RefPtr<GUI::Label> m_white_time_label;
+    RefPtr<GUI::Label> m_black_time_label;
+    bool m_unlimited_time_control { true };
+    i32 m_time_control_seconds { 0 };
+    i32 m_time_control_increment { 0 };
+    i32 m_white_time_elapsed { 0 };
+    i32 m_black_time_elapsed { 0 };
+    RefPtr<Core::Timer> m_timer;
 };
 
 }

--- a/Userland/Games/Chess/NewGameDialog.cpp
+++ b/Userland/Games/Chess/NewGameDialog.cpp
@@ -5,34 +5,68 @@
  */
 
 #include "NewGameDialog.h"
-#include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
-#include <LibGUI/Frame.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/SpinBox.h>
 
 namespace Chess {
 
-ErrorOr<NonnullRefPtr<NewGameDialog>> NewGameDialog::try_create(GUI::Window* parent_window)
+ErrorOr<NonnullRefPtr<NewGameDialog>> NewGameDialog::try_create(GUI::Window* parent_window, bool unlimited_time_control, i32 time_control_seconds, i32 time_control_increment)
 {
     auto new_game_widget = TRY(Chess::NewGameWidget::try_create());
-    auto new_game_dialog = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) NewGameDialog(move(new_game_widget), move(parent_window))));
+    auto new_game_dialog = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) NewGameDialog(move(new_game_widget), move(parent_window), unlimited_time_control, time_control_seconds, time_control_increment)));
     return new_game_dialog;
 }
 
-NewGameDialog::NewGameDialog(NonnullRefPtr<Chess::NewGameWidget> new_game_widget, GUI::Window* parent_window)
+NewGameDialog::NewGameDialog(NonnullRefPtr<Chess::NewGameWidget> new_game_widget, GUI::Window* parent_window, bool unlimited_time_control, i32 time_control_seconds, i32 time_control_increment)
     : GUI::Dialog(parent_window)
+    , m_unlimited_time_control(unlimited_time_control)
+    , m_time_control_seconds(time_control_seconds)
+    , m_time_control_increment(time_control_increment)
 {
     set_title("New Game");
     set_main_widget(new_game_widget);
+
+    m_minutes_spinbox_value = m_time_control_seconds / 60;
+    m_seconds_spinbox_value = m_time_control_seconds % 60;
+
+    m_minutes_spinbox = new_game_widget->find_descendant_of_type_named<GUI::SpinBox>("minutes_spinbox");
+    m_minutes_spinbox->set_value(m_minutes_spinbox_value);
+    m_minutes_spinbox->on_change = [&](auto value) {
+        m_minutes_spinbox_value = value;
+        m_time_control_seconds = m_minutes_spinbox_value * 60 + m_seconds_spinbox_value;
+    };
+
+    m_seconds_spinbox = new_game_widget->find_descendant_of_type_named<GUI::SpinBox>("seconds_spinbox");
+    m_seconds_spinbox->set_value(m_seconds_spinbox_value);
+    m_seconds_spinbox->on_change = [&](auto value) {
+        m_seconds_spinbox_value = value;
+        m_time_control_seconds = m_minutes_spinbox_value * 60 + m_seconds_spinbox_value;
+    };
+
+    m_increment_spinbox = new_game_widget->find_descendant_of_type_named<GUI::SpinBox>("increment_spinbox");
+    m_increment_spinbox->set_value(m_time_control_increment);
+    m_increment_spinbox->on_change = [&](auto value) {
+        m_time_control_increment = value;
+    };
+
+    auto unlimited_checkbox = new_game_widget->find_descendant_of_type_named<GUI::CheckBox>("unlimited_time_control");
+    unlimited_checkbox->set_checked(m_unlimited_time_control);
+    unlimited_checkbox->on_checked = [&](bool checked) {
+        m_unlimited_time_control = checked;
+        m_minutes_spinbox->set_enabled(!checked);
+        m_seconds_spinbox->set_enabled(!checked);
+        m_increment_spinbox->set_enabled(!checked);
+    };
+
+    m_minutes_spinbox->set_enabled(!m_unlimited_time_control);
+    m_seconds_spinbox->set_enabled(!m_unlimited_time_control);
+    m_increment_spinbox->set_enabled(!m_unlimited_time_control);
 
     auto start_button = new_game_widget->find_descendant_of_type_named<GUI::Button>("start_button");
     start_button->on_click = [this](auto) {
         done(ExecResult::OK);
     };
-}
-
-void NewGameDialog::event(Core::Event& event)
-{
-    GUI::Dialog::event(event);
 }
 
 }

--- a/Userland/Games/Chess/NewGameDialog.cpp
+++ b/Userland/Games/Chess/NewGameDialog.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "NewGameDialog.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Frame.h>
+
+namespace Chess {
+
+ErrorOr<NonnullRefPtr<NewGameDialog>> NewGameDialog::try_create(GUI::Window* parent_window)
+{
+    auto new_game_widget = TRY(Chess::NewGameWidget::try_create());
+    auto new_game_dialog = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) NewGameDialog(move(new_game_widget), move(parent_window))));
+    return new_game_dialog;
+}
+
+NewGameDialog::NewGameDialog(NonnullRefPtr<Chess::NewGameWidget> new_game_widget, GUI::Window* parent_window)
+    : GUI::Dialog(parent_window)
+{
+    set_title("New Game");
+    set_main_widget(new_game_widget);
+
+    auto start_button = new_game_widget->find_descendant_of_type_named<GUI::Button>("start_button");
+    start_button->on_click = [this](auto) {
+        done(ExecResult::OK);
+    };
+}
+
+void NewGameDialog::event(Core::Event& event)
+{
+    GUI::Dialog::event(event);
+}
+
+}

--- a/Userland/Games/Chess/NewGameDialog.h
+++ b/Userland/Games/Chess/NewGameDialog.h
@@ -15,11 +15,23 @@ namespace Chess {
 class NewGameDialog final : public GUI::Dialog {
     C_OBJECT_ABSTRACT(NewGameDialog)
 public:
-    static ErrorOr<NonnullRefPtr<NewGameDialog>> try_create(GUI::Window* parent_window);
+    static ErrorOr<NonnullRefPtr<NewGameDialog>> try_create(GUI::Window* parent_window, bool unlimited_time_control, i32 time_control_seconds, i32 time_control_increment);
+    bool unlimited_time_control() { return m_unlimited_time_control; }
+    i32 time_control_seconds() { return m_time_control_seconds; }
+    i32 time_control_increment() { return m_time_control_increment; }
 
 private:
-    NewGameDialog(NonnullRefPtr<Chess::NewGameWidget> new_game_widget_widget, GUI::Window* parent_window);
-    virtual void event(Core::Event&) override;
+    NewGameDialog(NonnullRefPtr<Chess::NewGameWidget> new_game_widget_widget, GUI::Window* parent_window, bool unlimited_time_control, i32 time_control_seconds, i32 time_control_increment);
+
+    bool m_unlimited_time_control;
+    i32 m_time_control_seconds;
+    i32 m_time_control_increment;
+    i32 m_minutes_spinbox_value;
+    i32 m_seconds_spinbox_value;
+
+    RefPtr<GUI::SpinBox> m_minutes_spinbox;
+    RefPtr<GUI::SpinBox> m_seconds_spinbox;
+    RefPtr<GUI::SpinBox> m_increment_spinbox;
 };
 
 }

--- a/Userland/Games/Chess/NewGameDialog.h
+++ b/Userland/Games/Chess/NewGameDialog.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ChessWidget.h"
+#include "NewGameWidget.h"
+#include <LibGUI/Dialog.h>
+
+namespace Chess {
+
+class NewGameDialog final : public GUI::Dialog {
+    C_OBJECT_ABSTRACT(NewGameDialog)
+public:
+    static ErrorOr<NonnullRefPtr<NewGameDialog>> try_create(GUI::Window* parent_window);
+
+private:
+    NewGameDialog(NonnullRefPtr<Chess::NewGameWidget> new_game_widget_widget, GUI::Window* parent_window);
+    virtual void event(Core::Event&) override;
+};
+
+}

--- a/Userland/Games/Chess/NewGameWidget.gml
+++ b/Userland/Games/Chess/NewGameWidget.gml
@@ -1,0 +1,18 @@
+@Chess::NewGameWidget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+    }
+
+    @GUI::Widget {
+        layout: @GUI::HorizontalBoxLayout {
+            spacing: 10
+        }
+
+        @GUI::Button {
+            name: "start_button"
+            text: "Start"
+            fixed_width: 80
+        }
+    }
+}

--- a/Userland/Games/Chess/NewGameWidget.gml
+++ b/Userland/Games/Chess/NewGameWidget.gml
@@ -4,10 +4,81 @@
         margins: [8]
     }
 
+    @GUI::GroupBox {
+        title: "Time Controls"
+        preferred_height: "fit"
+        min_width: 250
+        layout: @GUI::VerticalBoxLayout {
+            margins: [8]
+        }
+
+        @GUI::CheckBox {
+            name: "unlimited_time_control"
+            text: "Unlimited"
+            checkbox_position: "Right"
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Label {
+                text: "Minutes:"
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::SpinBox {
+                name: "minutes_spinbox"
+                min: 0
+                max: 180
+                fixed_width: 50
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Label {
+                text: "Seconds:"
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::SpinBox {
+                name: "seconds_spinbox"
+                min: 0
+                max: 59
+                fixed_width: 50
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Label {
+                text: "Increment in seconds:"
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::SpinBox {
+                name: "increment_spinbox"
+                min: 0
+                max: 180
+                fixed_width: 50
+            }
+        }
+    }
+
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {
             spacing: 10
         }
+
+        @GUI::Layout::Spacer {}
 
         @GUI::Button {
             name: "start_button"

--- a/Userland/Games/Chess/NewGameWidget.h
+++ b/Userland/Games/Chess/NewGameWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace Chess {
+
+class NewGameWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(NewGameWidget)
+public:
+    static ErrorOr<NonnullRefPtr<NewGameWidget>> try_create();
+    virtual ~NewGameWidget() override = default;
+
+private:
+    NewGameWidget() = default;
+};
+
+}

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -9,6 +9,7 @@
 
 #include "ChessWidget.h"
 #include "MainWidget.h"
+#include "NewGameDialog.h"
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
@@ -148,6 +149,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (chess_widget.resign() < 0)
                 return;
         }
+        auto new_game_dialog_or_error = Chess::NewGameDialog::try_create(window);
+        if (new_game_dialog_or_error.is_error()) {
+            GUI::MessageBox::show(window, "Failed to load the new game window"sv, "Unable to Open New Game Dialog"sv, GUI::MessageBox::Type::Error);
+            return;
+        }
+
+        auto new_game_dialog = new_game_dialog_or_error.release_value();
+        if (new_game_dialog->exec() != GUI::Dialog::ExecResult::OK)
+            return;
+
         chess_widget.reset();
     }));
     game_menu->add_separator();


### PR DESCRIPTION
This PR adds the ability to play with time controls. All rules related to this have been implementing, including losing on time and getting time bonuses after moves. The settings for this functionality were placed in a `NewGameDialog` widget instead of the `GameSettings` application due to the fact that the user should only be able to change the time controls when making a new game, which is very hard to enforce if going through `GameSettings`.

Edit: here is a screenshot:
![chess-timer](https://github.com/SerenityOS/serenity/assets/40000298/a9faab72-5095-42fe-9fc8-2ec9c1565c91)