### PR TITLE
had_any_timer is not set during the loop

### DIFF
--- a/WindowServer/WSMessageLoop.cpp
+++ b/WindowServer/WSMessageLoop.cpp
@@ -160,6 +160,7 @@ void WSMessageLoop::wait_for_message()
         auto& timer = *it.value;
         if (!had_any_timer) {
             timeout = timer.next_fire_time;
+	    had_any_timer = true;
             continue;
         }
         if (timer.next_fire_time.tv_sec > timeout.tv_sec || (timer.next_fire_time.tv_sec == timeout.tv_sec && timer.next_fire_time.tv_usec > timeout.tv_usec))


### PR DESCRIPTION
had_any_timer is not set during the loop;
so the rest of the loop will not be executed.