### PR TITLE
Ladybird/Qt: Calculate the 'physical pixels' for screens

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -543,8 +543,11 @@ void WebContentView::update_screen_rects()
     if (!screens.empty()) {
         Vector<Web::DevicePixelRect> screen_rects;
         for (auto const& screen : screens) {
+            // NOTE: QScreen::geometry() returns the 'device-independent pixels', we multiply
+            //       by the device pixel ratio to get the 'physical pixels' of the display.
             auto geometry = screen->geometry();
-            screen_rects.append(Web::DevicePixelRect(geometry.x(), geometry.y(), geometry.width(), geometry.height()));
+            auto device_pixel_ratio = screen->devicePixelRatio();
+            screen_rects.append(Web::DevicePixelRect(geometry.x(), geometry.y(), geometry.width() * device_pixel_ratio, geometry.height() * device_pixel_ratio));
         }
 
         // NOTE: The first item in QGuiApplication::screens is always the primary screen.


### PR DESCRIPTION
This fixes a regression introduced by GH-23855 in [1], and re-applies a previous change I made [2].

[1] https://github.com/SerenityOS/serenity/commit/dfc7534
[2] https://github.com/SerenityOS/serenity/commit/b7bd3fd