### PR TITLE
VideoPlayerSDL: Instruct the compiler to search SDL2's include path

### DIFF
--- a/Meta/Lagom/Contrib/VideoPlayerSDL/CMakeLists.txt
+++ b/Meta/Lagom/Contrib/VideoPlayerSDL/CMakeLists.txt
@@ -4,4 +4,5 @@ add_executable(VideoPlayerSDL
     main.cpp
 )
 
+target_include_directories(VideoPlayerSDL PRIVATE ${SDL2_INCLUDE_DIRS})
 target_link_libraries(VideoPlayerSDL PRIVATE LibMain LibCore LibGfx LibVideo SDL2::SDL2)


### PR DESCRIPTION
On my Mac system with Homebrew SDL + self-built Clang, SDL2's include
directory is not in the library search path by default. Add it to
unbreak the build.
