### PR TITLE
LibGfx/WebP+image: Add support for writing color index transforms, and fix an encoding bug

### DIFF
--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -186,6 +186,27 @@ TEST_CASE(test_webp)
     TRY_OR_FAIL((test_roundtrip<Gfx::WebPWriter, Gfx::WebPImageDecoderPlugin>(TRY_OR_FAIL(create_test_rgba_bitmap()))));
 }
 
+TEST_CASE(test_webp_color_indexing_transform)
+{
+    Array<Color, 256> colors;
+    for (size_t i = 0; i < colors.size(); ++i) {
+        colors[i].set_red(i);
+        colors[i].set_green(255 - i);
+        colors[i].set_blue(128);
+        colors[i].set_alpha(255 - i / 16);
+    }
+    for (int bits_per_pixel : { 1, 2, 4, 8 }) {
+        int number_of_colors = 1 << bits_per_pixel;
+
+        auto bitmap = TRY_OR_FAIL(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 47, 33 }));
+        for (int y = 0; y < bitmap->height(); ++y)
+            for (int x = 0; x < bitmap->width(); ++x)
+                bitmap->set_pixel(x, y, colors[(x * bitmap->width() + y) % number_of_colors]);
+
+        TRY_OR_FAIL((test_roundtrip<Gfx::WebPWriter, Gfx::WebPImageDecoderPlugin>(bitmap)));
+    }
+}
+
 TEST_CASE(test_webp_icc)
 {
     auto sRGB_icc_profile = MUST(Gfx::ICC::sRGB());

--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -213,7 +213,9 @@ TEST_CASE(test_webp_icc)
     auto sRGB_icc_data = MUST(Gfx::ICC::encode(sRGB_icc_profile));
 
     auto rgba_bitmap = TRY_OR_FAIL(create_test_rgba_bitmap());
-    auto encoded_rgba_bitmap = TRY_OR_FAIL((encode_bitmap<Gfx::WebPWriter>(rgba_bitmap, Gfx::WebPEncoderOptions { .icc_data = sRGB_icc_data })));
+    Gfx::WebPEncoderOptions options;
+    options.icc_data = sRGB_icc_data;
+    auto encoded_rgba_bitmap = TRY_OR_FAIL((encode_bitmap<Gfx::WebPWriter>(rgba_bitmap, options)));
 
     auto decoded_rgba_plugin = TRY_OR_FAIL(Gfx::WebPImageDecoderPlugin::create(encoded_rgba_bitmap));
     expect_bitmaps_equal(*TRY_OR_FAIL(expect_single_frame_of_size(*decoded_rgba_plugin, rgba_bitmap->size())), rgba_bitmap);

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -124,7 +124,7 @@ static ErrorOr<void> decode_webp_chunk_ALPH(RIFF::Chunk const& alph_chunk, Bitma
     u8 filtering_method = (flags >> 2) & 3;
     u8 compression_method = flags & 3;
 
-    dbgln_if(WEBP_DEBUG, "preprocessing {} filtering_method {} compression_method {}", preprocessing, filtering_method, compression_method);
+    dbgln_if(WEBP_DEBUG, "ALPH: preprocessing {} filtering_method {} compression_method {}", preprocessing, filtering_method, compression_method);
 
     ReadonlyBytes alpha_data = alph_chunk.data().slice(1);
 
@@ -258,7 +258,7 @@ static ErrorOr<VP8XHeader> decode_webp_chunk_VP8X(RIFF::Chunk const& vp8x_chunk)
     // 3 bytes height minus one
     u32 height = (vp8x_chunk[7] | (vp8x_chunk[8] << 8) | (vp8x_chunk[9] << 16)) + 1;
 
-    dbgln_if(WEBP_DEBUG, "flags {:#x} --{}{}{}{}{}{}, width {}, height {}",
+    dbgln_if(WEBP_DEBUG, "VP8X: flags {:#x} --{}{}{}{}{}{}, width {}, height {}",
         flags,
         has_icc ? " icc" : "",
         has_alpha ? " alpha" : "",
@@ -281,7 +281,7 @@ static ErrorOr<ANIMChunk> decode_webp_chunk_ANIM(RIFF::Chunk const& anim_chunk)
     u32 background_color = (u32)anim_chunk[0] | ((u32)anim_chunk[1] << 8) | ((u32)anim_chunk[2] << 16) | ((u32)anim_chunk[3] << 24);
     u16 loop_count = anim_chunk[4] | (anim_chunk[5] << 8);
 
-    dbgln_if(WEBP_DEBUG, "background_color {:x} loop_count {}", background_color, loop_count);
+    dbgln_if(WEBP_DEBUG, "ANIM: background_color {:x} loop_count {}", background_color, loop_count);
 
     return ANIMChunk { background_color, loop_count };
 }
@@ -314,7 +314,7 @@ static ErrorOr<ANMFChunk> decode_webp_chunk_ANMF(WebPLoadingContext& context, RI
     auto blending_method = static_cast<ANMFChunkHeader::BlendingMethod>((flags >> 1) & 1);
     auto disposal_method = static_cast<ANMFChunkHeader::DisposalMethod>(flags & 1);
 
-    dbgln_if(WEBP_DEBUG, "frame_x {} frame_y {} frame_width {} frame_height {} frame_duration {} blending_method {} disposal_method {}",
+    dbgln_if(WEBP_DEBUG, "ANMF: frame_x {} frame_y {} frame_width {} frame_height {} frame_duration {} blending_method {} disposal_method {}",
         frame_x, frame_y, frame_width, frame_height, frame_duration, (int)blending_method, (int)disposal_method);
 
     // https://developers.google.com/speed/webp/docs/riff_container#assembling_the_canvas_from_frames

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -179,11 +179,6 @@ static ErrorOr<PrefixCodeGroup> decode_webp_chunk_VP8L_prefix_code_group(u16 col
     return group;
 }
 
-enum class ImageKind {
-    SpatiallyCoded,
-    EntropyCoded,
-};
-
 static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_image(ImageKind image_kind, BitmapFormat format, IntSize const& size, LittleEndianInputBitStream& bit_stream)
 {
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#623_decoding_entropy-coded_image_data

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -875,20 +875,6 @@ ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&
         // transform            =  predictor-tx / color-tx / subtract-green-tx
         // transform            =/ color-indexing-tx
 
-        enum TransformType {
-            // predictor-tx         =  %b00 predictor-image
-            PREDICTOR_TRANSFORM = 0,
-
-            // color-tx             =  %b01 color-image
-            COLOR_TRANSFORM = 1,
-
-            // subtract-green-tx    =  %b10
-            SUBTRACT_GREEN_TRANSFORM = 2,
-
-            // color-indexing-tx    =  %b11 color-indexing-image
-            COLOR_INDEXING_TRANSFORM = 3,
-        };
-
         TransformType transform_type = static_cast<TransformType>(TRY(bit_stream.read_bits(2)));
         dbgln_if(WEBP_DEBUG, "transform type {}", (int)transform_type);
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -40,7 +40,7 @@ ErrorOr<VP8LHeader> decode_webp_chunk_VP8L_header(ReadonlyBytes vp8l_data)
     u8 version_number = TRY(bit_stream.read_bits(3));
     VERIFY(bit_stream.is_eof());
 
-    dbgln_if(WEBP_DEBUG, "width {}, height {}, is_alpha_used {}, version_number {}",
+    dbgln_if(WEBP_DEBUG, "VP8L: width {}, height {}, is_alpha_used {}, version_number {}",
         width, height, is_alpha_used, version_number);
 
     // "The version_number is a 3 bit code that must be set to 0. Any other value should be treated as an error."

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -66,4 +66,18 @@ enum class ImageKind {
     EntropyCoded,
 };
 
+enum TransformType {
+    // predictor-tx         =  %b00 predictor-image
+    PREDICTOR_TRANSFORM = 0,
+
+    // color-tx             =  %b01 color-image
+    COLOR_TRANSFORM = 1,
+
+    // subtract-green-tx    =  %b10
+    SUBTRACT_GREEN_TRANSFORM = 2,
+
+    // color-indexing-tx    =  %b11 color-indexing-image
+    COLOR_INDEXING_TRANSFORM = 3,
+};
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -61,4 +61,9 @@ private:
     Array<CanonicalCode, 5> m_codes;
 };
 
+enum class ImageKind {
+    SpatiallyCoded,
+    EntropyCoded,
+};
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.h
@@ -9,6 +9,7 @@
 #include <AK/Error.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImageFormats/WebPWriterLossless.h>
 #include <LibGfx/Point.h>
 
 namespace Gfx {
@@ -16,6 +17,7 @@ namespace Gfx {
 class AnimationWriter;
 
 struct WebPEncoderOptions {
+    VP8LEncoderOptions vp8l_options;
     Optional<ReadonlyBytes> icc_data;
 };
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -206,7 +206,7 @@ static ErrorOr<CanonicalCode> write_normal_code_lengths(LittleEndianOutputBitStr
         // "int length_nbits = 2 + 2 * ReadBits(3);
         //  int max_symbol = 2 + ReadBits(length_nbits);"
         // => length_nbits is at most 2 + 2*7 == 16
-        unsigned needed_length_nbits = floor(log2(encoded_lengths_count - 2) + 1);
+        unsigned needed_length_nbits = encoded_lengths_count > 2 ? floor(log2(encoded_lengths_count - 2) + 1) : 2;
         VERIFY(needed_length_nbits <= 16);
         needed_length_nbits = ceil_div(needed_length_nbits, 2) * 2;
         TRY(bit_stream.write_bits((needed_length_nbits - 2) / 2, 3u));

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -217,6 +217,7 @@ static ErrorOr<void> write_VP8L_image_data(Stream& stream, Bitmap const& bitmap,
 {
     LittleEndianOutputBitStream bit_stream { MaybeOwned<Stream>(stream) };
 
+    // image-stream  = optional-transform spatially-coded-image
     // optional-transform   =  (%b1 transform optional-transform) / %b0
     TRY(bit_stream.write_bits(0u, 1u)); // No transform for now.
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -189,8 +189,8 @@ static ErrorOr<CanonicalCode> write_normal_code_lengths(LittleEndianOutputBitStr
         unsigned needed_length_nbits = ceil(log2(encoded_lengths_count - 2));
         VERIFY(needed_length_nbits <= 16);
         needed_length_nbits = ceil_div(needed_length_nbits, 2) * 2;
-        TRY(bit_stream.write_bits((needed_length_nbits - 2) / 2, 3u));              // length_nbits = 2 + 2 * 3 == 8
-        TRY(bit_stream.write_bits(encoded_lengths_count - 2, needed_length_nbits)); // max_symbol = 2 + 254
+        TRY(bit_stream.write_bits((needed_length_nbits - 2) / 2, 3u));
+        TRY(bit_stream.write_bits(encoded_lengths_count - 2, needed_length_nbits));
     }
 
     // The rest is identical to write_dynamic_huffman() again. (Code 16 has different semantics, but that doesn't matter here.)

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -201,6 +201,7 @@ static ErrorOr<CanonicalCode> write_normal_code_lengths(LittleEndianOutputBitStr
     if (alphabet_size == encoded_lengths_count) {
         TRY(bit_stream.write_bits(0u, 1u)); // max_symbol is alphabet_size
     } else {
+        dbgln_if(WEBP_DEBUG, "writing max_symbol: {}", encoded_lengths_count);
         TRY(bit_stream.write_bits(1u, 1u)); // max_symbol is explicitly coded
         // "int length_nbits = 2 + 2 * ReadBits(3);
         //  int max_symbol = 2 + ReadBits(length_nbits);"

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -206,7 +206,7 @@ static ErrorOr<CanonicalCode> write_normal_code_lengths(LittleEndianOutputBitStr
         // "int length_nbits = 2 + 2 * ReadBits(3);
         //  int max_symbol = 2 + ReadBits(length_nbits);"
         // => length_nbits is at most 2 + 2*7 == 16
-        unsigned needed_length_nbits = ceil(log2(encoded_lengths_count - 2));
+        unsigned needed_length_nbits = floor(log2(encoded_lengths_count - 2) + 1);
         VERIFY(needed_length_nbits <= 16);
         needed_length_nbits = ceil_div(needed_length_nbits, 2) * 2;
         TRY(bit_stream.write_bits((needed_length_nbits - 2) / 2, 3u));

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.h
@@ -11,6 +11,11 @@
 
 namespace Gfx {
 
-ErrorOr<ByteBuffer> compress_VP8L_image_data(Bitmap const&, bool& is_fully_opaque);
+struct VP8LEncoderOptions {
+    // For each TransformType, set bit `1 << transform_type` if that transform type is allowed.
+    unsigned allowed_transforms { 0xf };
+};
+
+ErrorOr<ByteBuffer> compress_VP8L_image_data(Bitmap const&, VP8LEncoderOptions const&, bool& is_fully_opaque);
 
 }


### PR DESCRIPTION
If an image has 256 or fewer colors, WebP/Lossless allows storing
the colors in a helper image, and then storing just indexes into that
helper image in the main image's green channel, while setting
r, b, and a of the main image to 0.

Since constant-color channels need to space to store in WebP,
this reduces storage needed to 1/4th (if alpha is used) or 1/3rd
(if alpha is constant across the image).

If an image has <= 16 colors, WebP lossless files pack multiple
color table indexes into a single pixel's green channel, further
reducing file size.

GIFs can store at most 256 colors per frame, so animated gifs
often have 256 or fewer colors, making this effective when
transcoding gifs.

This adds support for writing that color index transform.

It also fixes a general encoding bug that the tests for this transform
exposed.

Some numbers on my test files:

sunset-retro.png: No performance or binary size impact. The input
quickly uses more than 256 colors.

giphy.gif (184k): 4.1M -> 3.9M, 95.5 ms ± 4.9 ms -> 106.4 ms ± 5.3 ms
Most frames use more than 256 colors, but just barely. So fairly
expensive runtime wise, with just a small win.

(See comment on #24454 for the previous 4.9 MiB -> 4.1 MiB drop.)

7z7c.gif (11K): 118K -> 40K
Every frame has less than 256 colors (but more than 16, so no packing),
and so we can cut filesize roughly to 1/3rd: We only need to store an
index per channel. From 10.7x as large as the input to 3.6x as large.

Also add an option to `image` to choose which transforms are used.
(Even though only one is supported so far, that flag supports all four
already.) `animation` doesn't have this flag yet; maybe I'll add that later.