### PR TITLE
WPT: Update to latest master and update test expectations

### DIFF
--- a/Tests/LibWeb/WPT/metadata.txt
+++ b/Tests/LibWeb/WPT/metadata.txt
@@ -75,10 +75,6 @@
 [floats-wrap-bfc-with-margin-006.tentative.html]
   expected: FAIL
 
---- css/CSS2/floats/floats-wrap-bfc-002-left-table.xht.ini ---
-[floats-wrap-bfc-002-left-table.xht]
-  expected: FAIL
-
 --- css/CSS2/floats/remove-block-between-inline-and-float.html.ini ---
 [remove-block-between-inline-and-float.html]
   expected: FAIL
@@ -234,29 +230,13 @@
 [floats-zero-height-wrap-001.xht]
   expected: FAIL
 
+--- css/CSS2/floats/zero-space-between-floats-004.html.ini ---
+[zero-space-between-floats-004.html]
+  [#container 1]
+    expected: FAIL
+
 --- css/CSS2/floats/float-no-interpolation.html.ini ---
 [float-no-interpolation.html]
-  [CSS Animations: property <float> from [initial\] to [right\] at (0.5) should be [right\]]
-    expected: FAIL
-
-  [CSS Animations: property <float> from [initial\] to [right\] at (0.6) should be [right\]]
-    expected: FAIL
-
-  [CSS Animations: property <float> from [initial\] to [right\] at (1) should be [right\]]
-    expected: FAIL
-
-  [CSS Animations: property <float> from [initial\] to [right\] at (1.5) should be [right\]]
-    expected: FAIL
-
-  [Web Animations: property <float> from [initial\] to [right\] at (-0.3) should be [initial\]]
-    expected: FAIL
-
-  [Web Animations: property <float> from [initial\] to [right\] at (0) should be [initial\]]
-    expected: FAIL
-
-  [Web Animations: property <float> from [initial\] to [right\] at (0.3) should be [initial\]]
-    expected: FAIL
-
   [Web Animations: property <float> from [initial\] to [right\] at (0.5) should be [right\]]
     expected: FAIL
 
@@ -269,8 +249,101 @@
   [Web Animations: property <float> from [initial\] to [right\] at (1.5) should be [right\]]
     expected: FAIL
 
+  [CSS Transitions: property <float> from [left\] to [right\] at (-1) should be [left\]]
+    expected: FAIL
+
+  [CSS Transitions: property <float> from [left\] to [right\] at (0) should be [left\]]
+    expected: FAIL
+
+  [CSS Transitions: property <float> from [left\] to [right\] at (0.4) should be [left\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <float> from [left\] to [right\] at (-1) should be [left\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <float> from [left\] to [right\] at (0) should be [left\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <float> from [left\] to [right\] at (0.4) should be [left\]]
+    expected: FAIL
+  
+  [Web Animations: property <float> from [left\] to [right\] at (-1) should be [left\]]
+    expected: FAIL
+
+  [Web Animations: property <float> from [left\] to [right\] at (0) should be [left\]]
+    expected: FAIL
+
+  [Web Animations: property <float> from [left\] to [right\] at (0.4) should be [left\]]
+    expected: FAIL
+
+  [Web Animations: property <float> from [left\] to [right\] at (0.5) should be [right\]]
+    expected: FAIL
+
+  [Web Animations: property <float> from [left\] to [right\] at (1) should be [right\]]
+    expected: FAIL
+
+  [Web Animations: property <float> from [left\] to [right\] at (1.5) should be [right\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <float> from [initial\] to [right\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <float> from [initial\] to [right\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <float> from [initial\] to [right\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <float> from [initial\] to [right\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <float> from [initial\] to [right\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <float> from [initial\] to [right\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <float> from [initial\] to [right\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <float> from [initial\] to [right\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <float> from [initial\] to [right\] at (0.3) should be [initial\]]
+    expected: FAIL
+
 --- css/CSS2/floats/floats-wrap-bfc-004.xht.ini ---
 [floats-wrap-bfc-004.xht]
   expected: FAIL
 
+--- css/CSS2/floats/float-with-absolutely-positioned-child-with-static-inset.html.ini ---
+[float-with-absolutely-positioned-child-with-static-inset.html]
+  expected: FAIL
 
+--- css/CSS2/floats/floats-in-table-caption-001.html.ini ---
+[floats-in-table-caption-001.html]
+  expected: FAIL
+
+--- css/CSS2/floats/floats-line-wrap-shifted-001.html.ini ---
+[floats-line-wrap-shifted-001.html]
+  expected: FAIL
+
+--- css/CSS2/floats/floats-placement-003.html.ini ---
+[floats-placement-003.html]
+  expected: FAIL
+
+--- css/CSS2/floats/floats-placement-005.html.ini ---
+[floats-placement-005.html]
+  expected: FAIL
+
+--- css/CSS2/floats/floats-wrap-bfc-007.xht.ini ---
+[floats-wrap-bfc-007.xht]
+  expected: FAIL
+
+--- css/CSS2/floats/floats-wrap-bfc-with-margin-004.html.ini ---
+[floats-wrap-bfc-with-margin-004.html]
+  expected: FAIL
+
+--- css/CSS2/floats/floats-wrap-bfc-with-margin-005.html.ini ---
+[floats-wrap-bfc-with-margin-005.html]
+  expected: FAIL

--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -51,7 +51,7 @@ if [ ! -d "${SCRIPT_DIR}/wpt" ]; then
     git -C wpt remote add origin https://github.com/web-platform-tests/wpt.git
 
     # Switch to the commit that was used to generate tests expectations. Requires periodic updates.
-    git -C wpt fetch --depth 1 origin eedf737ce39c512d0ca3471f988972e3ece11822
+    git -C wpt fetch --depth 1 origin 5930e386a5e1e59456dc810c9b21adf18bc1b6fe
     git -C wpt checkout FETCH_HEAD
 
     git apply 0001-tools-Pass-product-name-to-update-metadata-fallback-.patch


### PR DESCRIPTION
Previously, it was not possible to run `wpt` locally with a python version >= 3.12.

Our `metadata.txt` file now reflects the results we currently get, this should make CI output look a bit nicer.