### PR TITLE
LibWeb/WebDriver: Ensure error responses are serialized correctly

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -320,12 +320,15 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(Error const& err
     dbgln_if(WEBDRIVER_DEBUG, "Sending error response: {} {}: {}", error.http_status, error.error, error.message);
     auto reason = HTTP::HttpResponse::reason_phrase_for_code(error.http_status);
 
-    JsonObject result;
-    result.set("error", error.error);
-    result.set("message", error.message);
-    result.set("stacktrace", "");
+    JsonObject error_response;
+    error_response.set("error", error.error);
+    error_response.set("message", error.message);
+    error_response.set("stacktrace", "");
     if (error.data.has_value())
-        result.set("data", *error.data);
+        error_response.set("data", *error.data);
+
+    JsonObject result;
+    result.set("value", move(error_response));
 
     StringBuilder content_builder;
     result.serialize(content_builder);


### PR DESCRIPTION
Previously, the WPT client didn't quite understand the error responses we were sending. With the `wpt` version we were using prior to #24487 this led to a CRASH being logged rather than an ERROR. When using the latest version, this change makes no difference to the kind of result that is logged, but it does make the logged error messages easier to understand, so I think the change is still worthwhile.

Relevant WPT code:

https://github.com/web-platform-tests/wpt/blob/5930e386a5e1e59456dc810c9b21adf18bc1b6fe/tools/webdriver/webdriver/error.py#L189-L218