### PR TITLE
LibWeb: Specify input box width when parent does not

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -111,11 +111,6 @@ void HTMLInputElement::adjust_computed_style(CSS::StyleProperties& style)
     //         This is required for the internal shadow tree to work correctly in layout.
     if (style.display().is_inline_outside() && style.display().is_flow_inside())
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
-
-    if (type_state() != TypeAttributeState::FileUpload) {
-        if (style.property(CSS::PropertyID::Width)->has_auto())
-            style.set_property(CSS::PropertyID::Width, CSS::LengthStyleValue::create(CSS::Length(size(), CSS::Length::Type::Ch)));
-    }
 }
 
 void HTMLInputElement::set_checked(bool checked, ChangeSource change_source)

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Painting/PaintableBox.h>
 
@@ -12,11 +13,19 @@ namespace Web::Layout {
 BlockContainer::BlockContainer(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
     : Box(document, node, move(style))
 {
+    if (dom_node() && dom_node()->is_html_input_element()) {
+        set_natural_width(CSS::Length(static_cast<HTML::HTMLInputElement*>(dom_node())->size(), CSS::Length::Type::Ch).to_px(*this));
+        set_natural_height(CSS::Length(1, CSS::Length::Type::Lh).to_px(*this));
+    }
 }
 
 BlockContainer::BlockContainer(DOM::Document& document, DOM::Node* node, NonnullOwnPtr<CSS::ComputedValues> computed_values)
     : Box(document, node, move(computed_values))
 {
+    if (dom_node() && dom_node()->is_html_input_element()) {
+        set_natural_width(CSS::Length(static_cast<HTML::HTMLInputElement*>(dom_node())->size(), CSS::Length::Type::Ch).to_px(*this));
+        set_natural_height(CSS::Length(1, CSS::Length::Type::Lh).to_px(*this));
+    }
 }
 
 BlockContainer::~BlockContainer() = default;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1986,6 +1986,9 @@ CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(Box
 
 bool box_is_sized_as_replaced_element(Box const& box)
 {
+    if (box.dom_node() && box.dom_node()->is_html_input_element())
+        return true;
+
     // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
     // replaced element with a natural aspect ratio and no natural size in that axis, see e.g. CSS2 §10
     // and CSS Flexible Box Model Level 1 §9.2.


### PR DESCRIPTION
Text input boxes inside a parent with no defined width, such as the following, appear too short in Ladybird.
```
<div style = "float:left">
    <input style = "width:auto">
</div>
```
See #23915, which this fixes.

The fix was two parts: remove some hacky code from `HTMLInputElement::adjust_computed_style()` that set the width of any input box container with <... width:auto> and instead use `set_natural_width()` and `set_natural_height()` in the Layout::BlockContainer constructor.

NOTES/Pending issues
- Despite setting natural height to `1lh`, some text boxes (such as the one on the ladybird home screen) are now too short.  I believe natural width and height might ignore padding/margins/borders, but I'm not sure.
- Apologies, but this probably won't pass [the code submission policies](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#code-submission-policy) -- this is my first ever PR.
  - EDIT: all pending changes done -- we could use feedback on the failing checks, see previous note