### PR TITLE
LibWasm: Improve table support

### DIFF
--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -62,6 +62,9 @@ def parse_typed_value(ast):
         'i64.const': 'i64',
         'f32.const': 'float',
         'f64.const': 'double',
+        'ref.null': 'null',
+        'ref.extern': 'i32',
+        'ref.func': 'i32',
         'v128.const': 'bigint',
     }
 
@@ -331,9 +334,9 @@ def generate(ast):
                 "function": {
                     "module": module,
                     "name": name,
-                    "args": list(parse_typed_value(x) for x in entry[1][arg + 2:])
+                    "args": [parse_typed_value(entry[2])] if len(entry) == 3 else []
                 },
-                "result": parse_typed_value(entry[2]) if len(entry) == 3 + arg else None
+                "result": None
             })
         elif len(entry) > 1 and entry[0][0] == 'register':
             if len(entry) == 3:
@@ -370,6 +373,8 @@ def genarg(spec):
         x = spec['value']
         if spec['type'] == 'bigint':
             return f"0x{x}n"
+        if spec['type'] == 'null':
+            return 'null'
 
         if spec['type'] in ('i32', 'i64'):
             if x.startswith('0x'):

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -242,10 +242,18 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
             break;
         }
         case Wasm::ValueType::Kind::FunctionReference:
+            if (argument.is_null()) {
+                arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Null { Wasm::ValueType(Wasm::ValueType::Kind::FunctionReference) } }));
+                break;
+            }
             arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Func { static_cast<u64>(double_value) } }));
             break;
         case Wasm::ValueType::Kind::ExternReference:
-            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Func { static_cast<u64>(double_value) } }));
+            if (argument.is_null()) {
+                arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Null { Wasm::ValueType(Wasm::ValueType::Kind::ExternReference) } }));
+                break;
+            }
+            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Extern { static_cast<u64>(double_value) } }));
             break;
         case Wasm::ValueType::Kind::NullFunctionReference:
             arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Null { Wasm::ValueType(Wasm::ValueType::Kind::FunctionReference) } }));

--- a/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -106,10 +106,10 @@ WebIDL::ExceptionOr<JS::Value> Table::get(u32 index) const
         return vm.throw_completion<JS::RangeError>("Table element index out of range"sv);
 
     auto& ref = table->elements()[index];
-    if (!ref.has_value())
+    if (!ref.ref().has<Wasm::Reference::Null>())
         return JS::js_undefined();
 
-    Wasm::Value wasm_value { ref.value() };
+    Wasm::Value wasm_value { ref };
     return Detail::to_js_value(vm, wasm_value);
 }
 


### PR DESCRIPTION
Implements `table.get`, `table.set`, `elem.drop`, `table.size`, and `table.grow`. Also fixes a few issues when generating ref-related spectests. Also changes the `TableInstance` type to use `Vector<Reference>` instead of `Vector<Optional<Reference>>`, because the ability to be null is already encoded in the `Reference` type.

This makes a few hundred more spectests pass!