### PR TITLE
LibJS/Bytecode: Better codegen for `this`

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -58,8 +58,8 @@ public:
     auto const& source_map() const { return m_source_map; }
     void add_source_map_entry(size_t bytecode_offset, SourceRecord const& source_record) { m_source_map.set(bytecode_offset, source_record); }
 
-    auto const& this_() const { return m_this; }
-    void set_this(ScopedOperand operand) { m_this = operand; }
+    [[nodiscard]] bool has_resolved_this() const { return m_has_resolved_this; }
+    void set_has_resolved_this() { m_has_resolved_this = true; }
 
     [[nodiscard]] size_t last_instruction_start_offset() const { return m_last_instruction_start_offset; }
     void set_last_instruction_start_offset(size_t offset) { m_last_instruction_start_offset = offset; }
@@ -73,10 +73,9 @@ private:
     BasicBlock const* m_finalizer { nullptr };
     String m_name;
     bool m_terminated { false };
+    bool m_has_resolved_this { false };
 
     HashMap<size_t, SourceRecord> m_source_map;
-
-    Optional<ScopedOperand> m_this;
 
     size_t m_last_instruction_start_offset { 0 };
 };

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -17,7 +17,7 @@
 
 namespace JS::Bytecode {
 
-Generator::Generator(VM& vm, MustPropagateCompletion must_propagate_completion)
+Generator::Generator(VM& vm, GCPtr<ECMAScriptFunctionObject const> function, MustPropagateCompletion must_propagate_completion)
     : m_vm(vm)
     , m_string_table(make<StringTable>())
     , m_identifier_table(make<IdentifierTable>())
@@ -25,6 +25,7 @@ Generator::Generator(VM& vm, MustPropagateCompletion must_propagate_completion)
     , m_constants(vm.heap())
     , m_accumulator(*this, Operand(Register::accumulator()))
     , m_must_propagate_completion(must_propagate_completion == MustPropagateCompletion::Yes)
+    , m_function(function)
 {
 }
 
@@ -199,7 +200,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
 
 CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::compile(VM& vm, ASTNode const& node, FunctionKind enclosing_function_kind, GCPtr<ECMAScriptFunctionObject const> function, MustPropagateCompletion must_propagate_completion)
 {
-    Generator generator(vm, must_propagate_completion);
+    Generator generator(vm, function, must_propagate_completion);
 
     generator.switch_to_basic_block(generator.make_block());
     SourceLocationScope scope(generator, node);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1087,6 +1087,13 @@ ScopedOperand Generator::get_this(Optional<ScopedOperand> preferred_dst)
         m_current_basic_block->set_has_resolved_this();
         return this_value();
     }
+
+    // OPTIMIZATION: If we're compiling a function that doesn't allocate a FunctionEnvironment,
+    //               it will always have the same `this` value as the outer function,
+    //               and so the `this` value is already in the `this` register!
+    if (m_function && !m_function->allocates_function_environment())
+        return this_value();
+
     auto dst = preferred_dst.has_value() ? preferred_dst.value() : allocate_register();
     emit<Bytecode::Op::ResolveThisBinding>();
     m_current_basic_block->set_has_resolved_this();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -197,7 +197,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
     return {};
 }
 
-CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::emit_function_body_bytecode(VM& vm, ASTNode const& node, FunctionKind enclosing_function_kind, GCPtr<ECMAScriptFunctionObject const> function, MustPropagateCompletion must_propagate_completion)
+CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::compile(VM& vm, ASTNode const& node, FunctionKind enclosing_function_kind, GCPtr<ECMAScriptFunctionObject const> function, MustPropagateCompletion must_propagate_completion)
 {
     Generator generator(vm, must_propagate_completion);
 
@@ -431,12 +431,12 @@ CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::emit_function_body_by
 
 CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::generate_from_ast_node(VM& vm, ASTNode const& node, FunctionKind enclosing_function_kind)
 {
-    return emit_function_body_bytecode(vm, node, enclosing_function_kind, {});
+    return compile(vm, node, enclosing_function_kind, {});
 }
 
 CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::generate_from_function(VM& vm, ECMAScriptFunctionObject const& function)
 {
-    return emit_function_body_bytecode(vm, function.ecmascript_code(), function.kind(), &function, MustPropagateCompletion::No);
+    return compile(vm, function.ecmascript_code(), function.kind(), &function, MustPropagateCompletion::No);
 }
 
 void Generator::grow(size_t additional_size)

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -344,7 +344,7 @@ public:
 private:
     VM& m_vm;
 
-    static CodeGenerationErrorOr<NonnullGCPtr<Executable>> emit_function_body_bytecode(VM&, ASTNode const&, FunctionKind, GCPtr<ECMAScriptFunctionObject const>, MustPropagateCompletion = MustPropagateCompletion::Yes);
+    static CodeGenerationErrorOr<NonnullGCPtr<Executable>> compile(VM&, ASTNode const&, FunctionKind, GCPtr<ECMAScriptFunctionObject const>, MustPropagateCompletion = MustPropagateCompletion::Yes);
 
     enum class JumpType {
         Continue,

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -353,7 +353,7 @@ private:
     void generate_scoped_jump(JumpType);
     void generate_labelled_jump(JumpType, DeprecatedFlyString const& label);
 
-    Generator(VM&, MustPropagateCompletion);
+    Generator(VM&, GCPtr<ECMAScriptFunctionObject const>, MustPropagateCompletion);
     ~Generator() = default;
 
     void grow(size_t);
@@ -393,6 +393,8 @@ private:
 
     bool m_finished { false };
     bool m_must_propagate_completion { true };
+
+    GCPtr<ECMAScriptFunctionObject const> m_function;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -46,6 +46,7 @@ public:
     [[nodiscard]] ScopedOperand allocate_register();
     [[nodiscard]] ScopedOperand local(u32 local_index);
     [[nodiscard]] ScopedOperand accumulator();
+    [[nodiscard]] ScopedOperand this_value();
 
     void free_register(Register);
 
@@ -377,6 +378,7 @@ private:
     MarkedVector<Value> m_constants;
 
     ScopedOperand m_accumulator;
+    ScopedOperand m_this_value;
     Vector<Register> m_free_registers;
 
     u32 m_next_register { Register::reserved_register_count };

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -46,7 +46,11 @@ static ByteString format_operand(StringView name, Operand operand, Bytecode::Exe
         builder.appendff("\033[32m{}\033[0m:", name);
     switch (operand.type()) {
     case Operand::Type::Register:
-        builder.appendff("\033[33mreg{}\033[0m", operand.index());
+        if (operand.index() == Register::this_value().index()) {
+            builder.appendff("\033[33mthis\033[0m");
+        } else {
+            builder.appendff("\033[33mreg{}\033[0m", operand.index());
+        }
         break;
     case Operand::Type::Local:
         // FIXME: Show local name.

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -718,6 +718,7 @@ Interpreter::ResultAndReturnRegister Interpreter::run_executable(Executable& exe
 
     reg(Register::accumulator()) = initial_accumulator_value;
     reg(Register::return_value()) = {};
+    reg(Register::this_value()) = running_execution_context.this_value;
 
     running_execution_context.executable = &executable;
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -2550,23 +2550,14 @@ private:
 
 class ResolveThisBinding final : public Instruction {
 public:
-    explicit ResolveThisBinding(Operand dst)
+    ResolveThisBinding()
         : Instruction(Type::ResolveThisBinding)
-        , m_dst(dst)
     {
     }
 
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-    void visit_operands_impl(Function<void(Operand&)> visitor)
-    {
-        visitor(m_dst);
-    }
-
-    Operand dst() const { return m_dst; }
-
-private:
-    Operand m_dst;
+    void visit_operands_impl(Function<void(Operand&)>) { }
 };
 
 class ResolveSuperBase final : public Instruction {

--- a/Userland/Libraries/LibJS/Bytecode/ScopedOperand.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ScopedOperand.cpp
@@ -11,7 +11,7 @@ namespace JS::Bytecode {
 
 ScopedOperandImpl::~ScopedOperandImpl()
 {
-    if (!m_generator.is_finished() && m_operand.is_register() && m_operand.as_register().index() != 0)
+    if (!m_generator.is_finished() && m_operand.is_register() && m_operand.as_register().index() >= Register::reserved_register_count)
         m_generator.free_register(m_operand.as_register());
 }
 

--- a/Userland/Libraries/LibJS/Tests/copy-this-to-local.js
+++ b/Userland/Libraries/LibJS/Tests/copy-this-to-local.js
@@ -1,0 +1,10 @@
+test("copy this to a local", () => {
+    const foo = {
+        foo() {
+            let thisCopy = this;
+            thisCopy = "oops";
+            return this;
+        },
+    };
+    expect(foo.foo()).toBe(foo);
+});


### PR DESCRIPTION
Three main things here:
- The cached `this` register is now pre-populated when entering a bytecode executable.
- We no longer emit `ResolveThisBinding` at all when we know the pre-populated cache is non-empty (this is true for any function that doesn't require a unique function environment)
- When we do have `ResolveThisBinding`, it no longer has a `dst`, but instead always just populates the cached `this` register.

Net result: fewer instructions! Same result! Go faster! Whee! (And also fixes a bug, included a test for that!)

Benchmark results:
```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.1    2.470 ± 2.440 … 2.500     2.245 ± 2.200 … 2.290
Kraken      audio-beat-detection.js                  1.024  1.490 ± 1.450 … 1.530     1.455 ± 1.450 … 1.460
Kraken      audio-dft.js                             1.094  1.280 ± 1.270 … 1.290     1.170 ± 1.160 … 1.180
Kraken      audio-fft.js                             1.037  1.525 ± 1.470 … 1.580     1.470 ± 1.440 … 1.500
Kraken      audio-oscillator.js                      0.972  1.540 ± 1.540 … 1.540     1.585 ± 1.580 … 1.590
Kraken      imaging-darkroom.js                      1.005  2.050 ± 2.040 … 2.060     2.040 ± 2.040 … 2.040
Kraken      imaging-desaturate.js                    1.023  2.635 ± 2.630 … 2.640     2.575 ± 2.570 … 2.580
Kraken      imaging-gaussian-blur.js                 0.978  8.140 ± 7.920 … 8.360     8.325 ± 8.310 … 8.340
Kraken      json-parse-financial.js                  0.966  0.140 ± 0.140 … 0.140     0.145 ± 0.140 … 0.150
Kraken      json-stringify-tinderbox.js              0.885  0.230 ± 0.230 … 0.230     0.260 ± 0.260 … 0.260
Kraken      stanford-crypto-aes.js                   1.038  0.680 ± 0.670 … 0.690     0.655 ± 0.620 … 0.690
Kraken      stanford-crypto-ccm.js                   1.009  0.590 ± 0.590 … 0.590     0.585 ± 0.580 … 0.590
Kraken      stanford-crypto-pbkdf2.js                0.977  1.070 ± 1.070 … 1.070     1.095 ± 1.090 … 1.100
Kraken      stanford-crypto-sha256-iterative.js      0.989  0.435 ± 0.430 … 0.440     0.440 ± 0.420 … 0.460
Octane      box2d.js                                 0.949  2.135 ± 2.120 … 2.150     2.250 ± 2.060 … 2.440
Octane      code-load.js                             0.998  2.130 ± 2.130 … 2.130     2.135 ± 2.130 … 2.140
Octane      crypto.js                                0.922  6.315 ± 6.260 … 6.370     6.850 ± 6.320 … 7.380
Octane      deltablue.js                             0.998  2.015 ± 2.010 … 2.020     2.020 ± 2.020 … 2.020
Octane      earley-boyer.js                          0.984  15.560 ± 15.440 … 15.680  15.820 ± 14.980 … 16.660
Octane      gbemu.js                                 1.002  2.730 ± 2.630 … 2.830     2.725 ± 2.620 … 2.830
Octane      mandreel.js                              0.963  12.935 ± 12.890 … 12.980  13.430 ± 13.300 … 13.560
Octane      navier-stokes.js                         1.029  3.165 ± 3.160 … 3.170     3.075 ± 3.070 … 3.080
Octane      pdfjs.js                                 1.059  2.895 ± 2.810 … 2.980     2.735 ± 2.650 … 2.820
Octane      raytrace.js                              1.078  6.245 ± 6.220 … 6.270     5.795 ± 5.520 … 6.070
Octane      regexp.js                                1.064  23.035 ± 22.320 … 23.750  21.655 ± 21.560 … 21.750
Octane      richards.js                              1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.009  2.830 ± 2.800 … 2.860     2.805 ± 2.800 … 2.810
Octane      typescript.js                            1.023  26.485 ± 25.400 … 27.570  25.880 ± 25.280 … 26.480
Octane      zlib.js                                  1.049  78.190 ± 76.060 … 80.320  74.525 ± 74.410 … 74.640
Kraken      Total                                    1.01   24.275                    24.045
Octane      Total                                    1.027  188.675                   183.710
All Suites  Total                                    1.025  212.950                   207.755
```