### PR TITLE
LibWeb+Ladybird/Qt: Add location markers for Find in Page results

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -119,6 +119,7 @@ if (ENABLE_QT)
         Qt/Icon.cpp
         Qt/InspectorWidget.cpp
         Qt/LocationEdit.cpp
+        Qt/MarkedScrollBar.cpp
         Qt/Settings.cpp
         Qt/SettingsDialog.cpp
         Qt/Tab.cpp

--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -115,6 +115,7 @@ void FindInPageWidget::hideEvent(QHideEvent*)
 {
     if (m_tab && m_tab->isVisible())
         m_tab->update_hover_label();
+    m_content_view->clear_find_in_page_marks();
 }
 
 }

--- a/Ladybird/Qt/MarkedScrollBar.cpp
+++ b/Ladybird/Qt/MarkedScrollBar.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "MarkedScrollBar.h"
+#include <QPainter>
+
+namespace Ladybird {
+
+MarkedScrollBar::MarkedScrollBar(Qt::Orientation orientation, QWidget* parent)
+    : QScrollBar(orientation, parent)
+{
+}
+
+void MarkedScrollBar::set_marks(int height, QList<int> const& positions)
+{
+    m_page_marks_document_height = height;
+    m_page_marks_positions = positions;
+    update();
+}
+
+void MarkedScrollBar::clear_marks()
+{
+    set_marks(0, {});
+}
+
+void MarkedScrollBar::paintEvent(QPaintEvent* event)
+{
+    QScrollBar::paintEvent(event);
+
+    if (m_page_marks_positions.empty() || m_page_marks_document_height <= 0)
+        return;
+
+    QPainter painter(this);
+    painter.setPen(Qt::red);
+
+    for (int const position : m_page_marks_positions) {
+        auto const relative_position = static_cast<double>(position) / m_page_marks_document_height;
+        int const y = static_cast<int>(relative_position * maximum() * parentWidget()->height() / m_page_marks_document_height);
+        painter.drawLine(0, y, width(), y);
+    }
+}
+
+}

--- a/Ladybird/Qt/MarkedScrollBar.h
+++ b/Ladybird/Qt/MarkedScrollBar.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <QList>
+#include <QScrollBar>
+#include <QWidget>
+
+namespace Ladybird {
+
+class MarkedScrollBar final : public QScrollBar {
+    Q_OBJECT
+public:
+    MarkedScrollBar(Qt::Orientation orientation, QWidget* parent = nullptr);
+
+    void set_marks(int height, QList<int> const& positions);
+
+    void clear_marks();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    int m_page_marks_document_height { 0 };
+    QList<int> m_page_marks_positions;
+};
+
+}

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -37,6 +37,7 @@ using WebView::WebContentClient;
 
 namespace Ladybird {
 
+class MarkedScrollBar;
 class Tab;
 
 class WebContentView final
@@ -83,6 +84,8 @@ public:
 
     QPoint map_point_to_global_position(Gfx::IntPoint) const;
 
+    void clear_find_in_page_marks();
+
 signals:
     void urls_dropped(QList<QUrl> const&);
 
@@ -108,6 +111,7 @@ private:
 
     WebContentOptions m_web_content_options;
     StringView m_webdriver_content_ipc_path;
+    MarkedScrollBar* m_vertical_scrollbar { nullptr };
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -667,7 +667,7 @@ public:
     // Does document represent an embedded svg img
     [[nodiscard]] bool is_decoded_svg() const;
 
-    Vector<JS::Handle<DOM::Range>> find_matching_text(String const&, CaseSensitivity);
+    Vector<JS::Handle<DOM::Range>> find_matching_text(String const&, CaseSensitivity, Vector<int>&);
 
 protected:
     virtual void initialize(JS::Realm&) override;

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -1164,7 +1164,7 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
     return {};
 }
 
-// https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
+// https://drafts.csswg.org/cssom-view/#dom-range-getclientrects
 JS::NonnullGCPtr<Geometry::DOMRectList> Range::get_client_rects() const
 {
     dbgln("(STUBBED) Range::get_client_rects()");

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -12,6 +12,7 @@
 #include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/Tuple.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <Kernel/API/KeyCode.h>
@@ -180,7 +181,7 @@ public:
 
     void clear_selection();
 
-    void find_in_page(String const& query, CaseSensitivity);
+    Optional<Tuple<int, Vector<int>>> find_in_page(String const& query, CaseSensitivity);
     void find_in_page_next_match();
     void find_in_page_previous_match();
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -191,6 +191,7 @@ public:
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;
     Function<void(Web::KeyEvent const&)> on_finish_handling_key_event;
     Function<void()> on_text_test_finish;
+    Function<void(int, Vector<int> const&)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -78,6 +78,14 @@ void WebContentClient::did_finish_text_test(u64 page_id)
     }
 }
 
+void WebContentClient::did_find_in_page(u64 page_id, int document_height, Vector<int> const& vertical_match_positions)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_find_in_page)
+            view->on_find_in_page(document_height, vertical_match_positions);
+    }
+}
+
 void WebContentClient::did_request_navigate_back(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -97,6 +97,7 @@ private:
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items) override;
     virtual void did_finish_handling_input_event(u64 page_id, bool event_was_accepted) override;
     virtual void did_finish_text_test(u64 page_id) override;
+    virtual void did_find_in_page(u64 page_id, int document_height, Vector<int> const& vertical_match_positions) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, String const& data, String const& presentation_style, String const& mime_type) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -833,7 +833,12 @@ void ConnectionFromClient::find_in_page(u64 page_id, String const& query, CaseSe
     if (!page.has_value())
         return;
 
-    page->page().find_in_page(query, case_sensitivity);
+    auto const match_location_data = page->page().find_in_page(query, case_sensitivity);
+    if (match_location_data.has_value()) {
+        auto const& data = match_location_data.value();
+        async_did_find_in_page(page_id, data.get<int>(), data.get<Vector<int>>());
+    } else
+        async_did_find_in_page(page_id, 0, {});
 }
 
 void ConnectionFromClient::find_in_page_next_match(u64 page_id)

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -90,6 +90,8 @@ endpoint WebContentClient
 
     did_finish_text_test(u64 page_id) =|
 
+    did_find_in_page(u64 page_id, int document_height, Vector<int> vertical_match_positions) =|
+
     request_worker_agent(u64 page_id) => (IPC::File socket) // FIXME: Add required attributes to select a SharedWorker Agent
 
     inspector_did_load(u64 page_id) =|


### PR DESCRIPTION
Tried to match Mozilla Firefox behaviour for the match position vertical scroll bar markers. More specifically, at the end of the demo, when you show the find widget again we don't automatically mark the positions if the query is not empty, only when you change the content. Firefox also does this so I didn't add the ability to auto re-show the position marks in that scenario.

Also, I'm assuming the positions from the document will probably be a bit more precise once `Web::DOM::Range::get_client_rects()` is implemented, but they aren't **_too_** bad with this initial parent element-based implementation. Some improvements could probably be done on the client side too to make it more accurate, but I wanted to stop at my current checkpoint to see if what I have so far is promising.

https://github.com/SerenityOS/serenity/assets/11325341/82549236-4496-413b-9e9a-89bf2e2849ba

