### PR TITLE
Ladybird/Qt: Flatten the buttons in the find-in-page panel

### DIFF
--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -36,6 +36,7 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     m_previous_button->setFixedWidth(30);
     m_previous_button->setIcon(create_tvg_icon_with_theme_colors("up", palette()));
     m_previous_button->setToolTip("Find Previous Match");
+    m_previous_button->setFlat(true);
     connect(m_previous_button, &QPushButton::clicked, this, [this] {
         m_content_view->find_in_page_previous_match();
     });
@@ -44,6 +45,7 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     m_next_button->setFixedWidth(30);
     m_next_button->setIcon(create_tvg_icon_with_theme_colors("down", palette()));
     m_next_button->setToolTip("Find Next Match");
+    m_next_button->setFlat(true);
     connect(m_next_button, &QPushButton::clicked, this, [this] {
         m_content_view->find_in_page_next_match();
     });
@@ -52,6 +54,7 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     m_exit_button->setFixedWidth(30);
     m_exit_button->setIcon(create_tvg_icon_with_theme_colors("close", palette()));
     m_exit_button->setToolTip("Close Search Bar");
+    m_exit_button->setFlat(true);
     connect(m_exit_button, &QPushButton::clicked, this, [this] {
         setVisible(false);
     });


### PR DESCRIPTION
The non-flat version of these buttons look a bit out-of-place.

Before:
![before](https://github.com/SerenityOS/serenity/assets/5600524/4a8f36f0-7289-4ded-9bd8-459fdaf6e262)

After:
![after](https://github.com/SerenityOS/serenity/assets/5600524/743879f9-d1da-4eba-bb91-38cc003a2c59)
