### PR TITLE
RequestServer: Spin even _faster_

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install emscripten"
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.25
+          version: 3.1.61
 
       - name: Restore Caches
         uses: ./.github/actions/cache-restore

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -38,6 +38,7 @@ class DeprecatedStringCodePointIterator;
 class Duration;
 class Error;
 class FlyString;
+class GenericAwaiter;
 class GenericLexer;
 class IPv4Address;
 class JsonArray;

--- a/AK/GenericAwaiter.h
+++ b/AK/GenericAwaiter.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Coroutine.h>
+#include <AK/Error.h>
+#include <AK/Function.h>
+
+namespace AK {
+class GenericAwaiter {
+    AK_MAKE_NONMOVABLE(GenericAwaiter);
+    AK_MAKE_NONCOPYABLE(GenericAwaiter);
+
+public:
+    GenericAwaiter(Function<void(Function<void()>)>&& fn)
+    {
+        fn([this] { ready(); });
+    }
+
+    bool await_ready() const { return false; }
+    void await_suspend(std::coroutine_handle<> handle)
+    {
+        m_handle = handle;
+    }
+    ErrorOr<void> await_resume()
+    {
+        m_handle = {};
+        return {};
+    }
+
+private:
+    void ready()
+    {
+        if (m_handle)
+            m_handle.resume();
+    }
+
+    std::coroutine_handle<> m_handle;
+};
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::GenericAwaiter;
+#endif

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -200,6 +200,13 @@ struct Traits<OwnPtr<T>> : public DefaultTraits<OwnPtr<T>> {
     static bool equals(OwnPtr<T> const& a, OwnPtr<T> const& b) { return a.ptr() == b.ptr(); }
 };
 
+template<typename T>
+struct Formatter<OwnPtr<T>> : Formatter<T*> {
+    ErrorOr<void> format(FormatBuilder& builder, OwnPtr<T> const& value)
+    {
+        return Formatter<T*>::format(builder, value.ptr());
+    }
+};
 }
 
 #if USING_AK_GLOBALLY

--- a/Meta/Lagom/Contrib/VideoPlayerSDL/CMakeLists.txt
+++ b/Meta/Lagom/Contrib/VideoPlayerSDL/CMakeLists.txt
@@ -1,8 +1,10 @@
-add_compile_options(-DAK_DONT_REPLACE_STD)
+if(NOT EMSCRIPTEN)
+  add_compile_options(-DAK_DONT_REPLACE_STD)
 
-add_executable(VideoPlayerSDL
-    main.cpp
-)
+  add_executable(VideoPlayerSDL
+      main.cpp
+  )
 
-target_include_directories(VideoPlayerSDL PRIVATE ${SDL2_INCLUDE_DIRS})
-target_link_libraries(VideoPlayerSDL PRIVATE LibMain LibCore LibGfx LibVideo SDL2::SDL2)
+  target_include_directories(VideoPlayerSDL PRIVATE ${SDL2_INCLUDE_DIRS})
+  target_link_libraries(VideoPlayerSDL PRIVATE LibMain LibCore LibGfx LibVideo SDL2::SDL2)
+endif()

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -11,7 +11,7 @@
 
 namespace Core {
 
-NetworkJob::NetworkJob(Stream& output_stream)
+NetworkJob::NetworkJob(Core::File& output_stream)
     : m_output_stream(output_stream)
 {
 }

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Coroutine.h>
 #include <AK/MemoryStream.h>
 #include <LibCore/SOCKSProxyClient.h>
 
@@ -125,27 +126,27 @@ StringView reply_response_name(Reply reply)
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<void> send_version_identifier_and_method_selection_message(Core::Socket& socket, Core::SOCKSProxyClient::Version version, Method method)
+Coroutine<ErrorOr<void>> send_version_identifier_and_method_selection_message(Core::Socket& socket, Core::SOCKSProxyClient::Version version, Method method)
 {
     Socks5VersionIdentifierAndMethodSelectionMessage message {
         .version_identifier = to_underlying(version),
         .method_count = 1,
         .methods = { to_underlying(method) },
     };
-    TRY(socket.write_value(message));
+    CO_TRY(socket.write_value(message));
 
-    auto response = TRY(socket.read_value<Socks5InitialResponse>());
+    auto response = CO_TRY(socket.read_value<Socks5InitialResponse>());
 
     if (response.version_identifier != to_underlying(version))
-        return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
+        co_return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
 
     if (response.method != to_underlying(method))
-        return Error::from_string_literal("SOCKS negotiation failed: Failed to negotiate a method");
+        co_return Error::from_string_literal("SOCKS negotiation failed: Failed to negotiate a method");
 
-    return {};
+    co_return {};
 }
 
-ErrorOr<Reply> send_connect_request_message(Core::Socket& socket, Core::SOCKSProxyClient::Version version, Core::SOCKSProxyClient::HostOrIPV4 target, int port, Core::SOCKSProxyClient::Command command)
+Coroutine<ErrorOr<Reply>> send_connect_request_message(Core::Socket& socket, Core::SOCKSProxyClient::Version version, Core::SOCKSProxyClient::HostOrIPV4 target, int port, Core::SOCKSProxyClient::Command command)
 {
     AllocatingMemoryStream stream;
 
@@ -158,89 +159,89 @@ ErrorOr<Reply> send_connect_request_message(Core::Socket& socket, Core::SOCKSPro
         .port = htons(port),
     };
 
-    TRY(stream.write_value(header));
+    CO_TRY(stream.write_value(header));
 
-    TRY(target.visit(
-        [&](ByteString const& hostname) -> ErrorOr<void> {
+    CO_TRY(co_await target.visit(
+        [&](ByteString const& hostname) -> Coroutine<ErrorOr<void>> {
             u8 address_data[2];
             address_data[0] = to_underlying(AddressType::DomainName);
             address_data[1] = hostname.length();
-            TRY(stream.write_until_depleted({ address_data, sizeof(address_data) }));
-            TRY(stream.write_until_depleted({ hostname.characters(), hostname.length() }));
-            return {};
+            CO_TRY(stream.write_until_depleted({ address_data, sizeof(address_data) }));
+            CO_TRY(stream.write_until_depleted({ hostname.characters(), hostname.length() }));
+            co_return {};
         },
-        [&](u32 ipv4) -> ErrorOr<void> {
+        [&](u32 ipv4) -> Coroutine<ErrorOr<void>> {
             u8 address_data[5];
             address_data[0] = to_underlying(AddressType::IPV4);
             u32 network_ordered_ipv4 = NetworkOrdered<u32>(ipv4);
             memcpy(address_data + 1, &network_ordered_ipv4, sizeof(network_ordered_ipv4));
-            TRY(stream.write_until_depleted({ address_data, sizeof(address_data) }));
-            return {};
+            CO_TRY(stream.write_until_depleted({ address_data, sizeof(address_data) }));
+            co_return {};
         }));
 
-    TRY(stream.write_value(trailer));
+    CO_TRY(stream.write_value(trailer));
 
-    auto buffer = TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
-    TRY(stream.read_until_filled(buffer.bytes()));
-    TRY(socket.write_until_depleted(buffer));
+    auto buffer = CO_TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
+    CO_TRY(stream.read_until_filled(buffer.bytes()));
+    CO_TRY(socket.write_until_depleted(buffer));
 
-    auto response_header = TRY(socket.read_value<Socks5ConnectResponseHeader>());
+    auto response_header = CO_TRY(socket.read_value<Socks5ConnectResponseHeader>());
 
     if (response_header.version_identifier != to_underlying(version))
-        return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
+        co_return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
 
-    auto response_address_type = TRY(socket.read_value<u8>());
+    auto response_address_type = CO_TRY(socket.read_value<u8>());
 
     switch (AddressType(response_address_type)) {
     case AddressType::IPV4: {
         u8 response_address_data[4];
-        TRY(socket.read_until_filled({ response_address_data, sizeof(response_address_data) }));
+        CO_TRY(socket.read_until_filled({ response_address_data, sizeof(response_address_data) }));
         break;
     }
     case AddressType::DomainName: {
-        auto response_address_length = TRY(socket.read_value<u8>());
-        auto buffer = TRY(ByteBuffer::create_uninitialized(response_address_length));
-        TRY(socket.read_until_filled(buffer));
+        auto response_address_length = CO_TRY(socket.read_value<u8>());
+        auto buffer = CO_TRY(ByteBuffer::create_uninitialized(response_address_length));
+        CO_TRY(socket.read_until_filled(buffer));
         break;
     }
     case AddressType::IPV6:
     default:
-        return Error::from_string_literal("SOCKS negotiation failed: Invalid connect response address type");
+        co_return Error::from_string_literal("SOCKS negotiation failed: Invalid connect response address type");
     }
 
-    [[maybe_unused]] auto bound_port = TRY(socket.read_value<u16>());
+    [[maybe_unused]] auto bound_port = CO_TRY(socket.read_value<u16>());
 
-    return Reply(response_header.status);
+    co_return Reply(response_header.status);
 }
 
-ErrorOr<u8> send_username_password_authentication_message(Core::Socket& socket, Core::SOCKSProxyClient::UsernamePasswordAuthenticationData const& auth_data)
+Coroutine<ErrorOr<u8>> send_username_password_authentication_message(Core::Socket& socket, Core::SOCKSProxyClient::UsernamePasswordAuthenticationData const& auth_data)
 {
     AllocatingMemoryStream stream;
 
     u8 version = 0x01;
-    TRY(stream.write_value(version));
+    CO_TRY(stream.write_value(version));
 
     u8 username_length = auth_data.username.length();
-    TRY(stream.write_value(username_length));
+    CO_TRY(stream.write_value(username_length));
 
-    TRY(stream.write_until_depleted({ auth_data.username.characters(), auth_data.username.length() }));
+    CO_TRY(stream.write_until_depleted({ auth_data.username.characters(), auth_data.username.length() }));
 
     u8 password_length = auth_data.password.length();
-    TRY(stream.write_value(password_length));
+    CO_TRY(stream.write_value(password_length));
 
-    TRY(stream.write_until_depleted({ auth_data.password.characters(), auth_data.password.length() }));
+    CO_TRY(stream.write_until_depleted({ auth_data.password.characters(), auth_data.password.length() }));
 
-    auto buffer = TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
-    TRY(stream.read_until_filled(buffer.bytes()));
+    auto buffer = CO_TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
+    CO_TRY(stream.read_until_filled(buffer.bytes()));
 
-    TRY(socket.write_until_depleted(buffer));
+    CO_TRY(socket.write_until_depleted(buffer));
 
-    auto response = TRY(socket.read_value<Socks5UsernamePasswordResponse>());
+    auto response = CO_TRY(socket.read_value<Socks5UsernamePasswordResponse>());
 
     if (response.version_identifier != version)
-        return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
+        co_return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
 
-    return response.status;
+    co_return response.status;
 }
 }
 
@@ -252,49 +253,49 @@ SOCKSProxyClient::~SOCKSProxyClient()
     m_socket.on_ready_to_read = nullptr;
 }
 
-ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> SOCKSProxyClient::connect(Socket& underlying, Version version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data, Command command)
+Coroutine<ErrorOr<NonnullOwnPtr<SOCKSProxyClient>>> SOCKSProxyClient::async_connect(Socket& underlying, Version version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data, Command command)
 {
     if (version != Version::V5)
-        return Error::from_string_literal("SOCKS version not supported");
+        co_return Error::from_string_literal("SOCKS version not supported");
 
-    return auth_data.visit(
-        [&](Empty) -> ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> {
-            TRY(send_version_identifier_and_method_selection_message(underlying, version, Method::NoAuth));
-            auto reply = TRY(send_connect_request_message(underlying, version, target, target_port, command));
+    co_return co_await auth_data.visit(
+        [&](Empty) -> Coroutine<ErrorOr<NonnullOwnPtr<SOCKSProxyClient>>> {
+            CO_TRY(co_await send_version_identifier_and_method_selection_message(underlying, version, Method::NoAuth));
+            auto reply = CO_TRY(co_await send_connect_request_message(underlying, version, target, target_port, command));
             if (reply != Reply::Succeeded) {
                 underlying.close();
-                return Error::from_string_view(reply_response_name(reply));
+                co_return Error::from_string_view(reply_response_name(reply));
             }
 
-            return adopt_nonnull_own_or_enomem(new SOCKSProxyClient {
+            co_return adopt_nonnull_own_or_enomem(new SOCKSProxyClient {
                 underlying,
                 nullptr,
             });
         },
-        [&](UsernamePasswordAuthenticationData const& auth_data) -> ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> {
-            TRY(send_version_identifier_and_method_selection_message(underlying, version, Method::UsernamePassword));
-            auto auth_response = TRY(send_username_password_authentication_message(underlying, auth_data));
+        [&](UsernamePasswordAuthenticationData const& auth_data) -> Coroutine<ErrorOr<NonnullOwnPtr<SOCKSProxyClient>>> {
+            CO_TRY(co_await send_version_identifier_and_method_selection_message(underlying, version, Method::UsernamePassword));
+            auto auth_response = CO_TRY(co_await send_username_password_authentication_message(underlying, auth_data));
             if (auth_response != 0) {
                 underlying.close();
-                return Error::from_string_literal("SOCKS authentication failed");
+                co_return Error::from_string_literal("SOCKS authentication failed");
             }
 
-            auto reply = TRY(send_connect_request_message(underlying, version, target, target_port, command));
+            auto reply = CO_TRY(co_await send_connect_request_message(underlying, version, target, target_port, command));
             if (reply != Reply::Succeeded) {
                 underlying.close();
-                return Error::from_string_view(reply_response_name(reply));
+                co_return Error::from_string_view(reply_response_name(reply));
             }
 
-            return adopt_nonnull_own_or_enomem(new SOCKSProxyClient {
+            co_return adopt_nonnull_own_or_enomem(new SOCKSProxyClient {
                 underlying,
                 nullptr,
             });
         });
 }
 
-ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> SOCKSProxyClient::connect(HostOrIPV4 const& server, int server_port, Version version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data, Command command)
+Coroutine<ErrorOr<NonnullOwnPtr<SOCKSProxyClient>>> SOCKSProxyClient::async_connect(HostOrIPV4 const& server, int server_port, Version version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data, Command command)
 {
-    auto underlying = TRY(server.visit(
+    auto underlying = CO_TRY(server.visit(
         [&](u32 ipv4) {
             return Core::TCPSocket::connect({ IPv4Address(ipv4), static_cast<u16>(server_port) });
         },
@@ -302,10 +303,10 @@ ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> SOCKSProxyClient::connect(HostOrIPV4 co
             return Core::TCPSocket::connect(hostname, static_cast<u16>(server_port));
         }));
 
-    auto socket = TRY(connect(*underlying, version, target, target_port, auth_data, command));
+    auto socket = CO_TRY(co_await async_connect(*underlying, version, target, target_port, auth_data, command));
     socket->m_own_underlying_socket = move(underlying);
-    dbgln("SOCKS proxy connected, have {} available bytes", TRY(socket->m_socket.pending_bytes()));
-    return socket;
+    dbgln("SOCKS proxy connected, have {} available bytes", CO_TRY(socket->m_socket.pending_bytes()));
+    co_return socket;
 }
 
 }

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -34,6 +34,9 @@ public:
     static ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> connect(Socket& underlying, Version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data = {}, Command = Command::Connect);
     static ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> connect(HostOrIPV4 const& server, int server_port, Version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data = {}, Command = Command::Connect);
 
+    static Coroutine<ErrorOr<NonnullOwnPtr<SOCKSProxyClient>>> async_connect(Socket& underlying, Version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data = {}, Command = Command::Connect);
+    static Coroutine<ErrorOr<NonnullOwnPtr<SOCKSProxyClient>>> async_connect(HostOrIPV4 const& server, int server_port, Version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data = {}, Command = Command::Connect);
+
     virtual ~SOCKSProxyClient() override;
 
     // ^Stream::Stream

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Coroutine.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
 
@@ -214,6 +215,16 @@ ErrorOr<NonnullOwnPtr<TCPSocket>> TCPSocket::connect(SocketAddress const& addres
 
     socket->setup_notifier();
     return socket;
+}
+
+Coroutine<ErrorOr<NonnullOwnPtr<TCPSocket>>> TCPSocket::async_connect(Core::SocketAddress const& address)
+{
+    co_return CO_TRY(connect(address));
+}
+
+Coroutine<ErrorOr<NonnullOwnPtr<TCPSocket>>> TCPSocket::async_connect(const AK::ByteString& host, u16 port)
+{
+    co_return CO_TRY(connect(host, port));
 }
 
 ErrorOr<NonnullOwnPtr<TCPSocket>> TCPSocket::adopt_fd(int fd)

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -160,6 +160,9 @@ public:
     static ErrorOr<NonnullOwnPtr<TCPSocket>> connect(SocketAddress const& address);
     static ErrorOr<NonnullOwnPtr<TCPSocket>> adopt_fd(int fd);
 
+    static Coroutine<ErrorOr<NonnullOwnPtr<TCPSocket>>> async_connect(ByteString const& host, u16 port);
+    static Coroutine<ErrorOr<NonnullOwnPtr<TCPSocket>>> async_connect(SocketAddress const& address);
+
     TCPSocket(TCPSocket&& other)
         : Socket(static_cast<Socket&&>(other))
         , m_helper(move(other.m_helper))

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -95,8 +95,8 @@ void galois_multiply(u32 (&_z)[4], u32 const (&_x)[4], u32 const (&_y)[4])
 
     // Unrolled by 32, the access in y[3-(i/32)] can be cached throughout the loop.
 #pragma GCC unroll 32
-    for (ssize_t i = 127; i > -1; --i) {
-        auto r = -((y[3 - (i / 32)] >> (i % 32)) & 1);
+    for (ssize_t i = 127, j = 0; i > -1; --i, j++) {
+        auto r = -((y[j / 32] >> (i % 32)) & 1);
         z[0] ^= x[0] & r;
         z[1] ^= x[1] & r;
         z[2] ^= x[2] & r;

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp
@@ -94,15 +94,20 @@ ALWAYS_INLINE static void addition_with_carry(u32 a, u32 b, u32& z_carry, u32& z
  */
 UnsignedBigInteger::Word UnsignedBigIntegerAlgorithms::montgomery_fragment(UnsignedBigInteger& z, size_t offset_in_z, UnsignedBigInteger const& x, UnsignedBigInteger::Word y_digit, size_t num_words)
 {
+    VERIFY(x.m_words.size() >= num_words);
+    VERIFY(z.m_words.size() >= num_words + offset_in_z);
+    auto const* x_words = x.m_words.data();
+    auto* z_words = z.m_words.data();
+
     UnsignedBigInteger::Word carry { 0 };
     for (size_t i = 0; i < num_words; ++i) {
         UnsignedBigInteger::Word a_carry;
         UnsignedBigInteger::Word a;
-        linear_multiplication_with_carry(x.m_words[i], y_digit, z.m_words[offset_in_z + i], a_carry, a);
+        linear_multiplication_with_carry(x_words[i], y_digit, z_words[offset_in_z + i], a_carry, a);
         UnsignedBigInteger::Word b_carry;
         UnsignedBigInteger::Word b;
         addition_with_carry(a, carry, b_carry, b);
-        z.m_words[offset_in_z + i] = b;
+        z_words[offset_in_z + i] = b;
         carry = a_carry + b_carry;
     }
     return carry;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -112,19 +112,21 @@ size_t UnsignedBigInteger::export_data(Bytes data, bool remove_leading_zeros) co
         ssize_t leading_zeros = -1;
         if (remove_leading_zeros) {
             UnsignedBigInteger::Word word = m_words[word_count - 1];
+            u8 value[4] {};
             for (size_t i = 0; i < sizeof(u32); i++) {
                 u8 byte = (u8)(word >> ((sizeof(u32) - i - 1) * 8));
-                data[out++] = byte;
+                value[i] = byte;
                 if (leading_zeros < 0 && byte != 0)
                     leading_zeros = (int)i;
             }
+            data.overwrite(out, value, array_size(value));
+            out += array_size(value);
         }
         for (size_t i = word_count - (remove_leading_zeros ? 1 : 0); i > 0; i--) {
             auto word = m_words[i - 1];
-            data[out++] = (u8)(word >> 24);
-            data[out++] = (u8)(word >> 16);
-            data[out++] = (u8)(word >> 8);
-            data[out++] = (u8)word;
+            u8 value[] { (u8)(word >> 24), (u8)(word >> 16), (u8)(word >> 8), (u8)word };
+            data.overwrite(out, value, array_size(value));
+            out += array_size(value);
         }
         if (leading_zeros > 0)
             out -= leading_zeros;

--- a/Userland/Libraries/LibGemini/Job.h
+++ b/Userland/Libraries/LibGemini/Job.h
@@ -18,7 +18,7 @@ class Job : public Core::NetworkJob {
     C_OBJECT(Job);
 
 public:
-    explicit Job(GeminiRequest const&, Stream&);
+    explicit Job(GeminiRequest const&, Core::File&);
     virtual ~Job() override = default;
 
     virtual void start(Core::BufferedSocketBase&) override;

--- a/Userland/Libraries/LibHTTP/HttpsJob.h
+++ b/Userland/Libraries/LibHTTP/HttpsJob.h
@@ -30,7 +30,7 @@ public:
     Function<Vector<TLS::Certificate>()> on_certificate_requested;
 
 private:
-    explicit HttpsJob(HttpRequest&& request, Stream& output_stream)
+    explicit HttpsJob(HttpRequest&& request, Core::File& output_stream)
         : Job(move(request), output_stream)
     {
     }

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -5,20 +5,82 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AsyncStreamBuffer.h>
+#include <AK/AsyncStreamHelpers.h>
+#include <AK/AsyncStreamTransform.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
+#include <AK/GenericAwaiter.h>
+#include <AK/MemMem.h>
 #include <AK/MemoryStream.h>
 #include <AK/Try.h>
 #include <LibCompress/Brotli.h>
 #include <LibCompress/Gzip.h>
 #include <LibCompress/Zlib.h>
 #include <LibCore/Event.h>
+#include <LibCore/EventLoop.h>
 #include <LibHTTP/HttpResponse.h>
 #include <LibHTTP/Job.h>
 #include <stdio.h>
 #include <unistd.h>
 
 namespace HTTP {
+
+template<typename Stream>
+struct SyncStreamAsyncWrapper final : public AsyncInputStream {
+    explicit SyncStreamAsyncWrapper(MaybeOwned<Stream>&& stream)
+        : m_stream(move(stream))
+        , m_awaiter(GenericAwaiter { [&](auto cb) { m_stream->on_ready_to_read = move(cb); } })
+    {
+    }
+
+    virtual void reset() override
+    {
+    }
+
+    virtual Coroutine<ErrorOr<void>> close() override
+    {
+        if (m_stream->is_open())
+            m_stream->close();
+        co_return {};
+    }
+
+    virtual bool is_open() const override
+    {
+        return !m_stream->is_eof() || !m_buffer.is_empty();
+    }
+
+    virtual Coroutine<ErrorOr<bool>> enqueue_some(Badge<AsyncInputStream>) override
+    {
+        CO_TRY(co_await m_awaiter);
+        auto buffer = AK::Detail::ByteBuffer<16 * KiB> {};
+        auto bytes = CO_TRY(m_stream->read_some(buffer.must_get_bytes_for_writing(16 * KiB)));
+        if (bytes.is_empty())
+            co_return !m_stream->is_eof();
+        m_buffer.append(bytes);
+        co_return true;
+    }
+
+    virtual ReadonlyBytes buffered_data_unchecked(Badge<AsyncInputStream>) const override
+    {
+        return m_buffer.data();
+    }
+
+    virtual void dequeue(Badge<AsyncInputStream>, size_t bytes) override
+    {
+        m_buffer.dequeue(bytes);
+    }
+
+    Coroutine<ErrorOr<StringView>> read_line(size_t max_size)
+    {
+        co_return StringView { CO_TRY(co_await AsyncStreamHelpers::consume_until(*this, "\r\n"sv, max_size)) }.trim("\r\n"sv, TrimMode::Right);
+    }
+
+private:
+    MaybeOwned<Stream> m_stream;
+    GenericAwaiter m_awaiter;
+    AsyncStreamBuffer m_buffer;
+};
 
 static ErrorOr<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, ByteString const& content_encoding)
 {
@@ -89,7 +151,7 @@ static ErrorOr<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, ByteSt
     return buf;
 }
 
-Job::Job(HttpRequest&& request, Stream& output_stream)
+Job::Job(HttpRequest&& request, Core::File& output_stream)
     : Core::NetworkJob(output_stream)
     , m_request(move(request))
 {
@@ -119,81 +181,335 @@ void Job::shutdown(ShutdownMode mode)
     }
 }
 
-void Job::flush_received_buffers()
+Coroutine<void> Job::flush_received_buffers()
 {
-    if (!m_can_stream_response || m_buffered_size == 0)
-        return;
-    dbgln_if(JOB_DEBUG, "Job: Flushing received buffers: have {} bytes in {} buffers for {}", m_buffered_size, m_received_buffers.size(), m_request.url());
-    for (size_t i = 0; i < m_received_buffers.size(); ++i) {
-        auto& payload = m_received_buffers[i]->pending_flush;
-        auto result = do_write(payload);
-        if (result.is_error()) {
-            if (!result.error().is_errno()) {
-                dbgln_if(JOB_DEBUG, "Job: Failed to flush received buffers: {}", result.error());
-                continue;
+    if (!m_can_stream_response || m_has_scheduled_flush)
+        co_return;
+
+    TemporaryChange change(m_has_scheduled_flush, true);
+
+    while (m_buffered_size > 0) {
+        dbgln_if(JOB_DEBUG, "Job: Flushing received buffers: have {} bytes in {} buffers for {}", m_buffered_size, m_received_buffers.size(), m_request.url());
+        for (size_t i = 0; i < m_received_buffers.size(); ++i) {
+            auto& payload = m_received_buffers[i]->pending_flush;
+            auto result = co_await do_write(payload);
+            if (result.is_error())
+                break;
+            auto written = result.release_value();
+            m_buffered_size -= written;
+            if (written == payload.size()) {
+                // FIXME: Make this a take-first-friendly object?
+                (void)m_received_buffers.take_first();
+                break;
             }
-            if (result.error().code() == EINTR) {
-                i--;
-                continue;
-            }
+            VERIFY(written < payload.size());
+            payload = payload.slice(written, payload.size() - written);
             break;
         }
-        auto written = result.release_value();
-        m_buffered_size -= written;
-        if (written == payload.size()) {
-            // FIXME: Make this a take-first-friendly object?
-            (void)m_received_buffers.take_first();
-            --i;
-            continue;
-        }
-        VERIFY(written < payload.size());
-        payload = payload.slice(written, payload.size() - written);
-        break;
+        dbgln_if(JOB_DEBUG, "Job: Flushing received buffers done: have {} bytes in {} buffers for {}", m_buffered_size, m_received_buffers.size(), m_request.url());
     }
-    dbgln_if(JOB_DEBUG, "Job: Flushing received buffers done: have {} bytes in {} buffers for {}", m_buffered_size, m_received_buffers.size(), m_request.url());
+
+    if (m_request_done) {
+        m_has_scheduled_finish = true;
+        auto response = HttpResponse::create(m_code, move(m_headers), m_received_size);
+        // If the server responded with "Connection: close", close the connection
+        // as the server may or may not want to close the socket. Also, if this is
+        // a legacy HTTP server (1.0 or older), assume close is the default value.
+        if (auto result = response->headers().get("Connection"sv); result.has_value() ? result->equals_ignoring_ascii_case("close"sv) : m_legacy_connection)
+            shutdown(ShutdownMode::CloseSocket);
+        did_finish(response);
+    }
 }
 
-void Job::register_on_ready_to_read(Function<void()> callback)
+auto Job::parse_status(auto& stream) -> Coroutine<ErrorOr<void>>
 {
-    m_socket->on_ready_to_read = [this, callback = move(callback)] {
-        callback();
+    auto line = CO_TRY(co_await stream.read_line(PAGE_SIZE));
 
-        // As `m_socket` is a buffered object, we might not get notifications for data in the buffer
-        // so exhaust the buffer to ensure we don't end up waiting forever.
-        auto can_read_without_blocking = m_socket->can_read_without_blocking();
-        if (can_read_without_blocking.is_error())
-            return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-        if (can_read_without_blocking.value() && m_state != State::Finished && !has_error()) {
-            deferred_invoke([this] {
-                if (m_socket && m_socket->on_ready_to_read)
-                    m_socket->on_ready_to_read();
-            });
+    dbgln_if(JOB_DEBUG, "Job {} read line of length {}", m_request.url(), line.length());
+    auto parts = line.split_view(' ');
+    if (parts.size() < 2) {
+        dbgln("Job: Expected 2-part or 3-part HTTP status line, got '{}'", line);
+        deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
+        co_return {};
+    }
+
+    if (!parts[0].matches("HTTP/?.?"sv, CaseSensitivity::CaseSensitive) || !is_ascii_digit(parts[0][5]) || !is_ascii_digit(parts[0][7])) {
+        dbgln("Job: Expected HTTP-Version to be of the form 'HTTP/X.Y', got '{}'", parts[0]);
+        deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
+        co_return {};
+    }
+    auto http_major_version = parse_ascii_digit(parts[0][5]);
+    auto http_minor_version = parse_ascii_digit(parts[0][7]);
+    m_legacy_connection = http_major_version < 1 || (http_major_version == 1 && http_minor_version == 0);
+
+    auto code = parts[1].template to_number<unsigned>();
+    if (!code.has_value()) {
+        dbgln("Job: Expected numeric HTTP status");
+        deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
+        co_return {};
+    }
+    m_code = code.value();
+    co_return {};
+}
+
+auto Job::parse_headers(auto& stream, bool in_trailers) -> Coroutine<ErrorOr<void>>
+{
+    while (true) {
+        // There's no max limit defined on headers, but for our sanity, let's limit it to 32K.
+        auto line = StringView { CO_TRY(co_await stream.read_line(32 * KiB)) };
+
+        if (line.is_empty()) {
+            if (in_trailers) {
+                co_await finish_up();
+                co_return {};
+            }
+            if (on_headers_received)
+                on_headers_received(m_headers, m_code > 0 ? m_code : Optional<u32> {});
+
+            // We've reached the end of the headers, there's a possibility that the server
+            // responds with nothing (content-length = 0 with normal encoding); if that's the case,
+            // quit early as we won't be reading anything anyway.
+            if (auto result = m_headers.get("Content-Length"sv).value_or(""sv).to_number<unsigned>(); result.has_value()) {
+                if (result.value() == 0) {
+                    auto transfer_encoding = m_headers.get("Transfer-Encoding"sv);
+                    if (!transfer_encoding.has_value() || !transfer_encoding->view().trim_whitespace().equals_ignoring_ascii_case("chunked"sv)) {
+                        co_await finish_up();
+                        co_return {};
+                    }
+                }
+            }
+            // There's also the possibility that the server responds with 204 (No Content),
+            // and manages to set a Content-Length anyway, in such cases ignore Content-Length and quit early;
+            // As the HTTP spec explicitly prohibits presence of Content-Length when the response code is 204.
+            if (m_code == 204) {
+                co_await finish_up();
+                co_return {};
+            }
+
+            break;
         }
-    };
+        auto parts = line.split_view(':');
+        if (parts.is_empty()) {
+            if (in_trailers) {
+                // Some servers like to send two ending chunks
+                // use this fact as an excuse to ignore anything after the last chunk
+                // that is not a valid trailing header.
+                co_await finish_up();
+                co_return {};
+            }
+            dbgln("Job: Expected HTTP header with key/value");
+            deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
+            co_return {};
+        }
+        auto name = parts[0];
+        if (line.length() < name.length() + 2) {
+            if (in_trailers) {
+                // Some servers like to send two ending chunks
+                // use this fact as an excuse to ignore anything after the last chunk
+                // that is not a valid trailing header.
+                co_await finish_up();
+                co_return {};
+            }
+            dbgln("Job: Malformed HTTP header: '{}' ({})", line, line.length());
+            deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
+            co_return {};
+        }
+        auto value = line.substring_view(name.length() + 2, line.length() - name.length() - 2);
+        m_headers.set(name, value);
+        if (name.equals_ignoring_ascii_case("Content-Encoding"sv)) {
+            // Assume that any content-encoding means that we can't decode it as a stream :(
+            dbgln_if(JOB_DEBUG, "Content-Encoding {} detected, cannot stream output :(", value);
+            m_can_stream_response = false;
+        } else if (name.equals_ignoring_ascii_case("Content-Length"sv)) {
+            auto length = value.to_number<u64>();
+            if (length.has_value())
+                m_content_length = length.value();
+        }
+        dbgln_if(JOB_DEBUG, "Job: [{}] = '{}'", name, value);
+    }
+
+    co_return {};
 }
 
-ErrorOr<ByteString> Job::read_line(size_t size)
+auto Job::parse_body(auto& stream) -> Coroutine<ErrorOr<bool>>
 {
-    auto buffer = TRY(ByteBuffer::create_uninitialized(size));
-    auto bytes_read = TRY(m_socket->read_until(buffer, "\r\n"sv));
-    return ByteString::copy(bytes_read);
+    auto should_read_trailers = false;
+    while (true) {
+        auto read_size = 64 * KiB;
+        if (m_current_chunk_remaining_size.has_value()) {
+        read_chunk_size:;
+            auto remaining = m_current_chunk_remaining_size.value();
+            if (remaining == -1) {
+                // read size
+                auto size_data = CO_TRY(co_await stream.read_line(PAGE_SIZE));
+                if (m_should_read_chunk_ending_line) {
+                    // NOTE: Some servers seem to send an extra \r\n here despite there being no size.
+                    //       This makes us tolerate that.
+                    size_data = size_data.trim("\r\n"sv, TrimMode::Right);
+                    VERIFY(size_data.is_empty());
+                    m_should_read_chunk_ending_line = false;
+                    continue;
+                }
+                auto size_lines = size_data.trim_whitespace().lines();
+                dbgln_if(JOB_DEBUG, "Job: Received a chunk with size '{}'", size_data);
+                if (size_lines.size() == 0) {
+                    if (!m_socket->is_eof())
+                        break;
+                    dbgln("Job: Reached end of stream");
+                    co_await finish_up();
+                    break;
+                }
+                auto chunk = size_lines[0].split_view(';', SplitBehavior::KeepEmpty);
+                ByteString size_string = chunk[0];
+                char* endptr;
+                auto size = strtoul(size_string.characters(), &endptr, 16);
+                if (*endptr) {
+                    // invalid number
+                    deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
+                    break;
+                }
+                if (size == 0) {
+                    // This is the last chunk
+                    // '0' *[; chunk-ext-name = chunk-ext-value]
+                    // We're going to ignore _all_ chunk extensions
+                    read_size = 0;
+                    m_current_chunk_total_size = 0;
+                    m_current_chunk_remaining_size = 0;
+
+                    dbgln_if(JOB_DEBUG, "Job: Received the last chunk with extensions '{}'", size_string.substring_view(1, size_string.length() - 1));
+                } else {
+                    m_current_chunk_total_size = size;
+                    m_current_chunk_remaining_size = size;
+                    read_size = size;
+
+                    dbgln_if(JOB_DEBUG, "Job: Chunk of size '{}' started", size);
+                }
+            } else {
+                read_size = remaining;
+
+                dbgln_if(JOB_DEBUG, "Job: Resuming chunk with '{}' bytes left over", remaining);
+            }
+        } else {
+            auto transfer_encoding = m_headers.get("Transfer-Encoding");
+            if (transfer_encoding.has_value()) {
+                // HTTP/1.1 3.3.3.3:
+                // If a message is received with both a Transfer-Encoding and a Content-Length header field, the Transfer-Encoding overrides the Content-Length. [...]
+                // https://httpwg.org/specs/rfc7230.html#message.body.length
+                m_content_length = {};
+
+                // Note: Some servers add extra spaces around 'chunked', see #6302.
+                auto encoding = transfer_encoding.value().trim_whitespace();
+
+                dbgln_if(JOB_DEBUG, "Job: This content has transfer encoding '{}'", encoding);
+                if (encoding.equals_ignoring_ascii_case("chunked"sv)) {
+                    m_current_chunk_remaining_size = -1;
+                    goto read_chunk_size;
+                } else {
+                    dbgln("Job: Unknown transfer encoding '{}', the result will likely be wrong!", encoding);
+                }
+            } else if (m_content_length.has_value()) {
+                read_size = m_content_length.value() - m_received_size;
+                if (read_size == 0) {
+                    co_await finish_up();
+                    break;
+                }
+            }
+        }
+
+        auto payload = CO_TRY(ByteBuffer::copy(CO_TRY(co_await stream.read(read_size))));
+
+        if (payload.is_empty() && !stream.is_open()) {
+            co_await finish_up();
+            break;
+        }
+
+        bool read_everything = false;
+        if (m_content_length.has_value()) {
+            auto length = m_content_length.value();
+            if (m_received_size + payload.size() >= length) {
+                payload.resize(length - m_received_size);
+                read_everything = true;
+            }
+        }
+
+        m_received_buffers.append(make<ReceivedBuffer>(payload));
+        m_buffered_size += payload.size();
+        m_received_size += payload.size();
+        Core::EventLoop::current().adopt_coroutine(flush_received_buffers());
+
+        deferred_invoke([this] { did_progress(m_content_length, m_received_size); });
+
+        if (read_everything) {
+            VERIFY(m_received_size <= m_content_length.value());
+            co_await finish_up();
+            break;
+        }
+
+        // Check after reading all the buffered data if we have reached the end of stream
+        // for cases where the server didn't send a content length, chunked encoding but is
+        // directly closing the connection.
+        if (!m_content_length.has_value() && !m_current_chunk_remaining_size.has_value() && m_socket->is_eof()) {
+            co_await finish_up();
+            break;
+        }
+
+        if (m_current_chunk_remaining_size.has_value()) {
+            auto size = m_current_chunk_remaining_size.value() - payload.size();
+
+            dbgln_if(JOB_DEBUG, "Job: We have {} bytes left over in this chunk", size);
+            if (size == 0) {
+                dbgln_if(JOB_DEBUG, "Job: Finished a chunk of {} bytes", m_current_chunk_total_size.value());
+
+                if (m_current_chunk_total_size.value() == 0) {
+                    should_read_trailers = true;
+                    break;
+                }
+
+                // we've read everything, now let's get the next chunk
+                size = -1;
+
+                auto line = CO_TRY(co_await stream.read_line(PAGE_SIZE));
+                VERIFY(line.is_empty());
+            }
+            m_current_chunk_remaining_size = size;
+        }
+    }
+    co_return should_read_trailers;
 }
 
-ErrorOr<ByteBuffer> Job::receive(size_t size)
+auto Job::read_response() -> Coroutine<ErrorOr<void>>
 {
-    if (size == 0)
-        return ByteBuffer {};
+    auto stream = SyncStreamAsyncWrapper(MaybeOwned { *m_socket });
 
-    auto buffer = TRY(ByteBuffer::create_uninitialized(size));
-    size_t nread;
-    do {
-        auto result = m_socket->read_some(buffer);
-        if (result.is_error() && result.error().is_errno() && result.error().code() == EINTR)
-            continue;
-        nread = TRY(result).size();
-        break;
-    } while (true);
-    return buffer.slice(0, nread);
+    if (is_cancelled())
+        co_return {};
+
+    if (m_socket->is_eof()) {
+        // Some servers really like terminating connections by simply closing them (even TLS ones)
+        // to signal end-of-data, if there's no:
+        // - connection
+        // - content-size
+        // - transfer-encoding: chunked
+        // header, simply treat EOF as a termination signal.
+        if (m_headers.contains("connection"sv) || m_content_length.has_value() || m_current_chunk_total_size.has_value()) {
+            dbgln_if(JOB_DEBUG, "Read failure: Actually EOF!");
+            deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
+            co_return {};
+        }
+
+        co_await finish_up();
+        co_return {};
+    }
+
+    CO_TRY(co_await parse_status(stream));
+    CO_TRY(co_await parse_headers(stream, false));
+    auto should_read_trailers = CO_TRY(co_await parse_body(stream));
+    if (should_read_trailers)
+        CO_TRY(co_await parse_headers(stream, true));
+
+    co_await finish_up();
+
+    co_return {};
 }
 
 void Job::on_socket_connected()
@@ -205,381 +521,27 @@ void Job::on_socket_connected()
         dbgln("{}", ByteString::copy(raw_request));
     }
 
-    bool success = !m_socket->write_until_depleted(raw_request).is_error();
-    if (!success)
-        deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
+    if (m_socket->write_until_depleted(raw_request).is_error())
+        return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
 
-    register_on_ready_to_read([&] {
-        dbgln_if(JOB_DEBUG, "Ready to read for {}, state = {}, cancelled = {}", m_request.url(), to_underlying(m_state), is_cancelled());
-        if (is_cancelled())
-            return;
-
-        if (m_state == State::Finished) {
-            // We have everything we want, at this point, we can either get an EOF, or a bunch of extra newlines
-            // (unless "Connection: close" isn't specified)
-            // So just ignore everything after this.
-            return;
+    Core::EventLoop::current().adopt_coroutine([this] mutable -> Coroutine<void> {
+        auto result = co_await read_response();
+        if (result.is_error()) {
+            dbgln("Job: Failed to read response: {}", result.error());
+            did_fail(Core::NetworkJob::Error::TransmissionFailed);
         }
-
-        if (m_socket->is_eof()) {
-            // Some servers really like terminating connections by simply closing them (even TLS ones)
-            // to signal end-of-data, if there's no:
-            // - connection
-            // - content-size
-            // - transfer-encoding: chunked
-            // header, simply treat EOF as a termination signal.
-            if (m_headers.contains("connection"sv) || m_content_length.has_value() || m_current_chunk_total_size.has_value()) {
-                dbgln_if(JOB_DEBUG, "Read failure: Actually EOF!");
-                deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
-                return;
-            }
-
-            finish_up();
-            return;
-        }
-
-        while (m_state == State::InStatus) {
-            auto can_read_line = m_socket->can_read_up_to_delimiter("\r\n"sv.bytes());
-            if (can_read_line.is_error()) {
-                dbgln_if(JOB_DEBUG, "Job {} could not figure out whether we could read a line", m_request.url());
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            }
-
-            if (!can_read_line.value()) {
-                dbgln_if(JOB_DEBUG, "Job {} cannot read a full line", m_request.url());
-                // TODO: Should we retry here instead of failing instantly?
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            }
-
-            auto maybe_line = read_line(PAGE_SIZE);
-            if (maybe_line.is_error()) {
-                dbgln_if(JOB_DEBUG, "Job {} could not read line: {}", m_request.url(), maybe_line.error());
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            }
-
-            auto line = maybe_line.release_value();
-
-            dbgln_if(JOB_DEBUG, "Job {} read line of length {}", m_request.url(), line.length());
-            auto parts = line.split_view(' ');
-            if (parts.size() < 2) {
-                dbgln("Job: Expected 2-part or 3-part HTTP status line, got '{}'", line);
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
-            }
-
-            if (!parts[0].matches("HTTP/?.?"sv, CaseSensitivity::CaseSensitive) || !is_ascii_digit(parts[0][5]) || !is_ascii_digit(parts[0][7])) {
-                dbgln("Job: Expected HTTP-Version to be of the form 'HTTP/X.Y', got '{}'", parts[0]);
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
-            }
-            auto http_major_version = parse_ascii_digit(parts[0][5]);
-            auto http_minor_version = parse_ascii_digit(parts[0][7]);
-            m_legacy_connection = http_major_version < 1 || (http_major_version == 1 && http_minor_version == 0);
-
-            auto code = parts[1].to_number<unsigned>();
-            if (!code.has_value()) {
-                dbgln("Job: Expected numeric HTTP status");
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
-            }
-            m_code = code.value();
-            m_state = State::InHeaders;
-
-            auto can_read_without_blocking = m_socket->can_read_without_blocking();
-            if (can_read_without_blocking.is_error())
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-
-            if (!can_read_without_blocking.value())
-                return;
-        }
-        while (m_state == State::InHeaders || m_state == State::Trailers) {
-            auto can_read_line = m_socket->can_read_up_to_delimiter("\r\n"sv.bytes());
-            if (can_read_line.is_error()) {
-                dbgln_if(JOB_DEBUG, "Job {} could not figure out whether we could read a line", m_request.url());
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            }
-
-            if (!can_read_line.value()) {
-                dbgln_if(JOB_DEBUG, "Can't read lines anymore :(");
-                return;
-            }
-
-            // There's no max limit defined on headers, but for our sanity, let's limit it to 32K.
-            auto maybe_line = read_line(32 * KiB);
-            if (maybe_line.is_error()) {
-                dbgln_if(JOB_DEBUG, "Job {} could not read a header line: {}", m_request.url(), maybe_line.error());
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            }
-            auto line = maybe_line.release_value();
-
-            if (line.is_empty()) {
-                if (m_state == State::Trailers) {
-                    return finish_up();
-                }
-                if (on_headers_received) {
-                    on_headers_received(m_headers, m_code > 0 ? m_code : Optional<u32> {});
-                }
-                m_state = State::InBody;
-
-                // We've reached the end of the headers, there's a possibility that the server
-                // responds with nothing (content-length = 0 with normal encoding); if that's the case,
-                // quit early as we won't be reading anything anyway.
-                if (auto result = m_headers.get("Content-Length"sv).value_or(""sv).to_number<unsigned>(); result.has_value()) {
-                    if (result.value() == 0) {
-                        auto transfer_encoding = m_headers.get("Transfer-Encoding"sv);
-                        if (!transfer_encoding.has_value() || !transfer_encoding->view().trim_whitespace().equals_ignoring_ascii_case("chunked"sv))
-                            return finish_up();
-                    }
-                }
-                // There's also the possibility that the server responds with 204 (No Content),
-                // and manages to set a Content-Length anyway, in such cases ignore Content-Length and quit early;
-                // As the HTTP spec explicitly prohibits presence of Content-Length when the response code is 204.
-                if (m_code == 204)
-                    return finish_up();
-
-                break;
-            }
-            auto parts = line.split_view(':');
-            if (parts.is_empty()) {
-                if (m_state == State::Trailers) {
-                    // Some servers like to send two ending chunks
-                    // use this fact as an excuse to ignore anything after the last chunk
-                    // that is not a valid trailing header.
-                    return finish_up();
-                }
-                dbgln("Job: Expected HTTP header with key/value");
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
-            }
-            auto name = parts[0];
-            if (line.length() < name.length() + 2) {
-                if (m_state == State::Trailers) {
-                    // Some servers like to send two ending chunks
-                    // use this fact as an excuse to ignore anything after the last chunk
-                    // that is not a valid trailing header.
-                    return finish_up();
-                }
-                dbgln("Job: Malformed HTTP header: '{}' ({})", line, line.length());
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
-            }
-            auto value = line.substring(name.length() + 2, line.length() - name.length() - 2);
-            m_headers.set(name, value);
-            if (name.equals_ignoring_ascii_case("Content-Encoding"sv)) {
-                // Assume that any content-encoding means that we can't decode it as a stream :(
-                dbgln_if(JOB_DEBUG, "Content-Encoding {} detected, cannot stream output :(", value);
-                m_can_stream_response = false;
-            } else if (name.equals_ignoring_ascii_case("Content-Length"sv)) {
-                auto length = value.to_number<u64>();
-                if (length.has_value())
-                    m_content_length = length.value();
-            }
-            dbgln_if(JOB_DEBUG, "Job: [{}] = '{}'", name, value);
-
-            auto can_read_without_blocking = m_socket->can_read_without_blocking();
-            if (can_read_without_blocking.is_error())
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            if (!can_read_without_blocking.value()) {
-                dbgln_if(JOB_DEBUG, "Can't read headers anymore, byebye :(");
-                return;
-            }
-        }
-        VERIFY(m_state == State::InBody);
-
-        while (true) {
-            auto can_read_without_blocking = m_socket->can_read_without_blocking();
-            if (can_read_without_blocking.is_error())
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            if (!can_read_without_blocking.value())
-                break;
-
-            auto read_size = 64 * KiB;
-            if (m_current_chunk_remaining_size.has_value()) {
-            read_chunk_size:;
-                auto remaining = m_current_chunk_remaining_size.value();
-                if (remaining == -1) {
-                    // read size
-                    auto can_read_line = m_socket->can_read_up_to_delimiter("\r\n"sv.bytes());
-                    if (can_read_line.is_error())
-                        return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-                    if (!can_read_line.value()) // We'll try later.
-                        return;
-                    auto maybe_size_data = read_line(PAGE_SIZE);
-                    if (maybe_size_data.is_error()) {
-                        dbgln_if(JOB_DEBUG, "Job: Could not receive chunk: {}", maybe_size_data.error());
-                    }
-                    auto size_data = maybe_size_data.release_value();
-
-                    if (m_should_read_chunk_ending_line) {
-                        // NOTE: Some servers seem to send an extra \r\n here despite there being no size.
-                        //       This makes us tolerate that.
-                        size_data = size_data.trim("\r\n"sv, TrimMode::Right);
-                        VERIFY(size_data.is_empty());
-                        m_should_read_chunk_ending_line = false;
-                        continue;
-                    }
-                    auto size_lines = size_data.view().trim_whitespace().lines();
-                    dbgln_if(JOB_DEBUG, "Job: Received a chunk with size '{}'", size_data);
-                    if (size_lines.size() == 0) {
-                        if (!m_socket->is_eof())
-                            break;
-                        dbgln("Job: Reached end of stream");
-                        finish_up();
-                        break;
-                    } else {
-                        auto chunk = size_lines[0].split_view(';', SplitBehavior::KeepEmpty);
-                        ByteString size_string = chunk[0];
-                        char* endptr;
-                        auto size = strtoul(size_string.characters(), &endptr, 16);
-                        if (*endptr) {
-                            // invalid number
-                            deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-                            break;
-                        }
-                        if (size == 0) {
-                            // This is the last chunk
-                            // '0' *[; chunk-ext-name = chunk-ext-value]
-                            // We're going to ignore _all_ chunk extensions
-                            read_size = 0;
-                            m_current_chunk_total_size = 0;
-                            m_current_chunk_remaining_size = 0;
-
-                            dbgln_if(JOB_DEBUG, "Job: Received the last chunk with extensions '{}'", size_string.substring_view(1, size_string.length() - 1));
-                        } else {
-                            m_current_chunk_total_size = size;
-                            m_current_chunk_remaining_size = size;
-                            read_size = size;
-
-                            dbgln_if(JOB_DEBUG, "Job: Chunk of size '{}' started", size);
-                        }
-                    }
-                } else {
-                    read_size = remaining;
-
-                    dbgln_if(JOB_DEBUG, "Job: Resuming chunk with '{}' bytes left over", remaining);
-                }
-            } else {
-                auto transfer_encoding = m_headers.get("Transfer-Encoding");
-                if (transfer_encoding.has_value()) {
-                    // HTTP/1.1 3.3.3.3:
-                    // If a message is received with both a Transfer-Encoding and a Content-Length header field, the Transfer-Encoding overrides the Content-Length. [...]
-                    // https://httpwg.org/specs/rfc7230.html#message.body.length
-                    m_content_length = {};
-
-                    // Note: Some servers add extra spaces around 'chunked', see #6302.
-                    auto encoding = transfer_encoding.value().trim_whitespace();
-
-                    dbgln_if(JOB_DEBUG, "Job: This content has transfer encoding '{}'", encoding);
-                    if (encoding.equals_ignoring_ascii_case("chunked"sv)) {
-                        m_current_chunk_remaining_size = -1;
-                        goto read_chunk_size;
-                    } else {
-                        dbgln("Job: Unknown transfer encoding '{}', the result will likely be wrong!", encoding);
-                    }
-                }
-            }
-
-            can_read_without_blocking = m_socket->can_read_without_blocking();
-            if (can_read_without_blocking.is_error())
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            if (!can_read_without_blocking.value())
-                break;
-
-            dbgln_if(JOB_DEBUG, "Waiting for payload for {}", m_request.url());
-            auto maybe_payload = receive(read_size);
-            if (maybe_payload.is_error()) {
-                dbgln_if(JOB_DEBUG, "Could not read the payload: {}", maybe_payload.error());
-                return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-            }
-
-            auto payload = maybe_payload.release_value();
-
-            if (payload.is_empty() && m_socket->is_eof()) {
-                finish_up();
-                break;
-            }
-
-            bool read_everything = false;
-            if (m_content_length.has_value()) {
-                auto length = m_content_length.value();
-                if (m_received_size + payload.size() >= length) {
-                    payload.resize(length - m_received_size);
-                    read_everything = true;
-                }
-            }
-
-            m_received_buffers.append(make<ReceivedBuffer>(payload));
-            m_buffered_size += payload.size();
-            m_received_size += payload.size();
-            flush_received_buffers();
-
-            deferred_invoke([this] { did_progress(m_content_length, m_received_size); });
-
-            if (read_everything) {
-                VERIFY(m_received_size <= m_content_length.value());
-                finish_up();
-                break;
-            }
-
-            // Check after reading all the buffered data if we have reached the end of stream
-            // for cases where the server didn't send a content length, chunked encoding but is
-            // directly closing the connection.
-            if (!m_content_length.has_value() && !m_current_chunk_remaining_size.has_value() && m_socket->is_eof()) {
-                finish_up();
-                break;
-            }
-
-            if (m_current_chunk_remaining_size.has_value()) {
-                auto size = m_current_chunk_remaining_size.value() - payload.size();
-
-                dbgln_if(JOB_DEBUG, "Job: We have {} bytes left over in this chunk", size);
-                if (size == 0) {
-                    dbgln_if(JOB_DEBUG, "Job: Finished a chunk of {} bytes", m_current_chunk_total_size.value());
-
-                    if (m_current_chunk_total_size.value() == 0) {
-                        m_state = State::Trailers;
-                        break;
-                    }
-
-                    // we've read everything, now let's get the next chunk
-                    size = -1;
-
-                    auto can_read_line = m_socket->can_read_up_to_delimiter("\r\n"sv.bytes());
-                    if (can_read_line.is_error())
-                        return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-                    if (can_read_line.value()) {
-                        auto maybe_line = read_line(PAGE_SIZE);
-                        if (maybe_line.is_error()) {
-                            return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-                        }
-
-                        VERIFY(maybe_line.value().is_empty());
-                    } else {
-                        m_should_read_chunk_ending_line = true;
-                    }
-                }
-                m_current_chunk_remaining_size = size;
-            }
-        }
-
-        if (!m_socket->is_open()) {
-            dbgln_if(JOB_DEBUG, "Connection appears to have closed, finishing up");
-            finish_up();
-        }
-    });
+    }());
 }
 
-void Job::timer_event(Core::TimerEvent& event)
+Coroutine<void> Job::finish_up()
 {
-    event.accept();
-    finish_up();
-    if (m_buffered_size == 0)
-        stop_timer();
-}
+    if (m_has_scheduled_finish)
+        co_return;
 
-void Job::finish_up()
-{
-    VERIFY(!m_has_scheduled_finish);
-    m_state = State::Finished;
     if (!m_can_stream_response) {
         auto maybe_flattened_buffer = ByteBuffer::create_uninitialized(m_buffered_size);
         if (maybe_flattened_buffer.is_error())
-            return did_fail(Core::NetworkJob::Error::TransmissionFailed);
+            co_return did_fail(Core::NetworkJob::Error::TransmissionFailed);
         auto flattened_buffer = maybe_flattened_buffer.release_value();
 
         u8* flat_ptr = flattened_buffer.data();
@@ -596,7 +558,7 @@ void Job::finish_up()
             if (auto result = handle_content_encoding(flattened_buffer, content_encoding.value()); !result.is_error())
                 flattened_buffer = result.release_value();
             else
-                return did_fail(Core::NetworkJob::Error::TransmissionFailed);
+                co_return did_fail(Core::NetworkJob::Error::TransmissionFailed);
         }
 
         m_buffered_size = flattened_buffer.size();
@@ -604,28 +566,7 @@ void Job::finish_up()
         m_can_stream_response = true;
     }
 
-    flush_received_buffers();
-    if (m_buffered_size != 0) {
-        // We have to wait for the client to consume all the downloaded data
-        // before we can actually call `did_finish`. in a normal flow, this should
-        // never be hit since the client is reading as we are writing, unless there
-        // are too many concurrent downloads going on.
-        dbgln_if(JOB_DEBUG, "Flush finished with {} bytes remaining, will try again later", m_buffered_size);
-        if (!has_timer())
-            start_timer(50);
-        return;
-    }
-
-    stop_timer();
-    m_has_scheduled_finish = true;
-    auto response = HttpResponse::create(m_code, move(m_headers), m_received_size);
-    deferred_invoke([this, response = move(response)] {
-        // If the server responded with "Connection: close", close the connection
-        // as the server may or may not want to close the socket. Also, if this is
-        // a legacy HTTP server (1.0 or older), assume close is the default value.
-        if (auto result = response->headers().get("Connection"sv); result.has_value() ? result->equals_ignoring_ascii_case("close"sv) : m_legacy_connection)
-            shutdown(ShutdownMode::CloseSocket);
-        did_finish(response);
-    });
+    m_request_done = true;
+    Core::EventLoop::current().adopt_coroutine(flush_received_buffers());
 }
 }

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -9,6 +9,7 @@
 
 #include <LibJS/Forward.h>
 #include <LibJS/Module.h>
+#include <LibJS/Runtime/ModuleRequest.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -9,6 +9,7 @@
 
 #include <AK/Variant.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Runtime/AsyncGeneratorRequest.h>
 #include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/Object.h>
 

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -360,6 +360,9 @@ public:
     static ErrorOr<NonnullOwnPtr<TLSv12>> connect(ByteString const& host, u16 port, Options = {});
     static ErrorOr<NonnullOwnPtr<TLSv12>> connect(ByteString const& host, Core::Socket& underlying_stream, Options = {});
 
+    static Coroutine<ErrorOr<NonnullOwnPtr<TLSv12>>> async_connect(ByteString const& host, u16 port, Options = {});
+    static Coroutine<ErrorOr<NonnullOwnPtr<TLSv12>>> async_connect(ByteString const& host, Core::Socket& underlying_stream, Options = {});
+
     using StreamVariantType = Variant<OwnPtr<Core::Socket>, Core::Socket*>;
     explicit TLSv12(StreamVariantType, Options);
 

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -20,6 +20,9 @@
 #include <LibThreading/RWLockProtected.h>
 #include <LibURL/URL.h>
 
+#undef REQUESTSERVER_DEBUG
+#define REQUESTSERVER_DEBUG 0
+
 namespace RequestServer {
 
 enum class CacheLevel {

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -23,7 +23,7 @@ class ConnectionFromClient final
     C_OBJECT(ConnectionFromClient);
 
 public:
-    ~ConnectionFromClient() override = default;
+    ~ConnectionFromClient() override;
 
     virtual void die() override;
 
@@ -74,10 +74,18 @@ private:
 
     template<typename Pool>
     struct Looper : public Threading::ThreadPoolLooper<Pool> {
+        Looper(int pipe_fd)
+            : notifier(Core::Notifier::construct(pipe_fd, Core::NotificationType::Read))
+        {
+        }
+
         IterationDecision next(Pool& pool, bool wait);
         Core::EventLoop event_loop;
+        NonnullRefPtr<Core::Notifier> notifier;
+        bool done { false };
     };
 
+    Array<int, 2> m_thread_pipe_fds { -1, -1 };
     Threading::ThreadPool<Work, Looper> m_thread_pool;
     Threading::Mutex m_ipc_mutex;
 };


### PR DESCRIPTION
Through the power of coroutines, we shall ~~rule the world~~ make RS (almost; t.hanks t.hakis!) as fast as firefox in handling requests! (🔜 stats)

In this PR:
- Hacky garbage code!
- Revert Revert!
- Starring random LibCrypto optimisation!
- Threading woes multipled by async woes!
- Bad parenting practices! (`adopt_coroutine` to create orphans!)

NOT in this PR:
- Bugs
- Good syntax
- CxByte's sanity.

# (rough) perf test

## Setup
49 small files, accessible through `sub{0..9}.cxbyte.me/loadtest/N.bin`.
50 `fetch` requests, all concurrent, to a preselected random subdomain (one failing to ensure clean failures).

Accessible on `https://cxbyte.me/loadtest/test.html`.

## (rough) Results

WARNING: Not statistically valid, only individual tests have been done.

| | Cold Cache (ms) | Hot Cache (ms) |
| :-- | :- | :- |
| RS (master) | 1356 | 846 |
| RS (this PR) | 863 | 813 |
| Firefox | 625 | 423 |


TODO:
- better statistics
- commit cleanup
- worse code