### PR TITLE
LibWasm: Properly check `memory.copy` addresses

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -802,8 +802,12 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         auto source_offset = configuration.stack().pop().get<Value>().to<i32>().value();
         auto destination_offset = configuration.stack().pop().get<Value>().to<i32>().value();
 
-        TRAP_IF_NOT(static_cast<size_t>(source_offset + count) <= source_instance->data().size());
-        TRAP_IF_NOT(static_cast<size_t>(destination_offset + count) <= destination_instance->data().size());
+        Checked<size_t> source_position = source_offset;
+        source_position.saturating_add(count);
+        Checked<size_t> destination_position = destination_offset;
+        destination_position.saturating_add(count);
+        TRAP_IF_NOT(source_position <= source_instance->data().size());
+        TRAP_IF_NOT(destination_position <= destination_instance->data().size());
 
         if (count == 0)
             return;


### PR DESCRIPTION
Prevents overflow when checking that `memory.copy` addresses are valid. This prevents a potential crash in the VM.