### PR TITLE
Kernel: Add method to clean up remapping region loops

### DIFF
--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -207,9 +207,7 @@ size_t AnonymousVMObject::purge()
 
     m_was_purged = true;
 
-    for_each_region([](Region& region) {
-        region.remap();
-    });
+    remap_regions();
 
     return total_pages_purged;
 }
@@ -241,7 +239,7 @@ ErrorOr<void> AnonymousVMObject::set_volatile(bool is_volatile, bool& was_purged
         m_volatile = true;
         m_was_purged = false;
 
-        for_each_region([&](auto& region) { region.remap(); });
+        remap_regions();
         return {};
     }
     // When a VMObject is made non-volatile, we try to commit however many pages are not currently available.
@@ -267,7 +265,7 @@ ErrorOr<void> AnonymousVMObject::set_volatile(bool is_volatile, bool& was_purged
 
     m_volatile = false;
     m_was_purged = false;
-    for_each_region([&](auto& region) { region.remap(); });
+    remap_regions();
     return {};
 }
 

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -59,11 +59,8 @@ int InodeVMObject::release_all_clean_pages()
             ++count;
         }
     }
-    if (count) {
-        for_each_region([](auto& region) {
-            region.remap();
-        });
-    }
+    if (count)
+        remap_regions();
     return count;
 }
 
@@ -78,11 +75,8 @@ int InodeVMObject::try_release_clean_pages(int page_amount)
             ++count;
         }
     }
-    if (count) {
-        for_each_region([](auto& region) {
-            region.remap();
-        });
-    }
+    if (count)
+        remap_regions();
     return count;
 }
 

--- a/Kernel/Memory/SharedFramebufferVMObject.cpp
+++ b/Kernel/Memory/SharedFramebufferVMObject.cpp
@@ -79,17 +79,13 @@ void SharedFramebufferVMObject::switch_to_fake_sink_framebuffer_writes(Badge<Ker
 {
     SpinlockLocker locker(m_writes_state_lock);
     m_writes_are_faked = true;
-    for_each_region([](Region& region) {
-        region.remap();
-    });
+    remap_regions();
 }
 void SharedFramebufferVMObject::switch_to_real_framebuffer_writes(Badge<Kernel::DisplayConnector>)
 {
     SpinlockLocker locker(m_writes_state_lock);
     m_writes_are_faked = false;
-    for_each_region([](Region& region) {
-        region.remap();
-    });
+    remap_regions();
 }
 
 ReadonlySpan<RefPtr<PhysicalRAMPage>> SharedFramebufferVMObject::physical_pages() const

--- a/Kernel/Memory/VMObject.cpp
+++ b/Kernel/Memory/VMObject.cpp
@@ -38,4 +38,11 @@ VMObject::~VMObject()
     VERIFY(m_regions.is_empty());
 }
 
+void VMObject::remap_regions()
+{
+    for_each_region([](Region& region) {
+        region.remap();
+    });
+}
+
 }

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -62,6 +62,8 @@ protected:
     template<typename Callback>
     void for_each_region(Callback);
 
+    void remap_regions();
+
     IntrusiveListNode<VMObject> m_list_node;
     FixedArray<RefPtr<PhysicalRAMPage>> m_physical_pages;
 


### PR DESCRIPTION
In the VMObject code there are multiple examples of loops over the VMObject's regions (using for_each_region()) that call remap() on each region.

To clean up usage of this pattern, this patch adds a method in VMObject that does this remapping loop. VMObject code that needs to remap its regions call the new method.