### PR TITLE
LibJS: Improve deep equals algorithm in tests

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.sort.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.sort.js
@@ -153,7 +153,7 @@ describe("Array.prototype.sort", () => {
 
         obj = { 0: 3, 1: 2, 2: 1, a: "b", hello: "friends!", length: 2 };
         expect(Array.prototype.sort.call(obj)).toBe(obj);
-        expect(obj).toEqual({ 0: 2, 1: 3, 2: 1, 3: 0, a: "b", hello: "friends!", length: 2 });
+        expect(obj).toEqual({ 0: 2, 1: 3, 2: 1, a: "b", hello: "friends!", length: 2 });
 
         obj = { 0: 2, 1: 3, 2: 1, a: "b", hello: "friends!", length: 2 };
         expect(
@@ -163,7 +163,7 @@ describe("Array.prototype.sort", () => {
                 return b - a;
             })
         ).toBe(obj);
-        expect(obj).toEqual({ 0: 3, 1: 2, 2: 1, 3: 0, a: "b", hello: "friends!", length: 2 });
+        expect(obj).toEqual({ 0: 3, 1: 2, 2: 1, a: "b", hello: "friends!", length: 2 });
     });
 
     test("that it handles abrupt completions correctly", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.add.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.add.js
@@ -28,16 +28,16 @@ test("basic functionality (non-BigInt)", () => {
         const array = new ArrayType(4);
 
         expect(Atomics.add(array, 0, 1)).toBe(0);
-        expect(array).toEqual([1, 0, 0, 0]);
+        expect(array).toEqual(new ArrayType([1, 0, 0, 0]));
 
         expect(Atomics.add(array, 0, 1)).toBe(1);
-        expect(array).toEqual([2, 0, 0, 0]);
+        expect(array).toEqual(new ArrayType([2, 0, 0, 0]));
 
         expect(Atomics.add(array, 2, 3.14)).toBe(0);
-        expect(array).toEqual([2, 0, 3, 0]);
+        expect(array).toEqual(new ArrayType([2, 0, 3, 0]));
 
         expect(Atomics.add(array, 3, "1")).toBe(0);
-        expect(array).toEqual([2, 0, 3, 1]);
+        expect(array).toEqual(new ArrayType([2, 0, 3, 1]));
     });
 });
 
@@ -46,15 +46,15 @@ test("basic functionality (BigInt)", () => {
         const array = new ArrayType(4);
 
         expect(Atomics.add(array, 0, 1n)).toBe(0n);
-        expect(array).toEqual([1n, 0n, 0n, 0n]);
+        expect(array).toEqual(new ArrayType([1n, 0n, 0n, 0n]));
 
         expect(Atomics.add(array, 0, 1n)).toBe(1n);
-        expect(array).toEqual([2n, 0n, 0n, 0n]);
+        expect(array).toEqual(new ArrayType([2n, 0n, 0n, 0n]));
 
         expect(Atomics.add(array, 2, 3n)).toBe(0n);
-        expect(array).toEqual([2n, 0n, 3n, 0n]);
+        expect(array).toEqual(new ArrayType([2n, 0n, 3n, 0n]));
 
         expect(Atomics.add(array, 3, 4n)).toBe(0n);
-        expect(array).toEqual([2n, 0n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([2n, 0n, 3n, 4n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.and.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.and.js
@@ -30,19 +30,19 @@ test("basic functionality (non-BigInt)", () => {
         array[1] = 0b0101;
 
         expect(Atomics.and(array, 0, 0b0000)).toBe(0b0000);
-        expect(array).toEqual([0b0000, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0101]));
 
         expect(Atomics.and(array, 0, 0b1111)).toBe(0b0000);
-        expect(array).toEqual([0b0000, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0101]));
 
         expect(Atomics.and(array, 1, 0b0101)).toBe(0b0101);
-        expect(array).toEqual([0b0000, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0101]));
 
         expect(Atomics.and(array, 1, 0b0100)).toBe(0b0101);
-        expect(array).toEqual([0b0000, 0b0100]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0100]));
 
         expect(Atomics.and(array, 1, 0b0000)).toBe(0b0100);
-        expect(array).toEqual([0b0000, 0b0000]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0000]));
     });
 });
 
@@ -53,18 +53,18 @@ test("basic functionality (BigInt)", () => {
         array[1] = 0b0101n;
 
         expect(Atomics.and(array, 0, 0b0000n)).toBe(0b0000n);
-        expect(array).toEqual([0b0000n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0101n]));
 
         expect(Atomics.and(array, 0, 0b1111n)).toBe(0b0000n);
-        expect(array).toEqual([0b0000n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0101n]));
 
         expect(Atomics.and(array, 1, 0b0101n)).toBe(0b0101n);
-        expect(array).toEqual([0b0000n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0101n]));
 
         expect(Atomics.and(array, 1, 0b0100n)).toBe(0b0101n);
-        expect(array).toEqual([0b0000n, 0b0100n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0100n]));
 
         expect(Atomics.and(array, 1, 0b0000n)).toBe(0b0100n);
-        expect(array).toEqual([0b0000n, 0b0000n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0000n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.compareExchange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.compareExchange.js
@@ -30,16 +30,16 @@ test("basic functionality (non-BigInt)", () => {
         array[1] = 2;
 
         expect(Atomics.compareExchange(array, 0, 0, 5)).toBe(1);
-        expect(array).toEqual([1, 2]);
+        expect(array).toEqual(new ArrayType([1, 2]));
 
         expect(Atomics.compareExchange(array, 0, 1, "5")).toBe(1);
-        expect(array).toEqual([5, 2]);
+        expect(array).toEqual(new ArrayType([5, 2]));
 
         expect(Atomics.compareExchange(array, 0, "5", 6)).toBe(5);
-        expect(array).toEqual([6, 2]);
+        expect(array).toEqual(new ArrayType([6, 2]));
 
         expect(Atomics.compareExchange(array, 1, 2, 3.14)).toBe(2);
-        expect(array).toEqual([6, 3]);
+        expect(array).toEqual(new ArrayType([6, 3]));
     });
 });
 
@@ -50,15 +50,15 @@ test("basic functionality (BigInt)", () => {
         array[1] = 2n;
 
         expect(Atomics.compareExchange(array, 0, 0n, 5n)).toBe(1n);
-        expect(array).toEqual([1n, 2n]);
+        expect(array).toEqual(new ArrayType([1n, 2n]));
 
         expect(Atomics.compareExchange(array, 0, 1n, 5n)).toBe(1n);
-        expect(array).toEqual([5n, 2n]);
+        expect(array).toEqual(new ArrayType([5n, 2n]));
 
         expect(Atomics.compareExchange(array, 0, 5n, 6n)).toBe(5n);
-        expect(array).toEqual([6n, 2n]);
+        expect(array).toEqual(new ArrayType([6n, 2n]));
 
         expect(Atomics.compareExchange(array, 1, 2n, 3n)).toBe(2n);
-        expect(array).toEqual([6n, 3n]);
+        expect(array).toEqual(new ArrayType([6n, 3n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.exchange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.exchange.js
@@ -32,19 +32,19 @@ test("basic functionality (non-BigInt)", () => {
         array[3] = 4;
 
         expect(Atomics.exchange(array, 0, 5)).toBe(1);
-        expect(array).toEqual([5, 2, 3, 4]);
+        expect(array).toEqual(new ArrayType([5, 2, 3, 4]));
 
         expect(Atomics.exchange(array, 0, 6)).toBe(5);
-        expect(array).toEqual([6, 2, 3, 4]);
+        expect(array).toEqual(new ArrayType([6, 2, 3, 4]));
 
         expect(Atomics.exchange(array, "1", 7)).toBe(2);
-        expect(array).toEqual([6, 7, 3, 4]);
+        expect(array).toEqual(new ArrayType([6, 7, 3, 4]));
 
         expect(Atomics.exchange(array, 2, "8")).toBe(3);
-        expect(array).toEqual([6, 7, 8, 4]);
+        expect(array).toEqual(new ArrayType([6, 7, 8, 4]));
 
         expect(Atomics.exchange(array, 3.14, 9)).toBe(4);
-        expect(array).toEqual([6, 7, 8, 9]);
+        expect(array).toEqual(new ArrayType([6, 7, 8, 9]));
     });
 });
 
@@ -57,18 +57,18 @@ test("basic functionality (BigInt)", () => {
         array[3] = 4n;
 
         expect(Atomics.exchange(array, 0, 5n)).toBe(1n);
-        expect(array).toEqual([5n, 2n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([5n, 2n, 3n, 4n]));
 
         expect(Atomics.exchange(array, 0, 6n)).toBe(5n);
-        expect(array).toEqual([6n, 2n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([6n, 2n, 3n, 4n]));
 
         expect(Atomics.exchange(array, 1, 7n)).toBe(2n);
-        expect(array).toEqual([6n, 7n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([6n, 7n, 3n, 4n]));
 
         expect(Atomics.exchange(array, 2, 8n)).toBe(3n);
-        expect(array).toEqual([6n, 7n, 8n, 4n]);
+        expect(array).toEqual(new ArrayType([6n, 7n, 8n, 4n]));
 
         expect(Atomics.exchange(array, 3, 9n)).toBe(4n);
-        expect(array).toEqual([6n, 7n, 8n, 9n]);
+        expect(array).toEqual(new ArrayType([6n, 7n, 8n, 9n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.or.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.or.js
@@ -30,19 +30,19 @@ test("basic functionality (non-BigInt)", () => {
         array[1] = 0b0101;
 
         expect(Atomics.or(array, 0, 0b0000)).toBe(0b0000);
-        expect(array).toEqual([0b0000, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0101]));
 
         expect(Atomics.or(array, 0, 0b1111)).toBe(0b0000);
-        expect(array).toEqual([0b1111, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b0101]));
 
         expect(Atomics.or(array, 1, 0b0101)).toBe(0b0101);
-        expect(array).toEqual([0b1111, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b0101]));
 
         expect(Atomics.or(array, 1, 0b1000)).toBe(0b0101);
-        expect(array).toEqual([0b1111, 0b1101]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b1101]));
 
         expect(Atomics.or(array, 1, 0b0010)).toBe(0b1101);
-        expect(array).toEqual([0b1111, 0b1111]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b1111]));
     });
 });
 
@@ -53,18 +53,18 @@ test("basic functionality (BigInt)", () => {
         array[1] = 0b0101n;
 
         expect(Atomics.or(array, 0, 0b0000n)).toBe(0b0000n);
-        expect(array).toEqual([0b0000n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0101n]));
 
         expect(Atomics.or(array, 0, 0b1111n)).toBe(0b0000n);
-        expect(array).toEqual([0b1111n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b0101n]));
 
         expect(Atomics.or(array, 1, 0b0101n)).toBe(0b0101n);
-        expect(array).toEqual([0b1111n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b0101n]));
 
         expect(Atomics.or(array, 1, 0b1000n)).toBe(0b0101n);
-        expect(array).toEqual([0b1111n, 0b1101n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b1101n]));
 
         expect(Atomics.or(array, 1, 0b0010n)).toBe(0b1101n);
-        expect(array).toEqual([0b1111n, 0b1111n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b1111n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.sub.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.sub.js
@@ -32,19 +32,19 @@ test("basic functionality (non-BigInt)", () => {
         array[3] = 4;
 
         expect(Atomics.sub(array, 0, 1)).toBe(1);
-        expect(array).toEqual([0, 2, 3, 4]);
+        expect(array).toEqual(new ArrayType([0, 2, 3, 4]));
 
         expect(Atomics.sub(array, 1, 1)).toBe(2);
-        expect(array).toEqual([0, 1, 3, 4]);
+        expect(array).toEqual(new ArrayType([0, 1, 3, 4]));
 
         expect(Atomics.sub(array, 1, 1)).toBe(1);
-        expect(array).toEqual([0, 0, 3, 4]);
+        expect(array).toEqual(new ArrayType([0, 0, 3, 4]));
 
         expect(Atomics.sub(array, 2, 3.14)).toBe(3);
-        expect(array).toEqual([0, 0, 0, 4]);
+        expect(array).toEqual(new ArrayType([0, 0, 0, 4]));
 
         expect(Atomics.sub(array, 3, "1")).toBe(4);
-        expect(array).toEqual([0, 0, 0, 3]);
+        expect(array).toEqual(new ArrayType([0, 0, 0, 3]));
     });
 });
 
@@ -57,18 +57,18 @@ test("basic functionality (BigInt)", () => {
         array[3] = 4n;
 
         expect(Atomics.sub(array, 0, 1n)).toBe(1n);
-        expect(array).toEqual([0n, 2n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([0n, 2n, 3n, 4n]));
 
         expect(Atomics.sub(array, 1, 1n)).toBe(2n);
-        expect(array).toEqual([0n, 1n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([0n, 1n, 3n, 4n]));
 
         expect(Atomics.sub(array, 1, 1n)).toBe(1n);
-        expect(array).toEqual([0n, 0n, 3n, 4n]);
+        expect(array).toEqual(new ArrayType([0n, 0n, 3n, 4n]));
 
         expect(Atomics.sub(array, 2, 3n)).toBe(3n);
-        expect(array).toEqual([0n, 0n, 0n, 4n]);
+        expect(array).toEqual(new ArrayType([0n, 0n, 0n, 4n]));
 
         expect(Atomics.sub(array, 3, 1n)).toBe(4n);
-        expect(array).toEqual([0n, 0n, 0n, 3n]);
+        expect(array).toEqual(new ArrayType([0n, 0n, 0n, 3n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.xor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.xor.js
@@ -30,19 +30,19 @@ test("basic functionality (non-BigInt)", () => {
         array[1] = 0b0101;
 
         expect(Atomics.xor(array, 0, 0b0000)).toBe(0b0000);
-        expect(array).toEqual([0b0000, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b0000, 0b0101]));
 
         expect(Atomics.xor(array, 0, 0b1111)).toBe(0b0000);
-        expect(array).toEqual([0b1111, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b0101]));
 
         expect(Atomics.xor(array, 1, 0b0000)).toBe(0b0101);
-        expect(array).toEqual([0b1111, 0b0101]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b0101]));
 
         expect(Atomics.xor(array, 1, 0b0100)).toBe(0b0101);
-        expect(array).toEqual([0b1111, 0b0001]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b0001]));
 
         expect(Atomics.xor(array, 1, 0b0001)).toBe(0b0001);
-        expect(array).toEqual([0b1111, 0b0000]);
+        expect(array).toEqual(new ArrayType([0b1111, 0b0000]));
     });
 });
 
@@ -53,18 +53,18 @@ test("basic functionality (BigInt)", () => {
         array[1] = 0b0101n;
 
         expect(Atomics.xor(array, 0, 0b0000n)).toBe(0b0000n);
-        expect(array).toEqual([0b0000n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b0000n, 0b0101n]));
 
         expect(Atomics.xor(array, 0, 0b1111n)).toBe(0b0000n);
-        expect(array).toEqual([0b1111n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b0101n]));
 
         expect(Atomics.xor(array, 1, 0b0000n)).toBe(0b0101n);
-        expect(array).toEqual([0b1111n, 0b0101n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b0101n]));
 
         expect(Atomics.xor(array, 1, 0b0100n)).toBe(0b0101n);
-        expect(array).toEqual([0b1111n, 0b0001n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b0001n]));
 
         expect(Atomics.xor(array, 1, 0b0001n)).toBe(0b0001n);
-        expect(array).toEqual([0b1111n, 0b0000n]);
+        expect(array).toEqual(new ArrayType([0b1111n, 0b0000n]));
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.copyWithin.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.copyWithin.js
@@ -47,13 +47,13 @@ describe("normal behavior", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2]);
             expect(array.copyWithin(0, 0)).toEqual(array);
-            expect(array).toEqual([1, 2]);
+            expect(array).toEqual(new T([1, 2]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n]);
             expect(array.copyWithin(0, 0)).toEqual(array);
-            expect(array).toEqual([1n, 2n]);
+            expect(array).toEqual(new T([1n, 2n]));
         });
     });
 
@@ -61,19 +61,19 @@ describe("normal behavior", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2, 3]);
             expect(array.copyWithin(1, 2)).toEqual(array);
-            expect(array).toEqual([1, 3, 3]);
+            expect(array).toEqual(new T([1, 3, 3]));
 
             expect(array.copyWithin(2, 0)).toEqual(array);
-            expect(array).toEqual([1, 3, 1]);
+            expect(array).toEqual(new T([1, 3, 1]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n, 3n]);
             expect(array.copyWithin(1, 2)).toEqual(array);
-            expect(array).toEqual([1n, 3n, 3n]);
+            expect(array).toEqual(new T([1n, 3n, 3n]));
 
             expect(array.copyWithin(2, 0)).toEqual(array);
-            expect(array).toEqual([1n, 3n, 1n]);
+            expect(array).toEqual(new T([1n, 3n, 1n]));
         });
     });
 
@@ -81,13 +81,13 @@ describe("normal behavior", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2, 3]);
             expect(array.copyWithin(0, 1)).toEqual(array);
-            expect(array).toEqual([2, 3, 3]);
+            expect(array).toEqual(new T([2, 3, 3]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n, 3n]);
             expect(array.copyWithin(0, 1)).toEqual(array);
-            expect(array).toEqual([2n, 3n, 3n]);
+            expect(array).toEqual(new T([2n, 3n, 3n]));
         });
     });
 
@@ -95,13 +95,13 @@ describe("normal behavior", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2, 3]);
             expect(array.copyWithin(1, 0)).toEqual(array);
-            expect(array).toEqual([1, 1, 2]);
+            expect(array).toEqual(new T([1, 1, 2]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n, 3n]);
             expect(array.copyWithin(1, 0)).toEqual(array);
-            expect(array).toEqual([1n, 1n, 2n]);
+            expect(array).toEqual(new T([1n, 1n, 2n]));
         });
     });
 
@@ -109,13 +109,13 @@ describe("normal behavior", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2, 3]);
             expect(array.copyWithin(2, 0, 1)).toEqual(array);
-            expect(array).toEqual([1, 2, 1]);
+            expect(array).toEqual(new T([1, 2, 1]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n, 3n]);
             expect(array.copyWithin(2, 0, 1)).toEqual(array);
-            expect(array).toEqual([1n, 2n, 1n]);
+            expect(array).toEqual(new T([1n, 2n, 1n]));
         });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reverse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reverse.js
@@ -46,42 +46,42 @@ describe("basic functionality", () => {
     test("Odd length array", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2, 3]);
-            expect(array.reverse()).toEqual([3, 2, 1]);
-            expect(array).toEqual([3, 2, 1]);
+            expect(array.reverse()).toEqual(new T([3, 2, 1]));
+            expect(array).toEqual(new T([3, 2, 1]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n, 3n]);
-            expect(array.reverse()).toEqual([3n, 2n, 1n]);
-            expect(array).toEqual([3n, 2n, 1n]);
+            expect(array.reverse()).toEqual(new T([3n, 2n, 1n]));
+            expect(array).toEqual(new T([3n, 2n, 1n]));
         });
     });
 
     test("Even length array", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2]);
-            expect(array.reverse()).toEqual([2, 1]);
-            expect(array).toEqual([2, 1]);
+            expect(array.reverse()).toEqual(new T([2, 1]));
+            expect(array).toEqual(new T([2, 1]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n]);
-            expect(array.reverse()).toEqual([2n, 1n]);
-            expect(array).toEqual([2n, 1n]);
+            expect(array.reverse()).toEqual(new T([2n, 1n]));
+            expect(array).toEqual(new T([2n, 1n]));
         });
     });
 
     test("Empty array", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([]);
-            expect(array.reverse()).toEqual([]);
-            expect(array).toEqual([]);
+            expect(array.reverse()).toEqual(new T([]));
+            expect(array).toEqual(new T([]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([]);
-            expect(array.reverse()).toEqual([]);
-            expect(array).toEqual([]);
+            expect(array.reverse()).toEqual(new T([]));
+            expect(array).toEqual(new T([]));
         });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toReversed.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toReversed.js
@@ -47,42 +47,42 @@ describe("basic functionality", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2, 3]);
 
-            expect(array.toReversed()).toEqual([3, 2, 1]);
-            expect(array).toEqual([1, 2, 3]);
+            expect(array.toReversed()).toEqual(new T([3, 2, 1]));
+            expect(array).toEqual(new T([1, 2, 3]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n, 3n]);
-            expect(array.toReversed()).toEqual([3n, 2n, 1n]);
-            expect(array).toEqual([1n, 2n, 3n]);
+            expect(array.toReversed()).toEqual(new T([3n, 2n, 1n]));
+            expect(array).toEqual(new T([1n, 2n, 3n]));
         });
     });
 
     test("Even length array", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([1, 2]);
-            expect(array.toReversed()).toEqual([2, 1]);
-            expect(array).toEqual([1, 2]);
+            expect(array.toReversed()).toEqual(new T([2, 1]));
+            expect(array).toEqual(new T([1, 2]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([1n, 2n]);
-            expect(array.toReversed()).toEqual([2n, 1n]);
-            expect(array).toEqual([1n, 2n]);
+            expect(array.toReversed()).toEqual(new T([2n, 1n]));
+            expect(array).toEqual(new T([1n, 2n]));
         });
     });
 
     test("Empty array", () => {
         TYPED_ARRAYS.forEach(T => {
             const array = new T([]);
-            expect(array.toReversed()).toEqual([]);
-            expect(array).toEqual([]);
+            expect(array.toReversed()).toEqual(new T([]));
+            expect(array).toEqual(new T([]));
         });
 
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const array = new T([]);
-            expect(array.toReversed()).toEqual([]);
-            expect(array).toEqual([]);
+            expect(array.toReversed()).toEqual(new T([]));
+            expect(array).toEqual(new T([]));
         });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.with.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.with.js
@@ -83,15 +83,15 @@ describe("normal behavior", () => {
         TYPED_ARRAYS.forEach(T => {
             const a = new T([1, 2, 3, 4, 5]);
             const values = [
-                [0, 10, [10, 2, 3, 4, 5]],
-                [-5, 10, [10, 2, 3, 4, 5]],
-                [4, 10, [1, 2, 3, 4, 10]],
-                [-1, 10, [1, 2, 3, 4, 10]],
+                [0, 10, new T([10, 2, 3, 4, 5])],
+                [-5, 10, new T([10, 2, 3, 4, 5])],
+                [4, 10, new T([1, 2, 3, 4, 10])],
+                [-1, 10, new T([1, 2, 3, 4, 10])],
             ];
             for (const [index, value, expected] of values) {
                 const b = a.with(index, value);
                 expect(a).not.toBe(b);
-                expect(a).toEqual([1, 2, 3, 4, 5]);
+                expect(a).toEqual(new T([1, 2, 3, 4, 5]));
                 expect(b).toEqual(expected);
             }
         });
@@ -99,15 +99,15 @@ describe("normal behavior", () => {
         BIGINT_TYPED_ARRAYS.forEach(T => {
             const a = new T([1n, 2n, 3n, 4n, 5n]);
             const values = [
-                [0, 10n, [10n, 2n, 3n, 4n, 5n]],
-                [-5, 10n, [10n, 2n, 3n, 4n, 5n]],
-                [4, 10n, [1n, 2n, 3n, 4n, 10n]],
-                [-1, 10n, [1n, 2n, 3n, 4n, 10n]],
+                [0, 10n, new T([10n, 2n, 3n, 4n, 5n])],
+                [-5, 10n, new T([10n, 2n, 3n, 4n, 5n])],
+                [4, 10n, new T([1n, 2n, 3n, 4n, 10n])],
+                [-1, 10n, new T([1n, 2n, 3n, 4n, 10n])],
             ];
             for (const [index, value, expected] of values) {
                 const b = a.with(index, value);
                 expect(a).not.toBe(b);
-                expect(a).toEqual([1n, 2n, 3n, 4n, 5n]);
+                expect(a).toEqual(new T([1n, 2n, 3n, 4n, 5n]));
                 expect(b).toEqual(expected);
             }
         });

--- a/Userland/Libraries/LibJS/Tests/object-spread.js
+++ b/Userland/Libraries/LibJS/Tests/object-spread.js
@@ -8,7 +8,7 @@ const testObjSpread = obj => {
 };
 
 const testObjStrSpread = obj => {
-    expect(obj).toEqual(["a", "b", "c", "d"]);
+    expect(obj).toEqual({ 0: "a", 1: "b", 2: "c", 3: "d" });
 };
 
 test("spread object literal inside object literal", () => {

--- a/Userland/Libraries/LibJS/Tests/test-common.js
+++ b/Userland/Libraries/LibJS/Tests/test-common.js
@@ -29,11 +29,11 @@ class ExpectationError extends Error {
 
 // Use an IIFE to avoid polluting the global namespace as much as possible
 (() => {
-    // FIXME: This is a very naive deepEquals algorithm
     const deepEquals = (a, b) => {
+        if (Object.is(a, b)) return true; // Handles identical references and primitives
+        if ((a !== null && b === null) || (a === null && b !== null)) return false;
         if (Array.isArray(a)) return Array.isArray(b) && deepArrayEquals(a, b);
         if (typeof a === "object") return typeof b === "object" && deepObjectEquals(a, b);
-        return Object.is(a, b);
     };
 
     const deepArrayEquals = (a, b) => {
@@ -41,14 +41,19 @@ class ExpectationError extends Error {
         for (let i = 0; i < a.length; ++i) {
             if (!deepEquals(a[i], b[i])) return false;
         }
+
         return true;
     };
 
     const deepObjectEquals = (a, b) => {
-        if (a === null) return b === null;
-        for (let key of Reflect.ownKeys(a)) {
+        const keysA = Reflect.ownKeys(a);
+        const keysB = Reflect.ownKeys(b);
+
+        if (keysA.length !== keysB.length) return false;
+        for (let key of keysA) {
             if (!deepEquals(a[key], b[key])) return false;
         }
+
         return true;
     };
 


### PR DESCRIPTION
The `deepEquals` algorithm incorrectly evaluated equality of objects in the cases where the second object `b` has a superset of the keys of `a`, or had a different prototype.
For example: 
```js
let a = { x: 1, y: 2 };
let b = { x: 1, y: 2, z: 3 };
deepEquals(a, b); // true
```
The new algorithm considers that the second object could have more keys than the first, and compares the prototypes of the objects.