### PR TITLE
LibWeb: Support clip rects and opacity in the `AffineCommandExecutorCPU`

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/CornerRadius.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Quad.h>
@@ -56,22 +57,6 @@ public:
 
     void fill_rect_with_rounded_corners(IntRect const&, Color, int radius);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
-
-    struct CornerRadius {
-        int horizontal_radius;
-        int vertical_radius;
-
-        inline operator bool() const
-        {
-            return horizontal_radius > 0 && vertical_radius > 0;
-        }
-
-        Gfx::IntRect as_rect() const
-        {
-            return { 0, 0, horizontal_radius, vertical_radius };
-        }
-    };
-
     void fill_rect_with_rounded_corners(IntRect const&, Color, CornerRadius top_left, CornerRadius top_right, CornerRadius bottom_right, CornerRadius bottom_left, BlendMode blend_mode = BlendMode::Normal);
 
     Gfx::Painter& underlying_painter() { return m_underlying_painter; }

--- a/Userland/Libraries/LibGfx/CornerRadius.h
+++ b/Userland/Libraries/LibGfx/CornerRadius.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Rect.h>
+
+namespace Gfx {
+struct CornerRadius {
+    int horizontal_radius;
+    int vertical_radius;
+
+    inline operator bool() const
+    {
+        return horizontal_radius > 0 && vertical_radius > 0;
+    }
+
+    Gfx::IntRect as_rect() const
+    {
+        return { 0, 0, horizontal_radius, vertical_radius };
+    }
+};
+}

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -158,6 +158,56 @@ void Path::elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rot
         theta_delta);
 }
 
+void Path::quad(FloatQuad const& quad)
+{
+    move_to(quad.p1());
+    line_to(quad.p2());
+    line_to(quad.p3());
+    line_to(quad.p4());
+    close();
+}
+
+void Path::rounded_rect(FloatRect const& rect, CornerRadius top_left, CornerRadius top_right, CornerRadius bottom_right, CornerRadius bottom_left)
+{
+    auto x = rect.x();
+    auto y = rect.y();
+    auto width = rect.width();
+    auto height = rect.height();
+
+    if (top_left)
+        move_to({ x + top_left.horizontal_radius, y });
+    else
+        move_to({ x, y });
+
+    if (top_right) {
+        horizontal_line_to(x + width - top_right.horizontal_radius);
+        elliptical_arc_to({ x + width, y + top_right.horizontal_radius }, { top_right.horizontal_radius, top_right.vertical_radius }, 0, false, true);
+    } else {
+        horizontal_line_to(x + width);
+    }
+
+    if (bottom_right) {
+        vertical_line_to(y + height - bottom_right.vertical_radius);
+        elliptical_arc_to({ x + width - bottom_right.horizontal_radius, y + height }, { bottom_right.horizontal_radius, bottom_right.vertical_radius }, 0, false, true);
+    } else {
+        vertical_line_to(y + height);
+    }
+
+    if (bottom_left) {
+        horizontal_line_to(x + bottom_left.horizontal_radius);
+        elliptical_arc_to({ x, y + height - bottom_left.vertical_radius }, { bottom_left.horizontal_radius, bottom_left.vertical_radius }, 0, false, true);
+    } else {
+        horizontal_line_to(x);
+    }
+
+    if (top_left) {
+        vertical_line_to(y + top_left.vertical_radius);
+        elliptical_arc_to({ x + top_left.horizontal_radius, y }, { top_left.horizontal_radius, top_left.vertical_radius }, 0, false, true);
+    } else {
+        vertical_line_to(y);
+    }
+}
+
 void Path::text(Utf8View text, Font const& font)
 {
     if (!is<ScaledFont>(font)) {

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -9,9 +9,11 @@
 #include <AK/ByteString.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
+#include <LibGfx/CornerRadius.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Line.h>
 #include <LibGfx/Point.h>
+#include <LibGfx/Quad.h>
 #include <LibGfx/Rect.h>
 
 namespace Gfx {
@@ -182,6 +184,15 @@ public:
     {
         elliptical_arc_to(point, { radius, radius }, 0, large_arc, sweep);
     }
+
+    void rect(FloatRect const& rect)
+    {
+        return quad(rect);
+    }
+
+    void rounded_rect(FloatRect const& rect, CornerRadius top_left, CornerRadius top_right, CornerRadius bottom_right, CornerRadius bottom_left);
+
+    void quad(FloatQuad const& quad);
 
     void text(Utf8View, Font const&);
 

--- a/Userland/Libraries/LibGfx/Quad.h
+++ b/Userland/Libraries/LibGfx/Quad.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
 #include <LibGfx/Triangle.h>
 
 namespace Gfx {
@@ -19,6 +20,11 @@ public:
         , m_p2(p2)
         , m_p3(p3)
         , m_p4(p4)
+    {
+    }
+
+    Quad(Rect<T> const& rect)
+        : Quad(rect.top_left(), rect.top_right(), rect.bottom_right(), rect.bottom_left())
     {
     }
 

--- a/Userland/Libraries/LibGfx/Quad.h
+++ b/Userland/Libraries/LibGfx/Quad.h
@@ -45,6 +45,8 @@ public:
             || Triangle(m_p2, m_p4, m_p3).contains(point);
     }
 
+    bool operator==(Quad<T> const&) const = default;
+
 private:
     Point<T> m_p1;
     Point<T> m_p2;

--- a/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
@@ -102,7 +102,7 @@ private:
 
     void prepare_clipping(Gfx::IntRect bounding_rect);
 
-    void flush_clipping();
+    void flush_clipping(Optional<StackingContext const&> = {});
 
     bool needs_expensive_clipping(Gfx::IntRect bounding_rect) const;
 

--- a/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
@@ -60,10 +60,17 @@ public:
 private:
     // FIXME: Support masking.
     // FIXME: Support opacity < 1.0f.
+    struct Clip {
+        Gfx::FloatQuad quad;
+        Gfx::IntRect bounds;
+        bool is_rectangular = false;
+
+        bool operator==(Clip const&) const = default;
+    };
+
     struct StackingContext {
         Gfx::AffineTransform transform;
-        Gfx::FloatQuad clip;
-        Gfx::FloatRect clip_bounds;
+        Clip clip;
     };
 
     Gfx::AntiAliasingPainter aa_painter()
@@ -81,8 +88,17 @@ private:
         return m_stacking_contexts.last();
     }
 
+    void prepare_clipping(Gfx::IntRect bounding_rect);
+
+    void flush_clipping();
+
+    bool needs_expensive_clipping(Gfx::IntRect bounding_rect) const;
+
+    NonnullRefPtr<Gfx::Bitmap> m_target;
     Gfx::Painter m_painter;
     Vector<StackingContext> m_stacking_contexts;
+    RefPtr<Gfx::Bitmap> m_expensive_clipping_target;
+    RefPtr<Gfx::Bitmap> m_expensive_clipping_mask;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
@@ -73,11 +73,21 @@ private:
         NonnullRefPtr<Gfx::Bitmap> target;
         Gfx::IntPoint origin = {};
         float opacity = 1.0f;
+
+        Gfx::IntRect rect() const
+        {
+            return target->rect().translated(origin);
+        }
     };
 
     Gfx::AntiAliasingPainter aa_painter()
     {
         return Gfx::AntiAliasingPainter(m_painter);
+    }
+
+    Gfx::Painter& painter()
+    {
+        return m_painter;
     }
 
     StackingContext& stacking_context()
@@ -95,6 +105,12 @@ private:
     void flush_clipping();
 
     bool needs_expensive_clipping(Gfx::IntRect bounding_rect) const;
+
+    void set_target(Gfx::IntPoint origin, Gfx::Bitmap& bitmap)
+    {
+        m_painter = Gfx::Painter(bitmap);
+        m_painter.translate(-origin);
+    }
 
     Gfx::Painter m_painter;
     Vector<StackingContext> m_stacking_contexts;

--- a/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
@@ -58,8 +58,6 @@ public:
     virtual ~AffineCommandExecutorCPU() override = default;
 
 private:
-    // FIXME: Support masking.
-    // FIXME: Support opacity < 1.0f.
     struct Clip {
         Gfx::FloatQuad quad;
         Gfx::IntRect bounds;
@@ -68,9 +66,13 @@ private:
         bool operator==(Clip const&) const = default;
     };
 
+    // FIXME: Support masking.
     struct StackingContext {
         Gfx::AffineTransform transform;
         Clip clip;
+        NonnullRefPtr<Gfx::Bitmap> target;
+        Gfx::IntPoint origin = {};
+        float opacity = 1.0f;
     };
 
     Gfx::AntiAliasingPainter aa_painter()
@@ -94,7 +96,6 @@ private:
 
     bool needs_expensive_clipping(Gfx::IntRect bounding_rect) const;
 
-    NonnullRefPtr<Gfx::Bitmap> m_target;
     Gfx::Painter m_painter;
     Vector<StackingContext> m_stacking_contexts;
     RefPtr<Gfx::Bitmap> m_expensive_clipping_target;

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -61,7 +61,7 @@ Gfx::Color border_color(BorderEdge edge, BordersDataDevicePixels const& borders_
     return border_data.color;
 }
 
-void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect const& rect, Gfx::AntiAliasingPainter::CornerRadius const& radius, Gfx::AntiAliasingPainter::CornerRadius const& opposite_radius, BordersDataDevicePixels const& borders_data, Gfx::Path& path, bool last)
+void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect const& rect, Gfx::CornerRadius const& radius, Gfx::CornerRadius const& opposite_radius, BordersDataDevicePixels const& borders_data, Gfx::Path& path, bool last)
 {
     auto const& border_data = [&] {
         switch (edge) {

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.h
@@ -26,7 +26,7 @@ enum class BorderEdge {
 // Returns OptionalNone if there is no outline to paint.
 Optional<BordersData> borders_data_for_outline(Layout::Node const&, Color outline_color, CSS::OutlineStyle outline_style, CSSPixels outline_width);
 
-void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect const& rect, Gfx::AntiAliasingPainter::CornerRadius const& radius, Gfx::AntiAliasingPainter::CornerRadius const& opposite_radius, BordersDataDevicePixels const& borders_data, Gfx::Path& path, bool last);
+void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect const& rect, Gfx::CornerRadius const& radius, Gfx::CornerRadius const& opposite_radius, BordersDataDevicePixels const& borders_data, Gfx::Path& path, bool last);
 void paint_all_borders(RecordingPainter& painter, DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const&);
 
 Gfx::Color border_color(BorderEdge edge, BordersDataDevicePixels const& borders_data);

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiiData.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiiData.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::Painting {
 
-Gfx::AntiAliasingPainter::CornerRadius BorderRadiusData::as_corner(PaintContext const& context) const
+Gfx::CornerRadius BorderRadiusData::as_corner(PaintContext const& context) const
 {
-    return Gfx::AntiAliasingPainter::CornerRadius {
+    return Gfx::CornerRadius {
         context.floored_device_pixels(horizontal_radius).value(),
         context.floored_device_pixels(vertical_radius).value()
     };

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
@@ -17,7 +17,7 @@ struct BorderRadiusData {
     CSSPixels horizontal_radius { 0 };
     CSSPixels vertical_radius { 0 };
 
-    Gfx::AntiAliasingPainter::CornerRadius as_corner(PaintContext const& context) const;
+    Gfx::CornerRadius as_corner(PaintContext const& context) const;
 
     inline operator bool() const
     {
@@ -39,7 +39,7 @@ struct BorderRadiusData {
     }
 };
 
-using CornerRadius = Gfx::AntiAliasingPainter::CornerRadius;
+using CornerRadius = Gfx::CornerRadius;
 
 struct CornerRadii {
     CornerRadius top_left;

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -169,10 +169,10 @@ struct PaintTextShadow {
 struct FillRectWithRoundedCorners {
     Gfx::IntRect rect;
     Color color;
-    Gfx::AntiAliasingPainter::CornerRadius top_left_radius;
-    Gfx::AntiAliasingPainter::CornerRadius top_right_radius;
-    Gfx::AntiAliasingPainter::CornerRadius bottom_left_radius;
-    Gfx::AntiAliasingPainter::CornerRadius bottom_right_radius;
+    Gfx::CornerRadius top_left_radius;
+    Gfx::CornerRadius top_right_radius;
+    Gfx::CornerRadius bottom_left_radius;
+    Gfx::CornerRadius bottom_right_radius;
     Vector<Gfx::Path> clip_paths;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -369,7 +369,7 @@ void RecordingPainter::paint_text_shadow(int blur_radius, Gfx::IntRect bounding_
         .draw_location = state().translation.map(draw_location) });
 }
 
-void RecordingPainter::fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color color, Gfx::AntiAliasingPainter::CornerRadius top_left_radius, Gfx::AntiAliasingPainter::CornerRadius top_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_left_radius, Vector<Gfx::Path> const& clip_paths)
+void RecordingPainter::fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color color, Gfx::CornerRadius top_left_radius, Gfx::CornerRadius top_right_radius, Gfx::CornerRadius bottom_right_radius, Gfx::CornerRadius bottom_left_radius, Vector<Gfx::Path> const& clip_paths)
 {
     if (rect.is_empty())
         return;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -135,7 +135,7 @@ public:
     void paint_inner_box_shadow_params(PaintOuterBoxShadowParams params);
     void paint_text_shadow(int blur_radius, Gfx::IntRect bounding_rect, Gfx::IntRect text_rect, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, int fragment_baseline, Gfx::IntPoint draw_location);
 
-    void fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color color, Gfx::AntiAliasingPainter::CornerRadius top_left_radius, Gfx::AntiAliasingPainter::CornerRadius top_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_left_radius, Vector<Gfx::Path> const& clip_paths = {});
+    void fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color color, Gfx::CornerRadius top_left_radius, Gfx::CornerRadius top_right_radius, Gfx::CornerRadius bottom_right_radius, Gfx::CornerRadius bottom_left_radius, Vector<Gfx::Path> const& clip_paths = {});
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int radius, Vector<Gfx::Path> const& clip_paths = {});
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius, Vector<Gfx::Path> const& clip_paths = {});
 


### PR DESCRIPTION
This PR continues work to get the `AffineCommandExecutorCPU` to a usable state...  Implementing support for stacking context opacity and clip rects. Clip rects are quite tricky to handle as unlike the regular painter they're actually clip convex quadrilaterals. See commits for details.

**Demo:**

https://github.com/SerenityOS/serenity/assets/11597044/1998faa9-e6ba-4916-a55f-524c828432cd

The HTML is:
```html
<!-- Outer scale transform -->
<div id="foo" style="background-color: green; transform: scale(4);">
	<!-- #box20 has a rotation + opacity + overflow clipping -->
	<div id="box20" class="box" style="overflow: hidden; opacity: 0.4;">
		<!-- Both the image + div overflow #box20 and need to be clipped -->
		<div style="background-color: red;">
			<img src="https://ladybird.dev/ladybirb.png" width="200%" height="200%">
		</div>
	</div>
</div>
```
