### PR TITLE
LibJS/Bytecode: First random optimization pack for June

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -383,7 +383,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> UnaryExpression::genera
 Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> NumericLiteral::generate_bytecode(Bytecode::Generator& generator, [[maybe_unused]] Optional<ScopedOperand> preferred_dst) const
 {
     Bytecode::Generator::SourceLocationScope scope(generator, *this);
-    return generator.add_constant(Value(m_value), Bytecode::Generator::DeduplicateConstant::No);
+    return generator.add_constant(Value(m_value));
 }
 
 Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> BooleanLiteral::generate_bytecode(Bytecode::Generator& generator, [[maybe_unused]] Optional<ScopedOperand> preferred_dst) const
@@ -412,13 +412,13 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> BigIntLiteral::generate
             return MUST(Crypto::SignedBigInteger::from_base(2, m_value.substring(2, m_value.length() - 3)));
         return MUST(Crypto::SignedBigInteger::from_base(10, m_value.substring(0, m_value.length() - 1)));
     }();
-    return generator.add_constant(BigInt::create(generator.vm(), move(integer)), Bytecode::Generator::DeduplicateConstant::No);
+    return generator.add_constant(BigInt::create(generator.vm(), move(integer)));
 }
 
 Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> StringLiteral::generate_bytecode(Bytecode::Generator& generator, [[maybe_unused]] Optional<ScopedOperand> preferred_dst) const
 {
     Bytecode::Generator::SourceLocationScope scope(generator, *this);
-    return generator.add_constant(PrimitiveString::create(generator.vm(), m_value), Bytecode::Generator::DeduplicateConstant::No);
+    return generator.add_constant(PrimitiveString::create(generator.vm(), m_value));
 }
 
 Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> RegExpLiteral::generate_bytecode(Bytecode::Generator& generator, Optional<ScopedOperand> preferred_dst) const
@@ -1283,7 +1283,7 @@ static Bytecode::CodeGenerationErrorOr<void> generate_object_binding_pattern_byt
         if (name.has<NonnullRefPtr<Identifier const>>()) {
             auto const& identifier = name.get<NonnullRefPtr<Identifier const>>()->string();
             if (has_rest) {
-                excluded_property_names.append(generator.add_constant(PrimitiveString::create(generator.vm(), identifier), Bytecode::Generator::DeduplicateConstant::No));
+                excluded_property_names.append(generator.add_constant(PrimitiveString::create(generator.vm(), identifier)));
             }
             generator.emit_get_by_id(value, object, generator.intern_identifier(identifier));
         } else {

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1191,4 +1191,46 @@ ScopedOperand Generator::copy_if_needed_to_preserve_evaluation_order(ScopedOpera
     return new_register;
 }
 
+ScopedOperand Generator::add_constant(Value value)
+{
+    auto append_new_constant = [&] {
+        m_constants.append(value);
+        return ScopedOperand { *this, Operand(Operand::Type::Constant, m_constants.size() - 1) };
+    };
+
+    if (value.is_boolean()) {
+        if (value.as_bool()) {
+            if (!m_true_constant.has_value())
+                m_true_constant = append_new_constant();
+            return m_true_constant.value();
+        } else {
+            if (!m_false_constant.has_value())
+                m_false_constant = append_new_constant();
+            return m_false_constant.value();
+        }
+    }
+    if (value.is_undefined()) {
+        if (!m_undefined_constant.has_value())
+            m_undefined_constant = append_new_constant();
+        return m_undefined_constant.value();
+    }
+    if (value.is_null()) {
+        if (!m_null_constant.has_value())
+            m_null_constant = append_new_constant();
+        return m_null_constant.value();
+    }
+    if (value.is_empty()) {
+        if (!m_empty_constant.has_value())
+            m_empty_constant = append_new_constant();
+        return m_empty_constant.value();
+    }
+    if (value.is_int32()) {
+        auto as_int32 = value.as_i32();
+        return m_int32_constants.ensure(as_int32, [&] {
+            return append_new_constant();
+        });
+    }
+    return append_new_constant();
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -275,18 +275,49 @@ CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::compile(VM& vm, ASTNo
 
     HashMap<size_t, SourceRecord> source_map;
 
+    Optional<ScopedOperand> undefined_constant;
+
     for (auto& block : generator.m_root_basic_blocks) {
         if (!block->is_terminated()) {
             // NOTE: We must ensure that the "undefined" constant, which will be used by the not yet
             // emitted End instruction, is taken into account while shifting local operands by the
             // number of constants.
-            (void)generator.add_constant(js_undefined());
+            undefined_constant = generator.add_constant(js_undefined());
             break;
         }
     }
 
     auto number_of_registers = generator.m_next_register;
     auto number_of_constants = generator.m_constants.size();
+
+    // Pass: Rewrite the bytecode to use the correct register and constant indices.
+    for (auto& block : generator.m_root_basic_blocks) {
+        Bytecode::InstructionStreamIterator it(block->instruction_stream());
+        while (!it.at_end()) {
+            auto& instruction = const_cast<Instruction&>(*it);
+
+            instruction.visit_operands([number_of_registers, number_of_constants](Operand& operand) {
+                switch (operand.type()) {
+                case Operand::Type::Register:
+                    break;
+                case Operand::Type::Local:
+                    operand.offset_index_by(number_of_registers + number_of_constants);
+                    break;
+                case Operand::Type::Constant:
+                    operand.offset_index_by(number_of_registers);
+                    break;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            });
+
+            ++it;
+        }
+    }
+
+    // Also rewrite the `undefined` constant if we have one for inserting End.
+    if (undefined_constant.has_value())
+        undefined_constant.value().operand().offset_index_by(number_of_registers);
 
     for (auto& block : generator.m_root_basic_blocks) {
         basic_block_start_offsets.append(bytecode.size());
@@ -308,21 +339,6 @@ CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::compile(VM& vm, ASTNo
         Bytecode::InstructionStreamIterator it(block->instruction_stream());
         while (!it.at_end()) {
             auto& instruction = const_cast<Instruction&>(*it);
-
-            instruction.visit_operands([number_of_registers, number_of_constants](Operand& operand) {
-                switch (operand.type()) {
-                case Operand::Type::Register:
-                    break;
-                case Operand::Type::Local:
-                    operand.offset_index_by(number_of_registers + number_of_constants);
-                    break;
-                case Operand::Type::Constant:
-                    operand.offset_index_by(number_of_registers);
-                    break;
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            });
 
             // OPTIMIZATION: Don't emit jumps that just jump to the next block.
             if (instruction.type() == Instruction::Type::Jump) {
@@ -369,21 +385,7 @@ CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::compile(VM& vm, ASTNo
             ++it;
         }
         if (!block->is_terminated()) {
-            Op::End end(generator.add_constant(js_undefined()));
-            end.visit_operands([number_of_registers, number_of_constants](Operand& operand) {
-                switch (operand.type()) {
-                case Operand::Type::Register:
-                    break;
-                case Operand::Type::Local:
-                    operand.offset_index_by(number_of_registers + number_of_constants);
-                    break;
-                case Operand::Type::Constant:
-                    operand.offset_index_by(number_of_registers);
-                    break;
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            });
+            Op::End end(*undefined_constant);
             bytecode.append(reinterpret_cast<u8 const*>(&end), end.length());
         }
         if (block->handler() || block->finalizer()) {

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1156,4 +1156,13 @@ void Generator::emit_jump_if(ScopedOperand const& condition, Label true_target, 
     emit<Op::JumpIf>(condition, true_target, false_target);
 }
 
+ScopedOperand Generator::copy_if_needed_to_preserve_evaluation_order(ScopedOperand const& operand)
+{
+    if (!operand.operand().is_local())
+        return operand;
+    auto new_register = allocate_register();
+    emit<Bytecode::Op::Mov>(new_register, operand);
+    return new_register;
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -326,17 +326,7 @@ public:
         Yes,
         No,
     };
-    [[nodiscard]] ScopedOperand add_constant(Value value, DeduplicateConstant deduplicate_constant = DeduplicateConstant::Yes)
-    {
-        if (deduplicate_constant == DeduplicateConstant::Yes) {
-            for (size_t i = 0; i < m_constants.size(); ++i) {
-                if (m_constants[i] == value)
-                    return ScopedOperand(*this, Operand(Operand::Type::Constant, i));
-            }
-        }
-        m_constants.append(value);
-        return ScopedOperand(*this, Operand(Operand::Type::Constant, m_constants.size() - 1));
-    }
+    [[nodiscard]] ScopedOperand add_constant(Value);
 
     [[nodiscard]] Value get_constant(ScopedOperand const& operand) const
     {
@@ -384,6 +374,13 @@ private:
     NonnullOwnPtr<IdentifierTable> m_identifier_table;
     NonnullOwnPtr<RegexTable> m_regex_table;
     MarkedVector<Value> m_constants;
+
+    mutable Optional<ScopedOperand> m_true_constant;
+    mutable Optional<ScopedOperand> m_false_constant;
+    mutable Optional<ScopedOperand> m_null_constant;
+    mutable Optional<ScopedOperand> m_undefined_constant;
+    mutable Optional<ScopedOperand> m_empty_constant;
+    mutable HashMap<i32, ScopedOperand> m_int32_constants;
 
     ScopedOperand m_accumulator;
     ScopedOperand m_this_value;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -308,6 +308,8 @@ public:
         m_boundaries.take_last();
     }
 
+    [[nodiscard]] ScopedOperand copy_if_needed_to_preserve_evaluation_order(ScopedOperand const&);
+
     [[nodiscard]] ScopedOperand get_this(Optional<ScopedOperand> preferred_dst = {});
 
     void emit_get_by_id(ScopedOperand dst, ScopedOperand base, IdentifierTableIndex property_identifier, Optional<IdentifierTableIndex> base_identifier = {});

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -338,6 +338,12 @@ public:
         return ScopedOperand(*this, Operand(Operand::Type::Constant, m_constants.size() - 1));
     }
 
+    [[nodiscard]] Value get_constant(ScopedOperand const& operand) const
+    {
+        VERIFY(operand.operand().is_constant());
+        return m_constants[operand.operand().index()];
+    }
+
     UnwindContext const* current_unwind_context() const { return m_current_unwind_context; }
 
     [[nodiscard]] bool is_finished() const { return m_finished; }

--- a/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
+++ b/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
@@ -21,7 +21,8 @@ public:
 
     ~ScopedOperandImpl();
 
-    [[nodiscard]] Operand operand() const { return m_operand; }
+    [[nodiscard]] Operand const& operand() const { return m_operand; }
+    [[nodiscard]] Operand& operand() { return m_operand; }
 
 private:
     Generator& m_generator;
@@ -35,7 +36,8 @@ public:
     {
     }
 
-    [[nodiscard]] Operand operand() const { return m_impl->operand(); }
+    [[nodiscard]] Operand const& operand() const { return m_impl->operand(); }
+    [[nodiscard]] Operand& operand() { return m_impl->operand(); }
     operator Operand() const { return operand(); }
 
     [[nodiscard]] bool operator==(ScopedOperand const& other) const { return operand() == other.operand(); }


### PR DESCRIPTION
Basically:
- Constant folding of binary expressions.
- Fewer avoidable `Mov` instructions.
- Rewrite `Jump`-to-`End` or `Jump`-to-`Return` as just `End` or `Return`.
- Fix a dumb O(n^2) issue in constant deduplication.

Benchmarks move in the right direction:
```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              0.995  2.145 ± 2.120 … 2.170     2.155 ± 2.130 … 2.180
Kraken      audio-beat-detection.js                  1.018  1.440 ± 1.410 … 1.470     1.415 ± 1.410 … 1.420
Kraken      audio-dft.js                             1.009  1.150 ± 1.140 … 1.160     1.140 ± 1.140 … 1.140
Kraken      audio-fft.js                             1.022  1.365 ± 1.330 … 1.400     1.335 ± 1.330 … 1.340
Kraken      audio-oscillator.js                      1.004  1.360 ± 1.360 … 1.360     1.355 ± 1.320 … 1.390
Kraken      imaging-darkroom.js                      1.049  1.820 ± 1.820 … 1.820     1.735 ± 1.690 … 1.780
Kraken      imaging-desaturate.js                    1.219  2.475 ± 2.460 … 2.490     2.030 ± 2.020 … 2.040
Kraken      imaging-gaussian-blur.js                 1.016  7.405 ± 7.400 … 7.410     7.290 ± 7.240 … 7.340
Kraken      json-parse-financial.js                  0.963  0.130 ± 0.130 … 0.130     0.135 ± 0.130 … 0.140
Kraken      json-stringify-tinderbox.js              1.455  0.240 ± 0.240 … 0.240     0.165 ± 0.160 … 0.170
Kraken      stanford-crypto-aes.js                   0.969  0.630 ± 0.630 … 0.630     0.650 ± 0.620 … 0.680
Kraken      stanford-crypto-ccm.js                   1.028  0.545 ± 0.540 … 0.550     0.530 ± 0.530 … 0.530
Kraken      stanford-crypto-pbkdf2.js                1.015  1.010 ± 1.010 … 1.010     0.995 ± 0.990 … 1.000
Kraken      stanford-crypto-sha256-iterative.js      0.965  0.415 ± 0.410 … 0.420     0.430 ± 0.420 … 0.440
Octane      box2d.js                                 1.056  2.470 ± 2.470 … 2.470     2.340 ± 2.280 … 2.400
Octane      code-load.js                             1.009  2.150 ± 2.150 … 2.150     2.130 ± 2.120 … 2.140
Octane      crypto.js                                1.018  6.355 ± 6.340 … 6.370     6.245 ± 6.230 … 6.260
Octane      deltablue.js                             0.998  2.020 ± 2.010 … 2.030     2.025 ± 2.020 … 2.030
Octane      earley-boyer.js                          0.99   15.470 ± 15.400 … 15.540  15.630 ± 15.350 … 15.910
Octane      gbemu.js                                 0.966  2.570 ± 2.560 … 2.580     2.660 ± 2.610 … 2.710
Octane      mandreel.js                              0.997  12.715 ± 12.640 … 12.790  12.750 ± 12.370 … 13.130
Octane      navier-stokes.js                         0.976  3.085 ± 3.060 … 3.110     3.160 ± 3.160 … 3.160
Octane      pdfjs.js                                 1.04   2.845 ± 2.730 … 2.960     2.735 ± 2.650 … 2.820
Octane      raytrace.js                              1.012  5.865 ± 5.670 … 6.060     5.795 ± 5.520 … 6.070
Octane      regexp.js                                1.016  22.965 ± 22.160 … 23.770  22.595 ± 22.020 … 23.170
Octane      richards.js                              1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1      2.800 ± 2.800 … 2.800     2.800 ± 2.790 … 2.810
Octane      typescript.js                            1.005  25.625 ± 25.580 … 25.670  25.500 ± 24.940 … 26.060
Octane      zlib.js                                  1.021  75.200 ± 75.190 … 75.210  73.670 ± 71.350 … 75.990
Kraken      Total                                    1.036  22.130                    21.360
Octane      Total                                    1.012  184.145                   182.045
All Suites  Total                                    1.014  206.275                   203.405
```