### PR TITLE
LibWeb: Add Web::UIEvents::MouseButton enum, drop dependency on LibGUI

### DIFF
--- a/Ladybird/AppKit/UI/Event.h
+++ b/Ladybird/AppKit/UI/Event.h
@@ -12,7 +12,7 @@
 
 namespace Ladybird {
 
-Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type, NSEvent*, NSView*, NSScrollView*, GUI::MouseButton);
+Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type, NSEvent*, NSView*, NSScrollView*, Web::UIEvents::MouseButton);
 Web::KeyEvent ns_event_to_key_event(Web::KeyEvent::Type, NSEvent*);
 NSEvent* key_event_to_ns_event(Web::KeyEvent const&);
 

--- a/Ladybird/AppKit/UI/Event.mm
+++ b/Ladybird/AppKit/UI/Event.mm
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <AK/Utf8View.h>
 
 #import <System/Carbon.h>
@@ -12,7 +13,7 @@
 
 namespace Ladybird {
 
-static KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_flags, Optional<GUI::MouseButton&> button = {})
+static KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_flags, Optional<Web::UIEvents::MouseButton&> button = {})
 {
     unsigned modifiers = KeyModifier::Mod_None;
 
@@ -20,8 +21,8 @@ static KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_f
         modifiers |= KeyModifier::Mod_Shift;
     }
     if ((modifier_flags & NSEventModifierFlagControl) != 0) {
-        if (button == GUI::MouseButton::Primary) {
-            *button = GUI::MouseButton::Secondary;
+        if (button == Web::UIEvents::MouseButton::Primary) {
+            *button = Web::UIEvents::MouseButton::Secondary;
         } else {
             modifiers |= KeyModifier::Mod_Ctrl;
         }
@@ -36,7 +37,7 @@ static KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_f
     return static_cast<KeyModifier>(modifiers);
 }
 
-Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* event, NSView* view, NSScrollView* scroll_view, GUI::MouseButton button)
+Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* event, NSView* view, NSScrollView* scroll_view, Web::UIEvents::MouseButton button)
 {
     auto position = [view convertPoint:event.locationInWindow fromView:nil];
     auto device_position = ns_point_to_gfx_point(position).to_type<Web::DevicePixels>();

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1354,13 +1354,13 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 
 - (void)mouseMoved:(NSEvent*)event
 {
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], GUI::MouseButton::None);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], Web::UIEvents::MouseButton::None);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)scrollWheel:(NSEvent*)event
 {
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseWheel, event, self, [self scrollView], GUI::MouseButton::Middle);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseWheel, event, self, [self scrollView], Web::UIEvents::MouseButton::Middle);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
@@ -1368,19 +1368,19 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 {
     [[self window] makeFirstResponder:self];
 
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, [self scrollView], GUI::MouseButton::Primary);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, [self scrollView], Web::UIEvents::MouseButton::Primary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)mouseUp:(NSEvent*)event
 {
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, [self scrollView], GUI::MouseButton::Primary);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, [self scrollView], Web::UIEvents::MouseButton::Primary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)mouseDragged:(NSEvent*)event
 {
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], GUI::MouseButton::Primary);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], Web::UIEvents::MouseButton::Primary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
@@ -1388,19 +1388,19 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 {
     [[self window] makeFirstResponder:self];
 
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, [self scrollView], GUI::MouseButton::Primary);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, [self scrollView], Web::UIEvents::MouseButton::Primary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)rightMouseUp:(NSEvent*)event
 {
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, [self scrollView], GUI::MouseButton::Secondary);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, [self scrollView], Web::UIEvents::MouseButton::Secondary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)rightMouseDragged:(NSEvent*)event
 {
-    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], GUI::MouseButton::Secondary);
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], Web::UIEvents::MouseButton::Secondary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -28,6 +28,7 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/WebContentClient.h>
 #include <QApplication>
@@ -142,34 +143,34 @@ WebContentView::~WebContentView()
         m_client_state.client->unregister_view(m_client_state.page_index);
 }
 
-static GUI::MouseButton get_button_from_qt_event(QSinglePointEvent const& event)
+static Web::UIEvents::MouseButton get_button_from_qt_event(QSinglePointEvent const& event)
 {
     if (event.button() == Qt::MouseButton::LeftButton)
-        return GUI::MouseButton::Primary;
+        return Web::UIEvents::MouseButton::Primary;
     if (event.button() == Qt::MouseButton::RightButton)
-        return GUI::MouseButton::Secondary;
+        return Web::UIEvents::MouseButton::Secondary;
     if (event.button() == Qt::MouseButton::MiddleButton)
-        return GUI::MouseButton::Middle;
+        return Web::UIEvents::MouseButton::Middle;
     if (event.button() == Qt::MouseButton::BackButton)
-        return GUI::MouseButton::Backward;
+        return Web::UIEvents::MouseButton::Backward;
     if (event.buttons() == Qt::MouseButton::ForwardButton)
-        return GUI::MouseButton::Forward;
-    return GUI::MouseButton::None;
+        return Web::UIEvents::MouseButton::Forward;
+    return Web::UIEvents::MouseButton::None;
 }
 
-static GUI::MouseButton get_buttons_from_qt_event(QSinglePointEvent const& event)
+static Web::UIEvents::MouseButton get_buttons_from_qt_event(QSinglePointEvent const& event)
 {
-    auto buttons = GUI::MouseButton::None;
+    auto buttons = Web::UIEvents::MouseButton::None;
     if (event.buttons().testFlag(Qt::MouseButton::LeftButton))
-        buttons |= GUI::MouseButton::Primary;
+        buttons |= Web::UIEvents::MouseButton::Primary;
     if (event.buttons().testFlag(Qt::MouseButton::RightButton))
-        buttons |= GUI::MouseButton::Secondary;
+        buttons |= Web::UIEvents::MouseButton::Secondary;
     if (event.buttons().testFlag(Qt::MouseButton::MiddleButton))
-        buttons |= GUI::MouseButton::Middle;
+        buttons |= Web::UIEvents::MouseButton::Middle;
     if (event.buttons().testFlag(Qt::MouseButton::BackButton))
-        buttons |= GUI::MouseButton::Backward;
+        buttons |= Web::UIEvents::MouseButton::Backward;
     if (event.buttons().testFlag(Qt::MouseButton::ForwardButton))
-        buttons |= GUI::MouseButton::Forward;
+        buttons |= Web::UIEvents::MouseButton::Forward;
     return buttons;
 }
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -751,7 +751,7 @@ set(GENERATED_SOURCES
 serenity_lib(LibWeb web)
 
 # NOTE: We link with LibSoftGPU here instead of lazy loading it via dlopen() so that we do not have to unveil the library and pledge prot_exec.
-target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibMarkdown LibHTTP LibGemini LibGUI LibGfx LibIPC LibLocale LibRegex LibSoftGPU LibSyntax LibTextCodec LibUnicode LibAudio LibVideo LibWasm LibXML LibIDL LibURL LibTLS)
+target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibMarkdown LibHTTP LibGemini LibGfx LibIPC LibLocale LibRegex LibSoftGPU LibSyntax LibTextCodec LibUnicode LibAudio LibVideo LibWasm LibXML LibIDL LibURL LibTLS)
 
 if (HAS_ACCELERATED_GRAPHICS)
     target_link_libraries(LibWeb PRIVATE ${ACCEL_GFX_LIBS})

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Layout/Label.h>
@@ -12,6 +11,7 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/LabelablePaintable.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 
 namespace Web::Layout {
 
@@ -26,7 +26,7 @@ Label::~Label() = default;
 
 void Label::handle_mousedown_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint, unsigned button)
 {
-    if (button != GUI::MouseButton::Primary)
+    if (button != UIEvents::MouseButton::Primary)
         return;
 
     if (auto control = dom_node().control(); control && is<Painting::LabelablePaintable>(control->paintable())) {
@@ -39,7 +39,7 @@ void Label::handle_mousedown_on_label(Badge<Painting::TextPaintable>, CSSPixelPo
 
 void Label::handle_mouseup_on_label(Badge<Painting::TextPaintable>, CSSPixelPoint position, unsigned button)
 {
-    if (!m_tracking_mouse || button != GUI::MouseButton::Primary)
+    if (!m_tracking_mouse || button != UIEvents::MouseButton::Primary)
         return;
 
     if (auto control = dom_node().control(); control && is<Painting::LabelablePaintable>(control->paintable())) {

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Painting/RadioButtonPaintable.h>
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -24,6 +23,7 @@
 #include <LibWeb/Painting/TextPaintable.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/KeyboardEvent.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/UIEvents/WheelEvent.h>
 
@@ -270,9 +270,9 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
 
             bool run_activation_behavior = false;
             if (node.ptr() == m_mousedown_target) {
-                if (button == GUI::MouseButton::Primary) {
+                if (button == UIEvents::MouseButton::Primary) {
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
-                } else if (button == GUI::MouseButton::Secondary) {
+                } else if (button == UIEvents::MouseButton::Secondary) {
                     // Allow the user to bypass custom context menus by holding shift, like Firefox.
                     if ((modifiers & Mod_Shift) == 0)
                         run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
@@ -299,12 +299,12 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                     auto href = link->href();
                     auto url = document->parse_url(href);
                     dbgln("Web::EventHandler: Clicking on a link to {}", url);
-                    if (button == GUI::MouseButton::Middle) {
+                    if (button == UIEvents::MouseButton::Middle) {
                         m_navigable->page().client().page_did_middle_click_link(url, link->target().to_byte_string(), modifiers);
-                    } else if (button == GUI::MouseButton::Secondary) {
+                    } else if (button == UIEvents::MouseButton::Secondary) {
                         m_navigable->page().client().page_did_request_link_context_menu(top_level_position, url, link->target().to_byte_string(), modifiers);
                     }
-                } else if (button == GUI::MouseButton::Secondary) {
+                } else if (button == UIEvents::MouseButton::Secondary) {
                     if (is<HTML::HTMLImageElement>(*node)) {
                         auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
                         auto image_url = image_element.document().parse_url(image_element.src());
@@ -331,7 +331,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
     }
 
 after_node_use:
-    if (button == GUI::MouseButton::Primary)
+    if (button == UIEvents::MouseButton::Primary)
         m_in_mouse_selection = false;
     return handled_event;
 }
@@ -399,7 +399,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen
     if (!paint_root() || paint_root() != node->document().paintable_box())
         return true;
 
-    if (button == GUI::MouseButton::Primary) {
+    if (button == UIEvents::MouseButton::Primary) {
         if (auto result = paint_root()->hit_test(position, Painting::HitTestType::TextCursor); result.has_value()) {
             auto paintable = result->paintable;
             if (paintable->dom_node()) {
@@ -615,7 +615,7 @@ bool EventHandler::handle_doubleclick(CSSPixelPoint position, CSSPixelPoint scre
     if (!paint_root() || paint_root() != node->document().paintable_box())
         return true;
 
-    if (button == GUI::MouseButton::Primary) {
+    if (button == UIEvents::MouseButton::Primary) {
         if (auto result = paint_root()->hit_test(position, Painting::HitTestType::TextCursor); result.has_value()) {
             if (!result->paintable->dom_node())
                 return true;

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -10,7 +10,6 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/WeakPtr.h>
 #include <Kernel/API/KeyCode.h>
-#include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/GCPtr.h>

--- a/Userland/Libraries/LibWeb/Page/InputEvent.cpp
+++ b/Userland/Libraries/LibWeb/Page/InputEvent.cpp
@@ -63,8 +63,8 @@ ErrorOr<Web::MouseEvent> IPC::decode(Decoder& decoder)
     auto type = TRY(decoder.decode<Web::MouseEvent::Type>());
     auto position = TRY(decoder.decode<Web::DevicePixelPoint>());
     auto screen_position = TRY(decoder.decode<Web::DevicePixelPoint>());
-    auto button = TRY(decoder.decode<GUI::MouseButton>());
-    auto buttons = TRY(decoder.decode<GUI::MouseButton>());
+    auto button = TRY(decoder.decode<Web::UIEvents::MouseButton>());
+    auto buttons = TRY(decoder.decode<Web::UIEvents::MouseButton>());
     auto modifiers = TRY(decoder.decode<KeyModifier>());
     auto wheel_delta_x = TRY(decoder.decode<int>());
     auto wheel_delta_y = TRY(decoder.decode<int>());

--- a/Userland/Libraries/LibWeb/Page/InputEvent.h
+++ b/Userland/Libraries/LibWeb/Page/InputEvent.h
@@ -11,11 +11,11 @@
 #include <LibGfx/Point.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 
-// FIXME: These should not be included outside of Serenity. This FIXME appears in several locations across the Ladybird
-//        chromes. The classes in this file provide a good opportunity to remove LibGUI and Kernel types from LibWeb.
+// FIXME: This should not be included outside of Serenity. This FIXME appears in several locations across the Ladybird
+//        chromes. The classes in this file provide a good opportunity to remove Kernel types from LibWeb.
 #include <Kernel/API/KeyCode.h>
-#include <LibGUI/Event.h>
 
 namespace Web {
 
@@ -55,8 +55,8 @@ public:
     Type type;
     Web::DevicePixelPoint position;
     Web::DevicePixelPoint screen_position;
-    GUI::MouseButton button { GUI::MouseButton::None };
-    GUI::MouseButton buttons { GUI::MouseButton::None };
+    UIEvents::MouseButton button { UIEvents::MouseButton::None };
+    UIEvents::MouseButton buttons { UIEvents::MouseButton::None };
     KeyModifier modifiers { KeyModifier::Mod_None };
     int wheel_delta_x { 0 };
     int wheel_delta_y { 0 };

--- a/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Array.h>
 #include <AK/NumberFormat.h>
-#include <LibGUI/Event.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/AudioTrackList.h>

--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/Layout/ButtonBox.h>

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/GrayscaleBitmap.h>

--- a/Userland/Libraries/LibWeb/Painting/LabelablePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/LabelablePaintable.cpp
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/Label.h>
 #include <LibWeb/Painting/LabelablePaintable.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 
 namespace Web::Painting {
 
@@ -37,7 +37,7 @@ Layout::FormAssociatedLabelableNode& LabelablePaintable::layout_box()
 
 LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned)
 {
-    if (button != GUI::MouseButton::Primary || !layout_box().dom_node().enabled())
+    if (button != UIEvents::MouseButton::Primary || !layout_box().dom_node().enabled())
         return DispatchEventOfSameName::No;
 
     set_being_pressed(true);
@@ -48,7 +48,7 @@ LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mousedown
 
 LabelablePaintable::DispatchEventOfSameName LabelablePaintable::handle_mouseup(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
-    if (!m_tracking_mouse || button != GUI::MouseButton::Primary || !layout_box().dom_node().enabled())
+    if (!m_tracking_mouse || button != UIEvents::MouseButton::Primary || !layout_box().dom_node().enabled())
         return DispatchEventOfSameName::No;
 
     bool is_inside_node_or_label = absolute_rect().contains(position);

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Array.h>
 #include <AK/NumberFormat.h>
-#include <LibGUI/Event.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -16,6 +15,7 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/MediaPaintable.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 
 namespace Web::Painting {
 
@@ -269,7 +269,7 @@ void MediaPaintable::paint_control_bar_volume(PaintContext& context, HTML::HTMLM
 
 MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
-    if (button != GUI::MouseButton::Primary)
+    if (button != UIEvents::MouseButton::Primary)
         return DispatchEventOfSameName::Yes;
 
     auto& media_element = *verify_cast<HTML::HTMLMediaElement>(layout_box().dom_node());
@@ -312,7 +312,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<Eve
         return DispatchEventOfSameName::Yes;
     }
 
-    if (button != GUI::MouseButton::Primary)
+    if (button != UIEvents::MouseButton::Primary)
         return DispatchEventOfSameName::Yes;
 
     if (cached_layout_boxes.control_box_rect.has_value() && cached_layout_boxes.control_box_rect->contains(position)) {

--- a/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/Event.h>
 #include <LibGfx/StylePainter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Array.h>
-#include <LibGUI/Event.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>

--- a/Userland/Libraries/LibWeb/UIEvents/MouseButton.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseButton.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+
+namespace Web::UIEvents {
+
+enum MouseButton : u8 {
+    None = 0,
+    Primary = 1,
+    Secondary = 2,
+    Middle = 4,
+    Backward = 8,
+    Forward = 16,
+};
+
+AK_ENUM_BITWISE_OPERATORS(MouseButton);
+
+}

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -6,11 +6,11 @@
  */
 
 #include <Kernel/API/KeyCode.h>
-#include <LibGUI/Event.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MouseEventPrototype.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 
 namespace Web::UIEvents {
@@ -101,15 +101,15 @@ bool MouseEvent::get_modifier_state(String const& key_arg) const
 static i16 determine_button(unsigned mouse_button)
 {
     switch (mouse_button) {
-    case GUI::MouseButton::Primary:
+    case MouseButton::Primary:
         return 0;
-    case GUI::MouseButton::Middle:
+    case MouseButton::Middle:
         return 1;
-    case GUI::MouseButton::Secondary:
+    case MouseButton::Secondary:
         return 2;
-    case GUI::MouseButton::Backward:
+    case MouseButton::Backward:
         return 3;
-    case GUI::MouseButton::Forward:
+    case MouseButton::Forward:
         return 4;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -315,7 +315,7 @@ void OutOfProcessWebView::enqueue_native_event(Web::MouseEvent::Type type, GUI::
     auto wheel_delta_x = event.wheel_delta_x() * SCROLL_STEP_SIZE;
     auto wheel_delta_y = event.wheel_delta_y() * SCROLL_STEP_SIZE;
 
-    enqueue_input_event(Web::MouseEvent { type, position, screen_position, event.button(), static_cast<GUI::MouseButton>(event.buttons()), static_cast<KeyModifier>(event.modifiers()), wheel_delta_x, wheel_delta_y, nullptr });
+    enqueue_input_event(Web::MouseEvent { type, position, screen_position, static_cast<Web::UIEvents::MouseButton>(to_underlying(event.button())), static_cast<Web::UIEvents::MouseButton>(event.buttons()), static_cast<KeyModifier>(event.modifiers()), wheel_delta_x, wheel_delta_y, nullptr });
 }
 
 struct KeyData : Web::ChromeInputData {


### PR DESCRIPTION
This was the only thing LibWeb needed from LibGUI, and we can just duplicate the enum in LibWeb and get rid of a bogus dependency.