### PR TITLE
LibSyntax: Remove minor unnecessary use of LibGUI

### DIFF
--- a/Userland/Libraries/LibSyntax/Highlighter.cpp
+++ b/Userland/Libraries/LibSyntax/Highlighter.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGUI/TextEditor.h>
 #include <LibGfx/Color.h>
 #include <LibSyntax/Highlighter.h>
 
@@ -75,7 +74,7 @@ void Highlighter::highlight_matching_token_pair()
     auto pairs = matching_token_pairs();
 
     for (size_t i = 0; i < document.spans().size(); ++i) {
-        auto& span = const_cast<GUI::TextDocumentSpan&>(document.spans().at(i));
+        auto& span = const_cast<TextDocumentSpan&>(document.spans().at(i));
         auto token_type = span.data;
 
         for (auto& pair : pairs) {

--- a/Userland/Libraries/LibSyntax/Language.cpp
+++ b/Userland/Libraries/LibSyntax/Language.cpp
@@ -6,7 +6,6 @@
 
 #include "Language.h"
 #include <AK/LexicalPath.h>
-#include <LibGUI/TextEditor.h>
 #include <LibSyntax/Highlighter.h>
 
 namespace Syntax {


### PR DESCRIPTION
This was the only stuff that made it look like LibSyntax depends on LibGUI, when it really doesn't.