### PR TITLE
Meta: Update GN CC flags to match CMake, and fix WebContent's event loop in the GN build

### DIFF
--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -79,12 +79,21 @@ config("compiler_defaults") {
     # Linetables always go in the .o file, even with -gsplit-dwarf, so there's
     # no point in passing -gsplit-dwarf here.
   }
-  if (is_optimized) {
-    cflags += [ "-O3" ]
-  }
-  cflags += [ "-fdiagnostics-color" ]
 
-  cflags += [ "-ffp-contract=off" ]
+  if (is_optimized) {
+    cflags += [ "-O2" ]
+  }
+
+  cflags += [
+    "-D_FILE_OFFSET_BITS=64",
+    "-DENABLE_COMPILETIME_FORMAT_CHECK",
+  ]
+
+  cflags += [
+    "-fdiagnostics-color",
+    "-ffp-contract=off",
+    "-fsigned-char",
+  ]
 
   if (use_lld) {
     ldflags += [ "-Wl,--color-diagnostics" ]
@@ -103,11 +112,14 @@ config("compiler_defaults") {
   cflags += [
     "-Wall",
     "-Wextra",
+    "-Werror",
   ]
   cflags += [
-    "-Wno-unused-parameter",
     "-Wno-invalid-offsetof",
+    "-Wno-unknown-warning-option",
+    "-Wno-unused-parameter",
   ]
+
   if (is_clang) {
     cflags += [
       "-Wdelete-non-virtual-dtor",
@@ -116,6 +128,7 @@ config("compiler_defaults") {
       "-fconstexpr-steps=16777216",
       "-Wno-unused-private-field",
       "-Wno-implicit-const-int-float-conversion",
+      "-Wno-vla-cxx-extension",
     ]
   } else {
     cflags += [
@@ -166,7 +179,10 @@ config("compiler_defaults") {
       "-isysroot",
       rebase_path(sdk_path, root_build_dir),
     ]
+  } else {
+    cflags += [ "-fno-semantic-interposition" ]
   }
+
   if (sysroot != "" && current_os != "win" && is_clang) {
     cflags += [ "-Wpoison-system-directories" ]
   }

--- a/Meta/gn/build/toolchain/BUILD.gn
+++ b/Meta/gn/build/toolchain/BUILD.gn
@@ -190,6 +190,7 @@ unix_toolchain("unix") {
     current_os = host_os
     cc = host_cc
     cxx = host_cxx
+    ld = host_cxx
   }
 }
 

--- a/Meta/gn/build/toolchain/BUILD.gn
+++ b/Meta/gn/build/toolchain/BUILD.gn
@@ -65,9 +65,6 @@ template("unix_toolchain") {
     }
 
     tool("alink") {
-      if (enable_ccache) {
-        command_launcher = "ccache"
-      }
       if (current_os == "ios" || current_os == "mac") {
         command = "libtool -D -static -no_warning_for_no_symbols {{arflags}} -o {{output}} {{inputs}}"
         not_needed([ "ar" ])
@@ -93,9 +90,6 @@ template("unix_toolchain") {
     lib_dir_switch = "-L"
 
     tool("solink") {
-      if (enable_ccache) {
-        command_launcher = "ccache"
-      }
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       if (current_os == "ios" || current_os == "mac") {
         command = "$ld -shared {{ldflags}} -o $outfile {{inputs}} {{libs}} {{frameworks}} -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"
@@ -116,9 +110,6 @@ template("unix_toolchain") {
     }
 
     tool("solink_module") {
-      if (enable_ccache) {
-        command_launcher = "ccache"
-      }
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       if (current_os == "ios" || current_os == "mac") {
         command = "$ld -shared {{ldflags}} -Wl,-flat_namespace -Wl,-undefined,suppress -o $outfile {{inputs}} {{libs}} {{frameworks}} -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"

--- a/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
@@ -72,6 +72,7 @@ executable("WebContent") {
   ]
 
   if (enable_qt) {
+    defines = [ "HAVE_QT" ]
     configs += [ ":WebContent_qt" ]
     sources += [
       "//Ladybird/Qt/EventLoopImplementationQt.cpp",
@@ -83,6 +84,7 @@ executable("WebContent") {
     ]
 
     if (enable_qt_multimedia) {
+      defines += [ "HAVE_QT_MULTIMEDIA" ]
       sources += [
         "//Ladybird/Qt/AudioCodecPluginQt.cpp",
         "//Ladybird/Qt/AudioThread.cpp",


### PR DESCRIPTION
Without the last commit, loading xkcd.com in the GN build resulted in:

![Screenshot_20240531_120325](https://github.com/SerenityOS/serenity/assets/5600524/868116b2-9560-4f45-aed0-5739ab756cf9)

It's not clear why the Qt event loop is needed even when we use RequestServer for networking. But the same issue is reproducible in the CMake build if the Qt event loop is not installed. In any case, we need to define the `HAVE_QT` flag for `--enable-qt-networking` to work (we currently crash).