### PR TITLE
LibWasm+AK: Validate that names are utf8

### DIFF
--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -79,7 +79,10 @@ static ParseResult<ByteString> parse_name(Stream& stream)
 {
     ScopeLogger<WASM_BINPARSER_DEBUG> logger;
     auto data = TRY(parse_vector<u8>(stream));
-    return ByteString::copy(data);
+    auto string = ByteString::copy(data);
+    if (!Utf8View(string).validate())
+        return ParseError::InvalidUtf8;
+    return string;
 }
 
 template<typename T>
@@ -1546,6 +1549,8 @@ ByteString parse_error_to_byte_string(ParseError error)
         return "A parsed instruction immediate was invalid for the instruction it was used for";
     case ParseError::SectionSizeMismatch:
         return "A parsed section did not fulfill its expected size";
+    case ParseError::InvalidUtf8:
+        return "A parsed string was not valid Utf8";
     case ParseError::UnknownInstruction:
         return "A parsed instruction was not known to this parser";
     }

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -55,6 +55,7 @@ enum class ParseError {
     HugeAllocationRequested,
     OutOfMemory,
     SectionSizeMismatch,
+    InvalidUtf8,
     // FIXME: This should not exist!
     NotImplemented,
 };


### PR DESCRIPTION
This also fixes a bug where surrogate codepoints were accepted by the `Utf8View::validate` function.