### PR TITLE
AK: Introduce an `as<OutputType>()` cast 

### DIFF
--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -13,6 +13,25 @@
 namespace AK {
 
 template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>* as(InputType* input)
+{
+    if (!input)
+        return nullptr;
+
+    return as<OutputType>(*input);
+}
+
+template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>* as(InputType& input)
+{
+    if constexpr (requires { input.template fast_is<OutputType>(); }) {
+        if (input.template fast_is<OutputType>())
+            return static_cast<CopyConst<InputType, OutputType>*>(&input);
+    }
+    return dynamic_cast<CopyConst<InputType, OutputType>*>(&input);
+}
+
+template<typename OutputType, typename InputType>
 ALWAYS_INLINE bool is(InputType& input)
 {
     if constexpr (requires { input.template fast_is<OutputType>(); }) {
@@ -52,6 +71,7 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>& verify_cast(InputType& input)
 }
 
 #if USING_AK_GLOBALLY
+using AK::as;
 using AK::is;
 using AK::verify_cast;
 #endif

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/String.h>
+#include <AK/TypeCasts.h>
 
 #include "AST/AST.h"
 
@@ -105,7 +106,7 @@ TreeList::TreeList(Vector<Tree>&& trees)
 {
     for (auto const& tree : trees) {
         if (tree->is_list()) {
-            for (auto const& nested_tree : as<TreeList>(tree)->m_trees)
+            for (auto const& nested_tree : as<TreeList>(*tree)->m_trees)
                 m_trees.append(nested_tree);
         } else {
             m_trees.append(tree);

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
@@ -16,12 +16,6 @@
 
 namespace JSSpecCompiler {
 
-template<typename T>
-RefPtr<T> as(NullableTree const& tree)
-{
-    return dynamic_cast<T*>(tree.ptr());
-}
-
 class NodeSubtreePointer {
 public:
     NodeSubtreePointer(Tree* tree_ptr)

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/CFGBuildingPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/CFGBuildingPass.cpp
@@ -34,9 +34,8 @@ void CFGBuildingPass::process_function()
 
 RecursionDecision CFGBuildingPass::on_entry(Tree tree)
 {
-    m_is_expression_stack.append(!as<Expression>(tree).is_null());
-
-    if (auto if_else_if_chain = as<IfElseIfChain>(tree); if_else_if_chain) {
+    m_is_expression_stack.append(is<Expression>(tree.ptr()));
+    if (auto* if_else_if_chain = as<IfElseIfChain>(*tree); if_else_if_chain) {
         auto* end_block = create_empty_block();
 
         for (auto [i, current_condition] : enumerate(if_else_if_chain->m_conditions)) {
@@ -60,7 +59,7 @@ RecursionDecision CFGBuildingPass::on_entry(Tree tree)
         return RecursionDecision::Continue;
     }
 
-    if (auto return_node = as<ReturnNode>(tree); return_node) {
+    if (auto* return_node = as<ReturnNode>(*tree); return_node) {
         Tree return_assignment = make_ref_counted<BinaryOperation>(
             BinaryOperator::Assignment,
             make_ref_counted<Variable>(m_function->m_named_return_value),
@@ -79,7 +78,7 @@ void CFGBuildingPass::on_leave(Tree tree)
 {
     (void)m_is_expression_stack.take_last();
 
-    if (!m_is_expression_stack.last() && as<Expression>(tree))
+    if (!m_is_expression_stack.last() && as<Expression>(*tree))
         m_current_block->m_expressions.append(tree);
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/CFGSimplificationPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/CFGSimplificationPass.cpp
@@ -7,6 +7,7 @@
 #include "Compiler/Passes/CFGSimplificationPass.h"
 #include "AST/AST.h"
 #include "Function.h"
+#include <AK/TypeCasts.h>
 
 namespace JSSpecCompiler {
 
@@ -22,7 +23,7 @@ void CFGSimplificationPass::process_function()
     for (auto const& block : graph.blocks) {
         m_replacement[block->m_index] = block;
         if (block->m_expressions.size() == 0)
-            if (auto jump = as<ControlFlowJump>(block->m_continuation); jump)
+            if (auto* jump = as<ControlFlowJump>(*block->m_continuation); jump)
                 m_replacement[block->m_index] = jump->m_block;
     }
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/DeadCodeEliminationPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/DeadCodeEliminationPass.cpp
@@ -9,6 +9,7 @@
 #include "Compiler/ControlFlowGraph.h"
 #include "Compiler/StronglyConnectedComponents.h"
 #include "Function.h"
+#include <AK/TypeCasts.h>
 
 namespace JSSpecCompiler {
 
@@ -34,7 +35,7 @@ RecursionDecision DeadCodeEliminationPass::on_entry(Tree tree)
 
 void DeadCodeEliminationPass::on_leave(Tree tree)
 {
-    if (auto variable = as<Variable>(tree); variable)
+    if (auto* variable = as<Variable>(*tree); variable)
         as_vertex(variable)->is_referenced = true;
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/IfBranchMergingPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/IfBranchMergingPass.cpp
@@ -13,7 +13,7 @@ namespace JSSpecCompiler {
 
 RecursionDecision IfBranchMergingPass::on_entry(Tree tree)
 {
-    if (auto list = as<TreeList>(tree); list) {
+    if (auto* list = as<TreeList>(*tree); list) {
         Vector<Tree> result;
         Vector<Tree> unmerged_branches;
 
@@ -52,7 +52,7 @@ Tree IfBranchMergingPass::merge_branches(Vector<Tree> const& unmerged_branches)
     Vector<Tree> branches;
     NullableTree else_branch;
 
-    if (auto if_branch = as<IfBranch>(unmerged_branches[0]); if_branch) {
+    if (auto* if_branch = as<IfBranch>(*unmerged_branches[0]); if_branch) {
         conditions.append(if_branch->m_condition);
         branches.append(if_branch->m_branch);
     } else {
@@ -60,7 +60,7 @@ Tree IfBranchMergingPass::merge_branches(Vector<Tree> const& unmerged_branches)
     }
 
     for (size_t i = 1; i < unmerged_branches.size(); ++i) {
-        auto branch = as<ElseIfBranch>(unmerged_branches[i]);
+        auto* branch = as<ElseIfBranch>(*unmerged_branches[i]);
 
         if (!branch)
             return error;
@@ -74,9 +74,9 @@ Tree IfBranchMergingPass::merge_branches(Vector<Tree> const& unmerged_branches)
             //         ...
             //   3. Else,
             //      ...
-            auto substep_list = as<TreeList>(branch->m_branch);
+            auto* substep_list = as<TreeList>(*branch->m_branch);
             if (substep_list && substep_list->m_trees.size() == 1) {
-                if (auto nested_if = as<IfBranch>(substep_list->m_trees[0]); nested_if)
+                if (auto* nested_if = as<IfBranch>(*substep_list->m_trees[0]); nested_if)
                     branch = make_ref_counted<ElseIfBranch>(nested_if->m_condition, nested_if->m_branch);
             }
         }

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/ReferenceResolvingPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/Passes/ReferenceResolvingPass.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/TypeCasts.h>
 
 #include "AST/AST.h"
 #include "Compiler/Passes/ReferenceResolvingPass.h"
@@ -21,13 +22,13 @@ void ReferenceResolvingPass::process_function()
 
 RecursionDecision ReferenceResolvingPass::on_entry(Tree tree)
 {
-    if (auto binary_operation = as<BinaryOperation>(tree); binary_operation) {
+    if (auto* binary_operation = as<BinaryOperation>(*tree); binary_operation) {
         if (binary_operation->m_operation != BinaryOperator::Declaration)
             return RecursionDecision::Recurse;
 
         binary_operation->m_operation = BinaryOperator::Assignment;
 
-        if (auto variable_name = as<UnresolvedReference>(binary_operation->m_left); variable_name) {
+        if (auto* variable_name = as<UnresolvedReference>(*binary_operation->m_left); variable_name) {
             auto name = variable_name->m_name;
             if (!m_function->m_local_variables.contains(name))
                 m_function->m_local_variables.set(name, make_ref_counted<NamedVariableDeclaration>(name));
@@ -38,7 +39,7 @@ RecursionDecision ReferenceResolvingPass::on_entry(Tree tree)
 
 void ReferenceResolvingPass::on_leave(Tree tree)
 {
-    if (auto reference = as<UnresolvedReference>(tree); reference) {
+    if (auto* reference = as<UnresolvedReference>(*tree); reference) {
         auto name = reference->m_name;
 
         if (name.starts_with("[["sv) && name.ends_with("]]"sv)) {

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Runtime/Object.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Runtime/Object.h
@@ -49,12 +49,6 @@ struct DataProperty {
     }
 
     template<typename T>
-    T* as() const
-    {
-        return verify_cast<T>(value);
-    }
-
-    template<typename T>
     Optional<T*> get_or_diagnose(Realm* realm, QualifiedName name, Location location)
     {
         if (!is<T>()) {


### PR DESCRIPTION
There are many places in the codebase where we currently use this pattern and variations of it:

```c++
if (is<Bar>(foo)) {
    auto& bar = verify_cast<Bar>(foo);
    do_stuff(bar);
}
```

The `as<OutputType>(input)` cast returns a pointer to an object of type `OutputType`, which is null if `input` can't be cast to `OutputType`.

This allows the above to be rewritten as:

```c++
if (auto* bar = as<Bar>(foo)) {
    do_stuff(*bar);
}
```

This change also replaces the `as` function used in the JSSpecCompiler with this new AK function, as both of them existing at the same time was causing a compile error.

I've updated `LibWeb/Dump.cpp` to use `as` casts as part of this PR to show how the new cast is used. I'd be happy to apply a similar change in more places if people think this is a good approach.