### PR TITLE
LibGfx/WebPLoader: Survive calling loop_count() before other accessors

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -1381,9 +1381,9 @@ TEST_CASE(test_webp_extended_lossless_animated)
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
     auto plugin_decoder = TRY_OR_FAIL(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
 
+    EXPECT_EQ(plugin_decoder->loop_count(), 42u);
     EXPECT_EQ(plugin_decoder->frame_count(), 8u);
     EXPECT(plugin_decoder->is_animated());
-    EXPECT_EQ(plugin_decoder->loop_count(), 42u);
 
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(990, 1050));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -639,6 +639,11 @@ size_t WebPImageDecoderPlugin::loop_count()
     if (!is_animated())
         return 0;
 
+    if (m_context->state < WebPLoadingContext::State::ChunksDecoded) {
+        if (set_error(decode_webp_chunks(*m_context)))
+            return 0;
+    }
+
     if (m_context->state < WebPLoadingContext::State::AnimationFrameChunksDecoded) {
         if (set_error(decode_webp_animation_frame_chunks(*m_context)))
             return 0;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -484,6 +484,8 @@ static ErrorOr<void> decode_webp_animation_frame_chunks(WebPLoadingContext& cont
     if (context.state >= WebPLoadingContext::State::AnimationFrameChunksDecoded)
         return {};
 
+    VERIFY(context.state == WebPLoadingContext::State::ChunksDecoded);
+
     context.animation_header_chunk_data = TRY(decode_webp_chunk_ANIM(context.animation_header_chunk.value()));
 
     Vector<ANMFChunk> decoded_chunks;


### PR DESCRIPTION
Fixes `animation` asserting when reading a webp input.

(The other order of operations is still covered by TestImageWriter.cpp.)