### PR TITLE
Test: Skip flakey Text/input/WebAnimations/misc/DocumentTimeline test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,6 +1,7 @@
 [Skipped]
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
+Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html


### PR DESCRIPTION
Ref https://github.com/LadybirdWebBrowser/ladybird/issues/19

---

`git cherry-pick -x 41c9cb032f56a306bdc3098a2a0d203acb0dd0ff` after

    git remote add ladybird https://github.com/LadybirdWebBrowser/ladybird.git
    git fetch ladybird

Currently red on every CI / Lagom (macOS, macos-14, NO_FUZZ) run.