### PR TITLE
LibWeb: Implement static method ReadableStream.from(asyncIterable)

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-from-asyncIterator.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-from-asyncIterator.txt
@@ -1,0 +1,5 @@
+Well
+Hello
+Friends
+!
+🦬

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-from-asyncIterator.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-from-asyncIterator.html
@@ -1,0 +1,30 @@
+<script src="../include.js"></script>
+<script>
+    async function* asyncGenerator() {
+        yield "Well";
+        yield "Hello";
+        yield "Friends";
+        yield "!";
+        yield "🦬";
+    }
+
+    async function readStream(stream) {
+        const reader = stream.getReader();
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done)
+                break;
+            println(value);
+        }
+    }
+
+    test(async () => {
+        const asyncIterable = {
+            [Symbol.asyncIterator]: asyncGenerator,
+        };
+
+        const readableStream = ReadableStream.from(asyncIterable);
+
+        await readStream(readableStream);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -37,6 +37,7 @@ WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, doub
 
 void readable_stream_close(ReadableStream&);
 void readable_stream_error(ReadableStream&, JS::Value error);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> readable_stream_from_iterable(JS::VM& vm, JS::Value async_iterable);
 void readable_stream_add_read_request(ReadableStream&, JS::NonnullGCPtr<ReadRequest>);
 void readable_stream_add_read_into_request(ReadableStream&, JS::NonnullGCPtr<ReadIntoRequest>);
 JS::NonnullGCPtr<WebIDL::Promise> readable_stream_cancel(ReadableStream&, JS::Value reason);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -116,6 +116,7 @@ void readable_byte_stream_controller_handle_queue_drain(ReadableByteStreamContro
 void readable_byte_stream_controller_invalidate_byob_request(ReadableByteStreamController&);
 bool readable_byte_stream_controller_should_call_pull(ReadableByteStreamController const&);
 
+WebIDL::ExceptionOr<void> set_up_readable_stream(JS::Realm& realm, ReadableStream& stream, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<PullAlgorithm> pull_algorithm, JS::NonnullGCPtr<CancelAlgorithm> cancel_algorithm, Optional<double> high_water_mark = {}, JS::GCPtr<SizeAlgorithm> size_algorithm = {});
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_stream(JS::Realm& realm, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<PullAlgorithm> pull_algorithm, JS::NonnullGCPtr<CancelAlgorithm> cancel_algorithm, Optional<double> high_water_mark = {}, JS::GCPtr<SizeAlgorithm> size_algorithm = {});
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_byte_stream(JS::Realm& realm, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<PullAlgorithm> pull_algorithm, JS::NonnullGCPtr<CancelAlgorithm> cancel_algorithm);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> create_writable_stream(JS::Realm& realm, JS::NonnullGCPtr<StartAlgorithm> start_algorithm, JS::NonnullGCPtr<WriteAlgorithm> write_algorithm, JS::NonnullGCPtr<CloseAlgorithm> close_algorithm, JS::NonnullGCPtr<AbortAlgorithm> abort_algorithm, double high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> size_algorithm);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -68,6 +68,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::construct_
     return readable_stream;
 }
 
+// https://streams.spec.whatwg.org/#rs-from
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::from(JS::VM& vm, JS::Value async_iterable)
+{
+    // 1. Return ? ReadableStreamFromIterable(asyncIterable).
+    return TRY(readable_stream_from_iterable(vm, async_iterable));
+}
+
 ReadableStream::ReadableStream(JS::Realm& realm)
     : PlatformObject(realm)
 {

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -70,6 +70,8 @@ public:
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> construct_impl(JS::Realm&, Optional<JS::Handle<JS::Object>> const& underlying_source, QueuingStrategy const& = {});
 
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> from(JS::VM& vm, JS::Value async_iterable);
+
     virtual ~ReadableStream() override;
 
     bool locked() const;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.idl
@@ -29,7 +29,7 @@ dictionary ReadableStreamGetReaderOptions {
 interface ReadableStream {
     constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});
 
-    [FIXME] static ReadableStream from(any asyncIterable);
+    static ReadableStream from(any asyncIterable);
 
     readonly attribute boolean locked;
 


### PR DESCRIPTION
Adds the static method ReadableStream.from() which can be used to wrap iterable and async iterable objects as readable streams.

Commits cherry picked from: https://github.com/LadybirdWebBrowser/ladybird/pull/108