### PR TITLE
Meta: Use Python>=3.10 in the test262 action

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '>=3.10'
 
       - name: Install Python dependencies
         # The setup-python action set default python to python3.x. Note that we are not using system python here.


### PR DESCRIPTION
The new Wasm test generation script needs this.