### PR TITLE
LibHTTP+LibWeb+RequestServer: Add HTTP::HeaderMap + simplify Set-Cookie handling

### DIFF
--- a/Ladybird/Qt/RequestManagerQt.cpp
+++ b/Ladybird/Qt/RequestManagerQt.cpp
@@ -112,7 +112,7 @@ void RequestManagerQt::Request::did_finish()
 {
     auto buffer = m_reply.readAll();
     auto http_status_code = m_reply.attribute(QNetworkRequest::Attribute::HttpStatusCodeAttribute).toInt();
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> response_headers;
+    HTTP::HeaderMap response_headers;
     Vector<ByteString> set_cookie_headers;
     for (auto& it : m_reply.rawHeaderPairs()) {
         auto name = ByteString(it.first.data(), it.first.length());

--- a/Ladybird/Qt/RequestManagerQt.h
+++ b/Ladybird/Qt/RequestManagerQt.h
@@ -27,7 +27,7 @@ public:
     virtual void prefetch_dns(URL::URL const&) override { }
     virtual void preconnect(URL::URL const&) override { }
 
-    virtual RefPtr<Web::ResourceLoaderConnectorRequest> start_request(ByteString const& method, URL::URL const&, HashMap<ByteString, ByteString> const& request_headers, ReadonlyBytes request_body, Core::ProxyData const&) override;
+    virtual RefPtr<Web::ResourceLoaderConnectorRequest> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers, ReadonlyBytes request_body, Core::ProxyData const&) override;
     virtual RefPtr<Web::WebSockets::WebSocketClientSocket> websocket_connect(const URL::URL&, ByteString const& origin, Vector<ByteString> const& protocols) override;
 
 private slots:
@@ -39,7 +39,7 @@ private:
     class Request
         : public Web::ResourceLoaderConnectorRequest {
     public:
-        static ErrorOr<NonnullRefPtr<Request>> create(QNetworkAccessManager& qnam, ByteString const& method, URL::URL const& url, HashMap<ByteString, ByteString> const& request_headers, ReadonlyBytes request_body, Core::ProxyData const&);
+        static ErrorOr<NonnullRefPtr<Request>> create(QNetworkAccessManager& qnam, ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& request_headers, ReadonlyBytes request_body, Core::ProxyData const&);
 
         virtual ~Request() override;
 

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -315,7 +315,7 @@ void MapWidget::process_tile_queue()
     auto tile_key = m_tile_queue.dequeue();
 
     // Start HTTP GET request to load image
-    HashMap<ByteString, ByteString> headers;
+    HTTP::HeaderMap headers;
     headers.set("User-Agent", "SerenityOS Maps");
     headers.set("Accept", "image/png");
     URL::URL url(MUST(String::formatted(m_tile_provider.value_or(m_default_tile_provider), tile_key.zoom, tile_key.x, tile_key.y)));

--- a/Userland/Applications/Maps/SearchPanel.cpp
+++ b/Userland/Applications/Maps/SearchPanel.cpp
@@ -52,7 +52,7 @@ void SearchPanel::search(StringView query)
     m_start_container->set_visible(false);
 
     // Start HTTP GET request to load people.json
-    HashMap<ByteString, ByteString> headers;
+    HTTP::HeaderMap headers;
     headers.set("User-Agent", "SerenityOS Maps");
     headers.set("Accept", "application/json");
     URL::URL url(MUST(String::formatted("https://nominatim.openstreetmap.org/search?q={}&format=json", URL::percent_encode(query, URL::PercentEncodeSet::Query))));

--- a/Userland/Applications/Maps/UsersMapWidget.cpp
+++ b/Userland/Applications/Maps/UsersMapWidget.cpp
@@ -19,7 +19,7 @@ UsersMapWidget::UsersMapWidget(Options const& options)
 void UsersMapWidget::get_users()
 {
     // Start HTTP GET request to load people.json
-    HashMap<ByteString, ByteString> headers;
+    HTTP::HeaderMap headers;
     headers.set("User-Agent", "SerenityOS Maps");
     headers.set("Accept", "application/json");
     URL::URL url("https://usermap.serenityos.org/people.json");

--- a/Userland/Libraries/LibCore/NetworkJob.h
+++ b/Userland/Libraries/LibCore/NetworkJob.h
@@ -11,6 +11,7 @@
 #include <AK/Stream.h>
 #include <LibCore/EventReceiver.h>
 #include <LibCore/Forward.h>
+#include <LibHTTP/HeaderMap.h>
 
 namespace Core {
 
@@ -27,7 +28,7 @@ public:
     virtual ~NetworkJob() override = default;
 
     // Could fire twice, after Headers and after Trailers!
-    Function<void(HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> response_code)> on_headers_received;
+    Function<void(HTTP::HeaderMap const& response_headers, Optional<u32> response_code)> on_headers_received;
     Function<void(bool success)> on_finish;
     Function<void(Optional<u64>, u64)> on_progress;
 

--- a/Userland/Libraries/LibHTTP/Header.h
+++ b/Userland/Libraries/LibHTTP/Header.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace HTTP {
+
+struct Header {
+    ByteString name;
+    ByteString value;
+};
+
+}
+
+namespace IPC {
+
+template<>
+inline ErrorOr<void> encode(Encoder& encoder, HTTP::Header const& header)
+{
+    TRY(encoder.encode(header.name));
+    TRY(encoder.encode(header.value));
+    return {};
+}
+
+template<>
+inline ErrorOr<HTTP::Header> decode(Decoder& decoder)
+{
+    auto name = TRY(decoder.decode<ByteString>());
+    auto value = TRY(decoder.decode<ByteString>());
+    return HTTP::Header { move(name), move(value) };
+}
+
+}

--- a/Userland/Libraries/LibHTTP/HeaderMap.h
+++ b/Userland/Libraries/LibHTTP/HeaderMap.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibHTTP/Header.h>
+
+namespace HTTP {
+
+class HeaderMap {
+public:
+    HeaderMap() = default;
+    ~HeaderMap() = default;
+
+    void set(ByteString name, ByteString value)
+    {
+        m_map.set(name, value);
+        m_headers.append({ move(name), move(value) });
+    }
+
+    [[nodiscard]] bool contains(ByteString const& name) const
+    {
+        return m_map.contains(name);
+    }
+
+    [[nodiscard]] Optional<ByteString> get(ByteString const& name) const
+    {
+        return m_map.get(name);
+    }
+
+    [[nodiscard]] Vector<Header> const& headers() const
+    {
+        return m_headers;
+    }
+
+private:
+    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_map;
+    Vector<Header> m_headers;
+};
+
+}
+
+namespace IPC {
+
+template<>
+inline ErrorOr<void> encode(Encoder& encoder, HTTP::HeaderMap const& header_map)
+{
+    TRY(encoder.encode(header_map.headers()));
+    return {};
+}
+
+template<>
+inline ErrorOr<HTTP::HeaderMap> decode(Decoder& decoder)
+{
+    auto headers = TRY(decoder.decode<Vector<HTTP::Header>>());
+    HTTP::HeaderMap header_map;
+    for (auto& header : headers)
+        header_map.set(move(header.name), move(header.value));
+    return header_map;
+}
+
+}

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -12,6 +12,7 @@
 #include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibCore/Forward.h>
+#include <LibHTTP/HeaderMap.h>
 #include <LibURL/URL.h>
 
 namespace HTTP {
@@ -55,11 +56,6 @@ public:
         PUT,
     };
 
-    struct Header {
-        ByteString name;
-        ByteString value;
-    };
-
     struct BasicAuthenticationCredentials {
         ByteString username;
         ByteString password;
@@ -69,7 +65,7 @@ public:
     ~HttpRequest() = default;
 
     ByteString const& resource() const { return m_resource; }
-    Vector<Header> const& headers() const { return m_headers; }
+    HeaderMap const& headers() const { return m_headers; }
 
     URL::URL const& url() const { return m_url; }
     void set_url(URL::URL const& url) { m_url = url; }
@@ -83,7 +79,7 @@ public:
     StringView method_name() const;
     ErrorOr<ByteBuffer> to_raw_request() const;
 
-    void set_headers(HashMap<ByteString, ByteString> const&);
+    void set_headers(HeaderMap);
 
     static ErrorOr<HttpRequest, HttpRequest::ParseError> from_raw_request(ReadonlyBytes);
     static Optional<Header> get_http_basic_authentication_header(URL::URL const&);
@@ -93,7 +89,7 @@ private:
     URL::URL m_url;
     ByteString m_resource;
     Method m_method { GET };
-    Vector<Header> m_headers;
+    HeaderMap m_headers;
     ByteBuffer m_body;
 };
 

--- a/Userland/Libraries/LibHTTP/HttpResponse.cpp
+++ b/Userland/Libraries/LibHTTP/HttpResponse.cpp
@@ -9,7 +9,7 @@
 
 namespace HTTP {
 
-HttpResponse::HttpResponse(int code, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits>&& headers, size_t size)
+HttpResponse::HttpResponse(int code, HeaderMap&& headers, size_t size)
     : m_code(code)
     , m_headers(move(headers))
     , m_downloaded_size(size)

--- a/Userland/Libraries/LibHTTP/HttpResponse.h
+++ b/Userland/Libraries/LibHTTP/HttpResponse.h
@@ -10,13 +10,14 @@
 #include <AK/ByteString.h>
 #include <AK/HashMap.h>
 #include <LibCore/NetworkResponse.h>
+#include <LibHTTP/HeaderMap.h>
 
 namespace HTTP {
 
 class HttpResponse : public Core::NetworkResponse {
 public:
     virtual ~HttpResponse() override = default;
-    static NonnullRefPtr<HttpResponse> create(int code, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits>&& headers, size_t downloaded_size)
+    static NonnullRefPtr<HttpResponse> create(int code, HeaderMap&& headers, size_t downloaded_size)
     {
         return adopt_ref(*new HttpResponse(code, move(headers), downloaded_size));
     }
@@ -24,15 +25,15 @@ public:
     int code() const { return m_code; }
     size_t downloaded_size() const { return m_downloaded_size; }
     StringView reason_phrase() const { return reason_phrase_for_code(m_code); }
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& headers() const { return m_headers; }
+    HeaderMap const& headers() const { return m_headers; }
 
     static StringView reason_phrase_for_code(int code);
 
 private:
-    HttpResponse(int code, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits>&&, size_t size);
+    HttpResponse(int code, HeaderMap&&, size_t size);
 
     int m_code { 0 };
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_headers;
+    HeaderMap m_headers;
     size_t m_downloaded_size { 0 };
 };
 

--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -53,7 +53,7 @@ protected:
     Core::BufferedSocketBase* m_socket { nullptr };
     bool m_legacy_connection { false };
     int m_code { -1 };
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_headers;
+    HTTP::HeaderMap m_headers;
     Vector<ByteString> m_set_cookie_headers;
 
     struct ReceivedBuffer {

--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -54,7 +54,6 @@ protected:
     bool m_legacy_connection { false };
     int m_code { -1 };
     HTTP::HeaderMap m_headers;
-    Vector<ByteString> m_set_cookie_headers;
 
     struct ReceivedBuffer {
         ReceivedBuffer(ByteBuffer d)

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -94,7 +94,7 @@ void Request::did_progress(Badge<RequestClient>, Optional<u64> total_size, u64 d
         on_progress(total_size, downloaded_size);
 }
 
-void Request::did_receive_headers(Badge<RequestClient>, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> response_code)
+void Request::did_receive_headers(Badge<RequestClient>, HTTP::HeaderMap const& response_headers, Optional<u32> response_code)
 {
     if (on_headers_received)
         on_headers_received(response_headers, response_code);

--- a/Userland/Libraries/LibProtocol/Request.h
+++ b/Userland/Libraries/LibProtocol/Request.h
@@ -14,6 +14,7 @@
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Notifier.h>
+#include <LibHTTP/HeaderMap.h>
 #include <LibIPC/Forward.h>
 
 namespace Protocol {
@@ -36,13 +37,13 @@ public:
     int fd() const { return m_fd; }
     bool stop();
 
-    using BufferedRequestFinished = Function<void(bool success, u64 total_size, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> response_code, ReadonlyBytes payload)>;
+    using BufferedRequestFinished = Function<void(bool success, u64 total_size, HTTP::HeaderMap const& response_headers, Optional<u32> response_code, ReadonlyBytes payload)>;
 
     // Configure the request such that the entirety of the response data is buffered. The callback receives that data and
     // the response headers all at once. Using this method is mutually exclusive with `set_unbuffered_data_received_callback`.
     void set_buffered_request_finished_callback(BufferedRequestFinished);
 
-    using HeadersReceived = Function<void(HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> response_code)>;
+    using HeadersReceived = Function<void(HTTP::HeaderMap const& response_headers, Optional<u32> response_code)>;
     using DataReceived = Function<void(ReadonlyBytes data)>;
     using RequestFinished = Function<void(bool success, u64 total_size)>;
 
@@ -55,7 +56,7 @@ public:
 
     void did_finish(Badge<RequestClient>, bool success, u64 total_size);
     void did_progress(Badge<RequestClient>, Optional<u64> total_size, u64 downloaded_size);
-    void did_receive_headers(Badge<RequestClient>, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> response_code);
+    void did_receive_headers(Badge<RequestClient>, HTTP::HeaderMap const& response_headers, Optional<u32> response_code);
     void did_request_certificates(Badge<RequestClient>);
 
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
@@ -83,7 +84,7 @@ private:
 
     struct InternalBufferedData {
         AllocatingMemoryStream payload_stream;
-        HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> response_headers;
+        HTTP::HeaderMap response_headers;
         Optional<u32> response_code;
     };
 

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -80,20 +80,14 @@ void RequestClient::request_progress(i32 request_id, Optional<u64> const& total_
     }
 }
 
-void RequestClient::headers_became_available(i32 request_id, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> const& status_code)
+void RequestClient::headers_became_available(i32 request_id, HTTP::HeaderMap const& response_headers, Optional<u32> const& status_code)
 {
     auto request = const_cast<Request*>(m_requests.get(request_id).value_or(nullptr));
     if (!request) {
         warnln("Received headers for non-existent request {}", request_id);
         return;
     }
-    auto response_headers_clone_or_error = response_headers.clone();
-    if (response_headers_clone_or_error.is_error()) {
-        warnln("Error while receiving headers for request {}: {}", request_id, response_headers_clone_or_error.error());
-        return;
-    }
-
-    request->did_receive_headers({}, response_headers_clone_or_error.release_value(), status_code);
+    request->did_receive_headers({}, response_headers, status_code);
 }
 
 void RequestClient::certificate_requested(i32 request_id)

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -26,8 +26,7 @@ class RequestClient final
 public:
     explicit RequestClient(NonnullOwnPtr<Core::LocalSocket>);
 
-    template<typename RequestHashMapTraits = Traits<ByteString>>
-    RefPtr<Request> start_request(ByteString const& method, URL::URL const&, HashMap<ByteString, ByteString, RequestHashMapTraits> const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});
+    RefPtr<Request> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});
 
     RefPtr<WebSocket> websocket_connect(const URL::URL&, ByteString const& origin = {}, Vector<ByteString> const& protocols = {}, Vector<ByteString> const& extensions = {}, HashMap<ByteString, ByteString> const& request_headers = {});
 

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <LibHTTP/HeaderMap.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibProtocol/WebSocket.h>
 #include <LibWebSocket/WebSocket.h>
@@ -40,7 +41,7 @@ private:
     virtual void request_progress(i32, Optional<u64> const&, u64) override;
     virtual void request_finished(i32, bool, u64) override;
     virtual void certificate_requested(i32) override;
-    virtual void headers_became_available(i32, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const&, Optional<u32> const&) override;
+    virtual void headers_became_available(i32, HTTP::HeaderMap const&, Optional<u32> const&) override;
 
     virtual void websocket_connected(i32) override;
     virtual void websocket_received(i32, bool, ByteBuffer const&) override;

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1877,7 +1877,7 @@ static void log_load_request(auto const& load_request)
 static void log_response(auto const& status_code, auto const& headers, auto const& data)
 {
     dbgln("< HTTP/1.1 {}", status_code.value_or(0));
-    for (auto const& [name, value] : headers)
+    for (auto const& [name, value] : headers.headers())
         dbgln("< {}: {}", name, value);
     dbgln("<");
     for (auto line : StringView { data }.split_view('\n', SplitBehavior::KeepEmpty))
@@ -1985,7 +1985,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
                 log_response(status_code, response_headers, ReadonlyBytes {});
             }
 
-            for (auto const& [name, value] : response_headers) {
+            for (auto const& [name, value] : response_headers.headers()) {
                 auto header = Infrastructure::Header::from_string_pair(name, value);
                 response->header_list()->append(move(header));
             }
@@ -2050,7 +2050,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
             auto response = Infrastructure::Response::create(vm);
             response->set_status(status_code.value_or(200));
             response->set_body(move(body));
-            for (auto const& [name, value] : response_headers) {
+            for (auto const& [name, value] : response_headers.headers()) {
                 auto header = Infrastructure::Header::from_string_pair(name, value);
                 response->header_list()->append(move(header));
             }
@@ -2071,7 +2071,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
                 response->set_status(status_code.value_or(400));
                 auto [body, _] = TRY_OR_IGNORE(extract_body(realm, data));
                 response->set_body(move(body));
-                for (auto const& [name, value] : response_headers) {
+                for (auto const& [name, value] : response_headers.headers()) {
                     auto header = Infrastructure::Header::from_string_pair(name, value);
                     response->header_list()->append(move(header));
                 }

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -83,12 +83,12 @@ static bool is_valid_encoding(StringView encoding)
     return TextCodec::decoder_for(encoding).has_value();
 }
 
-void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& headers, Optional<u32> status_code)
+void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HTTP::HeaderMap const& headers, Optional<u32> status_code)
 {
     VERIFY(m_state == State::Pending);
     // FIXME: Handle OOM failure.
     m_encoded_data = ByteBuffer::copy(data).release_value_but_fixme_should_propagate_errors();
-    m_response_headers = headers.clone().release_value_but_fixme_should_propagate_errors();
+    m_response_headers = headers;
     m_status_code = move(status_code);
     m_state = State::Loaded;
 

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -14,6 +14,7 @@
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <LibGfx/Forward.h>
+#include <LibHTTP/HeaderMap.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/LoadRequest.h>
@@ -53,7 +54,7 @@ public:
     const URL::URL& url() const { return m_request.url(); }
     ByteBuffer const& encoded_data() const { return m_encoded_data; }
 
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers() const { return m_response_headers; }
+    [[nodiscard]] HTTP::HeaderMap const& response_headers() const { return m_response_headers; }
 
     [[nodiscard]] Optional<u32> status_code() const { return m_status_code; }
 
@@ -66,7 +67,7 @@ public:
 
     void for_each_client(Function<void(ResourceClient&)>);
 
-    void did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& headers, Optional<u32> status_code);
+    void did_load(Badge<ResourceLoader>, ReadonlyBytes data, HTTP::HeaderMap const&, Optional<u32> status_code);
     void did_fail(Badge<ResourceLoader>, ByteString const& error, Optional<u32> status_code);
 
 protected:
@@ -84,7 +85,7 @@ private:
     Optional<ByteString> m_encoding;
 
     ByteString m_mime_type;
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_response_headers;
+    HTTP::HeaderMap m_response_headers;
     Optional<u32> m_status_code;
     HashTable<ResourceClient*> m_clients;
 };

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -502,7 +502,7 @@ RefPtr<ResourceLoaderConnectorRequest> ResourceLoader::start_network_request(Loa
 {
     auto proxy = ProxyMappings::the().proxy_for_url(request.url());
 
-    HashMap<ByteString, ByteString> headers;
+    HTTP::HeaderMap headers;
     headers.set("User-Agent", m_user_agent.to_byte_string());
     headers.set("Accept-Encoding", "gzip, deflate, br");
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -72,13 +72,13 @@ public:
 
     RefPtr<Resource> load_resource(Resource::Type, LoadRequest&);
 
-    using SuccessCallback = JS::SafeFunction<void(ReadonlyBytes, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)>;
-    using ErrorCallback = JS::SafeFunction<void(ByteString const&, Optional<u32> status_code, ReadonlyBytes payload, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers)>;
+    using SuccessCallback = JS::SafeFunction<void(ReadonlyBytes, HTTP::HeaderMap const& response_headers, Optional<u32> status_code)>;
+    using ErrorCallback = JS::SafeFunction<void(ByteString const&, Optional<u32> status_code, ReadonlyBytes payload, HTTP::HeaderMap const& response_headers)>;
     using TimeoutCallback = JS::SafeFunction<void()>;
 
     void load(LoadRequest&, SuccessCallback success_callback, ErrorCallback error_callback = nullptr, Optional<u32> timeout = {}, TimeoutCallback timeout_callback = nullptr);
 
-    using OnHeadersReceived = JS::SafeFunction<void(HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)>;
+    using OnHeadersReceived = JS::SafeFunction<void(HTTP::HeaderMap const& response_headers, Optional<u32> status_code)>;
     using OnDataReceived = JS::SafeFunction<void(ReadonlyBytes data)>;
     using OnComplete = JS::SafeFunction<void(bool success, Optional<StringView> error_message)>;
 
@@ -107,7 +107,7 @@ private:
     static ErrorOr<NonnullRefPtr<ResourceLoader>> try_create(NonnullRefPtr<ResourceLoaderConnector>);
 
     RefPtr<ResourceLoaderConnectorRequest> start_network_request(LoadRequest const&);
-    void handle_network_response_headers(LoadRequest const&, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const&);
+    void handle_network_response_headers(LoadRequest const&, HTTP::HeaderMap const&);
     void finish_network_request(NonnullRefPtr<ResourceLoaderConnectorRequest> const&);
 
     int m_pending_loads { 0 };

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -57,7 +57,7 @@ public:
     virtual void prefetch_dns(URL::URL const&) = 0;
     virtual void preconnect(URL::URL const&) = 0;
 
-    virtual RefPtr<ResourceLoaderConnectorRequest> start_request(ByteString const& method, URL::URL const&, HashMap<ByteString, ByteString> const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {}) = 0;
+    virtual RefPtr<ResourceLoaderConnectorRequest> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {}) = 0;
     virtual RefPtr<Web::WebSockets::WebSocketClientSocket> websocket_connect(const URL::URL&, ByteString const& origin, Vector<ByteString> const& protocols) = 0;
 
 protected:

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -252,7 +252,7 @@ ErrorOr<JsonValue, Client::WrappedError> Client::read_body_as_json()
     // FIXME: Check the Content-Type is actually application/json.
     size_t content_length = 0;
 
-    for (auto const& header : m_request->headers()) {
+    for (auto const& header : m_request->headers().headers()) {
         if (header.name.equals_ignoring_ascii_case("Content-Length"sv)) {
             content_length = header.value.to_number<size_t>(TrimWhitespace::Yes).value_or(0);
             break;
@@ -281,7 +281,7 @@ ErrorOr<void, Client::WrappedError> Client::handle_request(JsonValue body)
 ErrorOr<void, Client::WrappedError> Client::send_success_response(JsonValue result)
 {
     bool keep_alive = false;
-    if (auto it = m_request->headers().find_if([](auto& header) { return header.name.equals_ignoring_ascii_case("Connection"sv); }); !it.is_end())
+    if (auto it = m_request->headers().headers().find_if([](auto& header) { return header.name.equals_ignoring_ascii_case("Connection"sv); }); !it.is_end())
         keep_alive = it->value.trim_whitespace().equals_ignoring_ascii_case("keep-alive"sv);
 
     result = make_success_response(move(result));

--- a/Userland/Libraries/LibWebView/RequestServerAdapter.cpp
+++ b/Userland/Libraries/LibWebView/RequestServerAdapter.cpp
@@ -75,7 +75,7 @@ RequestServerAdapter::RequestServerAdapter(NonnullRefPtr<Protocol::RequestClient
 
 RequestServerAdapter::~RequestServerAdapter() = default;
 
-RefPtr<Web::ResourceLoaderConnectorRequest> RequestServerAdapter::start_request(ByteString const& method, URL::URL const& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData const& proxy)
+RefPtr<Web::ResourceLoaderConnectorRequest> RequestServerAdapter::start_request(ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& headers, ReadonlyBytes body, Core::ProxyData const& proxy)
 {
     auto protocol_request = m_protocol_client->start_request(method, url, headers, body, proxy);
     if (!protocol_request)

--- a/Userland/Libraries/LibWebView/RequestServerAdapter.h
+++ b/Userland/Libraries/LibWebView/RequestServerAdapter.h
@@ -45,7 +45,7 @@ public:
     virtual void prefetch_dns(URL::URL const& url) override;
     virtual void preconnect(URL::URL const& url) override;
 
-    virtual RefPtr<Web::ResourceLoaderConnectorRequest> start_request(ByteString const& method, URL::URL const&, HashMap<ByteString, ByteString> const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {}) override;
+    virtual RefPtr<Web::ResourceLoaderConnectorRequest> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {}) override;
     virtual RefPtr<Web::WebSockets::WebSocketClientSocket> websocket_connect(const URL::URL&, ByteString const& origin, Vector<ByteString> const& protocols) override;
 
 private:

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -196,7 +196,7 @@ Messages::RequestServer::IsSupportedProtocolResponse ConnectionFromClient::is_su
     return supported;
 }
 
-void ConnectionFromClient::start_request(i32 request_id, ByteString const& method, URL::URL const& url, HashMap<ByteString, ByteString> const& request_headers, ByteBuffer const& request_body, Core::ProxyData const& proxy_data)
+void ConnectionFromClient::start_request(i32 request_id, ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& request_headers, ByteBuffer const& request_body, Core::ProxyData const& proxy_data)
 {
     if (!url.is_valid()) {
         dbgln("StartRequest: Invalid URL requested: '{}'", url);

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -231,9 +231,8 @@ Messages::RequestServer::StopRequestResponse ConnectionFromClient::stop_request(
 
 void ConnectionFromClient::did_receive_headers(Badge<Request>, Request& request)
 {
-    auto response_headers = request.response_headers().clone().release_value_but_fixme_should_propagate_errors();
     auto lock = Threading::MutexLocker(m_ipc_mutex);
-    async_headers_became_available(request.id(), move(response_headers), request.status_code());
+    async_headers_became_available(request.id(), request.response_headers(), request.status_code());
 }
 
 void ConnectionFromClient::did_finish_request(Badge<Request>, Request& request, bool success)

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -37,7 +37,7 @@ private:
 
     virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString const&) override;
-    virtual void start_request(i32 request_id, ByteString const&, URL::URL const&, HashMap<ByteString, ByteString> const&, ByteBuffer const&, Core::ProxyData const&) override;
+    virtual void start_request(i32 request_id, ByteString const&, URL::URL const&, HTTP::HeaderMap const&, ByteBuffer const&, Core::ProxyData const&) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(i32) override;
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, ByteString const&, ByteString const&) override;
     virtual void ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel const& cache_level) override;
@@ -53,7 +53,7 @@ private:
         i32 request_id;
         ByteString method;
         URL::URL url;
-        HashMap<ByteString, ByteString> request_headers;
+        HTTP::HeaderMap request_headers;
         ByteBuffer request_body;
         Core::ProxyData proxy_data;
     };

--- a/Userland/Services/RequestServer/GeminiProtocol.cpp
+++ b/Userland/Services/RequestServer/GeminiProtocol.cpp
@@ -17,7 +17,7 @@ GeminiProtocol::GeminiProtocol()
 {
 }
 
-OwnPtr<Request> GeminiProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const&, const URL::URL& url, HashMap<ByteString, ByteString> const&, ReadonlyBytes, Core::ProxyData proxy_data)
+OwnPtr<Request> GeminiProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const&, const URL::URL& url, HTTP::HeaderMap const&, ReadonlyBytes, Core::ProxyData proxy_data)
 {
     Gemini::GeminiRequest request;
     request.set_url(url);

--- a/Userland/Services/RequestServer/GeminiProtocol.h
+++ b/Userland/Services/RequestServer/GeminiProtocol.h
@@ -19,7 +19,7 @@ public:
 private:
     GeminiProtocol();
 
-    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL::URL&, HashMap<ByteString, ByteString> const&, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL::URL&, HTTP::HeaderMap const&, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/GeminiRequest.cpp
+++ b/Userland/Services/RequestServer/GeminiRequest.cpp
@@ -23,7 +23,7 @@ GeminiRequest::GeminiRequest(ConnectionFromClient& client, NonnullRefPtr<Gemini:
         if (auto* response = m_job->response()) {
             set_downloaded_size(MUST(m_job->response_length()));
             if (!response->meta().is_empty()) {
-                HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> headers;
+                HTTP::HeaderMap headers;
                 headers.set("meta", response->meta());
                 // Note: We're setting content-type to meta only on status==SUCCESS
                 //       we should perhaps have a better mechanism for this, since we

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -61,7 +61,7 @@ void init(TSelf* self, TJob job)
 }
 
 template<typename TBadgedProtocol, typename TPipeResult>
-OwnPtr<Request> start_request(TBadgedProtocol&& protocol, i32 request_id, ConnectionFromClient& client, ByteString const& method, const URL::URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, TPipeResult&& pipe_result, Core::ProxyData proxy_data = {})
+OwnPtr<Request> start_request(TBadgedProtocol&& protocol, i32 request_id, ConnectionFromClient& client, ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& headers, ReadonlyBytes body, TPipeResult&& pipe_result, Core::ProxyData proxy_data = {})
 {
     using TJob = typename TBadgedProtocol::Type::JobType;
     using TRequest = typename TBadgedProtocol::Type::RequestType;

--- a/Userland/Services/RequestServer/HttpProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpProtocol.cpp
@@ -22,7 +22,7 @@ HttpProtocol::HttpProtocol()
 {
 }
 
-OwnPtr<Request> HttpProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const& method, const URL::URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
+OwnPtr<Request> HttpProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
 {
     return Detail::start_request(Badge<HttpProtocol> {}, request_id, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }

--- a/Userland/Services/RequestServer/HttpProtocol.h
+++ b/Userland/Services/RequestServer/HttpProtocol.h
@@ -31,7 +31,7 @@ public:
 private:
     HttpProtocol();
 
-    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL::URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, URL::URL const&, HTTP::HeaderMap const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/HttpsProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpsProtocol.cpp
@@ -22,7 +22,7 @@ HttpsProtocol::HttpsProtocol()
 {
 }
 
-OwnPtr<Request> HttpsProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const& method, const URL::URL& url, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
+OwnPtr<Request> HttpsProtocol::start_request(i32 request_id, ConnectionFromClient& client, ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
 {
     return Detail::start_request(Badge<HttpsProtocol> {}, request_id, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }

--- a/Userland/Services/RequestServer/HttpsProtocol.h
+++ b/Userland/Services/RequestServer/HttpsProtocol.h
@@ -31,7 +31,7 @@ public:
 private:
     HttpsProtocol();
 
-    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL::URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, URL::URL const&, HTTP::HeaderMap const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/Protocol.h
+++ b/Userland/Services/RequestServer/Protocol.h
@@ -8,6 +8,7 @@
 
 #include <AK/RefPtr.h>
 #include <LibCore/Proxy.h>
+#include <LibHTTP/HeaderMap.h>
 #include <LibURL/URL.h>
 #include <RequestServer/Forward.h>
 
@@ -18,7 +19,7 @@ public:
     virtual ~Protocol() = default;
 
     ByteString const& name() const { return m_name; }
-    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, const URL::URL&, HashMap<ByteString, ByteString> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) = 0;
+    virtual OwnPtr<Request> start_request(i32, ConnectionFromClient&, ByteString const& method, URL::URL const&, HTTP::HeaderMap const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) = 0;
 
     static Protocol* find_by_name(ByteString const&);
 

--- a/Userland/Services/RequestServer/Request.cpp
+++ b/Userland/Services/RequestServer/Request.cpp
@@ -21,9 +21,9 @@ void Request::stop()
     m_client.did_finish_request({}, *this, false);
 }
 
-void Request::set_response_headers(HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers)
+void Request::set_response_headers(HTTP::HeaderMap response_headers)
 {
-    m_response_headers = response_headers;
+    m_response_headers = move(response_headers);
     m_client.did_receive_headers({}, *this);
 }
 

--- a/Userland/Services/RequestServer/Request.h
+++ b/Userland/Services/RequestServer/Request.h
@@ -25,7 +25,7 @@ public:
     Optional<u32> status_code() const { return m_status_code; }
     Optional<u64> total_size() const { return m_total_size; }
     size_t downloaded_size() const { return m_downloaded_size; }
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const& response_headers() const { return m_response_headers; }
+    HTTP::HeaderMap const& response_headers() const { return m_response_headers; }
 
     void stop();
     virtual void set_certificate(ByteString, ByteString);
@@ -38,7 +38,7 @@ public:
     void did_progress(Optional<u64> total_size, u64 downloaded_size);
     void set_status_code(u32 status_code) { m_status_code = status_code; }
     void did_request_certificates();
-    void set_response_headers(HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> const&);
+    void set_response_headers(HTTP::HeaderMap);
     void set_downloaded_size(size_t size) { m_downloaded_size = size; }
     Core::File const& output_stream() const { return *m_output_stream; }
 
@@ -53,7 +53,7 @@ private:
     Optional<u64> m_total_size {};
     size_t m_downloaded_size { 0 };
     NonnullOwnPtr<Core::File> m_output_stream;
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_response_headers;
+    HTTP::HeaderMap m_response_headers;
 };
 
 }

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -1,3 +1,4 @@
+#include <LibHTTP/HeaderMap.h>
 #include <LibURL/URL.h>
 
 endpoint RequestClient
@@ -5,7 +6,7 @@ endpoint RequestClient
     request_started(i32 request_id, IPC::File fd) =|
     request_progress(i32 request_id, Optional<u64> total_size, u64 downloaded_size) =|
     request_finished(i32 request_id, bool success, u64 total_size) =|
-    headers_became_available(i32 request_id, HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> response_headers, Optional<u32> status_code) =|
+    headers_became_available(i32 request_id, HTTP::HeaderMap response_headers, Optional<u32> status_code) =|
 
     // Websocket API
     // FIXME: See if this can be merged with the regular APIs

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -1,3 +1,4 @@
+#include <LibHTTP/HeaderMap.h>
 #include <LibURL/URL.h>
 #include <RequestServer/ConnectionCache.h>
 
@@ -8,7 +9,7 @@ endpoint RequestServer
     // Test if a specific protocol is supported, e.g "http"
     is_supported_protocol(ByteString protocol) => (bool supported)
 
-    start_request(i32 request_id, ByteString method, URL::URL url, HashMap<ByteString, ByteString> request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) =|
+    start_request(i32 request_id, ByteString method, URL::URL url, HTTP::HeaderMap request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) =|
     stop_request(i32 request_id) => (bool success)
     set_certificate(i32 request_id, ByteString certificate, ByteString key) => (bool success)
 

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -39,7 +39,7 @@ private:
     void die();
     void log_response(unsigned code, HTTP::HttpRequest const&);
     ErrorOr<void> handle_directory_listing(String const& requested_path, String const& real_path, HTTP::HttpRequest const&);
-    bool verify_credentials(Vector<HTTP::HttpRequest::Header> const&);
+    bool verify_credentials(Vector<HTTP::Header> const&);
 
     NonnullOwnPtr<Core::BufferedTCPSocket> m_socket;
     StringBuilder m_remaining_request;

--- a/Userland/Utilities/pkg/AvailablePort.cpp
+++ b/Userland/Utilities/pkg/AvailablePort.cpp
@@ -96,7 +96,7 @@ ErrorOr<int> AvailablePort::update_available_ports_list_file()
     }
     RefPtr<Protocol::Request> request;
     auto protocol_client = TRY(Protocol::RequestClient::try_create());
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> request_headers;
+    HTTP::HeaderMap request_headers;
     Core::ProxyData proxy_data {};
 
     auto output_stream = TRY(Core::File::open("/usr/Ports/AvailablePorts.md"sv, Core::File::OpenMode::ReadWrite, 0644));

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -156,7 +156,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView proxy_spec;
     ByteString method = "GET";
     StringView method_override;
-    HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> request_headers;
+    HTTP::HeaderMap request_headers;
     String credentials;
 
     Core::ArgsParser args_parser;
@@ -298,8 +298,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (verbose_output && is_http_url) {
             warnln("* Setting up request");
             warnln("> Method={}, URL={}", method, url);
-            for (auto const& header : request_headers) {
-                warnln("> {}: {}", header.key, header.value);
+            for (auto const& header : request_headers.headers()) {
+                warnln("> {}: {}", header.name, header.value);
             }
         }
 

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -317,8 +317,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     ? HTTP::HttpResponse::reason_phrase_for_code(value)
                     : "UNKNOWN"sv;
                 warnln("< Code={}, Reason={}", value, reason_phrase);
-                for (auto const& header : response_headers) {
-                    warnln("< {}: {}", header.key, header.value);
+                for (auto const& header : response_headers.headers()) {
+                    warnln("< {}: {}", header.name, header.value);
                 }
             }
 


### PR DESCRIPTION
Commits cherry picked from: https://github.com/LadybirdBrowser/ladybird/pull/116 and https://github.com/LadybirdBrowser/ladybird/pull/119