### PR TITLE
LibWeb: Add support for text in the `AffineCommandExecutorCPU`

### DIFF
--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -85,7 +85,18 @@ RefPtr<Gfx::Bitmap> ScaledFont::rasterize_glyph(u32 glyph_id, GlyphSubpixelOffse
 
 bool ScaledFont::append_glyph_path_to(Gfx::Path& path, u32 glyph_id) const
 {
-    return m_font->append_glyph_path_to(path, glyph_id, m_x_scale, m_y_scale);
+    auto glyph_iterator = m_glyph_cache.find(glyph_id);
+    if (glyph_iterator != m_glyph_cache.end()) {
+        path.append_path(glyph_iterator->value, Path::AppendRelativeToLastPoint::Yes);
+        return true;
+    }
+    Gfx::Path glyph_path;
+    bool success = m_font->append_glyph_path_to(glyph_path, glyph_id, m_x_scale, m_y_scale);
+    if (success) {
+        path.append_path(glyph_path, Path::AppendRelativeToLastPoint::Yes);
+        m_glyph_cache.set(glyph_id, move(glyph_path));
+    }
+    return success;
 }
 
 Gfx::Glyph ScaledFont::glyph(u32 code_point) const

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -80,6 +80,8 @@ private:
     float m_y_scale { 0.0f };
     float m_point_width { 0.0f };
     float m_point_height { 0.0f };
+
+    mutable HashMap<u32, Gfx::Path> m_glyph_cache;
     mutable HashMap<GlyphIndexWithSubpixelOffset, RefPtr<Gfx::Bitmap>> m_cached_glyph_bitmaps;
     Gfx::FontPixelMetrics m_pixel_metrics;
 

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -417,6 +417,19 @@ Path Path::copy_transformed(Gfx::AffineTransform const& transform) const
     return result;
 }
 
+void Path::append_path(Path const& path, AppendRelativeToLastPoint relative_to_last_point)
+{
+    auto previous_last_point = last_point();
+    auto new_points_start = m_points.size();
+    m_commands.extend(path.m_commands);
+    m_points.extend(path.m_points);
+    if (relative_to_last_point == AppendRelativeToLastPoint::Yes) {
+        for (size_t i = new_points_start; i < m_points.size(); i++)
+            m_points[i] += previous_last_point;
+    }
+    invalidate_split_lines();
+}
+
 template<typename T>
 struct RoundTrip {
     RoundTrip(ReadonlySpan<T> span)

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -417,6 +417,12 @@ Path Path::copy_transformed(Gfx::AffineTransform const& transform) const
     return result;
 }
 
+void Path::transform(AffineTransform const& transform)
+{
+    for (auto& point : m_points)
+        point = transform.map(point);
+}
+
 void Path::append_path(Path const& path, AppendRelativeToLastPoint relative_to_last_point)
 {
     auto previous_last_point = last_point();

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -212,6 +212,8 @@ public:
 
     Path copy_transformed(AffineTransform const&) const;
 
+    void transform(AffineTransform const&);
+
     ReadonlySpan<FloatLine> split_lines() const
     {
         if (!m_split_lines.has_value()) {

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -227,12 +227,12 @@ public:
         return m_split_lines->bounding_box;
     }
 
-    void append_path(Path const& path)
-    {
-        m_commands.extend(path.m_commands);
-        m_points.extend(path.m_points);
-        invalidate_split_lines();
-    }
+    enum class AppendRelativeToLastPoint {
+        Yes,
+        No
+    };
+
+    void append_path(Path const& path, AppendRelativeToLastPoint = AppendRelativeToLastPoint::No);
 
     ByteString to_byte_string() const;
 


### PR DESCRIPTION
**Demo:**
![image](https://github.com/SerenityOS/serenity/assets/11597044/5acfa713-eb5a-44ac-bff1-bdee88ce231c)

https://github.com/SerenityOS/serenity/assets/11597044/83662807-688b-4ce7-bc89-5ec0910ebd7c


