### PR TITLE
LibWeb: Implement and wire up TransformStream's cancel callback

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-can-cancel.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-can-cancel.txt
@@ -1,0 +1,1 @@
+ReadableStream cancelled due to: Test cancellation

--- a/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-readable-side.txt
+++ b/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-readable-side.txt
@@ -1,0 +1,1 @@
+TransformStream cancelled due to: cancel called by the readable side.

--- a/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-writable-side.txt
+++ b/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-writable-side.txt
@@ -1,0 +1,1 @@
+TransformStream cancelled due to: abort called by the writable side.

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-can-cancel.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-can-cancel.html
@@ -1,0 +1,17 @@
+<script src="../include.js"></script>
+<script>
+    function testReadableStreamCancellation() {
+        const readableStream = new ReadableStream({
+            cancel(reason) {
+                println(`ReadableStream cancelled due to: ${reason}`);
+                return Promise.resolve();
+            }
+        });
+
+        readableStream.cancel('Test cancellation');
+    }
+
+    test(() => {
+        testReadableStreamCancellation();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-readable-side.html
+++ b/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-readable-side.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    function testTransformStreamReadableStreamCancellation() {
+        const transformStream = new TransformStream({
+            cancel(reason) {
+                println(`TransformStream cancelled due to: ${reason}`);
+                return Promise.resolve();
+            }
+        });
+        transformStream.readable.cancel('cancel called by the readable side.');
+    }
+
+    test(() => {
+        testTransformStreamReadableStreamCancellation();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-writable-side.html
+++ b/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-writable-side.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    function testTransformStreamReadableStreamCancellation() {
+        const transformStream = new TransformStream({
+            cancel(reason) {
+                println(`TransformStream cancelled due to: ${reason}`);
+                return Promise.resolve();
+            }
+        });
+        transformStream.writable.abort('abort called by the writable side.');
+    }
+
+    test(() => {
+        testTransformStreamReadableStreamCancellation();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -5174,6 +5174,14 @@ void transform_stream_set_up(TransformStream& stream, JS::NonnullGCPtr<Transform
     set_up_transform_stream_default_controller(stream, controller, transform_algorithm_wrapper, flush_algorithm_wrapper);
 }
 
+// https://streams.spec.whatwg.org/#transform-stream-unblock-write
+void transform_stream_unblock_write(TransformStream& stream)
+{
+    // 1. If stream.[[backpressure]] is true, perform ! TransformStreamSetBackpressure(stream, false).
+    if (stream.backpressure().has_value() && stream.backpressure().value())
+        transform_stream_set_backpressure(stream, false);
+}
+
 // https://streams.spec.whatwg.org/#is-non-negative-number
 bool is_non_negative_number(JS::Value value)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -4741,12 +4741,9 @@ void initialize_transform_stream(TransformStream& stream, JS::NonnullGCPtr<JS::P
     });
 
     // 7. Let cancelAlgorithm be the following steps, taking a reason argument:
-    auto cancel_algorithm = JS::create_heap_function(realm.heap(), [&stream, &realm](JS::Value reason) {
-        // 1. Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, reason).
-        transform_stream_error_writable_and_unblock_write(stream, reason);
-
-        // 2. Return a promise resolved with undefined.
-        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    auto cancel_algorithm = JS::create_heap_function(realm.heap(), [&stream](JS::Value reason) {
+        // 1. Return ! TransformStreamDefaultSourceCancelAlgorithm(stream, reason).
+        return transform_stream_default_source_cancel_algorithm(stream, reason);
     });
 
     // 8. Set stream.[[readable]] to ! CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, readableHighWaterMark, readableSizeAlgorithm).

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -168,7 +168,7 @@ void writable_stream_default_controller_process_write(WritableStreamDefaultContr
 void writable_stream_default_controller_write(WritableStreamDefaultController&, JS::Value chunk, JS::Value chunk_size);
 
 void initialize_transform_stream(TransformStream&, JS::NonnullGCPtr<JS::PromiseCapability> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm);
-void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, JS::NonnullGCPtr<TransformAlgorithm>, JS::NonnullGCPtr<FlushAlgorithm>);
+void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, JS::NonnullGCPtr<TransformAlgorithm>, JS::NonnullGCPtr<FlushAlgorithm>, JS::NonnullGCPtr<CancelAlgorithm>);
 void set_up_transform_stream_default_controller_from_transformer(TransformStream&, JS::Value transformer, Transformer&);
 void transform_stream_default_controller_clear_algorithms(TransformStreamDefaultController&);
 WebIDL::ExceptionOr<void> transform_stream_default_controller_enqueue(TransformStreamDefaultController&, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -179,6 +179,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_abort_algorithm(
 JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_close_algorithm(TransformStream&);
 JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_write_algorithm(TransformStream&, JS::Value chunk);
 JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_pull_algorithm(TransformStream&);
+JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_cancel_algorithm(TransformStream&, JS::Value reason);
 void transform_stream_error(TransformStream&, JS::Value error);
 void transform_stream_error_writable_and_unblock_write(TransformStream&, JS::Value error);
 void transform_stream_set_backpressure(TransformStream&, bool backpressure);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -183,6 +183,7 @@ void transform_stream_error(TransformStream&, JS::Value error);
 void transform_stream_error_writable_and_unblock_write(TransformStream&, JS::Value error);
 void transform_stream_set_backpressure(TransformStream&, bool backpressure);
 void transform_stream_set_up(TransformStream&, JS::NonnullGCPtr<TransformAlgorithm>, JS::GCPtr<FlushAlgorithm> = {}, JS::GCPtr<CancelAlgorithm> = {});
+void transform_stream_unblock_write(TransformStream&);
 
 bool is_non_negative_number(JS::Value);
 bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer);

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2023-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,6 +30,8 @@ void TransformStreamDefaultController::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_stream);
+    visitor.visit(m_cancel_algorithm);
+    visitor.visit(m_finish_promise);
     visitor.visit(m_flush_algorithm);
     visitor.visit(m_transform_algorithm);
 }

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.h
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2023-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +24,12 @@ public:
     void error(Optional<JS::Value> reason = {});
     void terminate();
 
+    JS::GCPtr<CancelAlgorithm> cancel_algorithm() { return m_cancel_algorithm; }
+    void set_cancel_algorithm(JS::GCPtr<CancelAlgorithm> value) { m_cancel_algorithm = value; }
+
+    JS::GCPtr<JS::PromiseCapability> finish_promise() { return m_finish_promise; }
+    void set_finish_promise(JS::GCPtr<JS::PromiseCapability> value) { m_finish_promise = value; }
+
     JS::GCPtr<FlushAlgorithm> flush_algorithm() { return m_flush_algorithm; }
     void set_flush_algorithm(JS::GCPtr<FlushAlgorithm>&& value) { m_flush_algorithm = move(value); }
 
@@ -37,6 +43,12 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
+
+    // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-cancelalgorithm
+    JS::GCPtr<CancelAlgorithm> m_cancel_algorithm;
+
+    // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-finishpromise
+    JS::GCPtr<JS::PromiseCapability> m_finish_promise;
 
     // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-flushalgorithm
     JS::GCPtr<FlushAlgorithm> m_flush_algorithm;

--- a/Userland/Libraries/LibWeb/Streams/Transformer.cpp
+++ b/Userland/Libraries/LibWeb/Streams/Transformer.cpp
@@ -22,6 +22,7 @@ JS::ThrowCompletionOr<Transformer> Transformer::from_value(JS::VM& vm, JS::Value
         .start = TRY(property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
         .transform = TRY(property_to_callback(vm, value, "transform", WebIDL::OperationReturnsPromise::Yes)),
         .flush = TRY(property_to_callback(vm, value, "flush", WebIDL::OperationReturnsPromise::Yes)),
+        .cancel = TRY(property_to_callback(vm, value, "cancel", WebIDL::OperationReturnsPromise::Yes)),
         .readable_type = {},
         .writable_type = {},
     };

--- a/Userland/Libraries/LibWeb/Streams/Transformer.h
+++ b/Userland/Libraries/LibWeb/Streams/Transformer.h
@@ -20,6 +20,8 @@ struct Transformer {
     JS::Handle<WebIDL::CallbackType> transform;
     // https://streams.spec.whatwg.org/#dom-transformer-flush
     JS::Handle<WebIDL::CallbackType> flush;
+    // https://streams.spec.whatwg.org/#dom-transformer-cancel
+    JS::Handle<WebIDL::CallbackType> cancel;
 
     // https://streams.spec.whatwg.org/#dom-transformer-readabletype
     Optional<JS::Value> readable_type;


### PR DESCRIPTION
This implements the cancel callback for TransformStream. The cancel callback is raised when the readable side of the TransformStream is cancelled, or the writable side is aborted.

Also added a test to prove a ReadableStream can be cancelled, noticed this behavior lacked a test.

Commits are cherry-picked from: https://github.com/LadybirdBrowser/ladybird/pull/95