### PR TITLE
LibWeb: Use viewport position for did_enter_tooltip_area

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -549,7 +549,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
     if (hovered_node_changed) {
         JS::GCPtr<HTML::HTMLElement const> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
         if (hovered_html_element && hovered_html_element->title().has_value()) {
-            page.client().page_did_enter_tooltip_area(m_navigable->active_document()->navigable()->to_top_level_position(position), hovered_html_element->title()->to_byte_string());
+            page.client().page_did_enter_tooltip_area(viewport_position, hovered_html_element->title()->to_byte_string());
         } else {
             page.client().page_did_leave_tooltip_area();
         }


### PR DESCRIPTION
This now matches the behavior of did_request_link_context_menu and friends. Previously the coordinates relative to the page rather than viewport were sent to the chrome.

(cherry picked from commit 990cf9b4e9476d15494a9538614762119d759b2d)

Depends on #24554