### PR TITLE
Kernel/Memory: Make mmap objects track dirty and clean pages

### DIFF
--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -48,6 +48,18 @@ size_t InodeVMObject::amount_dirty() const
     return count * PAGE_SIZE;
 }
 
+bool InodeVMObject::is_page_dirty(size_t page_index) const
+{
+    VERIFY(m_lock.is_locked());
+    return m_dirty_pages.get(page_index);
+}
+
+void InodeVMObject::set_page_dirty(size_t page_index, bool is_dirty)
+{
+    VERIFY(m_lock.is_locked());
+    m_dirty_pages.set(page_index, is_dirty);
+}
+
 int InodeVMObject::release_all_clean_pages()
 {
     return try_release_clean_pages(page_count());

--- a/Kernel/Memory/InodeVMObject.h
+++ b/Kernel/Memory/InodeVMObject.h
@@ -22,6 +22,9 @@ public:
     size_t amount_dirty() const;
     size_t amount_clean() const;
 
+    bool is_page_dirty(size_t page_index) const;
+    void set_page_dirty(size_t page_index, bool is_dirty);
+
     int release_all_clean_pages();
     int try_release_clean_pages(int page_amount);
 

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -185,6 +185,8 @@ public:
 
     [[nodiscard]] size_t cow_pages() const;
 
+    [[nodiscard]] bool should_dirty_on_write(size_t page_index) const;
+
     void set_readable(bool b)
     {
         set_access_bit(Access::Read, b);
@@ -243,8 +245,9 @@ private:
     }
 
     [[nodiscard]] PageFaultResponse handle_cow_fault(size_t page_index);
-    [[nodiscard]] PageFaultResponse handle_inode_fault(size_t page_index);
+    [[nodiscard]] PageFaultResponse handle_inode_fault(size_t page_index, bool mark_page_dirty = false);
     [[nodiscard]] PageFaultResponse handle_zero_fault(size_t page_index, PhysicalRAMPage& page_in_slot_at_time_of_fault);
+    [[nodiscard]] PageFaultResponse handle_dirty_on_write_fault(size_t page_index);
 
     [[nodiscard]] bool map_individual_page_impl(size_t page_index);
     [[nodiscard]] bool map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage>);

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -19,7 +19,8 @@ public:
     static ErrorOr<NonnullLockRefPtr<SharedInodeVMObject>> try_create_with_inode_and_range(Inode&, u64 offset, size_t range_size);
     virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override;
 
-    ErrorOr<void> sync(off_t offset_in_pages = 0, size_t pages = -1);
+    ErrorOr<void> sync(off_t offset_in_pages, size_t pages);
+    ErrorOr<void> sync_before_destroying();
 
 private:
     virtual bool is_shared_inode() const override { return true; }
@@ -30,6 +31,8 @@ private:
     virtual StringView class_name() const override { return "SharedInodeVMObject"sv; }
 
     SharedInodeVMObject& operator=(SharedInodeVMObject const&) = delete;
+
+    ErrorOr<void> sync_impl(off_t offset_in_pages, size_t pages, bool should_remap);
 };
 
 }

--- a/Tests/Kernel/TestEmptyPrivateInodeVMObject.cpp
+++ b/Tests/Kernel/TestEmptyPrivateInodeVMObject.cpp
@@ -11,12 +11,13 @@
 #include <sys/mman.h>
 
 static u8* private_ptr = nullptr;
+size_t const mmap_len = 0x1000;
 
 static void private_zero_length_inode_vmobject_sync_signal_handler(int)
 {
-    auto rc = msync(private_ptr, 0x1000, MS_ASYNC);
+    auto rc = msync(private_ptr, mmap_len, MS_ASYNC);
     EXPECT(rc == 0);
-    rc = munmap(private_ptr, 0x1000);
+    rc = munmap(private_ptr, mmap_len);
     EXPECT(rc == 0);
     exit(0);
 }
@@ -32,7 +33,7 @@ TEST_CASE(private_zero_length_inode_vmobject_sync)
     }
     int fd = open("/tmp/private_msync_test", O_RDWR | O_CREAT, 0644);
     VERIFY(fd >= 0);
-    private_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    private_ptr = (u8*)mmap(nullptr, mmap_len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
     EXPECT(private_ptr != MAP_FAILED);
     private_ptr[0] = 0x1;
     VERIFY_NOT_REACHED();

--- a/Tests/Kernel/TestEmptySharedInodeVMObject.cpp
+++ b/Tests/Kernel/TestEmptySharedInodeVMObject.cpp
@@ -11,12 +11,13 @@
 #include <sys/mman.h>
 
 static u8* shared_ptr = nullptr;
+size_t const mmap_len = 0x1000;
 
 static void shared_zero_length_inode_vmobject_sync_signal_handler(int)
 {
-    auto rc = msync(shared_ptr, 0x1000, MS_ASYNC);
+    auto rc = msync(shared_ptr, mmap_len, MS_ASYNC);
     EXPECT(rc == 0);
-    rc = munmap(shared_ptr, 0x1000);
+    rc = munmap(shared_ptr, mmap_len);
     EXPECT(rc == 0);
     exit(0);
 }
@@ -32,7 +33,7 @@ TEST_CASE(shared_zero_length_inode_vmobject_sync)
     }
     int fd = open("/tmp/shared_msync_test", O_RDWR | O_CREAT, 0644);
     VERIFY(fd >= 0);
-    shared_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    shared_ptr = (u8*)mmap(nullptr, mmap_len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     EXPECT(shared_ptr != MAP_FAILED);
     shared_ptr[0] = 0x1;
     VERIFY_NOT_REACHED();

--- a/Tests/Kernel/TestPrivateInodeVMObject.cpp
+++ b/Tests/Kernel/TestPrivateInodeVMObject.cpp
@@ -15,12 +15,13 @@
 #include <unistd.h>
 
 static u8* private_ptr = nullptr;
+size_t const buf_len = 0x1000;
 
 static void private_non_empty_inode_vmobject_sync_signal_handler(int)
 {
-    auto rc = msync(private_ptr, 0x1000, MS_ASYNC);
+    auto rc = msync(private_ptr, buf_len, MS_ASYNC);
     EXPECT(rc == 0);
-    rc = munmap(private_ptr, 0x1000);
+    rc = munmap(private_ptr, buf_len);
     EXPECT(rc == 0);
     exit(0);
 }
@@ -34,16 +35,31 @@ TEST_CASE(private_non_empty_inode_vmobject_sync)
         int rc = sigaction(SIGBUS, &new_action, nullptr);
         VERIFY(rc == 0);
     }
-    u8 buf[0x1000];
+    int mmap_len = buf_len * 2;
+    u8 buf[buf_len];
     memset(buf, 0, sizeof(buf));
     int fd = open("/tmp/private_non_empty_msync_test", O_RDWR | O_CREAT, 0644);
     VERIFY(fd >= 0);
     auto rc = write(fd, buf, sizeof(buf));
     VERIFY(rc == sizeof(buf));
-    private_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    private_ptr = (u8*)mmap(nullptr, mmap_len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
     EXPECT(private_ptr != MAP_FAILED);
-    rc = msync(private_ptr, 0x2000, MS_ASYNC);
+
+    // test that writes to the private mmap are not visible to read()
+    u8 old_val = private_ptr[0];
+    private_ptr[0] = old_val + 1;
+    rc = msync(private_ptr, mmap_len, MS_SYNC);
+    VERIFY(rc == 0);
+    rc = lseek(fd, 0, SEEK_SET);
+    VERIFY(rc == 0);
+    u8 read_byte = 0;
+    rc = read(fd, &read_byte, 1);
+    VERIFY(rc == 1);
+    EXPECT(read_byte == old_val);
+
+    // test that writes between the file length (buf_len) and mmap_len cause a SIGBUS
+    rc = msync(private_ptr, mmap_len, MS_ASYNC);
     EXPECT(rc == 0);
-    private_ptr[0x1001] = 0x1;
+    private_ptr[buf_len + 1] = 0x1;
     VERIFY_NOT_REACHED();
 }

--- a/Tests/Kernel/TestSharedInodeVMObject.cpp
+++ b/Tests/Kernel/TestSharedInodeVMObject.cpp
@@ -14,13 +14,20 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-static u8* shared_ptr = nullptr;
+static u8* first_mmap = nullptr;
+static u8* second_mmap = nullptr;
+size_t const buf_len = 0x1000;
 
 static void shared_non_empty_inode_vmobject_sync_signal_handler(int)
 {
-    auto rc = msync(shared_ptr, 0x1000, MS_ASYNC);
+    auto rc = msync(first_mmap, buf_len, MS_ASYNC);
     EXPECT(rc == 0);
-    rc = munmap(shared_ptr, 0x1000);
+    rc = munmap(first_mmap, buf_len);
+    EXPECT(rc == 0);
+
+    rc = msync(second_mmap, buf_len, MS_ASYNC);
+    EXPECT(rc == 0);
+    rc = munmap(second_mmap, buf_len);
     EXPECT(rc == 0);
     exit(0);
 }
@@ -34,16 +41,52 @@ TEST_CASE(shared_non_empty_inode_vmobject_sync)
         int rc = sigaction(SIGBUS, &new_action, nullptr);
         VERIFY(rc == 0);
     }
-    u8 buf[0x1000];
+    size_t mmap_len = buf_len * 2;
+    u8 buf[buf_len];
     memset(buf, 0, sizeof(buf));
     int fd = open("/tmp/shared_non_empty_msync_test", O_RDWR | O_CREAT, 0644);
     VERIFY(fd >= 0);
     auto rc = write(fd, buf, sizeof(buf));
     VERIFY(rc == sizeof(buf));
-    shared_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    EXPECT(shared_ptr != MAP_FAILED);
-    rc = msync(shared_ptr, 0x2000, MS_ASYNC);
+    first_mmap = (u8*)mmap(nullptr, mmap_len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    EXPECT(first_mmap != MAP_FAILED);
+
+    second_mmap = (u8*)mmap(nullptr, mmap_len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    EXPECT(second_mmap != MAP_FAILED);
+
+    // test that changes to one shared mmap are visible in the other shared mmap
+    u8 new_val = first_mmap[0] + 1;
+    first_mmap[0] = new_val;
+    EXPECT(second_mmap[0] == new_val);
+    new_val = second_mmap[1] + 1;
+    second_mmap[1] = new_val;
+    EXPECT(first_mmap[1] == new_val);
+
+    // test that changes in the shared mmap are visible to read()
+    new_val = first_mmap[0] + 1;
+    first_mmap[0] = new_val;
+    rc = msync(first_mmap, mmap_len, MS_SYNC);
+    VERIFY(rc == 0);
+    rc = lseek(fd, 0, SEEK_SET);
+    VERIFY(rc == 0);
+    u8 read_byte = 0;
+    rc = read(fd, &read_byte, 1);
+    VERIFY(rc == 1);
+    EXPECT(read_byte == new_val);
+
+    // test that changes made by write() are visible in shared mmaps
+    rc = lseek(fd, 0, SEEK_SET);
+    VERIFY(rc == 0);
+    new_val = first_mmap[0] + 1;
+    rc = write(fd, &new_val, 1);
+    VERIFY(rc == 1);
+    EXPECT(first_mmap[0] == new_val && second_mmap[0] == new_val);
+
+    // test that writes between the file length (buf_len) and mmap_len cause a SIGBUS
+    rc = msync(first_mmap, mmap_len, MS_ASYNC);
     EXPECT(rc == 0);
-    shared_ptr[0x1001] = 0x1;
+    rc = msync(second_mmap, mmap_len, MS_ASYNC);
+    EXPECT(rc == 0);
+    first_mmap[buf_len + 1] = 0x1;
     VERIFY_NOT_REACHED();
 }


### PR DESCRIPTION
This PR fixes this issue https://github.com/SerenityOS/serenity/issues/15951

* Pages of file mmap regions with no writes to them are marked as clean
* Writing to a clean page will mark the page as dirty
* When msync() is called:
    * Only dirty pages are flushed to storage
    * The flushed pages are now synced with storage, so they are marked clean and remapped
    * NOTE: This only applies to SharedInodeVMObjects
* When purge() is called, only clean pages are evicted from memory

This PR also adds a few more test cases for private and shared file mmaps