### PR TITLE
SystemMonitor: Add pause and refresh actions

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -471,6 +471,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(make_frequency_action(5));
 
     auto view_menu = window->add_menu("&View"_string);
+    auto refresh_action = GUI::Action::create("&Refresh", { Mod_Ctrl, Key_R }, Key_F5, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"sv)), [&refresh_timer, &update_stats](auto&) {
+        if (refresh_timer.is_active())
+            refresh_timer.restart();
+        update_stats();
+    });
+    view_menu->add_action(*refresh_action);
+    view_menu->add_separator();
     view_menu->add_action(GUI::CommonActions::make_fullscreen_action([&](auto&) {
         window->set_fullscreen(!window->is_fullscreen());
     }));


### PR DESCRIPTION
Revives #22745.

I changed things slightly - when pausing the window title will include the "Paused" word and when selecting a refresh frequency again, it will disappear :)

cc @tcl3 as this is your patches and I'd want to see if you think we should change them somehow :)