### PR TITLE
Calculator: Add c constant

### DIFF
--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -79,7 +79,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     constants_menu->add_action(GUI::Action::create("&Phi", TRY(Gfx::Bitmap::load_from_file("/res/icons/calculator/phi.png"sv)), [&](auto&) {
         widget->set_typed_entry(Crypto::BigFraction { Crypto::SignedBigInteger(16180339887), power });
     }));
-
+    constants_menu->add_action(GUI::Action::create("&C", TRY(Gfx::Bitmap::load_from_file("/res/icons/calculator/c.png"sv)), [&](auto&) {
+        widget->set_typed_entry(Crypto::BigFraction { Crypto::SignedBigInteger(2997924580000000000), power });
+    }));
     auto round_menu = window->add_menu("&Round"_string);
     GUI::ActionGroup preview_actions;
 


### PR DESCRIPTION
I have added the "c" constant to the calculator
This is the speed of light in a vacuum, 299,792,458 metres/second. 
I Figured it would be an interesting thing to have added.

I also have created a quick and dirty c icon, that should be replaced.
It should be considered a placeholder for now.