### PR TITLE
Fuzzers: Use libc++ on OSS-Fuzz for Lagom code generators

### DIFF
--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -47,7 +47,10 @@ unset CXXFLAGS
 export AFL_NOOPT=1
 
 if [ "$#" -gt "0" ] && [ "--oss-fuzz" = "$1" ] ; then
-    CXXFLAGS="$CXXFLAGS -DOSS_FUZZ=ON"
+    # The oss-fuzz runner image (as of June 2024) has libstdc++ 9, which lacks the
+    # <coroutine> header. Use the more modern libc++ shipped with oss-fuzz's Clang.
+    # It's already set in CXXFLAGS_SAVE.
+    CXXFLAGS="$CXXFLAGS -DOSS_FUZZ=ON -stdlib=libc++"
 fi
 
 # FIXME: Replace these CMake invocations with a CMake superbuild?


### PR DESCRIPTION
By unsetting `CXXFLAGS` in order to build Lagom code generators without
instrumentation, we were also removing `-stdlib=libc++`, so Clang ended
up using the runner image's libstdc++ 9 headers. These are too old, and
don't contain `<coroutine>`, leading to a build failure.

Fixes #24578
