### PR TITLE
Everywhere: Build fixes from clang trunk (and make LibProtocol exit fatally on disappearing connection)

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -88,7 +88,7 @@ public:
     template<typename TUnaryPredicate>
     bool remove_all_matching(TUnaryPredicate const& predicate)
     {
-        return m_table.template remove_all_matching([&](auto& entry) {
+        return m_table.remove_all_matching([&](auto& entry) {
             return predicate(entry.key, entry.value);
         });
     }

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -450,7 +450,7 @@ public:
     decltype(auto) downcast() const&
     {
         if constexpr (sizeof...(NewTs) == 1 && (IsSpecializationOf<NewTs, Variant> && ...)) {
-            return (*this).template downcast_variant(TypeWrapper<NewTs...> {});
+            return (*this).downcast_variant(TypeWrapper<NewTs...> {});
         } else {
             Variant<NewTs...> instance { Variant<NewTs...>::invalid_index, Detail::VariantConstructTag {} };
             visit([&](auto const& value) {

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -16,6 +16,8 @@ NetworkJob::NetworkJob(Core::File& output_stream)
 {
 }
 
+NetworkJob::~NetworkJob() = default;
+
 void NetworkJob::did_finish(NonnullRefPtr<NetworkResponse>&& response)
 {
     if (is_cancelled())

--- a/Userland/Libraries/LibCore/NetworkJob.h
+++ b/Userland/Libraries/LibCore/NetworkJob.h
@@ -26,7 +26,7 @@ public:
         ProtocolFailed,
         Cancelled,
     };
-    virtual ~NetworkJob() override = default;
+    virtual ~NetworkJob() override;
 
     // Could fire twice, after Headers and after Trailers!
     Function<void(HTTP::HeaderMap const& response_headers, Optional<u32> response_code)> on_headers_received;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -2627,6 +2627,8 @@ JBIG2ImageDecoderPlugin::JBIG2ImageDecoderPlugin()
     m_context = make<JBIG2LoadingContext>();
 }
 
+JBIG2ImageDecoderPlugin::~JBIG2ImageDecoderPlugin() = default;
+
 IntSize JBIG2ImageDecoderPlugin::size()
 {
     return m_context->page.size;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.h
@@ -19,7 +19,7 @@ public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
-    virtual ~JBIG2ImageDecoderPlugin() override = default;
+    virtual ~JBIG2ImageDecoderPlugin() override;
 
     virtual IntSize size() override;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -988,6 +988,8 @@ JPEG2000ImageDecoderPlugin::JPEG2000ImageDecoderPlugin()
     m_context = make<JPEG2000LoadingContext>();
 }
 
+JPEG2000ImageDecoderPlugin::~JPEG2000ImageDecoderPlugin() = default;
+
 IntSize JPEG2000ImageDecoderPlugin::size()
 {
     return m_context->size;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.h
@@ -37,7 +37,7 @@ public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
-    virtual ~JPEG2000ImageDecoderPlugin() override = default;
+    virtual ~JPEG2000ImageDecoderPlugin() override;
 
     virtual IntSize size() override;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -748,6 +748,8 @@ TIFFImageDecoderPlugin::TIFFImageDecoderPlugin(NonnullOwnPtr<FixedMemoryStream> 
     m_context = make<TIFF::TIFFLoadingContext>(move(stream));
 }
 
+TIFFImageDecoderPlugin::~TIFFImageDecoderPlugin() = default;
+
 bool TIFFImageDecoderPlugin::sniff(ReadonlyBytes bytes)
 {
     if (bytes.size() < 4)

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
@@ -38,7 +38,7 @@ public:
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ExifMetadata>> read_exif_metadata(ReadonlyBytes);
 
-    virtual ~TIFFImageDecoderPlugin() override = default;
+    virtual ~TIFFImageDecoderPlugin() override;
 
     virtual IntSize size() override;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -550,6 +550,8 @@ TinyVGImageDecoderPlugin::TinyVGImageDecoderPlugin(ReadonlyBytes bytes)
 {
 }
 
+TinyVGImageDecoderPlugin::~TinyVGImageDecoderPlugin() = default;
+
 ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> TinyVGImageDecoderPlugin::create(ReadonlyBytes bytes)
 {
     auto plugin = TRY(adopt_nonnull_own_or_enomem(new (nothrow) TinyVGImageDecoderPlugin(bytes)));

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -86,7 +86,7 @@ public:
     virtual NaturalFrameFormat natural_frame_format() const override { return NaturalFrameFormat::Vector; }
     virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) override;
 
-    virtual ~TinyVGImageDecoderPlugin() override = default;
+    virtual ~TinyVGImageDecoderPlugin() override;
 
 private:
     TinyVGImageDecoderPlugin(ReadonlyBytes);

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -132,7 +132,7 @@ ErrorOr<T> decode(Decoder& decoder)
 
     for (size_t i = 0; i < size; ++i) {
         auto value = TRY(decoder.decode<typename T::ValueType>());
-        vector.template unchecked_append(move(value));
+        vector.unchecked_append(move(value));
     }
 
     return vector;

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -24,6 +24,8 @@ CyclicModule::CyclicModule(Realm& realm, StringView filename, bool has_top_level
 {
 }
 
+CyclicModule::~CyclicModule() = default;
+
 void CyclicModule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -29,6 +29,8 @@ class CyclicModule : public Module {
     JS_DECLARE_ALLOCATOR(CyclicModule);
 
 public:
+    virtual ~CyclicModule() override;
+
     // Note: Do not call these methods directly unless you are HostResolveImportedModule.
     //       Badges cannot be used because other hosts must be able to call this (and it is called recursively)
     virtual ThrowCompletionOr<void> link(VM& vm) override final;

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -34,6 +34,8 @@ AsyncGenerator::AsyncGenerator(Realm&, Object& prototype, NonnullOwnPtr<Executio
 {
 }
 
+AsyncGenerator::~AsyncGenerator() = default;
+
 void AsyncGenerator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -31,7 +31,7 @@ public:
 
     static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>);
 
-    virtual ~AsyncGenerator() override = default;
+    virtual ~AsyncGenerator() override;
 
     void async_generator_enqueue(Completion, NonnullGCPtr<PromiseCapability>);
     ThrowCompletionOr<void> resume(VM&, Completion completion);

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -116,6 +116,8 @@ SourceTextModule::SourceTextModule(Realm& realm, StringView filename, Script::Ho
 {
 }
 
+SourceTextModule::~SourceTextModule() = default;
+
 void SourceTextModule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/SourceTextModule.h
+++ b/Userland/Libraries/LibJS/SourceTextModule.h
@@ -19,6 +19,8 @@ class SourceTextModule final : public CyclicModule {
     JS_DECLARE_ALLOCATOR(SourceTextModule);
 
 public:
+    virtual ~SourceTextModule() override;
+
     static Result<NonnullGCPtr<SourceTextModule>, Vector<ParserError>> parse(StringView source_text, Realm&, StringView filename = {}, Script::HostDefined* host_defined = nullptr);
 
     Program const& parse_node() const { return *m_ecmascript_code; }

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -14,6 +14,13 @@ RequestClient::RequestClient(NonnullOwnPtr<Core::LocalSocket> socket)
 {
 }
 
+void RequestClient::die()
+{
+    // FIXME: Gracefully handle this, or relaunch and reconnect to RequestServer.
+    warnln("\033[31;1mLost connection to RequestServer\033[0m");
+    VERIFY_NOT_REACHED();
+}
+
 void RequestClient::ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel cache_level)
 {
     async_ensure_connection(url, cache_level);

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -14,6 +14,8 @@ RequestClient::RequestClient(NonnullOwnPtr<Core::LocalSocket> socket)
 {
 }
 
+RequestClient::~RequestClient() = default;
+
 void RequestClient::die()
 {
     // FIXME: Gracefully handle this, or relaunch and reconnect to RequestServer.

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -36,6 +36,8 @@ public:
     bool set_certificate(Badge<Request>, Request&, ByteString, ByteString);
 
 private:
+    virtual void die() override;
+
     virtual void request_started(i32, IPC::File const&) override;
     virtual void request_progress(i32, Optional<u64> const&, u64) override;
     virtual void request_finished(i32, bool, u64) override;

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -25,6 +25,7 @@ class RequestClient final
 
 public:
     explicit RequestClient(NonnullOwnPtr<Core::LocalSocket>);
+    virtual ~RequestClient() override;
 
     RefPtr<Request> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});
 

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -326,7 +326,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             matches.resize(m_pattern->parser_result.capture_groups_count + 1);
         if (!input.regex_options.has_flag_set(AllFlags::SkipTrimEmptyMatches)) {
             for (auto& matches : result.capture_group_matches)
-                matches.template remove_all_matching([](auto& match) { return match.view.is_null(); });
+                matches.remove_all_matching([](auto& match) { return match.view.is_null(); });
         }
     } else {
         result.capture_group_matches.clear_with_capacity();

--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -198,6 +198,8 @@ FontFace::FontFace(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::Promise> font_stat
         m_status = Bindings::FontFaceLoadStatus::Error;
 }
 
+FontFace::~FontFace() = default;
+
 void FontFace::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -35,7 +35,7 @@ public:
     using FontFaceSource = Variant<String, JS::Handle<WebIDL::BufferSource>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<FontFace> construct_impl(JS::Realm&, String family, FontFaceSource source, FontFaceDescriptors const& descriptors);
-    virtual ~FontFace() override = default;
+    virtual ~FontFace() override;
 
     String family() const { return m_family; }
     WebIDL::ExceptionOr<void> set_family(String const&);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -26,6 +26,8 @@ ImageStyleValue::ImageStyleValue(URL::URL const& url)
 {
 }
 
+ImageStyleValue::~ImageStyleValue() = default;
+
 void ImageStyleValue::load_any_resources(DOM::Document& document)
 {
     if (m_image_request)

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -26,7 +26,7 @@ public:
     {
         return adopt_ref(*new (nothrow) ImageStyleValue(url));
     }
-    virtual ~ImageStyleValue() override = default;
+    virtual ~ImageStyleValue() override;
 
     void visit_edges(JS::Cell::Visitor& visitor) const
     {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -555,7 +555,7 @@ public:
     template<typename Callback>
     void for_each_child(Callback callback) const
     {
-        return const_cast<Node*>(this)->template for_each_child(move(callback));
+        return const_cast<Node*>(this)->for_each_child(move(callback));
     }
 
     template<typename Callback>

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -219,7 +219,7 @@ public:
     template<typename Callback>
     void for_each_child(Callback callback) const
     {
-        return const_cast<TreeNode*>(this)->template for_each_child(move(callback));
+        return const_cast<TreeNode*>(this)->for_each_child(move(callback));
     }
 
     template<typename Callback>

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -62,6 +62,8 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> sock
     async_notify_process_information({ ::getpid() });
 }
 
+ConnectionFromClient::~ConnectionFromClient() = default;
+
 void ConnectionFromClient::die()
 {
     Web::Platform::EventLoopPlugin::the().quit();

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -32,7 +32,7 @@ class ConnectionFromClient final
     C_OBJECT(ConnectionFromClient);
 
 public:
-    ~ConnectionFromClient() override = default;
+    ~ConnectionFromClient() override;
 
     virtual void die() override;
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -75,6 +75,8 @@ PageClient::PageClient(PageHost& owner, u64 id)
 #endif
 }
 
+PageClient::~PageClient() = default;
+
 void PageClient::schedule_repaint()
 {
     if (m_paint_state != PaintState::Ready) {

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -29,6 +29,8 @@ class PageClient final : public Web::PageClient {
 public:
     static JS::NonnullGCPtr<PageClient> create(JS::VM& vm, PageHost& page_host, u64 id);
 
+    virtual ~PageClient() override;
+
     static void set_use_gpu_painter();
     static void set_use_experimental_cpu_transform_support();
 


### PR DESCRIPTION
Cherry-picks the commits from https://github.com/LadybirdBrowser/ladybird/pull/44, and the first commit from https://github.com/LadybirdBrowser/ladybird/pull/79 (to make the other two commits apply cleanly. The second commit on 79 doesn't make sense downstream.)