### PR TITLE
LibJS: Initialize fields of on-stack `buf` structure

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -332,7 +332,7 @@ NO_SANITIZE_ADDRESS void Heap::gather_conservative_roots(HashMap<Cell*, HeapRoot
 
     dbgln_if(HEAP_DEBUG, "gather_conservative_roots:");
 
-    jmp_buf buf;
+    jmp_buf buf {};
     setjmp(buf);
 
     HashMap<FlatPtr, HeapRoot> possible_pointers;


### PR DESCRIPTION
We pass all fields of `buf` to `add_possible_value()`, and at least on Linux `setjmp()` does not initialize all fields.

Fixes #24560.