### PR TITLE
Meta: Add a warning suppression used in the cmake build to the gn build

### DIFF
--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -129,6 +129,7 @@ config("compiler_defaults") {
       "-Wno-unused-private-field",
       "-Wno-implicit-const-int-float-conversion",
       "-Wno-vla-cxx-extension",
+      "-Wno-coroutine-missing-unhandled-exception",
     ]
   } else {
     cflags += [


### PR DESCRIPTION
8263e0a6199 added `-Wno-coroutine-missing-unhandled-exception` to the cmake build, and the coroutine code does not build without it.

Unbreaks building e.g. `js` with GN.