### PR TITLE
Kernel/Storage: Dump storage devices to the framebuffer console as well

### DIFF
--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -178,16 +178,16 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_storage_devices()
 
 UNMAP_AFTER_INIT void StorageManagement::dump_storage_devices_and_partitions() const
 {
-    dbgln("StorageManagement: Detected {} storage devices", m_storage_devices.size_slow());
+    critical_dmesgln("StorageManagement: Detected {} storage devices", m_storage_devices.size_slow());
     for (auto const& storage_device : m_storage_devices) {
         auto const& partitions = storage_device.partitions();
         if (partitions.is_empty()) {
-            dbgln("  Device: block{}:{} (no partitions)", storage_device.major(), storage_device.minor());
+            critical_dmesgln("  Device: block{}:{} (no partitions)", storage_device.major(), storage_device.minor());
         } else {
-            dbgln("  Device: block{}:{} ({} partitions)", storage_device.major(), storage_device.minor(), partitions.size());
+            critical_dmesgln("  Device: block{}:{} ({} partitions)", storage_device.major(), storage_device.minor(), partitions.size());
             unsigned partition_number = 1;
             for (auto const& partition : partitions) {
-                dbgln("    Partition: {}, block{}:{} (UUID {})", partition_number, partition->major(), partition->minor(), partition->metadata().unique_guid().to_string());
+                critical_dmesgln("    Partition: {}, block{}:{} (UUID {})", partition_number, partition->major(), partition->minor(), partition->metadata().unique_guid().to_string());
                 partition_number++;
             }
         }


### PR DESCRIPTION
This is helps bringing up bare metal devices without having to use the serial console.