### PR TITLE
Cherry-pick "LibWebSocket: Use HTTP::HeaderMap in WebSocket code"

### DIFF
--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -102,12 +102,9 @@ void RequestClient::certificate_requested(i32 request_id)
     }
 }
 
-RefPtr<WebSocket> RequestClient::websocket_connect(const URL::URL& url, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HashMap<ByteString, ByteString> const& request_headers)
+RefPtr<WebSocket> RequestClient::websocket_connect(const URL::URL& url, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HTTP::HeaderMap const& request_headers)
 {
-    auto headers_or_error = request_headers.clone();
-    if (headers_or_error.is_error())
-        return nullptr;
-    auto connection_id = IPCProxy::websocket_connect(url, origin, protocols, extensions, headers_or_error.release_value());
+    auto connection_id = IPCProxy::websocket_connect(url, origin, protocols, extensions, request_headers);
     if (connection_id < 0)
         return nullptr;
     auto connection = WebSocket::create_from_id({}, *this, connection_id);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -29,7 +29,7 @@ public:
 
     RefPtr<Request> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});
 
-    RefPtr<WebSocket> websocket_connect(const URL::URL&, ByteString const& origin = {}, Vector<ByteString> const& protocols = {}, Vector<ByteString> const& extensions = {}, HashMap<ByteString, ByteString> const& request_headers = {});
+    RefPtr<WebSocket> websocket_connect(const URL::URL&, ByteString const& origin = {}, Vector<ByteString> const& protocols = {}, Vector<ByteString> const& extensions = {}, HTTP::HeaderMap const& request_headers = {});
 
     void ensure_connection(URL::URL const&, ::RequestServer::CacheLevel);
 

--- a/Userland/Libraries/LibWebSocket/ConnectionInfo.h
+++ b/Userland/Libraries/LibWebSocket/ConnectionInfo.h
@@ -8,6 +8,7 @@
 
 #include <AK/Vector.h>
 #include <LibCore/EventReceiver.h>
+#include <LibHTTP/HeaderMap.h>
 #include <LibTLS/TLSv12.h>
 #include <LibURL/URL.h>
 #include <LibWebSocket/Message.h>
@@ -29,12 +30,8 @@ public:
     Vector<ByteString> const& extensions() const { return m_extensions; }
     void set_extensions(Vector<ByteString> extensions) { m_extensions = move(extensions); }
 
-    struct Header {
-        ByteString name;
-        ByteString value;
-    };
-    Vector<Header> const& headers() const { return m_headers; }
-    void set_headers(Vector<Header> headers) { m_headers = move(headers); }
+    HTTP::HeaderMap const& headers() const { return m_headers; }
+    void set_headers(HTTP::HeaderMap headers) { m_headers = move(headers); }
 
     // secure flag - defined in RFC 6455 Section 3
     bool is_secure() const;
@@ -47,7 +44,7 @@ private:
     ByteString m_origin;
     Vector<ByteString> m_protocols {};
     Vector<ByteString> m_extensions {};
-    Vector<Header> m_headers {};
+    HTTP::HeaderMap m_headers;
 };
 
 }

--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -212,7 +212,7 @@ void WebSocket::send_client_handshake()
     }
 
     // 12. Additional headers
-    for (auto& header : m_connection.headers()) {
+    for (auto& header : m_connection.headers().headers()) {
         builder.appendff("{}: {}\r\n", header.name, header.value);
     }
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -322,7 +322,7 @@ void ConnectionFromClient::ensure_connection(URL::URL const& url, ::RequestServe
 }
 
 static i32 s_next_websocket_id = 1;
-Messages::RequestServer::WebsocketConnectResponse ConnectionFromClient::websocket_connect(URL::URL const& url, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HashMap<ByteString, ByteString> const& additional_request_headers)
+Messages::RequestServer::WebsocketConnectResponse ConnectionFromClient::websocket_connect(URL::URL const& url, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HTTP::HeaderMap const& additional_request_headers)
 {
     if (!url.is_valid()) {
         dbgln("WebSocket::Connect: Invalid URL requested: '{}'", url);
@@ -333,12 +333,7 @@ Messages::RequestServer::WebsocketConnectResponse ConnectionFromClient::websocke
     connection_info.set_origin(origin);
     connection_info.set_protocols(protocols);
     connection_info.set_extensions(extensions);
-
-    Vector<WebSocket::ConnectionInfo::Header> headers;
-    for (auto const& header : additional_request_headers) {
-        headers.append({ header.key, header.value });
-    }
-    connection_info.set_headers(headers);
+    connection_info.set_headers(additional_request_headers);
 
     auto id = ++s_next_websocket_id;
     auto connection = WebSocket::WebSocket::create(move(connection_info));

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -42,7 +42,7 @@ private:
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, ByteString const&, ByteString const&) override;
     virtual void ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel const& cache_level) override;
 
-    virtual Messages::RequestServer::WebsocketConnectResponse websocket_connect(URL::URL const&, ByteString const&, Vector<ByteString> const&, Vector<ByteString> const&, HashMap<ByteString, ByteString> const&) override;
+    virtual Messages::RequestServer::WebsocketConnectResponse websocket_connect(URL::URL const&, ByteString const&, Vector<ByteString> const&, Vector<ByteString> const&, HTTP::HeaderMap const&) override;
     virtual Messages::RequestServer::WebsocketReadyStateResponse websocket_ready_state(i32) override;
     virtual Messages::RequestServer::WebsocketSubprotocolInUseResponse websocket_subprotocol_in_use(i32) override;
     virtual void websocket_send(i32, bool, ByteBuffer const&) override;

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -16,7 +16,7 @@ endpoint RequestServer
     ensure_connection(URL::URL url, ::RequestServer::CacheLevel cache_level) =|
 
     // Websocket Connection API
-    websocket_connect(URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, HashMap<ByteString, ByteString> additional_request_headers) => (i32 connection_id)
+    websocket_connect(URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, HTTP::HeaderMap additional_request_headers) => (i32 connection_id)
     websocket_ready_state(i32 connection_id) => (u32 ready_state)
     websocket_subprotocol_in_use(i32 connection_id) => (ByteString subprotocol_in_use)
     websocket_send(i32 connection_id, bool is_text, ByteBuffer data) =|


### PR DESCRIPTION
(cherry picked from commit 0d22e0703f4d668fab78b6e4960dfdc2b607369d)

---

Cherry-picks the commit from https://github.com/LadybirdBrowser/ladybird/pull/247