### PR TITLE
Cherry-pick "LibWeb: Check for navigable destruction in declarative refresh timer"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4051,8 +4051,11 @@ void Document::shared_declarative_refresh_steps(StringView input, JS::GCPtr<HTML
         if (has_meta_element && has_flag(active_sandboxing_flag_set(), HTML::SandboxingFlagSet::SandboxedAutomaticFeatures))
             return;
 
-        VERIFY(navigable());
-        MUST(navigable()->navigate({ .url = url_record, .source_document = *this }));
+        auto navigable = this->navigable();
+        if (!navigable || navigable->has_been_destroyed())
+            return;
+
+        MUST(navigable->navigate({ .url = url_record, .source_document = *this, .history_handling = Bindings::NavigationHistoryBehavior::Replace }));
     });
 
     // For the purposes of the previous paragraph, a refresh is said to have come due as soon as the later of the


### PR DESCRIPTION
If the Document's navigable has been destroyed since we started this timer, or it's no longer the active document of its navigable, we shouldn't navigate to it.

(cherry picked from commit 7b67fa706fd2dabfda3c72a752ac70d8c95bb060; amended commit message to say "LibWeb:" instead of "DOM:")

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/69