### PR TITLE
Cherry-pick "LibWeb: Avoid null dereference when performing mixed content checks"

### DIFF
--- a/Userland/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
@@ -80,7 +80,7 @@ Fetch::Infrastructure::RequestOrResponseBlocking should_fetching_request_be_bloc
         || false
 
         // 4. request’s destination is "document", and request’s target browsing context has no parent browsing context.
-        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && !request.client()->target_browsing_context->parent())) {
+        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && !(request.client()->target_browsing_context && request.client()->target_browsing_context->parent()))) {
         return Fetch::Infrastructure::RequestOrResponseBlocking::Allowed;
     }
 
@@ -104,7 +104,7 @@ Web::Fetch::Infrastructure::RequestOrResponseBlocking should_response_to_request
         || false
 
         // 4. request’s destination is "document", and request’s target browsing context has no parent browsing context.
-        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && !request.client()->target_browsing_context->parent())) {
+        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && !(request.client()->target_browsing_context && request.client()->target_browsing_context->parent()))) {
         return Fetch::Infrastructure::RequestOrResponseBlocking::Allowed;
     }
 


### PR DESCRIPTION
Previously, navigating to or from `about:newtab` caused a crash due to inadvertent null dereferences when checking whether a request or response to a request should be blocked as mixed content.

(cherry picked from commit 572ebe00eacd5aaeecc17207c75c6bf2327a3897)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/161