### PR TITLE
Cherry-pick "Tests/LibWeb: Wait until document fully loaded before simulating click"

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,7 +1,6 @@
 [Skipped]
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
-Text/input/HTML/form-image-submission.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html

--- a/Tests/LibWeb/Text/input/HTML/form-image-submission.html
+++ b/Tests/LibWeb/Text/input/HTML/form-image-submission.html
@@ -28,7 +28,7 @@
             done();
         });
 
-        image.addEventListener("load", () => {
+        window.addEventListener("load", () => {
             const imageRect = image.getBoundingClientRect();
             internals.click(imageRect.x + 10, imageRect.y + 20);
         });


### PR DESCRIPTION
This makes the `form-image-submission.html` test pass more reliably.

(cherry picked from commit 2fed064791d3117e0571453210000d285ee9359c)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/104