### PR TITLE
Cherry-pick "LibWeb/CSS: Avoid capturing structured binding in generic lambda"

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
@@ -116,8 +116,8 @@ double EasingStyleValue::Function::evaluate_at(double input_progress, bool befor
             auto x = input_progress;
 
             auto solve = [&](auto t) {
-                auto x = cubic_bezier_at(x1, x2, t);
-                auto y = cubic_bezier_at(y1, y2, t);
+                auto x = cubic_bezier_at(bezier.x1, bezier.x2, t);
+                auto y = cubic_bezier_at(bezier.y1, bezier.y2, t);
                 return CubicBezier::CachedSample { x, y, t };
             };
 


### PR DESCRIPTION
Apple Clang doesn't like this, rather than waiting for their version of random-clang-commit-to-call-a-release to catch up with llvm trunk, just work around the issue.

Fixes https://github.com/LadybirdBrowser/ladybird/pull/186.

(cherry picked from commit 8c9d3b30cf62016ffb03e425f1e7e3f2461262bf)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/203