### PR TITLE
Cherry-pick "LibWeb: Disallow pasting into non-editable text nodes"

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -882,6 +882,8 @@ void EventHandler::handle_paste(String const& text)
         return;
 
     if (auto cursor_position = m_navigable->cursor_position()) {
+        if (!cursor_position->node()->is_editable())
+            return;
         active_document->update_layout();
         m_edit_event_handler->handle_insert(*cursor_position, text);
         cursor_position->set_offset(cursor_position->offset() + text.code_points().length());


### PR DESCRIPTION
(cherry picked from commit 8969f2e34af196e935c57257ef7eec8f00b45d33)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/237