### PR TITLE
Ladybird/AppKit: Send mouse event on middle click

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1404,6 +1404,35 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
+- (void)otherMouseDown:(NSEvent*)event
+{
+    if (event.buttonNumber != 2)
+        return;
+
+    [[self window] makeFirstResponder:self];
+
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, [self scrollView], Web::UIEvents::MouseButton::Middle);
+    m_web_view_bridge->enqueue_input_event(move(mouse_event));
+}
+
+- (void)otherMouseUp:(NSEvent*)event
+{
+    if (event.buttonNumber != 2)
+        return;
+
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, [self scrollView], Web::UIEvents::MouseButton::Middle);
+    m_web_view_bridge->enqueue_input_event(move(mouse_event));
+}
+
+- (void)otherMouseDragged:(NSEvent*)event
+{
+    if (event.buttonNumber != 2)
+        return;
+
+    auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, [self scrollView], Web::UIEvents::MouseButton::Middle);
+    m_web_view_bridge->enqueue_input_event(move(mouse_event));
+}
+
 - (BOOL)performKeyEquivalent:(NSEvent*)event
 {
     if ([event window] != [self window]) {


### PR DESCRIPTION
My external mouse also has a 4th and 5th button, but the `Web::UIEvents::MouseButton::` abstraction doesn't support that yet, so I'm just early-outing for those.

With this and #24613, middle-clicking does open links in a new tab. (The more natural cmd-left-clicking doesn't work, though.)