### PR TITLE
Cherry-pick "LibWeb: Add HTMLSelectElement showPicker()"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -53,6 +53,8 @@ public:
     bool is_open() const { return m_is_open; }
     void set_is_open(bool);
 
+    WebIDL::ExceptionOr<void> show_picker();
+
     Vector<JS::Handle<HTMLOptionElement>> list_of_options() const;
 
     // ^EventTarget
@@ -100,6 +102,8 @@ private:
     virtual i32 default_tab_index_value() const override;
 
     virtual void computed_css_values_changed() override;
+
+    void show_the_picker_if_applicable();
 
     void create_shadow_tree_if_needed();
     void update_inner_text_element();

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -37,5 +37,7 @@ interface HTMLSelectElement : HTMLElement {
     [FIXME] boolean reportValidity();
     [FIXME] undefined setCustomValidity(DOMString error);
 
+    undefined showPicker();
+
     readonly attribute NodeList labels;
 };


### PR DESCRIPTION
Adds the showPicker() function for select elements. This doesn't do the check for "being rendered" which is in the spec.

(cherry picked from commit 5098ed6b1f881659dbdab10c74a0e17b362ce7a8)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/153