### PR TITLE
Cherry-pick "LibWeb: Prevent select.click() opening the dropdown"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -431,9 +431,10 @@ WebIDL::ExceptionOr<void> HTMLSelectElement::show_picker()
     return {};
 }
 
-void HTMLSelectElement::activation_behavior(DOM::Event const&)
+void HTMLSelectElement::activation_behavior(DOM::Event const& event)
 {
-    show_the_picker_if_applicable();
+    if (event.is_trusted())
+        show_the_picker_if_applicable();
 }
 
 void HTMLSelectElement::did_select_item(Optional<u32> const& id)


### PR DESCRIPTION
No other browser allows opening the select element dropdown with the select.click() function.
This change stops this happening in Ladybird.

(cherry picked from commit 564e546ff0bd78cc7ba770b53377457bf1ef88d6)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/154