### PR TITLE
Meta+Toolchain: Let BuildQemu.sh use `shasum -a 256` instead of `sha256sum` on macOS

### DIFF
--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -99,3 +99,21 @@ disk_usage() {
 inode_usage() {
     find "$1" | wc -l
 }
+
+check_sha256() {
+    if [ $# -ne 2 ]; then
+        error "Usage: check_sha256 FILE EXPECTED_HASH"
+        return 1
+    fi
+
+    FILE="${1}"
+    EXPECTED_HASH="${2}"
+
+    SYSTEM_NAME="$(uname -s)"
+    if [ "$SYSTEM_NAME" = "Darwin" ]; then
+        SEEN_HASH="$(shasum -a 256 "${FILE}" | cut -d " " -f 1)"
+    else
+        SEEN_HASH="$(sha256sum "${FILE}" | cut -d " " -f 1)"
+    fi
+    test "${EXPECTED_HASH}" = "${SEEN_HASH}"
+}

--- a/Toolchain/BuildCMake.sh
+++ b/Toolchain/BuildCMake.sh
@@ -17,24 +17,6 @@ TARBALLS_DIR="$DIR/Tarballs"
 NPROC=$(get_number_of_processing_units)
 [ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
-check_sha256() {
-    if [ $# -ne 2 ]; then
-        error "Usage: check_sha256 FILE EXPECTED_HASH"
-        return 1
-    fi
-
-    FILE="${1}"
-    EXPECTED_HASH="${2}"
-
-    SYSTEM_NAME="$(uname -s)"
-    if [ "$SYSTEM_NAME" = "Darwin" ]; then
-        SEEN_HASH="$(shasum -a 256 "${FILE}" | cut -d " " -f 1)"
-    else
-        SEEN_HASH="$(sha256sum "${FILE}" | cut -d " " -f 1)"
-    fi
-    test "${EXPECTED_HASH}" = "${SEEN_HASH}"
-}
-
 # Note: Update this alongside the cmake port, and Meta/CMake/cmake-version.cmake if the build requires this version of cmake.
 CMAKE_VERSION=3.26.4
 CMAKE_ARCHIVE_SHA256=313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208

--- a/Toolchain/BuildCMake.sh
+++ b/Toolchain/BuildCMake.sh
@@ -17,9 +17,9 @@ TARBALLS_DIR="$DIR/Tarballs"
 NPROC=$(get_number_of_processing_units)
 [ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
-check_sha() {
+check_sha256() {
     if [ $# -ne 2 ]; then
-        error "Usage: check_sha FILE EXPECTED_HASH"
+        error "Usage: check_sha256 FILE EXPECTED_HASH"
         return 1
     fi
 
@@ -50,7 +50,7 @@ pushd "$DIR"/Tarballs
         echo "${CMAKE_ARCHIVE} already exists, not downloading archive"
     fi
 
-    if ! check_sha "${CMAKE_ARCHIVE}" "${CMAKE_ARCHIVE_SHA256}"; then
+    if ! check_sha256 "${CMAKE_ARCHIVE}" "${CMAKE_ARCHIVE_SHA256}"; then
         echo "CMake archive SHA256 sum mismatch, please run script again"
         rm -f "${CMAKE_ARCHIVE}"
         exit 1

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -31,7 +31,7 @@ pushd "$DIR/Tarballs"
         echo "Skipped downloading ${QEMU_ARCHIVE}"
     fi
 
-    if ! sha256sum --status -c <(echo "${QEMU_ARCHIVE_SHA256SUM}" "${QEMU_ARCHIVE}"); then
+    if ! check_sha256 "${QEMU_ARCHIVE}" "${QEMU_ARCHIVE_SHA256SUM}"; then
         echo "qemu sha256 sum mismatching, please run script again."
         rm -f "${QEMU_ARCHIVE}"
         exit 1


### PR DESCRIPTION
With this, `Toolchain/BuildQemu.sh` makes it past the download on macOS (and then falls over building fairly quickly).