### PR TITLE
AK+LibTest: Choose definition of CO_TRY and CO_TRY_OR_FAIL more robustly

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -158,6 +158,16 @@
 #    define AK_BUILTIN_SUBC_BROKEN
 #endif
 
+#if defined(AK_COMPILER_CLANG) && __clang_major__ < 19
+#    define AK_COROUTINE_DESTRUCTION_BROKEN
+#endif
+
+#ifdef AK_COMPILER_GCC
+// FIXME: Reduce and report these to GCC.
+#    define AK_COROUTINE_STATEMENT_EXPRS_BROKEN
+#    define AK_COROUTINE_TYPE_DEDUCTION_BROKEN
+#endif
+
 #ifdef ALWAYS_INLINE
 #    undef ALWAYS_INLINE
 #endif

--- a/Tests/AK/TestCoroutine.cpp
+++ b/Tests/AK/TestCoroutine.cpp
@@ -238,18 +238,22 @@ namespace {
 Coroutine<ErrorOr<void>> co_try_success()
 {
     auto c = CO_TRY(co_await return_class_3());
+#ifndef AK_COROUTINE_DESTRUCTION_BROKEN
     // 1. Construct temporary as an argument for the constructor of a temporary ErrorOr<Class>.
     // 2. Move temporary ErrorOr<Class> into Coroutine.
     // -. Some magic is done in TryAwaiter.
     // 3. Move Class from ErrorOr<Class> inside Coroutine to c.
     EXPECT_EQ(c.cookie(), 3);
+#else
+    EXPECT_EQ(c.cookie(), 4);
+#endif
     co_return {};
 }
 
 Coroutine<ErrorOr<void>> co_try_fail()
 {
     ErrorOr<void> error = Error::from_string_literal("ERROR!");
-    CO_TRY(error);
+    CO_TRY(move(error));
     co_return {};
 }
 

--- a/Userland/Libraries/LibHTTP/Http11Connection.h
+++ b/Userland/Libraries/LibHTTP/Http11Connection.h
@@ -90,7 +90,7 @@ public:
         if (response->is_open()) {
             auto close_result = co_await response->close();
             if (!result.is_error()) // Preserve callback error in case it has failed.
-                CO_TRY(close_result);
+                CO_TRY(move(close_result));
         }
         co_return result;
     }


### PR DESCRIPTION
There are three compiler bugs that influence this decision:

 - Clang writing to (validly) destroyed coroutine frame with -O0 and -fsanitize=null,address under some conditions (https://godbolt.org/z/17Efq5Ma5) (AK_COROUTINE_DESTRUCTION_BROKEN);

 - GCC being unable to handle statement expressions in coroutines (AK_COROUTINE_STATEMENT_EXPRS_BROKEN);

 - GCC being unable to deduce template type parameter for TryAwaiter with nested CO_TRYs (AK_COROUTINE_TYPE_DEDUCTION_BROKEN).

Instead of growing an ifdef soup in AK/Coroutine.h and LibTest/AsyncTestCase.h, define three macros in AK/Platform.h that correspond to these bugs and use them accordingly in the said files.