### PR TITLE
Everywhere: Define even more destructors out of line

### DIFF
--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Error.h>
 #include <AK/OwnPtr.h>
 #include <AK/Stream.h>

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Function.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Function.cpp
@@ -88,6 +88,8 @@ FunctionDefinition::FunctionDefinition(Declaration&& declaration, Location locat
 {
 }
 
+FunctionDefinition::~FunctionDefinition() = default;
+
 void FunctionDefinition::reindex_ssa_variables()
 {
     size_t index = 0;

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Function.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Function.h
@@ -139,6 +139,7 @@ private:
 class FunctionDefinition : public FunctionDeclaration {
 public:
     FunctionDefinition(Declaration&& declaration, Location location, Tree ast);
+    ~FunctionDefinition();
 
     void reindex_ssa_variables();
 

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -13,6 +13,7 @@
 #include <AK/Forward.h>
 #include <AK/Span.h>
 #include <LibCore/File.h>
+#include <LibCore/Socket.h>
 
 namespace Core {
 

--- a/Userland/Libraries/LibGUI/Event.cpp
+++ b/Userland/Libraries/LibGUI/Event.cpp
@@ -20,6 +20,8 @@ DropEvent::DropEvent(Gfx::IntPoint position, ByteString const& text, NonnullRefP
 {
 }
 
+DropEvent::~DropEvent() = default;
+
 ByteString KeyEvent::to_byte_string() const
 {
     Vector<ByteString, 8> parts;
@@ -52,5 +54,7 @@ ActionEvent::ActionEvent(Type type, Action& action)
     , m_action(action)
 {
 }
+
+ActionEvent::~ActionEvent() = default;
 
 }

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -503,7 +503,7 @@ class DropEvent final : public Event {
 public:
     DropEvent(Gfx::IntPoint, ByteString const& text, NonnullRefPtr<Core::MimeData const> mime_data);
 
-    ~DropEvent() = default;
+    ~DropEvent();
 
     Gfx::IntPoint position() const { return m_position; }
     ByteString const& text() const { return m_text; }
@@ -579,7 +579,7 @@ private:
 class ActionEvent final : public Event {
 public:
     ActionEvent(Type, Action&);
-    ~ActionEvent() = default;
+    ~ActionEvent();
 
     Action const& action() const { return *m_action; }
     Action& action() { return *m_action; }

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -31,6 +31,8 @@ HeaderView::HeaderView(AbstractTableView& table_view, Gfx::Orientation orientati
     }
 }
 
+HeaderView::~HeaderView() = default;
+
 void HeaderView::set_section_size(int section, int size)
 {
     auto& data = section_data(section);

--- a/Userland/Libraries/LibGUI/HeaderView.h
+++ b/Userland/Libraries/LibGUI/HeaderView.h
@@ -16,7 +16,7 @@ class HeaderView final : public Widget {
     C_OBJECT(HeaderView);
 
 public:
-    virtual ~HeaderView() override = default;
+    virtual ~HeaderView() override;
 
     Gfx::Orientation orientation() const { return m_orientation; }
 


### PR DESCRIPTION
You guessed it, this fixes compilation with LLVM trunk.