### PR TITLE
AudioServer: Handle missing audio device gracefully

### DIFF
--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -19,7 +19,12 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     auto config = TRY(Core::ConfigFile::open_for_app("Audio", Core::ConfigFile::AllowWriting::Yes));
     TRY(Core::System::unveil(config->filename(), "rwc"sv));
-    TRY(Core::System::unveil("/dev/audio", "wc"));
+
+    auto audio_unveil_result = Core::System::unveil("/dev/audio", "wc");
+    // System may not have audio devices, which we handle gracefully.
+    if (audio_unveil_result.is_error())
+        dbgln("Couldn't unveil audio devices: {}", audio_unveil_result.error());
+
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop event_loop;


### PR DESCRIPTION
On several platforms, we don't yet have audio support, so audio devices are missing. Instead of having AudioServer crash repeatedly, and not having the ability to open any app that relies on it, we should instead handle missing devices gracefully. This implementation is minimal, audio device hotplugging support and such should be implemented together with multi-device support. AudioServer will start up and seem to function normally without an audio device, but it will pretend the device has a sample rate of 44.1 kHz and all audio input is discarded.