### PR TITLE
Meta: Enable VirtIO on Windows QEMU

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -430,10 +430,6 @@ def set_up_basic_kernel_cmdline(config: Configuration):
         # Split environment variable at spaces, since we don't pass arguments like shell scripts do.
         config.kernel_cmdline.extend(provided_cmdline.split(sep=None))
 
-    # Handle system-specific arguments now, boot type specific arguments are handled later.
-    if config.qemu_kind == QEMUKind.NativeWindows:
-        config.kernel_cmdline.append("disable_virtio")
-
 
 def set_up_disk_image_path(config: Configuration):
     provided_disk_image = environ.get("SERENITY_DISK_IMAGE")


### PR DESCRIPTION
VirtIO was probably broken on Windows versions of QEMU, but this seems to no longer be the case. Enabling VirtIO is currently required for RISC-V mouse and keyboard support.

**Requests for testing:** If you use Windows QEMU (i.e. build SerenityOS with WSL, but have a Windows QEMU installed), please test this commit and make sure it still boots and works fine! I have tested both RISC-V and x86 under QEMU 8.1.0.