### PR TITLE
Cherry-pick "UI/Qt: Ignore tab bar middle clicks if the user didn't click on a tab"

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -1008,8 +1008,10 @@ bool BrowserWindow::eventFilter(QObject* obj, QEvent* event)
         if (mouse_event->button() == Qt::MouseButton::MiddleButton) {
             if (obj == m_tabs_container) {
                 auto const tab_index = m_tabs_container->tabBar()->tabAt(mouse_event->pos());
-                close_tab(tab_index);
-                return true;
+                if (tab_index != -1) {
+                    close_tab(tab_index);
+                    return true;
+                }
             }
         }
     }


### PR DESCRIPTION
This avoids a segfault that would previously occur when middle clicking to close a tab if only 1 tab was open.

(cherry picked from commit b95c05b6115c8eb84fe6fec55f5152db852fe743)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/312