### PR TITLE
Cherry-pick "LibWeb: Implement the `HTMLTrackElement.kind` attribute"

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLTrackElement-kind-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLTrackElement-kind-attribute.txt
@@ -1,0 +1,7 @@
+kind initial value: 'subtitles'
+kind value after setting to "invalid": 'metadata'
+kind value after setting to "captions": 'captions'
+kind value after setting to null: 'metadata'
+kind value after setting to "CHAPTERS": 'chapters'
+kind value after setting to "": 'metadata'
+kind value after calling removeAttribute: 'subtitles'

--- a/Tests/LibWeb/Text/input/HTML/HTMLTrackElement-kind-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLTrackElement-kind-attribute.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const trackElement = document.createElement("track");
+        println(`kind initial value: '${trackElement.kind}'`);
+        trackElement.kind = "invalid";
+        println(`kind value after setting to "invalid": '${trackElement.kind}'`);
+        trackElement.kind = "captions";
+        println(`kind value after setting to "captions": '${trackElement.kind}'`);
+        trackElement.kind = null;
+        println(`kind value after setting to null: '${trackElement.kind}'`);
+        trackElement.kind = "CHAPTERS";
+        println(`kind value after setting to "CHAPTERS": '${trackElement.kind}'`);
+        trackElement.kind = "";
+        println(`kind value after setting to "": '${trackElement.kind}'`);
+        trackElement.removeAttribute("kind");
+        println(`kind value after calling removeAttribute: '${trackElement.kind}'`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -94,6 +94,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(is)                         \
     __ENUMERATE_HTML_ATTRIBUTE(ismap)                      \
     __ENUMERATE_HTML_ATTRIBUTE(itemscope)                  \
+    __ENUMERATE_HTML_ATTRIBUTE(kind)                       \
     __ENUMERATE_HTML_ATTRIBUTE(label)                      \
     __ENUMERATE_HTML_ATTRIBUTE(lang)                       \
     __ENUMERATE_HTML_ATTRIBUTE(language)                   \

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
@@ -1,12 +1,22 @@
 #import <HTML/HTMLElement.idl>
 
+// https://html.spec.whatwg.org/multipage/media.html#attr-track-kind
+[MissingValueDefault=subtitles, InvalidValueDefault=metadata]
+enum TrackKindAttribute {
+    "subtitles",
+    "captions",
+    "descriptions",
+    "chapters",
+    "metadata"
+};
+
 // https://html.spec.whatwg.org/multipage/media.html#htmltrackelement
 [Exposed=Window]
 interface HTMLTrackElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [FIXME, CEReactions] attribute DOMString kind;
+    [CEReactions, Enumerated=TrackKindAttribute, Reflect] attribute DOMString kind;
     [CEReactions, Reflect] attribute DOMString src;
     [CEReactions, Reflect] attribute DOMString srclang;
     [CEReactions, Reflect] attribute DOMString label;


### PR DESCRIPTION
This reflects the HTML `kind` attribute.

(cherry picked from commit bdaa7f0e8ed738ad0bd6e19878f296436fe40377)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/316