### PR TITLE
Kernel/Memory: Various fixes for anonymous mmaps

### DIFF
--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -148,11 +148,6 @@ ErrorOr<Region*> AddressSpace::try_allocate_split_region(Region const& source_re
     new_region->set_syscall_region(source_region.is_syscall_region());
     new_region->set_mmap(source_region.is_mmap(), source_region.mmapped_from_readable(), source_region.mmapped_from_writable());
     new_region->set_stack(source_region.is_stack());
-    size_t page_offset_in_source_region = (offset_in_vmobject - source_region.offset_in_vmobject()) / PAGE_SIZE;
-    for (size_t i = 0; i < new_region->page_count(); ++i) {
-        if (source_region.should_cow(page_offset_in_source_region + i))
-            TRY(new_region->set_should_cow(i, true));
-    }
     TRY(m_region_tree.place_specifically(*new_region, range));
     return new_region.leak_ptr();
 }

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -34,7 +34,7 @@ ErrorOr<NonnullLockRefPtr<VMObject>> AnonymousVMObject::try_clone()
     // non-volatile memory available.
     size_t new_cow_pages_needed = 0;
     for (auto const& page : m_physical_pages) {
-        if (!page->is_shared_zero_page())
+        if (!page->is_shared_zero_page() && !page->is_lazy_committed_page())
             ++new_cow_pages_needed;
     }
 

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -58,6 +58,7 @@ private:
 
     ErrorOr<void> ensure_cow_map();
     ErrorOr<void> ensure_or_reset_cow_map();
+    void reset_cow_map();
 
     Optional<CommittedPhysicalPageSet> m_unused_committed_pages;
     Bitmap m_cow_map;

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -544,7 +544,10 @@ PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region, Physica
     }
 
     if (m_shared) {
-        anonymous_vmobject.remap_regions();
+        if (!anonymous_vmobject.remap_regions_one_page(page_index_in_vmobject, *new_physical_page)) {
+            dmesgln("MM: handle_zero_fault was unable to allocate a physical page");
+            return PageFaultResponse::OutOfMemory;
+        }
     } else {
         if (!remap_vmobject_page(page_index_in_vmobject, *new_physical_page)) {
             dmesgln("MM: handle_zero_fault was unable to allocate a physical page");

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -201,14 +201,6 @@ bool Region::should_cow(size_t page_index) const
     return static_cast<AnonymousVMObject const&>(vmobject()).should_cow(first_page_index() + page_index, m_shared);
 }
 
-ErrorOr<void> Region::set_should_cow(size_t page_index, bool cow)
-{
-    VERIFY(!m_shared);
-    if (vmobject().is_anonymous())
-        TRY(static_cast<AnonymousVMObject&>(vmobject()).set_should_cow(first_page_index() + page_index, cow));
-    return {};
-}
-
 bool Region::should_dirty_on_write(size_t page_index) const
 {
     if (!vmobject().is_inode())

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -36,6 +36,8 @@ class Region final
     friend class AddressSpace;
     friend class MemoryManager;
     friend class RegionTree;
+    friend class AnonymousVMObject;
+    friend class VMObject;
 
 public:
     enum Access : u8 {

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -181,7 +181,6 @@ public:
     [[nodiscard]] size_t amount_dirty() const;
 
     [[nodiscard]] bool should_cow(size_t page_index) const;
-    ErrorOr<void> set_should_cow(size_t page_index, bool);
 
     [[nodiscard]] size_t cow_pages() const;
 

--- a/Kernel/Memory/VMObject.cpp
+++ b/Kernel/Memory/VMObject.cpp
@@ -45,4 +45,14 @@ void VMObject::remap_regions()
     });
 }
 
+bool VMObject::remap_regions_one_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage> page)
+{
+    bool success = true;
+    for_each_region([&](Region& region) {
+        if (!region.remap_vmobject_page(page_index, *page))
+            success = false;
+    });
+    return success;
+}
+
 }

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -64,6 +64,7 @@ protected:
     void for_each_region(Callback);
 
     void remap_regions();
+    bool remap_regions_one_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage> page);
 
     IntrusiveListNode<VMObject> m_list_node;
     FixedArray<RefPtr<PhysicalRAMPage>> m_physical_pages;

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(fuzz-syscalls PRIVATE LibSystem)
 serenity_test("crash.cpp" Kernel MAIN_ALREADY_DEFINED)
 
 set(LIBTEST_BASED_SOURCES
+    TestAnonymousMmap.cpp
     TestEmptyPrivateInodeVMObject.cpp
     TestEmptySharedInodeVMObject.cpp
     TestExt2FS.cpp

--- a/Tests/Kernel/TestAnonymousMmap.cpp
+++ b/Tests/Kernel/TestAnonymousMmap.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void check_if_page_zeroed(char* ptr, size_t page)
+{
+    for (size_t j = 0; j < PAGE_SIZE; ++j)
+        EXPECT(ptr[page * PAGE_SIZE + j] == 0);
+}
+
+TEST_CASE(shared_anonymous_mmap)
+{
+    size_t pages = 100;
+    size_t len = pages * PAGE_SIZE;
+    char* shared_ptr = (char*)mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+    EXPECT(shared_ptr != MAP_FAILED);
+
+    size_t forks = 20;
+    for (size_t i = 0; i < forks; ++i) {
+        pid_t pid = fork();
+        VERIFY(pid != -1);
+        if (pid == 0) {
+            // sleep so that multiple child processes can be created before performing the writes
+            sleep(1);
+            char c = '$' + (char)i;
+            shared_ptr[i * PAGE_SIZE] = c;
+            exit(EXIT_SUCCESS);
+        }
+    }
+
+    // wait for all child processes to exit
+    for (size_t i = 0; i < forks; ++i)
+        wait(nullptr);
+
+    // check that writes to the shared anonymous mmap in the multiple child processes are visible
+    for (size_t i = 0; i < forks; ++i) {
+        char c = '$' + (char)i;
+        EXPECT(shared_ptr[i * PAGE_SIZE] == c);
+    }
+
+    // check that the pages that haven't been written to are zeroed
+    for (size_t i = forks; i < pages; ++i)
+        check_if_page_zeroed(shared_ptr, i);
+}
+
+TEST_CASE(private_anonymous_mmap)
+{
+    size_t pages = 100;
+    size_t len = pages * PAGE_SIZE;
+    char* private_ptr = (char*)mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    EXPECT(private_ptr != MAP_FAILED);
+
+    pid_t pid = fork();
+    VERIFY(pid != -1);
+    if (pid == 0) {
+        // write to all pages of the mmap region
+        for (size_t i = 0; i < pages; ++i)
+            private_ptr[i * PAGE_SIZE] = '$';
+        exit(EXIT_SUCCESS);
+    } else {
+        wait(NULL);
+        // check that the writes that happened in the child process are not visible, all pages should be zeroed
+        for (size_t i = 0; i < pages; ++i)
+            check_if_page_zeroed(private_ptr, i);
+    }
+}
+
+TEST_CASE(test_that_partial_munmap_does_not_break_cow)
+{
+    size_t pages = 3;
+    size_t len = pages * PAGE_SIZE;
+    char* map = (char*)mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    EXPECT(map != MAP_FAILED);
+
+    // make writes before forking so the pages are marked as cow
+    map[0] = 'A';
+    map[PAGE_SIZE] = 'B';
+    map[2 * PAGE_SIZE] = 'C';
+
+    pid_t pid = fork();
+    VERIFY(pid != -1);
+    if (pid == 0) {
+        EXPECT(map[0] == 'A');
+        EXPECT(map[PAGE_SIZE] == 'B');
+        EXPECT(map[2 * PAGE_SIZE] == 'C');
+
+        // unmap part of the range, this should not interfere with the cow status of map's pages
+        int rc = munmap(map + PAGE_SIZE, PAGE_SIZE);
+        VERIFY(rc != -1);
+
+        EXPECT(map[0] == 'A');
+        EXPECT(map[2 * PAGE_SIZE] == 'C');
+
+        // write to map, these writes should be local to this child process
+        map[0] = '!';
+        map[2 * PAGE_SIZE] = '!';
+
+        exit(EXIT_SUCCESS);
+    } else {
+        wait(NULL);
+        // test that the writes made in the child process are not visible in this parent process
+        EXPECT(map[0] == 'A');
+        EXPECT(map[PAGE_SIZE] == 'B');
+        EXPECT(map[2 * PAGE_SIZE] == 'C');
+    }
+}


### PR DESCRIPTION
This PR fixes the following problems related to anonymous mmaps:
* After a fork, writes to an anonymous mmap  cause redundant page faults (#24637)
* Writes to a shared anonymous mmap are not visible to other processes that share the mmap (#24638)
* VMObject::try_clone() overcommits pages to m_shared_committed_cow_pages

This PR also adds more test cases for anonymous mmaps.