### PR TITLE
AK: Small preparations for LibDateTime

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/Format.h>
+#include <AK/FormatParser.h>
 #include <AK/GenericLexer.h>
 #include <AK/IntegralMath.h>
 #include <AK/String.h>
@@ -34,21 +35,6 @@
 #endif
 
 namespace AK {
-
-class FormatParser : public GenericLexer {
-public:
-    struct FormatSpecifier {
-        StringView flags;
-        size_t index;
-    };
-
-    explicit FormatParser(StringView input);
-
-    StringView consume_literal();
-    bool consume_number(size_t& value);
-    bool consume_specifier(FormatSpecifier& specifier);
-    bool consume_replacement_field(size_t& index);
-};
 
 namespace {
 

--- a/AK/FormatParser.h
+++ b/AK/FormatParser.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/GenericLexer.h>
+
+namespace AK {
+
+class FormatParser : public GenericLexer {
+public:
+    struct FormatSpecifier {
+        StringView flags;
+        size_t index;
+    };
+
+    explicit FormatParser(StringView input);
+
+    StringView consume_literal();
+    bool consume_number(size_t& value);
+    bool consume_specifier(FormatSpecifier& specifier);
+    bool consume_replacement_field(size_t& index);
+};
+
+}

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -238,6 +238,12 @@ public:
     // Rounds towards -inf (it was the easiest to implement).
     [[nodiscard]] timeval to_timeval() const;
 
+    [[nodiscard]] constexpr i64 nanoseconds_within_second() const
+    {
+        VERIFY(m_nanoseconds < 1'000'000'000);
+        return m_nanoseconds;
+    }
+
     [[nodiscard]] bool is_zero() const { return (m_seconds == 0) && (m_nanoseconds == 0); }
     [[nodiscard]] bool is_negative() const { return m_seconds < 0; }
 
@@ -489,7 +495,7 @@ public:
     [[nodiscard]] i64 nanoseconds() const { return m_offset.to_nanoseconds(); }
     // Never returns a point in the future, since fractional seconds are cut off.
     [[nodiscard]] i64 truncated_seconds() const { return m_offset.to_truncated_seconds(); }
-    [[nodiscard]] i64 nanoseconds_within_second() const { return to_timespec().tv_nsec; }
+    [[nodiscard]] i64 nanoseconds_within_second() const { return m_offset.nanoseconds_within_second(); }
 
     constexpr bool operator==(MonotonicTime const& other) const { return this->m_offset == other.m_offset; }
     constexpr int operator<=>(MonotonicTime const& other) const { return this->m_offset <=> other.m_offset; }


### PR DESCRIPTION
Simplify the #22990 revival. No functional changes.

### AK: Move nanoseconds_within_second to Duration

### AK: Move FormatParser to a new header

Since it was intentionally removed from Format.h to untangle dependencies, this is a new small header that can be included by anyone needing custom format parsing.