### PR TITLE
Meta: Make disk_usage() not depend on GNU du

### DIFF
--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -83,17 +83,24 @@ get_number_of_processing_units() {
   ($number_of_processing_units)
 }
 
-# We depend on GNU coreutils du for the --apparent-size extension.
-# GNU coreutils is a build dependency.
+# Discover how to get apparent size from `du`. GNU du has --apparent-size / -b,
+# BSD du has `-A`.
 if command -v gdu > /dev/null 2>&1 && gdu --version | grep -q "GNU coreutils"; then
-    GNUDU="gdu"
+    DU="gdu"
+    DU_APPARENT_SIZE_FLAG="-b"
 else
-    GNUDU="du"
+    DU="du"
+    SYSTEM_NAME="$(uname -s)"
+    if [ "$SYSTEM_NAME" = "Darwin" ]; then
+        DU_APPARENT_SIZE_FLAG="-A"
+    else
+        DU_APPARENT_SIZE_FLAG="-b"
+    fi
 fi
 
 disk_usage() {
     # shellcheck disable=SC2003,SC2307
-    expr "$(${GNUDU} -sbm "$1" | cut -f1)"
+    expr "$(${DU} ${DU_APPARENT_SIZE_FLAG} -sm "$1" | cut -f1)"
 }
 
 inode_usage() {


### PR DESCRIPTION
BSD `du` can also print apparent size, it just needs a different flag.

Makes `serenity.sh run` get a bit farther trying to build the disk image on macOS without brew installed. No intended behavior change elsewhere.