### PR TITLE
Cherry-pick "LibWeb: Use double as the argument for AnimationFrameCallbacks"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -15,7 +15,7 @@
 namespace Web::HTML {
 
 struct AnimationFrameCallbackDriver {
-    using Callback = Function<void(i32)>;
+    using Callback = Function<void(double)>;
 
     AnimationFrameCallbackDriver()
     {


### PR DESCRIPTION
This avoids an unnecessary lossy conversion for the current time from double to i32. And avoids an UBSAN failure on macOS that's dependent on the current uptime.

(cherry picked from commit 55c1b5d1f4d7c82f0a68323260cb2e0f7de2faae,
amended to fix a typo in the commit message)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/335