### PR TITLE
Cherry-pick "LibWeb/Geometry: Make DOMRect doubles unrestricted"

### DIFF
--- a/Tests/LibWeb/Text/expected/geometry/domrect-create.txt
+++ b/Tests/LibWeb/Text/expected/geometry/domrect-create.txt
@@ -3,24 +3,24 @@ Testing DOMRect:
 2. {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
 3. {"x":-10,"y":-20,"width":30,"height":40,"top":-20,"right":20,"bottom":20,"left":-10}
 4. {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
-5. Exception: TypeError
-6. Exception: TypeError
-7. Exception: TypeError
-8. Exception: TypeError
-9. Exception: TypeError
-10. Exception: TypeError
-11. Exception: TypeError
-12. Exception: TypeError
+5. {"x":null,"y":20,"width":30,"height":40,"top":20,"right":null,"bottom":60,"left":null}
+6. {"x":10,"y":null,"width":30,"height":40,"top":null,"right":40,"bottom":null,"left":10}
+7. {"x":10,"y":20,"width":null,"height":40,"top":20,"right":null,"bottom":60,"left":null}
+8. {"x":10,"y":20,"width":30,"height":null,"top":null,"right":40,"bottom":null,"left":10}
+9. {"x":null,"y":20,"width":30,"height":40,"top":20,"right":null,"bottom":60,"left":null}
+10. {"x":10,"y":null,"width":30,"height":40,"top":null,"right":40,"bottom":null,"left":10}
+11. {"x":10,"y":20,"width":null,"height":40,"top":20,"right":null,"bottom":60,"left":10}
+12. {"x":10,"y":20,"width":30,"height":null,"top":20,"right":40,"bottom":null,"left":10}
 Testing DOMRectReadOnly:
 1. {"x":0,"y":0,"width":0,"height":0,"top":0,"right":0,"bottom":0,"left":0}
 2. {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
 3. {"x":-10,"y":-20,"width":30,"height":40,"top":-20,"right":20,"bottom":20,"left":-10}
 4. {"x":10,"y":20,"width":30,"height":40,"top":20,"right":40,"bottom":60,"left":10}
-5. Exception: TypeError
-6. Exception: TypeError
-7. Exception: TypeError
-8. Exception: TypeError
-9. Exception: TypeError
-10. Exception: TypeError
-11. Exception: TypeError
-12. Exception: TypeError
+5. {"x":null,"y":20,"width":30,"height":40,"top":20,"right":null,"bottom":60,"left":null}
+6. {"x":10,"y":null,"width":30,"height":40,"top":null,"right":40,"bottom":null,"left":10}
+7. {"x":10,"y":20,"width":null,"height":40,"top":20,"right":null,"bottom":60,"left":null}
+8. {"x":10,"y":20,"width":30,"height":null,"top":null,"right":40,"bottom":null,"left":10}
+9. {"x":null,"y":20,"width":30,"height":40,"top":20,"right":null,"bottom":60,"left":null}
+10. {"x":10,"y":null,"width":30,"height":40,"top":null,"right":40,"bottom":null,"left":10}
+11. {"x":10,"y":20,"width":null,"height":40,"top":20,"right":null,"bottom":60,"left":10}
+12. {"x":10,"y":20,"width":30,"height":null,"top":20,"right":40,"bottom":null,"left":10}

--- a/Tests/LibWeb/Text/input/geometry/domrect-create.html
+++ b/Tests/LibWeb/Text/input/geometry/domrect-create.html
@@ -13,7 +13,7 @@
 
         for (const Rect of [DOMRect, DOMRectReadOnly]) {
             println(`Testing ${Rect.name}:`);
-            
+
             // 1. Creating a DOMRect with no arguments
             testPart(() => new Rect());
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
@@ -62,12 +62,14 @@ JS::NonnullGCPtr<DOMQuad> DOMQuad::from_quad(JS::VM& vm, DOMQuadInit const& othe
 // https://drafts.fxtf.org/geometry/#dom-domquad-getbounds
 JS::NonnullGCPtr<DOMRect> DOMQuad::get_bounds() const
 {
+    // The NaN-safe minimum of a non-empty list of unrestricted double values is NaN if any member of the list is NaN, or the minimum of the list otherwise.
     auto nan_safe_minimum = [](double a, double b, double c, double d) -> double {
         if (isnan(a) || isnan(b) || isnan(c) || isnan(d))
             return NAN;
         return min(a, min(b, min(c, d)));
     };
 
+    // Analogously, the NaN-safe maximum of a non-empty list of unrestricted double values is NaN if any member of the list is NaN, or the maximum of the list otherwise.
     auto nan_safe_maximum = [](double a, double b, double c, double d) -> double {
         if (isnan(a) || isnan(b) || isnan(c) || isnan(d))
             return NAN;

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.idl
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.idl
@@ -3,14 +3,13 @@
 // https://drafts.fxtf.org/geometry/#dompoint
 [Exposed=(Window,Worker), Serializable, LegacyWindowAlias=SVGRect]
 interface DOMRect : DOMRectReadOnly {
-
-    constructor(optional double x = 0, optional double y = 0, optional double width = 0, optional double height = 0);
+    constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
+        optional unrestricted double width = 0, optional unrestricted double height = 0);
 
     [NewObject] static DOMRect fromRect(optional DOMRectInit other = {});
 
-    attribute double x;
-    attribute double y;
-    attribute double width;
-    attribute double height;
-
+    attribute unrestricted double x;
+    attribute unrestricted double y;
+    attribute unrestricted double width;
+    attribute unrestricted double height;
 };

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.idl
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.idl
@@ -1,25 +1,25 @@
 // https://drafts.fxtf.org/geometry/#domrectreadonly
 [Exposed=(Window, Worker), Serializable]
 interface DOMRectReadOnly {
-
-    constructor(optional double x = 0, optional double y = 0, optional double width = 0, optional double height = 0);
+    constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
+        optional unrestricted double width = 0, optional unrestricted double height = 0);
 
     [NewObject] static DOMRectReadOnly fromRect(optional DOMRectInit other = {});
 
-    readonly attribute double x;
-    readonly attribute double y;
-    readonly attribute double width;
-    readonly attribute double height;
+    readonly attribute unrestricted double x;
+    readonly attribute unrestricted double y;
+    readonly attribute unrestricted double width;
+    readonly attribute unrestricted double height;
 
-    readonly attribute double top;
-    readonly attribute double right;
-    readonly attribute double bottom;
-    readonly attribute double left;
+    readonly attribute unrestricted double top;
+    readonly attribute unrestricted double right;
+    readonly attribute unrestricted double bottom;
+    readonly attribute unrestricted double left;
 
     [Default] object toJSON();
-
 };
 
+// https://drafts.fxtf.org/geometry/#dictdef-domrectinit
 dictionary DOMRectInit {
     unrestricted double x = 0;
     unrestricted double y = 0;


### PR DESCRIPTION
(cherry picked from commit bff6c0680aff5862e05c68af03a653f2250328b4)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/337