### PR TITLE
Update outdated male-specific language

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -110,7 +110,7 @@ for what to do when this happens.
 If, during build, an error like `fusermount: failed to open /etc/mtab: No such file or directory` appears, you have installed `fuse2fs` but your system does not provide the mtab symlink for various reasons. Simply create this symlink with `ln -sv /proc/self/mounts /etc/mtab`.
 
 Note that the `anon` user is able to become `root` without a password by default, as a development convenience.
-To prevent this, remove `anon` from the `wheel` group and he will no longer be able to run `/bin/su`.
+To prevent this, remove `anon` from the `wheel` group and they will no longer be able to run `/bin/su`.
 
 By default the `anon` user account's password is: `foo`
 

--- a/Kernel/Syscalls/jail.cpp
+++ b/Kernel/Syscalls/jail.cpp
@@ -46,7 +46,7 @@ ErrorOr<FlatPtr> Process::sys$jail_attach(Userspace<Syscall::SC_jail_attach_para
 
     // NOTE: Because the user might run a binary that is using this syscall and
     // that binary was marked as SUID, then the user might be unaware of the
-    // fact that while no new setuid binaries might be executed, he is already
+    // fact that while no new setuid binaries might be executed, they are already
     // running within such binary so for the sake of completeness and preventing
     // naive sense of being secure, we should block that.
     TRY(with_protected_data([&](auto& protected_data) -> ErrorOr<void> {

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -248,7 +248,7 @@ public:
             // With UDP datagrams, reading a datagram into a buffer that's
             // smaller than the datagram's size will cause the rest of the
             // datagram to be discarded. That's not very nice, so let's bail
-            // early, telling the caller that he should allocate a bigger
+            // early, telling the caller that they should allocate a bigger
             // buffer.
             return Error::from_errno(EMSGSIZE);
         }


### PR DESCRIPTION
The pronouns “they”/“them” are a better choice, as Serenity does not cater to only men.