### PR TITLE
Grammar fixes

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -110,7 +110,7 @@ for what to do when this happens.
 If, during build, an error like `fusermount: failed to open /etc/mtab: No such file or directory` appears, you have installed `fuse2fs` but your system does not provide the mtab symlink for various reasons. Simply create this symlink with `ln -sv /proc/self/mounts /etc/mtab`.
 
 Note that the `anon` user is able to become `root` without a password by default, as a development convenience.
-To prevent this, remove `anon` from the `wheel` group and he will no longer be able to run `/bin/su`.
+To prevent this, remove `anon` from the `wheel` group and it will no longer be able to run `/bin/su`.
 
 By default the `anon` user account's password is: `foo`
 

--- a/Documentation/Kernel/RAMFS.md
+++ b/Documentation/Kernel/RAMFS.md
@@ -36,7 +36,7 @@ hotplugging any kind of hardware was not even a consideration.
 
 As the project grew larger and more hardware support was introduced, it became obvious
 that this "solution" was not future-proof. For example, if one user has two SATA drives
-connected to his computer, and another user has just one old IDE drive being used,
+connected to their computer, and another user has just one old IDE drive being used,
 then how should we support both cases? The answer was that each user could simply invoke
 the `mknod` utility to create device nodes. This solution meant that user interaction as well
 as a deep understanding of kernel internals was required to achieve a proper setup.

--- a/Kernel/Syscalls/jail.cpp
+++ b/Kernel/Syscalls/jail.cpp
@@ -46,7 +46,7 @@ ErrorOr<FlatPtr> Process::sys$jail_attach(Userspace<Syscall::SC_jail_attach_para
 
     // NOTE: Because the user might run a binary that is using this syscall and
     // that binary was marked as SUID, then the user might be unaware of the
-    // fact that while no new setuid binaries might be executed, he is already
+    // fact that while no new setuid binaries might be executed, they are already
     // running within such binary so for the sake of completeness and preventing
     // naive sense of being secure, we should block that.
     TRY(with_protected_data([&](auto& protected_data) -> ErrorOr<void> {

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -248,8 +248,7 @@ public:
             // With UDP datagrams, reading a datagram into a buffer that's
             // smaller than the datagram's size will cause the rest of the
             // datagram to be discarded. That's not very nice, so let's bail
-            // early, telling the caller that he should allocate a bigger
-            // buffer.
+            // early, telling the caller to allocate a bigger buffer.
             return Error::from_errno(EMSGSIZE);
         }
 

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -367,7 +367,7 @@ void Editor::enter_search()
 
         // ^L - This is a source of issues, as the search editor refreshes first,
         // and we end up with the wrong order of prompts, so we will first refresh
-        // ourselves, then refresh the search editor, and then tell him not to process
+        // ourselves, then refresh the search editor, and then tell it not to process
         // this event.
         m_search_editor->register_key_input_callback(ctrl('L'), [this](auto& search_editor) {
             fprintf(stderr, "\033[3J\033[H\033[2J"); // Clear screen.


### PR DESCRIPTION
There are a few instances where comments and documentation have minor grammar
issues likely resulting from English being the author's second language.

This PR fixes several such cases, changing to idiomatic English and resolving
where it is unclear whether the user or program/code is being referred to.