### PR TITLE
Cherry-pick "Ladybird/AppKit: Enable reload action"

### DIFF
--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -420,7 +420,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         auto* button = [self create_button:NSImageNameRefreshTemplate
                                with_action:@selector(reload:)
                               with_tooltip:@"Reload page"];
-        [button setEnabled:NO];
+        [button setEnabled:YES];
 
         _reload_toolbar_item = [[NSToolbarItem alloc] initWithItemIdentifier:TOOLBAR_RELOAD_IDENTIFIER];
         [_reload_toolbar_item setView:button];


### PR DESCRIPTION
Is necessary, since history navigation was refactored

(cherry picked from commit 8a7afffdd357b3fb16c7e6c6ff32198165294b60)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/363