### PR TITLE
Cherry-pick "UI/AppKit: Make the header buttons more accessible"

### DIFF
--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -379,7 +379,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     if (tooltip) {
         [button setToolTip:tooltip];
     }
-    [button setBordered:NO];
+
+    [button setBordered:YES];
 
     return button;
 }


### PR DESCRIPTION
By Setting setBordered propperty on header buttons to `Yes` this path makes the whole button clickable. Previously the only the icon was clickable, now it's easy to click.

(cherry picked from commit af909784547c4f0ea8218ce464f45b3a1b0f4cb7)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/328