### PR TITLE
Documentation: Improve 'On ideologically motivated changes'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,4 +135,10 @@ To make this easier, we do appreciate it if folks enable the "Allow edits from m
 
 ## On ideologically motivated changes
 
-This is a purely technical project. As such, it is not an appropriate arena to advertise your personal politics or religious beliefs. Any changes that appear ideologically motivated will be rejected.
+Serenity's goal is to enable collaboration between as many groups as *reasonably* possible, and we welcome contributions that make the project more accessisble to people.
+
+However, Serenity is intended to be a purely technical exercise, in the sense of it not being meant to invoke any sociopolitical change. We explicitly try to avoid drama or getting involved in "external" culture wars, and can reject changes that we feel to be sensitive.
+
+For instance, we can reject changes promoting dogwhistles, religious beliefs—which are unambiguously off-topic—or real-world political candidates.
+
+We may miss the mark sometimes, but we encourage good-faith dialogue over anger.


### PR DESCRIPTION
From my previous interactions with the Serenity community, it was clear to me that this rule (for better or worse) was introduced by the author that wanted to focus on the code and not let an open-source operating system project be used as a 'political vehicle' and so as to not have to possess a political science degree to operate the project thought to be a technical exercise, like building a sandcastle.

For better or worse.

Unfortunately, the wording as-is can be interpreted as a dogwhistle in the direction of "keep politics out of tech", which has been present in communities like, as of recently, NixCPP - and this seems to have caused the problems that Serenity has been intentionally trying to avoid.

It might also disregard cases of technical arguments, arguments involving how people treat each other _within_ the community as well as how to change the wording in documentation with the sole intent of making the project more attractive to more contributors.

Given recent commits and governance changes, I decided to rewrite the rule to make it more clear and encourage people to be "more excellent to each other", while not compromising on what I see as the original meaning.