### PR TITLE
LibGfx/AnimationWriter+WebPWriter: Compress identical pixels in consecutive frames 

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/AnimationWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/AnimationWriter.h
@@ -16,13 +16,34 @@ class AnimationWriter {
 public:
     virtual ~AnimationWriter();
 
+    enum class BlendMode {
+        // The new frame replaces the data below it.
+        Replace,
+
+        // The new frame is blended on top of the data below it.
+        // Use only when the new frame has completely opaque and completely transparent pixels.
+        // The opaque pixels will replace the pixels below them, the transparent pixels will leave pixels below them unchanged.
+        // Use only with AnimationWriter subclasses that return true from can_blend_frames().
+        Blend,
+    };
+
     // Flushes the frame to disk.
     // IntRect { at, at + bitmap.size() } must fit in the dimensions
     // passed to `start_writing_animation()`.
-    // FIXME: Consider passing in disposal method and blend mode.
-    virtual ErrorOr<void> add_frame(Bitmap&, int duration_ms, IntPoint at = {}) = 0;
+    virtual ErrorOr<void> add_frame(Bitmap&, int duration_ms, IntPoint at = {}, BlendMode disposal_method = BlendMode::Replace) = 0;
 
-    ErrorOr<void> add_frame_relative_to_last_frame(Bitmap&, int duration_ms, RefPtr<Bitmap> last_frame);
+    // If this is set to Yes and can_blend_frames() returns true, add_frame_relative_to_last_frame() may
+    // call add_frame() with BlendMode::Blend and a frame that has transparent pixels.
+    enum class AllowInterFrameCompression {
+        No,
+        Yes,
+    };
+    ErrorOr<void> add_frame_relative_to_last_frame(Bitmap&, int duration_ms, RefPtr<Bitmap> last_frame, AllowInterFrameCompression = AllowInterFrameCompression::Yes);
+
+    virtual bool can_blend_frames() const { return false; }
+
+private:
+    bool can_zero_out_unchanging_pixels(Bitmap& new_frame, Gfx::IntRect new_frame_rect, Bitmap& last_frame, AllowInterFrameCompression) const;
 };
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFWriter.cpp
@@ -168,15 +168,19 @@ public:
     {
     }
 
-    virtual ErrorOr<void> add_frame(Bitmap&, int, IntPoint) override;
+    virtual ErrorOr<void> add_frame(Bitmap&, int, IntPoint, BlendMode) override;
 
 private:
     SeekableStream& m_stream;
     bool m_is_first_frame { true };
 };
 
-ErrorOr<void> GIFAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, IntPoint at = {})
+ErrorOr<void> GIFAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, IntPoint at, BlendMode)
 {
+    // FIXME: After implementing support for writing GIFs with transparent pixels:
+    // * Set "Transparency Flag" in write_graphic_control_extension() to true for them if BlendMode is set
+    // * Override AnimationWriter::can_blend_frames() to return true
+
     // Let's get rid of the previously written trailer
     if (!m_is_first_frame)
         TRY(m_stream.seek(-1, SeekMode::FromCurrentPosition));

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriter.cpp
@@ -223,7 +223,7 @@ public:
     {
     }
 
-    virtual ErrorOr<void> add_frame(Bitmap&, int, IntPoint) override;
+    virtual ErrorOr<void> add_frame(Bitmap&, int, IntPoint, BlendMode) override;
 
     ErrorOr<void> update_size_in_header();
     ErrorOr<void> set_alpha_bit_in_header();
@@ -299,8 +299,10 @@ static ErrorOr<void> write_ANMF_chunk_header(Stream& stream, ANMFChunkHeader con
     return {};
 }
 
-ErrorOr<void> WebPAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, IntPoint at)
+ErrorOr<void> WebPAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, IntPoint at, BlendMode)
 {
+    // FIXME: Honor BlendMode.
+
     if (at.x() < 0 || at.y() < 0 || at.x() + bitmap.width() > m_dimensions.width() || at.y() + bitmap.height() > m_dimensions.height())
         return Error::from_string_literal("Frame does not fit in animation dimensions");
 


### PR DESCRIPTION
AnimationWriter already only stores the smallest rect that contains
changing pixels between two frames. For example, when doing a screen
recording and only the mouse cursor moves, we already only encode
the pixels in the (single) rectangle containing old and new mouse cursor
positions.

Within that rectangle, there can still be many pixels that are identical
over the two frames. When possible, we now replace all identical pixels
with transparent black. This has two advantages:

1. It can reduce the number of colors in the image. In particular,
   for wow.gif (and likely many other gifs), new frames had more
   than 256 colors before, and have fewer than 256 colors after this
   change.

2. Long run of identical pixels compress better.

In some cases, this transform might make things slighly worse,
for example if the input image already consists of long runs of
a single color. We'll now add another color to it (transparent black),
without it helping much. And the decoder now must do some blending,
slowing down decoding a bit.

But most of the time this should be a pretty big win. We can tweak
the heuristic when to do it later.

This transform is possible when:

* The new frame doesn't already have transparent pixels (which are
  different from the old frame)

* The encoder/decoder can handle frames with transparent pixels

For the latter reason, encoders currently have to opt in to this.

## LibGfx/WebPWriter: Opt in WebPAnimationWriter to inter frame compression

No effect on sunset-retro.png since that's not animated.

        wow.gif (nee giphy.gif) (184k):
            1.4M -> 255K
            74.0 ms ± 1.1 ms -> 86.9 ms ± 3.3 ms

    (from 7.6x as big as the gif input to 1.4x as big.
    About 82% smaller, for a 16% slowdown.)

        7z7c.gif (11K):
            8.4K -> 8.6K
            12.9 ms ± 0.5 ms -> 12.7 ms ± 0.5 ms

    (2.4% bigger, so the transform makes things a bit worse for this
    image.)
