### PR TITLE
Cherry-pick "LibWeb: Stop deadlocking on unit tests"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/Performance.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
@@ -335,6 +336,13 @@ void EventLoop::process()
             }
         }
     });
+
+    // FIXME: Not in the spec: If there is a screenshot request queued, process it now.
+    //        This prevents tests deadlocking on screenshot requests on macOS.
+    for (auto& document : docs) {
+        if (document->page().top_level_traversable()->needs_repaint())
+            document->page().client().process_screenshot_requests();
+    }
 
     // 13. If all of the following are true
     // - this is a window event loop

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -258,6 +258,7 @@ public:
     virtual double device_pixels_per_css_pixel() const = 0;
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
     virtual void paint_next_frame() = 0;
+    virtual void process_screenshot_requests() = 0;
     virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, PaintOptions = {}) = 0;
     virtual void page_did_change_title(ByteString const&) { }
     virtual void page_did_change_url(URL::URL const&) { }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -74,6 +74,7 @@ public:
     virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page->client().preferred_color_scheme(); }
     virtual void request_file(FileRequest) override { }
     virtual void paint_next_frame() override { }
+    virtual void process_screenshot_requests() override { }
     virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override { }
     virtual void schedule_repaint() override { }
     virtual bool is_ready_to_paint() const override { return true; }

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -185,11 +185,16 @@ Web::Layout::Viewport* PageClient::layout_root()
     return document->layout_node();
 }
 
-void PageClient::paint_next_frame()
+void PageClient::process_screenshot_requests()
 {
     if (!m_backing_stores.back_bitmap) {
         return;
     }
+}
+
+void PageClient::paint_next_frame()
+{
+    process_screenshot_requests();
 
     auto& back_bitmap = *m_backing_stores.back_bitmap;
     auto viewport_rect = page().css_to_device_rect(page().top_level_traversable()->viewport_rect());

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -43,6 +43,7 @@ public:
     ErrorOr<void> connect_to_webdriver(ByteString const& webdriver_ipc_path);
 
     virtual void paint_next_frame() override;
+    virtual void process_screenshot_requests() override;
     virtual void paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap&, Web::PaintOptions = {}) override;
 
     void set_palette_impl(Gfx::PaletteImpl&);

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -30,6 +30,7 @@ public:
     virtual double device_pixels_per_css_pixel() const override;
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
     virtual void paint_next_frame() override {};
+    virtual void process_screenshot_requests() override { }
     virtual void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;
     virtual void schedule_repaint() override {};


### PR DESCRIPTION
Unit tests on macOS deadlock because the WebContent process is waiting for the next opportunity to render before a screenshot is taken. For some reason unknown to myself, this opportunity never arrives. In order to not deadlock, screenshot requests are now also processed separately from rendering.

(cherry picked from commit 31698281b6ec9da6abb695625d766a9450536eed; manually amended to fix a minor clang-format violation)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/386