### PR TITLE
Window.cpp: Remove TODOs that have been done

### DIFF
--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -53,15 +53,8 @@ struct Sample {
 
     void clip()
     {
-        if (left > 1)
-            left = 1;
-        else if (left < -1)
-            left = -1;
-
-        if (right > 1)
-            right = 1;
-        else if (right < -1)
-            right = -1;
+        left = clamp(left, -1, 1);
+        right = clamp(right, -1, 1);
     }
 
     // Logarithmic scaling, as audio should ALWAYS do.

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -53,8 +53,15 @@ struct Sample {
 
     void clip()
     {
-        left = clamp(left, -1, 1);
-        right = clamp(right, -1, 1);
+        if (left > 1)
+            left = 1;
+        else if (left < -1)
+            left = -1;
+
+        if (right > 1)
+            right = 1;
+        else if (right < -1)
+            right = -1;
     }
 
     // Logarithmic scaling, as audio should ALWAYS do.

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -293,7 +293,6 @@ void Window::set_minimizable(bool minimizable)
         return;
     m_minimizable = minimizable;
     update_window_menu_items();
-    // TODO: Hide/show (or alternatively change enabled state of) window minimize button dynamically depending on value of m_minimizable
 }
 
 void Window::set_closeable(bool closeable)
@@ -443,7 +442,6 @@ void Window::set_resizable(bool resizable)
         return;
     m_resizable = resizable;
     update_window_menu_items();
-    // TODO: Hide/show (or alternatively change enabled state of) window maximize button dynamically depending on value of is_resizable()
 }
 
 void Window::event(Core::Event& event)


### PR DESCRIPTION
Userland/Services/WindowServer/Window.cpp contained two TODO comments.
They were about disabling the min/maximize buttons on windows.
This feature has been added, so I removed the comments.