### PR TITLE
Meta: Update the Ladybird repo notice and remove it from the README

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -1,6 +1,7 @@
 # Ladybird browser build instructions
 
-**NOTE:** The Ladybird cross-platform web browser project is now separate from SerenityOS, and is now actively developed in the [LadybirdBrowser/ladybird](https://github.com/LadybirdBrowser/ladybird) repository.
+> [!NOTE]
+> The Ladybird web browser project has moved to [LadybirdBrowser/ladybird](https://github.com/LadybirdBrowser/ladybird), this version is kept as a developer convenience for the testing of LibWeb and LibJS libraries included with SerenityOS.
 
 ## Build Prerequisites
 

--- a/Ladybird/README.md
+++ b/Ladybird/README.md
@@ -1,14 +1,14 @@
 # Ladybird
 
+> [!NOTE]
+> The Ladybird web browser project has moved to [LadybirdBrowser/ladybird](https://github.com/LadybirdBrowser/ladybird), this version is kept as a developer convenience for the testing of LibWeb and LibJS libraries included with SerenityOS.
+
 Ladybird is a web browser built on the [LibWeb](https://github.com/SerenityOS/serenity/tree/master/Userland/Libraries/LibWeb) and [LibJS](https://github.com/SerenityOS/serenity/tree/master/Userland/Libraries/LibJS) engines from [SerenityOS](https://github.com/SerenityOS/serenity).
 The Browser UI has a cross-platform GUI in Qt6 and a macOS-specific GUI in AppKit.
 
 Ladybird aims to be a standards-compliant, independent web browser with no third-party dependencies.
 Currently, the only dependencies are UI frameworks like Qt6 and AppKit, and low-level platform-specific
 libraries like PulseAudio, CoreAudio and OpenGL.
-
-> [!IMPORTANT]
-> Ladybird is in a pre-alpha state, and only suitable for use by developers
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Graphical Unix-like operating system for x86-64 computers.
 
-**NOTE:** The Ladybird cross-platform web browser project is now separate from SerenityOS, and is now actively developed in the [LadybirdBrowser/ladybird](https://github.com/LadybirdBrowser/ladybird) repository.
-
 [![GitHub Actions Status](https://github.com/SerenityOS/serenity/workflows/Build,%20lint,%20and%20test/badge.svg)](https://github.com/SerenityOS/serenity/actions?query=workflow%3A"Build%2C%20lint%2C%20and%20test")
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:serenity)
 [![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/serenityos)


### PR DESCRIPTION
As it has been a month since the migration, I believe it is safe to remove the warning and specify the state of the SerenityOS version of the Ladybird browser.