### PR TITLE
LibGUI: Add alt shortcut for make_quit_action

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -160,9 +160,11 @@ void BrowserWindow::build_menus(StringView const man_file)
     file_menu->add_action(close_tab_action);
 
     file_menu->add_separator();
-    file_menu->add_action(GUI::CommonActions::make_quit_action([](auto&) {
-        GUI::Application::the()->quit();
-    }));
+    file_menu->add_action(GUI::CommonActions::make_quit_action(
+        [](auto&) {
+            GUI::Application::the()->quit();
+        },
+        GUI::CommonActions::QuitAltShortcut::None));
 
     auto view_menu = add_menu("&View"_string);
     view_menu->add_action(WindowActions::the().show_bookmarks_bar_action());

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -75,7 +75,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto quit_action = GUI::CommonActions::make_quit_action(
         [&](auto&) {
             app->quit();
-        });
+        },
+        GUI::CommonActions::QuitAltShortcut::None);
 
     auto auto_modifier_action = GUI::Action::create("Auto-Modifier", [&](auto& act) {
         keyboard_mapper_widget->set_automatic_modifier(act.is_checked());

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -286,10 +286,12 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
     file_menu->add_action(*m_close_image_action);
 
-    file_menu->add_action(GUI::CommonActions::make_quit_action([this](auto&) {
-        if (request_close())
-            GUI::Application::the()->quit();
-    }));
+    file_menu->add_action(GUI::CommonActions::make_quit_action(
+        [this](auto&) {
+            if (request_close())
+                GUI::Application::the()->quit();
+        },
+        GUI::CommonActions::QuitAltShortcut::None));
 
     m_edit_menu = window.add_menu("&Edit"_string);
 

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -384,11 +384,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return GUI::MessageBox::ExecResult::OK;
     };
 
-    file_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) {
-        dbgln("Terminal: Quit menu activated!");
-        if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
-            GUI::Application::the()->quit();
-    }));
+    file_menu->add_action(GUI::CommonActions::make_quit_action(
+        [&](auto&) {
+            dbgln("Terminal: Quit menu activated!");
+            if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
+                GUI::Application::the()->quit();
+        },
+        GUI::CommonActions::QuitAltShortcut::None));
 
     auto edit_menu = window->add_menu("&Edit"_string);
     edit_menu->add_action(terminal->copy_action());

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         action.set_icon(catdog_widget->is_sleeping() ? catdog_icon_wake : catdog_icon_sleep);
     }));
     context_menu->add_separator();
-    context_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
+    context_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }, GUI::CommonActions::QuitAltShortcut::None));
 
     window->show();
     window->set_always_on_top();

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -24,6 +24,11 @@
 namespace GUI {
 
 namespace CommonActions {
+enum class QuitAltShortcut {
+    None,
+    CtrlW
+};
+
 NonnullRefPtr<Action> make_about_action(String const& app_name, Icon const& app_icon, Window* parent = nullptr);
 NonnullRefPtr<Action> make_open_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
 NonnullRefPtr<Action> make_save_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
@@ -38,7 +43,7 @@ NonnullRefPtr<Action> make_move_to_front_action(Function<void(Action&)>, Core::E
 NonnullRefPtr<Action> make_move_to_back_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
 NonnullRefPtr<Action> make_insert_emoji_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
 NonnullRefPtr<Action> make_fullscreen_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
-NonnullRefPtr<Action> make_quit_action(Function<void(Action&)>);
+NonnullRefPtr<Action> make_quit_action(Function<void(Action&)>, QuitAltShortcut = QuitAltShortcut::CtrlW);
 NonnullRefPtr<Action> make_help_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
 NonnullRefPtr<Action> make_go_back_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);
 NonnullRefPtr<Action> make_go_forward_action(Function<void(Action&)>, Core::EventReceiver* parent = nullptr);

--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -117,9 +117,12 @@ NonnullRefPtr<Action> make_fullscreen_action(Function<void(Action&)> callback, C
     return action;
 }
 
-NonnullRefPtr<Action> make_quit_action(Function<void(Action&)> callback)
+NonnullRefPtr<Action> make_quit_action(Function<void(Action&)> callback, QuitAltShortcut quit_alt_shortcut)
 {
-    auto action = Action::create("&Quit", { Mod_Alt, Key_F4 }, move(callback));
+    Shortcut alternate_shortcut = { Mod_Ctrl, Key_W };
+    if (quit_alt_shortcut == QuitAltShortcut::None)
+        alternate_shortcut = {};
+    auto action = Action::create("&Quit", { Mod_Alt, Key_F4 }, alternate_shortcut, move(callback));
     action->set_status_tip("Quit the application"_string);
     return action;
 }


### PR DESCRIPTION
This patch adds the common Ctrl-W shortcut to `make_quit_action` as an alternate shortcut by default.

The shortcut can be disabled in programs using this key binding for a different purpose, e.g. closing tabs, or instances where the "close window" concept would not be applicable, such as CatDog.

To the best of my knowledge, I have disabled the shortcut for any existing programs in the system where the aforementioned examples or any additional conflicts would apply.