### PR TITLE
Window.cpp: Remove TODOs

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -293,7 +293,6 @@ void Window::set_minimizable(bool minimizable)
         return;
     m_minimizable = minimizable;
     update_window_menu_items();
-    // TODO: Hide/show (or alternatively change enabled state of) window minimize button dynamically depending on value of m_minimizable
 }
 
 void Window::set_closeable(bool closeable)
@@ -443,7 +442,6 @@ void Window::set_resizable(bool resizable)
         return;
     m_resizable = resizable;
     update_window_menu_items();
-    // TODO: Hide/show (or alternatively change enabled state of) window maximize button dynamically depending on value of is_resizable()
 }
 
 void Window::event(Core::Event& event)


### PR DESCRIPTION
Userland/Services/WindowServer/Window.cpp contained two TODO comments about disabling the min/maximize buttons on windows. This feature has been added, so I removed the comments.

The feature was added on lines 237 and 240 of Window.cpp, in Window::update_window_menu_items().

[This pull request](https://github.com/SerenityOS/serenity/commit/74ae6ac94b990037ae5ef412781e74e4c896af2f#diff-ee8b9ee1447ca3309e2ff182ed1a16a553b519a598548e98d72288279a6bc605) first implemented the feature. Some pull requests later on, like [this one](https://github.com/SerenityOS/serenity/commit/5aa9f128fca5a377d88323e7e4a5dc57efdae547), updated it.