### PR TITLE
LibAudio: Use clamp() in Sample::clip()

### DIFF
--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -53,15 +53,8 @@ struct Sample {
 
     void clip()
     {
-        if (left > 1)
-            left = 1;
-        else if (left < -1)
-            left = -1;
-
-        if (right > 1)
-            right = 1;
-        else if (right < -1)
-            right = -1;
+        left = clamp(left, -1, 1);
+        right = clamp(right, -1, 1);
     }
 
     // Logarithmic scaling, as audio should ALWAYS do.


### PR DESCRIPTION
Sample::clip() now uses clamp().