### PR TITLE
AK: Do not build against libexecinfo on non-glibc systems

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -10,7 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 
-#if defined(AK_OS_LINUX) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
+#if (defined(AK_OS_LINUX) && defined(AK_LIBC_GLIBC)) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
 #    define EXECINFO_BACKTRACE
 #endif
 


### PR DESCRIPTION
See [this](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/36722) for more context; the libexecinfo package got removed from Alpine last year, and for recent builds I've resorted to using a version from one of the old repositories. Looks like there's no point in building with it considering that it's broken anyways.