### PR TITLE
AK: Re-enable execinfo for GNU Hurd

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -10,7 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 
-#if (defined(AK_OS_LINUX) && defined(AK_LIBC_GLIBC)) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
+#if (defined(AK_OS_LINUX) && defined(AK_LIBC_GLIBC)) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU) || defined(AK_OS_GNU_HURD)
 #    define EXECINFO_BACKTRACE
 #endif
 


### PR DESCRIPTION
Spiritual continuation of #24669 (I couldn't add more commits to the previous branch, so a new MR it is...)

Adds an explicit check for Hurd due to previous regression. 

@ADKaster do you see any way this could break? I think that Hurd is an outlier and otherwise nothing (that's not Linux) uses glibc; If I'm wrong, then maybe the correct way is to stop checking for Linux and just check for glibc itself?