### PR TITLE
AK+LibWeb: First steps for PowerPC CPU architecture support

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -21,4 +21,6 @@ static constexpr bool TODO = false;
 #    define TODO() VERIFY(TODO)                /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #    define TODO_AARCH64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #    define TODO_RISCV64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define TODO_PPC64() VERIFY(TODO)          /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define TODO_PPC() VERIFY(TODO)            /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #endif

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -39,6 +39,23 @@
 #    define AK_IS_ARCH_RISCV64() 0
 #endif
 
+#if defined(__ppc64__) || defined(__PPC64__)
+#    define AK_IS_ARCH_PPC64() 1
+#else
+#    define AK_IS_ARCH_PPC64() 0
+#endif
+#if defined(__ppc64le__) || defined(__PPC64LE__)
+#    define AK_IS_ARCH_PPC64LE() 1
+#else
+#    define AK_IS_ARCH_PPC64LE() 0
+#endif
+
+#if defined(__ppc__) || defined(__PPC__) || defined(__powerpc__) || defined(__powerpc) || defined(__POWERPC__)
+#    define AK_IS_ARCH_PPC() 1
+#else
+#    define AK_IS_ARCH_PPC() 0
+#endif
+
 #ifdef __wasm32__
 #    define AK_IS_ARCH_WASM32() 1
 #else

--- a/Userland/Libraries/LibWeb/Loader/UserAgent.h
+++ b/Userland/Libraries/LibWeb/Loader/UserAgent.h
@@ -19,6 +19,10 @@ namespace Web {
 #    define CPU_STRING "x86"
 #elif ARCH(RISCV64)
 #    define CPU_STRING "RISC-V 64"
+#elif ARCH(PPC64) || ARCH(PPC64LE)
+#    define CPU_STRING "PowerPC 64"
+#elif ARCH(PPC)
+#    define CPU_STRING "PowerPC"
 #else
 #    error Unknown architecture
 #endif


### PR DESCRIPTION
This PR adds `AK_IS_ARCH` defines for ppc/ppc64/ppc64le and user agent CPU strings for 32-bit and 64-bit PowerPC.

For the 64-bit PowerPC user agent I followed the `RISC-V 64` pretty-printed example instead of using `ppc64(le)` like `x86_64` or `AArch64`.

-----
This is a copy of LadybirdBrowser/Ladybird#391 and has not been tested in SerenityOS, because I don't have a system running SerenityOS.