### PR TITLE
LibJS: Implement extract_pointer_bits for ppc64

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -435,8 +435,11 @@ public:
         // For x86_64 and riscv64 the top 16 bits should be sign extending the "real" top bit (47th).
         // So first shift the top 16 bits away then using the right shift it sign extends the top 16 bits.
         return static_cast<FlatPtr>((static_cast<i64>(encoded << 16)) >> 16);
-#elif ARCH(AARCH64)
+#elif ARCH(AARCH64) || ARCH(PPC64) || ARCH(PPC64LE)
         // For AArch64 the top 16 bits of the pointer should be zero.
+        // For PPC64: all 64 bits can be used for pointers, however on Linux only
+        //            the lower 43 bits are used for user-space addresses, so
+        //            masking off the top 16 bits should match the rest of LibJS.
         return static_cast<FlatPtr>(encoded & 0xffff'ffff'ffffULL);
 #else
 #    error "Unknown architecture. Don't know whether pointers need to be sign-extended."


### PR DESCRIPTION
On PowerPC 64 pointers can use all 64 bits, however by convention on Linux user-space addresses use only the lower 43 bits. I'm not 100% certain that the masking off of the 16 high bits is the proper solution, but it matches the rest of the LibJS code which assumes pointers only use the lower 48 bits.

https://www.kernel.org/doc/ols/2001/ppc64.pdf

-----
This is a copy of LadybirdBrowser/Ladybird#504 and has not been tested in SerenityOS, because I don't have a system running SerenityOS.