### PR TITLE
AK: Fix {:c} formatter for big-endian

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -879,13 +879,17 @@ template<Integral T>
 ErrorOr<void> Formatter<T>::format(FormatBuilder& builder, T value)
 {
     if (m_mode == Mode::Character) {
-        // FIXME: We just support ASCII for now, in the future maybe unicode?
-        //        VERIFY(value >= 0 && value <= 127);
-
         m_mode = Mode::String;
 
         Formatter<StringView> formatter { *this };
-        return formatter.format(builder, StringView { reinterpret_cast<char const*>(&value), 1 });
+
+        // FIXME: We just support ASCII for now, in the future maybe unicode?
+        VERIFY(value >= 0 && value <= 127);
+
+        // Convert value to a single byte. This is important for big-endian systems, because the LSB is stored in the last byte.
+        char const c = (value & 0x7f);
+
+        return formatter.format(builder, StringView { &c, 1 });
     }
 
     if (m_precision.has_value())


### PR DESCRIPTION
Just casting an integer type to a char pointer does not work on big endian.
Instead, the value needs to be properly converted into a char.

I uncommented the 7-bit ASCII check while at it. I think it's better to be safer than necessary to spot cases where high ASCII/UTF-8 support would be needed earlier.

-----
This is a copy of LadybirdBrowser/Ladybird#434 and has not been tested in SerenityOS, because I don't have a system running SerenityOS.