### PR TITLE
LibELF: Fix incorrect treatment of DT_REL&DT_RELA

### DIFF
--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -127,7 +127,7 @@ void DynamicObject::parse()
             break;
         case DT_PLTREL:
             m_procedure_linkage_table_relocation_type = entry.val();
-            VERIFY(m_procedure_linkage_table_relocation_type & (DT_REL | DT_RELA));
+            VERIFY(m_procedure_linkage_table_relocation_type == DT_REL || m_procedure_linkage_table_relocation_type == DT_RELA);
             break;
         case DT_JMPREL:
             m_plt_relocation_offset_location = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
@@ -305,7 +305,7 @@ DynamicObject::RelocationSection DynamicObject::relocation_section() const
 
 DynamicObject::RelocationSection DynamicObject::plt_relocation_section() const
 {
-    return RelocationSection(Section(*this, m_plt_relocation_offset_location, m_size_of_plt_relocation_entry_list, m_size_of_relocation_entry, "DT_JMPREL"sv), m_procedure_linkage_table_relocation_type & DT_RELA);
+    return RelocationSection(Section(*this, m_plt_relocation_offset_location, m_size_of_plt_relocation_entry_list, m_size_of_relocation_entry, "DT_JMPREL"sv), m_procedure_linkage_table_relocation_type == DT_RELA);
 }
 
 DynamicObject::Section DynamicObject::relr_relocation_section() const


### PR DESCRIPTION
In the current code, these are treated as if they were a bitmap. They are not, and (DT_REL & DT_RELA) is actually nonzero. This causes the linker to treat all sections as having addends, which is not correct.