### PR TITLE
Calendar: Initial support for iCalendar format

### DIFF
--- a/Userland/Applications/Calendar/CalendarWidget.cpp
+++ b/Userland/Applications/Calendar/CalendarWidget.cpp
@@ -225,7 +225,10 @@ ErrorOr<NonnullRefPtr<GUI::Action>> CalendarWidget::create_new_calendar_action()
 NonnullRefPtr<GUI::Action> CalendarWidget::create_open_calendar_action()
 {
     return GUI::CommonActions::make_open_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().open_file(window());
+        GUI::FileTypeFilter calendar_files;
+        calendar_files.name = "Calendar Files";
+        calendar_files.extensions = Vector<ByteString> { "cal", "ics" };
+        auto response = FileSystemAccessClient::Client::the().open_file(window(), { .allowed_file_types = Vector { calendar_files, GUI::FileTypeFilter::all_files() } });
         if (response.is_error())
             return;
         (void)load_file(response.release_value());

--- a/Userland/Applications/Calendar/EventManager.cpp
+++ b/Userland/Applications/Calendar/EventManager.cpp
@@ -10,6 +10,7 @@
 #include <AK/QuickSort.h>
 #include <LibConfig/Client.h>
 #include <LibFileSystemAccessClient/Client.h>
+#include <LibTimeZone/TimeZone.h>
 
 namespace Calendar {
 
@@ -97,14 +98,103 @@ ErrorOr<Vector<Event>> EventManager::deserialize_events(JsonArray const& json)
     return result;
 }
 
+Core::DateTime EventManager::format_icalendar_vevent_datetime(String const& parameter)
+{
+    auto invalid_datetime = Core::DateTime::create(0);
+    auto date_time_bytes = parameter.bytes();
+
+    // https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.5
+    // 3.3.5.  Date-Time
+    //     date-time  = date "T" time ;As specified in the DATE and TIME
+    //                                ;value definitions
+    if (date_time_bytes.size() < 15 || date_time_bytes[8] != 'T')
+        return invalid_datetime;
+
+    auto formatted_string = String::formatted("{:c}-{:c}-{:c}T{:c}:{:c}:{:c}",
+        date_time_bytes.slice(0, 4), date_time_bytes.slice(4, 2),
+        date_time_bytes.slice(6, 2), date_time_bytes.slice(9, 2),
+        date_time_bytes.slice(11, 2), date_time_bytes.slice(13, 2));
+    if (formatted_string.is_error())
+        return invalid_datetime;
+    auto datetime = Core::DateTime::parse(DATE_FORMAT, formatted_string.value());
+    if (!datetime.has_value())
+        return invalid_datetime;
+
+    // FORM #1: DATE WITH LOCAL TIME
+    if (date_time_bytes.size() == 15)
+        return datetime.value();
+
+    // FORM #2: DATE WITH UTC TIME
+    if (date_time_bytes.size() == 16 && date_time_bytes[15] == 'Z') {
+        auto offset = TimeZone::get_time_zone_offset(TimeZone::system_time_zone(), UnixDateTime::epoch());
+        if (!offset.has_value())
+            return invalid_datetime;
+        auto utc_timestamp = datetime.value().timestamp();
+        datetime = Core::DateTime::from_timestamp(utc_timestamp + offset.value().seconds);
+        return datetime.has_value() ? datetime.value() : invalid_datetime;
+    }
+
+    // FIXME: Implement FORM #3: DATE WITH LOCAL TIME AND TIME ZONE REFERENCE
+    return invalid_datetime;
+}
+
+// https://datatracker.ietf.org/doc/html/rfc5545
+ErrorOr<Vector<Event>> EventManager::parse_icalendar_vevents(ByteBuffer const& content)
+{
+    Event event;
+    Vector<Event> events;
+    ICalendarParserState state = ICalendarParserState::Idle;
+    auto lines = StringView(content.bytes()).split_view('\n');
+    for (size_t i = 0; i < lines.size(); i++) {
+        auto section = TRY(String::formatted("{}", lines[i]).value().split_limit(':', 2));
+        if (section.size() > 1) {
+            auto property = section[0];
+            auto parameter = TRY(section[1].trim_ascii_whitespace());
+            switch (state) {
+            case ICalendarParserState::InVEvent:
+                if (property.bytes().starts_with("DTSTART"sv.bytes()))
+                    event.start = format_icalendar_vevent_datetime(parameter);
+                if (property.bytes().starts_with("DTEND"sv.bytes()))
+                    event.end = format_icalendar_vevent_datetime(parameter);
+                if (property == "SUMMARY")
+                    event.summary = parameter;
+                if (property == "END" && parameter == "VEVENT") {
+                    if (event.start.year() && event.end.year())
+                        events.append(event);
+                    state = ICalendarParserState::Idle;
+                }
+                break;
+            case ICalendarParserState::Idle:
+                if (property == "BEGIN" && parameter == "VEVENT")
+                    state = ICalendarParserState::InVEvent;
+                break;
+            default:
+                break;
+            }
+        }
+    }
+    return events;
+}
+
+ErrorOr<Vector<Event>> EventManager::parse_events(ByteBuffer const& content)
+{
+    // If content is iCalendar format, try to parse VEVENTs
+    if (content.span().starts_with("BEGIN:VCALENDAR"sv.bytes())) {
+        set_filename("");
+        return parse_icalendar_vevents(content);
+    }
+    // Otherwise, try to parse content as JSON
+    auto json = TRY(AK::JsonParser(content).parse());
+    return deserialize_events(json.as_array());
+}
+
 ErrorOr<void> EventManager::load_file(FileSystemAccessClient::File& file)
 {
     set_filename(file.filename());
 
     auto content = TRY(file.stream().read_until_eof());
-    auto json = TRY(AK::JsonParser(content).parse());
-    auto events = TRY(deserialize_events(json.as_array()));
-    set_events(events);
+    auto events = parse_events(content);
+    set_events(TRY(events));
 
     m_dirty = false;
 

--- a/Userland/Applications/Calendar/EventManager.h
+++ b/Userland/Applications/Calendar/EventManager.h
@@ -47,8 +47,16 @@ public:
 private:
     explicit EventManager();
 
+    enum class ICalendarParserState {
+        Idle = 0,
+        InVEvent
+    };
+
     ErrorOr<JsonArray> serialize_events();
     ErrorOr<Vector<Event>> deserialize_events(JsonArray const& json);
+    ErrorOr<Vector<Event>> parse_events(ByteBuffer const& content);
+    ErrorOr<Vector<Event>> parse_icalendar_vevents(ByteBuffer const& content);
+    Core::DateTime format_icalendar_vevent_datetime(String const& parameter);
 
     Vector<Event> m_events;
 


### PR DESCRIPTION
This PR adds basic support for loading iCalendar (.ics) files and parsing VEVENT properties that are currently supported by Calendar Events: summary, start and end.