### PR TITLE
LibGfx/WebPLoader: Use transparent black as animation background color

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -1395,7 +1395,7 @@ TEST_CASE(test_webp_extended_lossless_animated)
         EXPECT_EQ(frame.image->get_pixel(500, 700), Gfx::Color::Yellow);
 
         // This one isn't the same in all frames.
-        EXPECT_EQ(frame.image->get_pixel(500, 0), (frame_index == 2 || frame_index == 6) ? Gfx::Color::Black : Gfx::Color(255, 255, 255, 0));
+        EXPECT_EQ(frame.image->get_pixel(500, 0), (frame_index == 2 || frame_index == 6) ? Gfx::Color::Black : Gfx::Color(0, 0, 0, 0));
     }
 }
 


### PR DESCRIPTION
This matches libwebp (see ZeroFillCanvas() call in libwebp/src/demux/anim_decode.c:355 and ZeroFillFrameRect() call in line 435, but in WebPAnimDecoderGetNext()) and makes files written e.g. by asesprite look correct -- even though the old behavior is also spec-compliant and arguably makes more sense. Now nothing looks at the background color stored in the file.

See PR for an example image where it makes a visible difference.