### PR TITLE
LibGfx/WebPWriter: Add support for writing color cache symbols

### DIFF
--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -249,6 +249,22 @@ TEST_CASE(test_webp_color_indexing_transform_single_channel)
     }
 }
 
+TEST_CASE(test_webp_color_cache)
+{
+    auto bitmap = TRY_OR_FAIL(create_test_rgba_bitmap());
+    for (int color_cache_bits = 0; color_cache_bits <= 11; ++color_cache_bits) {
+        Gfx::WebPEncoderOptions options;
+        if (color_cache_bits == 0)
+            options.vp8l_options.color_cache_bits = {};
+        else
+            options.vp8l_options.color_cache_bits = color_cache_bits;
+
+        auto encoded_data = TRY_OR_FAIL(encode_bitmap<Gfx::WebPWriter>(bitmap));
+        auto decoded_bitmap = TRY_OR_FAIL(expect_single_frame_of_size(*TRY_OR_FAIL(Gfx::WebPImageDecoderPlugin::create(encoded_data)), bitmap->size()));
+        expect_bitmaps_equal(*decoded_bitmap, *bitmap);
+    }
+}
+
 TEST_CASE(test_webp_icc)
 {
     auto sRGB_icc_profile = MUST(Gfx::ICC::sRGB());

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.h
@@ -14,6 +14,11 @@ namespace Gfx {
 struct VP8LEncoderOptions {
     // For each TransformType, set bit `1 << transform_type` if that transform type is allowed.
     unsigned allowed_transforms { 0xf };
+
+    // If set, must be in [1, 11].
+    // Even if this set, if the encoder decides that a color cache would not be useful, it may not use one
+    // (e.g. for images that use a color indexing transform already).
+    Optional<unsigned> color_cache_bits { 6 };
 };
 
 ErrorOr<ByteBuffer> compress_VP8L_image_data(Bitmap const&, VP8LEncoderOptions const&, bool& is_fully_opaque);


### PR DESCRIPTION
Lossless WebP allows having a 1-bit to 11-bit addressed
"color cache", where pixels are inserted into a content-addressed
cache of size `1 << color_cache_bits`. Pixels in the color
cache can be addressed using their index. This can be used
to refer to literal pixels using a single color_cache_bits
large symbol, instead of up to 4 symbols for GBRA.

We default to always using a color cache with 6 bits, unless
the input image already uses only a single channel already
(either as-is, or if we write a color indexing transform).

    sunset_retro.png (876K):
        1.6M -> 1.4M, 29.1 ms ± 0.9 ms -> 31.7 ms ± 0.9 ms

From 83% larger than the input file to 60% larger (12.5% smaller),
for a 9% slowdown.

The two gifs I usually test with don't change: Files using the
color _index_ transform (i.e. that have < 256 colors) don't
use the color _cache_ in our encoder.

---

Not too much longer, and we'll have most of the features of the QOI writer, for just a small multiple of the code size :P