### PR TITLE
Cherry-pick "LibWeb: Don't fire resize event until document actually resizes once"

### DIFF
--- a/Tests/LibWeb/Text/expected/no-window-resize-on-load.txt
+++ b/Tests/LibWeb/Text/expected/no-window-resize-on-load.txt
@@ -1,0 +1,1 @@
+resize count: 0

--- a/Tests/LibWeb/Text/input/no-window-resize-on-load.html
+++ b/Tests/LibWeb/Text/input/no-window-resize-on-load.html
@@ -1,0 +1,12 @@
+<script>
+    var resizeCount = 0;
+    onresize = function() {
+        ++resizeCount;
+    }
+</script>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println("resize count: " + resizeCount);
+    })
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2553,11 +2553,14 @@ void Document::run_the_resize_steps()
     //    fire an event named resize at the Window object associated with doc.
 
     auto viewport_size = viewport_rect().size().to_type<int>();
+    bool is_initial_size = !m_last_viewport_size.has_value();
+
     if (m_last_viewport_size == viewport_size)
         return;
     m_last_viewport_size = viewport_size;
 
-    window()->dispatch_event(DOM::Event::create(realm(), UIEvents::EventNames::resize));
+    if (!is_initial_size)
+        window()->dispatch_event(DOM::Event::create(realm(), UIEvents::EventNames::resize));
 
     schedule_layout_update();
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -786,7 +786,7 @@ private:
     bool m_page_showing { false };
 
     // Used by run_the_resize_steps().
-    Gfx::IntSize m_last_viewport_size;
+    Optional<Gfx::IntSize> m_last_viewport_size;
 
     HashTable<ViewportClient*> m_viewport_clients;
 


### PR DESCRIPTION
The first time Document learns its viewport size, we now suppress firing of the resize event.

This fixes an issue on multiple websites that were not expecting resize events to fire so early in the loading process.

(cherry picked from commit 4e7558c88b7a993686bb3dc173731e677efe5e26)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/547