### PR TITLE
Cherry-pick "LibWeb: Invalidate input element style on focus change"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1093,16 +1093,21 @@ void HTMLInputElement::update_slider_thumb_element()
 
 void HTMLInputElement::did_receive_focus()
 {
-    auto navigable = document().navigable();
-    if (!navigable)
-        return;
     if (!m_text_node)
         return;
+    m_text_node->invalidate_style();
+    auto navigable = document().navigable();
+    if (!navigable) {
+        return;
+    }
     navigable->set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
 }
 
 void HTMLInputElement::did_lose_focus()
 {
+    if (m_text_node)
+        m_text_node->invalidate_style();
+
     commit_pending_changes();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -67,16 +67,21 @@ void HTMLTextAreaElement::visit_edges(Cell::Visitor& visitor)
 
 void HTMLTextAreaElement::did_receive_focus()
 {
-    auto navigable = document().navigable();
-    if (!navigable)
-        return;
     if (!m_text_node)
         return;
+    m_text_node->invalidate_style();
+    auto navigable = document().navigable();
+    if (!navigable) {
+        return;
+    }
     navigable->set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
 }
 
 void HTMLTextAreaElement::did_lose_focus()
 {
+    if (m_text_node)
+        m_text_node->invalidate_style();
+
     // The change event fires when the value is committed, if that makes sense for the control,
     // or else when the control loses focus
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {


### PR DESCRIPTION
The style of input and textarea elements is now invalidated when focus is changed to a new element. This ensures any `:focus` selectors are applied correctly.

(cherry picked from commit 572324d47b99bcfbc5db5ff6aef0d6c4eb15ce4c)

--

https://github.com/LadybirdBrowser/ladybird/pull/499