### PR TITLE
Cherry-pick "LibWeb: Define width for -webkit-slider-runnable-track"

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -79,6 +79,7 @@ input[type=range]::-webkit-slider-runnable-track, input[type=range]::-webkit-sli
 }
 input[type=range]::-webkit-slider-runnable-track {
     height: 4px;
+    width: 100%;
     margin-top: 6px;
     background-color:  hsl(217, 71%, 53%);
     border: 1px solid rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Fixes https://github.com/LadybirdBrowser/ladybird/issues/512

(cherry picked from commit b5e80db2259448bc0b3dc48d88f53e8d1880987e)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/518