### PR TITLE
Cherry-pick "LibWeb: Populate filename in `WindowOrWorkerGlobalScope.reportError()`"

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
+++ b/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
@@ -1,5 +1,6 @@
 message = Reporting an Error!
-filename = 
 lineno = 0
 colno = 0
 error = Error: Reporting an Error!
+filename URL scheme = file:
+filename URL final path segment = WindowOrWorkerGlobalScope-reportError.html

--- a/Tests/LibWeb/Text/input/HTML/WindowOrWorkerGlobalScope-reportError.html
+++ b/Tests/LibWeb/Text/input/HTML/WindowOrWorkerGlobalScope-reportError.html
@@ -3,11 +3,13 @@
     test(() => {
         window.onerror = (message, filename, lineno, colno, error) => {
             println(`message = ${message}`);
-            println(`filename = ${filename}`);
             println(`lineno = ${lineno}`);
             println(`colno = ${colno}`);
             println(`error = ${error}`);
-
+            // We can't simply print the filename because it is the full path to the active script, which varies between machines.
+            const filenameURL = new URL(filename);
+            println(`filename URL scheme = ${filenameURL.protocol}`);
+            println(`filename URL final path segment = ${filenameURL.pathname.split('/').pop()}`);
             return true;
         };
 


### PR DESCRIPTION
Previously, when `WindowOrWorkerGlobalScope.reportError()` was called the `filename` property of the dispatched error event was blank. It is now populated with the full path of the active script.

(cherry picked from commit 34b987366449313c96a73ec1d70e88e60f2c4510)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/493