### PR TITLE
Cherry-pick "LibWeb: Harmonize look of range input element"

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -78,9 +78,10 @@ input[type=range]::-webkit-slider-runnable-track, input[type=range]::-webkit-sli
     display: block;
 }
 input[type=range]::-webkit-slider-runnable-track {
+    position: relative;
     height: 4px;
     margin-top: 6px;
-    background-color: AccentColor;
+    background-color: Background;
     border: 1px solid rgba(0, 0, 0, 0.5);
 }
 input[type=range]::-webkit-slider-thumb {
@@ -89,8 +90,9 @@ input[type=range]::-webkit-slider-thumb {
     height: 16px;
     transform: translateX(-50%);
     border-radius: 50%;
-    background-color: Background;
+    background-color: AccentColor;
     outline: 1px solid rgba(0, 0, 0, 0.5);
+    z-index: 1;
 }
 
 /* Custom <meter> styles */

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -317,6 +317,8 @@ private:
     String m_last_src_value;
 
     bool m_has_uncommitted_changes { false };
+
+    JS::GCPtr<DOM::Element> m_range_progress_element;
 };
 
 }


### PR DESCRIPTION
Previously the entire slider track was colored.
Now only the lower part of the slider track (left side of the thumb) is colored.
Chrome and Firefox do the same.

(cherry picked from commit 7766909415312b971252f8c7750b0a1873fd5ba0)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/513