### PR TITLE
Cherry-pick "LibWeb: Remove set_event_characteristics()"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1354,6 +1354,9 @@ void Document::set_hovered_node(Node* node)
     // https://w3c.github.io/uievents/#mouseout
     if (old_hovered_node && old_hovered_node != m_hovered_node) {
         UIEvents::MouseEventInit mouse_event_init {};
+        mouse_event_init.bubbles = true;
+        mouse_event_init.cancelable = true;
+        mouse_event_init.composed = true;
         mouse_event_init.related_target = m_hovered_node;
         auto event = UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseout, mouse_event_init);
         old_hovered_node->dispatch_event(event);
@@ -1373,6 +1376,9 @@ void Document::set_hovered_node(Node* node)
     // https://w3c.github.io/uievents/#mouseover
     if (m_hovered_node && m_hovered_node != old_hovered_node) {
         UIEvents::MouseEventInit mouse_event_init {};
+        mouse_event_init.bubbles = true;
+        mouse_event_init.cancelable = true;
+        mouse_event_init.composed = true;
         mouse_event_init.related_target = old_hovered_node;
         auto event = UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseover, mouse_event_init);
         m_hovered_node->dispatch_event(event);

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -47,7 +47,6 @@ MouseEvent::MouseEvent(JS::Realm& realm, FlyString const& event_name, MouseEvent
     , m_buttons(event_init.buttons)
     , m_related_target(event_init.related_target)
 {
-    set_event_characteristics();
 }
 
 MouseEvent::~MouseEvent() = default;
@@ -146,15 +145,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platfo
     auto event = MouseEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double());
     event->set_is_trusted(true);
     return event;
-}
-
-void MouseEvent::set_event_characteristics()
-{
-    if (type().is_one_of(EventNames::mousedown, EventNames::mousemove, EventNames::mouseout, EventNames::mouseover, EventNames::mouseup, HTML::EventNames::click, EventNames::dblclick, EventNames::contextmenu)) {
-        set_bubbles(true);
-        set_cancelable(true);
-        set_composed(true);
-    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -77,8 +77,6 @@ protected:
 private:
     virtual bool is_mouse_event() const override { return true; }
 
-    void set_event_characteristics();
-
     double m_screen_x { 0 };
     double m_screen_y { 0 };
     double m_page_x { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -23,7 +23,6 @@ WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEvent
     , m_delta_z(event_init.delta_z)
     , m_delta_mode(event_init.delta_mode)
 {
-    set_event_characteristics();
 }
 
 WheelEvent::~WheelEvent() = default;
@@ -63,13 +62,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platfo
     auto event = WheelEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double());
     event->set_is_trusted(true);
     return event;
-}
-
-void WheelEvent::set_event_characteristics()
-{
-    set_bubbles(true);
-    set_cancelable(true);
-    set_composed(true);
 }
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -48,8 +48,6 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    void set_event_characteristics();
-
     double m_delta_x { 0 };
     double m_delta_y { 0 };
     double m_delta_z { 0 };


### PR DESCRIPTION
These methods were overriding properties specified by the EventInit property bags in the constructor for WheelEvent and MouseEvent.

They appear to be legacy code and no longer relevant, as they would have been used for ensuring natively dispatched events had the correct properties --- This is now done in separate create methods, such as MouseEvent::create_from_platform_event.

This fixes a couple WPT failures (e.g. in
/dom/events/Event-subclasses-constructors.html)

(cherry picked from commit 2c396b5378fec5f4470e1e1e950806dff8005f08)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/586