### PR TITLE
Cherry-pick "LibWeb: Implement `Node.normalize()`"

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Node-normalize.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Node-normalize.txt
@@ -1,0 +1,8 @@
+Document fragment initial text: 12, child nodes: 3
+Element initial text: 34, child nodes: 2
+Element text after document.normalize(): 34, child nodes: 2
+Document fragment text after documentFragment.normalize(): 1234, child nodes: 2
+Text node 1 data: 12
+Text node 2 data: 2
+Text node 3 data: 34
+Text node 4 data: 4

--- a/Tests/LibWeb/Text/input/DOM/Node-normalize.html
+++ b/Tests/LibWeb/Text/input/DOM/Node-normalize.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const documentFragment = document.createDocumentFragment();
+        const textNode1 = document.createTextNode("1");
+        const textNode2 = document.createTextNode("2");
+        const textNode3 = document.createTextNode("3");
+        const textNode4 = document.createTextNode("4");
+        const emptyTextNode = document.createTextNode("");
+        documentFragment.appendChild(textNode1);
+        documentFragment.appendChild(emptyTextNode);
+        documentFragment.appendChild(textNode2);
+        println(`Document fragment initial text: ${documentFragment.textContent}, child nodes: ${documentFragment.childNodes.length}`);
+        let element = document.createElement('div');
+        documentFragment.appendChild(element);
+        element.appendChild(textNode3);
+        element.appendChild(textNode4);
+        println(`Element initial text: ${element.textContent}, child nodes: ${element.childNodes.length}`);
+        document.normalize();
+        println(`Element text after document.normalize(): ${element.textContent}, child nodes: ${element.childNodes.length}`);
+        documentFragment.normalize();
+        println(`Document fragment text after documentFragment.normalize(): ${documentFragment.textContent}, child nodes: ${documentFragment.childNodes.length}`);
+        println(`Text node 1 data: ${textNode1.data}`);
+        println(`Text node 2 data: ${textNode2.data}`);
+        println(`Text node 3 data: ${textNode3.data}`);
+        println(`Text node 4 data: ${textNode4.data}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -156,6 +156,8 @@ public:
     Optional<String> text_content() const;
     void set_text_content(Optional<String> const&);
 
+    WebIDL::ExceptionOr<void> normalize();
+
     Optional<String> node_value() const;
     void set_node_value(Optional<String> const&);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -28,6 +28,7 @@ interface Node : EventTarget {
     //        However, we only apply it to setters, so this works as a stop gap.
     //        Replace this with something like a special cased [LegacyNullToEmptyString].
     [LegacyNullToEmptyString, CEReactions] attribute DOMString? textContent;
+    [CEReactions] undefined normalize();
 
     [CEReactions] Node appendChild(Node node);
     [ImplementedAs=pre_insert, CEReactions] Node insertBefore(Node node, Node? child);


### PR DESCRIPTION
This method puts the given node and all of its sub-tree into a normalized form. A normalized sub-tree has no empty text nodes and no adjacent text nodes.

(cherry picked from commit 0a0651f34ea927a0ca44dc5d2c7786f3dcf8da25)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/588