### PR TITLE
Cherry-pick "LibWeb: Align transform_stream_error_writable_and_unblock_write w/ spec"

### DIFF
--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -5211,9 +5211,8 @@ void transform_stream_error_writable_and_unblock_write(TransformStream& stream, 
     // 2. Perform ! WritableStreamDefaultControllerErrorIfNeeded(stream.[[writable]].[[controller]], e).
     writable_stream_default_controller_error_if_needed(*stream.writable()->controller(), error);
 
-    // 3. If stream.[[backpressure]] is true, perform ! TransformStreamSetBackpressure(stream, false).
-    if (stream.backpressure().has_value() && *stream.backpressure())
-        transform_stream_set_backpressure(stream, false);
+    // 3. Perform ! TransformStreamUnblockWrite(stream).
+    transform_stream_unblock_write(stream);
 }
 
 //  https://streams.spec.whatwg.org/#transform-stream-set-backpressure


### PR DESCRIPTION
This aligns AO transform_stream_error_writable_and_unblock_write() with the spec.

No functional change is introduced by this amendment.

(cherry picked from commit 24bed027b2db59935da185d3bd490718ccb37baa)

--

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/585