### PR TITLE
LibC: Call pthread key destructors before global destructors

### DIFF
--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -349,6 +349,10 @@ extern "C" {
 
 void exit(int status)
 {
+#ifndef _DYNAMIC_LOADER
+    __pthread_key_destroy_for_current_thread();
+#endif
+
     __cxa_finalize(nullptr);
 
     if (secure_getenv("LIBC_DUMP_MALLOC_STATS"))
@@ -356,10 +360,6 @@ void exit(int status)
 
     __call_fini_functions();
     fflush(nullptr);
-
-#ifndef _DYNAMIC_LOADER
-    __pthread_key_destroy_for_current_thread();
-#endif
 
     _exit(status);
 }


### PR DESCRIPTION
Since be2bf055 the ThreadEventQueue is now destroyed via a phread key destructor, which leads to many other objects being destroyed. A bunch of these destructors reference globals, but exit() calls destructors on globals before phread destructors, this bad state leads to the hangs seen in #24694.

Fixes #24694