### PR TITLE
Cherry-pick "LibWeb: Implement WebIDL constructor flow for derived classes"

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/derived-interface-prototype.txt
+++ b/Tests/LibWeb/Text/expected/DOM/derived-interface-prototype.txt
@@ -1,0 +1,1 @@
+derived class method present and invoked!

--- a/Tests/LibWeb/Text/input/DOM/derived-interface-prototype.html
+++ b/Tests/LibWeb/Text/input/DOM/derived-interface-prototype.html
@@ -1,0 +1,19 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        class MyEventTarget extends EventTarget {
+            derivedClassMethod() {
+                println("derived class method present and invoked!");
+            }
+        }
+        let instance = new MyEventTarget();
+        if (instance.__proto__ !== MyEventTarget.prototype) {
+            println("Derived class MyEventTarget has incorrect prototype.");
+        }
+        try {
+            instance.derivedClassMethod();
+        } catch (e) {
+            println(e);
+        }
+    });
+</script>


### PR DESCRIPTION
Following the rules in the algorithm from
https://webidl.spec.whatwg.org/#js-platform-objects, "To Internally create a new object implementing the interface interface", this change incorporates the steps to load a prototype from new.target, and write it to the created instance returned from constructor_impl(). This mirrors the code for generate_html_constructor(), which incorporates additional steps needed by Custom Elements.

Bug https://github.com/LadybirdBrowser/ladybird/issues/334

(cherry picked from commit 80cd3712c2c52bf749a19cbd21af0c5c479a87c9)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/379