### PR TITLE
Cherry-pick "LibWebView: Trim whitespace when sanitizing file paths"

### DIFF
--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -36,8 +36,8 @@ Optional<String> get_public_suffix([[maybe_unused]] StringView host)
 
 Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engine, AppendTLD append_tld)
 {
-    if (FileSystem::exists(url)) {
-        auto path = FileSystem::real_path(url);
+    if (FileSystem::exists(url.trim_whitespace())) {
+        auto path = FileSystem::real_path(url.trim_whitespace());
         if (path.is_error())
             return {};
 


### PR DESCRIPTION
Previously, the presence of surrounding whitespace would give file paths the `https` schema instead of the `file` schema, making navigation unsuccessful.

(cherry picked from commit ff7ca5c48c316e07b1bf631b2d7ed14c358dfa42)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/631