### PR TITLE
Cherry-pick "LibWeb: Add null check in Document::ancestor_navigables()"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3073,9 +3073,13 @@ Vector<JS::Handle<HTML::Navigable>> Document::inclusive_descendant_navigables()
 // https://html.spec.whatwg.org/multipage/document-sequences.html#ancestor-navigables
 Vector<JS::Handle<HTML::Navigable>> Document::ancestor_navigables()
 {
+    // NOTE: This isn't in the spec, but if we don't have a navigable, we can't have ancestors either.
+    auto document_node_navigable = this->navigable();
+    if (!document_node_navigable)
+        return {};
+
     // 1. Let navigable be document's node navigable's parent.
-    VERIFY(navigable());
-    auto navigable = this->navigable()->parent();
+    auto navigable = document_node_navigable->parent();
 
     // 2. Let ancestors be an empty list.
     Vector<JS::Handle<HTML::Navigable>> ancestors;


### PR DESCRIPTION
The spec doesn't explicitly forbid calling this when the document doesn't have a node navigable, so let's handle that situation gracefully by just returning an empty list of ancestors.

I hit this VERIFY somewhere on the web, but I don't know how to reproduce it.

---

Cherry-picks PR-less (!) https://github.com/LadybirdBrowser/ladybird/commit/b118c99c271e

Without this, the render process crashes when going to "resource://asdf" or "google.com:22" when testing https://github.com/SerenityOS/serenity/pull/24702.