### PR TITLE
Kernel/FileSystem: Clean up duplicated if statements

### DIFF
--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -56,11 +56,10 @@ OpenFileDescription::~OpenFileDescription()
     m_file->detach(*this);
     // FIXME: Should this error path be observed somehow?
     (void)m_file->close();
-    if (m_inode)
+    if (m_inode) {
         m_inode->detach(*this);
-
-    if (m_inode)
         m_inode->remove_flocks_for_description(*this);
+    }
 }
 
 ErrorOr<void> OpenFileDescription::attach()


### PR DESCRIPTION
This commit merges 2 if statements that check the same condition in OpenFileDescription::~OpenFileDescription().