### PR TITLE
CI: Stop running WPT on Lagom (Linux, ubuntu-22.04, NO_FUZZ) / CI)

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -166,13 +166,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      - name: WPT
-        if: ${{ inputs.os_name == 'Linux' && inputs.fuzzer == 'NO_FUZZ' }}
-        working-directory: ${{ github.workspace }}/Tests/LibWeb/WPT
-        run: ./run.sh --remove-wpt-repository
-        env:
-          QT_QPA_PLATFORM: 'offscreen'
-
       - name: Lints
         if: ${{ inputs.os_name == 'Linux' && inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
This step runs a small subset of WPT. Several of the tests it runs fail, but the step doesn't fail, indicating that nobody looks at the step's output.

The step takes 3 minutes to run. We can add it back later if someone is interested in looking at the output.