### PR TITLE
Meta: Update Wasm LibJS build for "recent" emscripten changes

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -571,8 +571,8 @@ if (BUILD_LAGOM)
         if (EMSCRIPTEN)
             lagom_utility(libjs SOURCES Wasm/js_repl.cpp LIBS LibJS LibLocale LibTimeZone LibUnicode)
             target_link_options(libjs PRIVATE
-                    -sEXPORTED_FUNCTIONS=_initialize_repl,_execute
-                    -sEXPORTED_RUNTIME_METHODS=allocateUTF8
+                    -sEXPORTED_FUNCTIONS=_initialize_repl,_execute,_free
+                    -sEXPORTED_RUNTIME_METHODS=stringToNewUTF8
                     -sERROR_ON_UNDEFINED_SYMBOLS=0
                     -sENVIRONMENT=web)
         endif()


### PR DESCRIPTION
- `_free` is no longer exported by default, export it manually
- `allocateUTF8` is deprecated, and replaced with `stringToNewUTF8`