### PR TITLE
Kernel/FileSystem: Small code cleanups

### DIFF
--- a/Kernel/FileSystem/Ext2FS/Definitions.h
+++ b/Kernel/FileSystem/Ext2FS/Definitions.h
@@ -17,6 +17,7 @@
 #define _LINUX_EXT2_FS_H
 
 static constexpr size_t max_block_size = 4096;
+static constexpr size_t super_block_offset_on_device = 1024;
 
 #include "ext2_types.h" /* Changed from linux/types.h */
 

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -34,8 +34,7 @@ ErrorOr<void> Ext2FS::flush_super_block()
 
     // FIXME: We currently have no ability of writing within a device block, but the ability to do so would allow us to use device block sizes larger than 1024.
     VERIFY((sizeof(ext2_super_block) % device_block_size()) == 0);
-    // First superblock is always at offset 1024 (physical block index 2).
-    TRY(raw_write_blocks(1024 / device_block_size(), superblock_physical_block_count, super_block_buffer));
+    TRY(raw_write_blocks(super_block_offset_on_device / device_block_size(), superblock_physical_block_count, super_block_buffer));
 
     auto is_sparse = has_flag(get_features_readonly(), FeaturesReadOnly::SparseSuperblock);
 
@@ -72,7 +71,7 @@ ErrorOr<void> Ext2FS::initialize_while_locked()
 
     VERIFY((sizeof(ext2_super_block) % device_block_size()) == 0);
     auto super_block_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&m_super_block);
-    TRY(raw_read_blocks(1024 / device_block_size(), (sizeof(ext2_super_block) / device_block_size()), super_block_buffer));
+    TRY(raw_read_blocks(super_block_offset_on_device / device_block_size(), (sizeof(ext2_super_block) / device_block_size()), super_block_buffer));
 
     auto const& super_block = this->super_block();
     if constexpr (EXT2_DEBUG) {

--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -280,11 +280,11 @@ bool OpenFileDescription::is_tty() const
     return m_file->is_tty();
 }
 
-const TTY* OpenFileDescription::tty() const
+TTY const* OpenFileDescription::tty() const
 {
     if (!is_tty())
         return nullptr;
-    return static_cast<const TTY*>(m_file.ptr());
+    return static_cast<TTY const*>(m_file.ptr());
 }
 
 TTY* OpenFileDescription::tty()

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -73,7 +73,7 @@ public:
     Device* device();
 
     bool is_tty() const;
-    const TTY* tty() const;
+    TTY const* tty() const;
     TTY* tty();
 
     bool is_inode_watcher() const;


### PR DESCRIPTION
This PR adds some small code cleanups to the FileSystem code.

The 2 commits do the following:
* Update the placement of some const keywords to match the 'const placement' rule of the style guide.
* Replace a hardcoded offset in the Ext2FS code with a constexpr