### PR TITLE
Cherry-pick "LibWeb: Implement the `:has()` pseudo-class"

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -72,6 +72,7 @@ struct PseudoClassMetadata {
         ANPlusBOf,
         CompoundSelector,
         ForgivingSelectorList,
+        ForgivingRelativeSelectorList,
         Ident,
         LanguageRanges,
         SelectorList,
@@ -167,6 +168,8 @@ PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
                 parameter_type = "CompoundSelector"_string;
             } else if (argument_string == "<forgiving-selector-list>"sv) {
                 parameter_type = "ForgivingSelectorList"_string;
+            } else if (argument_string == "<forgiving-relative-selector-list>"sv) {
+                parameter_type = "ForgivingRelativeSelectorList"_string;
             } else if (argument_string == "<ident>"sv) {
                 parameter_type = "Ident"_string;
             } else if (argument_string == "<language-ranges>"sv) {

--- a/Tests/LibWeb/Ref/css-has-compound.html
+++ b/Tests/LibWeb/Ref/css-has-compound.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="match" href="reference/css-has-compound.html" />
+<style>
+    a:has(span.nice > em) {
+        color: orange;
+    }
+</style>
+<a href="https://example.com"><em><span class="nice"><em>Link</em></span></em></a>
+<a href="https://example.com"><em>Link</em></a>
+<a href="https://example.com"><em><span class="hello"><em>Link</em></span></em></a>
+<a href="https://example.com"><em><span class="nice">Link</span></em></a>

--- a/Tests/LibWeb/Ref/css-has-descendant.html
+++ b/Tests/LibWeb/Ref/css-has-descendant.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<link rel="match" href="reference/css-has-descendant.html" />
+<style>
+    a:has(span) {
+        color: orange;
+    }
+</style>
+<a href="https://example.com"><em><span>Link</span></em></a>
+<a href="https://example.com"><em>Link</em></a>

--- a/Tests/LibWeb/Ref/css-has-direct-child.html
+++ b/Tests/LibWeb/Ref/css-has-direct-child.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<link rel="match" href="reference/css-has-direct-child.html" />
+<style>
+    a:has(> span) {
+        color: orange;
+    }
+</style>
+<a href="https://example.com"><span>Link</span></a>
+<a href="https://example.com"><em><span>Link</span></em></a>

--- a/Tests/LibWeb/Ref/css-has-next-sibling.html
+++ b/Tests/LibWeb/Ref/css-has-next-sibling.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="match" href="reference/css-has-next-sibling.html" />
+<style>
+    a:has(+ span) {
+        color: orange;
+    }
+</style>
+<a href="https://example.com">Link</a><span>Hello!</span>
+<a href="https://example.com">Link</a><em>Hello!</em>
+<a href="https://example.com">Link</a><em>Hello</em><span>world!</span>
+<a href="https://example.com">Link</a>

--- a/Tests/LibWeb/Ref/css-has-subsequent-sibling.html
+++ b/Tests/LibWeb/Ref/css-has-subsequent-sibling.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<link rel="match" href="reference/css-has-subsequent-sibling.html" />
+<style>
+    a:has(~ span) {
+        color: orange;
+    }
+</style>
+<div>
+    <a href="https://example.com">Link</a><span>Hello!</span>
+</div>
+<div>
+    <a href="https://example.com">Link</a><em>Hello!</em>
+</div>
+<div>
+    <a href="https://example.com">Link</a><em>Hello</em><span>world!</span>
+</div>
+<div>
+    <a href="https://example.com">Link</a>
+</div>

--- a/Tests/LibWeb/Ref/css-nested-has.html
+++ b/Tests/LibWeb/Ref/css-nested-has.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<link rel="match" href="reference/css-nested-has.html" />
+<style>
+    a:has(span:has(strong)) {
+        color: orange;
+    }
+</style>
+<a href="https://example.com"><em><span><strong>Link</strong></span></em></a>

--- a/Tests/LibWeb/Ref/css-pseudo-element-in-has.html
+++ b/Tests/LibWeb/Ref/css-pseudo-element-in-has.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<link rel="match" href="reference/css-pseudo-element-in-has.html" />
+<style>
+    span::after {
+        content: "bar";
+        color: red;
+    }
+    a:has(::after) {
+        color: orange;
+    }
+</style>
+<a href="https://example.com"><span>foo</span></a>

--- a/Tests/LibWeb/Ref/reference/css-has-compound.html
+++ b/Tests/LibWeb/Ref/reference/css-has-compound.html
@@ -1,0 +1,4 @@
+<a href="https://example.com" style="color: orange"><em><span class="nice"><em>Link</em></span></em></a>
+<a href="https://example.com"><em>Link</em></a>
+<a href="https://example.com"><em><span class="hello"><em>Link</em></span></em></a>
+<a href="https://example.com"><em><span class="nice">Link</span></em></a>

--- a/Tests/LibWeb/Ref/reference/css-has-descendant.html
+++ b/Tests/LibWeb/Ref/reference/css-has-descendant.html
@@ -1,0 +1,2 @@
+<a href="https://example.com" style="color: orange"><em><span class="nice"><em>Link</em></span></em></a>
+<a href="https://example.com"><em>Link</em></a>

--- a/Tests/LibWeb/Ref/reference/css-has-direct-child.html
+++ b/Tests/LibWeb/Ref/reference/css-has-direct-child.html
@@ -1,0 +1,2 @@
+<a href="https://example.com" style="color: orange"><span>Link</span></a>
+<a href="https://example.com"><em><span>Link</span></em></a>

--- a/Tests/LibWeb/Ref/reference/css-has-next-sibling.html
+++ b/Tests/LibWeb/Ref/reference/css-has-next-sibling.html
@@ -1,0 +1,4 @@
+<a href="https://example.com" style="color: orange">Link</a><span>Hello!</span>
+<a href="https://example.com">Link</a><em>Hello!</em>
+<a href="https://example.com">Link</a><em>Hello</em><span>world!</span>
+<a href="https://example.com">Link</a>

--- a/Tests/LibWeb/Ref/reference/css-has-subsequent-sibling.html
+++ b/Tests/LibWeb/Ref/reference/css-has-subsequent-sibling.html
@@ -1,0 +1,12 @@
+<div>
+    <a href="https://example.com" style="color: orange">Link</a><span>Hello!</span>
+</div>
+<div>
+    <a href="https://example.com">Link</a><em>Hello!</em>
+</div>
+<div>
+    <a href="https://example.com" style="color: orange">Link</a><em>Hello</em><span>world!</span>
+</div>
+<div>
+    <a href="https://example.com">Link</a>
+</div>

--- a/Tests/LibWeb/Ref/reference/css-nested-has.html
+++ b/Tests/LibWeb/Ref/reference/css-nested-has.html
@@ -1,0 +1,1 @@
+<a href="https://example.com"><em><span><strong>Link</strong></span></em></a>

--- a/Tests/LibWeb/Ref/reference/css-pseudo-element-in-has.html
+++ b/Tests/LibWeb/Ref/reference/css-pseudo-element-in-has.html
@@ -1,0 +1,1 @@
+<a href="https://example.com"><span>foo<span style="color: red">bar</span></span></a>

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -516,10 +516,14 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                     .argument_selector_list = { move(selector) } }
             };
         }
+        case PseudoClassMetadata::ParameterType::ForgivingRelativeSelectorList:
         case PseudoClassMetadata::ParameterType::ForgivingSelectorList: {
             auto function_token_stream = TokenStream(pseudo_function.values());
+            auto selector_type = metadata.parameter_type == PseudoClassMetadata::ParameterType::ForgivingSelectorList
+                ? SelectorType::Standalone
+                : SelectorType::Relative;
             // NOTE: Because it's forgiving, even complete garbage will parse OK as an empty selector-list.
-            auto argument_selector_list = MUST(parse_a_selector_list(function_token_stream, SelectorType::Standalone, SelectorParsingMode::Forgiving));
+            auto argument_selector_list = MUST(parse_a_selector_list(function_token_stream, selector_type, SelectorParsingMode::Forgiving));
 
             return Selector::SimpleSelector {
                 .type = Selector::SimpleSelector::Type::PseudoClass,

--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -44,6 +44,9 @@
   "focus-within": {
     "argument": ""
   },
+  "has": {
+    "argument": "<forgiving-relative-selector-list>"
+  },
   "host": {
     "argument": "<compound-selector>?"
   },

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -119,6 +119,7 @@ u32 Selector::specificity() const
             case SimpleSelector::Type::PseudoClass: {
                 auto& pseudo_class = simple_selector.pseudo_class();
                 switch (pseudo_class.type) {
+                case PseudoClass::Has:
                 case PseudoClass::Is:
                 case PseudoClass::Not: {
                     // The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -11,7 +11,12 @@
 
 namespace Web::SelectorEngine {
 
-bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type> = {}, JS::GCPtr<DOM::ParentNode const> scope = {});
+enum class SelectorKind {
+    Normal,
+    Relative,
+};
+
+bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type> = {}, JS::GCPtr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal);
 
 [[nodiscard]] bool fast_matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&);
 [[nodiscard]] bool can_use_fast_matches(CSS::Selector const&);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -527,6 +527,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 }
                 case CSS::PseudoClassMetadata::ParameterType::CompoundSelector:
                 case CSS::PseudoClassMetadata::ParameterType::ForgivingSelectorList:
+                case CSS::PseudoClassMetadata::ParameterType::ForgivingRelativeSelectorList:
                 case CSS::PseudoClassMetadata::ParameterType::SelectorList: {
                     builder.append("(["sv);
                     for (auto& selector : pseudo_class.argument_selector_list)


### PR DESCRIPTION
See https://drafts.csswg.org/selectors-4/#relational.

(cherry picked from commit f63a945ba0300551417c740e450957f29c9b73d1)

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/613