### PR TITLE
Cherry-pick "LibJS: Implement CreatePerIterationEnvironment for 'for' statements"

### DIFF
--- a/Userland/Libraries/LibJS/Tests/loops/for-scopes.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-scopes.js
@@ -16,3 +16,19 @@ test("const in for head", () => {
         c;
     }).toThrowWithMessage(ReferenceError, "'c' is not defined");
 });
+
+test("let variables captured by value", () => {
+    let result = "";
+    let functionList = [];
+    for (let i = 0; i < 9; i++) {
+        result += i;
+        functionList.push(function () {
+            return i;
+        });
+    }
+    for (let i = 0; i < functionList.length; i++) {
+        result += functionList[i]();
+    }
+
+    expect(result).toEqual("012345678012345678");
+});


### PR DESCRIPTION
Implement for CreatePerIterationEnvironment for 'for' loops per the Ecma Standard. This ensures each iteration of a 'for' loop has its own lexical environment so that variables declared in the loop are scoped to the current iteration.

(cherry picked from commit dbc2f7ed48f00234f5f94a30b06b83842d9cf4dd)

---

https://github.com/LadybirdBrowser/ladybird/pull/675