### PR TITLE
Cherry-pick "LibWeb: Subtract left inset from size_available_for_margins for abspos"

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-insets-and-auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-insets-and-auto-margins.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x418 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x402 children: not-inline
+      BlockContainer <div.features-list> at (9,9) content-size 400x400 positioned children: not-inline
+        BlockContainer <div.feature> at (109,10) content-size 200x200 positioned [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [109,10 102.625x17] baseline: 13.296875
+              "Autocorrect"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x418]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x402]
+      PaintableWithLines (BlockContainer<DIV>.features-list) [8,8 402x402]
+        PaintableWithLines (BlockContainer<DIV>.feature) [108,9 202x202]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-with-insets-and-auto-margins.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-with-insets-and-auto-margins.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><style>
+.features-list {
+    position: relative;
+    width: 400px;
+    height: 400px;
+    border: 1px solid red;
+}
+
+.feature {
+    position: absolute;
+    margin: auto;
+    border: 1px solid black;
+    left: 100px;
+    right: 100px;
+    width: 200px;
+    height: 200px;
+}
+</style><div class="features-list"><div class="feature">Autocorrect</div></div>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -726,7 +726,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             // If both margin-left and margin-right are auto,
             // solve the equation under the extra constraint that the two margins get equal values
             // FIXME: unless this would make them negative, in which case when direction of the containing block is ltr (rtl), set margin-left (margin-right) to 0 and solve for margin-right (margin-left).
-            auto size_available_for_margins = width_of_containing_block - border_left - padding_left - width.to_px(box) - padding_right - border_right - right;
+            auto size_available_for_margins = width_of_containing_block - border_left - padding_left - width.to_px(box) - padding_right - border_right - left - right;
             if (margin_left.is_auto() && margin_right.is_auto()) {
                 margin_left = CSS::Length::make_px(size_available_for_margins / 2);
                 margin_right = CSS::Length::make_px(size_available_for_margins / 2);


### PR DESCRIPTION
Fixes https://github.com/LadybirdBrowser/ladybird/issues/712

(cherry picked from commit 0be57df54dd57d1544eead1c1bc8fe117c0a3450)

---

https://github.com/LadybirdBrowser/ladybird/pull/714