### PR TITLE
Cherry-pick "ImageDecoder: Pass decoded images as Gfx::Bitmap over IPC"

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -22,6 +22,9 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 #include <LibGfx/ShareableBitmap.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibIPC/File.h>
 #include <errno.h>
 #include <stdio.h>
 
@@ -675,6 +678,47 @@ void Bitmap::flood_visit_from_point(Gfx::IntPoint start_point, int threshold,
             flood_mask.set(flood_mask_index, true);
         }
     }
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, AK::NonnullRefPtr<Gfx::Bitmap> const& bitmap)
+{
+    Core::AnonymousBuffer buffer;
+    if (bitmap->anonymous_buffer().is_valid()) {
+        buffer = bitmap->anonymous_buffer();
+    } else {
+        buffer = MUST(Core::AnonymousBuffer::create_with_size(bitmap->size_in_bytes()));
+        memcpy(buffer.data<void>(), bitmap->scanline(0), bitmap->size_in_bytes());
+    }
+    TRY(encoder.encode(TRY(IPC::File::clone_fd(buffer.fd()))));
+    TRY(encoder.encode(static_cast<u32>(bitmap->format())));
+    TRY(encoder.encode(bitmap->size_in_bytes()));
+    TRY(encoder.encode(bitmap->pitch()));
+    TRY(encoder.encode(bitmap->size()));
+    TRY(encoder.encode(bitmap->scale()));
+    return {};
+}
+
+template<>
+ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> decode(Decoder& decoder)
+{
+    auto anon_file = TRY(decoder.decode<IPC::File>());
+    auto raw_bitmap_format = TRY(decoder.decode<u32>());
+    if (!Gfx::is_valid_bitmap_format(raw_bitmap_format))
+        return Error::from_string_literal("IPC: Invalid Gfx::ShareableBitmap format");
+    auto bitmap_format = static_cast<Gfx::BitmapFormat>(raw_bitmap_format);
+    auto size_in_bytes = TRY(decoder.decode<size_t>());
+    auto pitch = TRY(decoder.decode<size_t>());
+    auto size = TRY(decoder.decode<Gfx::IntSize>());
+    auto scale = TRY(decoder.decode<int>());
+    auto* data = TRY(Core::System::mmap(nullptr, round_up_to_power_of_two(size_in_bytes, PAGE_SIZE), PROT_READ | PROT_WRITE, MAP_SHARED, anon_file.fd(), 0));
+    return Gfx::Bitmap::create_wrapper(bitmap_format, size, scale, pitch, data, [data, size_in_bytes] {
+        MUST(Core::System::munmap(data, size_in_bytes));
+    });
 }
 
 }

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -98,7 +98,7 @@ class Bitmap : public RefCounted<Bitmap> {
 public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create(BitmapFormat, IntSize, int intrinsic_scale = 1);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_shareable(BitmapFormat, IntSize, int intrinsic_scale = 1);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, IntSize, int intrinsic_scale, size_t pitch, void*);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, IntSize, int intrinsic_scale, size_t pitch, void*, Function<void()>&& destruction_callback = {});
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_file(StringView path, int scale_factor = 1, Optional<IntSize> ideal_size = {});
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_file(NonnullOwnPtr<Core::File>, StringView path, Optional<IntSize> ideal_size = {});
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_bytes(ReadonlyBytes, Optional<IntSize> ideal_size = {}, Optional<ByteString> mine_type = {});
@@ -236,7 +236,7 @@ public:
 
 private:
     Bitmap(BitmapFormat, IntSize, int, BackingStore const&);
-    Bitmap(BitmapFormat, IntSize, int, size_t pitch, void*);
+    Bitmap(BitmapFormat, IntSize, int, size_t pitch, void*, Function<void()>&& destruction_callback);
     Bitmap(BitmapFormat, Core::AnonymousBuffer, IntSize, int);
 
     static ErrorOr<BackingStore> allocate_backing_store(BitmapFormat format, IntSize size, int scale_factor);
@@ -246,8 +246,8 @@ private:
     void* m_data { nullptr };
     size_t m_pitch { 0 };
     BitmapFormat m_format { BitmapFormat::Invalid };
-    bool m_data_is_malloced { false };
     Core::AnonymousBuffer m_buffer;
+    Function<void()> m_destruction_callback;
 };
 
 ALWAYS_INLINE u8* Bitmap::scanline_u8(int y)

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2024, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -15,6 +15,7 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <LibIPC/Forward.h>
 
 #define ENUMERATE_IMAGE_FORMATS                \
     __ENUMERATE_IMAGE_FORMAT(bmp, ".bmp")      \
@@ -370,5 +371,15 @@ ALWAYS_INLINE void Bitmap::set_pixel(int x, int y, Color color)
         VERIFY_NOT_REACHED();
     }
 }
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, AK::NonnullRefPtr<Gfx::Bitmap> const&);
+
+template<>
+ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> decode(Decoder&);
 
 }

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -60,7 +60,7 @@ NonnullRefPtr<Core::Promise<DecodedImage>> Client::decode_image(ReadonlyBytes en
     return promise;
 }
 
-void Client::did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale)
+void Client::did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale)
 {
     VERIFY(!bitmaps.is_empty());
 
@@ -77,13 +77,13 @@ void Client::did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Ve
     image.scale = scale;
     image.frames.ensure_capacity(bitmaps.size());
     for (size_t i = 0; i < bitmaps.size(); ++i) {
-        if (!bitmaps[i].is_valid()) {
+        if (!bitmaps[i].has_value()) {
             dbgln("ImageDecoderClient: Invalid bitmap for request {} at index {}", image_id, i);
             promise->reject(Error::from_string_literal("Invalid bitmap"));
             return;
         }
 
-        image.frames.empend(*bitmaps[i].bitmap(), durations[i]);
+        image.frames.empend(*bitmaps[i], durations[i]);
     }
 
     promise->resolve(move(image));

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -41,7 +41,7 @@ public:
 private:
     virtual void die() override;
 
-    virtual void did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale) override;
+    virtual void did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>> const& bitmaps, Vector<u32> const& durations, Gfx::FloatPoint scale) override;
     virtual void did_fail_to_decode_image(i64 image_id, String const& error_message) override;
 
     HashMap<i64, NonnullRefPtr<Core::Promise<DecodedImage>>> m_pending_decoded_images;

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -29,16 +29,16 @@ void ConnectionFromClient::die()
     Core::EventLoop::current().quit(0);
 }
 
-static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder const& decoder, Optional<Gfx::IntSize> ideal_size, Vector<Gfx::ShareableBitmap>& bitmaps, Vector<u32>& durations)
+static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder const& decoder, Optional<Gfx::IntSize> ideal_size, Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>>& bitmaps, Vector<u32>& durations)
 {
     for (size_t i = 0; i < decoder.frame_count(); ++i) {
         auto frame_or_error = decoder.frame(i, ideal_size);
         if (frame_or_error.is_error()) {
-            bitmaps.append(Gfx::ShareableBitmap {});
+            bitmaps.append({});
             durations.append(0);
         } else {
             auto frame = frame_or_error.release_value();
-            bitmaps.append(frame.image->to_shareable_bitmap());
+            bitmaps.append(frame.image.release_nonnull());
             durations.append(frame.duration);
         }
     }

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.h
@@ -28,7 +28,7 @@ public:
         bool is_animated = false;
         u32 loop_count = 0;
         Gfx::FloatPoint scale { 1, 1 };
-        Vector<Gfx::ShareableBitmap> bitmaps;
+        Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>> bitmaps;
         Vector<u32> durations;
     };
 

--- a/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
@@ -2,6 +2,6 @@
 
 endpoint ImageDecoderClient
 {
-    did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations, Gfx::FloatPoint scale) =|
+    did_decode_image(i64 image_id, bool is_animated, u32 loop_count, Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>> bitmaps, Vector<u32> durations, Gfx::FloatPoint scale) =|
     did_fail_to_decode_image(i64 image_id, String error_message) =|
 }


### PR DESCRIPTION
https://github.com/LadybirdBrowser/ladybird/pull/688 , and the 3rd commit from https://github.com/LadybirdBrowser/ladybird/pull/233