### PR TITLE
Cherry-pick "LibWeb: Change grid item placement to look for area by boundary lines"

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/define-area-using-line-names.txt
+++ b/Tests/LibWeb/Layout/expected/grid/define-area-using-line-names.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17 [GFC] children: not-inline
+      BlockContainer <main> at (150,8) content-size 500x17 [BFC] children: not-inline
+        BlockContainer <div#item> at (150,8) content-size 500x17 children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [150,8 105.953125x17] baseline: 13.296875
+              "Smartphones"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableBox (Box<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer<MAIN>) [150,8 500x17]
+        PaintableWithLines (BlockContainer<DIV>#item) [150,8 500x17]
+          TextPaintable (TextNode<#text>)
+

--- a/Tests/LibWeb/Layout/input/grid/define-area-using-line-names.html
+++ b/Tests/LibWeb/Layout/input/grid/define-area-using-line-names.html
@@ -1,0 +1,17 @@
+<!doctype html><style>                    
+    * {    
+        outline: 1px solid black;    
+    }        
+    html {       
+        background: white;    
+    }      
+    body {      
+        display: grid;    
+        grid-template-columns: 1fr [content-start] 500px [content-end] 1fr;    
+        background: wheat;      
+    }      
+    main {    
+        grid-column: content;      
+        background: pink;
+    }        
+</style><body><main><div id="item">Smartphones

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -161,8 +161,6 @@ private:
 
     void init_grid_lines(GridDimension);
 
-    HashMap<String, GridArea> m_grid_areas;
-
     Vector<GridTrack> m_grid_rows;
     Vector<GridTrack> m_grid_columns;
 


### PR DESCRIPTION
Areas are disassembled into boundary lines on `build_grid_areas()` step, so we can always use them to find grid item's position during placement. This way we support both ways to define area: `grid-template-areas` and implicitly using `-start` and `-end` boundary line names.

(cherry picked from commit 7a1f3f7ae3af2744e2f99df29baf09153d631b24)

---

https://github.com/LadybirdBrowser/ladybird/pull/691