### PR TITLE
Cherry-pick "LibWeb: Fix flexible track sizing in GFC"

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/1fr-1000px.txt
+++ b/Tests/LibWeb/Layout/expected/grid/1fr-1000px.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17 [GFC] children: not-inline
+      BlockContainer <nav> at (8,8) content-size 39.78125x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 39.78125x17] baseline: 13.296875
+            "Hello"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableBox (Box<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer<NAV>) [8,8 39.78125x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/1fr-1000px.html
+++ b/Tests/LibWeb/Layout/input/grid/1fr-1000px.html
@@ -1,0 +1,12 @@
+<!doctype html><style>                    
+    * {    
+        outline: 1px solid black;    
+    }    
+    body {    
+        display: grid;    
+        grid-template-columns: 1fr 1000px;                                      
+    }    
+    nav {    
+        background: pink;    
+    }      
+</style><body><nav>Hello</nav>


### PR DESCRIPTION
- Change min track sizing function to be "auto" when flex size is specified.
- Never check if min track sizing funciton is flexible, because only max is allowed to be flexible.
- Address FIXME in automatic_minimum_size to avoid regressions after making two fixes mentioned above.

(cherry picked from commit 3270df476dd46b140e1b9de1e8328647744b56ab)

---

https://github.com/LadybirdBrowser/ladybird/pull/685