### PR TITLE
Kernel: Don't assume sizes of needed buffers early in the execve syscall

### DIFF
--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -713,7 +713,7 @@ private:
 
     ErrorOr<FlatPtr> do_statvfs(FileSystem const& path, Custody const*, statvfs* buf);
 
-    ErrorOr<RefPtr<OpenFileDescription>> find_elf_interpreter_for_executable(OpenFileDescription&, StringView path, Elf_Ehdr const& main_executable_header, size_t main_executable_header_size, size_t file_size, Optional<size_t>& minimum_stack_size);
+    ErrorOr<RefPtr<OpenFileDescription>> find_elf_interpreter_for_executable(OpenFileDescription&, StringView path, Elf_Ehdr const& main_executable_header, size_t file_size, Optional<size_t>& minimum_stack_size);
 
     ErrorOr<void> do_kill(Process&, int signal);
     ErrorOr<void> do_killpg(ProcessGroupID pgrp, int signal);


### PR DESCRIPTION
Instead, start by trying to read a buffer with size of Elf_Ehdr, and check it for the shebang sign. If it's indeed an executable with shebang then read again from the file, now with PAGE_SIZE size, which should suffice for finding the interpreter path.

However, if the executable is an ELF, we quickly validate it and then pass the preliminary buffer to the find_elf_interpreter_for_executable method.

That method calculates the last byte offset which is needed to read all of the program headers, so we don't just assume 4096 bytes is sufficient anymore. The same pattern is applied when loading the interpreter ELF main header and its program headers.