### PR TITLE
Cherry-pick "LibWebView: Add keyboard navigation to the Inspector" + 2 others

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -190,6 +190,7 @@ set(SOURCES
     DOM/StyleElementUtils.cpp
     DOM/Text.cpp
     DOM/TreeWalker.cpp
+    DOM/Utils.cpp
     DOM/XMLDocument.cpp
     DOMParsing/XMLSerializer.cpp
     DOMURL/DOMURL.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1914,7 +1914,7 @@ void Document::update_active_element()
     Node* candidate = focused_element();
 
     // 2. Set candidate to the result of retargeting candidate against this DocumentOrShadowRoot.
-    candidate = retarget<Node>(candidate, this);
+    candidate = verify_cast<Node>(retarget(candidate, this));
 
     // 3. If candidate's root is not this DocumentOrShadowRoot, then return null.
     if (&candidate->root() != this) {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -692,6 +692,8 @@ private:
 
     void tear_down_layout_tree();
 
+    void update_active_element();
+
     void run_unloading_cleanup_steps();
 
     void evaluate_media_rules();

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -196,7 +196,7 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
     JS::GCPtr<EventTarget> activation_target;
 
     // 4. Let relatedTarget be the result of retargeting event’s relatedTarget against target.
-    JS::GCPtr<EventTarget> related_target = retarget<EventTarget>(event.related_target(), target);
+    JS::GCPtr<EventTarget> related_target = retarget(event.related_target(), target);
 
     bool clear_targets = false;
     // 5. If target is not relatedTarget or target is event’s relatedTarget, then:
@@ -206,7 +206,7 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
 
         // 2. For each touchTarget of event’s touch target list, append the result of retargeting touchTarget against target to touchTargets.
         for (auto& touch_target : event.touch_target_list()) {
-            touch_targets.append(retarget<EventTarget>(touch_target, target));
+            touch_targets.append(retarget(touch_target, target));
         }
 
         // 3. Append to an event path with event, target, targetOverride, relatedTarget, touchTargets, and false.
@@ -253,14 +253,14 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
                 slottable = parent;
 
             // 3. Let relatedTarget be the result of retargeting event’s relatedTarget against parent.
-            related_target = retarget<EventTarget>(event.related_target(), parent);
+            related_target = retarget(event.related_target(), parent);
 
             // 4. Let touchTargets be a new list.
             touch_targets.clear();
 
             // 5. For each touchTarget of event’s touch target list, append the result of retargeting touchTarget against parent to touchTargets.
             for (auto& touch_target : event.touch_target_list()) {
-                touch_targets.append(retarget<EventTarget>(touch_target, parent));
+                touch_targets.append(retarget(touch_target, parent));
             }
 
             // 6. If parent is a Window object, or parent is a node and target’s root is a shadow-including inclusive ancestor of parent, then:

--- a/Userland/Libraries/LibWeb/DOM/Utils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Utils.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2024, circl <circl.lastname@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOM/Utils.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#retarget
+EventTarget* retarget(EventTarget* a, EventTarget* b)
+{
+    // To retarget an object A against an object B, repeat these steps until they return an object:
+    for (;;) {
+        // 1. If one of the following is true then return A.
+        // - A is not a node
+        if (!is<Node>(a))
+            return a;
+
+        // - A’s root is not a shadow root
+        auto* a_node = verify_cast<Node>(a);
+        auto& a_root = a_node->root();
+        if (!is<ShadowRoot>(a_root))
+            return a;
+
+        // - B is a node and A’s root is a shadow-including inclusive ancestor of B
+        if (is<Node>(b) && a_root.is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*b)))
+            return a;
+
+        // 2. Set A to A’s root’s host.
+        auto& a_shadow_root = verify_cast<ShadowRoot>(a_root);
+        a = a_shadow_root.host();
+    }
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Utils.h
+++ b/Userland/Libraries/LibWeb/DOM/Utils.h
@@ -13,8 +13,7 @@
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#retarget
-template<typename T>
-T* retarget(T* a, T* b)
+inline EventTarget* retarget_impl(EventTarget* a, EventTarget* b)
 {
     // To retarget an object A against an object B, repeat these steps until they return an object:
     for (;;) {
@@ -37,6 +36,13 @@ T* retarget(T* a, T* b)
         auto& a_shadow_root = verify_cast<ShadowRoot>(a_root);
         a = a_shadow_root.host();
     }
+}
+
+// https://dom.spec.whatwg.org/#retarget
+template<typename T>
+T* retarget(T* a, T* b)
+{
+    return static_cast<T*>(retarget_impl(a, b));
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Utils.h
+++ b/Userland/Libraries/LibWeb/DOM/Utils.h
@@ -7,42 +7,10 @@
 
 #pragma once
 
-#include <LibWeb/DOM/Node.h>
-#include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOM/EventTarget.h>
 
 namespace Web::DOM {
 
-// https://dom.spec.whatwg.org/#retarget
-inline EventTarget* retarget_impl(EventTarget* a, EventTarget* b)
-{
-    // To retarget an object A against an object B, repeat these steps until they return an object:
-    for (;;) {
-        // 1. If one of the following is true then return A.
-        // - A is not a node
-        if (!is<Node>(a))
-            return a;
-
-        // - A’s root is not a shadow root
-        auto* a_node = verify_cast<Node>(a);
-        auto& a_root = a_node->root();
-        if (!is<ShadowRoot>(a_root))
-            return a;
-
-        // - B is a node and A’s root is a shadow-including inclusive ancestor of B
-        if (is<Node>(b) && a_root.is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*b)))
-            return a;
-
-        // 2. Set A to A’s root’s host.
-        auto& a_shadow_root = verify_cast<ShadowRoot>(a_root);
-        a = a_shadow_root.host();
-    }
-}
-
-// https://dom.spec.whatwg.org/#retarget
-template<typename T>
-T* retarget(T* a, T* b)
-{
-    return static_cast<T*>(retarget_impl(a, b));
-}
+EventTarget* retarget(EventTarget* a, EventTarget* b);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Utils.h
+++ b/Userland/Libraries/LibWeb/DOM/Utils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2024, circl <circl.lastname@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#retarget
+template<typename T>
+T* retarget(T* a, T* b)
+{
+    // To retarget an object A against an object B, repeat these steps until they return an object:
+    for (;;) {
+        // 1. If one of the following is true then return A.
+        // - A is not a node
+        if (!is<Node>(a))
+            return a;
+
+        // - A’s root is not a shadow root
+        auto* a_node = verify_cast<Node>(a);
+        auto& a_root = a_node->root();
+        if (!is<ShadowRoot>(a_root))
+            return a;
+
+        // - B is a node and A’s root is a shadow-including inclusive ancestor of B
+        if (is<Node>(b) && a_root.is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*b)))
+            return a;
+
+        // 2. Set A to A’s root’s host.
+        auto& a_shadow_root = verify_cast<ShadowRoot>(a_root);
+        a = a_shadow_root.host();
+    }
+}
+
+}


### PR DESCRIPTION
Now keep a track of the DOM nodes which are actually visible in the Inspector, and allow the user to navigate the tree using the keyboard.
<hr>

Cherry-picks LadybirdBrowser/ladybird#628

Cherry-picks LadybirdBrowser/ladybird#706

Cherry-picks LadybirdBrowser/ladybird#748