### PR TITLE
Cherry-pick "LibWeb: Support percentage values in SVG text/line element"

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg-text-with-percentage-values.txt
+++ b/Tests/LibWeb/Layout/expected/svg-text-with-percentage-values.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x261.328125 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x261.328125] baseline: 261.328125
+      SVGSVGBox <svg> at (8,8) content-size 784x261.328125 [SVG] children: inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.small> at (86.40625,65.5) content-size 48.109375x37.484375 children: inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.heavy> at (141.28125,21.078125) content-size 148.234375x79.71875 children: inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.small> at (204,117.765625) content-size 34.59375x34.703125 children: inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.Rrrrr> at (243.1875,47.21875) content-size 519.34375x115.359375 children: inline
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x261.328125]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x261.328125]
+        SVGPathPaintable (SVGTextBox<text>.small) [86.40625,65.5 48.109375x37.484375]
+        SVGPathPaintable (SVGTextBox<text>.heavy) [141.28125,21.078125 148.234375x79.71875]
+        SVGPathPaintable (SVGTextBox<text>.small) [204,117.765625 34.59375x34.703125]
+        SVGPathPaintable (SVGTextBox<text>.Rrrrr) [243.1875,47.21875 519.34375x115.359375]

--- a/Tests/LibWeb/Layout/expected/svg/svg-line-with-percentage-values.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-line-with-percentage-values.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x408 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x392 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x392] baseline: 392
+      SVGSVGBox <svg> at (8,8) content-size 784x392 [SVG] children: inline
+        TextNode <#text>
+        SVGGeometryBox <line> at (6.046875,135.40625) content-size 787.921875x3.921875 children: not-inline
+        TextNode <#text>
+        SVGGeometryBox <line> at (6.046875,264.765625) content-size 787.921875x3.921875 children: not-inline
+        TextNode <#text>
+        SVGGeometryBox <line> at (264.765625,6.046875) content-size 3.921875x395.921875 children: not-inline
+        TextNode <#text>
+        SVGGeometryBox <line> at (523.484375,6.046875) content-size 3.921875x395.921875 children: not-inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x408]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x392]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x392]
+        SVGPathPaintable (SVGGeometryBox<line>) [6.046875,135.40625 787.921875x3.921875]
+        SVGPathPaintable (SVGGeometryBox<line>) [6.046875,264.765625 787.921875x3.921875]
+        SVGPathPaintable (SVGGeometryBox<line>) [264.765625,6.046875 3.921875x395.921875]
+        SVGPathPaintable (SVGGeometryBox<line>) [523.484375,6.046875 3.921875x395.921875]

--- a/Tests/LibWeb/Layout/input/svg-text-with-percentage-values.html
+++ b/Tests/LibWeb/Layout/input/svg-text-with-percentage-values.html
@@ -1,0 +1,20 @@
+<svg viewBox="0 0 240 80" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .small {
+      font: italic 13px sans-serif;
+    }
+    .heavy {
+      font: bold 30px sans-serif;
+    }
+
+    .Rrrrr {
+      font: italic 40px serif;
+      fill: red;
+    }
+  </style>
+
+  <text x="10%" y="35%" class="small">My</text>
+  <text x="17%" y="35%" class="heavy">cat</text>
+  <text x="25%" y="55%" class="small">is</text>
+  <text x="30%" y="55%" class="Rrrrr">Grumpy!</text>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/svg-line-with-percentage-values.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-line-with-percentage-values.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+line {
+    stroke: red;
+}
+</style>
+<svg viewbox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+    <line x1="0" y1="33%" x2="100%" y2="33%"></line>
+    <line x1="0" y1="66%" x2="100%" y2="66%"></line>
+
+    <line x1="33%" y1="0" x2="33%" y2="100%"></line>
+    <line x1="66%" y1="0" x2="66%" y2="100%"></line>
+</svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -308,7 +308,7 @@ Gfx::Path SVGFormattingContext::compute_path_for_text(SVGTextBox const& text_box
     auto text_contents = text_element.text_contents();
     Utf8View text_utf8 { text_contents };
     auto text_width = font.width(text_utf8);
-    auto text_offset = text_element.get_offset();
+    auto text_offset = text_element.get_offset(m_viewport_size);
 
     // https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties
     switch (text_element.text_anchor().value_or(SVG::TextAnchor::Start)) {

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -30,23 +30,26 @@ void SVGLineElement::attribute_changed(FlyString const& name, Optional<String> c
     SVGGeometryElement::attribute_changed(name, old_value, value);
 
     if (name == SVG::AttributeNames::x1) {
-        m_x1 = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_x1 = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::y1) {
-        m_y1 = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_y1 = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::x2) {
-        m_x2 = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_x2 = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::y2) {
-        m_y2 = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_y2 = AttributeParser::parse_number_percentage(value.value_or(String {}));
     }
 }
 
-Gfx::Path SVGLineElement::get_path(CSSPixelSize)
+Gfx::Path SVGLineElement::get_path(CSSPixelSize viewport_size)
 {
+    auto const viewport_width = viewport_size.width().to_float();
+    auto const viewport_height = viewport_size.height().to_float();
+
     Gfx::Path path;
-    float x1 = m_x1.value_or(0);
-    float y1 = m_y1.value_or(0);
-    float x2 = m_x2.value_or(0);
-    float y2 = m_y2.value_or(0);
+    float const x1 = m_x1.value_or({ 0, false }).resolve_relative_to(viewport_width);
+    float const y1 = m_y1.value_or({ 0, false }).resolve_relative_to(viewport_height);
+    float const x2 = m_x2.value_or({ 0, false }).resolve_relative_to(viewport_width);
+    float const y2 = m_y2.value_or({ 0, false }).resolve_relative_to(viewport_height);
 
     // 1. perform an absolute moveto operation to absolute location (x1,y1)
     path.move_to({ x1, y1 });
@@ -62,8 +65,8 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::x1() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x1.value_or(0));
-    auto anim_length = SVGLength::create(realm(), 0, m_x1.value_or(0));
+    auto base_length = SVGLength::create(realm(), 0, m_x1.value_or({ 0, false }).value());
+    auto anim_length = SVGLength::create(realm(), 0, m_x1.value_or({ 0, false }).value());
     return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
@@ -72,8 +75,8 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::y1() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y1.value_or(0));
-    auto anim_length = SVGLength::create(realm(), 0, m_y1.value_or(0));
+    auto base_length = SVGLength::create(realm(), 0, m_y1.value_or({ 0, false }).value());
+    auto anim_length = SVGLength::create(realm(), 0, m_y1.value_or({ 0, false }).value());
     return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
@@ -82,8 +85,8 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::x2() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x2.value_or(0));
-    auto anim_length = SVGLength::create(realm(), 0, m_x2.value_or(0));
+    auto base_length = SVGLength::create(realm(), 0, m_x2.value_or({ 0, false }).value());
+    auto anim_length = SVGLength::create(realm(), 0, m_x2.value_or({ 0, false }).value());
     return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
@@ -92,8 +95,8 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::y2() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y2.value_or(0));
-    auto anim_length = SVGLength::create(realm(), 0, m_y2.value_or(0));
+    auto base_length = SVGLength::create(realm(), 0, m_y2.value_or({ 0, false }).value());
+    auto anim_length = SVGLength::create(realm(), 0, m_y2.value_or({ 0, false }).value());
     return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -32,10 +32,10 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    Optional<float> m_x1;
-    Optional<float> m_y1;
-    Optional<float> m_x2;
-    Optional<float> m_y2;
+    Optional<NumberPercentage> m_x1;
+    Optional<NumberPercentage> m_y1;
+    Optional<NumberPercentage> m_x2;
+    Optional<NumberPercentage> m_y2;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -34,19 +34,27 @@ void SVGTextPositioningElement::attribute_changed(FlyString const& name, Optiona
     SVGGraphicsElement::attribute_changed(name, old_value, value);
 
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_x);
+        m_x = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_y);
+        m_y = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::dx) {
-        m_dx = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_dx);
+        m_dx = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::dy) {
-        m_dy = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_dy);
+        m_dy = AttributeParser::parse_number_percentage(value.value_or(String {}));
     }
 }
 
-Gfx::FloatPoint SVGTextPositioningElement::get_offset() const
+Gfx::FloatPoint SVGTextPositioningElement::get_offset(CSSPixelSize const& viewport_size) const
 {
-    return { m_x + m_dx, m_y + m_dy };
+    auto const viewport_width = viewport_size.width().to_float();
+    auto const viewport_height = viewport_size.height().to_float();
+
+    float const x = m_x.value_or({ 0, false }).resolve_relative_to(viewport_width);
+    float const y = m_y.value_or({ 0, false }).resolve_relative_to(viewport_height);
+    float const dx = m_dx.value_or({ 0, false }).resolve_relative_to(viewport_width);
+    float const dy = m_dy.value_or({ 0, false }).resolve_relative_to(viewport_height);
+
+    return { x + dx, y + dy };
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
@@ -18,7 +18,7 @@ class SVGTextPositioningElement : public SVGTextContentElement {
 public:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
 
-    Gfx::FloatPoint get_offset() const;
+    Gfx::FloatPoint get_offset(CSSPixelSize const& viewport_size) const;
 
     JS::NonnullGCPtr<SVGAnimatedLength> x() const;
     JS::NonnullGCPtr<SVGAnimatedLength> y() const;
@@ -31,10 +31,10 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
 private:
-    float m_x { 0 };
-    float m_y { 0 };
-    float m_dx { 0 };
-    float m_dy { 0 };
+    Optional<NumberPercentage> m_x;
+    Optional<NumberPercentage> m_y;
+    Optional<NumberPercentage> m_dx;
+    Optional<NumberPercentage> m_dy;
 };
 
 }


### PR DESCRIPTION
Text element before:
![screenshot-2024-07-21-16-27-00](https://github.com/user-attachments/assets/793975d7-9d40-44c0-bfc7-fb096f4703da)

After:
![screenshot-2024-07-21-16-25-44](https://github.com/user-attachments/assets/e72a71d1-6c48-425d-82c2-df58ac6a35f4)

Line element before:
\<blank page\>

After:
![screenshot-2024-07-21-19-25-31](https://github.com/user-attachments/assets/4c7ed3b2-be18-456b-862a-a0c0791aa355)<hr>Cherry-picks LadybirdBrowser/ladybird#752<br><sub>Generated with LBSync, did I do well?</sub>