### PR TITLE
Cherry-pick "LibWeb: Use correct scope when removing style sheet inside a shadow tree"

### DIFF
--- a/Tests/LibWeb/Text/expected/ShadowDOM/remove-style-element-inside-shadow-tree.txt
+++ b/Tests/LibWeb/Text/expected/ShadowDOM/remove-style-element-inside-shadow-tree.txt
@@ -1,0 +1,4 @@
+  hello    [object StyleSheetList]
+Before remove, sheet count: 1
+After remove, sheet count: 0
+After setting innerText of removed sheet, we're still alive!

--- a/Tests/LibWeb/Text/input/ShadowDOM/remove-style-element-inside-shadow-tree.html
+++ b/Tests/LibWeb/Text/input/ShadowDOM/remove-style-element-inside-shadow-tree.html
@@ -1,0 +1,20 @@
+<div id=foo>
+<template shadowrootmode="open">
+<style>
+div { border: 5px solid black; }
+</style>
+<div>hello</div>
+</template>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(foo.shadowRoot.styleSheets);
+        println("Before remove, sheet count: " + foo.shadowRoot.styleSheets.length);
+        let style = foo.shadowRoot.firstElementChild;
+        style.remove()
+        println("After remove, sheet count: " + foo.shadowRoot.styleSheets.length);
+        style.innerText = "div { border: 10px solid red; }";
+        println("After setting innerText of removed sheet, we're still alive!");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -115,7 +115,8 @@ void StyleSheetList::add_sheet(CSSStyleSheet& sheet)
 void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
 {
     sheet.set_style_sheet_list({}, nullptr);
-    m_sheets.remove_first_matching([&](auto& entry) { return entry.ptr() == &sheet; });
+    bool did_remove = m_sheets.remove_first_matching([&](auto& entry) { return entry.ptr() == &sheet; });
+    VERIFY(did_remove);
 
     if (sheet.rules().length() == 0) {
         // NOTE: If the removed sheet had no rules, we don't have to invalidate anything.

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -14,7 +14,7 @@ namespace Web::DOM {
 
 class StyleElementUtils {
 public:
-    void update_a_style_block(DOM::Element& style_element);
+    void update_a_style_block(DOM::Element& style_element, JS::GCPtr<DOM::Node> old_parent_if_removed_from = nullptr);
 
     CSS::CSSStyleSheet* sheet() { return m_associated_css_style_sheet; }
     CSS::CSSStyleSheet const* sheet() const { return m_associated_css_style_sheet; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -46,7 +46,7 @@ void HTMLStyleElement::inserted()
 
 void HTMLStyleElement::removed_from(Node* old_parent)
 {
-    m_style_element_utils.update_a_style_block(*this);
+    m_style_element_utils.update_a_style_block(*this, old_parent);
     Base::removed_from(old_parent);
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -44,7 +44,7 @@ void SVGStyleElement::inserted()
 
 void SVGStyleElement::removed_from(Node* old_parent)
 {
-    m_style_element_utils.update_a_style_block(*this);
+    m_style_element_utils.update_a_style_block(*this, old_parent);
     Base::removed_from(old_parent);
 }
 


### PR DESCRIPTION
Before this change, removing a style element from inside a shadow tree
would cause it to be unregistered with the document-level list of sheets
instead of the shadow-root-level list.
    
This would eventually lead to a verification failure if someone tried to
update the text contents of that style element, since it was still in
the shadow-root-level list, but now with a null owner element.
    
Fixes a crash on https://www.swedbank.se/<hr>Cherry-picks LadybirdBrowser/ladybird#784<br><sub>Generated with LBSync, did I do well?</sub>