### PR TITLE
Kernel/x86: Stop the APIC timer before configuring it

### DIFF
--- a/Kernel/Arch/x86_64/Interrupts/APIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.cpp
@@ -584,6 +584,9 @@ UNMAP_AFTER_INIT APICTimer* APIC::initialize_timers(HardwareTimerBase& calibrati
 
 void APIC::setup_local_timer(u32 ticks, TimerMode timer_mode, bool enable)
 {
+    // Write 0 to the initial count so we don't accidentally start the timer when writing to the divide configuration register.
+    write_register(APIC_REG_TIMER_INITIAL_COUNT, 0);
+
     u32 flags = 0;
     switch (timer_mode) {
     case TimerMode::OneShot:


### PR DESCRIPTION
This avoids spurious interrupts during APIC timer calibration, as the timer might otherwise immediately generate an interrupt when enabling interrupts if the initial count was at a low enough value.