### PR TITLE
Kernel: Don't truncate the pc value in the scheduler state dump

### DIFF
--- a/Kernel/Tasks/Scheduler.cpp
+++ b/Kernel/Tasks/Scheduler.cpp
@@ -512,7 +512,7 @@ void dump_thread_list(bool with_stack_traces)
 {
     dbgln("Scheduler thread list for processor {}:", Processor::current_id());
 
-    auto get_eip = [](Thread& thread) -> u32 {
+    auto get_pc = [](Thread& thread) -> FlatPtr {
         if (!thread.current_trap())
             return thread.regs().ip();
         return thread.get_register_dump_from_stack().ip();
@@ -525,7 +525,7 @@ void dump_thread_list(bool with_stack_traces)
             dmesgln("  {}{:30}\x1b[0m @ {:08x} is {:14} (Finalizable: {}, nsched: {})",
                 color,
                 thread,
-                get_eip(thread),
+                get_pc(thread),
                 thread.state_string(),
                 thread.is_finalizable(),
                 thread.times_scheduled());
@@ -534,7 +534,7 @@ void dump_thread_list(bool with_stack_traces)
             dmesgln("  {}{:30}\x1b[0m @ {:08x} is {:14} (Pr:{:2}, nsched: {})",
                 color,
                 thread,
-                get_eip(thread),
+                get_pc(thread),
                 thread.state_string(),
                 thread.priority(),
                 thread.times_scheduled());


### PR DESCRIPTION
This is likely a leftover from the i686-only days. Also rename the get_eip function to get_pc to be more arch-agnostic.