### PR TITLE
Mail: Don't spam commands on mailbox node selection

### DIFF
--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -246,11 +246,12 @@ bool MailWidget::is_supported_alternative(Alternative const& alternative) const
 
 void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
 {
+    if (!index.is_valid() || index == m_mailbox_index)
+        return;
+    m_mailbox_index = index;
+
     m_mailbox_model = InboxModel::create({});
     m_individual_mailbox_view->set_model(m_mailbox_model);
-
-    if (!index.is_valid())
-        return;
 
     auto& base_node = *static_cast<BaseNode*>(index.internal_data());
 

--- a/Userland/Applications/Mail/MailWidget.h
+++ b/Userland/Applications/Mail/MailWidget.h
@@ -40,6 +40,7 @@ private:
 
     OwnPtr<IMAP::Client> m_imap_client;
 
+    GUI::ModelIndex m_mailbox_index;
     RefPtr<GUI::TreeView> m_mailbox_list;
     RefPtr<InboxModel> m_mailbox_model;
     RefPtr<GUI::SortingProxyModel> m_mailbox_sorting_model;


### PR DESCRIPTION
This PR fixes a bug where selecting a mailbox node would send multiple repeated IMAP commands, ultimately hanging the parser.