### PR TITLE
LibIMAP: Properly parse parenthesized address lists

### DIFF
--- a/Userland/Libraries/LibIMAP/Parser.cpp
+++ b/Userland/Libraries/LibIMAP/Parser.cpp
@@ -790,11 +790,8 @@ ErrorOr<Vector<Address>> Parser::parse_address_list()
 
     auto addresses = Vector<Address>();
     TRY(consume("("sv));
-    while (!consume_if(")"sv)) {
+    while (!consume_if(")"sv))
         addresses.append(TRY(parse_address()));
-        if (!at_end() && m_buffer[m_position] != ')')
-            TRY(consume(" "sv));
-    }
     return { addresses };
 }
 


### PR DESCRIPTION
This PR fixes a crash where the parser assumes parenthesized lists of address structures should be separated by whitespace. Per RFC-9051, there is no indication of this.