### PR TITLE
Kernel/USB: Correctly parse USB descriptors

### DIFF
--- a/Kernel/Bus/USB/USBConfiguration.cpp
+++ b/Kernel/Bus/USB/USBConfiguration.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/FixedArray.h>
+#include <AK/MemoryStream.h>
 #include <Kernel/Bus/USB/USBClasses.h>
 #include <Kernel/Bus/USB/USBConfiguration.h>
 #include <Kernel/Bus/USB/USBInterface.h>
@@ -15,6 +16,9 @@ namespace Kernel::USB {
 
 ErrorOr<void> USBConfiguration::enumerate_interfaces()
 {
+    if (m_descriptor.total_length < sizeof(USBConfigurationDescriptor))
+        return EINVAL;
+
     auto descriptor_hierarchy_buffer = TRY(FixedArray<u8>::create(m_descriptor.total_length)); // Buffer for us to store the entire hierarchy into
 
     // The USB spec is a little bit janky here... Interface and Endpoint descriptors aren't fetched
@@ -22,54 +26,85 @@ ErrorOr<void> USBConfiguration::enumerate_interfaces()
     // to us in one go.
     auto transfer_length = TRY(m_device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8) | m_descriptor_index, 0, m_descriptor.total_length, descriptor_hierarchy_buffer.data()));
 
+    FixedMemoryStream stream { descriptor_hierarchy_buffer.span() };
+
     // FIXME: Why does transfer length return the actual size +8 bytes?
     if (transfer_length < m_descriptor.total_length)
         return EIO;
 
-    u8* interface_descriptors_base = descriptor_hierarchy_buffer.data() + sizeof(USBConfigurationDescriptor);
-    USBInterfaceDescriptor* interface_descriptor = reinterpret_cast<USBInterfaceDescriptor*>(interface_descriptors_base);
-    Vector<USBEndpointDescriptor> endpoint_descriptors;
+    auto const configuration_descriptor = TRY(stream.read_value<USBConfigurationDescriptor>());
+    if (configuration_descriptor.descriptor_header.length < sizeof(USBConfigurationDescriptor))
+        return EINVAL;
+
+    if (configuration_descriptor.total_length != m_descriptor.total_length)
+        return EINVAL;
+
+    USBInterface* current_interface = nullptr;
+
     TRY(m_interfaces.try_ensure_capacity(m_descriptor.number_of_interfaces));
-    for (auto interface = 0u; interface < m_descriptor.number_of_interfaces; interface++) {
-        endpoint_descriptors.ensure_capacity(interface_descriptor->number_of_endpoints);
 
-        if constexpr (USB_DEBUG) {
-            dbgln("Interface Descriptor {}", interface);
-            dbgln("interface_id: {:02x}", interface_descriptor->interface_id);
-            dbgln("alternate_setting: {:02x}", interface_descriptor->alternate_setting);
-            dbgln("number_of_endpoints: {:02x}", interface_descriptor->number_of_endpoints);
-            dbgln("interface_class_code: {:02x}", interface_descriptor->interface_class_code);
-            dbgln("interface_sub_class_code: {:02x}", interface_descriptor->interface_sub_class_code);
-            dbgln("interface_protocol: {:02x}", interface_descriptor->interface_protocol);
-            dbgln("interface_string_descriptor_index: {}", interface_descriptor->interface_string_descriptor_index);
-        }
+    auto read_descriptor = [&stream]<typename T>(USBDescriptorCommon const& header) -> ErrorOr<T> {
+        if (header.length < sizeof(T))
+            return EINVAL;
 
-        // Get all the endpoint descriptors
-        for (auto endpoint = 0u; endpoint < interface_descriptor->number_of_endpoints; endpoint++) {
-            u8* raw_endpoint_descriptor_offset = reinterpret_cast<u8*>(interface_descriptor) + sizeof(USBInterfaceDescriptor) + (endpoint * sizeof(USBEndpointDescriptor));
+        auto descriptor = TRY(stream.read_value<T>());
 
-            // FIXME: It looks like HID descriptors come BEFORE the endpoint descriptors for a HID device, so we should load
-            // these too eventually.
-            // See here: https://www.usb.org/defined-class-codes
-            if (interface_descriptor->interface_class_code == USB_CLASS_HID)
-                raw_endpoint_descriptor_offset += sizeof(USBHIDDescriptor); // Skip the HID descriptor (this was worked out via buffer inspection)
+        // Skip additional bytes.
+        TRY(stream.seek(header.length - sizeof(T), SeekMode::FromCurrentPosition));
 
-            USBEndpointDescriptor* endpoint_descriptor = reinterpret_cast<USBEndpointDescriptor*>(raw_endpoint_descriptor_offset);
+        return descriptor;
+    };
+
+    while (!stream.is_eof()) {
+        // Peek the descriptor header.
+        auto const descriptor_header = TRY(stream.read_value<USBDescriptorCommon>());
+        MUST(stream.seek(-sizeof(USBDescriptorCommon), SeekMode::FromCurrentPosition));
+
+        switch (descriptor_header.descriptor_type) {
+        case DESCRIPTOR_TYPE_INTERFACE: {
+            auto interface_descriptor = TRY(read_descriptor.operator()<USBInterfaceDescriptor>(descriptor_header));
 
             if constexpr (USB_DEBUG) {
-                dbgln("Endpoint Descriptor {}", endpoint);
-                dbgln("Endpoint Address: {}", endpoint_descriptor->endpoint_address);
-                dbgln("Endpoint Attribute Bitmap: {:08b}", endpoint_descriptor->endpoint_attributes_bitmap);
-                dbgln("Endpoint Maximum Packet Size: {}", endpoint_descriptor->max_packet_size);
-                dbgln("Endpoint Poll Interval (in frames): {}", endpoint_descriptor->poll_interval_in_frames);
+                dbgln("Interface Descriptor:");
+                dbgln("  interface_id: {:02x}", interface_descriptor.interface_id);
+                dbgln("  alternate_setting: {:02x}", interface_descriptor.alternate_setting);
+                dbgln("  number_of_endpoints: {:02x}", interface_descriptor.number_of_endpoints);
+                dbgln("  interface_class_code: {:02x}", interface_descriptor.interface_class_code);
+                dbgln("  interface_sub_class_code: {:02x}", interface_descriptor.interface_sub_class_code);
+                dbgln("  interface_protocol: {:02x}", interface_descriptor.interface_protocol);
+                dbgln("  interface_string_descriptor_index: {}", interface_descriptor.interface_string_descriptor_index);
             }
 
-            endpoint_descriptors.unchecked_append(*endpoint_descriptor);
+            TRY(m_interfaces.try_empend(*this, interface_descriptor));
+            current_interface = &m_interfaces.last();
+
+            break;
         }
 
-        USBInterface device_interface(*this, *interface_descriptor, move(endpoint_descriptors));
-        m_interfaces.unchecked_append(move(device_interface));
-        interface_descriptor = reinterpret_cast<USBInterfaceDescriptor*>(reinterpret_cast<u8*>(interface_descriptor) + sizeof(USBInterfaceDescriptor) + interface_descriptor->number_of_endpoints * sizeof(USBEndpointDescriptor));
+        case DESCRIPTOR_TYPE_ENDPOINT: {
+            auto endpoint_descriptor = TRY(read_descriptor.operator()<USBEndpointDescriptor>(descriptor_header));
+
+            if constexpr (USB_DEBUG) {
+                dbgln("Endpoint Descriptor:");
+                dbgln("  Endpoint Address: {}", endpoint_descriptor.endpoint_address);
+                dbgln("  Endpoint Attribute Bitmap: {:08b}", endpoint_descriptor.endpoint_attributes_bitmap);
+                dbgln("  Endpoint Maximum Packet Size: {}", endpoint_descriptor.max_packet_size);
+                dbgln("  Endpoint Poll Interval (in frames): {}", endpoint_descriptor.poll_interval_in_frames);
+            }
+
+            if (current_interface == nullptr)
+                return EINVAL;
+
+            TRY(current_interface->add_endpoint_descriptor({}, endpoint_descriptor));
+
+            break;
+        }
+
+        default:
+            dbgln_if(USB_DEBUG, "Skipping descriptor of unknown type {}", descriptor_header.descriptor_type);
+            TRY(stream.seek(descriptor_header.length, SeekMode::FromCurrentPosition));
+            break;
+        }
     }
 
     return {};

--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 namespace Kernel::USB {
@@ -39,7 +40,7 @@ struct [[gnu::packed]] USBDeviceDescriptor {
     u8 serial_number_descriptor_index;
     u8 num_configurations;
 };
-static_assert(sizeof(USBDeviceDescriptor) == 18);
+static_assert(AssertSize<USBDeviceDescriptor, 18>());
 
 //
 //  Configuration Descriptor
@@ -57,6 +58,7 @@ struct [[gnu::packed]] USBConfigurationDescriptor {
     u8 attributes_bitmap;
     u8 max_power_in_ma;
 };
+static_assert(AssertSize<USBConfigurationDescriptor, 9>());
 
 //
 //  Interface Descriptor
@@ -77,6 +79,7 @@ struct [[gnu::packed]] USBInterfaceDescriptor {
     u8 interface_protocol;
     u8 interface_string_descriptor_index;
 };
+static_assert(AssertSize<USBInterfaceDescriptor, 9>());
 
 //
 //  Endpoint Descriptor
@@ -94,6 +97,7 @@ struct [[gnu::packed]] USBEndpointDescriptor {
     u16 max_packet_size;
     u8 poll_interval_in_frames;
 };
+static_assert(AssertSize<USBEndpointDescriptor, 7>());
 
 struct [[gnu::packed]] USBSuperSpeedEndpointCompanionDescriptor {
     USBDescriptorCommon descriptor_header;
@@ -112,6 +116,7 @@ struct [[gnu::packed]] USBSuperSpeedEndpointCompanionDescriptor {
     } endpoint_attributes_bitmap;
     u16 bytes_per_interval;
 };
+static_assert(AssertSize<USBSuperSpeedEndpointCompanionDescriptor, 6>());
 
 //
 //  USB 1.1/2.0 Hub Descriptor
@@ -135,6 +140,7 @@ struct [[gnu::packed]] USBHubDescriptor {
     u8 hub_controller_current;
     // NOTE: This does not contain DeviceRemovable or PortPwrCtrlMask because a struct cannot have two VLAs in a row.
 };
+static_assert(AssertSize<USBHubDescriptor, 7>());
 
 //
 //  USB Human Interface Device (HID) Descriptor
@@ -148,6 +154,7 @@ struct [[gnu::packed]] USBHIDDescriptor {
     u8 following_descriptor_type;
     u16 hid_report_descriptor_size;
 };
+static_assert(AssertSize<USBHIDDescriptor, 9>());
 
 static constexpr u8 DESCRIPTOR_TYPE_DEVICE = 0x01;
 static constexpr u8 DESCRIPTOR_TYPE_CONFIGURATION = 0x02;

--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StdLibExtraDetails.h>
+#include <AK/Traits.h>
 #include <AK/Types.h>
 
 namespace Kernel::USB {
@@ -166,3 +167,33 @@ static constexpr u8 DESCRIPTOR_TYPE_HUB = 0x29;
 static constexpr u8 DESCRIPTOR_TYPE_USB_SUPERSPEED_ENDPOINT_COMPANION = 0x30;
 
 }
+
+template<>
+class AK::Traits<Kernel::USB::USBDescriptorCommon> : public DefaultTraits<Kernel::USB::USBDescriptorCommon> {
+public:
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+class AK::Traits<Kernel::USB::USBDeviceDescriptor> : public DefaultTraits<Kernel::USB::USBDeviceDescriptor> {
+public:
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+class AK::Traits<Kernel::USB::USBConfigurationDescriptor> : public DefaultTraits<Kernel::USB::USBConfigurationDescriptor> {
+public:
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+class AK::Traits<Kernel::USB::USBInterfaceDescriptor> : public DefaultTraits<Kernel::USB::USBInterfaceDescriptor> {
+public:
+    static constexpr bool is_trivially_serializable() { return true; }
+};
+
+template<>
+class AK::Traits<Kernel::USB::USBEndpointDescriptor> : public DefaultTraits<Kernel::USB::USBEndpointDescriptor> {
+public:
+    static constexpr bool is_trivially_serializable() { return true; }
+};

--- a/Kernel/Bus/USB/USBInterface.h
+++ b/Kernel/Bus/USB/USBInterface.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/USB/USBDescriptors.h>
 
@@ -16,13 +17,13 @@ class USBConfiguration;
 class USBInterface final {
 public:
     USBInterface() = delete;
-    USBInterface(USBConfiguration const& configuration, USBInterfaceDescriptor const descriptor, Vector<USBEndpointDescriptor> endpoint_descriptors)
+    USBInterface(USBConfiguration const& configuration, USBInterfaceDescriptor const descriptor)
         : m_configuration(configuration)
         , m_descriptor(descriptor)
-        , m_endpoint_descriptors(move(endpoint_descriptors))
     {
-        m_endpoint_descriptors.ensure_capacity(descriptor.number_of_endpoints);
     }
+
+    ErrorOr<void> add_endpoint_descriptor(Badge<USBConfiguration>, USBEndpointDescriptor endpoint_descriptor) { return m_endpoint_descriptors.try_empend(endpoint_descriptor); }
 
     Vector<USBEndpointDescriptor> const& endpoints() const { return m_endpoint_descriptors; }
 


### PR DESCRIPTION
This PR fixes incorrect assumptions about the layout of descriptors and gets rid of all the pointer arithmetic by using an AK::Stream instead.
The USB spec doesn't define a strict order for all descriptors to appear in.
It just says that endpoint descriptors follow its interface descriptor.
We also have to skip all unknown descriptors (which also can appear anywhere), not just HID descriptors.