### PR TITLE
LibGfx/WebPWriterLossless: Use predictor transform

### DIFF
--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -239,7 +239,7 @@ TEST_CASE(test_webp_color_indexing_transform_single_channel)
         expect_bitmaps_equal(*decoded_bitmap, *bitmap);
 
         Gfx::WebPEncoderOptions options;
-        options.vp8l_options.allowed_transforms = options.vp8l_options.allowed_transforms & ~(1u << Gfx::COLOR_INDEXING_TRANSFORM);
+        options.vp8l_options.allowed_transforms = options.vp8l_options.allowed_transforms & ~((1u << Gfx::COLOR_INDEXING_TRANSFORM) | (1u << Gfx::PREDICTOR_TRANSFORM));
         auto encoded_data_without_color_indexing = TRY_OR_FAIL(encode_bitmap<Gfx::WebPWriter>(bitmap, options));
         if (bits_per_pixel == 8)
             EXPECT(encoded_data.size() <= encoded_data_without_color_indexing.size());


### PR DESCRIPTION
...for images that don't use a color indexing transform.

For now, write the predictor transform unconditionally, and predict every pixel as its left neighbor (that is, use predictor 1 everywhere).

This will grow a better heuristic in time, and eventually we might want to use more than 1 of the 13 different predictor modes. But on average, doing this unconditionally is better than not doing it unconditionally. (Also, it's possible to disable this transform using `image`'s `--webp-allowed-transforms` flag.)

Using the same benchmark as in #24819, this reduces the total size of the test images further, from 88M to 69M (21.6%). It does increase runtime for compressing all these images from about 4.4s to 4.7s, a 6.8% slowdown.

For the usual test image (no effect on the two animations, which use the color indexing transform):

    sunset_retro.png (876K):
        1.2M -> 730K, 31.4 ms ± 0.8 ms -> 31.4 ms ± 0.7 ms

From 37% larger than the input to 16% _smaller_ than the input :^) (A 39% size reduction for this image.)

Compressing sunset_retro.png with zopflipng produces a 820K image, so we're smaller even than what the best PNG encoder can do with this image.

It's not a win for all images: For example, the size of qoi_benchmark_suite/screenshot_web/sublime.png goes from 1.0M to 1.5M, a fairly dramatic size increase. Hopefully we can get that back in the future with better heuristics. (The input sublime.png is 1.3M, and sublime.png encoded using our QOI encoder creates a 1.6M file, so the 1.5M isn't atrocious, even though it's much bigger than the size without the predictor transform.)

Our WebP Lossless writer currently now has a similar feature set to our QOI writer: RLE, color cache, left prediction, and subtract green is somewhat similar to QOI's luma chunk. The WebP writer also writes huffman trees, which QOI doesn't do. For most images, the WebP writer creates smaller files than the QOI writer, while being about 50% slower. The WebP writer also writes smaller files than Serenity OS's png writer, while being ~40x as fast (for sunset_retro, ~30ms instead of ~1.3s; 730K output instead of 999K).

Only doing RLE and using a single predictor for the entire image is similar to what fpng is doing (...but fpng uses the T predictor always).

We still don't write a meta prefix image to keep the huffman trees flatter, we still don't do full LZ77 backward matches, and we still don't write color transforms. But the writer has now enough features to be in usable shape. It's now Serenity OS's best-compressing lossless image writer.