### PR TITLE
Cherry-pick "LibWeb: Use absolute padding box to calculate max scroll offset"

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -83,8 +83,9 @@ void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
     document().set_needs_to_refresh_clip_state(true);
     document().set_needs_to_refresh_scroll_state(true);
 
-    auto max_x_offset = max(scrollable_overflow_rect->width() - content_size().width(), 0);
-    auto max_y_offset = max(scrollable_overflow_rect->height() - content_size().height(), 0);
+    auto padding_rect = absolute_padding_box_rect();
+    auto max_x_offset = max(scrollable_overflow_rect->width() - padding_rect.width(), 0);
+    auto max_y_offset = max(scrollable_overflow_rect->height() - padding_rect.height(), 0);
 
     offset.set_x(clamp(offset.x(), 0, max_x_offset));
     offset.set_y(clamp(offset.y(), 0, max_y_offset));


### PR DESCRIPTION
In `PaintableBox::set_scroll_offset()` the scrollport size was measured by `content_size()` instead of `absolute_padding_box_rect()`.

Fixes #788

(cherry picked from commit 54066ec5a454f33d8c5e4ea1f8695942b95b1b82)

---

https://github.com/LadybirdBrowser/ladybird/pull/789