### PR TITLE
Cherry-pick 'LibWeb: Fix typo "rtr" -> "rtl"'

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -192,7 +192,7 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
             String dirname = attribute.value();
 
             // 2. Let dir be the string "ltr" if the directionality of the element is 'ltr', and "rtl" otherwise (i.e., when the directionality of the element is 'rtl').
-            String dir = MUST((control->directionality() == DOM::Element::Directionality::Ltr) ? String::from_utf8("ltr"sv) : String::from_utf8("rtr"sv));
+            String dir = MUST((control->directionality() == DOM::Element::Directionality::Ltr) ? String::from_utf8("ltr"sv) : String::from_utf8("rtl"sv));
 
             // 3. Create an entry with dirname and dir, and append it to entry list.
             entry_list.append(XHR::FormDataEntry { .name = dirname, .value = dir });


### PR DESCRIPTION
(cherry picked from commit cdfc7a92f72165ad530bfaf920f1caf18974692f)

---

https://github.com/LadybirdBrowser/ladybird/pull/825