### PR TITLE
Cherry-pick "LibWeb: Don't proceed with Element.click() on disabled form controls"

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/submit-button-click-when-disabled.txt
+++ b/Tests/LibWeb/Text/expected/HTML/submit-button-click-when-disabled.txt
@@ -1,0 +1,1 @@
+   PASS! Did not click

--- a/Tests/LibWeb/Text/input/HTML/submit-button-click-when-disabled.html
+++ b/Tests/LibWeb/Text/input/HTML/submit-button-click-when-disabled.html
@@ -1,0 +1,12 @@
+<form id="theForm" style="display:none"><button id="theButton" type="submit" disabled></button></form>
+<script src="../include.js"></script>
+<script>
+    theForm.onclick = function() {
+        println("FAIL! Should not click!");
+    }
+
+    test(() => {
+        theButton.click();
+        println("PASS! Did not click");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -464,7 +464,11 @@ JS::GCPtr<DOM::NodeList> HTMLElement::labels()
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-click
 void HTMLElement::click()
 {
-    // FIXME: 1. If this element is a form control that is disabled, then return.
+    // 1. If this element is a form control that is disabled, then return.
+    if (auto* form_control = dynamic_cast<FormAssociatedElement*>(this)) {
+        if (!form_control->enabled())
+            return;
+    }
 
     // 2. If this element's click in progress flag is set, then return.
     if (m_click_in_progress)


### PR DESCRIPTION
Fixes an infinite reload loop on some of the dom/events/ tests in WPT.

(cherry picked from commit 273593afba71a42f1d760ac5b6664b77f74ffb7a)

---

https://github.com/LadybirdBrowser/ladybird/pull/841