### PR TITLE
Kernel: Create coredump by using the crashed process VFS root context

### DIFF
--- a/Kernel/Tasks/Coredump.cpp
+++ b/Kernel/Tasks/Coredump.cpp
@@ -96,11 +96,11 @@ Coredump::Coredump(NonnullRefPtr<Process> process, NonnullRefPtr<OpenFileDescrip
 ErrorOr<NonnullRefPtr<OpenFileDescription>> Coredump::try_create_target_file(Process const& process, StringView output_path)
 {
     auto output_directory = KLexicalPath::dirname(output_path);
-    auto current_vfs_root_context = Process::current().vfs_root_context();
-    auto current_vfs_root_context_root_custody = current_vfs_root_context->root_custody().with([](auto& custody) -> NonnullRefPtr<Custody> {
+    auto process_vfs_root_context = process.vfs_root_context();
+    auto vfs_root_context_root_custody = process_vfs_root_context->root_custody().with([](auto& custody) -> NonnullRefPtr<Custody> {
         return custody;
     });
-    auto dump_directory = TRY(VirtualFileSystem::open_directory(current_vfs_root_context, Process::current().credentials(), output_directory, *current_vfs_root_context_root_custody));
+    auto dump_directory = TRY(VirtualFileSystem::open_directory(process_vfs_root_context, Process::current().credentials(), output_directory, *vfs_root_context_root_custody));
     auto dump_directory_metadata = dump_directory->inode().metadata();
     if (dump_directory_metadata.uid != 0 || dump_directory_metadata.gid != 0 || dump_directory_metadata.mode != 040777) {
         dbgln("Refusing to put coredump in sketchy directory '{}'", output_directory);
@@ -109,7 +109,7 @@ ErrorOr<NonnullRefPtr<OpenFileDescription>> Coredump::try_create_target_file(Pro
 
     auto process_credentials = process.credentials();
     return TRY(VirtualFileSystem::open(
-        current_vfs_root_context,
+        process_vfs_root_context,
         Process::current().credentials(),
         KLexicalPath::basename(output_path),
         O_CREAT | O_WRONLY | O_EXCL,


### PR DESCRIPTION
This unbreaks coredump generation, because we need to use the VFS root context of the crashed process and not of the FinalizerTask, as it will hold an empty VFS root context that is assigned to kernel processes.