### PR TITLE
Cherry-pick "Utilities/js: Make it possible to exit via two consecutive ^C's"

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -31,10 +31,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-namespace {
-constexpr u32 ctrl(char c) { return c & 0x3f; }
-}
-
 namespace Line {
 
 Configuration Configuration::from_config(StringView libname)

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -36,6 +36,8 @@
 
 namespace Line {
 
+static constexpr u32 ctrl(char c) { return c & 0x3f; }
+
 struct KeyBinding {
     Vector<Key> keys;
     enum class Kind {

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -15,10 +15,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-namespace {
-constexpr u32 ctrl(char c) { return c & 0x3f; }
-}
-
 namespace Line {
 
 Function<bool(Editor&)> Editor::find_internal_function(StringView name)

--- a/Userland/Libraries/LibLine/KeyCallbackMachine.cpp
+++ b/Userland/Libraries/LibLine/KeyCallbackMachine.cpp
@@ -7,10 +7,6 @@
 #include <AK/Debug.h>
 #include <LibLine/Editor.h>
 
-namespace {
-constexpr u32 ctrl(char c) { return c & 0x3f; }
-}
-
 namespace Line {
 
 void KeyCallbackMachine::register_key_input_callback(Vector<Key> keys, Function<bool(Editor&)> callback)


### PR DESCRIPTION
Apparently this is common in the js repl world.
Fixes #743.

(cherry picked from commit d3f089dc268931e670ea6a00ac8bcb06ed9822e6)

---

https://github.com/LadybirdBrowser/ladybird/pull/839