### PR TITLE
Cherry-pick "LibWeb/DOM: Check if name is valid in Element.toggleAttribute"

### DIFF
--- a/Tests/LibWeb/Text/expected/Element-toggleAttribute-invalid-name.txt
+++ b/Tests/LibWeb/Text/expected/Element-toggleAttribute-invalid-name.txt
@@ -1,0 +1,2 @@
+  PASS (''): InvalidCharacterError
+PASS ('0'): InvalidCharacterError

--- a/Tests/LibWeb/Text/input/Element-toggleAttribute-invalid-name.html
+++ b/Tests/LibWeb/Text/input/Element-toggleAttribute-invalid-name.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="test"></div>
+<script>
+    test(() => {
+        const element = document.getElementById("test");
+
+        // toggleAttribute should throw an exception if the name isn't a valid
+        // XML Name (e.g. "", or "0").
+        try {
+            element.toggleAttribute("");
+            println("FAIL ('')");
+        } catch (err) {
+            println("PASS (''): " + err.name);
+        }
+
+        try {
+            element.toggleAttribute("0");
+            println("FAIL ('0')");
+        } catch (err) {
+            println("PASS ('0'): " + err.name);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -338,9 +338,8 @@ bool Element::has_attribute_ns(Optional<FlyString> const& namespace_, FlyString 
 WebIDL::ExceptionOr<bool> Element::toggle_attribute(FlyString const& name, Optional<bool> force)
 {
     // 1. If qualifiedName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
-    // FIXME: Proper name validation
-    if (name.is_empty())
-        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty"_fly_string);
+    if (!Document::is_valid_name(name.to_string()))
+        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty or contain invalid characters"_fly_string);
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     bool insert_as_lowercase = namespace_uri() == Namespace::HTML && document().document_type() == Document::Type::HTML;


### PR DESCRIPTION
This resolves a test in https://wpt.live/dom/nodes/attributes.html.

(cherry picked from commit f774d75f890e89a8483e5c7459de4fd96ce1b479)

---

https://github.com/LadybirdBrowser/ladybird/pull/819