### PR TITLE
Cherry-pick "LibWeb: Only inject "User-Agent"/"Accept" headers when they're missing"

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -503,12 +503,16 @@ RefPtr<ResourceLoaderConnectorRequest> ResourceLoader::start_network_request(Loa
     auto proxy = ProxyMappings::the().proxy_for_url(request.url());
 
     HTTP::HeaderMap headers;
-    headers.set("User-Agent", m_user_agent.to_byte_string());
-    headers.set("Accept-Encoding", "gzip, deflate, br");
 
     for (auto const& it : request.headers()) {
         headers.set(it.key, it.value);
     }
+
+    if (!headers.contains("User-Agent"))
+        headers.set("User-Agent", m_user_agent.to_byte_string());
+
+    if (!headers.contains("Accept-Encoding"))
+        headers.set("Accept-Encoding", "gzip, deflate, br");
 
     auto protocol_request = m_connector->start_request(request.method(), request.url(), headers, request.body(), proxy);
     if (!protocol_request) {


### PR DESCRIPTION
...otherwise we send out HTTP requests with duplicates of these headers.

(cherry picked from commit 847243b7065b80739fdd4d015bc6559b0581bb66)

---

https://github.com/LadybirdBrowser/ladybird/commit/847243b7065b80739fdd4d015bc6559b0581bb66 (sneak commit without PR)