### PR TITLE
Cherry-pick "LibWeb: Rename HTMLInputElement members related to range shadow tree"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -287,8 +287,9 @@ private:
     JS::GCPtr<DOM::Element> m_file_button;
     JS::GCPtr<DOM::Element> m_file_label;
 
-    void update_slider_thumb_element();
+    void update_slider_shadow_tree_elements();
     JS::GCPtr<DOM::Element> m_slider_thumb;
+    JS::GCPtr<DOM::Element> m_slider_progress_element;
 
     JS::GCPtr<DecodedImageData> image_data() const;
     JS::GCPtr<SharedImageRequest> m_image_request;
@@ -322,8 +323,6 @@ private:
     String m_last_src_value;
 
     bool m_has_uncommitted_changes { false };
-
-    JS::GCPtr<DOM::Element> m_range_progress_element;
 };
 
 }


### PR DESCRIPTION
Choose a better name for private members which were added in https://github.com/LadybirdBrowser/ladybird/pull/513

(cherry picked from commit b1d7a27468e5dca58039c79a455c9f8ac1b80680)

---

https://github.com/LadybirdBrowser/ladybird/pull/669