### PR TITLE
Kernel/PCI: Handle 64-bit MSI-X BARs

### DIFF
--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Arch/Interrupts.h>
 #include <Kernel/Arch/PCIMSI.h>
 #include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/BarMapping.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Memory/TypedMapping.h>
 
@@ -110,10 +111,10 @@ PhysicalAddress Device::msix_table_entry_address(u8 irq)
 
     VERIFY(index < m_interrupt_range.m_irq_count);
     VERIFY(index >= 0);
-    auto table_bar_ptr = PCI::get_BAR(device_identifier(), static_cast<PCI::HeaderType0BaseRegister>(m_pci_identifier->get_msix_table_bar())) & PCI::bar_address_mask;
+    auto table_bar_paddr = PCI::get_bar_address(device_identifier(), static_cast<PCI::HeaderType0BaseRegister>(m_pci_identifier->get_msix_table_bar())).release_value_but_fixme_should_propagate_errors();
     auto table_offset = m_pci_identifier->get_msix_table_offset();
 
-    return PhysicalAddress(table_bar_ptr + table_offset + (index * 16));
+    return table_bar_paddr.offset(table_offset + (index * 16));
 }
 
 // This function is used to allocate an irq at an index and returns


### PR DESCRIPTION
This allows us to boot without putting the NVMe drive behind a i82801b11-bridge when using recent SeaBIOS versions with more than 4GiB RAM (context: #22720, #22710).