### PR TITLE
ImageViewer: Call clear() in the ViewWidget before loading a new image

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -249,6 +249,8 @@ ErrorOr<void> ViewWidget::try_open_file(String const& path, Core::File& file)
         }
     }
 
+    clear();
+
     m_image = frames[0].image;
     if (is_animated && frames.size() > 1) {
         m_animation = Animation { loop_count, move(frames) };


### PR DESCRIPTION
We need to do this to stop the animation timer and delete the current animation, otherwise the new image will be shown only for a moment before the previous animation continues.