### PR TITLE
Kernel/USB: Make USBHubDescriptor::hub_characteristics union packed

### DIFF
--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -126,7 +126,7 @@ static_assert(AssertSize<USBSuperSpeedEndpointCompanionDescriptor, 6>());
 struct [[gnu::packed]] USBHubDescriptor {
     USBDescriptorCommon descriptor_header;
     u8 number_of_downstream_ports;
-    union {
+    union [[gnu::packed]] {
         u16 raw;
         struct {
             u16 logical_power_switching_mode : 2;


### PR DESCRIPTION
AArch64 Clang otherwise complains that this anonymous union is more aligned than the struct.