### PR TITLE
LibGfx/PNGWriter+image: Make PNG writing 4-5x as fast while reducing output size 2-9%

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -19,7 +19,7 @@ class PNGChunk;
 
 // This is not a nested struct to work around https://llvm.org/PR36684
 struct PNGWriterOptions {
-    Compress::ZlibCompressionLevel compression_level { Compress::ZlibCompressionLevel::Best };
+    Compress::ZlibCompressionLevel compression_level { Compress::ZlibCompressionLevel::Default };
 
     // Data for the iCCP chunk.
     // FIXME: Allow writing cICP, sRGB, or gAMA instead too.

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -40,6 +40,7 @@ private:
     ErrorOr<void> add_png_header();
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
     ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data, Compress::ZlibCompressionLevel);
+    template<bool include_alpha>
     ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&, Compress::ZlibCompressionLevel);
     ErrorOr<void> add_IEND_chunk();
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -9,6 +9,7 @@
 
 #include <AK/Optional.h>
 #include <AK/Vector.h>
+#include <LibCompress/Zlib.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/ImageFormats/PNGShared.h>
 
@@ -18,6 +19,8 @@ class PNGChunk;
 
 // This is not a nested struct to work around https://llvm.org/PR36684
 struct PNGWriterOptions {
+    Compress::ZlibCompressionLevel compression_level { Compress::ZlibCompressionLevel::Best };
+
     // Data for the iCCP chunk.
     // FIXME: Allow writing cICP, sRGB, or gAMA instead too.
     Optional<ReadonlyBytes> icc_data;
@@ -36,8 +39,8 @@ private:
     ErrorOr<void> add_chunk(PNGChunk&);
     ErrorOr<void> add_png_header();
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
-    ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data);
-    ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&);
+    ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data, Compress::ZlibCompressionLevel);
+    ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&, Compress::ZlibCompressionLevel);
     ErrorOr<void> add_IEND_chunk();
 };
 

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -223,7 +223,7 @@ struct Options {
     StringView assign_color_profile_path;
     StringView convert_color_profile_path;
     bool strip_color_profile = false;
-    Compress::ZlibCompressionLevel png_compression_level { Compress::ZlibCompressionLevel::Best };
+    Compress::ZlibCompressionLevel png_compression_level { Compress::ZlibCompressionLevel::Default };
     bool ppm_ascii = false;
     u8 quality = 75;
     unsigned webp_color_cache_bits = 6;
@@ -286,7 +286,7 @@ static ErrorOr<Options> parse_options(Main::Arguments arguments)
     args_parser.add_option(options.assign_color_profile_path, "Load color profile from file and assign it to output image", "assign-color-profile", {}, "FILE");
     args_parser.add_option(options.convert_color_profile_path, "Load color profile from file and convert output image from current profile to loaded profile", "convert-to-color-profile", {}, "FILE");
     args_parser.add_option(options.strip_color_profile, "Do not write color profile to output", "strip-color-profile", {});
-    auto png_compression_level = static_cast<unsigned>(Compress::ZlibCompressionLevel::Best);
+    auto png_compression_level = static_cast<unsigned>(Compress::ZlibCompressionLevel::Default);
     args_parser.add_option(png_compression_level, "PNG compression level, in [0, 3]. Higher values take longer and produce smaller outputs. Default: 2", "png-compression-level", {}, {});
     args_parser.add_option(options.ppm_ascii, "Convert to a PPM in ASCII", "ppm-ascii", {});
     args_parser.add_option(options.quality, "Quality used for the JPEG encoder, the default value is 75 on a scale from 0 to 100", "quality", {}, {});


### PR DESCRIPTION
Also give `image` a `--png-compression-level` flag.

The wins come from:

1. Writing only RGB instead of RGBA data for opaque images
2. Switching the compression from Best to Default

With 1, 2 is still a small size win and a huge speedup. See commits for detailed numbers.