### PR TITLE
Kernel/x86: Properly restore rflags in the syscall handler

### DIFF
--- a/Kernel/Arch/x86_64/SyscallEntry.cpp
+++ b/Kernel/Arch/x86_64/SyscallEntry.cpp
@@ -80,7 +80,8 @@ extern "C" NO_SANITIZE_COVERAGE [[gnu::naked]] void syscall_entry()
         "    popq %%r15 \n"
         "    addq $8, %%rsp \n"
         "    popq %%rcx \n"
-        "    addq $16, %%rsp \n"
+        "    addq $8, %%rsp \n"
+        "    popq %%r11 \n"
 
         // Disable interrupts before we restore the user stack pointer. sysret will re-enable interrupts when it restores
         // rflags.


### PR DESCRIPTION
The sysret instruction restores the rflags value from the r11 register. Before, we expected that the value in RegisterState::r11 is still the rflags value saved by syscall and therefore didn't copy RegisterState::rflags to r11 before the sysret.

But signal handlers and ptrace can change the value in RegisterState::r11 while we are handling a syscall, so we shouldn't assume that it still contains the saved rflags.
While handling a syscall the contents of RegisterState::rflags may also have been updated by e.g. ptrace in which case we should restore the updated rflags, not the original state on syscall entry.