### PR TITLE
Toolchain: Fix default library paths when building with clang

### DIFF
--- a/Ports/epsilon/patches/0001-Add-serenity-toolchain-information-and-makefile-file.patch
+++ b/Ports/epsilon/patches/0001-Add-serenity-toolchain-information-and-makefile-file.patch
@@ -4,17 +4,17 @@ Date: Tue, 13 Jul 2021 21:17:44 +0200
 Subject: [PATCH] Add serenity toolchain information and makefile files
 
 ---
- build/platform.simulator.serenity.mak |  6 ++++
- build/toolchain.x86_64-pc-serenity.mak  |  4 +++
- ion/src/simulator/serenity/Makefile   | 43 +++++++++++++++++++++++++++
- 3 files changed, 53 insertions(+)
+ build/platform.simulator.serenity.mak  |  6 ++++
+ build/toolchain.x86_64-pc-serenity.mak |  1 +
+ ion/src/simulator/serenity/Makefile    | 43 ++++++++++++++++++++++++++
+ 3 files changed, 50 insertions(+)
  create mode 100644 build/platform.simulator.serenity.mak
  create mode 100644 build/toolchain.x86_64-pc-serenity.mak
  create mode 100644 ion/src/simulator/serenity/Makefile
 
 diff --git a/build/platform.simulator.serenity.mak b/build/platform.simulator.serenity.mak
 new file mode 100644
-index 0000000..ff985de
+index 0000000000000000000000000000000000000000..0ac83c0bb06554bfa3077b9c2b67516291018e3b
 --- /dev/null
 +++ b/build/platform.simulator.serenity.mak
 @@ -0,0 +1,6 @@
@@ -26,17 +26,14 @@ index 0000000..ff985de
 +SHOULD_USE_DYNAMIC_SDL = 1
 diff --git a/build/toolchain.x86_64-pc-serenity.mak b/build/toolchain.x86_64-pc-serenity.mak
 new file mode 100644
-index 0000000..d6110e2
+index 0000000000000000000000000000000000000000..bb49f4ed4dcec21891f94ec9c3c9f602d6f4cbcf
 --- /dev/null
 +++ b/build/toolchain.x86_64-pc-serenity.mak
-@@ -0,0 +1,4 @@
+@@ -0,0 +1 @@
 +TOOLCHAIN_PREFIX = x86_64-pc-serenity
-+CC = $(TOOLCHAIN_PREFIX)-gcc
-+CXX = $(TOOLCHAIN_PREFIX)-g++
-+LD = $(TOOLCHAIN_PREFIX)-g++
 diff --git a/ion/src/simulator/serenity/Makefile b/ion/src/simulator/serenity/Makefile
 new file mode 100644
-index 0000000..5d4bb13
+index 0000000000000000000000000000000000000000..5d4bb131983ba85c79042cfa790b94e400158705
 --- /dev/null
 +++ b/ion/src/simulator/serenity/Makefile
 @@ -0,0 +1,43 @@

--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -9,7 +9,6 @@ configopts=(
     "--target=${SERENITY_ARCH}-pc-serenity"
     "--with-lib=${SERENITY_INSTALL_ROOT}/usr/local"
     'CFLAGS=-DNO_IPV6'
-    "LDFLAGS=-L${SERENITY_INSTALL_ROOT}/usr/local/lib"
 )
 depends=(
     'curl'

--- a/Ports/ja2/patches/0001-Make-it-build-with-SDL-2-instead-of-1.2.patch
+++ b/Ports/ja2/patches/0001-Make-it-build-with-SDL-2-instead-of-1.2.patch
@@ -176,7 +176,7 @@ index 6db811f..53103d3 100644
 +# using Serenity SDL2 library
 +ifdef SERENITY
 +CFLAGS_SDL= -I${SERENITY_BUILD_DIR}/Root/usr/local/include/SDL2 -D_REENTRANT
-+LDFLAGS_SDL= -L${SERENITY_BUILD_DIR}/Root/usr/local/lib -lSDL2
++LDFLAGS_SDL= -lSDL2
 +endif
 +
  # using system SDL library

--- a/Ports/openssl/package.sh
+++ b/Ports/openssl/package.sh
@@ -21,8 +21,6 @@ configopts=(
 )
 
 configure() {
-    export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include"
-    export LDFLAGS="-L${SERENITY_INSTALL_ROOT}/usr/local/lib"
     run ./"${configscript}" "${configopts[@]}"
 }
 

--- a/Ports/sam/patches/0002-Manually-set-the-SDL2-include-path-and-library-dir.patch
+++ b/Ports/sam/patches/0002-Manually-set-the-SDL2-include-path-and-library-dir.patch
@@ -18,7 +18,7 @@ index 1153e0c..da26e9d 100644
 -CFLAGS =  -Wall -O2 -DUSESDL `sdl-config --cflags`
 -LFLAGS = `sdl-config --libs`
 +CFLAGS =  -Wall -O2 -DUSESDL -I$(SERENITY_INSTALL_ROOT)/usr/local/include/SDL2 -D_REENTRANT
-+LFLAGS = -L$(SERENITY_INSTALL_ROOT)/usr/local/lib -lSDL2
++LFLAGS = -lSDL2
  
  # no libsdl present
  #CFLAGS =  -Wall -O2

--- a/Ports/sl/package.sh
+++ b/Ports/sl/package.sh
@@ -8,5 +8,5 @@ files=(
 depends=("ncurses")
 
 build() {
-    run ${CC} -I${SERENITY_INSTALL_ROOT}/usr/local/include/ncurses -L${SERENITY_INSTALL_ROOT}/usr/local/lib -o sl sl.c -lncurses -ltinfo
+    run ${CC} -I${SERENITY_INSTALL_ROOT}/usr/local/include/ncurses -o sl sl.c -lncurses -ltinfo
 }

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -9,6 +9,5 @@ depends=(
 )
 
 pre_configure() {
-    export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include"
-    export LDFLAGS="-L${SERENITY_INSTALL_ROOT}/usr/local/lib -lzlib"
+    export LDFLAGS="-lzlib"
 }

--- a/Toolchain/Patches/llvm/0001-clang-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/llvm/0001-clang-Add-support-for-SerenityOS.patch
@@ -180,7 +180,7 @@ new file mode 100644
 index 000000000000..2167758100bc
 --- /dev/null
 +++ b/clang/lib/Driver/ToolChains/Serenity.cpp
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,221 @@
 +//===---- Serenity.cpp - SerenityOS ToolChain Implementation ----*- C++ -*-===//
 +//
 +// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -343,6 +343,8 @@ index 000000000000..2167758100bc
 +    CmdArgs.push_back("--pop-state");
 +  }
 +
++  CmdArgs.push_back("-L=/usr/local/lib");
++
 +  // Silence warnings when linking C code with a C++ '-stdlib' argument.
 +  Args.ClaimAllArgs(options::OPT_stdlib_EQ);
 +
@@ -394,6 +396,9 @@ index 000000000000..2167758100bc
 +
 +  if (DriverArgs.hasArg(options::OPT_nostdlibinc))
 +    return;
++
++  addSystemInclude(
++      DriverArgs, CC1Args, concat(D.SysRoot, "/usr/local/include"));
 +
 +  addSystemInclude(DriverArgs, CC1Args, concat(D.SysRoot, "/usr/include"));
 +}


### PR DESCRIPTION
So i went to compare behavior between GNU and Clang, and it seems that GNU has `/usr/local/lib` and `/usr/local/include` in the search paths by default, while Clang only has `/usr/lib` and `/usr/include`. Various packages are broken on Clang because of this, and while we could patch each one of them to include the proper paths manually, IMO a more centarlized approach is in order.

Incomplete list of packages that this concerns:
- SDL2 (this supersedes e128d8efef6031d6b9b6b8b6a33661eb036b5850 from #24891)
- libpng (upgraded in this MR)
- aria2 (zlib is an optional dependency and it wasn't linking properly with Clang builds)

Open to comments, I may be misunderstanding *something* here :)