### PR TITLE
Ports/SuperTuxKart: Fix building on Clang

### DIFF
--- a/Ports/SuperTuxKart/package.sh
+++ b/Ports/SuperTuxKart/package.sh
@@ -39,8 +39,8 @@ configopts=(
     '-DUSE_DNS_C=ON'
     '-Bbuild'
     '-GNinja'
-    "-DCMAKE_C_FLAGS=-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2 -I${SERENITY_INSTALL_ROOT}/usr/local/include -lcurl -lharfbuzz -lfreetype"
-    "-DCMAKE_CXX_FLAGS=-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2 -I${SERENITY_INSTALL_ROOT}/usr/local/include -lcurl -lharfbuzz -lfreetype"
+    "-DCMAKE_C_FLAGS=-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2 -lcurl -lharfbuzz -lfreetype"
+    "-DCMAKE_CXX_FLAGS=-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2"
     '-DUSE_IPV6=OFF'
     '-DUSE_SYSTEM_ENET=OFF'
 )


### PR DESCRIPTION
Removed redundant link flags from CXXFLAGS, which was necessary due to clang treating them as errors.

This depends on #24893 for some dependencies.