### PR TITLE
RequestServer: Make the ThreadPool global

### DIFF
--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -32,22 +32,18 @@ public:
     void did_progress_request(Badge<Request>, Request&);
     void did_request_certificates(Badge<Request>, Request&);
 
-private:
-    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
+    template<typename Pool>
+    struct Looper : public Threading::ThreadPoolLooper<Pool> {
+        Looper(int pipe_fd)
+            : notifier(Core::Notifier::construct(pipe_fd, Core::NotificationType::Read))
+        {
+        }
 
-    virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;
-    virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString const&) override;
-    virtual void start_request(i32 request_id, ByteString const&, URL::URL const&, HTTP::HeaderMap const&, ByteBuffer const&, Core::ProxyData const&) override;
-    virtual Messages::RequestServer::StopRequestResponse stop_request(i32) override;
-    virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, ByteString const&, ByteString const&) override;
-    virtual void ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel const& cache_level) override;
-
-    virtual Messages::RequestServer::WebsocketConnectResponse websocket_connect(URL::URL const&, ByteString const&, Vector<ByteString> const&, Vector<ByteString> const&, HTTP::HeaderMap const&) override;
-    virtual Messages::RequestServer::WebsocketReadyStateResponse websocket_ready_state(i32) override;
-    virtual Messages::RequestServer::WebsocketSubprotocolInUseResponse websocket_subprotocol_in_use(i32) override;
-    virtual void websocket_send(i32, bool, ByteBuffer const&) override;
-    virtual void websocket_close(i32, u16, ByteString const&) override;
-    virtual Messages::RequestServer::WebsocketSetCertificateResponse websocket_set_certificate(i32, ByteString const&, ByteString const&) override;
+        IterationDecision next(Pool& pool, bool wait);
+        Core::EventLoop event_loop;
+        NonnullRefPtr<Core::Notifier> notifier;
+        bool done { false };
+    };
 
     struct StartRequest {
         i32 request_id;
@@ -67,26 +63,28 @@ private:
 
     void worker_do_work(Work);
 
+private:
+    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
+
+    virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;
+    virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString const&) override;
+    virtual void start_request(i32 request_id, ByteString const&, URL::URL const&, HTTP::HeaderMap const&, ByteBuffer const&, Core::ProxyData const&) override;
+    virtual Messages::RequestServer::StopRequestResponse stop_request(i32) override;
+    virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, ByteString const&, ByteString const&) override;
+    virtual void ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel const& cache_level) override;
+
+    virtual Messages::RequestServer::WebsocketConnectResponse websocket_connect(URL::URL const&, ByteString const&, Vector<ByteString> const&, Vector<ByteString> const&, HTTP::HeaderMap const&) override;
+    virtual Messages::RequestServer::WebsocketReadyStateResponse websocket_ready_state(i32) override;
+    virtual Messages::RequestServer::WebsocketSubprotocolInUseResponse websocket_subprotocol_in_use(i32) override;
+    virtual void websocket_send(i32, bool, ByteBuffer const&) override;
+    virtual void websocket_close(i32, u16, ByteString const&) override;
+    virtual Messages::RequestServer::WebsocketSetCertificateResponse websocket_set_certificate(i32, ByteString const&, ByteString const&) override;
+
     Threading::MutexProtected<HashMap<i32, OwnPtr<Request>>> m_requests;
     HashMap<i32, RefPtr<WebSocket::WebSocket>> m_websockets;
 
     void enqueue(Work);
 
-    template<typename Pool>
-    struct Looper : public Threading::ThreadPoolLooper<Pool> {
-        Looper(int pipe_fd)
-            : notifier(Core::Notifier::construct(pipe_fd, Core::NotificationType::Read))
-        {
-        }
-
-        IterationDecision next(Pool& pool, bool wait);
-        Core::EventLoop event_loop;
-        NonnullRefPtr<Core::Notifier> notifier;
-        bool done { false };
-    };
-
-    Array<int, 2> m_thread_pipe_fds { -1, -1 };
-    Threading::ThreadPool<Work, Looper> m_thread_pool;
     Threading::Mutex m_ipc_mutex;
 };
 


### PR DESCRIPTION
Previously we made one thread pool per ipc client, which is excessive and can eat up all the available fds very fast.

This is a manual port of commit 18499c4eac301db7e8915284f33766ca96cdeef2 from Ladybird.