### PR TITLE
Meta: Remove /mod

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -137,11 +137,10 @@ chmod 755 mnt/res/devel/templates/*.postcreate
 echo "done"
 
 printf "creating initial filesystem structure... "
-for dir in bin etc proc mnt tmp boot www mod var/run usr/local usr/Ports usr/bin; do
+for dir in bin etc proc mnt tmp boot www var/run usr/local usr/Ports usr/bin; do
     mkdir -p mnt/$dir
 done
 chmod 700 mnt/boot
-chmod 700 mnt/mod
 chmod 1777 mnt/tmp
 echo "done"
 


### PR DESCRIPTION
This directory was introduced with commit a43b115a6c99881c964daa5012cd076e82a7d72f and is no longer needed.