### PR TITLE
Presenter: Modify CSS to hide scrollbars

### DIFF
--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -188,6 +188,7 @@ ErrorOr<ByteString> Presentation::render()
         top: 0;
         width: 100%;
         height: 100%;
+        overflow: hidden;
     }
     .hidden {
         display: none;

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -26,7 +26,6 @@ PresenterWidget::PresenterWidget()
     m_web_view->set_frame_style(Gfx::FrameStyle::NoFrame);
     m_web_view->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_web_view->set_content_scales_to_viewport(true);
-    // FIXME: Don't show scrollbars.
 }
 
 void PresenterWidget::resize_event(GUI::ResizeEvent& event)


### PR DESCRIPTION
This PR modifies the style for the `slide` class generated in `Presentation::render()` to hide the scrollbars.

Before:

![before](https://github.com/user-attachments/assets/6eef8a9b-9a62-4247-9467-781ab315e5c8)

After: 

![after](https://github.com/user-attachments/assets/cabdb652-542d-4d22-a990-50a006e56da1)
