### PR TITLE
AK+LibGfx: Use SIMD for PNG score calculation

### DIFF
--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -50,6 +50,12 @@ ALWAYS_INLINE static u32x4 to_u32x4(TSrc v)
 }
 
 template<typename TSrc>
+ALWAYS_INLINE static i8x4 to_i8x4(TSrc v)
+{
+    return __builtin_convertvector(v, i8x4);
+}
+
+template<typename TSrc>
 ALWAYS_INLINE static i32x4 to_i32x4(TSrc v)
 {
     return __builtin_convertvector(v, i32x4);

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.cpp
@@ -185,19 +185,13 @@ ErrorOr<void> PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap, Compress::Zli
             ByteBuffer buffer {};
             AK::SIMD::i32x4 sum { 0, 0, 0, 0 };
 
-            ErrorOr<void> append(u8 byte)
-            {
-                TRY(buffer.try_append(byte));
-                return {};
-            }
-
             ErrorOr<void> append(AK::SIMD::u8x4 simd)
             {
-                TRY(append(simd[0]));
-                TRY(append(simd[1]));
-                TRY(append(simd[2]));
+                TRY(buffer.try_append(simd[0]));
+                TRY(buffer.try_append(simd[1]));
+                TRY(buffer.try_append(simd[2]));
                 if constexpr (include_alpha)
-                    TRY(append(simd[3]));
+                    TRY(buffer.try_append(simd[3]));
                 sum += AK::SIMD::to_i32x4(AK::SIMD::to_i8x4(simd));
                 return {};
             }


### PR DESCRIPTION
Produces exactly the same output, but a bit faster.

The speedup is relatively bigger for worse compression:

    image -o sunset_retro.png sunset_retro.bmp --png-compression-level 0
       56.8 ms ±  1.5 ms ->  34.8 ms ± 0.9 ms (38.7% faster)

    image -o sunset_retro.png sunset_retro.bmp --png-compression-level 1
       84.6 ms ±  1.7 ms ->  64.2 ms ± 4.9 ms (24.1% faster)

    image -o sunset_retro.png sunset_retro.bmp --png-compression-level 2
      212.1 ms ±  2.5 ms -> 190.3 ms ± 1.6 ms (10.3% faster)

    image -o sunset_retro.png sunset_retro.bmp --png-compression-level 3
      671.4 ms ± 12.3 ms -> 646.5 ms ± 4.7 ms (3.7% faster)

Compression level 2 is the default, so about a 10% speedup in practice.

For comparison, `sips` needs 49.9 ms ± 3.0 ms to convert sunset_retro.bmp to sunset_retro.png, and judging from the output file size, it uses something similar to our compression level 1. We used to take 1.7x as long as sips, now we take 1.29x as long.