### PR TITLE
LibGfx/PNGWriter+AK: SIMDify paeth predictor more

### DIFF
--- a/AK/SIMDMath.h
+++ b/AK/SIMDMath.h
@@ -38,6 +38,19 @@ ALWAYS_INLINE static f32x4 frac_int_range(f32x4 v)
     return v - floor_int_range(v);
 }
 
+template<SIMDVector T>
+ALWAYS_INLINE T bitselect(T v1, T v2, T control_mask)
+{
+    return (v1 & control_mask) | (v2 & ~control_mask);
+}
+
+template<SIMDVector T>
+requires(IsIntegral<ElementOf<T>>)
+ALWAYS_INLINE T abs(T x)
+{
+    return bitselect(x, -x, x > 0);
+}
+
 ALWAYS_INLINE static f32x4 clamp(f32x4 v, f32x4 min, f32x4 max)
 {
     return v < min ? min : (v > max ? max : v);

--- a/Tests/LibGfx/BenchmarkPNG.cpp
+++ b/Tests/LibGfx/BenchmarkPNG.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/FixedArray.h>
+#include <LibCore/File.h>
+#include <LibGfx/ImageFormats/JPEGLoader.h>
+#include <LibGfx/ImageFormats/PNGShared.h>
+#include <LibTest/TestCase.h>
+
+#ifdef AK_OS_SERENITY
+#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
+#else
+#    define TEST_INPUT(x) ("test-inputs/" x)
+#endif
+
+auto bitmap = Gfx::JPEGImageDecoderPlugin::create(Core::File::open(TEST_INPUT("jpg/big_image.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value()).release_value()->frame(0).release_value().image;
+
+BENCHMARK_CASE(paeth)
+{
+    Vector<AK::SIMD::u8x4> output;
+    output.ensure_capacity(bitmap->width() * bitmap->height());
+
+    auto dummy_scanline = MUST(FixedArray<Gfx::ARGB32>::create(bitmap->width()));
+    auto const* scanline_minus_1 = dummy_scanline.data();
+
+    for (int y = 0; y < bitmap->height(); ++y) {
+        auto* scanline = bitmap->scanline(y);
+
+        auto pixel_x_minus_1 = (AK::SIMD::u8x4)dummy_scanline[0];
+        auto pixel_xy_minus_1 = (AK::SIMD::u8x4)dummy_scanline[0];
+
+        for (int x = 0; x < bitmap->width(); ++x) {
+            auto pixel = (AK::SIMD::u8x4)(scanline[x]);
+            auto pixel_y_minus_1 = (AK::SIMD::u8x4)(scanline_minus_1[x]);
+
+            auto out = pixel - Gfx::PNG::paeth_predictor(pixel_x_minus_1, pixel_y_minus_1, pixel_xy_minus_1);
+
+            output.append(out);
+
+            pixel_x_minus_1 = pixel;
+            pixel_xy_minus_1 = pixel_y_minus_1;
+        }
+
+        scanline_minus_1 = scanline;
+    }
+}

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     BenchmarkGfxPainter.cpp
     BenchmarkJPEGLoader.cpp
+    BenchmarkPNG.cpp
     TestColor.cpp
     TestDeltaE.cpp
     TestFontHandling.cpp

--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -175,6 +175,27 @@ TEST_CASE(test_png)
     TRY_OR_FAIL((test_roundtrip<Gfx::PNGWriter, Gfx::PNGImageDecoderPlugin>(TRY_OR_FAIL(create_test_rgba_bitmap()))));
 }
 
+TEST_CASE(test_png_paeth_simd)
+{
+    for (int a = 0; a < 256; ++a) {
+        for (int b = 0; b < 256; ++b) {
+            for (int c = 0; c < 256; ++c) {
+                u8 expected = Gfx::PNG::paeth_predictor(a, b, c);
+
+                AK::SIMD::u8x4 va { (u8)a, (u8)a, (u8)a, (u8)a };
+                AK::SIMD::u8x4 vb { (u8)b, (u8)b, (u8)b, (u8)b };
+                AK::SIMD::u8x4 vc { (u8)c, (u8)c, (u8)c, (u8)c };
+                AK::SIMD::u8x4 actual = Gfx::PNG::paeth_predictor(va, vb, vc);
+
+                EXPECT_EQ(actual[0], expected);
+                EXPECT_EQ(actual[1], expected);
+                EXPECT_EQ(actual[2], expected);
+                EXPECT_EQ(actual[3], expected);
+            }
+        }
+    }
+}
+
 TEST_CASE(test_qoi)
 {
     TRY_OR_FAIL((test_roundtrip<Gfx::QOIWriter, Gfx::QOIImageDecoderPlugin>(TRY_OR_FAIL(create_test_rgb_bitmap()))));


### PR DESCRIPTION
Takes

    (cd Tests/LibGfx; ../../Build/lagom/bin/BenchmarkPNG)

from 59ms to 32ms on my system.

Adds AK::SIMD::bitselect() (modeled after the wasm SIMD equivalent),
and AK::SIMD::abs() implemented on top of it.

No behavior change.

---

I'll wait for #24909 to land and will then rebase this on top of that once it's in.