### PR TITLE
cat: Add -b to number non-blank lines

### DIFF
--- a/Tests/Utilities/CMakeLists.txt
+++ b/Tests/Utilities/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestSed.cpp
     TestPatch.cpp
     TestUniq.cpp
+    TestCat.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/Utilities/TestCat.cpp
+++ b/Tests/Utilities/TestCat.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Rodrigo Tobar <rtobarc@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ScopeGuard.h>
+#include <AK/StringView.h>
+#include <LibCore/Command.h>
+#include <LibCore/File.h>
+#include <LibTest/Macros.h>
+#include <LibTest/TestCase.h>
+
+static void run_cat(Vector<char const*>&& arguments, StringView standard_input, StringView expected_stdout)
+{
+    MUST(arguments.try_insert(0, "cat"));
+    MUST(arguments.try_append(nullptr));
+    auto cat = MUST(Core::Command::create("cat"sv, arguments.data()));
+    MUST(cat->write(standard_input));
+    auto [stdout, stderr] = MUST(cat->read_all());
+    auto status = MUST(cat->status());
+    if (status != Core::Command::ProcessResult::DoneWithZeroExitCode) {
+        FAIL(ByteString::formatted("cat didn't exit cleanly: status: {}, stdout:{}, stderr: {}", static_cast<int>(status), StringView { stdout.bytes() }, StringView { stderr.bytes() }));
+    }
+
+    EXPECT_EQ(StringView { expected_stdout.bytes() }, StringView { stdout.bytes() });
+}
+
+TEST_CASE(show_lines)
+{
+    run_cat({ "-n" }, "hello"sv, "     1\thello"sv);
+    run_cat({ "-n" }, "hello\nworld"sv, "     1\thello\n     2\tworld"sv);
+    run_cat({ "-n" }, "hello\n\nworld"sv, "     1\thello\n     2\t\n     3\tworld"sv);
+    run_cat({ "-n" }, "\nhello"sv, "     1\t\n     2\thello"sv);
+    run_cat({ "-n" }, "hello\n"sv, "     1\thello\n"sv);
+    run_cat({ "-n" }, "hello\n\n"sv, "     1\thello\n     2\t\n"sv);
+}
+
+TEST_CASE(show_only_non_blank_lines)
+{
+    run_cat({ "-b" }, "hello"sv, "     1\thello"sv);
+    run_cat({ "-b" }, "hello\nworld"sv, "     1\thello\n     2\tworld"sv);
+    run_cat({ "-b" }, "hello\n\nworld"sv, "     1\thello\n\n     2\tworld"sv);
+    run_cat({ "-b" }, "\nhello"sv, "\n     1\thello"sv);
+    run_cat({ "-b" }, "hello\n"sv, "     1\thello\n"sv);
+    run_cat({ "-b" }, "hello\n\n"sv, "     1\thello\n\n"sv);
+}

--- a/Userland/Utilities/cat.cpp
+++ b/Userland/Utilities/cat.cpp
@@ -16,17 +16,54 @@ struct LineTracker {
     bool display_line_number = true;
 };
 
-static void output_buffer_with_line_numbers(LineTracker& line_tracker, ReadonlyBytes buffer_span)
+static void output_buffer_with_line_numbers(LineTracker& line_tracker, ReadonlyBytes buffer_span, bool show_only_non_blank_lines = false)
 {
-    for (auto const curr_value : buffer_span) {
+    if (buffer_span.size() == 0) {
+        return;
+    }
+
+    size_t i = 0;
+
+    // Handle special case where file starts with newlines
+    if (show_only_non_blank_lines) {
+        while (i < buffer_span.size() && buffer_span[i] == '\n') {
+            out("{:c}", buffer_span[i]);
+            i += 1;
+        }
+    }
+
+    while (i < buffer_span.size()) {
         if (line_tracker.display_line_number) {
             out("{: >6}\t", line_tracker.line_count);
             line_tracker.line_count++;
             line_tracker.display_line_number = false;
         }
-        if (curr_value == '\n')
+        if (buffer_span[i] == '\n') {
+            if (show_only_non_blank_lines) {
+                // Suck up all the newlines until we're looking at the last newline.
+                //
+                // Then let the code outside of this for loop process the current
+                // character so we drop out if we're on the last character OR we're
+                // at the last newline.
+                while (i < buffer_span.size()) {
+                    if (i == buffer_span.size() - 1) {
+                        // Last character - print it out and be done
+                        out("{:c}", buffer_span[i]);
+                        return;
+                    }
+                    if (buffer_span[i + 1] != '\n') {
+                        // We're at the last newline
+                        break;
+                    }
+                    // Still more newlines to go
+                    out("{:c}", buffer_span[i]);
+                    i += 1;
+                }
+            }
             line_tracker.display_line_number = true;
-        out("{:c}", curr_value);
+        }
+        out("{:c}", buffer_span[i]);
+        i += 1;
     }
 }
 
@@ -36,12 +73,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Vector<StringView> paths;
     bool show_lines = false;
+    bool show_only_non_blank_lines = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Concatenate files or pipes to stdout.");
     args_parser.add_positional_argument(paths, "File path", "path", Core::ArgsParser::Required::No);
     args_parser.add_option(show_lines, "Number all output lines", "number", 'n');
+    args_parser.add_option(show_only_non_blank_lines, "Number all non-blank output lines", "number-non-blank", 'b');
     args_parser.parse(arguments);
+
+    dbgln("show_only_non_blank_lines: {}", show_only_non_blank_lines);
 
     if (paths.is_empty())
         paths.append("-"sv);
@@ -58,20 +99,21 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio"));
 
-    // used only if we are using the -n option
+    // used only if we are using the -n or -b option
     LineTracker line_tracker;
 
     Array<u8, 32768> buffer;
     for (auto const& file : files) {
         while (!file->is_eof()) {
             auto const buffer_span = TRY(file->read_some(buffer));
-            if (show_lines) {
-                output_buffer_with_line_numbers(line_tracker, buffer_span);
+            if (show_lines || show_only_non_blank_lines) {
+                output_buffer_with_line_numbers(line_tracker, buffer_span, show_only_non_blank_lines);
             } else {
                 out("{:s}", buffer_span);
             }
         }
     }
 
+    dbgln("files.size, paths.size: {}, {}", files.size(), paths.size());
     return files.size() != paths.size();
 }


### PR DESCRIPTION
This PR adds a `-b` option to the `cat` command to number non-blank lines:

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/e6da910c-c691-4f73-9fbb-7bd42a60294a">

This is one of two implementations I came up with. It most closely follows the approach of the existing implementation, where we set the flag whether we need to print out a line number at the end of the for loop then check the flag at the beginning of the next iteration for loop.

The other approach diverges fro this approach and opts for a state machine-based approach https://github.com/SerenityOS/serenity/pull/24918

I personally think this approach is more difficult to understand than the other state machine-based approach.