### PR TITLE
Kernel/USB: Get MassStorage working on riscv

### DIFF
--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -131,6 +131,75 @@ ErrorOr<void> MassStorageDriver::initialise_bulk_only_device(USB::Device& device
     auto in_pipe = TRY(BulkInPipe::create(device.controller(), device, in_pipe_address, in_max_packet_size));
     auto out_pipe = TRY(BulkOutPipe::create(device.controller(), device, out_pipe_address, out_max_packet_size));
 
+    SCSI::Inquiry inquiry_command {};
+    inquiry_command.allocation_length = sizeof(SCSI::StandardInquiryData);
+
+    SCSI::StandardInquiryData inquiry_data;
+
+    auto inquiry_response = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, inquiry_command, &inquiry_data, sizeof(inquiry_data)));
+    if (inquiry_response.status != CSWStatus::Passed) {
+        dmesgln("SCSI/BBB: Inquiry failed with code {}", to_underlying(inquiry_response.status));
+        return EIO;
+    }
+    dmesgln("    Device Type: {}", inquiry_data.device_type_string());
+    dmesgln("    Peripheral Qualifier: {:#03b}", (u8)inquiry_data.peripheral_info.qualifier);
+    dmesgln("    Removable: {}", (inquiry_data.removable & 0x80) == 0x80);
+    dmesgln("    Version: {:#02x}", inquiry_data.version);
+    dmesgln("    Vendor: {}", StringView { inquiry_data.vendor_id, 8 });
+    dmesgln("    Product: {}", StringView { inquiry_data.product_id, 16 });
+    dmesgln("    Revision: {}", StringView { inquiry_data.product_revision_level, 4 });
+    if (inquiry_data.peripheral_info.device_type != SCSI::StandardInquiryData::DeviceType::DirectAccessBlockDevice) {
+        dmesgln("SCSI/BBB: Device is not a Direct Access Block device; Rejecting");
+        return ENOTSUP;
+    }
+    if (inquiry_data.version < 3 || inquiry_data.version > 7) {
+        dmesgln("SCSI/BBB: Device SCSI version not supported ({:#02x}); Rejecting", inquiry_data.version);
+        return ENOTSUP;
+    }
+    if (inquiry_data.response_data.response_data_format != 2) {
+        // SCSI Commands Reference Manual, Rev. J states that only format 2 is valid,
+        // and that format 1 is obsolete, but does not actually specify what format 1 would have been
+        // so ENOTSUP to be safe
+        dmesgln("SCSI/BBB: Device does not support response data format 2 (got {} instead); Rejecting", (u8)inquiry_data.response_data.response_data_format);
+        return ENOTSUP;
+    }
+
+    // FIXME: Re-query INQUIRY if the DRIVE SERIAL NUMBER field is present (see the ADDITIONAL LENGTH field), to record it
+    //        (bytes 36-43 ~ 8 bytes)
+
+    size_t tries = 0;
+    constexpr size_t max_tries = 5;
+    while (tries < max_tries) {
+        SCSI::TestUnitReady test_unit_ready_command {};
+        auto test_unit_ready_response = TRY(send_scsi_command<SCSIDataDirection::NoData>(*out_pipe, *in_pipe, test_unit_ready_command));
+
+        if (test_unit_ready_response.status == CSWStatus::Passed)
+            break;
+
+        SCSI::RequestSense request_sense_command {};
+        SCSI::FixedFormatSenseData sense_data;
+
+        request_sense_command.allocation_length = sizeof(sense_data);
+
+        auto request_sense_response = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, request_sense_command, &sense_data, sizeof(sense_data)));
+        if (request_sense_response.status != CSWStatus::Passed) {
+            dmesgln("SCSI/BBB: Request Sense failed with code {}, possibly unimplemented", to_underlying(request_sense_response.status));
+            return EIO;
+        }
+        // FIXME: Maybe hide this behind a debug flag, as some hardware fails once after startup
+        dbgln("SCSI/BBB: TestUnitReady Failed:");
+        // FIXME: to_string() these
+        dbgln("    Sense Key: {:#02x}", (u8)sense_data.sense_key);
+        dbgln("    Additional Sense Code: {:#02x}", (u8)sense_data.additional_sense_code);
+        dbgln("    Additional Sense Code Qualifier: {:#02x}", (u8)sense_data.additional_sense_code_qualifier);
+
+        ++tries;
+    }
+    if (tries == max_tries) {
+        dmesgln("SCSI/BBB: TestUnitReady failed too many times");
+        return EIO;
+    }
+
     SCSI::ReadCapacity10Parameters capacity;
     auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, SCSI::ReadCapacity10 {}, &capacity, sizeof(capacity)));
 

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -123,7 +123,7 @@ BulkOutPipe::BulkOutPipe(USBController const& controller, Device const& device, 
 {
 }
 
-ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, void* data)
+ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, void const* data)
 {
     VERIFY(length <= m_dma_buffer->size());
 
@@ -140,7 +140,7 @@ ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, void* data)
     return transfer_length;
 }
 
-ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, UserOrKernelBuffer data)
+ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, UserOrKernelBuffer const data)
 {
     VERIFY(length <= m_dma_buffer->size());
 

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -99,8 +99,8 @@ class BulkOutPipe : public Pipe {
 public:
     static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
-    ErrorOr<size_t> submit_bulk_out_transfer(size_t length, void* data);
-    ErrorOr<size_t> submit_bulk_out_transfer(size_t length, UserOrKernelBuffer data);
+    ErrorOr<size_t> submit_bulk_out_transfer(size_t length, void const* data);
+    ErrorOr<size_t> submit_bulk_out_transfer(size_t length, UserOrKernelBuffer const data);
 
 private:
     BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -43,7 +43,7 @@ void Transfer::set_setup_packet(USBRequestData const& request)
     m_request = request;
 }
 
-ErrorOr<void> Transfer::write_buffer(u16 len, void* data)
+ErrorOr<void> Transfer::write_buffer(u16 len, void const* data)
 {
     VERIFY(len <= m_dma_buffer.size());
     m_transfer_data_size = len;
@@ -52,7 +52,7 @@ ErrorOr<void> Transfer::write_buffer(u16 len, void* data)
     return {};
 }
 
-ErrorOr<void> Transfer::write_buffer(u16 len, UserOrKernelBuffer data)
+ErrorOr<void> Transfer::write_buffer(u16 len, UserOrKernelBuffer const data)
 {
     VERIFY(len <= m_dma_buffer.size());
     m_transfer_data_size = len;

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -29,8 +29,8 @@ public:
     void set_complete() { m_complete = true; }
     void set_error_occurred() { m_error_occurred = true; }
 
-    ErrorOr<void> write_buffer(u16 len, void* data);
-    ErrorOr<void> write_buffer(u16 len, UserOrKernelBuffer data);
+    ErrorOr<void> write_buffer(u16 len, void const* data);
+    ErrorOr<void> write_buffer(u16 len, UserOrKernelBuffer const data);
 
     // `const` here makes sure we don't blow up by writing to a physical address
     USBRequestData const& request() const { return m_request; }

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
@@ -16,6 +16,117 @@ BulkSCSIInterface::BulkSCSIInterface(LUNAddress logical_unit_number_address, u32
     , m_in_pipe(move(in_pipe))
     , m_out_pipe(move(out_pipe))
 {
+    // Note: If this fails, it only means that we may be inefficient in our way
+    //       of talking to the device.
+    (void)query_characteristics();
+}
+
+ErrorOr<void> BulkSCSIInterface::query_characteristics()
+{
+    SCSI::Inquiry inquiry_command {};
+    inquiry_command.enable_vital_product_data = 1;
+    alignas(SCSI::SupportedVitalProductPages) u8 vital_product_page_buffer[0xfc];
+    SCSI::SupportedVitalProductPages& vital_product_page = *reinterpret_cast<SCSI::SupportedVitalProductPages*>(vital_product_page_buffer);
+
+    inquiry_command.page_code = SCSI::VitalProductDataPageCode::SupportedVitalProductDataPages;
+    inquiry_command.allocation_length = sizeof(vital_product_page_buffer);
+
+    auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*m_out_pipe, *m_in_pipe, inquiry_command, &vital_product_page, sizeof(vital_product_page_buffer)));
+
+    if (status.status != CSWStatus::Passed) {
+        dbgln("SCSI/BBB: Inquiry failed to inquire supported vital product data pages with code {}", to_underlying(status.status));
+        // FIXME: Maybe request sense here
+        // FIXME: Treating this as an error for now
+        // Some HW seems to stall this and/or send garbage...
+        return EIO;
+    }
+    if (vital_product_page.page_code != SCSI::VitalProductDataPageCode::SupportedVitalProductDataPages) {
+        dmesgln("SCSI/BBB: Returned wrong page code for supported vital product data pages: {:#02x}", to_underlying(vital_product_page.page_code));
+        return EIO;
+    }
+
+    if ((vital_product_page.page_length + 4uz) > sizeof(vital_product_page_buffer)) {
+        // Note: This should not be possible, as there are less than 253 page codes allocated
+        dmesgln("SCSI/BBB: Warning: Returned page length for supported vital product data pages is bigger than the allocated buffer, we might be missing some supported pages");
+    }
+
+    // FIXME: Maybe check status.residual_data here
+    auto available_pages = min(vital_product_page.page_length, sizeof(vital_product_page_buffer) - sizeof(SCSI::VitalProductPage));
+    bool found_block_limits = false;
+    for (size_t i = 0; i < available_pages; i++) {
+        if (vital_product_page.supported_pages[i] == SCSI::VitalProductDataPageCode::BlockLimits) {
+            found_block_limits = true;
+            break;
+        }
+        if (to_underlying(vital_product_page.supported_pages[i]) >= to_underlying(SCSI::VitalProductDataPageCode::BlockLimits)) {
+            // The available pages are (supposedly) sorted in ascending order
+            // so we can break here early
+            break;
+        }
+    }
+
+    if (!found_block_limits) {
+        dmesgln("SCSI/BBB: Device does not support block limits page");
+        // This is not an error, we just won't be able to optimize our transfers
+        return {};
+    }
+
+    inquiry_command.page_code = SCSI::VitalProductDataPageCode::BlockLimits;
+    SCSI::BlockLimitsPage block_limits_page {};
+    inquiry_command.allocation_length = sizeof(SCSI::BlockLimitsPage);
+    status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*m_out_pipe, *m_in_pipe, inquiry_command, &block_limits_page, sizeof(SCSI::BlockLimitsPage)));
+    if (status.status != CSWStatus::Passed) {
+        dbgln("SCSI/BBB: Inquiry failed to inquire block limits with code {}", to_underlying(status.status));
+        // FIXME: Maybe request sense here
+    }
+
+    if (block_limits_page.page_code != SCSI::VitalProductDataPageCode::BlockLimits) {
+        dmesgln("SCSI/BBB: Returned wrong page code for block limits {:#02x}", to_underlying(block_limits_page.page_code));
+        return EIO;
+    }
+
+    if (block_limits_page.page_length != sizeof(SCSI::BlockLimitsPage) - 4) {
+        dmesgln("SCSI/BBB: Returned wrong page length for block limits {}", block_limits_page.page_length);
+        return EIO;
+    }
+
+    if (block_limits_page.maximum_transfer_length != 0)
+        m_maximum_transfer_length = block_limits_page.maximum_transfer_length;
+    if (block_limits_page.optimal_transfer_length != 0)
+        m_optimal_transfer_length = block_limits_page.optimal_transfer_length;
+    if (block_limits_page.optimal_transfer_length_granularity != 0)
+        m_optimal_transfer_length_granularity = block_limits_page.optimal_transfer_length_granularity;
+
+    dbgln("SCSI/BBB: Maximum transfer length: {}", m_maximum_transfer_length);
+    dbgln("SCSI/BBB: Optimal transfer length: {}", m_optimal_transfer_length);
+    dbgln("SCSI/BBB: Optimal transfer length granularity: {}", m_optimal_transfer_length_granularity);
+
+    return {};
+}
+
+u32 BulkSCSIInterface::optimal_block_count(u32 blocks)
+{
+    if (m_maximum_transfer_length.has_value() && blocks > m_maximum_transfer_length.value())
+        return m_maximum_transfer_length.value();
+    // quot. OPTIMAL TRANSFER LENGTH field:
+    // "[...] If a device server receives one of these commands with a transfer size greater than this value,
+    //  then the device server may incur significant delays in processing the command."
+    if (m_optimal_transfer_length.has_value() && blocks > m_optimal_transfer_length.value())
+        return m_optimal_transfer_length.value();
+
+    if (!m_optimal_transfer_length_granularity.has_value())
+        return blocks;
+
+    // quot. OPTIMAL TRANSFER LENGTH GRANULARITY field:
+    // "[...] If a device server receives one of these commands with a transfer size that
+    //  is not equal to a multiple of this value, then the device server may incur significant
+    //  delays in processing the command."
+    // FIXME: This sounds like it may be faster to align up to the granularity in some cases
+    //        But that might be difficult to accomplish in some cases (Ie writing)
+    if (blocks < m_optimal_transfer_length_granularity.value())
+        return blocks;
+
+    return blocks - (blocks % m_optimal_transfer_length_granularity.value());
 }
 
 void BulkSCSIInterface::start_request(AsyncBlockDeviceRequest& request)
@@ -46,7 +157,9 @@ ErrorOr<void> BulkSCSIInterface::do_read(u32 block_index, u32 block_count, UserO
     while (blocks_read < block_count) {
         read_command.logical_block_address = block_index_to_read;
 
-        u16 transfer_length_bytes = min((block_count - blocks_read) * block_size(), AK::NumericLimits<u16>::max());
+        // FIXME: We only use READ(10) so we only ever read u16::max blocks at a time
+        auto blocks_to_transfer = optimal_block_count(block_count - blocks_read);
+        u16 transfer_length_bytes = min(blocks_to_transfer * block_size(), AK::NumericLimits<u16>::max());
 
         read_command.transfer_length = transfer_length_bytes / block_size();
 
@@ -80,7 +193,9 @@ ErrorOr<void> BulkSCSIInterface::do_write(u32 block_index, u32 block_count, User
     while (blocks_read < block_count) {
         read_command.logical_block_address = block_index_to_read;
 
-        u16 transfer_length_bytes = min((block_count - blocks_read) * block_size(), AK::NumericLimits<u16>::max());
+        // FIXME: We only use WRITE(10) so we only ever write u16::max blocks at a time
+        auto blocks_to_transfer = optimal_block_count(block_count - blocks_read);
+        u16 transfer_length_bytes = min(blocks_to_transfer * block_size(), AK::NumericLimits<u16>::max());
 
         read_command.transfer_length = transfer_length_bytes / block_size();
 

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
@@ -160,8 +160,16 @@ private:
     NonnullOwnPtr<BulkInPipe> m_in_pipe;
     NonnullOwnPtr<BulkOutPipe> m_out_pipe;
 
+    Optional<u16> m_optimal_transfer_length;
+    Optional<u32> m_optimal_transfer_length_granularity;
+    Optional<u32> m_maximum_transfer_length;
+
+    u32 optimal_block_count(u32 blocks);
+
     ErrorOr<void> do_read(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t buffer_size);
     ErrorOr<void> do_write(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t buffer_size);
+
+    ErrorOr<void> query_characteristics();
 
     IntrusiveListNode<BulkSCSIInterface, NonnullLockRefPtr<BulkSCSIInterface>> m_list_node;
 

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
@@ -58,6 +58,93 @@ struct CommandStatusWrapper {
 };
 static_assert(AssertSize<CommandStatusWrapper, 13>());
 
+enum class SCSIDataDirection {
+    DataToTarget,
+    DataToInitiator,
+    NoData
+};
+
+template<SCSIDataDirection Direction, typename Command, typename CommandData = void>
+static ErrorOr<CommandStatusWrapper> send_scsi_command(
+    USB::BulkOutPipe& out_pipe, USB::BulkInPipe& in_pipe,
+    Command const& command,
+    Conditional<Direction == SCSIDataDirection::DataToInitiator, CommandData, CommandData const>* data = nullptr, size_t data_size = 0)
+{
+    CommandBlockWrapper command_block {};
+    command_block.transfer_length = data_size;
+    if constexpr (Direction == SCSIDataDirection::DataToInitiator)
+        command_block.direction = CBWDirection::DataIn;
+    else
+        command_block.direction = CBWDirection::DataOut;
+
+    command_block.set_command(command);
+
+    TRY(out_pipe.submit_bulk_out_transfer(sizeof(command_block), &command_block));
+
+    if constexpr (Direction == SCSIDataDirection::DataToInitiator) {
+        TRY(in_pipe.submit_bulk_in_transfer(data_size, data));
+    } else if constexpr (Direction == SCSIDataDirection::DataToTarget) {
+        TRY(out_pipe.submit_bulk_out_transfer(data_size, data));
+    } else {
+        static_assert(IsSame<CommandData, void>);
+        VERIFY(data_size == 0);
+        VERIFY(data == nullptr);
+    }
+
+    CommandStatusWrapper status;
+    TRY(in_pipe.submit_bulk_in_transfer(sizeof(status), &status));
+    if (status.signature != 0x53425355) {
+        dmesgln("SCSI: Command status signature mismatch, expected 0x53425355, got {:#x}", status.signature);
+        return EIO;
+    }
+
+    if (status.tag != command_block.tag) {
+        dmesgln("SCSI: Command tag mismatch, expected {}, got {}", command_block.tag, status.tag);
+        return EIO;
+    }
+
+    return status;
+}
+
+template<SCSIDataDirection Direction, typename Command>
+requires(Direction != SCSIDataDirection::NoData)
+static ErrorOr<CommandStatusWrapper> send_scsi_command(
+    USB::BulkOutPipe& out_pipe, USB::BulkInPipe& in_pipe,
+    Command const& command,
+    Conditional<Direction == SCSIDataDirection::DataToInitiator, UserOrKernelBuffer, UserOrKernelBuffer const> data, size_t data_size)
+{
+    CommandBlockWrapper command_block {};
+    command_block.transfer_length = data_size;
+    if constexpr (Direction == SCSIDataDirection::DataToInitiator)
+        command_block.direction = CBWDirection::DataIn;
+    else
+        command_block.direction = CBWDirection::DataOut;
+
+    command_block.set_command(command);
+
+    TRY(out_pipe.submit_bulk_out_transfer(sizeof(command_block), &command_block));
+
+    if constexpr (Direction == SCSIDataDirection::DataToInitiator) {
+        TRY(in_pipe.submit_bulk_in_transfer(data_size, data));
+    } else if constexpr (Direction == SCSIDataDirection::DataToTarget) {
+        TRY(out_pipe.submit_bulk_out_transfer(data_size, data));
+    }
+
+    CommandStatusWrapper status;
+    TRY(in_pipe.submit_bulk_in_transfer(sizeof(status), &status));
+    if (status.signature != 0x53425355) {
+        dmesgln("SCSI: Command status signature mismatch, expected 0x53425355, got {:#x}", status.signature);
+        return EIO;
+    }
+
+    if (status.tag != command_block.tag) {
+        dmesgln("SCSI: Command tag mismatch, expected {}, got {}", command_block.tag, status.tag);
+        return EIO;
+    }
+
+    return status;
+}
+
 class BulkSCSIInterface : public StorageDevice {
     // https://www.usb.org/sites/default/files/usbmassbulk_10.pdf
 public:

--- a/Kernel/Devices/Storage/USB/SCSIComands.h
+++ b/Kernel/Devices/Storage/USB/SCSIComands.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "SCSIVitalProductData.h"
+
 #include <AK/Endian.h>
 #include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
@@ -39,7 +41,7 @@ static_assert(AssertSize<FixedFormatSenseData, 18>());
 struct Inquiry {
     u8 opcode { 0x12 };
     u8 enable_vital_product_data { 0 }; // EVPD, Also CMDDT in the second bit, but thats obsolete
-    u8 page_code { 0 };
+    VitalProductDataPageCode page_code { VitalProductDataPageCode::SupportedVitalProductDataPages };
     BigEndian<u16> allocation_length;
     u8 control { 0 };
 };

--- a/Kernel/Devices/Storage/USB/SCSIComands.h
+++ b/Kernel/Devices/Storage/USB/SCSIComands.h
@@ -13,22 +13,143 @@
 // https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
 
 namespace Kernel::SCSI {
-// 3.22.1
-struct ReadCapacity10 {
-    u8 opcode { 0x25 };
-    u8 reserved1 { 0 };
-    BigEndian<u32> oboslete_logical_block_address { 0 };
-    u16 reserved2 { 0 };
-    u8 reserved3 { 0 };
+
+// 2.4.1.2
+struct FixedFormatSenseData {
+    u8 response_code : 7;
+    u8 valid : 1;
+    u8 obsolete;
+    u8 sense_key : 4;
+    u8 : 1;
+    u8 incorrect_length_indicator : 1; // ILI
+    u8 end_of_medium : 1;              // EOM
+    u8 file_mark : 1;
+    BigEndian<u32> information;
+    u8 additional_sense_length;
+    BigEndian<u32> command_specific_information;
+    u8 additional_sense_code;
+    u8 additional_sense_code_qualifier;
+    u8 field_replaceable_unit_code;
+    u8 sense_key_specific[3];
+    u8 additional_sense_bytes[];
+};
+static_assert(AssertSize<FixedFormatSenseData, 18>());
+
+// 3.6.1
+struct Inquiry {
+    u8 opcode { 0x12 };
+    u8 enable_vital_product_data { 0 }; // EVPD, Also CMDDT in the second bit, but thats obsolete
+    u8 page_code { 0 };
+    BigEndian<u16> allocation_length;
     u8 control { 0 };
 };
-static_assert(AssertSize<ReadCapacity10, 10>());
-// 3.22.2
-struct ReadCapacity10Parameters {
-    BigEndian<u32> block_count;
-    BigEndian<u32> block_size;
+static_assert(AssertSize<Inquiry, 6>());
+
+// 3.6.2
+struct StandardInquiryData {
+    // Table 61
+    enum class DeviceType : u8 {
+        DirectAccessBlockDevice = 0x00,
+        SequentialAccessDevice = 0x01,
+        PrinterDevice = 0x02,
+        ProcessorDevice = 0x03,
+        WriteOnceDevice = 0x04,
+        CDDVDDevice = 0x05,
+        // 0x06 was Scanner device
+        OpticalMemoryDevice = 0x07,
+        MediumChangerDevice = 0x08,
+        // 0x09 was Communications device
+        // 0x0A-0x0B are obsolete
+        StorageArrayControllerDevice = 0x0C,
+        EnclosureServicesDevice = 0x0D,
+        SimplifiedDirectAccessDevice = 0x0E,
+        OpticalCardReaderWriterDevice = 0x0F,
+        BridgeControllerCommands = 0x10,
+        ObjectBasedStorageDevice = 0x11,
+        AutomationDriveInterface = 0x12,
+        // 0x13-0x1D are reserved
+        WellKnownLogicalUnit = 0x1E,
+        UnknownOrNoDeviceType = 0x1F,
+    };
+    struct {
+        DeviceType device_type : 5;
+        u8 qualifier : 3;
+    } peripheral_info;
+    u8 removable; // 0x80 for removable, 0x00 for fixed, The remaining bits used to be the device qualifier (SCSI-1)
+    u8 version;
+    struct {
+        u8 response_data_format : 4;
+        u8 hierarchical_support : 1; // HISUP
+        u8 normal_aca_support : 1;   // NORMACA
+        u8 obsolete : 2;
+    } response_data;
+    u8 additional_length; // N-4
+    struct {
+        u8 protect : 1;
+        u8 : 2;
+        u8 third_party_copy : 1;
+        u8 target_port_group_support : 2;
+        u8 access_control_coordinator : 1;
+        u8 scc_support : 1;
+
+        u8 : 4;
+        u8 multi_port : 1;
+        u8 vendor_specific1 : 1;
+        u8 enclosure_services : 1;
+        u8 : 1;
+
+        u8 vendor_specific2 : 1;
+        u8 command_queueing : 1;
+        u8 : 6;
+    } capabilities;
+
+    char vendor_id[8]; // These are padded with spaces
+    char product_id[16];
+    char product_revision_level[4];
+
+    StringView device_type_string() const
+    {
+        switch (peripheral_info.device_type) {
+        case DeviceType::DirectAccessBlockDevice:
+            return "Direct Access Block Device"sv;
+        case DeviceType::SequentialAccessDevice:
+            return "Sequential Access Device"sv;
+        case DeviceType::PrinterDevice:
+            return "Printer Device"sv;
+        case DeviceType::ProcessorDevice:
+            return "Processor Device"sv;
+        case DeviceType::WriteOnceDevice:
+            return "Write Once Device"sv;
+        case DeviceType::CDDVDDevice:
+            return "CD/DVD Device"sv;
+        case DeviceType::OpticalMemoryDevice:
+            return "Optical Memory Device"sv;
+        case DeviceType::MediumChangerDevice:
+            return "Medium Changer Device"sv;
+        case DeviceType::StorageArrayControllerDevice:
+            return "Storage Array Controller Device"sv;
+        case DeviceType::EnclosureServicesDevice:
+            return "Enclosure Services Device"sv;
+        case DeviceType::SimplifiedDirectAccessDevice:
+            return "Simplified Direct Access Device"sv;
+        case DeviceType::OpticalCardReaderWriterDevice:
+            return "Optical Card Reader/Writer Device"sv;
+        case DeviceType::BridgeControllerCommands:
+            return "Bridge Controller Commands"sv;
+        case DeviceType::ObjectBasedStorageDevice:
+            return "Object Based Storage Device"sv;
+        case DeviceType::AutomationDriveInterface:
+            return "Automation Drive Interface"sv;
+        case DeviceType::WellKnownLogicalUnit:
+            return "Well Known Logical Unit"sv;
+        case DeviceType::UnknownOrNoDeviceType:
+            return "Canonical Unknown or No Device Type"sv;
+        default:
+            return "Unknown Device Type"sv;
+        }
+    }
 };
-static_assert(AssertSize<ReadCapacity10Parameters, 8>());
+static_assert(AssertSize<StandardInquiryData, 36>());
 
 // 3.16
 struct Read10 {
@@ -49,6 +170,40 @@ struct Read10 {
     u8 control { 0 };
 };
 static_assert(AssertSize<Read10, 10>());
+// 3.22.1
+struct ReadCapacity10 {
+    u8 opcode { 0x25 };
+    u8 reserved1 { 0 };
+    BigEndian<u32> obsolete_logical_block_address { 0 };
+    u16 reserved2 { 0 };
+    u8 reserved3 { 0 };
+    u8 control { 0 };
+};
+static_assert(AssertSize<ReadCapacity10, 10>());
+// 3.22.2
+struct ReadCapacity10Parameters {
+    BigEndian<u32> block_count;
+    BigEndian<u32> block_size;
+};
+static_assert(AssertSize<ReadCapacity10Parameters, 8>());
+
+// 3.37
+struct RequestSense {
+    u8 opcode { 0x03 };
+    u8 descriptor_format { 0 }; // 0 for fixed format, 1 for descriptor format
+    u8 reserved[2] { 0 };
+    u8 allocation_length;
+    u8 control { 0 };
+};
+static_assert(AssertSize<RequestSense, 6>());
+
+// 3.53
+struct TestUnitReady {
+    u8 opcode { 0x00 };
+    u8 reserved[4] { 0 };
+    u8 control { 0 };
+};
+static_assert(AssertSize<TestUnitReady, 6>());
 
 // 3.60
 struct Write10 {

--- a/Kernel/Devices/Storage/USB/SCSIVitalProductData.h
+++ b/Kernel/Devices/Storage/USB/SCSIVitalProductData.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Endian.h>
+#include <AK/Types.h>
+
+namespace Kernel::SCSI {
+
+// 5.4.1
+// Table 437 Vital product data page codes
+enum class VitalProductDataPageCode : u8 {
+    SupportedVitalProductDataPages = 0x00,
+    ASCIIInformation = 0x01,
+    // 0x02-0x7F Are also ASCII INFORMATION Pages
+    UnitSerialNumber = 0x80,
+    DeviceIdentification = 0x83,
+    SoftwareInterfaceIdentification = 0x84,
+    ManagementNetworkAddresses = 0x85,
+    ExtendedInquiryData = 0x86,
+    ModePagePolicy = 0x87,
+    SCSIPorts = 0x88,
+    PowerCondition = 0x8A,
+    DeviceConstituents = 0x8B,
+    CFAProfileInformation = 0x8C,
+    PowerConsumption = 0x8D,
+    BlockLimits = 0xB0,
+    BlockDeviceCharacteristics = 0xB1,
+    LogicalBlockProvisioning = 0xB2,
+    Referrals = 0xB3,
+    SupportedBlockLengthsAndProtectionTypes = 0xB4,
+    BlockDeviceCharacteristicsExtension = 0xB5,
+    ZonedBlockDeviceCharacteristics = 0xB6,
+    BlockLimitsExtension = 0xB7,
+    FirmwareNumbersPage = 0xC0,
+    DateCodePage = 0xC1,
+    JumperSettingsPage = 0xC2,
+    DeviceBehaviorPage = 0xC3,
+};
+
+struct VitalProductPage {
+    struct {
+        u8 device_type : 5;
+        u8 qualifier : 3;
+    } peripheral_info;
+    VitalProductDataPageCode page_code;
+    BigEndian<u16> page_length; // N - 3
+};
+static_assert(AssertSize<VitalProductPage, 0x04>());
+
+// 5.4.5 Block limits page
+struct BlockLimitsPage : VitalProductPage {
+    u8 write_same_non_zero; // WSNZ 1 bit
+    u8 maximum_compare_and_write_length;
+    BigEndian<u16> optimal_transfer_length_granularity;
+    BigEndian<u32> maximum_transfer_length;
+    BigEndian<u32> optimal_transfer_length;
+    BigEndian<u32> maximum_prefetch;
+    BigEndian<u32> maximum_unmap_lba_count;
+    BigEndian<u32> maximum_unmap_block_descriptor_count;
+    BigEndian<u32> optimal_unmap_granularity;
+    BigEndian<u32> unmap_granularity_alignment; // Also unamap granularity alignment (UGA) valid in the highest bit
+    BigEndian<u64> maximum_write_same_length;
+    BigEndian<u32> maximum_atomic_transfer_length;
+    BigEndian<u32> atomic_alignment;
+    BigEndian<u32> atomic_transfer_length_granularity;
+    BigEndian<u32> maximum_atomic_transfer_length_with_atomic_boundary;
+    BigEndian<u32> maximum_atomic_boundary_size;
+};
+static_assert(AssertSize<BlockLimitsPage, 0x003C + 4>());
+
+// 5.4.18
+struct SupportedVitalProductPages : VitalProductPage {
+    // Note: The page length is only 8 bytes for this page
+    VitalProductDataPageCode supported_pages[];
+};
+
+}


### PR DESCRIPTION
### Kernel/USB: Be a bit more const-correct with USB transfers


### Kernel/USBMS: Add and use a `send_scsi_command` helper

This makes sending commands less repetitive

### Kernel/USBMS: Inquire and wait for the storage device to become ready

This is apparently what bootloaders do before using a USB storage device
so we should likely do so as well, especially when no BIOS is present,
like on riscv.

----

@spholz Still no clue why I don't need your signaling PR and timing hacks for x86 to work
Can you verify again that this makes xhci work for you on all platforms