### PR TITLE
PDFViewer: Fix outline page number off-by-one

### DIFF
--- a/Userland/Applications/PDFViewer/OutlineModel.cpp
+++ b/Userland/Applications/PDFViewer/OutlineModel.cpp
@@ -79,7 +79,7 @@ GUI::Variant OutlineModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
         case Columns::Page: {
             auto maybe_page_number = outline_item->dest.page;
             if (maybe_page_number.has_value()) {
-                return maybe_page_number.release_value();
+                return maybe_page_number.release_value() + 1;
             }
             return {};
         }


### PR DESCRIPTION
This PR fixes an off-by-one in the outline tree view, where the page number did not match the corresponding page in the document.