### PR TITLE
LibGfx/PNGWriter: Implement support for writing animated PNGs

### DIFF
--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -196,6 +196,37 @@ TEST_CASE(test_png_paeth_simd)
     }
 }
 
+TEST_CASE(test_png_animation)
+{
+    auto rgb_bitmap = TRY_OR_FAIL(create_test_rgb_bitmap());
+    auto rgba_bitmap = TRY_OR_FAIL(create_test_rgba_bitmap());
+
+    // 20 kiB is enough for two 47x33 frames.
+    auto stream_buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(20 * 1024));
+    FixedMemoryStream stream { Bytes { stream_buffer } };
+
+    auto animation_writer = TRY_OR_FAIL(Gfx::PNGWriter::start_encoding_animation(stream, rgb_bitmap->size()));
+
+    TRY_OR_FAIL(animation_writer->add_frame(*rgb_bitmap, 100));
+    TRY_OR_FAIL(animation_writer->add_frame(*rgba_bitmap, 200));
+
+    auto encoded_animation = ReadonlyBytes { stream_buffer.data(), stream.offset() };
+
+    auto decoded_animation_plugin = TRY_OR_FAIL(Gfx::PNGImageDecoderPlugin::create(encoded_animation));
+    EXPECT(decoded_animation_plugin->is_animated());
+    EXPECT_EQ(decoded_animation_plugin->frame_count(), 2u);
+    EXPECT_EQ(decoded_animation_plugin->loop_count(), 0u);
+    EXPECT_EQ(decoded_animation_plugin->size(), rgb_bitmap->size());
+
+    auto frame0 = TRY_OR_FAIL(decoded_animation_plugin->frame(0));
+    EXPECT_EQ(frame0.duration, 100);
+    expect_bitmaps_equal(*frame0.image, *rgb_bitmap);
+
+    auto frame1 = TRY_OR_FAIL(decoded_animation_plugin->frame(1));
+    EXPECT_EQ(frame1.duration, 200);
+    expect_bitmaps_equal(*frame1.image, *rgba_bitmap);
+}
+
 TEST_CASE(test_qoi)
 {
     TRY_OR_FAIL((test_roundtrip<Gfx::QOIWriter, Gfx::QOIImageDecoderPlugin>(TRY_OR_FAIL(create_test_rgb_bitmap()))));

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -1126,8 +1126,10 @@ static ErrorOr<void> process_fcTL(ReadonlyBytes data, PNGLoadingContext& context
         return Error::from_string_literal("fcTL chunk has an abnormal size");
 
     auto const& fcTL = *bit_cast<fcTL_Chunk* const>(data.data());
-    if (fcTL.sequence_number != context.animation_next_expected_seq)
+    if (fcTL.sequence_number != context.animation_next_expected_seq) {
+        dbgln_if(PNG_DEBUG, "Expected fcTL sequence number: {}, got: {}", context.animation_next_expected_seq, fcTL.sequence_number);
         return Error::from_string_literal("Unexpected sequence number");
+    }
 
     context.animation_next_expected_seq++;
 
@@ -1164,8 +1166,10 @@ static ErrorOr<void> process_fdAT(ReadonlyBytes data, PNGLoadingContext& context
         return Error::from_string_literal("fdAT chunk has an abnormal size");
 
     u32 sequence_number = *bit_cast<NetworkOrdered<u32> const*>(data.data());
-    if (sequence_number != context.animation_next_expected_seq)
+    if (sequence_number != context.animation_next_expected_seq) {
+        dbgln_if(PNG_DEBUG, "Expected fdAT sequence number: {}, got: {}", context.animation_next_expected_seq, sequence_number);
         return Error::from_string_literal("Unexpected sequence number");
+    }
     context.animation_next_expected_seq++;
 
     if (context.animation_frames.is_empty())

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -625,6 +625,8 @@ static bool decode_png_image_data_chunk(PNGLoadingContext& context)
     while (!streamer.at_end() && !context.has_seen_iend) {
         if (auto result = process_chunk(streamer, context); result.is_error()) {
             context.state = PNGLoadingContext::State::Error;
+            // FIXME: Return this to caller instead of logging it.
+            dbgln("PNGLoader: Error processing chunk: {}", result.error());
             return false;
         }
 
@@ -653,6 +655,8 @@ static bool decode_png_animation_data_chunks(PNGLoadingContext& context, u32 req
     Streamer streamer(context.data_current_ptr, data_remaining);
     while (!streamer.at_end() && !context.has_seen_iend) {
         if (auto result = process_chunk(streamer, context); result.is_error()) {
+            // FIXME: Return this to caller instead of logging it.
+            dbgln("PNGLoader: Error processing chunk: {}", result.error());
             context.state = PNGLoadingContext::State::Error;
             return false;
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.cpp
@@ -403,6 +403,7 @@ public:
     }
 
     virtual ErrorOr<void> add_frame(Bitmap&, int, IntPoint, BlendMode) override;
+    virtual bool can_blend_frames() const override { return true; }
 
 private:
     PNGWriter m_writer;
@@ -419,7 +420,7 @@ private:
     PNGWriter::Options const m_options;
 };
 
-ErrorOr<void> PNGAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, IntPoint at, BlendMode)
+ErrorOr<void> PNGAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, IntPoint at, BlendMode blend_mode)
 {
     ++m_number_of_frames;
     bool const is_first_frame = m_number_of_frames == 1;
@@ -465,6 +466,8 @@ ErrorOr<void> PNGAnimationWriter::add_frame(Bitmap& bitmap, int duration_ms, Int
     fcTL_data.delay_denominator = 1000;
     fcTL_data.x_offset = at.x();
     fcTL_data.y_offset = at.y();
+    if (blend_mode == BlendMode::Blend)
+        fcTL_data.blend_operation = 1;
     TRY(m_writer.add_fcTL_chunk(fcTL_data));
     m_sequence_number++;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Pierre Hoffmeister
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Torben Jonas Virtmann
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,6 +12,7 @@
 #include <AK/Vector.h>
 #include <LibCompress/Zlib.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImageFormats/AnimationWriter.h>
 #include <LibGfx/ImageFormats/PNGShared.h>
 
 namespace Gfx {
@@ -26,6 +28,8 @@ struct PNGWriterOptions {
     Optional<ReadonlyBytes> icc_data;
 };
 
+struct fcTLData;
+
 class PNGWriter {
 public:
     using Options = PNGWriterOptions;
@@ -33,13 +37,20 @@ public:
     static ErrorOr<void> encode(Stream&, Bitmap const&, Options const& = {});
     static ErrorOr<ByteBuffer> encode(Gfx::Bitmap const&, Options options = Options {});
 
+    static ErrorOr<NonnullOwnPtr<AnimationWriter>> start_encoding_animation(SeekableStream&, IntSize dimensions, int loop_count = 0, Options const& = {});
+
 private:
+    friend class PNGAnimationWriter;
     PNGWriter(Stream&);
 
     Stream& m_stream;
 
     ErrorOr<void> add_chunk(PNGChunk&);
     ErrorOr<void> add_png_header();
+    ErrorOr<void> add_acTL_chunk(u32 num_frames, u32 loop_count);
+    ErrorOr<void> add_fcTL_chunk(fcTLData const& data);
+    template<bool include_alpha>
+    ErrorOr<void> add_fdAT_chunk(Gfx::Bitmap const&, u32 sequence_number, Compress::ZlibCompressionLevel);
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
     ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data, Compress::ZlibCompressionLevel);
     template<bool include_alpha>

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -30,12 +30,14 @@ class PNGWriter {
 public:
     using Options = PNGWriterOptions;
 
+    static ErrorOr<void> encode(Stream&, Bitmap const&, Options const& = {});
     static ErrorOr<ByteBuffer> encode(Gfx::Bitmap const&, Options options = Options {});
 
 private:
-    PNGWriter() = default;
+    PNGWriter(Stream&);
 
-    Vector<u8> m_data;
+    Stream& m_stream;
+
     ErrorOr<void> add_chunk(PNGChunk&);
     ErrorOr<void> add_png_header();
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);

--- a/Userland/Utilities/animation.cpp
+++ b/Userland/Utilities/animation.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/ImageFormats/AnimationWriter.h>
 #include <LibGfx/ImageFormats/GIFWriter.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
+#include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibGfx/ImageFormats/WebPWriter.h>
 
 struct Options {
@@ -65,6 +66,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto output_stream = TRY(Core::OutputBufferedFile::create(move(output_file)));
 
     auto animation_writer = TRY([&]() -> ErrorOr<NonnullOwnPtr<Gfx::AnimationWriter>> {
+        if (options.out_path.ends_with(".apng"sv))
+            return Gfx::PNGWriter::start_encoding_animation(*output_stream, decoder->size(), decoder->loop_count());
         if (options.out_path.ends_with(".webp"sv))
             return Gfx::WebPWriter::start_encoding_animation(*output_stream, decoder->size(), decoder->loop_count());
         if (options.out_path.ends_with(".gif"sv))

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -178,6 +178,10 @@ static ErrorOr<void> save_image(LoadedImage& image, StringView out_path, bool pp
         TRY(Gfx::JPEGWriter::encode(*TRY(stream()), *frame, { .icc_data = image.icc_data, .quality = jpeg_quality }));
         return {};
     }
+    if (out_path.ends_with(".png"sv, CaseSensitivity::CaseInsensitive)) {
+        TRY(Gfx::PNGWriter::encode(*TRY(stream()), *frame, { .compression_level = png_compression_level, .icc_data = image.icc_data }));
+        return {};
+    }
     if (out_path.ends_with(".ppm"sv, CaseSensitivity::CaseInsensitive)) {
         auto const format = ppm_ascii ? Gfx::PortableFormatWriter::Options::Format::ASCII : Gfx::PortableFormatWriter::Options::Format::Raw;
         TRY(Gfx::PortableFormatWriter::encode(*TRY(stream()), *frame, { .format = format }));
@@ -199,8 +203,6 @@ static ErrorOr<void> save_image(LoadedImage& image, StringView out_path, bool pp
     ByteBuffer bytes;
     if (out_path.ends_with(".bmp"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::BMPWriter::encode(*frame, { .icc_data = image.icc_data }));
-    } else if (out_path.ends_with(".png"sv, CaseSensitivity::CaseInsensitive)) {
-        bytes = TRY(Gfx::PNGWriter::encode(*frame, { .compression_level = png_compression_level, .icc_data = image.icc_data }));
     } else if (out_path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::QOIWriter::encode(*frame));
     } else {

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -78,8 +78,7 @@ static PDF::PDFErrorOr<void> save_rendered_page(NonnullRefPtr<Gfx::Bitmap> bitma
 
     auto output_stream = TRY(Core::File::open(out_path, Core::File::OpenMode::Write));
     auto buffered_stream = TRY(Core::OutputBufferedFile::create(move(output_stream)));
-    ByteBuffer bytes = TRY(Gfx::PNGWriter::encode(*bitmap));
-    TRY(buffered_stream->write_until_depleted(bytes));
+    TRY(Gfx::PNGWriter::encode(*buffered_stream, *bitmap));
 
     return {};
 }


### PR DESCRIPTION
Based on #24021.

To not make this need unbounded memory, convert PNGWriter to use a stream-based API first.

Here's wow.png as written by `Build/lagom/bin/animation -o wow.apng wow.gif`. I had to rename it to `.png`, else GitHub wouldn't let me attach it. Let's see if it shows up as animating. (Edit: It does!)

![wow](https://github.com/user-attachments/assets/9f6ed9ec-56c1-4306-a7ff-3fe64c5981b0)

On my system, it takes `animation` 167ms to write this file and it's 606K. For comparison, writing wow.webp currently takes 88ms and produces a 255K file. (The webp file sadly can't be displayed inline on github though, https://github.com/orgs/community/discussions/5470.) The input wow.gif is 184K.
