### PR TITLE
Cherry-pick "LibWeb: Account for header size when reading MessagePort message payload"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -279,7 +279,7 @@ ErrorOr<MessagePort::ParseDecision> MessagePort::parse_message()
         [[fallthrough]];
     }
     case SocketState::Data: {
-        if (num_bytes_ready < m_socket_incoming_message_size)
+        if (num_bytes_ready < HEADER_SIZE + m_socket_incoming_message_size)
             return ParseDecision::NotEnoughData;
 
         auto payload = m_buffered_data.span().slice(HEADER_SIZE, m_socket_incoming_message_size);


### PR DESCRIPTION
Cherry-picks LadybirdBrowser/ladybird#906<br><sub>Generated with [LBSync](https://github.com/circl-lastname/LBSync), did I do well?</sub>