### PR TITLE
Kernel: Remove Processor::is_kernel_mode

### DIFF
--- a/Kernel/Arch/Processor.cpp
+++ b/Kernel/Arch/Processor.cpp
@@ -112,7 +112,6 @@ void exit_kernel_thread(void)
 void do_context_first_init(Thread* from_thread, Thread* to_thread)
 {
     VERIFY(!Processor::are_interrupts_enabled());
-    VERIFY(Processor::is_kernel_mode());
 
     dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {} (context_first_init)", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -136,8 +136,6 @@ public:
     ALWAYS_INLINE static void disable_interrupts();
     ALWAYS_INLINE static FlatPtr current_in_irq();
 
-    ALWAYS_INLINE static bool is_kernel_mode();
-
     ALWAYS_INLINE void set_idle_thread(Thread& idle_thread)
     {
         m_idle_thread = &idle_thread;

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -154,13 +154,6 @@ ALWAYS_INLINE void ProcessorBase<T>::disable_interrupts()
 }
 
 template<typename T>
-ALWAYS_INLINE bool ProcessorBase<T>::is_kernel_mode()
-{
-    // FIXME: Implement this correctly.
-    return true;
-}
-
-template<typename T>
 ALWAYS_INLINE bool ProcessorBase<T>::current_in_scheduler()
 {
     return current().m_in_scheduler;

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -151,13 +151,6 @@ ALWAYS_INLINE void ProcessorBase<T>::disable_interrupts()
 }
 
 template<typename T>
-ALWAYS_INLINE bool ProcessorBase<T>::is_kernel_mode()
-{
-    // FIXME: Implement this correctly.
-    return true;
-}
-
-template<typename T>
 ALWAYS_INLINE bool ProcessorBase<T>::current_in_scheduler()
 {
     return current().m_in_scheduler;

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -1492,7 +1492,6 @@ StringView ProcessorBase<T>::platform_string()
 template<typename T>
 FlatPtr ProcessorBase<T>::init_context(Thread& thread, bool leave_crit)
 {
-    VERIFY(is_kernel_mode());
     VERIFY(g_scheduler_lock.is_locked());
     if (leave_crit) {
         // Leave the critical section we set up in in Process::exec,
@@ -1599,7 +1598,6 @@ void ProcessorBase<T>::switch_context(Thread*& from_thread, Thread*& to_thread)
 {
     VERIFY(!m_in_irq);
     VERIFY(m_in_critical == 1);
-    VERIFY(is_kernel_mode());
     auto* self = static_cast<Processor*>(this);
 
     dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context --> switching out of: {} {}", VirtualAddress(from_thread), *from_thread);

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -233,16 +233,6 @@ ALWAYS_INLINE NO_SANITIZE_COVERAGE bool ProcessorBase<T>::are_interrupts_enabled
 }
 
 template<typename T>
-ALWAYS_INLINE bool ProcessorBase<T>::is_kernel_mode()
-{
-    u16 cs;
-    asm volatile(
-        "mov %%cs, %[cs] \n"
-        : [cs] "=g"(cs));
-    return (cs & 3) == 0;
-}
-
-template<typename T>
 ALWAYS_INLINE bool ProcessorBase<T>::current_in_scheduler()
 {
     auto value = read_gs_ptr(__builtin_offsetof(ProcessorBase<T>, m_in_scheduler));


### PR DESCRIPTION
This function was only used to verify that we are running in kernel mode. But it is pretty much impossible that we will ever end up in kernel code and actually are able to execute it in user mode. A lot of stuff must go completely wrong to end up in such a situation.

Getting the current privilege level is also impossible on RISC-V by design.