### PR TITLE
Minor fixes in LibCore

### DIFF
--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -22,6 +22,8 @@ namespace Core {
 
 ErrorOr<NonnullOwnPtr<Command>> Command::create(StringView command, char const* const arguments[])
 {
+    // FIXME: Close pipes in every branch, probably with something nicer than 6 (Armed)ScopeGuards
+    //        (maybe introduce some new variant/api of Core::File that doesn't allocate, just returns RAII owner?).
     auto stdin_fds = TRY(Core::System::pipe2(O_CLOEXEC));
     auto stdout_fds = TRY(Core::System::pipe2(O_CLOEXEC));
     auto stderr_fds = TRY(Core::System::pipe2(O_CLOEXEC));

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
  * Copyright (c) 2022, David Tuin <davidot@serenityos.org>
  * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2024, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,7 +20,7 @@
 
 namespace Core {
 
-ErrorOr<OwnPtr<Command>> Command::create(StringView command, char const* const arguments[])
+ErrorOr<NonnullOwnPtr<Command>> Command::create(StringView command, char const* const arguments[])
 {
     auto stdin_fds = TRY(Core::System::pipe2(O_CLOEXEC));
     auto stdout_fds = TRY(Core::System::pipe2(O_CLOEXEC));
@@ -46,7 +47,7 @@ ErrorOr<OwnPtr<Command>> Command::create(StringView command, char const* const a
 
     runner_kill.disarm();
 
-    return make<Command>(pid, move(stdin_file), move(stdout_file), move(stderr_file));
+    return adopt_nonnull_own_or_enomem(new (nothrow) Command(pid, move(stdin_file), move(stdout_file), move(stderr_file)));
 }
 
 Command::Command(pid_t pid, NonnullOwnPtr<Core::File> stdin_file, NonnullOwnPtr<Core::File> stdout_file, NonnullOwnPtr<Core::File> stderr_file)

--- a/Userland/Libraries/LibCore/Command.h
+++ b/Userland/Libraries/LibCore/Command.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
  * Copyright (c) 2022, David Tuin <davidot@serenityos.org>
  * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2024, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -35,7 +36,7 @@ public:
         ByteBuffer standard_error;
     };
 
-    static ErrorOr<OwnPtr<Command>> create(StringView command, char const* const arguments[]);
+    static ErrorOr<NonnullOwnPtr<Command>> create(StringView command, char const* const arguments[]);
 
     Command(pid_t pid, NonnullOwnPtr<Core::File> stdin_file, NonnullOwnPtr<Core::File> stdout_file, NonnullOwnPtr<Core::File> stderr_file);
 

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Time.h>
 #include <LibCore/EventLoopImplementation.h>
 

--- a/Userland/Libraries/LibCore/MappedFile.cpp
+++ b/Userland/Libraries/LibCore/MappedFile.cpp
@@ -29,11 +29,11 @@ ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core:
 
 ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] StringView path, Mode mode)
 {
-    TRY(Core::System::fcntl(fd, F_SETFD, FD_CLOEXEC));
-
     ScopeGuard fd_close_guard = [fd] {
         ::close(fd);
     };
+
+    TRY(Core::System::fcntl(fd, F_SETFD, FD_CLOEXEC));
 
     auto stat = TRY(Core::System::fstat(fd));
     auto size = stat.st_size;

--- a/Userland/Libraries/LibCore/ThreadedPromise.h
+++ b/Userland/Libraries/LibCore/ThreadedPromise.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  * Copyright (c) 2021-2023, Ali Mohammad Pur <mpfard@serenityos.org>
  * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ * Copyright (c) 2024, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -125,7 +126,7 @@ public:
         auto new_promise = ThreadedPromise<T, ErrorType>::create();
         when_resolved([=, chained_resolution = move(chained_resolution)](ResultType&& result) mutable -> ErrorOr<void> {
             chained_resolution(forward<ResultType>(result))
-                ->when_resolved([=](auto&& new_result) { new_promise->resolve(move(new_result)); })
+                ->when_resolved([=](auto&& new_result) { new_promise->resolve(forward(new_result)); })
                 .when_rejected([=](ErrorType&& error) { new_promise->reject(move(error)); });
             return {};
         });


### PR DESCRIPTION
This PR contains small fixes in LibCore: more verbose return value in Command, adding missing include, closing some resources on error (manually and with ScopeGuards) and following clang-tidy hint. 