### PR TITLE
Documentation: Correct fuse2fs instructions for Fedora

### DIFF
--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -5,7 +5,7 @@
 ```console
 sudo dnf install texinfo binutils-devel curl cmake mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja-build patch ccache rsync @"C Development Tools and Libraries" @Virtualization
 ```
-Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
+Optional: `e2fsprogs` package for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 
 ## openSUSE
 


### PR DESCRIPTION
`fuse2fs` comes from the `e2fsprogs` package in Fedora:

```
AlgorithmWolf@neon:~/Documents/github-com/serenity$ which fuse2fs
/usr/bin/fuse2fs
AlgorithmWolf@neon:~/Documents/github-com/serenity$ dnf provides /usr/bin/fuse2fs
[...]
e2fsprogs-1.47.0-5.fc40.x86_64 : Utilities for managing ext2, ext3, and ext4
                               : file systems
Repo        : @System
Matched from:
Filename    : /usr/bin/fuse2fs

e2fsprogs-1.47.0-5.fc40.x86_64 : Utilities for managing ext2, ext3, and ext4
                               : file systems
Repo        : fedora
Matched from:
Filename    : /usr/bin/fuse2fs
```