### PR TITLE
ImageViewer: Set scaling mode's default value to "Box Sampling"

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -166,7 +166,7 @@ private:
     bool m_scaled_for_first_image { false };
     Vector<ByteString> m_files_in_same_dir;
     Optional<size_t> m_current_index;
-    Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::NearestNeighbor };
+    Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::BoxSampling };
 };
 
 }

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -256,7 +256,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto nearest_neighbor_action = GUI::Action::create_checkable("&Nearest Neighbor", [&](auto&) {
         widget.set_scaling_mode(Gfx::Painter::ScalingMode::NearestNeighbor);
     });
-    nearest_neighbor_action->set_checked(true);
 
     auto smooth_pixels_action = GUI::Action::create_checkable("&Smooth Pixels", [&](auto&) {
         widget.set_scaling_mode(Gfx::Painter::ScalingMode::SmoothPixels);
@@ -269,6 +268,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto box_sampling_action = GUI::Action::create_checkable("B&ox Sampling", [&](auto&) {
         widget.set_scaling_mode(Gfx::Painter::ScalingMode::BoxSampling);
     });
+    box_sampling_action->set_checked(true);
 
     widget.on_image_change = [&](Image const* image) {
         bool should_enable_image_actions = (image != nullptr);


### PR DESCRIPTION
This provides a way better experience when visualizing images. At some point, we should probably remove the option to control it from the GUI.

Old default on the left (Nearest Neighbor) new default on the right "Box Sampling".
![image](https://github.com/user-attachments/assets/b244559d-59b8-464d-bda3-c4b67ce7b81b)
