### PR TITLE
LibCrypto: Improve GHash / GCM performance

### DIFF
--- a/AK/SIMD.h
+++ b/AK/SIMD.h
@@ -108,10 +108,18 @@ struct IndexVectorFor<T> {
 };
 #endif
 
+template<typename T, size_t element_count>
+struct MakeVectorImpl {
+    using Type __attribute__((vector_size(sizeof(T) * element_count))) = T;
+};
+
 }
 
 template<SIMDVector T>
 using IndexVectorFor = typename Detail::IndexVectorFor<T>::Type;
+
+template<typename T, size_t element_count>
+using MakeVector = typename Detail::MakeVectorImpl<T, element_count>::Type;
 
 static_assert(IsSame<IndexVectorFor<i8x16>, i8x16>);
 static_assert(IsSame<IndexVectorFor<u32x4>, u32x4>);


### PR DESCRIPTION
Before:

```
$ ./Build/lagom/bin/crypto-bench ghash
Benchmarking ghash...
Running benchmark for ghash with size 16 for ~3000ms...3001ms, 1360348 ops, 4.7 MiB/s
Running benchmark for ghash with size 1024 for ~3000ms...3001ms, 38981 ops, 12.3 MiB/s
Running benchmark for ghash with size 16384 for ~3000ms...3001ms, 2267 ops, 11.4 MiB/s
Running benchmark for ghash with size 262144 for ~3000ms...3021ms, 121 ops, 9.5 MiB/s
Running benchmark for ghash with size 1048576 for ~3000ms...3035ms, 33 ops, 10.4 MiB/s
Running benchmark for ghash with size 16777216 for ~3000ms...3888ms, 2 ops, 7.6 MiB/s
Algorithm            Size       Min us/op  Max us/op  Avg us/op  Throughput
ghash                16 B       2          569799     2          4.7 MiB   /s
ghash                1.0 KiB    53         608996     77         12.3 MiB  /s
ghash                16.0 KiB   833        686917     1323       11.4 MiB  /s
ghash                256.0 KiB  13665      792689     24964      9.5 MiB   /s
ghash                1.0 MiB    55907      760158     91949      10.4 MiB  /s
ghash                16.0 MiB   1764273    2122790    1943531    7.6 MiB   /s
```

After:

```
$ ./Build/lagom/bin/crypto-bench ghash
Benchmarking ghash...
Running benchmark for ghash with size 16 for ~3000ms...3001ms, 4387171 ops, 12.3 MiB/s
Running benchmark for ghash with size 1024 for ~3000ms...3001ms, 162412 ops, 51.4 MiB/s
Running benchmark for ghash with size 16384 for ~3000ms...3071ms, 5510 ops, 27.6 MiB/s
Running benchmark for ghash with size 262144 for ~3000ms...3003ms, 215 ops, 17.1 MiB/s
Running benchmark for ghash with size 1048576 for ~3000ms...3008ms, 105 ops, 34.3 MiB/s
Running benchmark for ghash with size 16777216 for ~3000ms...3337ms, 7 ops, 33.3 MiB/s
Algorithm            Size       Min us/op  Max us/op  Avg us/op  Throughput
ghash                16 B       1          322042     1          12.3 MiB  /s
ghash                1.0 KiB    13         287760     18         51.4 MiB  /s
ghash                16.0 KiB   194        750283     557        27.6 MiB  /s
ghash                256.0 KiB  3246       762895     13966      17.1 MiB  /s
ghash                1.0 MiB    13144      776244     28645      34.3 MiB  /s
ghash                16.0 MiB   237858     1063187    476582     33.3 MiB  /s
```