### PR TITLE
Kernel: Remove passing of register state to IRQ handlers

### DIFF
--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -129,7 +129,7 @@ extern "C" void handle_interrupt(TrapFrame& trap_frame)
             auto* handler = s_interrupt_handlers[irq];
             VERIFY(handler);
             handler->increment_call_count();
-            handler->handle_interrupt(*trap_frame.regs);
+            handler->handle_interrupt();
             handler->eoi();
 
             irq += 1;

--- a/Kernel/Arch/aarch64/RPi/Timer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Timer.cpp
@@ -59,9 +59,9 @@ u64 Timer::microseconds_since_boot()
     return (static_cast<u64>(high) << 32) | low;
 }
 
-bool Timer::handle_irq(RegisterState const& regs)
+bool Timer::handle_irq()
 {
-    auto result = HardwareTimer::handle_irq(regs);
+    auto result = HardwareTimer::handle_irq();
 
     set_compare(TimerID::Timer1, microseconds_since_boot() + m_interrupt_interval);
     clear_interrupt(TimerID::Timer1);

--- a/Kernel/Arch/aarch64/RPi/Timer.h
+++ b/Kernel/Arch/aarch64/RPi/Timer.h
@@ -77,7 +77,7 @@ private:
     void clear_interrupt(TimerID);
 
     //^ IRQHandler
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     TimerRegisters volatile* m_registers;
     u32 m_interrupt_interval { 0 };

--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -68,7 +68,7 @@ extern "C" void trap_handler(TrapFrame& trap_frame)
         Processor::current().enter_trap(trap_frame, true);
 
         if (scause == RISCV64::CSR::SCAUSE::SupervisorTimerInterrupt) {
-            RISCV64::Timer::the().handle_interrupt(*trap_frame.regs);
+            RISCV64::Timer::the().handle_interrupt();
         } else if (scause == RISCV64::CSR::SCAUSE::SupervisorExternalInterrupt) {
             for (auto& interrupt_controller : InterruptManagement::the().controllers()) {
                 u8 pending_interrupt = 0;
@@ -76,7 +76,7 @@ extern "C" void trap_handler(TrapFrame& trap_frame)
                     auto* handler = s_interrupt_handlers[pending_interrupt];
                     VERIFY(handler);
                     handler->increment_call_count();
-                    handler->handle_interrupt(*trap_frame.regs);
+                    handler->handle_interrupt();
                     handler->eoi();
                 }
             }

--- a/Kernel/Arch/riscv64/Timer.cpp
+++ b/Kernel/Arch/riscv64/Timer.cpp
@@ -42,10 +42,10 @@ u64 Timer::current_ticks()
     return RISCV64::CSR::read(RISCV64::CSR::Address::TIME);
 }
 
-void Timer::handle_interrupt(RegisterState const& regs)
+void Timer::handle_interrupt()
 {
     if (m_callback)
-        m_callback(regs);
+        m_callback();
     set_compare(current_ticks() + m_interrupt_interval);
 }
 

--- a/Kernel/Arch/riscv64/Timer.h
+++ b/Kernel/Arch/riscv64/Timer.h
@@ -34,7 +34,7 @@ public:
     virtual size_t calculate_nearest_possible_frequency(size_t) const override { TODO_RISCV64(); }
 
     virtual void will_be_destroyed() override { }
-    virtual Function<void(RegisterState const&)> set_callback(Function<void(RegisterState const&)> callback) override
+    virtual Function<void()> set_callback(Function<void()> callback) override
     {
         auto previous_callback = move(m_callback);
         m_callback = move(callback);
@@ -43,7 +43,7 @@ public:
 
     // FIXME: Share code with HPET::update_time
     u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);
-    void handle_interrupt(RegisterState const&);
+    void handle_interrupt();
 
 private:
     Timer();
@@ -51,7 +51,7 @@ private:
     static u64 current_ticks();
     static void set_compare(u64 compare);
 
-    Function<void(RegisterState const&)> m_callback;
+    Function<void()> m_callback;
     u64 m_frequency { 0 };
     u32 m_interrupt_interval { 0 };
 

--- a/Kernel/Arch/x86_64/ISABus/I8042Controller.cpp
+++ b/Kernel/Arch/x86_64/ISABus/I8042Controller.cpp
@@ -27,7 +27,7 @@ UNMAP_AFTER_INIT ErrorOr<NonnullOwnPtr<I8042ControllerIRQHandler>> I8042Controll
     return adopt_nonnull_own_or_enomem(new I8042ControllerIRQHandler(controller, irq_number));
 }
 
-bool I8042ControllerIRQHandler::handle_irq(RegisterState const&)
+bool I8042ControllerIRQHandler::handle_irq()
 {
     return m_controller->handle_irq({}, interrupt_number());
 }

--- a/Kernel/Arch/x86_64/ISABus/I8042Controller.h
+++ b/Kernel/Arch/x86_64/ISABus/I8042Controller.h
@@ -80,7 +80,7 @@ private:
     I8042ControllerIRQHandler(I8042Controller const& controller, u8 irq_number);
 
     // ^IRQHandler
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
     virtual StringView purpose() const override { return "I8042ControllerIRQHandler"sv; }
 
     NonnullRefPtr<I8042Controller> const m_controller;

--- a/Kernel/Arch/x86_64/Interrupts.cpp
+++ b/Kernel/Arch/x86_64/Interrupts.cpp
@@ -311,7 +311,7 @@ void handle_interrupt(TrapFrame* trap)
     }
     VERIFY(handler);
     handler->increment_call_count();
-    handler->handle_interrupt(regs);
+    handler->handle_interrupt();
     handler->eoi();
 }
 

--- a/Kernel/Arch/x86_64/Interrupts/APIC.cpp
+++ b/Kernel/Arch/x86_64/Interrupts/APIC.cpp
@@ -75,7 +75,7 @@ public:
         handler->register_interrupt_handler();
     }
 
-    virtual bool handle_interrupt(RegisterState const&) override;
+    virtual bool handle_interrupt() override;
 
     virtual bool eoi() override;
 
@@ -105,7 +105,7 @@ public:
         handler->register_interrupt_handler();
     }
 
-    virtual bool handle_interrupt(RegisterState const&) override;
+    virtual bool handle_interrupt() override;
 
     virtual bool eoi() override;
 
@@ -648,7 +648,7 @@ u32 APIC::get_timer_divisor()
     return 16;
 }
 
-bool APICIPIInterruptHandler::handle_interrupt(RegisterState const&)
+bool APICIPIInterruptHandler::handle_interrupt()
 {
     dbgln_if(APIC_SMP_DEBUG, "APIC IPI on CPU #{}", Processor::current_id());
     return true;
@@ -661,7 +661,7 @@ bool APICIPIInterruptHandler::eoi()
     return true;
 }
 
-bool APICErrInterruptHandler::handle_interrupt(RegisterState const&)
+bool APICErrInterruptHandler::handle_interrupt()
 {
     dbgln("APIC: SMP error on CPU #{}", Processor::current_id());
     return true;

--- a/Kernel/Arch/x86_64/Time/APICTimer.h
+++ b/Kernel/Arch/x86_64/Time/APICTimer.h
@@ -35,7 +35,7 @@ public:
     void disable_local_timer();
 
 private:
-    explicit APICTimer(u8, Function<void(RegisterState const&)>);
+    explicit APICTimer(u8, Function<void()>);
 
     bool calibrate(HardwareTimerBase&);
 

--- a/Kernel/Arch/x86_64/Time/HPETComparator.cpp
+++ b/Kernel/Arch/x86_64/Time/HPETComparator.cpp
@@ -53,9 +53,9 @@ void HPETComparator::set_non_periodic()
     HPET::the().disable_periodic_interrupt(*this);
 }
 
-bool HPETComparator::handle_irq(RegisterState const& regs)
+bool HPETComparator::handle_irq()
 {
-    auto result = HardwareTimer::handle_irq(regs);
+    auto result = HardwareTimer::handle_irq();
     if (!is_periodic())
         set_new_countdown();
     return result;

--- a/Kernel/Arch/x86_64/Time/HPETComparator.h
+++ b/Kernel/Arch/x86_64/Time/HPETComparator.h
@@ -41,7 +41,7 @@ public:
 
 private:
     void set_new_countdown();
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
     HPETComparator(u8 number, u8 irq, bool periodic_capable, bool is_64bit_capable);
     bool m_periodic : 1;
     bool m_periodic_capable : 1;

--- a/Kernel/Arch/x86_64/Time/PIT.cpp
+++ b/Kernel/Arch/x86_64/Time/PIT.cpp
@@ -16,7 +16,7 @@
 #define IRQ_TIMER 0
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<PIT> PIT::initialize(Function<void(RegisterState const&)> callback)
+UNMAP_AFTER_INIT NonnullLockRefPtr<PIT> PIT::initialize(Function<void()> callback)
 {
     return adopt_lock_ref(*new PIT(move(callback)));
 }
@@ -28,7 +28,7 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PIT> PIT::initialize(Function<void(RegisterSt
     IO::out8(TIMER0_CTL, MSB(timer_reload));
 }
 
-PIT::PIT(Function<void(RegisterState const&)> callback)
+PIT::PIT(Function<void()> callback)
     : HardwareTimer(IRQ_TIMER, move(callback))
     , m_periodic(true)
 {

--- a/Kernel/Arch/x86_64/Time/PIT.h
+++ b/Kernel/Arch/x86_64/Time/PIT.h
@@ -34,7 +34,7 @@ namespace Kernel {
 
 class PIT final : public HardwareTimer<IRQHandler> {
 public:
-    static NonnullLockRefPtr<PIT> initialize(Function<void(RegisterState const&)>);
+    static NonnullLockRefPtr<PIT> initialize(Function<void()>);
     virtual HardwareTimerType timer_type() const override { return HardwareTimerType::i8253; }
     virtual StringView model() const override { return "i8254"sv; }
 
@@ -50,7 +50,7 @@ public:
     virtual size_t calculate_nearest_possible_frequency(size_t frequency) const override;
 
 private:
-    explicit PIT(Function<void(RegisterState const&)>);
+    explicit PIT(Function<void()>);
     bool m_periodic { true };
 };
 }

--- a/Kernel/Arch/x86_64/Time/RTC.cpp
+++ b/Kernel/Arch/x86_64/Time/RTC.cpp
@@ -15,11 +15,11 @@ namespace Kernel {
 #define IRQ_TIMER 8
 #define MAX_FREQUENCY 8000
 
-NonnullLockRefPtr<RealTimeClock> RealTimeClock::create(Function<void(RegisterState const&)> callback)
+NonnullLockRefPtr<RealTimeClock> RealTimeClock::create(Function<void()> callback)
 {
     return adopt_lock_ref(*new RealTimeClock(move(callback)));
 }
-RealTimeClock::RealTimeClock(Function<void(RegisterState const&)> callback)
+RealTimeClock::RealTimeClock(Function<void()> callback)
     : HardwareTimer(IRQ_TIMER, move(callback))
 {
     InterruptDisabler disabler;
@@ -28,9 +28,9 @@ RealTimeClock::RealTimeClock(Function<void(RegisterState const&)> callback)
     CMOS::write(0x8B, CMOS::read(0xB) | 0x40);
     reset_to_default_ticks_per_second();
 }
-bool RealTimeClock::handle_irq(RegisterState const& regs)
+bool RealTimeClock::handle_irq()
 {
-    auto result = HardwareTimer::handle_irq(regs);
+    auto result = HardwareTimer::handle_irq();
     CMOS::read(0x8C);
     return result;
 }

--- a/Kernel/Arch/x86_64/Time/RTC.h
+++ b/Kernel/Arch/x86_64/Time/RTC.h
@@ -13,7 +13,7 @@
 namespace Kernel {
 class RealTimeClock final : public HardwareTimer<IRQHandler> {
 public:
-    static NonnullLockRefPtr<RealTimeClock> create(Function<void(RegisterState const&)> callback);
+    static NonnullLockRefPtr<RealTimeClock> create(Function<void()> callback);
     virtual HardwareTimerType timer_type() const override { return HardwareTimerType::RTC; }
     virtual StringView model() const override { return "Real Time Clock"sv; }
 
@@ -29,7 +29,7 @@ public:
     virtual size_t calculate_nearest_possible_frequency(size_t frequency) const override;
 
 private:
-    explicit RealTimeClock(Function<void(RegisterState const&)> callback);
-    virtual bool handle_irq(RegisterState const&) override;
+    explicit RealTimeClock(Function<void()> callback);
+    virtual bool handle_irq() override;
 };
 }

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -722,7 +722,7 @@ ErrorOr<void> UHCIController::spawn_async_poll_process()
     return {};
 }
 
-bool UHCIController::handle_irq(RegisterState const&)
+bool UHCIController::handle_irq()
 {
     u32 status = read_usbsts();
 

--- a/Kernel/Bus/USB/UHCI/UHCIController.h
+++ b/Kernel/Bus/USB/UHCI/UHCIController.h
@@ -82,7 +82,7 @@ private:
     void write_portsc1(u16 value) { m_registers_io_window->write16(0x10, value); }
     void write_portsc2(u16 value) { m_registers_io_window->write16(0x12, value); }
 
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     ErrorOr<void> create_structures();
     void setup_schedule();

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
@@ -22,7 +22,7 @@ xHCIInterrupter::xHCIInterrupter(xHCIController& controller, u16 interrupter_id,
     enable_irq();
 }
 
-bool xHCIInterrupter::handle_irq(RegisterState const&)
+bool xHCIInterrupter::handle_irq()
 {
     m_controller.handle_interrupt({}, m_interrupter_id);
     return true;

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
@@ -22,7 +22,7 @@ public:
 private:
     xHCIInterrupter(xHCIController& controller, u16 interrupter_id, u16 irq);
 
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     xHCIController& m_controller;
     u16 m_interrupter_id { 0 };

--- a/Kernel/Bus/VirtIO/Transport/PCIe/InterruptHandler.cpp
+++ b/Kernel/Bus/VirtIO/Transport/PCIe/InterruptHandler.cpp
@@ -19,7 +19,7 @@ PCIeTransportInterruptHandler::PCIeTransportInterruptHandler(PCIeTransportLink& 
 {
 }
 
-bool PCIeTransportInterruptHandler::handle_irq(RegisterState const&)
+bool PCIeTransportInterruptHandler::handle_irq()
 {
     return notify_parent_device_on_interrupt();
 }

--- a/Kernel/Bus/VirtIO/Transport/PCIe/InterruptHandler.h
+++ b/Kernel/Bus/VirtIO/Transport/PCIe/InterruptHandler.h
@@ -26,6 +26,6 @@ private:
     PCIeTransportInterruptHandler(PCIeTransportLink&, VirtIO::Device&, u8 irq);
 
     //^ IRQHandler
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 };
 }

--- a/Kernel/Devices/Audio/AC97/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97/AC97.cpp
@@ -64,7 +64,7 @@ UNMAP_AFTER_INIT AC97::AC97(PCI::DeviceIdentifier const& pci_device_identifier, 
 
 UNMAP_AFTER_INIT AC97::~AC97() = default;
 
-bool AC97::handle_irq(RegisterState const&)
+bool AC97::handle_irq()
 {
     auto pcm_out_status = m_pcm_out_channel->io_window().read16(AC97Channel::Register::Status);
     dbgln_if(AC97_DEBUG, "AC97 @ {}: interrupt received - status: {:#05b}", device_identifier().address(), pcm_out_status);

--- a/Kernel/Devices/Audio/AC97/AC97.h
+++ b/Kernel/Devices/Audio/AC97/AC97.h
@@ -161,7 +161,7 @@ private:
     AC97(PCI::DeviceIdentifier const&, NonnullOwnPtr<AC97Channel> pcm_out_channel, NonnullOwnPtr<IOWindow> mixer_io_window, NonnullOwnPtr<IOWindow> bus_io_window);
 
     // ^IRQHandler
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     void set_master_output_volume(u8, u8, Muted);
     u32 read_pcm_output_sample_rate();

--- a/Kernel/Devices/Audio/IntelHDA/InterruptHandler.cpp
+++ b/Kernel/Devices/Audio/IntelHDA/InterruptHandler.cpp
@@ -16,7 +16,7 @@ InterruptHandler::InterruptHandler(Controller& controller)
     enable_irq();
 }
 
-bool InterruptHandler::handle_irq(RegisterState const&)
+bool InterruptHandler::handle_irq()
 {
     auto result_or_error = m_controller.handle_interrupt({});
     if (result_or_error.is_error()) {

--- a/Kernel/Devices/Audio/IntelHDA/InterruptHandler.h
+++ b/Kernel/Devices/Audio/IntelHDA/InterruptHandler.h
@@ -29,7 +29,7 @@ private:
     InterruptHandler(Controller& controller);
 
     // ^PCI::IRQHandler
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     Controller& m_controller;
 };

--- a/Kernel/Devices/Storage/AHCI/InterruptHandler.cpp
+++ b/Kernel/Devices/Storage/AHCI/InterruptHandler.cpp
@@ -38,7 +38,7 @@ AHCI::MaskedBitField AHCIInterruptHandler::create_pending_ports_interrupts_bitfi
 
 AHCIInterruptHandler::~AHCIInterruptHandler() = default;
 
-bool AHCIInterruptHandler::handle_irq(RegisterState const&)
+bool AHCIInterruptHandler::handle_irq()
 {
     dbgln_if(AHCI_DEBUG, "AHCI Port Handler: IRQ received");
     if (m_pending_ports_interrupts.is_zeroed())

--- a/Kernel/Devices/Storage/AHCI/InterruptHandler.h
+++ b/Kernel/Devices/Storage/AHCI/InterruptHandler.h
@@ -42,7 +42,7 @@ private:
     void allocate_resources_and_initialize_ports();
 
     //^ IRQHandler
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     enum class Direction : u8 {
         Read,

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -29,7 +29,7 @@ void NVMeInterruptQueue::initialize_interrupt_queue()
     enable_irq();
 }
 
-bool NVMeInterruptQueue::handle_irq(RegisterState const&)
+bool NVMeInterruptQueue::handle_irq()
 {
     return process_cq() ? true : false;
 }

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
@@ -25,6 +25,6 @@ protected:
 
 private:
     virtual void complete_current_request(u16 cmdid, u16 status) override;
-    bool handle_irq(RegisterState const&) override;
+    bool handle_irq() override;
 };
 }

--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -148,7 +148,7 @@ UNMAP_AFTER_INIT Optional<PhysicalAddress> Parser::find_table(StringView signatu
     return {};
 }
 
-bool Parser::handle_irq(RegisterState const&)
+bool Parser::handle_irq()
 {
     TODO();
 }

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -55,7 +55,7 @@ public:
     static void must_initialize(PhysicalAddress rsdp, PhysicalAddress fadt, u8 irq_number);
 
     virtual StringView purpose() const override { return "ACPI Parser"sv; }
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
 
     Optional<PhysicalAddress> find_table(StringView signature);
 

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -28,7 +28,7 @@ public:
     }
     // Note: this method returns boolean value, to indicate if the handler handled
     // the interrupt or not. This is useful for shared handlers mostly.
-    virtual bool handle_interrupt(RegisterState const& regs) = 0;
+    virtual bool handle_interrupt() = 0;
 
     void will_be_destroyed();
     bool is_registered() const { return m_registered; }

--- a/Kernel/Interrupts/IRQHandler.h
+++ b/Kernel/Interrupts/IRQHandler.h
@@ -17,8 +17,8 @@ class IRQHandler : public GenericInterruptHandler {
 public:
     virtual ~IRQHandler();
 
-    virtual bool handle_interrupt(RegisterState const& regs) override { return handle_irq(regs); }
-    virtual bool handle_irq(RegisterState const&) = 0;
+    virtual bool handle_interrupt() override { return handle_irq(); }
+    virtual bool handle_irq() = 0;
 
     void enable_irq();
     void disable_irq();

--- a/Kernel/Interrupts/PCIIRQHandler.cpp
+++ b/Kernel/Interrupts/PCIIRQHandler.cpp
@@ -63,9 +63,9 @@ void IRQHandler::disable_irq()
         device.disable_interrupt(interrupt_number());
 }
 
-bool IRQHandler::handle_interrupt(RegisterState const& regs)
+bool IRQHandler::handle_interrupt()
 {
-    return handle_irq(regs);
+    return handle_irq();
 }
 
 }

--- a/Kernel/Interrupts/PCIIRQHandler.h
+++ b/Kernel/Interrupts/PCIIRQHandler.h
@@ -18,8 +18,8 @@ class IRQHandler : public GenericInterruptHandler {
 public:
     virtual ~IRQHandler() = default;
 
-    virtual bool handle_interrupt(RegisterState const& regs) override;
-    virtual bool handle_irq(RegisterState const&) = 0;
+    virtual bool handle_interrupt() override;
+    virtual bool handle_irq() = 0;
 
     void enable_irq();
     void disable_irq();

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -61,7 +61,7 @@ SharedIRQHandler::~SharedIRQHandler()
     disable_interrupt_vector();
 }
 
-bool SharedIRQHandler::handle_interrupt(RegisterState const& regs)
+bool SharedIRQHandler::handle_interrupt()
 {
     VERIFY_INTERRUPTS_DISABLED();
 
@@ -73,7 +73,7 @@ bool SharedIRQHandler::handle_interrupt(RegisterState const& regs)
     bool was_handled = false;
     m_handlers.for_each([&](auto& handler) {
         dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {}", i, interrupt_number());
-        if (handler.handle_interrupt(regs)) {
+        if (handler.handle_interrupt()) {
             handler.increment_call_count();
             was_handled = true;
         }

--- a/Kernel/Interrupts/SharedIRQHandler.h
+++ b/Kernel/Interrupts/SharedIRQHandler.h
@@ -19,7 +19,7 @@ class SharedIRQHandler final : public GenericInterruptHandler {
 public:
     static void initialize(u8 interrupt_number);
     virtual ~SharedIRQHandler();
-    virtual bool handle_interrupt(RegisterState const& regs) override;
+    virtual bool handle_interrupt() override;
 
     void register_handler(GenericInterruptHandler&);
     void unregister_handler(GenericInterruptHandler&);

--- a/Kernel/Interrupts/SpuriousInterruptHandler.cpp
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.cpp
@@ -68,12 +68,12 @@ SpuriousInterruptHandler::SpuriousInterruptHandler(u8 irq)
 
 SpuriousInterruptHandler::~SpuriousInterruptHandler() = default;
 
-bool SpuriousInterruptHandler::handle_interrupt(RegisterState const& state)
+bool SpuriousInterruptHandler::handle_interrupt()
 {
     // Actually check if IRQ7 or IRQ15 are spurious, and if not, call the real handler to handle the IRQ.
     if (m_responsible_irq_controller->get_isr() & (1 << interrupt_number())) {
         m_real_irq = true; // remember that we had a real IRQ, when EOI later!
-        if (m_real_handler->handle_interrupt(state)) {
+        if (m_real_handler->handle_interrupt()) {
             m_real_handler->increment_call_count();
             return true;
         }

--- a/Kernel/Interrupts/SpuriousInterruptHandler.h
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.h
@@ -19,7 +19,7 @@ public:
     static void initialize_for_disabled_master_pic();
     static void initialize_for_disabled_slave_pic();
     virtual ~SpuriousInterruptHandler();
-    virtual bool handle_interrupt(RegisterState const& regs) override;
+    virtual bool handle_interrupt() override;
 
     void register_handler(GenericInterruptHandler&);
     void unregister_handler(GenericInterruptHandler&);

--- a/Kernel/Interrupts/UnhandledInterruptHandler.cpp
+++ b/Kernel/Interrupts/UnhandledInterruptHandler.cpp
@@ -13,7 +13,7 @@ UnhandledInterruptHandler::UnhandledInterruptHandler(u8 interrupt_vector)
 {
 }
 
-bool UnhandledInterruptHandler::handle_interrupt(RegisterState const&)
+bool UnhandledInterruptHandler::handle_interrupt()
 {
     PANIC("Interrupt: Unhandled vector {} was invoked for handle_interrupt(RegisterState&).", interrupt_number());
 }

--- a/Kernel/Interrupts/UnhandledInterruptHandler.h
+++ b/Kernel/Interrupts/UnhandledInterruptHandler.h
@@ -15,7 +15,7 @@ public:
     explicit UnhandledInterruptHandler(u8 interrupt_vector);
     virtual ~UnhandledInterruptHandler();
 
-    virtual bool handle_interrupt(RegisterState const&) override;
+    virtual bool handle_interrupt() override;
 
     [[noreturn]] virtual bool eoi() override;
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -243,7 +243,7 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(StringView interface_n
 
 UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter() = default;
 
-bool E1000NetworkAdapter::handle_irq(RegisterState const&)
+bool E1000NetworkAdapter::handle_irq()
 {
     u32 status = in32(REG_INTERRUPT_CAUSE_READ);
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -48,7 +48,7 @@ protected:
         NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
         NonnullOwnPtr<Memory::Region> tx_descriptors_region);
 
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
     virtual StringView class_name() const override { return "E1000NetworkAdapter"sv; }
 
     struct [[gnu::packed]] e1000_rx_desc {

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
@@ -1286,7 +1286,7 @@ UNMAP_AFTER_INIT void RTL8168NetworkAdapter::initialize_tx_descriptors()
 
 UNMAP_AFTER_INIT RTL8168NetworkAdapter::~RTL8168NetworkAdapter() = default;
 
-bool RTL8168NetworkAdapter::handle_irq(RegisterState const&)
+bool RTL8168NetworkAdapter::handle_irq()
 {
     bool was_handled = false;
     for (;;) {

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -44,7 +44,7 @@ private:
 
     RTL8168NetworkAdapter(StringView, PCI::DeviceIdentifier const&, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window);
 
-    virtual bool handle_irq(RegisterState const&) override;
+    virtual bool handle_irq() override;
     virtual StringView class_name() const override { return "RTL8168NetworkAdapter"sv; }
 
     bool determine_supported_version() const;

--- a/Kernel/Tasks/PerformanceManager.h
+++ b/Kernel/Tasks/PerformanceManager.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <Kernel/Arch/TrapFrame.h>
 #include <Kernel/Tasks/PerformanceEventBuffer.h>
 #include <Kernel/Tasks/Process.h>
 #include <Kernel/Tasks/Thread.h>
@@ -129,7 +130,7 @@ public:
         }
     }
 
-    static void timer_tick(RegisterState const& regs)
+    static void timer_tick()
     {
         static UnixDateTime last_wakeup;
         auto now = kgettimeofday();
@@ -144,7 +145,7 @@ public:
             return;
 
         auto lost_samples = delay.to_microseconds() / ideal_interval.to_microseconds();
-        PerformanceManager::add_cpu_sample_event(*current_thread, regs, lost_samples);
+        PerformanceManager::add_cpu_sample_event(*current_thread, *current_thread->current_trap()->regs, lost_samples);
     }
 };
 

--- a/Kernel/Tasks/Scheduler.cpp
+++ b/Kernel/Tasks/Scheduler.cpp
@@ -413,7 +413,7 @@ void Scheduler::add_time_scheduled(u64 time_to_add, bool is_kernel)
     });
 }
 
-void Scheduler::timer_tick(RegisterState const& regs)
+void Scheduler::timer_tick()
 {
     VERIFY_INTERRUPTS_DISABLED();
     VERIFY(Processor::current_in_irq());
@@ -424,7 +424,6 @@ void Scheduler::timer_tick(RegisterState const& regs)
 
     // Sanity checks
     VERIFY(current_thread->current_trap());
-    VERIFY(current_thread->current_trap()->regs == &regs);
 
     if (current_thread->process().is_kernel_process()) {
         // Because the previous mode when entering/exiting kernel threads never changes

--- a/Kernel/Tasks/Scheduler.h
+++ b/Kernel/Tasks/Scheduler.h
@@ -34,7 +34,7 @@ public:
     static void initialize();
     static Thread* create_ap_idle_thread(u32 cpu);
     static void set_idle_thread(Thread* idle_thread);
-    static void timer_tick(RegisterState const&);
+    static void timer_tick();
     [[noreturn]] static void start();
     static void pick_next();
     static void yield();

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -43,7 +43,7 @@ public:
 
     virtual StringView model() const = 0;
     virtual HardwareTimerType timer_type() const = 0;
-    virtual Function<void(RegisterState const&)> set_callback(Function<void(RegisterState const&)>) = 0;
+    virtual Function<void()> set_callback(Function<void()>) = 0;
 
     virtual bool is_periodic() const = 0;
     virtual bool is_periodic_capable() const = 0;
@@ -79,7 +79,7 @@ public:
         return model();
     }
 
-    virtual Function<void(RegisterState const&)> set_callback(Function<void(RegisterState const&)> callback) override
+    virtual Function<void()> set_callback(Function<void()> callback) override
     {
         disable_irq();
         auto previous_callback = move(m_callback);
@@ -91,17 +91,17 @@ public:
     virtual size_t ticks_per_second() const override { return m_frequency; }
 
 protected:
-    HardwareTimer(u8 irq_number, Function<void(RegisterState const&)> callback = nullptr)
+    HardwareTimer(u8 irq_number, Function<void()> callback = nullptr)
         : IRQHandler(irq_number)
         , m_callback(move(callback))
     {
     }
 
-    virtual bool handle_irq(RegisterState const& regs) override
+    virtual bool handle_irq() override
     {
         // Note: if we have an IRQ on this line, it's going to be the timer always
         if (m_callback) {
-            m_callback(regs);
+            m_callback();
             return true;
         }
         return false;
@@ -110,7 +110,7 @@ protected:
     u64 m_frequency { OPTIMAL_TICKS_PER_SECOND_RATE };
 
 private:
-    Function<void(RegisterState const&)> m_callback;
+    Function<void()> m_callback;
 };
 
 template<>
@@ -128,7 +128,7 @@ public:
         return model();
     }
 
-    virtual Function<void(RegisterState const&)> set_callback(Function<void(RegisterState const&)> callback) override
+    virtual Function<void()> set_callback(Function<void()> callback) override
     {
         auto previous_callback = move(m_callback);
         m_callback = move(callback);
@@ -143,17 +143,17 @@ public:
     virtual size_t ticks_per_second() const override { return m_frequency; }
 
 protected:
-    HardwareTimer(u8 irq_number, Function<void(RegisterState const&)> callback = nullptr)
+    HardwareTimer(u8 irq_number, Function<void()> callback = nullptr)
         : GenericInterruptHandler(irq_number)
         , m_callback(move(callback))
     {
     }
 
-    virtual bool handle_interrupt(RegisterState const& regs) override
+    virtual bool handle_interrupt() override
     {
         // Note: if we have an IRQ on this line, it's going to be the timer always
         if (m_callback) {
-            m_callback(regs);
+            m_callback();
             return true;
         }
         return false;
@@ -162,7 +162,7 @@ protected:
     u64 m_frequency { OPTIMAL_TICKS_PER_SECOND_RATE };
 
 private:
-    Function<void(RegisterState const&)> m_callback;
+    Function<void()> m_callback;
 };
 
 }

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -14,7 +14,6 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/API/TimePage.h>
-#include <Kernel/Arch/RegisterState.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UnixTypes.h>
@@ -85,7 +84,7 @@ private:
     bool probe_and_set_x86_legacy_hardware_timers();
     bool probe_and_set_x86_non_legacy_hardware_timers();
     void increment_time_since_boot_hpet();
-    static void update_time(RegisterState const&);
+    static void update_time();
 #elif ARCH(AARCH64)
     bool probe_and_set_aarch64_hardware_timers();
 #elif ARCH(RISCV64)
@@ -97,7 +96,7 @@ private:
     Vector<HardwareTimerBase*> scan_for_non_periodic_timers();
     Vector<NonnullLockRefPtr<HardwareTimerBase>> m_hardware_timers;
     void set_system_timer(HardwareTimerBase&);
-    static void system_timer_tick(RegisterState const&);
+    static void system_timer_tick();
 
     // Variables between m_update1 and m_update2 are synchronized
     // FIXME: Replace m_update1 and m_update2 with a SpinlockLocker


### PR DESCRIPTION
Linux did the same thing 18 years ago and their reasons for the change are similar to ours - https://github.com/torvalds/linux/commit/7d12e78

Most interrupt handlers (i.e. IRQ handlers) never used the register state reference anywhere so there's simply no need of passing it around. I didn't measure the performance boost but surely this change can't make things worse anyway.