### PR TITLE
LibVT: Handle concealed ANSI escape codes

### DIFF
--- a/Userland/Libraries/LibVT/Attribute.h
+++ b/Userland/Libraries/LibVT/Attribute.h
@@ -49,6 +49,7 @@ struct Attribute {
         Negative = 0x08,
         Blink = 0x10,
         Touched = 0x20,
+        Concealed = 0x40,
     };
     AK_ENUM_BITWISE_FRIEND_OPERATORS(Flags);
 

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -300,6 +300,9 @@ void Terminal::SGR(Parameters params)
             case 7:
                 m_current_state.attribute.flags |= Attribute::Flags::Negative;
                 break;
+            case 8:
+                m_current_state.attribute.flags |= Attribute::Flags::Concealed;
+                break;
             case 22:
                 m_current_state.attribute.flags &= ~Attribute::Flags::Bold;
                 break;
@@ -314,6 +317,9 @@ void Terminal::SGR(Parameters params)
                 break;
             case 27:
                 m_current_state.attribute.flags &= ~Attribute::Flags::Negative;
+                break;
+            case 28:
+                m_current_state.attribute.flags &= ~Attribute::Flags::Concealed;
                 break;
             case 30:
             case 31:

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -428,6 +428,10 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
             if (code_point == ' ')
                 continue;
 
+            if (has_flag(attribute.flags, VT::Attribute::Flags::Concealed)) {
+                continue;
+            }
+
             auto character_rect = glyph_rect(visual_row, column);
 
             if (m_hovered_href_id.has_value() && attribute.href_id == m_hovered_href_id) {


### PR DESCRIPTION
This implements concealed and not concealed ANSI escape sequences: 8 and 28 respectively, as per https://en.wikipedia.org/wiki/ANSI_escape_code

