### PR TITLE
shot: Use "popup" window type for screenshot area selection

### DIFF
--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -119,6 +119,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto container = window->set_main_widget<SelectableLayover>(window);
 
         window->set_title("shot");
+        window->set_window_type(GUI::WindowType::Popup);
         window->set_has_alpha_channel(true);
         window->set_fullscreen(true);
         window->show();


### PR DESCRIPTION
This allows the selection to appear above all normal window types including the task bar.

**Before** (taskbar never faded):
![Screenshot from 2024-08-25 14-42-54](https://github.com/user-attachments/assets/2ab9a5ee-c2df-4543-92a5-9af013227df9)

**After**:
![Screenshot from 2024-08-25 14-41-51](https://github.com/user-attachments/assets/76c6d137-f251-4cd2-95e3-59f36643a523)
