### PR TITLE
CI: Build riscv64 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
 
           - toolchain: 'GNU'
             os: ubuntu-22.04
+            arch: 'riscv64'
+            debug_options: 'NORMAL_DEBUG'
+
+          - toolchain: 'GNU'
+            os: ubuntu-22.04
             arch: 'x86_64'
             debug_options: 'ALL_DEBUG'
 

--- a/.github/workflows/serenity-template.yml
+++ b/.github/workflows/serenity-template.yml
@@ -157,7 +157,7 @@ jobs:
         run: ninja install && ninja qemu-image
 
       - name: Run On-Target Tests
-        if: ${{ inputs.debug_options == 'NORMAL_DEBUG' && inputs.arch != 'aarch64' }}
+        if: ${{ inputs.debug_options == 'NORMAL_DEBUG' && inputs.arch != 'aarch64' && inputs.arch != 'riscv64' }}
         working-directory: ${{ steps.build-parameters.outputs.build_directory }}
         env:
           SERENITY_QEMU_CPU: "max,vmx=off"


### PR DESCRIPTION
Don't run any tests on riscv64 for now, since some tests still fail (mostly due to missing generic AK/Math.h implementations).