### PR TITLE
Kernel/Net+ifconfig+SystemMonitor: Add IPv6 address support to network interfaces

### DIFF
--- a/Kernel/API/POSIX/sys/socket.h
+++ b/Kernel/API/POSIX/sys/socket.h
@@ -109,7 +109,8 @@ static inline void* CMSG_DATA(struct cmsghdr* cmsg)
 
 struct sockaddr {
     sa_family_t sa_family;
-    char sa_data[14];
+    // For network interface ioctl(), this needs to fit all sockaddr_* structures (excluding Unix domain sockets).
+    char sa_data[26];
 };
 
 struct ucred {

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.cpp
@@ -36,6 +36,12 @@ ErrorOr<void> SysFSNetworkAdaptersStats::try_generate(KBufferBuilder& builder)
             auto ipv4_netmask = TRY(adapter.ipv4_netmask().to_string());
             TRY(obj.add("ipv4_netmask"sv, ipv4_netmask->view()));
         }
+        if (!adapter.ipv6_address().is_zero()) {
+            auto ipv6_address = TRY(adapter.ipv6_address().to_string());
+            TRY(obj.add("ipv6_address"sv, ipv6_address->view()));
+            auto ipv6_netmask = TRY(adapter.ipv6_netmask().to_string());
+            TRY(obj.add("ipv6_netmask"sv, ipv6_netmask->view()));
+        }
         TRY(obj.add("packets_in"sv, adapter.packets_in()));
         TRY(obj.add("bytes_in"sv, adapter.bytes_in()));
         TRY(obj.add("packets_out"sv, adapter.packets_out()));

--- a/Kernel/Net/IPv4/Socket.cpp
+++ b/Kernel/Net/IPv4/Socket.cpp
@@ -755,17 +755,22 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
         case SIOCSIFADDR:
             if (!current_process_credentials->is_superuser())
                 return EPERM;
-            if (ifr.ifr_addr.sa_family != AF_INET)
+            if (ifr.ifr_addr.sa_family == AF_INET) {
+                adapter->set_ipv4_address(IPv4Address(bit_cast<sockaddr_in*>(&ifr.ifr_addr)->sin_addr.s_addr));
+                return {};
+            } else if (ifr.ifr_addr.sa_family == AF_INET6) {
+                adapter->set_ipv6_address(IPv6Address(bit_cast<sockaddr_in6*>(&ifr.ifr_addr)->sin6_addr.s6_addr));
+                return {};
+            } else {
                 return EAFNOSUPPORT;
-            adapter->set_ipv4_address(IPv4Address(((sockaddr_in&)ifr.ifr_addr).sin_addr.s_addr));
-            return {};
+            }
 
         case SIOCSIFNETMASK:
             if (!current_process_credentials->is_superuser())
                 return EPERM;
             if (ifr.ifr_addr.sa_family != AF_INET)
                 return EAFNOSUPPORT;
-            adapter->set_ipv4_netmask(IPv4Address(((sockaddr_in&)ifr.ifr_netmask).sin_addr.s_addr));
+            adapter->set_ipv4_netmask(IPv4Address(bit_cast<sockaddr_in*>(&ifr.ifr_netmask)->sin_addr.s_addr));
             return {};
 
         case SIOCGIFADDR: {

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -231,6 +231,7 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
 
     setup_link();
     setup_interrupts();
+    autoconfigure_link_local_ipv6();
     return {};
 }
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -207,6 +207,7 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingM
     setup_interrupts();
 
     m_link_up = ((in32(REG_STATUS) & STATUS_LU) != 0);
+    autoconfigure_link_local_ipv6();
 
     return {};
 }
@@ -257,6 +258,7 @@ bool E1000NetworkAdapter::handle_irq()
         out32(REG_CTRL, flags | ECTRL_SLU);
 
         m_link_up = ((in32(REG_STATUS) & STATUS_LU) != 0);
+        autoconfigure_link_local_ipv6();
     }
     if (status & INTERRUPT_RXDMT0) {
         // Threshold OK?

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -159,4 +159,14 @@ void NetworkAdapter::set_ipv4_netmask(IPv4Address const& netmask)
     m_ipv4_netmask = netmask;
 }
 
+void NetworkAdapter::set_ipv6_address(IPv6Address const& address)
+{
+    m_ipv6_address = address;
+}
+
+void NetworkAdapter::set_ipv6_netmask(IPv6Address const& netmask)
+{
+    m_ipv6_netmask = netmask;
+}
+
 }

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -169,4 +169,34 @@ void NetworkAdapter::set_ipv6_netmask(IPv6Address const& netmask)
     m_ipv6_netmask = netmask;
 }
 
+void NetworkAdapter::autoconfigure_link_local_ipv6()
+{
+    auto mac = mac_address();
+    if (mac.is_zero() || !link_up())
+        return;
+
+    // TODO: other IPv6 autoconf modes
+    // TODO: duplicate address detection as mandated by RFC 4862, this is only a very naive implementation of autoconf
+    auto ipv6_ll = IPv6Address({ 0xfe,
+        0x80,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        static_cast<u8>(mac[0] ^ 0b00000010),
+        mac[1],
+        mac[2],
+        0xff,
+        0xfe,
+        mac[3],
+        mac[4],
+        mac[5] });
+    auto netmask = IPv6Address({ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0 });
+    set_ipv6_address(ipv6_ll);
+    set_ipv6_netmask(netmask);
+    dbgln("autoconfigured link-local address {}", ipv6_ll.to_string());
+}
+
 }

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -117,6 +117,7 @@ protected:
     void set_mac_address(MACAddress const& mac_address) { m_mac_address = mac_address; }
     void did_receive(ReadonlyBytes);
     virtual void send_raw(ReadonlyBytes) = 0;
+    void autoconfigure_link_local_ipv6();
 
 private:
     MACAddress m_mac_address;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -9,6 +9,7 @@
 #include <AK/AtomicRefCounted.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Function.h>
+#include <AK/IPv6Address.h>
 #include <AK/IntrusiveList.h>
 #include <AK/MACAddress.h>
 #include <AK/Types.h>
@@ -65,6 +66,12 @@ public:
     IPv4Address ipv4_address() const { return m_ipv4_address; }
     IPv4Address ipv4_netmask() const { return m_ipv4_netmask; }
     IPv4Address ipv4_broadcast() const { return IPv4Address { (m_ipv4_address.to_u32() & m_ipv4_netmask.to_u32()) | ~m_ipv4_netmask.to_u32() }; }
+
+    IPv6Address ipv6_address() const { return m_ipv6_address; }
+    IPv6Address ipv6_netmask() const { return m_ipv6_netmask; }
+    // TODO: implement other multicast addresses
+    IPv6Address ipv6_multicast() const { return IPv6Address({ 0xff, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }); }
+
     virtual bool link_up() { return false; }
     virtual i32 link_speed()
     {
@@ -75,6 +82,9 @@ public:
 
     void set_ipv4_address(IPv4Address const&);
     void set_ipv4_netmask(IPv4Address const&);
+
+    void set_ipv6_address(IPv6Address const&);
+    void set_ipv6_netmask(IPv6Address const&);
 
     void send(MACAddress const&, ARPPacket const&);
     void fill_in_ipv4_header(PacketWithTimestamp&, IPv4Address const&, MACAddress const&, IPv4Address const&, IPv4Protocol, size_t, u8 type_of_service, u8 ttl);
@@ -110,8 +120,11 @@ protected:
 
 private:
     MACAddress m_mac_address;
+    // FIXME: Allow for more than one IPv4/IPv6 address each.
     IPv4Address m_ipv4_address;
     IPv4Address m_ipv4_netmask;
+    IPv6Address m_ipv6_address;
+    IPv6Address m_ipv6_netmask;
 
     // FIXME: Make this configurable
     static constexpr size_t max_packet_buffers = 1024;

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -72,6 +72,19 @@ RefPtr<NetworkAdapter> NetworkingManagement::from_ipv4_address(IPv4Address const
     });
 }
 
+RefPtr<NetworkAdapter> NetworkingManagement::from_ipv6_address(IPv6Address const& address) const
+{
+    if (address.is_loopback())
+        return m_loopback_adapter;
+    return m_adapters.with([&](auto& adapters) -> RefPtr<NetworkAdapter> {
+        for (auto& adapter : adapters) {
+            if (adapter->ipv6_address() == address || adapter->ipv6_multicast() == address)
+                return adapter;
+        }
+        return nullptr;
+    });
+}
+
 RefPtr<NetworkAdapter> NetworkingManagement::lookup_by_name(StringView name) const
 {
     return m_adapters.with([&](auto& adapters) -> RefPtr<NetworkAdapter> {

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -34,6 +34,7 @@ public:
     ErrorOr<void> try_for_each(Function<ErrorOr<void>(NetworkAdapter&)>);
 
     RefPtr<NetworkAdapter> from_ipv4_address(IPv4Address const&) const;
+    RefPtr<NetworkAdapter> from_ipv6_address(IPv6Address const&) const;
     RefPtr<NetworkAdapter> lookup_by_name(StringView) const;
 
     NonnullRefPtr<NetworkAdapter> loopback_adapter() const;

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
@@ -437,6 +437,7 @@ void RTL8168NetworkAdapter::startup()
 
     // update link status
     m_link_up = (in8(REG_PHYSTATUS) & PHY_LINK_STATUS) != 0;
+    autoconfigure_link_local_ipv6();
 }
 
 void RTL8168NetworkAdapter::configure_phy()
@@ -1322,6 +1323,7 @@ bool RTL8168NetworkAdapter::handle_irq()
         if (status & INT_LINK_CHANGE) {
             m_link_up = (in8(REG_PHYSTATUS) & PHY_LINK_STATUS) != 0;
             dmesgln_pci(*this, "Link status changed up={}", m_link_up);
+            autoconfigure_link_local_ipv6();
         }
         if (status & INT_RX_FIFO_OVERFLOW) {
             dmesgln_pci(*this, "RX FIFO overflow");

--- a/Kernel/Net/VirtIO/VirtIONetworkAdapter.cpp
+++ b/Kernel/Net/VirtIO/VirtIONetworkAdapter.cpp
@@ -189,6 +189,7 @@ ErrorOr<void> VirtIONetworkAdapter::handle_device_config_change()
             m_link_duplex = duplex == 0x01;
         }
     });
+    autoconfigure_link_local_ipv6();
     return {};
 }
 

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -65,6 +65,10 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
             [](JsonObject const& object) -> ByteString {
                 return object.get_byte_string("ipv4_address"sv).value_or(""sv);
             });
+        net_adapters_fields.empend("IPv6"_string, Gfx::TextAlignment::CenterLeft,
+            [](JsonObject const& object) -> ByteString {
+                return object.get_byte_string("ipv6_address"sv).value_or(""sv);
+            });
         net_adapters_fields.empend("packets_in", "Pkt In"_string, Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("packets_out", "Pkt Out"_string, Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("bytes_in", "Bytes In"_string, Gfx::TextAlignment::CenterRight);

--- a/Userland/Utilities/ifconfig.cpp
+++ b/Userland/Utilities/ifconfig.cpp
@@ -45,7 +45,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto class_name = if_object.get_byte_string("class_name"sv).value_or({});
             auto mac_address = if_object.get_byte_string("mac_address"sv).value_or({});
             auto ipv4_address = if_object.get_byte_string("ipv4_address"sv).value_or({});
-            auto netmask = if_object.get_byte_string("ipv4_netmask"sv).value_or({});
+            auto ipv4_netmask = if_object.get_byte_string("ipv4_netmask"sv).value_or({});
+            auto ipv6_address = if_object.get_byte_string("ipv6_address"sv).value_or({});
+            auto ipv6_netmask = if_object.get_byte_string("ipv6_netmask"sv).value_or({});
             auto packets_in = if_object.get_u32("packets_in"sv).value_or(0);
             auto bytes_in = if_object.get_u32("bytes_in"sv).value_or(0);
             auto packets_out = if_object.get_u32("packets_out"sv).value_or(0);
@@ -54,8 +56,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             outln("{}:", name);
             outln("\tmac: {}", mac_address);
-            outln("\tipv4: {}", ipv4_address);
-            outln("\tnetmask: {}", netmask);
+            if (!ipv4_address.is_empty()) {
+                outln("\tipv4: {}", ipv4_address);
+                outln("\tnetmask: {}", ipv4_netmask);
+            }
+            if (!ipv6_address.is_empty()) {
+                outln("\tipv6: {}", ipv6_address);
+                // TODO: this should probably displayed as a CIDR instead for better readability
+                outln("\tnetmask: {}", ipv6_netmask);
+            }
             outln("\tclass: {}", class_name);
             outln("\tRX: {} packets {} bytes ({})", packets_in, bytes_in, human_readable_size(bytes_in));
             outln("\tTX: {} packets {} bytes ({})", packets_out, bytes_out, human_readable_size(bytes_out));


### PR DESCRIPTION
###### (Commit batch 1 from SIP6TF)

This set of commits adds minimal IPv6 address support to network interfaces, as well as some userland support to query and set them. This is not compliant with even a single RFC: multiple addresses are not supported, and using a full IPv6 address for a network mask is pointless. Both will be addressed in further changes. This will be enough for initial link-local communications.

CC @famfo @sdomi 

### AK: Add IPv6 subnet and address category handling

IPv6Address can now determine the broad address
categories as defined in various RFCs, and check
if addresses belong to certain subnets.

### Kernel/Net: Add basic IPv6 address support to NetworkAdapter

### Kernel+ifconfig: Allow setting an IPv6 address on an interface

Since we take a socket address with an address
type, this allows us to support setting an IPv6
address using an IPv4 socket without a
particularly hacky API. This deviates from Linux's
behavior (see
https://www.man7.org/linux/man-pages/man7/netdevice.7.html
) where AF_INET6 uses a completely different
control structure, but this doesn't seem
necessary.

This requires changing the sockaddr size to fit
sockaddr_in6, as the network ioctl's are the only
place where sockaddr is used with a fixed size
(and not with variable size data like in POSIX
APIs, which would support sockaddr_in6 without
changes).

ifconfig takes a new parameter for setting the
IPv6 address of an interface. The IPv4 address
short option '-i' is removed, as it only yields
confusion (which IP version is the default? and
usually such options are called -4 or -6, if they
exist) and isn't necessary thanks to the brief
long option name.

This commit's main purpose for now is to allow
participating in IPv6 NDP and pings without
requiring SLAC.

### Kernel/SysFS: Expose IPv6 information for adapters

This commit adds the ipv6_address and ipv6_netmask parameters to the
adapters SysFS JSON if present on the interface.

### Kernel/Net: Naive IPv6 autoconfiguration

This commit introduces very naive IPv6 autoconfiguration by just
setting fe80::{mac address} as the adapters link local address every
time the link state comes up. Note: this is currently not complient
with RFC4862 which mandates Duplicate Address Detection, which is
missing from this implementation.

### ifconfig: Display IPv6 addresses

This commit displays IPv6 addresses and netmasks of adapters if
present. Also adds a check to omit IPv4 addresses if e.g. a system
is running IPv6 only.

### SystemMonitor: Display IPv6 addresses on adapters