### PR TITLE
AK/Optional: Make some member functions constexpr

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -58,19 +58,19 @@ requires(!IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional()
+    ALWAYS_INLINE constexpr Optional()
         : m_null()
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional(V)
+    constexpr Optional(V)
         : m_null()
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
@@ -79,7 +79,7 @@ public:
     Optional(Optional const& other)
     requires(!IsCopyConstructible<T>)
     = delete;
-    Optional(Optional const& other) = default;
+    constexpr Optional(Optional const& other) = default;
 
     Optional(Optional&& other)
     requires(!IsMoveConstructible<T>)
@@ -88,7 +88,14 @@ public:
     Optional& operator=(Optional const&)
     requires(!IsCopyConstructible<T> || !IsDestructible<T>)
     = delete;
-    Optional& operator=(Optional const&) = default;
+    constexpr Optional& operator=(Optional const& other)
+    {
+        m_has_value = other.m_has_value;
+        if (m_has_value) {
+            m_storage = other.m_storage;
+        }
+        return *this;
+    }
 
     Optional& operator=(Optional&& other)
     requires(!IsMoveConstructible<T> || !IsDestructible<T>)
@@ -97,9 +104,9 @@ public:
     ~Optional()
     requires(!IsDestructible<T>)
     = delete;
-    ~Optional() = default;
+    constexpr ~Optional() = default;
 
-    ALWAYS_INLINE Optional(Optional const& other)
+    ALWAYS_INLINE constexpr Optional(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T>)
         : m_null()
         , m_has_value(other.m_has_value)
@@ -108,7 +115,7 @@ public:
             construct_at(&m_storage, other.value());
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    ALWAYS_INLINE constexpr Optional(Optional&& other)
         : m_null()
         , m_has_value(other.m_has_value)
     {
@@ -117,7 +124,7 @@ public:
     }
 
     template<typename U>
-    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit Optional(Optional<U> const& other)
+    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE constexpr explicit Optional(Optional<U> const& other)
         : m_null()
         , m_has_value(other.m_has_value)
     {
@@ -126,7 +133,7 @@ public:
     }
 
     template<typename U>
-    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit Optional(Optional<U>&& other)
+    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE constexpr explicit Optional(Optional<U>&& other)
         : m_null()
         , m_has_value(other.m_has_value)
     {
@@ -136,15 +143,14 @@ public:
 
     template<typename U = T>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value)
+    ALWAYS_INLINE constexpr explicit(!IsConvertible<U&&, T>) Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<T>> && IsConstructible<T, U &&>)
-        : m_null()
+        : m_storage(forward<U>(value))
         , m_has_value(true)
     {
-        construct_at(&m_storage, forward<U>(value));
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
     {
         if (this != &other) {
@@ -157,7 +163,7 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -170,24 +176,24 @@ public:
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    ALWAYS_INLINE constexpr bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    ALWAYS_INLINE ~Optional()
+    ALWAYS_INLINE constexpr ~Optional()
     requires(!IsTriviallyDestructible<T>)
     {
         clear();
     }
 
-    ALWAYS_INLINE void clear()
+    ALWAYS_INLINE constexpr void clear()
     {
         if (m_has_value) {
             value().~T();
@@ -196,7 +202,7 @@ public:
     }
 
     template<typename... Parameters>
-    ALWAYS_INLINE void emplace(Parameters&&... parameters)
+    ALWAYS_INLINE constexpr void emplace(Parameters&&... parameters)
     {
         clear();
         m_has_value = true;
@@ -204,33 +210,33 @@ public:
     }
 
     template<typename Callable>
-    ALWAYS_INLINE void lazy_emplace(Callable callable)
+    ALWAYS_INLINE constexpr void lazy_emplace(Callable callable)
     {
         clear();
         m_has_value = true;
         construct_at(&m_storage, callable());
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_has_value; }
+    [[nodiscard]] ALWAYS_INLINE constexpr bool has_value() const { return m_has_value; }
 
-    [[nodiscard]] ALWAYS_INLINE T& value() &
+    [[nodiscard]] ALWAYS_INLINE constexpr T& value() &
     {
         VERIFY(m_has_value);
         return m_storage;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& value() const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T const& value() const&
     {
         VERIFY(m_has_value);
         return m_storage;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value() &&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T release_value()
     {
         VERIFY(m_has_value);
         T released_value = move(value());
@@ -239,14 +245,14 @@ public:
         return released_value;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T const& fallback) const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or(T const& fallback) const&
     {
         if (m_has_value)
             return value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T&& fallback) &&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or(T&& fallback) &&
     {
         if (m_has_value)
             return move(value());
@@ -254,7 +260,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or_lazy_evaluated(Callback callback) const
     {
         if (m_has_value)
             return value();
@@ -262,7 +268,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_has_value)
             return value();
@@ -270,7 +276,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (m_has_value)
             return value();
@@ -278,21 +284,21 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_has_value)
             return value();
         return TRY(callback());
     }
 
-    ALWAYS_INLINE T const& operator*() const { return value(); }
-    ALWAYS_INLINE T& operator*() { return value(); }
+    ALWAYS_INLINE constexpr T const& operator*() const { return value(); }
+    ALWAYS_INLINE constexpr T& operator*() { return value(); }
 
-    ALWAYS_INLINE T const* operator->() const { return &value(); }
-    ALWAYS_INLINE T* operator->() { return &value(); }
+    ALWAYS_INLINE constexpr T const* operator->() const { return &value(); }
+    ALWAYS_INLINE constexpr T* operator->() { return &value(); }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (m_has_value)
@@ -307,7 +313,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (m_has_value)
@@ -340,63 +346,63 @@ requires(IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    ALWAYS_INLINE constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
     template<typename U = T>
-    ALWAYS_INLINE Optional(U& value)
+    ALWAYS_INLINE constexpr Optional(U& value)
     requires(CanBePlacedInOptional<U&>)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(RemoveReference<T>& value)
+    ALWAYS_INLINE constexpr Optional(RemoveReference<T>& value)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(Optional const& other)
+    ALWAYS_INLINE constexpr Optional(Optional const& other)
         : m_pointer(other.m_pointer)
     {
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    ALWAYS_INLINE constexpr Optional(Optional&& other)
         : m_pointer(other.m_pointer)
     {
         other.m_pointer = nullptr;
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U> const& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U> const& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.m_pointer)
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U>&& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U>&& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.m_pointer)
     {
         other.m_pointer = nullptr;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional const& other)
     {
         m_pointer = other.m_pointer;
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional&& other)
     {
         m_pointer = other.m_pointer;
         other.m_pointer = nullptr;
@@ -404,7 +410,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U> const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U> const& other)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = other.m_pointer;
@@ -412,7 +418,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U>&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U>&& other)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = other.m_pointer;
@@ -423,7 +429,7 @@ public:
     // Note: Disallows assignment from a temporary as this does not do any lifetime extension.
     template<typename U>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE Optional& operator=(U&& value)
+    ALWAYS_INLINE constexpr Optional& operator=(U&& value)
     requires(CanBePlacedInOptional<U> && IsLvalueReference<U>)
     {
         m_pointer = &value;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -68,9 +68,16 @@ constexpr T&& move(T& arg)
     return static_cast<T&&>(arg);
 }
 
+template<typename T, typename... Args>
+constexpr T* construct_at(T* p, Args&&... args)
+{
+    return new (const_cast<void*>(static_cast<void const*>(p))) T(forward<Args>(args)...);
+}
+
 }
 
 namespace AK {
+using AK_REPLACED_STD_NAMESPACE::construct_at;
 using AK_REPLACED_STD_NAMESPACE::forward;
 using AK_REPLACED_STD_NAMESPACE::move;
 }
@@ -215,6 +222,7 @@ __DEFINE_GENERIC_ABS(long double, 0.0L, fabsl);
 using AK::array_size;
 using AK::ceil_div;
 using AK::clamp;
+using AK::construct_at;
 using AK::exchange;
 using AK::forward;
 using AK::is_constant_evaluated;

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -592,7 +592,6 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_multiboot(MemoryManager::G
         PhysicalAddress upper;
     };
 
-    Optional<ContiguousPhysicalVirtualRange> last_contiguous_physical_range;
     for (auto* mmap = mmap_begin; mmap < mmap_end; mmap++) {
         // We have to copy these onto the stack, because we take a reference to these when printing them out,
         // and doing so on a packed struct field is UB.

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -269,3 +269,8 @@ TEST_CASE(comparison_reference)
     EXPECT_EQ(opt1, opt2);
     EXPECT_NE(opt1, opt3);
 }
+
+TEST_CASE(constexpr_usable)
+{
+    static_assert(Optional<int>(5).value() == 5);
+}

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -253,7 +253,7 @@ ErrorOr<void> MoveTool::update_cached_preview_bitmap(Layer const* layer)
     return {};
 }
 
-Optional<ResizeAnchorLocation const> MoveTool::resize_anchor_location_from_cursor_position(Layer const* layer, MouseEvent& event)
+Optional<ResizeAnchorLocation> MoveTool::resize_anchor_location_from_cursor_position(Layer const* layer, MouseEvent& event)
 {
     auto layer_rect = m_editor->content_to_frame_rect(layer->relative_rect()).to_type<int>();
     auto size = max(resize_anchor_min_size, resize_anchor_size(layer_rect));

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -47,7 +47,7 @@ private:
     static Array<Gfx::IntRect, 4> resize_anchor_rects(Gfx::IntRect layer_rect_in_frame_coordinates, int resize_anchor_size);
     virtual StringView tool_name() const override { return "Move Tool"sv; }
     ErrorOr<void> update_cached_preview_bitmap(Layer const* layer);
-    Optional<ResizeAnchorLocation const> resize_anchor_location_from_cursor_position(Layer const*, MouseEvent&);
+    Optional<ResizeAnchorLocation> resize_anchor_location_from_cursor_position(Layer const*, MouseEvent&);
     void toggle_selection_mode();
 
     LayerSelectionMode m_layer_selection_mode { LayerSelectionMode::ForegroundLayer };
@@ -56,7 +56,7 @@ private:
     Gfx::IntPoint m_layer_origin;
     Gfx::IntRect m_new_layer_rect;
     bool m_scaling { false };
-    Optional<ResizeAnchorLocation const> m_resize_anchor_location {};
+    Optional<ResizeAnchorLocation> m_resize_anchor_location {};
     bool m_keep_aspect_ratio { false };
     RefPtr<GUI::Widget> m_properties_widget;
     RefPtr<GUI::RadioButton> m_selection_mode_foreground;

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -415,7 +415,6 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         CSSPixels initial_image_x = image_rect.x();
         CSSPixels image_y = image_rect.y();
-        Optional<DevicePixelRect> last_image_device_rect;
 
         image.resolve_for_size(layout_node, image_rect.size());
 

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
@@ -46,7 +46,6 @@ RefPtr<MultiScaleBitmaps> MultiScaleBitmaps::create(StringView filename, StringV
 
 bool MultiScaleBitmaps::load(StringView filename, StringView default_filename)
 {
-    Optional<Gfx::BitmapFormat> bitmap_format;
     bool did_load_any = false;
 
     m_bitmaps.clear(); // If we're reloading the bitmaps get rid of the old ones


### PR DESCRIPTION
This PR changes some of Optional's member functions to be constexpr - for now only the non-reference variant. Notably, this requires using construct_at instead of placement new to create the contained object and storing it in a union instead of a byte buffer.