### PR TITLE
Tests/LibC+LibC+crash: Don't assume `__builtin_trap` causes SIGILL

### DIFF
--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -125,7 +125,23 @@ int main(int argc, char** argv)
 
     if (do_illegal_instruction || do_all_crash_types) {
         any_failures |= !Crash("Illegal instruction", []() {
-            __builtin_trap();
+#if ARCH(AARCH64)
+            asm volatile("udf #0" :);
+#elif ARCH(X86_64)
+            asm volatile("ud2" :);
+#elif ARCH(RISCV64)
+            // Invalid instructions are not required to trap on RISC-V.
+            // However, writing to a read-only CSR, which the non-compressed unimp pseudoinstruction
+            // gets expanded to, is required to cause an illegal-instruction exception.
+            asm volatile(R"(
+                .option push
+                .option norvc
+                    unimp
+                .option pop
+            )" :);
+#else
+#    error Unknown architecture
+#endif
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }

--- a/Tests/LibC/TestAbort.cpp
+++ b/Tests/LibC/TestAbort.cpp
@@ -15,10 +15,6 @@ TEST_CASE(_abort)
         _abort();
         return Test::Crash::Failure::DidNotCrash;
     });
-    EXPECT_CRASH_WITH_SIGNAL("This should _abort with SIGILL signal", SIGILL, [] {
-        _abort();
-        return Test::Crash::Failure::DidNotCrash;
-    });
 }
 
 TEST_CASE(abort)

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -377,7 +377,7 @@ int atexit(void (*handler)())
 void _abort()
 {
     // According to the GCC manual __builtin_trap() can call abort() so using it here might not seem safe at first. However,
-    // on all the platforms we support GCC emits an undefined instruction instead of a call.
+    // on all the platforms we support GCC emits a trapping instruction instead of a call.
     __builtin_trap();
 }
 


### PR DESCRIPTION
`__builtin_trap()` gets compiled to a breakpoint instruction on
riscv64 GCC, aarch64 GCC, and aarch64 Clang.