### PR TITLE
 EFI Prekernel (3/N): Kernel/EFI: Add EFI service and protocol headers

### DIFF
--- a/Kernel/Firmware/EFI/EFI.cpp
+++ b/Kernel/Firmware/EFI/EFI.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+namespace Kernel::EFI {
+
+Optional<StringView> status_description(Status status)
+{
+    using enum Kernel::EFI::Status;
+    switch (status) {
+    case Success:
+        return "The operation completed successfully."sv;
+    case LoadError:
+        return "The image failed to load."sv;
+    case InvalidParameter:
+        return "A parameter was incorrect."sv;
+    case Unsupported:
+        return "The operation is not supported."sv;
+    case BadBufferSize:
+        return "The buffer was not the proper size for the request."sv;
+    case BufferTooSmall:
+        return "The buffer is not large enough to hold the requested data. The required buffer size is returned in the appropriate parameter when this error occurs."sv;
+    case NotReady:
+        return "There is no data pending upon return."sv;
+    case DeviceError:
+        return "The physical device reported an error while attempting the operation."sv;
+    case WriteProtected:
+        return "The device cannot be written to."sv;
+    case OutOfResources:
+        return "A resource has run out."sv;
+    case VolumeCorrupted:
+        return "An inconstancy was detected on the file system causing the operating to fail."sv;
+    case VolumeFull:
+        return "There is no more space on the file system."sv;
+    case NoMedia:
+        return "The device does not contain any medium to perform the operation."sv;
+    case MediaChanged:
+        return "The medium in the device has changed since the last access."sv;
+    case NotFound:
+        return "The item was not found."sv;
+    case AccessDenied:
+        return "Access was denied."sv;
+    case NoResponse:
+        return "The server was not found or did not respond to the request."sv;
+    case NoMapping:
+        return "A mapping to a device does not exist."sv;
+    case Timeout:
+        return "The timeout time expired."sv;
+    case NotStarted:
+        return "The protocol has not been started."sv;
+    case AlreadyStarted:
+        return "The protocol has already been started."sv;
+    case Aborted:
+        return "The operation was aborted."sv;
+    case ICMPError:
+        return "An ICMP error occurred during the network operation."sv;
+    case TFTPError:
+        return "A TFTP error occurred during the network operation."sv;
+    case ProtocolError:
+        return "A protocol error occurred during the network operation."sv;
+    case IncompatibleVersion:
+        return "The function encountered an internal version that was incompatible with a version requested by the caller."sv;
+    case SecurityViolation:
+        return "The function was not performed due to a security violation."sv;
+    case CRCError:
+        return "A CRC error was detected."sv;
+    case EndOfMedia:
+        return "Beginning or end of media was reached"sv;
+    case EndOfFile:
+        return "The end of the file was reached."sv;
+    case InvalidLanguage:
+        return "The language specified was invalid."sv;
+    case CompromisedData:
+        return "The security status of the data is unknown or compromised and the data must be updated or replaced to restore a valid security status."sv;
+    case IPAddressConflict:
+        return "There is an address conflict address allocation"sv;
+    case HTTPError:
+        return "A HTTP error occurred during the network operation."sv;
+    }
+
+    return {};
+}
+
+}

--- a/Kernel/Firmware/EFI/EFI.h
+++ b/Kernel/Firmware/EFI/EFI.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <AK/NumericLimits.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Types.h>
+
+// UEFI uses the Microsoft calling convention on x86.
+#if ARCH(X86_64)
+#    define EFIAPI __attribute__((ms_abi))
+#else
+#    define EFIAPI
+#endif
+
+namespace Kernel::EFI {
+
+// The UEFI spec requires 4K pages to be used for all its current architectures.
+// All function arguments and struct members that refer to "pages" also assume 4K pages.
+// e.g. the AllocatePages() "Pages" argument: https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+static constexpr size_t EFI_PAGE_SIZE = 4 * KiB;
+
+// EFI Data Types: https://uefi.org/specs/UEFI/2.10/02_Overview.html#data-types
+
+// BOOLEAN, Logical Boolean. 1-byte value containing a 0 for FALSE or a 1 for TRUE. Other values are undefined.
+enum class Boolean : u8 {
+    False = 0,
+    True = 1,
+};
+
+// EFI_GUID, 128-bit buffer containing a unique identifier value. Unless otherwise specified, aligned on a 64-bit boundary.
+struct alignas(u64) GUID {
+    u32 part1;
+    u16 part2;
+    u16 part3;
+    u8 part4[8];
+
+    bool operator==(GUID const&) const = default;
+};
+static_assert(AssertSize<GUID, 16>());
+
+// EFI_STATUS, Status code
+// Standard status codes are defined here: https://uefi.org/specs/UEFI/2.10/Apx_D_Status_Codes.html
+static constexpr FlatPtr ERROR_MASK = 1ull << (NumericLimits<FlatPtr>::digits() - 1);
+enum class Status : FlatPtr {
+    Success = 0,
+
+    LoadError = 1 | ERROR_MASK,
+    InvalidParameter = 2 | ERROR_MASK,
+    Unsupported = 3 | ERROR_MASK,
+    BadBufferSize = 4 | ERROR_MASK,
+    BufferTooSmall = 5 | ERROR_MASK,
+    NotReady = 6 | ERROR_MASK,
+    DeviceError = 7 | ERROR_MASK,
+    WriteProtected = 8 | ERROR_MASK,
+    OutOfResources = 9 | ERROR_MASK,
+    VolumeCorrupted = 10 | ERROR_MASK,
+    VolumeFull = 11 | ERROR_MASK,
+    NoMedia = 12 | ERROR_MASK,
+    MediaChanged = 13 | ERROR_MASK,
+    NotFound = 14 | ERROR_MASK,
+    AccessDenied = 15 | ERROR_MASK,
+    NoResponse = 16 | ERROR_MASK,
+    NoMapping = 17 | ERROR_MASK,
+    Timeout = 18 | ERROR_MASK,
+    NotStarted = 19 | ERROR_MASK,
+    AlreadyStarted = 20 | ERROR_MASK,
+    Aborted = 21 | ERROR_MASK,
+    ICMPError = 22 | ERROR_MASK,
+    TFTPError = 23 | ERROR_MASK,
+    ProtocolError = 24 | ERROR_MASK,
+    IncompatibleVersion = 25 | ERROR_MASK,
+    SecurityViolation = 26 | ERROR_MASK,
+    CRCError = 27 | ERROR_MASK,
+    EndOfMedia = 28 | ERROR_MASK,
+
+    EndOfFile = 31 | ERROR_MASK,
+    InvalidLanguage = 32 | ERROR_MASK,
+    CompromisedData = 33 | ERROR_MASK,
+    IPAddressConflict = 34 | ERROR_MASK,
+    HTTPError = 35 | ERROR_MASK,
+};
+
+Optional<StringView> status_description(Status);
+
+// EFI_HANDLE, A collection of related interfaces
+using Handle = FlatPtr;
+
+// EFI_EVENT, Handle to an event structure
+using Event = void*;
+
+// EFI_TPL, Task priority level
+using TPL = FlatPtr;
+
+// EFI_TABLE_HEADER, Data structure that precedes all of the standard EFI table types.
+// https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#id4
+struct TableHeader {
+    u64 signature;
+    u32 revision;
+    u32 header_size;
+    u32 crc32;
+    u32 reserved;
+};
+static_assert(AssertSize<TableHeader, 24>());
+
+// EFI_TIME: https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html#gettime
+struct Time {
+    u16 year;  // 1900 - 9999
+    u8 month;  // 1 - 12
+    u8 day;    // 1 - 31
+    u8 hour;   // 0 - 23
+    u8 minute; // 0 - 59
+    u8 second; // 0 - 59
+    u8 pad1;
+    u32 nanosecond; // 0 - 999,999,999
+    i16 time_zone;  // —1440 to 1440 or 2047
+    u8 daylight;
+    u8 pad2;
+};
+static_assert(AssertSize<Time, 16>());
+
+// EFI_PHYSICAL_ADDRESS: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+using PhysicalAddress = u64;
+
+// EFI_VIRTUAL_ADDRESS: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+using VirtualAddress = u64;
+
+}
+
+template<>
+struct AK::Formatter<Kernel::EFI::Status> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Kernel::EFI::Status status)
+    {
+        if (auto maybe_description = Kernel::EFI::status_description(status); maybe_description.has_value())
+            return builder.put_string(maybe_description.release_value());
+
+        TRY(builder.put_literal("(EFI::Status)"sv));
+        return builder.put_u64(to_underlying(status), 16, true);
+    }
+};

--- a/Kernel/Firmware/EFI/Protocols/ConsoleSupport.h
+++ b/Kernel/Firmware/EFI/Protocols/ConsoleSupport.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+// https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html
+
+namespace Kernel::EFI {
+
+// EFI_INPUT_KEY: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-simple-text-input-protocol-readkeystroke
+struct InputKey {
+    u16 scan_code;
+    char16_t unicode_char;
+};
+static_assert(AssertSize<InputKey, 4>());
+
+// EFI_SIMPLE_TEXT_INPUT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-input-protocol
+struct SimpleTextInputProtocol {
+    static constexpr GUID guid = { 0x387477c1, 0x69c7, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using InputResetFn = EFIAPI Status (*)(SimpleTextInputProtocol*, Boolean extended_verification);
+    using InputReadKeyFn = EFIAPI Status (*)(SimpleTextInputProtocol*, InputKey* key);
+
+    InputResetFn reset;
+    InputReadKeyFn read_key_stroke;
+    Event wait_for_key;
+};
+static_assert(AssertSize<SimpleTextInputProtocol, 24>());
+
+// https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-output-protocol
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-simple-text-output-protocol-setattribute
+struct [[gnu::packed]] TextAttribute {
+    enum class ForegroundColor : i32 {
+        Black = 0x00,
+        Blue = 0x01,
+        Green = 0x02,
+        Cyan = 0x03,
+        Red = 0x04,
+        Magenta = 0x05,
+        Brown = 0x06,
+        LightGray = 0x07,
+        DarkGray = 0x08,
+        LightBlue = 0x09,
+        LightGreen = 0x0a,
+        LightCyan = 0x0b,
+        LightRed = 0x0c,
+        LightMagenta = 0x0d,
+        Yellow = 0x0e,
+        White = 0x0f,
+    };
+
+    enum class BackgroundColor : i32 {
+        Black = 0x00,
+        Blue = 0x01,
+        Green = 0x02,
+        Cyan = 0x03,
+        Red = 0x04,
+        Magenta = 0x05,
+        Brown = 0x06,
+        LightGray = 0x07,
+    };
+
+    ForegroundColor foreground_color : 4;
+    BackgroundColor background_color : 3;
+    i32 : 32 - (4 + 3);
+};
+static_assert(AssertSize<TextAttribute, 4>());
+
+// SIMPLE_TEXT_OUTPUT_MODE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-output-protocol
+struct SimpleTextOutputMode {
+    i32 max_mode;
+    i32 mode;
+    TextAttribute attribute;
+    i32 cursor_column;
+    i32 cursor_row;
+    Boolean cursor_visible;
+};
+static_assert(AssertSize<SimpleTextOutputMode, 24>());
+
+// EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#simple-text-output-protocol
+struct SimpleTextOutputProtocol {
+    static constexpr GUID guid = { 0x387477c2, 0x69c7, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using TextResetFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, Boolean extended_verification);
+    using TextStringFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, char16_t* string);
+    using TextTestStringFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, char16_t* string);
+    using TextQueryModeFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, FlatPtr mode_number, FlatPtr* columns, FlatPtr* rows);
+    using TextSetModeFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, FlatPtr mode_number);
+    using TextSetAttributeFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, TextAttribute attribute);
+    using TextClearScreenFn = EFIAPI Status (*)(SimpleTextOutputProtocol*);
+    using TextSetCursorPositionFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, FlatPtr column, FlatPtr row);
+    using TextEnableCursorFn = EFIAPI Status (*)(SimpleTextOutputProtocol*, Boolean visible);
+
+    TextResetFn reset;
+    TextStringFn output_string;
+    TextTestStringFn test_string;
+    TextQueryModeFn query_mode;
+    TextSetModeFn set_mode;
+    TextSetAttributeFn set_attribute;
+    TextClearScreenFn clear_screen;
+    TextSetCursorPositionFn set_cursor_position;
+    TextEnableCursorFn enable_cursor;
+    SimpleTextOutputMode* mode;
+};
+static_assert(AssertSize<SimpleTextOutputProtocol, 80>());
+static_assert(__builtin_offsetof(SimpleTextOutputProtocol, output_string) == 8);
+
+// EFI_GRAPHICS_OUTPUT_BLT_PIXEL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+struct GraphicsOutputBltPixel {
+    u8 blue;
+    u8 green;
+    u8 red;
+    u8 reserved;
+};
+static_assert(AssertSize<GraphicsOutputBltPixel, 4>());
+
+// EFI_GRAPHICS_OUTPUT_BLT_OPERATION: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+enum class GraphicsOutputBltOperation {
+    VideoFill,
+    VideoToBltBuffer,
+    BufferToVideo,
+    VideoToVideo,
+    Max,
+};
+
+// EFI_GRAPHICS_PIXEL_FORMAT: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+enum class GraphicsPixelFormat {
+    RedGreenBlueReserved8BitPerColor,
+    BlueGreenRedReserved8BitPerColor,
+    BitMask,
+    BltOnly,
+    Max,
+};
+
+// EFI_PIXEL_BITMASK: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+struct PixelBitmask {
+    u32 red_mask;
+    u32 green_mask;
+    u32 blue_mask;
+    u32 reserved_mask;
+};
+static_assert(AssertSize<PixelBitmask, 16>());
+
+// EFI_GRAPHICS_OUTPUT_MODE_INFORMATION: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol-blt
+struct GraphicsOutputModeInformation {
+    u32 version;
+    u32 horizontal_resolution;
+    u32 vertical_resolution;
+    GraphicsPixelFormat pixel_format;
+    PixelBitmask pixel_information;
+    u32 pixels_per_scan_line;
+};
+static_assert(AssertSize<GraphicsOutputModeInformation, 36>());
+
+// EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol
+struct GraphicsOutputProtocolMode {
+    u32 max_mode;
+    u32 mode;
+    GraphicsOutputModeInformation* info;
+    FlatPtr size_of_info;
+    PhysicalAddress frame_buffer_base;
+    FlatPtr frame_buffer_size;
+};
+static_assert(AssertSize<GraphicsOutputProtocolMode, 40>());
+
+// EFI_GRAPHICS_OUTPUT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-graphics-output-protocol
+struct GraphicsOutputProtocol {
+    static constexpr GUID guid = { 0x9042a9de, 0x23dc, 0x4a38, { 0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a } };
+
+    using QueryModeFn = EFIAPI Status (*)(GraphicsOutputProtocol*, u32 mode_number, FlatPtr* size_of_info, GraphicsOutputModeInformation** Info);
+    using SetModeFn = EFIAPI Status (*)(GraphicsOutputProtocol*, u32 mode_number);
+    using BltFn = EFIAPI Status (*)(GraphicsOutputProtocol*, GraphicsOutputBltPixel* blt_buffer, GraphicsOutputBltOperation blt_operation, FlatPtr source_x, FlatPtr source_y, FlatPtr destination_x, FlatPtr destination_y, FlatPtr width, FlatPtr height, FlatPtr delta);
+
+    QueryModeFn query_mode;
+    SetModeFn set_mode;
+    BltFn blt;
+    GraphicsOutputProtocolMode* mode;
+};
+static_assert(AssertSize<GraphicsOutputProtocol, 32>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/DevicePath.h
+++ b/Kernel/Firmware/EFI/Protocols/DevicePath.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+// https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html
+
+namespace Kernel::EFI {
+
+// EFI_DEVICE_PATH_PROTOCOL: https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#efi-device-path-protocol
+struct DevicePathProtocol {
+    static constexpr GUID guid = { 0x09576e91, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    u8 type;
+    u8 sub_type;
+    u8 length[2];
+};
+static_assert(AssertSize<DevicePathProtocol, 4>());
+
+// EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL: https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#device-path-from-text-protocol
+struct DevicePathFromTextProtocol {
+    static constexpr GUID guid = { 0x5c99a21, 0xc70f, 0x4ad2, { 0x8a, 0x5f, 0x35, 0xdf, 0x33, 0x43, 0xf5, 0x1e } };
+
+    using DevicePathFromTextNodeFn = EFIAPI DevicePathProtocol (*)(char16_t const* text_device_node);
+    using DevicePathFromTextPathFn = EFIAPI DevicePathProtocol (*)(char16_t const* text_device_path);
+
+    DevicePathFromTextNodeFn convert_text_to_device_node;
+    DevicePathFromTextPathFn convert_text_to_device_path;
+};
+static_assert(AssertSize<DevicePathFromTextProtocol, 16>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/LoadedImage.h
+++ b/Kernel/Firmware/EFI/Protocols/LoadedImage.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/Protocols/DevicePath.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+// https://uefi.org/specs/UEFI/2.10/09_Protocols_EFI_Loaded_Image.html
+
+namespace Kernel::EFI {
+
+// EFI_LOADED_IMAGE_PROTOCOL: https://uefi.org/specs/UEFI/2.10/09_Protocols_EFI_Loaded_Image.html#efi-loaded-image-protocol
+struct LoadedImageProtocol {
+    static constexpr GUID guid = { 0x5b1b31a1, 0x9562, 0x11d2, { 0x8e, 0x3f, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using ImageUnloadFn = EFIAPI Status (*)(Handle* image_handle);
+
+    u32 revision;
+    Handle parent_handle;
+    SystemTable* system_table;
+
+    // Source location of the image
+    Handle device_handle;
+    DevicePathProtocol* file_path;
+    void* reserved;
+
+    // Image’s load options
+    u32 load_options_size;
+    void* load_options;
+
+    // Location where image was loaded
+    void* image_base;
+    u64 image_size;
+    MemoryType image_code_type;
+    MemoryType image_data_type;
+    ImageUnloadFn unload;
+};
+static_assert(AssertSize<LoadedImageProtocol, 96>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/MediaAccess.h
+++ b/Kernel/Firmware/EFI/Protocols/MediaAccess.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+// https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html
+
+namespace Kernel::EFI {
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-protocol-open
+enum class FileOpenMode : u64 {
+    Read = 0x1,
+    Write = 0x2,
+    Create = 0x8000000000000000,
+};
+AK_ENUM_BITWISE_OPERATORS(FileOpenMode)
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-protocol-open
+enum class FileAttribute : u64 {
+    None = 0x0,
+    ReadOnly = 0x1,
+    Hidden = 0x2,
+    System = 0x4,
+    Reserved = 0x8,
+    Directory = 0x10,
+    Archive = 0x20,
+};
+AK_ENUM_BITWISE_OPERATORS(FileAttribute)
+
+// EFI_FILE_INFO: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-info
+struct FileInfo {
+    static constexpr GUID guid = { 0x09576e92, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    u64 size;
+    u64 file_size;
+    u64 physical_size;
+    Time create_time;
+    Time last_access_time;
+    Time modification_time;
+    FileAttribute attribute;
+    char16_t file_name[];
+};
+static_assert(AssertSize<FileInfo, 80>());
+
+// EFI_FILE_IO_TOKEN: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#efi-file-protocol-openex
+struct FileIOToken {
+    Event event;
+    Status status;
+    FlatPtr buffer_size;
+    void* buffer;
+};
+static_assert(AssertSize<FileIOToken, 32>());
+
+// EFI_FILE_PROTOCOL: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#file-protocol
+struct FileProtocol {
+    using FileOpenFn = EFIAPI Status (*)(FileProtocol*, FileProtocol** new_handle, char16_t* file_name, FileOpenMode open_mode, FileAttribute attributes);
+    using FileCloseFn = EFIAPI Status (*)(FileProtocol*);
+    using FileDeleteFn = EFIAPI Status (*)(FileProtocol*);
+    using FileReadFn = EFIAPI Status (*)(FileProtocol*, FlatPtr* buffer_size, void* buffer);
+    using FileWriteFn = EFIAPI Status (*)(FileProtocol*, FlatPtr* buffer_size, void* buffer);
+    using FileOpenExFn = EFIAPI Status (*)(FileProtocol*, FileProtocol** new_handle, char16_t* file_name, FileOpenMode open_mode, FileAttribute attributes, FileIOToken* token);
+    using FileReadExFn = EFIAPI Status (*)(FileProtocol*, FileIOToken* token);
+    using FileWriteExFn = EFIAPI Status (*)(FileProtocol*, FileIOToken* token);
+    using FileFlushExFn = EFIAPI Status (*)(FileProtocol*, FileIOToken* token);
+    using FileSetPositionFn = EFIAPI Status (*)(FileProtocol*, u64 position);
+    using FileGetPositionFn = EFIAPI Status (*)(FileProtocol*, u64* position);
+    using FileGetInfoFn = EFIAPI Status (*)(FileProtocol*, GUID* information_type, FlatPtr* buffer_size, void* buffer);
+    using FileSetInfoFn = EFIAPI Status (*)(FileProtocol*, GUID* information_type, FlatPtr buffer_size, void* buffer);
+    using FileFlushFn = EFIAPI Status (*)(FileProtocol*);
+
+    u64 revision;
+    FileOpenFn open;
+    FileCloseFn close;
+    FileDeleteFn delete_;
+    FileReadFn read;
+    FileWriteFn write;
+    FileGetPositionFn get_position;
+    FileSetPositionFn set_position;
+    FileGetInfoFn get_info;
+    FileSetInfoFn set_info;
+    FileFlushFn flush;
+
+    // Revision 2+
+
+    FileOpenExFn open_ex;
+    FileReadExFn read_ex;
+    FileWriteExFn write_ex;
+    FileFlushExFn flush_ex;
+};
+static_assert(AssertSize<FileProtocol, 120>());
+
+// EFI_SIMPLE_FILE_SYSTEM_PROTOCOL: https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#simple-file-system-protocol
+struct SimpleFileSystemProtocol {
+    static constexpr GUID guid = { 0x0964e5b22, 0x6459, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+    using SimpleFileSystemProtocolOpenVolumeFn = EFIAPI Status (*)(SimpleFileSystemProtocol*, FileProtocol** root);
+
+    u64 revision;
+    SimpleFileSystemProtocolOpenVolumeFn open_volume;
+};
+static_assert(AssertSize<SimpleFileSystemProtocol, 16>());
+
+}

--- a/Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h
+++ b/Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+namespace Kernel::EFI {
+
+// RISCV_EFI_BOOT_PROTOCOL: https://github.com/riscv-non-isa/riscv-uefi/releases/download/1.0.0/RISCV_UEFI_PROTOCOL-spec.pdf
+struct RISCVBootProtocol {
+    static constexpr GUID guid = { 0xccd15fec, 0x6f73, 0x4eec, { 0x83, 0x95, 0x3e, 0x69, 0xe4, 0xb9, 0x40, 0xbf } };
+
+    using GetBootHartIDFn = EFIAPI Status (*)(RISCVBootProtocol*, FlatPtr* boot_hart_id);
+
+    u64 revision;
+    GetBootHartIDFn get_boot_hart_id;
+};
+static_assert(AssertSize<RISCVBootProtocol, 16>());
+
+}

--- a/Kernel/Firmware/EFI/Services/BootServices.h
+++ b/Kernel/Firmware/EFI/Services/BootServices.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+// https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html
+
+namespace Kernel::EFI {
+
+// EFI_ALLOCATE_TYPE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+enum class AllocateType {
+    AnyPages,
+    MaxAddress,
+    Address,
+};
+
+// EFI_MEMORY_TYPE: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-allocatepages
+enum class MemoryType : u32 {
+    Reserved,
+    LoaderCode,
+    LoaderData,
+    BootServicesCode,
+    BootServicesData,
+    RuntimeServicesCode,
+    RuntimeServicesData,
+    Conventional,
+    Unusable,
+    ACPIReclaim,
+    ACPI_NVS,
+    MemoryMappedIO,
+    MemoryMappedIOPortSpace,
+    PALCode,
+    Persistent,
+    Unaccepted,
+};
+
+// See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+enum class MemoryAttribute : u64 {
+    SupportsNotCachable = 0x0000000000000001,                       // UC
+    SupportsWriteCombining = 0x0000000000000002,                    // WC
+    SupportsWriteThrough = 0x0000000000000004,                      // WT
+    SupportsWriteBack = 0x0000000000000008,                         // WB
+    SupportsNotCachableExportedAndFetchAndAdd = 0x0000000000000010, // UCE
+    SupportsWriteProtection = 0x0000000000001000,                   // WP
+    SupportsReadProtection = 0x0000000000002000,                    // RP
+    SupportsExecuteProtection = 0x0000000000004000,                 // XP
+    PersistentMemory = 0x0000000000008000,                          // NV
+    MoreReliable = 0x0000000000010000,                              // MORE_RELIABLE
+    SupportsReadOnly = 0x0000000000020000,                          // RO
+    SpecificPurposeMemory = 0x0000000000040000,                     // SP
+    SupportsCryptographicProtection = 0x0000000000080000,           // CPU_CRYPTO
+    Runtime = 0x8000000000000000,                                   // RUNTIME
+    ISAValid = 0x4000000000000000,                                  // ISA_VALID
+    ISAMask = 0x0ffff00000000000,                                   // ISA_MASK
+};
+
+// EFI_MEMORY_DESCRIPTOR: See "Related Definitions" at https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-getmemorymap
+struct MemoryDescriptor {
+    MemoryType type;
+    PhysicalAddress physical_start;
+    VirtualAddress virtual_start;
+    u64 number_of_pages;
+    MemoryAttribute attribute;
+};
+static_assert(AssertSize<MemoryDescriptor, 40>());
+
+// EFI_BOOT_SERVICES: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-boot-services-table
+struct BootServices {
+    static constexpr u64 signature = 0x56524553544f4f42;
+
+    using RaiseTPLFn = void*;
+    using RestoreTPLFn = void*;
+    using AllocatePagesFn = EFIAPI Status (*)(AllocateType type, MemoryType memory_type, FlatPtr pages, PhysicalAddress* memory);
+    using FreePagesFn = EFIAPI Status (*)(PhysicalAddress memory, FlatPtr pages);
+    using GetMemoryMapFn = EFIAPI Status (*)(FlatPtr* memory_map_size, MemoryDescriptor* memory_map, FlatPtr* map_key, FlatPtr* descriptor_size, u32* descriptor_version);
+    using AllocatePoolFn = EFIAPI Status (*)(MemoryType pool_type, FlatPtr size, void** buffer);
+    using FreePoolFn = EFIAPI Status (*)(void* buffer);
+    using CreateEventFn = void*;
+    using SetTimerFn = void*;
+    using WaitForEventFn = void*;
+    using SignalEventFn = void*;
+    using CloseEventFn = void*;
+    using CheckEventFn = void*;
+    using InstallProtocolInterfaceFn = void*;
+    using ReinstallProtocolInterfaceFn = void*;
+    using UninstallProtocolInterfaceFn = void*;
+    using HandleProtocolFn = EFIAPI Status (*)(Handle handle, GUID* protocol, void** interface);
+    using RegisterProtocolNotifyFn = void*;
+    using LocateHandleFn = void*;
+    using LocateDevicePathFn = void*;
+    using InstallConfigurationTableFn = void*;
+    using ImageUnloadFn = void*;
+    using ImageStartFn = void*;
+    using ExitFn = void*;
+    using ExitBootServicesFn = EFIAPI Status (*)(Handle image_handle, FlatPtr map_key);
+    using GetNextMonotonicCountFn = void*;
+    using StallFn = void*;
+    using SetWatchdogTimerFn = void*;
+    using ConnectControllerFn = void*;
+    using DisconnectControllerFn = void*;
+    using OpenProtocolFn = void*;
+    using CloseProtocolFn = void*;
+    using OpenProtocolInformationFn = void*;
+    using ProtocolsPerHandleFn = void*;
+    using LocateHandleBufferFn = void*;
+    using LocateProtocolFn = EFIAPI Status (*)(GUID* protocol, void* registration, void** interface);
+    using UninstallMultipleProtocolInterfacesFn = void*;
+    using CalculateCrc32Fn = void*;
+    using CopyMemFn = void*;
+    using SetMemFn = void*;
+    using CreateEventExFn = void*;
+
+    TableHeader hdr;
+
+    // EFI 1.0+
+
+    // Task Priority Services
+    RaiseTPLFn raise_tpl;
+    RestoreTPLFn restore_tpl;
+
+    // Memory Services
+    AllocatePagesFn allocate_pages;
+    FreePagesFn free_pages;
+    GetMemoryMapFn get_memory_map;
+    AllocatePoolFn allocate_pool;
+    FreePoolFn free_pool;
+
+    // Event & Timer Services
+    CreateEventFn create_event;
+    SetTimerFn set_timer;
+    WaitForEventFn wait_for_event;
+    SignalEventFn signal_event;
+    CloseEventFn close_event;
+    CheckEventFn check_event;
+
+    // Protocol Handler Services
+    InstallProtocolInterfaceFn install_protocol_interface;
+    ReinstallProtocolInterfaceFn reinstall_protocol_interface;
+    UninstallProtocolInterfaceFn uninstall_protocol_interface;
+    HandleProtocolFn handle_protocol;
+    void* reserved;
+    RegisterProtocolNotifyFn register_protocol_notify;
+    LocateHandleFn locate_handle;
+    LocateDevicePathFn locate_device_path;
+    InstallConfigurationTableFn install_configuration_table;
+
+    // Image Services
+    ImageUnloadFn load_image;
+    ImageStartFn start_image;
+    ExitFn exit;
+    ImageUnloadFn unload_image;
+    ExitBootServicesFn exit_boot_services;
+
+    // Miscellaneous Services
+    GetNextMonotonicCountFn get_next_monotonic_count;
+    StallFn stall;
+    SetWatchdogTimerFn set_watchdog_timer;
+
+    // EFI 1.1+
+
+    // DriverSupport Services
+    ConnectControllerFn connect_controller;
+    DisconnectControllerFn disconnect_controller;
+
+    // Open and Close Protocol Services
+    OpenProtocolFn open_protocol;
+    CloseProtocolFn close_protocol;
+    OpenProtocolInformationFn open_protocol_information;
+
+    // Library Services
+    ProtocolsPerHandleFn protocols_per_handle;
+    LocateHandleBufferFn locate_handle_buffer;
+    LocateProtocolFn locate_protocol;
+    UninstallMultipleProtocolInterfacesFn install_multiple_protocol_interfaces;
+    UninstallMultipleProtocolInterfacesFn uninstall_multiple_protocol_interfaces;
+
+    // 32-bit CRC Services
+    CalculateCrc32Fn calculate_crc32;
+
+    // Miscellaneous Services
+    CopyMemFn copy_mem;
+    SetMemFn set_mem;
+
+    // UEFI 2.0+
+
+    CreateEventExFn create_event_ex;
+};
+static_assert(AssertSize<BootServices, 376>());
+
+}

--- a/Kernel/Firmware/EFI/SystemTable.h
+++ b/Kernel/Firmware/EFI/SystemTable.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/Protocols/ConsoleSupport.h>
+#include <Kernel/Firmware/EFI/Services/BootServices.h>
+
+// https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html
+
+namespace Kernel::EFI {
+
+// EFI_CONFIGURATION_TABLE: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-configuration-table-properties-table
+struct ConfigurationTable {
+    GUID vendor_guid;
+    void* vendor_table;
+};
+static_assert(AssertSize<ConfigurationTable, 24>());
+
+// EFI_DTB_TABLE_GUID: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#devicetree-tables
+static constexpr GUID DTB_TABLE_GUID = { 0xb1b621d5, 0xf19c, 0x41a5, { 0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0 } };
+
+// EFI_SYSTEM_TABLE: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-system-table-1
+struct SystemTable {
+    static constexpr u64 signature = 0x5453595320494249;
+
+    using RuntimeServices = void;
+
+    TableHeader hdr;
+    char16_t* firmware_vendor;
+    u32 firmware_revision;
+    Handle console_in_handle;
+    SimpleTextInputProtocol* con_in;
+    Handle console_out_handle;
+    SimpleTextOutputProtocol* con_out;
+    Handle standard_error_handle;
+    SimpleTextOutputProtocol* std_err;
+    RuntimeServices* runtime_services;
+    BootServices* boot_services;
+    FlatPtr number_of_table_entries;
+    ConfigurationTable* configuration_table;
+};
+static_assert(AssertSize<SystemTable, 120>());
+
+}


### PR DESCRIPTION
These headers will be used by the EFI Prekernel to communicate with the platform firmware.
The definitions are adapted from the [UEFI specification](https://uefi.org/specs/UEFI/2.10/index.html) to match our code style.

This PR does not depend on any of the other EFI Prekernel PRs.