### PR TITLE
Kernel: Use write(2) to /dev/(u)random as entropy source

### DIFF
--- a/Kernel/Devices/Generic/RandomDevice.cpp
+++ b/Kernel/Devices/Generic/RandomDevice.cpp
@@ -40,10 +40,13 @@ ErrorOr<size_t> RandomDevice::read(OpenFileDescription&, u64, UserOrKernelBuffer
     });
 }
 
-ErrorOr<size_t> RandomDevice::write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t size)
+ErrorOr<size_t> RandomDevice::write(OpenFileDescription&, u64, UserOrKernelBuffer const& buffer, size_t size)
 {
-    // FIXME: Use input for entropy? I guess that could be a neat feature?
-    return size;
+    return buffer.read_buffered<128>(size, [&](ReadonlyBytes bytes) {
+        for (auto const& byte : bytes)
+            m_entropy_source.add_random_event(byte);
+        return bytes.size();
+    });
 }
 
 }

--- a/Kernel/Devices/Generic/RandomDevice.h
+++ b/Kernel/Devices/Generic/RandomDevice.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/Security/Random.h>
 
 namespace Kernel {
 
@@ -29,6 +30,8 @@ private:
     virtual bool can_read(OpenFileDescription const&, u64) const override;
     virtual bool can_write(OpenFileDescription const&, u64) const override { return true; }
     virtual StringView class_name() const override { return "RandomDevice"sv; }
+
+    EntropySource m_entropy_source;
 };
 
 }

--- a/Userland/Utilities/init.cpp
+++ b/Userland/Utilities/init.cpp
@@ -124,7 +124,7 @@ static ErrorOr<void> prepare_bare_minimum_devtmpfs_directory_structure()
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/mem"sv, 0600, 1, 1));
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/null"sv, 0666, 1, 3));
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/full"sv, 0666, 1, 7));
-    TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/random"sv, 0666, 1, 8));
+    TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/random"sv, 0644, 1, 8));
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/console"sv, 0666, 5, 1));
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/ptmx"sv, 0666, 5, 2));
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/tty"sv, 0666, 5, 0));
@@ -134,7 +134,7 @@ static ErrorOr<void> prepare_bare_minimum_devtmpfs_directory_structure()
 #endif
     umask(old_mask);
     TRY(Core::System::symlink("/dev/random"sv, "/dev/urandom"sv));
-    TRY(Core::System::chmod("/dev/urandom"sv, 0666));
+    TRY(Core::System::chmod("/dev/urandom"sv, 0644));
     return {};
 }
 


### PR DESCRIPTION
This feature allows userspace to supply the kernel's random event pool by using the `write(2)` system call on random device nodes. This functionality is widely adopted by other UNIX-like systems and allows the use of software events as an entropy source. To mitigate the potential effects of repetitive or malicious input, writing to random device nodes is restricted to the root user.