### PR TITLE
AK: Array and Tuple structured bindings

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
+#include <AK/Tuple.h>
 #include <AK/TypedTransfer.h>
 
 namespace AK {
@@ -61,6 +62,30 @@ struct Array {
     {
         VERIFY(index < size());
         return __data[index];
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T& get() &
+    {
+        return at(S);
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T const& get() const&
+    {
+        return at(S);
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T&& get() &&
+    {
+        return move(at(S));
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T const&& get() const&&
+    {
+        return move(at(S));
     }
 
     [[nodiscard]] constexpr T const& first() const { return at(0); }
@@ -176,6 +201,16 @@ constexpr auto to_array(T (&&a)[N])
     return Detail::to_array_impl(move(a), MakeIndexSequence<N>());
 }
 
+}
+
+namespace AK_REPLACED_STD_NAMESPACE {
+template<size_t I, typename T, size_t N>
+struct tuple_element<I, Array<T, N>> {
+    using type = T;
+};
+
+template<typename T, size_t N>
+struct tuple_size<Array<T, N>> : AK::Detail::IntegralConstant<size_t, N> { };
 }
 
 #if USING_AK_GLOBALLY

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -68,11 +68,19 @@ constexpr T&& move(T& arg)
     return static_cast<T&&>(arg);
 }
 
+template<size_t I, typename T>
+struct tuple_element;
+
+template<typename T>
+struct tuple_size;
+
 }
 
 namespace AK {
 using AK_REPLACED_STD_NAMESPACE::forward;
 using AK_REPLACED_STD_NAMESPACE::move;
+using AK_REPLACED_STD_NAMESPACE::tuple_element;
+using AK_REPLACED_STD_NAMESPACE::tuple_size;
 }
 
 namespace AK::Detail {
@@ -227,4 +235,6 @@ using AK::RawPtr;
 using AK::round_up_to_power_of_two;
 using AK::swap;
 using AK::to_underlying;
+using AK::tuple_element;
+using AK::tuple_size;
 #endif

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -141,27 +141,51 @@ struct Tuple : Detail::Tuple<Ts...> {
     }
 
     template<typename T>
-    auto& get()
+    auto& get() &
     {
         return Detail::Tuple<Ts...>::template get<T>();
-    }
-
-    template<size_t index>
-    auto& get()
-    {
-        return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
     }
 
     template<typename T>
-    auto& get() const
+    auto&& get() &&
+    {
+        return move(Detail::Tuple<Ts...>::template get<T>());
+    }
+
+    template<size_t index>
+    auto& get() &
+    {
+        return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
+    }
+
+    template<size_t index>
+    auto&& get() &&
+    {
+        return move(Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>());
+    }
+
+    template<typename T>
+    auto& get() const&
     {
         return Detail::Tuple<Ts...>::template get<T>();
     }
 
+    template<typename T>
+    auto&& get() const&&
+    {
+        return move(Detail::Tuple<Ts...>::template get<T>());
+    }
+
     template<size_t index>
-    auto& get() const
+    auto& get() const&
     {
         return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
+    }
+
+    template<size_t index>
+    auto&& get() const&&
+    {
+        return move(Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>());
     }
 
     template<typename F>

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -219,8 +219,24 @@ private:
 template<class... Args>
 Tuple(Args... args) -> Tuple<Args...>;
 
+template<size_t I, typename T>
+struct TupleElement;
+
+template<size_t I, typename... Ts>
+struct TupleElement<I, Tuple<Ts...>> {
+    using Type = TypeListElement<I, typename Tuple<Ts...>::Types>::Type;
+};
+
+template<typename T>
+struct TupleSize;
+
+template<typename... Ts>
+struct TupleSize<Tuple<Ts...>> : Detail::IntegralConstant<size_t, sizeof...(Ts)> { };
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::Tuple;
+using AK::TupleElement;
+using AK::TupleSize;
 #endif

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -235,6 +235,16 @@ struct TupleSize<Tuple<Ts...>> : Detail::IntegralConstant<size_t, sizeof...(Ts)>
 
 }
 
+namespace AK_REPLACED_STD_NAMESPACE {
+template<size_t I, typename... Ts>
+struct tuple_element<I, AK::Tuple<Ts...>> {
+    using type = AK::TupleElement<I, AK::Tuple<Ts...>>::Type;
+};
+
+template<typename... Ts>
+struct tuple_size<AK::Tuple<Ts...>> : AK::TupleSize<AK::Tuple<Ts...>> { };
+}
+
 #if USING_AK_GLOBALLY
 using AK::Tuple;
 using AK::TupleElement;

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -55,3 +55,13 @@ TEST_CASE(to_array)
     static_assert(array[1] == 2);
     static_assert(array[2] == 1);
 }
+
+TEST_CASE(structured_binding)
+{
+    Array<int, 4> array = { 2, 3, 5, 7 };
+    auto const& [a, b, c, d] = array;
+    EXPECT_EQ(a, 2);
+    EXPECT_EQ(b, 3);
+    EXPECT_EQ(c, 5);
+    EXPECT_EQ(d, 7);
+}

--- a/Tests/AK/TestTuple.cpp
+++ b/Tests/AK/TestTuple.cpp
@@ -107,3 +107,12 @@ TEST_CASE(apply)
         EXPECT(was_called);
     }
 }
+
+TEST_CASE(structured_binding)
+{
+    Tuple<int, int, ByteString> tuple { 1, 2, "foo" };
+    auto const& [a, b, c] = tuple;
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 2);
+    EXPECT_EQ(c, "foo");
+}


### PR DESCRIPTION
This PR allows Array and Tuple to be used in structured binding declarations.

This is a new copy of #24986 because apparently I can't re-open closed PRs.