### PR TITLE
EFI Prekernel (5/N): EFIPrekernel: Add basic skeleton

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -878,7 +878,7 @@ add_custom_command(
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
     COMMAND ${CMAKE_OBJCOPY} --set-section-flags .heap=load Kernel Kernel_shared_object
     COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_image --set-section-alignment .Kernel_image=4096 Kernel_shared_object Kernel.o
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel_shared_object ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
 )
 
 # Architectures (x86_64, aarch64, riscv64) share the same location in their respective architecture build folder.

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -906,7 +906,9 @@ endif()
 serenity_install_headers(Kernel)
 serenity_install_sources(Kernel)
 
-# Only x86 needs a Prekernel
+# Only x86 uses the Multiboot Prekernel
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     add_subdirectory(Prekernel)
 endif()
+
+add_subdirectory(EFIPrekernel)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -860,38 +860,29 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     target_link_libraries(Kernel PRIVATE kernel_heap clang_rt.builtins)
 endif()
 
-if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+if ("${SERENITY_ARCH}" STREQUAL "aarch64")
+    set(KERNEL_ELF_OBJCOPY_TARGET "elf64-littleaarch64")
+elseif ("${SERENITY_ARCH}" STREQUAL "riscv64")
+    set(KERNEL_ELF_OBJCOPY_TARGET "elf64-littleriscv")
+elseif ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(KERNEL_ELF_OBJCOPY_TARGET "elf64-x86-64")
 endif()
 
-# In x86_64 the Kernel is linked to the Pre-kernel binary.
-if ("${SERENITY_ARCH}" STREQUAL "x86_64")
-    add_custom_command(
-        TARGET Kernel POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-        COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
-        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
-        COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
-        COMMAND ${CMAKE_OBJCOPY} --set-section-flags .heap=load Kernel Kernel_shared_object
-        COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_image --set-section-alignment .Kernel_image=4096 Kernel_shared_object Kernel.o
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
-    )
-elseif ("${SERENITY_ARCH}" STREQUAL "aarch64" OR "${SERENITY_ARCH}" STREQUAL "riscv64")
-    add_custom_command(
-        TARGET Kernel POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-        COMMAND "${CMAKE_COMMAND}" -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
-        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
-        COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
-    )
-endif()
+# The Kernel is linked to the Pre-kernel binary.
+add_custom_command(
+    TARGET Kernel POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+    COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
+    COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
+    COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
+    COMMAND ${CMAKE_OBJCOPY} --set-section-flags .heap=load Kernel Kernel_shared_object
+    COMMAND ${CMAKE_OBJCOPY} -I binary -O ${KERNEL_ELF_OBJCOPY_TARGET} --rename-section .data=.Kernel_image --set-section-alignment .Kernel_image=4096 Kernel_shared_object Kernel.o
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.o ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
+)
 
 # Architectures (x86_64, aarch64, riscv64) share the same location in their respective architecture build folder.
-# In x86_64 the Kernel is linked to the Pre-kernel binary and then generates the result Kernel binary.
-# In aarch64 and riscv64 there's no Pre-kernel stage yet, so we immediately get a Kernel binary.
+# The Kernel is linked to the Pre-kernel binary and then generates the result Kernel binary.
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.debug" DESTINATION boot)

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -1,0 +1,69 @@
+set(PREKERNEL_KERNEL_IMAGE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../Kernel_shared_object)
+configure_file(KernelImage.S.in KernelImage.S @ONLY)
+
+set(SOURCES
+    init.cpp
+
+    DebugOutput.cpp
+    Panic.cpp
+    Runtime.cpp
+    kmalloc.cpp
+
+    KernelImage.S
+
+    ../Firmware/EFI/EFI.cpp
+    ../Library/MiniStdLib.cpp
+    ../Prekernel/UBSanitizer.cpp
+
+    ../../AK/Format.cpp
+    ../../AK/StringBuilder.cpp
+    ../../AK/StringUtils.cpp
+    ../../AK/StringView.cpp
+)
+
+set_source_files_properties(KernelImage.S PROPERTIES OBJECT_DEPENDS ${PREKERNEL_KERNEL_IMAGE_PATH})
+
+add_compile_definitions(PREKERNEL)
+
+add_executable(EFIPrekernel ${SOURCES})
+
+add_dependencies(EFIPrekernel Kernel)
+add_dependencies(EFIPrekernel install_libc_headers)
+
+target_compile_options(EFIPrekernel PRIVATE -fno-threadsafe-statics)
+target_link_options(EFIPrekernel PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld LINKER:--no-dynamic-linker -nostdlib)
+set_target_properties(EFIPrekernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(EFIPrekernel PRIVATE gcc)
+
+    # Prevent naively implemented string functions (like strlen) from being "optimized" into a call to themselves.
+    set_source_files_properties(../Library/MiniStdLib.cpp
+        PROPERTIES COMPILE_FLAGS "-fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    target_link_libraries(EFIPrekernel PRIVATE clang_rt.builtins)
+endif()
+
+# The PrekernelPEImageGenerator doesn't support RELR relocations.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    target_link_options(EFIPrekernel PRIVATE LINKER:-z,nopack-relative-relocs LINKER:--pack-dyn-relocs=none)
+elseif("${SERENITY_ARCH}" STREQUAL "x86_64")
+    target_link_options(EFIPrekernel PRIVATE LINKER:-z,nopack-relative-relocs)
+endif()
+
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi
+    COMMAND $<TARGET_FILE:Lagom::PrekernelPEImageGenerator> ${CMAKE_CURRENT_BINARY_DIR}/EFIPrekernel ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi
+    VERBATIM
+    DEPENDS EFIPrekernel Lagom::PrekernelPEImageGenerator
+)
+
+add_custom_target(generate_kernel_efi_image ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Kernel.efi DESTINATION boot)
+
+# Remove options which the Prekernel environment doesn't support.
+get_target_property(EFI_PREKERNEL_COMPILE_OPTIONS EFIPrekernel COMPILE_OPTIONS)
+list(REMOVE_ITEM EFI_PREKERNEL_COMPILE_OPTIONS "-fsanitize-coverage=trace-pc")
+list(REMOVE_ITEM EFI_PREKERNEL_COMPILE_OPTIONS "-fsanitize=kernel-address")
+set_target_properties(EFIPrekernel PROPERTIES COMPILE_OPTIONS "${EFI_PREKERNEL_COMPILE_OPTIONS}")

--- a/Kernel/EFIPrekernel/DebugOutput.cpp
+++ b/Kernel/EFIPrekernel/DebugOutput.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <AK/kstdio.h>
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+void ucs2_dbgln(char16_t const* message)
+{
+    if (g_efi_system_table == nullptr || g_efi_system_table->con_out == nullptr)
+        return;
+
+    g_efi_system_table->con_out->output_string(g_efi_system_table->con_out, const_cast<char16_t*>(message));
+    g_efi_system_table->con_out->output_string(g_efi_system_table->con_out, const_cast<char16_t*>(u"\r\n"));
+}
+
+}
+
+extern "C" void dbgputstr(char const* characters, size_t length)
+{
+    if (Kernel::g_efi_system_table == nullptr || Kernel::g_efi_system_table->con_out == nullptr)
+        return;
+
+    Vector<char16_t, 256> utf16_string;
+    StringView string_view { characters, length };
+
+    // FIXME: Support non-ASCII messages
+    for (auto c : string_view) {
+        if (c == '\n') {
+            if (utf16_string.try_append(u'\r').is_error())
+                return;
+        }
+
+        if (utf16_string.try_append(c).is_error())
+            return;
+    }
+
+    if (utf16_string.try_append(0).is_error())
+        return;
+
+    Kernel::g_efi_system_table->con_out->output_string(Kernel::g_efi_system_table->con_out, bit_cast<char16_t*>(utf16_string.data()));
+}

--- a/Kernel/EFIPrekernel/DebugOutput.h
+++ b/Kernel/EFIPrekernel/DebugOutput.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+void ucs2_dbgln(char16_t const* message);
+
+}

--- a/Kernel/EFIPrekernel/Error.h
+++ b/Kernel/EFIPrekernel/Error.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+
+#include <Kernel/Firmware/EFI/EFI.h>
+
+namespace Kernel {
+
+template<typename T>
+using EFIErrorOr = ErrorOr<T, EFI::Status>;
+
+}

--- a/Kernel/EFIPrekernel/Globals.h
+++ b/Kernel/EFIPrekernel/Globals.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+namespace Kernel {
+
+extern EFI::Handle g_efi_image_handle;
+extern EFI::SystemTable* g_efi_system_table;
+
+}

--- a/Kernel/EFIPrekernel/KernelImage.S.in
+++ b/Kernel/EFIPrekernel/KernelImage.S.in
@@ -1,0 +1,11 @@
+// The kernel image has to be in a writable section, so we can apply relocations while EFI boot services are still available
+// (we are not allowed to change page tables until we call ExitBootServices()).
+.section .data
+
+.global start_of_kernel_image
+.global end_of_kernel_image
+
+.p2align 12
+start_of_kernel_image:
+.incbin "@PREKERNEL_KERNEL_IMAGE_PATH@"
+end_of_kernel_image:

--- a/Kernel/EFIPrekernel/Panic.cpp
+++ b/Kernel/EFIPrekernel/Panic.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+[[noreturn]] void __panic(char const* file, unsigned int line, char const* function)
+{
+    dbgln("at {}:{} in {}", file, line, function);
+
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Panic.h
+++ b/Kernel/EFIPrekernel/Panic.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+
+namespace Kernel {
+
+[[noreturn]] void __panic(char const* file, unsigned int line, char const* function);
+
+#define PANIC(...)                                                  \
+    do {                                                            \
+        ::Kernel::ucs2_dbgln(u"PREKERNEL PANIC! :^(");              \
+        dbgln(__VA_ARGS__);                                         \
+        ::Kernel::__panic(__FILE__, __LINE__, __PRETTY_FUNCTION__); \
+    } while (0)
+
+}

--- a/Kernel/EFIPrekernel/Runtime.cpp
+++ b/Kernel/EFIPrekernel/Runtime.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+[[noreturn]] void halt()
+{
+    for (;;) {
+#if ARCH(AARCH64)
+        asm volatile("msr daifset, #2; wfi");
+#elif ARCH(RISCV64)
+        asm volatile("csrw sie, zero; wfi");
+#elif ARCH(X86_64)
+        asm volatile("cli; hlt");
+#else
+#    error Unknown architecture
+#endif
+    }
+}
+
+}

--- a/Kernel/EFIPrekernel/Runtime.h
+++ b/Kernel/EFIPrekernel/Runtime.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+[[noreturn]] void halt();
+
+}

--- a/Kernel/EFIPrekernel/VirtualMemoryLayout.h
+++ b/Kernel/EFIPrekernel/VirtualMemoryLayout.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+// Kernel virtual memory layout:
+// Kernel stack | BootInfo | Quickmap page table | EFI memory map | Kernel
+// ^ KERNEL_MAPPING_BASE
+// NOTE: If the memory map overflows into the kernel memory range, we catch that in the map_pages function (a page is not allowed to be remapped)
+
+static constexpr size_t KERNEL_STACK_SIZE = 64 * KiB;
+static_assert(KERNEL_STACK_SIZE % PAGE_SIZE == 0);
+
+static constexpr FlatPtr KERNEL_STACK_VADDR = KERNEL_MAPPING_BASE;
+static constexpr FlatPtr BOOT_INFO_VADDR = KERNEL_MAPPING_BASE + KERNEL_STACK_SIZE;
+
+static constexpr FlatPtr QUICKMAP_PAGE_TABLE_VADDR = round_up_to_power_of_two(BOOT_INFO_VADDR + sizeof(BootInfo), PAGE_SIZE);
+
+// This assumes PAGE_SIZE == PAGE_TABLE_SIZE
+static constexpr FlatPtr EFI_MEMORY_MAP_VADDR = QUICKMAP_PAGE_TABLE_VADDR + PAGE_SIZE;
+
+}

--- a/Kernel/EFIPrekernel/init.cpp
+++ b/Kernel/EFIPrekernel/init.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/SystemTable.h>
+
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+// FIXME: Initialize the __stack_chk_guard with a random value via the EFI_RNG_PROTOCOL or other arch-specific methods.
+uintptr_t __stack_chk_guard __attribute__((used));
+
+namespace Kernel {
+
+extern "C" [[noreturn]] void __stack_chk_fail();
+extern "C" [[noreturn]] void __stack_chk_fail()
+{
+    PANIC("Stack protector failure, stack smashing detected!");
+}
+
+EFI::Handle g_efi_image_handle = 0;
+EFI::SystemTable* g_efi_system_table = nullptr;
+
+static_assert(EFI::EFI_PAGE_SIZE == PAGE_SIZE, "The EFIPrekernel assumes that EFI_PAGE_SIZE == PAGE_SIZE");
+
+extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table);
+extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table)
+{
+    // We use some EFI 1.10 functions from the System Table, so reject older versions.
+    static constexpr u32 efi_version_1_10 = (1 << 16) | 10;
+    if (system_table->hdr.signature != EFI::SystemTable::signature || system_table->hdr.revision < efi_version_1_10)
+        return EFI::Status::Unsupported;
+
+    g_efi_image_handle = image_handle;
+    g_efi_system_table = system_table;
+
+    system_table->con_out->set_attribute(system_table->con_out,
+        EFI::TextAttribute {
+            .foreground_color = EFI::TextAttribute::ForegroundColor::White,
+            .background_color = EFI::TextAttribute::BackgroundColor::Black,
+        });
+
+    // Clear the screen. This also removes the manufacturer logo, if present.
+    system_table->con_out->clear_screen(system_table->con_out);
+
+    ucs2_dbgln(u"SerenityOS EFI Prekernel");
+
+    TODO();
+}
+
+}
+
+void __assertion_failed(char const* msg, char const* file, unsigned int line, char const* func)
+{
+    dbgln("ASSERTION FAILED: {}", msg);
+    dbgln("{}:{} in {}", file, line, func);
+    Kernel::halt();
+}

--- a/Kernel/EFIPrekernel/kmalloc.cpp
+++ b/Kernel/EFIPrekernel/kmalloc.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/kmalloc.h>
+
+#include <Kernel/EFIPrekernel/Globals.h>
+
+static size_t s_kmalloc_call_count;
+static size_t s_kfree_call_count;
+
+void kfree_sized(void* ptr, size_t)
+{
+    if (Kernel::g_efi_system_table == nullptr || Kernel::g_efi_system_table->boot_services == nullptr)
+        return;
+
+    s_kfree_call_count++;
+    Kernel::g_efi_system_table->boot_services->free_pool(ptr);
+}
+
+void* kmalloc(size_t size)
+{
+    if (Kernel::g_efi_system_table == nullptr || Kernel::g_efi_system_table->boot_services == nullptr)
+        return nullptr;
+
+    void* ret;
+
+    s_kmalloc_call_count++;
+
+    if (Kernel::g_efi_system_table->boot_services->allocate_pool(Kernel::EFI::MemoryType::LoaderData, size, &ret) != Kernel::EFI::Status::Success)
+        return nullptr;
+
+    return ret;
+}
+
+size_t kmalloc_good_size(size_t size)
+{
+    return size;
+}
+
+void get_kmalloc_stats(kmalloc_stats& stats)
+{
+    stats.bytes_allocated = 0;
+    stats.bytes_free = 0;
+    stats.kmalloc_call_count = s_kmalloc_call_count;
+    stats.kfree_call_count = s_kfree_call_count;
+}

--- a/Kernel/EFIPrekernel/linker.ld
+++ b/Kernel/EFIPrekernel/linker.ld
@@ -1,0 +1,45 @@
+ENTRY(init)
+
+SECTIONS
+{
+    /* This is symbol is used to tell the PrekernelPEImageGenerator that the PE base address is 0 */
+    pe_image_base = .;
+
+    /* PE doesn't have segments, so PE sections behave similarly to ELF segments. */
+
+    /* PE sections have to be aligned by the section alignment specified in the windows-specific fields. We define it to be 4K.
+       So all output sections that won't be discard by PrekernelPEImageGenerator have to be properly aligned. */
+
+    /* Skip over the PE headers. The virtual addresses of all PE sections have to bigger than the size of the PE headers. */
+    . = 0x1000;
+
+    /* The output sections are named after https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#special-sections.
+       PrekernelPEImageGenerator will add the PE .reloc section by converting ELF R_*_RELATIVE relocations to PE base relocations. */
+
+    .text ALIGN(4K) :
+    {
+        *(.text*)
+    }
+
+    .rdata ALIGN(4K) :
+    {
+        *(.rodata* .srodata*)
+    }
+
+    .data ALIGN(4K) :
+    {
+        *(.data* .sdata*)
+    }
+
+    .got ALIGN(4K) :
+    {
+        *(.got.plt)
+        *(.got)
+    }
+
+    .bss ALIGN(4K) (NOLOAD) :
+    {
+        *(COMMON)
+        *(.bss* .sbss*)
+    }
+}

--- a/Kernel/Prekernel/UBSanitizer.cpp
+++ b/Kernel/Prekernel/UBSanitizer.cpp
@@ -15,11 +15,17 @@ extern "C" {
 
 static void print_location(SourceLocation const&)
 {
-#if ARCH(X86_64)
-    asm volatile("cli; hlt");
+    for (;;) {
+#if ARCH(AARCH64)
+        asm volatile("msr daifset, #2; wfi");
+#elif ARCH(RISCV64)
+        asm volatile("csrw sie, zero; wfi");
+#elif ARCH(X86_64)
+        asm volatile("cli; hlt");
 #else
-    for (;;) { }
+#    error Unknown architecture
 #endif
+    }
 }
 
 void __ubsan_handle_load_invalid_value(InvalidValueData const&, ValueHandle) __attribute__((used));


### PR DESCRIPTION
This skeleton is already bootable on all our supported architectures.

~~This PR depends on #24984 and #24985, therefore draft.~~