### PR TITLE
LibCompress: Remove needless check

### DIFF
--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -54,8 +54,8 @@ private:
 
 ALWAYS_INLINE ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& stream, u32 symbol) const
 {
-    auto code = symbol < m_bit_codes.size() ? m_bit_codes[symbol] : 0u;
-    auto length = symbol < m_bit_code_lengths.size() ? m_bit_code_lengths[symbol] : 0u;
+    auto code = m_bit_codes[symbol];
+    auto length = m_bit_code_lengths[symbol];
     TRY(stream.write_bits(code, length));
     return {};
 }


### PR DESCRIPTION
I added this check in #18216 in commit 6d388249851e71.

Back then, I mentioned that `m_bit_codes` is only used for writing, but only added reading support. `CanonicalCode::from_bytes()` sets up both tables for reading and writing, so I needed the construction of the writing tables to not crash. This check in
`CanonicalCode::write_symbol()` was dead code back then though.

Later, #24700 added support for writing WebP files, and it can create canonical codes with more than 288 symbols. This works just fine, is now under test, and this check in `write_symbol()` isn't needed (and never was). So remove it again.

No behavior change.

(I saw this in the profiler once, so maybe a tiny speedup for writing deflate-compressed data, but on the order of < 2%.)