### PR TITLE
Ext2FS+LibFileSystem: Make working with large files manageable

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -144,6 +144,7 @@ set(KERNEL_SOURCES
     FileSystem/DevLoopFS/Inode.cpp
     FileSystem/DevPtsFS/FileSystem.cpp
     FileSystem/DevPtsFS/Inode.cpp
+    FileSystem/Ext2FS/BlockView.cpp
     FileSystem/Ext2FS/FileSystem.cpp
     FileSystem/Ext2FS/Inode.cpp
     FileSystem/FATFS/FileSystem.cpp

--- a/Kernel/FileSystem/Ext2FS/BlockView.cpp
+++ b/Kernel/FileSystem/Ext2FS/BlockView.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/Ext2FS/BlockView.h>
+#include <Kernel/FileSystem/Ext2FS/Inode.h>
+
+namespace Kernel {
+
+static constexpr size_t max_blocks_in_view = 16384; // 2^14
+
+Ext2FSBlockView::Ext2FSBlockView(Ext2FSInode& inode)
+    : m_inode(inode) {};
+
+ErrorOr<void> Ext2FSBlockView::ensure_block(BlockBasedFileSystem::BlockIndex block)
+{
+    VERIFY(m_block_list_lock.is_locked());
+    if (block >= m_first_block && block <= m_last_block && m_block_list_initialized.was_set())
+        return {};
+
+    BlockBasedFileSystem::BlockIndex new_first_block = (block.value() / max_blocks_in_view) * max_blocks_in_view;
+    BlockBasedFileSystem::BlockIndex new_last_block = new_first_block.value() + max_blocks_in_view - 1;
+
+    m_block_list = TRY(m_inode.compute_block_list(new_first_block, new_last_block));
+
+    m_first_block = new_first_block;
+    m_last_block = new_last_block;
+
+    m_block_list_initialized.set();
+
+    return {};
+}
+
+ErrorOr<BlockBasedFileSystem::BlockIndex> Ext2FSBlockView::get_block(BlockBasedFileSystem::BlockIndex block)
+{
+    MutexLocker block_list_locker(m_block_list_lock);
+    TRY(ensure_block(block));
+
+    auto it = m_block_list.find(block);
+    if (it == m_block_list.end())
+        return BlockBasedFileSystem::BlockIndex { 0 };
+
+    auto on_disk_block = (*it).value;
+    VERIFY(on_disk_block != 0);
+    return on_disk_block;
+}
+
+ErrorOr<BlockBasedFileSystem::BlockIndex> Ext2FSBlockView::get_or_allocate_block(BlockBasedFileSystem::BlockIndex block, bool zero_newly_allocated_block, bool allow_cache)
+{
+    MutexLocker block_list_locker(m_block_list_lock);
+    TRY(ensure_block(block));
+
+    auto it = m_block_list.find(block);
+    if (it != m_block_list.end()) {
+        auto on_disk_block = (*it).value;
+        VERIFY(on_disk_block != 0);
+        return on_disk_block;
+    }
+
+    auto on_disk_block = TRY(m_inode.allocate_block(block, zero_newly_allocated_block, allow_cache));
+    TRY(m_block_list.try_set(block, on_disk_block));
+
+    return on_disk_block;
+}
+
+ErrorOr<void> Ext2FSBlockView::write_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index)
+{
+    MutexLocker block_list_locker(m_block_list_lock);
+
+    TRY(m_inode.write_block_pointer(logical_block_index, on_disk_index));
+
+    if (on_disk_index == 0)
+        m_block_list.remove(logical_block_index);
+    else
+        TRY(m_block_list.try_set(logical_block_index, on_disk_index));
+
+    return {};
+}
+
+}

--- a/Kernel/FileSystem/Ext2FS/BlockView.h
+++ b/Kernel/FileSystem/Ext2FS/BlockView.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SetOnce.h>
+#include <Kernel/FileSystem/BlockBasedFileSystem.h>
+#include <Kernel/FileSystem/Ext2FS/FileSystem.h>
+
+namespace Kernel {
+
+class Ext2FSInode;
+
+class Ext2FSBlockView {
+public:
+    Ext2FSBlockView(Ext2FSInode&);
+    ErrorOr<BlockBasedFileSystem::BlockIndex> get_block(BlockBasedFileSystem::BlockIndex);
+    ErrorOr<BlockBasedFileSystem::BlockIndex> get_or_allocate_block(BlockBasedFileSystem::BlockIndex, bool zero_newly_allocated_block, bool allow_cache);
+    ErrorOr<void> write_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
+
+private:
+    ErrorOr<void> ensure_block(BlockBasedFileSystem::BlockIndex);
+
+    Ext2FSInode& m_inode;
+    Ext2FS::BlockList m_block_list;
+    BlockBasedFileSystem::BlockIndex m_first_block = 0;
+    BlockBasedFileSystem::BlockIndex m_last_block = 0;
+    SetOnce m_block_list_initialized;
+
+    Mutex m_block_list_lock { "BlockList"sv };
+};
+
+}

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -104,6 +104,8 @@ ErrorOr<void> Ext2FS::initialize_while_locked()
 
     VERIFY(logical_block_size() <= (int)max_block_size);
 
+    m_i_blocks_increment = logical_block_size() / 512;
+
     m_block_group_count = ceil_div(super_block.s_blocks_count, super_block.s_blocks_per_group);
 
     if (m_block_group_count == 0) {

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -55,8 +55,12 @@ public:
     FeaturesOptional get_features_optional() const;
     FeaturesReadOnly get_features_readonly() const;
 
+    u32 i_blocks_increment() { return m_i_blocks_increment; }
+
     virtual StringView class_name() const override { return "Ext2FS"sv; }
     virtual Inode& root_inode() override;
+
+    using BlockList = HashMap<BlockBasedFileSystem::BlockIndex, BlockBasedFileSystem::BlockIndex>;
 
 private:
     AK_TYPEDEF_DISTINCT_ORDERED_ID(unsigned, GroupIndex);
@@ -104,9 +108,8 @@ private:
     void uncache_inode(InodeIndex);
     ErrorOr<void> free_inode(Ext2FSInode&);
 
-    using BlockList = HashMap<BlockBasedFileSystem::BlockIndex, BlockBasedFileSystem::BlockIndex>;
-
     u64 m_block_group_count { 0 };
+    u32 m_i_blocks_increment { 0 };
 
     mutable ext2_super_block m_super_block {};
     mutable OwnPtr<KBuffer> m_cached_group_descriptor_table;

--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/IntegralMath.h>
+#include <AK/IterationDecision.h>
 #include <AK/MemoryStream.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Debug.h>
@@ -66,6 +67,7 @@ ErrorOr<void> Ext2FSInode::write_singly_indirect_block_pointer(BlockBasedFileSys
 
     TRY(fs().set_block_allocation_state(m_raw_inode.i_block[EXT2_IND_BLOCK], false));
     m_raw_inode.i_block[EXT2_IND_BLOCK] = 0;
+    m_raw_inode.i_blocks -= fs().i_blocks_increment();
     set_metadata_dirty(true);
 
     return {};
@@ -113,6 +115,7 @@ ErrorOr<void> Ext2FSInode::write_doubly_indirect_block_pointer(BlockBasedFileSys
 
     TRY(fs().set_block_allocation_state(doubly_indirect_block_contents[offset_in_doubly_indirect_block], false));
     doubly_indirect_block_contents[offset_in_doubly_indirect_block] = 0;
+    m_raw_inode.i_blocks -= fs().i_blocks_increment();
     TRY(fs().write_block(m_raw_inode.i_block[EXT2_DIND_BLOCK], doubly_indirect_block_buffer, block_size));
 
     if (!doubly_indirect_block_contents.filled_with(0))
@@ -120,6 +123,7 @@ ErrorOr<void> Ext2FSInode::write_doubly_indirect_block_pointer(BlockBasedFileSys
 
     TRY(fs().set_block_allocation_state(m_raw_inode.i_block[EXT2_DIND_BLOCK], false));
     m_raw_inode.i_block[EXT2_DIND_BLOCK] = 0;
+    m_raw_inode.i_blocks -= fs().i_blocks_increment();
     set_metadata_dirty(true);
 
     return {};
@@ -180,6 +184,7 @@ ErrorOr<void> Ext2FSInode::write_triply_indirect_block_pointer(BlockBasedFileSys
 
     TRY(fs().set_block_allocation_state(doubly_indirect_block_contents[offset_in_doubly_indirect_block], false));
     doubly_indirect_block_contents[offset_in_doubly_indirect_block] = 0;
+    m_raw_inode.i_blocks -= fs().i_blocks_increment();
     TRY(fs().write_block(triply_indirect_block_contents[offset_in_triply_indirect_block], doubly_indirect_block_buffer, block_size));
 
     if (!doubly_indirect_block_contents.filled_with(0))
@@ -187,6 +192,7 @@ ErrorOr<void> Ext2FSInode::write_triply_indirect_block_pointer(BlockBasedFileSys
 
     TRY(fs().set_block_allocation_state(triply_indirect_block_contents[offset_in_triply_indirect_block], false));
     triply_indirect_block_contents[offset_in_triply_indirect_block] = 0;
+    m_raw_inode.i_blocks -= fs().i_blocks_increment();
     TRY(fs().write_block(m_raw_inode.i_block[EXT2_TIND_BLOCK], triply_indirect_block_buffer, block_size));
 
     if (!triply_indirect_block_contents.filled_with(0))
@@ -194,6 +200,7 @@ ErrorOr<void> Ext2FSInode::write_triply_indirect_block_pointer(BlockBasedFileSys
 
     TRY(fs().set_block_allocation_state(m_raw_inode.i_block[EXT2_TIND_BLOCK], false));
     m_raw_inode.i_block[EXT2_TIND_BLOCK] = 0;
+    m_raw_inode.i_blocks -= fs().i_blocks_increment();
     set_metadata_dirty(true);
 
     return {};
@@ -204,6 +211,7 @@ ErrorOr<u32> Ext2FSInode::allocate_and_zero_block()
     auto const block_size = fs().logical_block_size();
 
     auto blocks = TRY(fs().allocate_blocks(fs().group_index_from_inode(index()), 1));
+    m_raw_inode.i_blocks += fs().i_blocks_increment();
     auto block = blocks.first();
 
     auto buffer_content = TRY(ByteBuffer::create_zeroed(block_size));
@@ -214,7 +222,14 @@ ErrorOr<u32> Ext2FSInode::allocate_and_zero_block()
 ErrorOr<void> Ext2FSInode::write_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index)
 {
     VERIFY(m_inode_lock.is_locked());
-    VERIFY(logical_block_index >= EXT2_NDIR_BLOCKS);
+
+    if (logical_block_index < EXT2_NDIR_BLOCKS) {
+        if (m_raw_inode.i_block[logical_block_index.value()] != on_disk_index) {
+            m_raw_inode.i_block[logical_block_index.value()] = on_disk_index.value();
+            set_metadata_dirty(true);
+        }
+        return {};
+    }
 
     if (logical_block_index < singly_indirect_block_capacity())
         return write_singly_indirect_block_pointer(logical_block_index, on_disk_index);
@@ -228,52 +243,7 @@ ErrorOr<void> Ext2FSInode::write_block_pointer(BlockBasedFileSystem::BlockIndex 
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<void> Ext2FSInode::flush_block_list(Ext2FS::BlockList const& old_block_list)
-{
-    MutexLocker locker(m_inode_lock);
-
-    for (unsigned i = 0; i < EXT2_NDIR_BLOCKS; ++i) {
-        auto block = get_block(i);
-        if (m_raw_inode.i_block[i] != block) {
-            set_metadata_dirty(true);
-            m_raw_inode.i_block[i] = block.value();
-        }
-    }
-
-    for (auto const& [logical_block_index, _] : old_block_list) {
-        if (logical_block_index < EXT2_NDIR_BLOCKS)
-            continue;
-        if (!m_block_list.contains(logical_block_index))
-            TRY(write_block_pointer(logical_block_index, 0));
-    }
-
-    for (auto const& [logical_block_index, on_disk_index] : m_block_list) {
-        if (logical_block_index < EXT2_NDIR_BLOCKS)
-            continue;
-        auto iterator = old_block_list.find(logical_block_index);
-        if (iterator == old_block_list.end() || (*iterator).value != on_disk_index)
-            TRY(write_block_pointer(logical_block_index, on_disk_index));
-    }
-
-    auto meta_blocks = TRY(compute_meta_blocks());
-    m_raw_inode.i_blocks = (m_block_list.size() + meta_blocks.size()) * (fs().logical_block_size() / 512);
-
-    return {};
-}
-
-ErrorOr<Ext2FS::BlockList> Ext2FSInode::compute_block_list() const
-{
-    return compute_block_list_impl();
-}
-
-ErrorOr<Vector<Ext2FS::BlockIndex>> Ext2FSInode::compute_meta_blocks() const
-{
-    Vector<Ext2FS::BlockIndex> meta_blocks {};
-    TRY(compute_block_list_impl(&meta_blocks));
-    return meta_blocks;
-}
-
-ErrorOr<Ext2FS::BlockList> Ext2FSInode::compute_block_list_impl(Vector<Ext2FS::BlockIndex>* meta_blocks) const
+ErrorOr<Ext2FS::BlockList> Ext2FSInode::compute_block_list(BlockBasedFileSystem::BlockIndex first_block, BlockBasedFileSystem::BlockIndex last_block) const
 {
     dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::block_list_for_inode(): i_size={}, i_blocks={}", identifier(), m_raw_inode.i_size, m_raw_inode.i_blocks);
     Ext2FS::BlockList list {};
@@ -289,51 +259,57 @@ ErrorOr<Ext2FS::BlockList> Ext2FSInode::compute_block_list_impl(Vector<Ext2FS::B
     unsigned const block_size = fs().logical_block_size();
     unsigned const entries_per_block = EXT2_ADDR_PER_BLOCK(&fs().super_block());
 
-    auto set_block = [&](auto logical_index, auto on_disk_index) -> ErrorOr<void> {
+    auto set_block = [&](auto logical_index, auto on_disk_index) -> ErrorOr<IterationDecision> {
+        if (logical_index < first_block)
+            return IterationDecision::Continue;
+        if (logical_index > last_block)
+            return IterationDecision::Break;
+
         TRY(list.try_set(logical_index, on_disk_index));
-        return {};
+        return IterationDecision::Continue;
     };
 
-    auto process_block_array = [&](auto current_logical_index, unsigned level, auto array_block_index, ByteBuffer& array_storage, auto&& callback) -> ErrorOr<void> {
-        if (meta_blocks)
-            TRY(meta_blocks->try_append(array_block_index));
-
+    auto process_block_array = [&](auto current_logical_index, unsigned level, auto array_block_index, ByteBuffer& array_storage, auto&& callback) -> ErrorOr<IterationDecision> {
         TRY(array_storage.try_resize(block_size));
         auto* array = (u32*)array_storage.data();
         auto buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)array);
         TRY(fs().read_block(array_block_index, &buffer, block_size, 0));
         for (unsigned i = 0; i < block_size / sizeof(u32); ++i) {
-            if (array[i] != 0)
-                TRY(callback(current_logical_index + i * AK::pow(entries_per_block, level - 1), array[i]));
+            if (array[i] != 0) {
+                if (TRY(callback(current_logical_index + i * AK::pow(entries_per_block, level - 1), array[i])) == IterationDecision::Break)
+                    return IterationDecision::Break;
+            }
         }
-        return {};
+        return IterationDecision::Continue;
     };
 
-    for (size_t i = 0; i < EXT2_NDIR_BLOCKS; ++i) {
-        if (m_raw_inode.i_block[i] != 0)
-            TRY(set_block(i, m_raw_inode.i_block[i]));
+    if (first_block < EXT2_NDIR_BLOCKS) {
+        for (size_t i = 0; i < EXT2_NDIR_BLOCKS; ++i) {
+            if (m_raw_inode.i_block[i] != 0)
+                TRY(set_block(i, m_raw_inode.i_block[i]));
+        }
     }
 
     ByteBuffer block_storage[3] = {};
 
-    if (m_raw_inode.i_block[EXT2_IND_BLOCK]) {
-        TRY(process_block_array(EXT2_NDIR_BLOCKS, 1, m_raw_inode.i_block[EXT2_IND_BLOCK], block_storage[0], [&](auto logical_block_index, auto on_disk_index) -> ErrorOr<void> {
+    if (first_block < singly_indirect_block_capacity() && m_raw_inode.i_block[EXT2_IND_BLOCK]) {
+        TRY(process_block_array(EXT2_NDIR_BLOCKS, 1, m_raw_inode.i_block[EXT2_IND_BLOCK], block_storage[0], [&](auto logical_block_index, auto on_disk_index) -> ErrorOr<IterationDecision> {
             return set_block(logical_block_index, on_disk_index);
         }));
     }
 
-    if (m_raw_inode.i_block[EXT2_DIND_BLOCK]) {
-        TRY(process_block_array(singly_indirect_block_capacity(), 2, m_raw_inode.i_block[EXT2_DIND_BLOCK], block_storage[1], [&](auto logical_block_index, auto on_disk_index) -> ErrorOr<void> {
-            return process_block_array(logical_block_index, 1, on_disk_index, block_storage[0], [&](auto logical_block_index2, auto on_disk_index2) -> ErrorOr<void> {
+    if (first_block < doubly_indirect_block_capacity() && m_raw_inode.i_block[EXT2_DIND_BLOCK]) {
+        TRY(process_block_array(singly_indirect_block_capacity(), 2, m_raw_inode.i_block[EXT2_DIND_BLOCK], block_storage[1], [&](auto logical_block_index, auto on_disk_index) -> ErrorOr<IterationDecision> {
+            return process_block_array(logical_block_index, 1, on_disk_index, block_storage[0], [&](auto logical_block_index2, auto on_disk_index2) -> ErrorOr<IterationDecision> {
                 return set_block(logical_block_index2, on_disk_index2);
             });
         }));
     }
 
-    if (m_raw_inode.i_block[EXT2_TIND_BLOCK]) {
-        TRY(process_block_array(doubly_indirect_block_capacity(), 3, m_raw_inode.i_block[EXT2_TIND_BLOCK], block_storage[2], [&](auto logical_block_index, auto on_disk_index) -> ErrorOr<void> {
-            return process_block_array(logical_block_index, 2, on_disk_index, block_storage[1], [&](auto logical_block_index2, auto on_disk_index2) -> ErrorOr<void> {
-                return process_block_array(logical_block_index2, 1, on_disk_index2, block_storage[0], [&](auto logical_block_index3, auto on_disk_index3) -> ErrorOr<void> {
+    if (first_block < triply_indirect_block_capacity() && m_raw_inode.i_block[EXT2_TIND_BLOCK]) {
+        TRY(process_block_array(doubly_indirect_block_capacity(), 3, m_raw_inode.i_block[EXT2_TIND_BLOCK], block_storage[2], [&](auto logical_block_index, auto on_disk_index) -> ErrorOr<IterationDecision> {
+            return process_block_array(logical_block_index, 2, on_disk_index, block_storage[1], [&](auto logical_block_index2, auto on_disk_index2) -> ErrorOr<IterationDecision> {
+                return process_block_array(logical_block_index2, 1, on_disk_index2, block_storage[0], [&](auto logical_block_index3, auto on_disk_index3) -> ErrorOr<IterationDecision> {
                     return set_block(logical_block_index3, on_disk_index3);
                 });
             });
@@ -357,6 +333,7 @@ ErrorOr<void> Ext2FSInode::free_all_blocks()
 
     auto deallocate_block = [&](auto on_disk_block_index) -> ErrorOr<void> {
         TRY(fs().set_block_allocation_state(on_disk_block_index, false));
+        m_raw_inode.i_blocks -= fs().i_blocks_increment();
         return {};
     };
 
@@ -411,6 +388,7 @@ ErrorOr<void> Ext2FSInode::free_all_blocks()
 
 Ext2FSInode::Ext2FSInode(Ext2FS& fs, InodeIndex index)
     : Inode(fs, index)
+    , m_block_view(*this)
 {
 }
 
@@ -475,19 +453,6 @@ ErrorOr<void> Ext2FSInode::flush_metadata()
     return {};
 }
 
-ErrorOr<void> Ext2FSInode::compute_block_list_with_exclusive_locking()
-{
-    // Note: We verify that the inode mutex is being held locked. Because only the read_bytes_locked()
-    // method uses this method and the mutex can be locked in shared mode when reading the Inode if
-    // it is an ext2 regular file, but also in exclusive mode, when the Inode is an ext2 directory and being
-    // traversed, we use another exclusive lock to ensure we always mutate the block list safely.
-    VERIFY(m_inode_lock.is_locked());
-    MutexLocker block_list_locker(m_block_list_lock);
-    if (m_block_list.is_empty())
-        m_block_list = TRY(compute_block_list());
-    return {};
-}
-
 ErrorOr<size_t> Ext2FSInode::read_bytes_locked(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription* description) const
 {
     VERIFY(m_inode_lock.is_locked());
@@ -507,13 +472,6 @@ ErrorOr<size_t> Ext2FSInode::read_bytes_locked(off_t offset, size_t count, UserO
         return nread;
     }
 
-    // Note: We bypass the const declaration of this method, but this is a strong
-    // requirement to be able to accomplish the read operation successfully.
-    // We call this special method because it locks a separate mutex to ensure we
-    // update the block list of the inode safely, as the m_inode_lock is locked in
-    // shared mode.
-    TRY(const_cast<Ext2FSInode&>(*this).compute_block_list_with_exclusive_locking());
-
     bool allow_cache = !description || !description->is_direct();
 
     int const block_size = fs().logical_block_size();
@@ -529,7 +487,7 @@ ErrorOr<size_t> Ext2FSInode::read_bytes_locked(off_t offset, size_t count, UserO
     dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::read_bytes(): Reading up to {} bytes, {} bytes into inode to {}", identifier(), count, offset, buffer.user_or_kernel_ptr());
 
     while (remaining_count) {
-        auto block_index = get_block(current_block_logical_index);
+        auto block_index = TRY(m_block_view.get_block(current_block_logical_index));
         size_t offset_into_block = (current_block_logical_index == first_block_logical_index) ? offset_into_first_block : 0;
         size_t num_bytes_to_copy = min((size_t)block_size - offset_into_block, (size_t)remaining_count);
         auto buffer_offset = buffer.offset(nread);
@@ -564,12 +522,8 @@ ErrorOr<void> Ext2FSInode::resize(u64 new_size)
         BlockBasedFileSystem::BlockIndex first_block_logical_index = ceil_div(new_size, block_size);
         BlockBasedFileSystem::BlockIndex last_block_logical_index = size() / block_size;
 
-        if (m_block_list.is_empty())
-            m_block_list = TRY(compute_block_list());
-        auto old_block_list = TRY(m_block_list.clone());
-
         for (auto bi = first_block_logical_index; bi <= last_block_logical_index; bi = bi.value() + 1) {
-            auto block = get_block(bi);
+            auto block = TRY(m_block_view.get_block(bi));
             if (block == 0) {
                 // This is a hole, skip it.
                 continue;
@@ -578,9 +532,9 @@ ErrorOr<void> Ext2FSInode::resize(u64 new_size)
                 dbgln("Ext2FSInode[{}]::resize(): Failed to free block {}: {}", identifier(), block, result.error());
                 return result;
             }
-            m_block_list.remove(bi);
+            m_raw_inode.i_blocks -= fs().i_blocks_increment();
+            TRY(m_block_view.write_block_pointer(bi, 0));
         }
-        TRY(flush_block_list(old_block_list));
     }
 
     m_raw_inode.i_size = new_size;
@@ -618,9 +572,6 @@ ErrorOr<size_t> Ext2FSInode::write_bytes_locked(off_t offset, size_t count, User
 
     TRY(resize(new_size));
 
-    if (m_block_list.is_empty())
-        m_block_list = TRY(compute_block_list());
-
     BlockBasedFileSystem::BlockIndex first_block_logical_index = offset / block_size;
 
     size_t offset_into_first_block = offset % block_size;
@@ -630,12 +581,12 @@ ErrorOr<size_t> Ext2FSInode::write_bytes_locked(off_t offset, size_t count, User
     auto current_block_logical_index = first_block_logical_index;
 
     dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::write_bytes_locked(): Writing {} bytes, {} bytes into inode from {}", identifier(), count, offset, data.user_or_kernel_ptr());
-    auto old_block_list = TRY(m_block_list.clone());
 
     while (remaining_count) {
         size_t offset_into_block = (current_block_logical_index == first_block_logical_index) ? offset_into_first_block : 0;
         size_t num_bytes_to_copy = min((size_t)block_size - offset_into_block, (size_t)remaining_count);
-        auto block_index = TRY(get_or_allocate_block(current_block_logical_index, num_bytes_to_copy != block_size, allow_cache));
+        auto block_index = TRY(m_block_view.get_or_allocate_block(current_block_logical_index, num_bytes_to_copy != block_size, allow_cache));
+        TRY(m_block_view.write_block_pointer(current_block_logical_index, block_index));
 
         dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_bytes_locked(): Writing block {} (offset_into_block: {})", identifier(), block_index, offset_into_block);
         if (auto result = fs().write_block(block_index, data.offset(nwritten), num_bytes_to_copy, offset_into_block, allow_cache); result.is_error()) {
@@ -647,10 +598,9 @@ ErrorOr<size_t> Ext2FSInode::write_bytes_locked(off_t offset, size_t count, User
         nwritten += num_bytes_to_copy;
     }
 
-    TRY(flush_block_list(old_block_list));
     did_modify_contents();
 
-    dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::write_bytes_locked(): After write, i_size={}, i_blocks={} ({} blocks in list)", identifier(), size(), m_raw_inode.i_blocks, m_block_list.size());
+    dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::write_bytes_locked(): After write, i_size={}, i_blocks={}", identifier(), size(), m_raw_inode.i_blocks);
     return nwritten;
 }
 
@@ -747,40 +697,24 @@ ErrorOr<void> Ext2FSInode::write_directory(Vector<Ext2FSDirectoryEntry>& entries
     return {};
 }
 
-ErrorOr<BlockBasedFileSystem::BlockIndex> Ext2FSInode::get_or_allocate_block(BlockBasedFileSystem::BlockIndex block_index, bool zero_newly_allocated_block, bool allow_cache)
+ErrorOr<BlockBasedFileSystem::BlockIndex> Ext2FSInode::allocate_block(BlockBasedFileSystem::BlockIndex block_index, bool zero_newly_allocated_block, bool allow_cache)
 {
-    auto it = m_block_list.find(block_index);
-    if (it != m_block_list.end()) {
-        auto block = (*it).value;
-        VERIFY(block != 0);
-        return block;
-    }
-
     // FIXME: Preallocate some extra blocks here.
     auto blocks = TRY(fs().allocate_blocks(fs().group_index_from_inode(index()), 1));
+    m_raw_inode.i_blocks += fs().i_blocks_increment();
 
     VERIFY(blocks.size() == 1);
     auto block = blocks.first();
-    TRY(m_block_list.try_set(block_index, block));
 
     if (zero_newly_allocated_block) {
         u8 zero_buffer[PAGE_SIZE] {};
         if (auto result = fs().write_block(block, UserOrKernelBuffer::for_kernel_buffer(zero_buffer), fs().logical_block_size(), 0, allow_cache); result.is_error()) {
-            dbgln("Ext2FSInode[{}]::get_or_allocate_block(): Failed to zero block {} (index {})", identifier(), block, block_index);
+            dbgln("Ext2FSInode[{}]::allocate_block(): Failed to zero block {} (index {})", identifier(), block, block_index);
             return result.release_error();
         }
     }
 
     return block;
-}
-
-BlockBasedFileSystem::BlockIndex Ext2FSInode::get_block(BlockBasedFileSystem::BlockIndex block_index) const
-{
-    auto it = m_block_list.find(block_index);
-    if (it == m_block_list.end())
-        return 0;
-
-    return (*it).value;
 }
 
 ErrorOr<NonnullRefPtr<Inode>> Ext2FSInode::create_child(StringView name, mode_t mode, dev_t dev, UserID uid, GroupID gid)
@@ -1046,13 +980,10 @@ ErrorOr<int> Ext2FSInode::get_block_address(int index)
 {
     MutexLocker locker(m_inode_lock);
 
-    if (m_block_list.is_empty())
-        m_block_list = TRY(compute_block_list());
-
     if (index < 0)
         return 0;
 
-    return get_block(index).value();
+    return TRY(m_block_view.get_block(index)).value();
 }
 
 }

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -63,6 +63,8 @@ private:
     ErrorOr<Ext2FS::BlockList> compute_block_list_impl(Vector<Ext2FS::BlockIndex>* meta_blocks = nullptr) const;
     ErrorOr<Vector<Ext2FS::BlockIndex>> compute_meta_blocks() const;
 
+    ErrorOr<void> free_all_blocks();
+
     u64 singly_indirect_block_capacity() const
     {
         auto const entries_per_block = EXT2_ADDR_PER_BLOCK(&fs().super_block());

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <Kernel/FileSystem/Ext2FS/BlockView.h>
 #include <Kernel/FileSystem/Ext2FS/Definitions.h>
 #include <Kernel/FileSystem/Ext2FS/DirectoryEntry.h>
 #include <Kernel/FileSystem/Ext2FS/FileSystem.h>
@@ -17,6 +18,7 @@ namespace Kernel {
 
 class Ext2FSInode final : public Inode {
     friend class Ext2FS;
+    friend class Ext2FSBlockView;
 
 public:
     virtual ~Ext2FSInode() override;
@@ -45,8 +47,7 @@ private:
     virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<int> get_block_address(int) override;
 
-    ErrorOr<BlockBasedFileSystem::BlockIndex> get_or_allocate_block(BlockBasedFileSystem::BlockIndex, bool zero_newly_allocated_block, bool allow_cache);
-    BlockBasedFileSystem::BlockIndex get_block(BlockBasedFileSystem::BlockIndex) const;
+    ErrorOr<BlockBasedFileSystem::BlockIndex> allocate_block(BlockBasedFileSystem::BlockIndex, bool zero_newly_allocated_block, bool allow_cache);
     ErrorOr<u32> allocate_and_zero_block();
 
     ErrorOr<void> write_directory(Vector<Ext2FSDirectoryEntry>&);
@@ -56,12 +57,8 @@ private:
     ErrorOr<void> write_doubly_indirect_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
     ErrorOr<void> write_triply_indirect_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
     ErrorOr<void> write_block_pointer(BlockBasedFileSystem::BlockIndex logical_block_index, BlockBasedFileSystem::BlockIndex on_disk_index);
-    ErrorOr<void> flush_block_list(Ext2FS::BlockList const& old_block_list);
 
-    ErrorOr<void> compute_block_list_with_exclusive_locking();
-    ErrorOr<Ext2FS::BlockList> compute_block_list() const;
-    ErrorOr<Ext2FS::BlockList> compute_block_list_impl(Vector<Ext2FS::BlockIndex>* meta_blocks = nullptr) const;
-    ErrorOr<Vector<Ext2FS::BlockIndex>> compute_meta_blocks() const;
+    ErrorOr<Ext2FS::BlockList> compute_block_list(BlockBasedFileSystem::BlockIndex, BlockBasedFileSystem::BlockIndex) const;
 
     ErrorOr<void> free_all_blocks();
 
@@ -87,11 +84,9 @@ private:
     Ext2FS const& fs() const;
     Ext2FSInode(Ext2FS&, InodeIndex);
 
-    Ext2FS::BlockList m_block_list;
+    mutable Ext2FSBlockView m_block_view;
     HashMap<NonnullOwnPtr<KString>, InodeIndex> m_lookup_cache;
     ext2_inode m_raw_inode {};
-
-    Mutex m_block_list_lock { "BlockList"sv };
 };
 
 inline Ext2FS& Ext2FSInode::fs()

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -208,13 +208,10 @@ ErrorOr<void> copy_file(StringView destination_path, StringView source_path, str
     if (source_stat.st_size > 0)
         TRY(destination->truncate(source_stat.st_size));
 
-    while (true) {
-        auto bytes_read = TRY(source.read_until_eof());
-
-        if (bytes_read.is_empty())
-            break;
-
-        TRY(destination->write_until_depleted(bytes_read));
+    ByteBuffer buffer = TRY(ByteBuffer::create_uninitialized(1 * MiB));
+    while (!source.is_eof()) {
+        auto bytes = TRY(source.read_some(buffer));
+        TRY(destination->write_until_depleted(bytes));
     }
 
     auto my_umask = umask(0);


### PR DESCRIPTION
See individual commits for details. The biggest change here is that we no longer store entire block lists in memory, since that can OOM way too easily. Instead, we now keep a 'view' to the actual block list, which can hold up to 10 000 blocks at once.