### PR TITLE
Kernel/riscv64: Fix typo in naming of Devicetree

### DIFF
--- a/Kernel/Arch/riscv64/boot.S
+++ b/Kernel/Arch/riscv64/boot.S
@@ -36,7 +36,7 @@ start:
   // We also expect that an implementation of the RISC-V Supervisor Binary Interface is available.
 
   // Don't touch a0/a1 as we expect those registers to contain the hart ID
-  // and a pointer to the Flattened Fevice Tree.
+  // and a pointer to the Flattened Devicetree.
 
   // Clear sstatus.SIE, which disables all interrupts in supervisor mode.
   csrci sstatus, 1 << 1


### PR DESCRIPTION
First time contributor here. Just fixing a small comment  typo: "Fevice Tree" -> "Devicetree". :)