### PR TITLE
Kernel/Net: Cleanup the ICMP handler

### DIFF
--- a/Kernel/Net/ICMP.h
+++ b/Kernel/Net/ICMP.h
@@ -9,35 +9,15 @@
 #include <AK/MACAddress.h>
 #include <Kernel/Net/IPv4/IPv4.h>
 
-struct ICMPv4Type {
-    enum {
-        EchoReply = 0,
-        EchoRequest = 8,
-    };
+enum class ICMPType : u8 {
+    EchoReply = 0,
+    EchoRequest = 8,
 };
 
-class [[gnu::packed]] ICMPHeader {
-public:
-    ICMPHeader() = default;
-    ~ICMPHeader() = default;
-
-    u8 type() const { return m_type; }
-    void set_type(u8 b) { m_type = b; }
-
-    u8 code() const { return m_code; }
-    void set_code(u8 b) { m_code = b; }
-
-    u16 checksum() const { return m_checksum; }
-    void set_checksum(u16 w) { m_checksum = w; }
-
-    void const* payload() const { return this + 1; }
-    void* payload() { return this + 1; }
-
-private:
-    u8 m_type { 0 };
-    u8 m_code { 0 };
-    NetworkOrdered<u16> m_checksum { 0 };
-    // NOTE: The rest of the header is 4 bytes
+struct [[gnu::packed]] ICMPHeader {
+    ICMPType type { 0 };
+    u8 code { 0 };
+    NetworkOrdered<u16> checksum { 0 };
 };
 
 static_assert(AssertSize<ICMPHeader, 4>());
@@ -46,6 +26,5 @@ struct [[gnu::packed]] ICMPEchoPacket {
     ICMPHeader header;
     NetworkOrdered<u16> identifier;
     NetworkOrdered<u16> sequence_number;
-    void* payload() { return this + 1; }
-    void const* payload() const { return this + 1; }
+    u8 payload[];
 };


### PR DESCRIPTION
this may be a bit opinionated, but I think it improves readability by quite a lot + the cast is safer :)

---

This change fixes up handle_icmp to use a bit_cast instead of a reinterpret_cast, which got used due to legacy reasons.

A few dbgln's got turned into dbgln_if's, in accordance with the behavior throughout the rest of the file.

Furthermore, we revert a part of commit ad73adef5d2f8 which introduced inconsistency between struct names. There's no ICMPv4, only ICMP and ICMPv6. Thus, it makes more sense to revert the ICMPv4Type back to ICMPType.

We also remove the FIXME about the TTL - as per RFC1700, TTL of 64 is a recommended default, so the current behavior can stay.