### PR TITLE
AK: Introduce IPAddressCidr datatype

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -149,7 +149,7 @@ public:
     using ResultType = T;
     using ErrorType = E;
 
-    ErrorOr()
+    constexpr ErrorOr()
     requires(IsSame<T, Empty>)
         : m_value_or_error(Empty {})
     {

--- a/AK/IPv6Address.h
+++ b/AK/IPv6Address.h
@@ -36,6 +36,13 @@ public:
             m_data[i] = data[i];
     }
 
+    constexpr IPv6Address(NetworkOrdered<u128> const& data)
+    {
+        auto array = bit_cast<Array<u8, 16>>(data);
+        for (size_t i = 0; i < 16; i++)
+            m_data[i] = array[i];
+    }
+
     constexpr IPv6Address(IPv4Address const& ipv4_address)
     {
         // IPv4 mapped IPv6 address
@@ -233,6 +240,11 @@ public:
                 return false;
         }
         return true;
+    }
+
+    constexpr NetworkOrdered<u128> to_u128() const
+    {
+        return bit_cast<NetworkOrdered<u128>>(m_data);
     }
 
     constexpr bool is_ipv4_mapped() const

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -239,7 +239,7 @@ public:
 
     bool contains(IPv6Address other) const
     {
-        IPv6AddressCidr other_cidr = IPv6AddressCidr::create(other, length()).value();
+        IPv6AddressCidr other_cidr = IPv6AddressCidr::create(other, length()).release_value();
         return first_address_of_subnet() == other_cidr.first_address_of_subnet();
     }
 };

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -242,7 +242,7 @@ private:
     constexpr NetworkOrdered<u128> address_mask() const
     {
         u8 const free_bits = MAX_LENGTH - length();
-        NetworkOrdered<u128> mask = (u128)0;
+        NetworkOrdered<u128> mask = static_cast<u128>(0);
 
         if (free_bits != 128) {
             mask = NumericLimits<u128>::max() << free_bits;

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024, famfo <famfo@famfo.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/IPv4Address.h>
+#include <AK/IPv6Address.h>
+
+namespace AK {
+
+class IPv4AddressCidr;
+class IPv6AddressCidr;
+
+namespace Details {
+
+template<typename Address>
+class AddressTraits;
+
+template<OneOf<IPv4AddressCidr, IPv6AddressCidr> AddressFamily>
+class IPAddressCidr {
+public:
+    enum class IPAddressCidrError {
+        CidrTooLong,
+        StringParsingFailed,
+    };
+
+    using IPAddress = Details::AddressTraits<AddressFamily>::IPAddress;
+
+    static constexpr ErrorOr<AddressFamily, IPAddressCidrError> create(IPAddress address, u8 length)
+    {
+        if (length > AddressFamily::MAX_LENGTH)
+            return IPAddressCidrError::CidrTooLong;
+
+        return AddressFamily(address, length);
+    }
+
+    constexpr IPAddress const& ip_address() const& { return m_address; }
+    constexpr u32 length() const { return m_length; }
+
+    constexpr void set_ip_address(IPAddress address) { m_address = address; }
+    constexpr ErrorOr<void, IPAddressCidrError> set_length(u32 length)
+    {
+        if (length > AddressFamily::MAX_LENGTH)
+            return IPAddressCidrError::CidrTooLong;
+
+        m_length = length;
+        return {};
+    }
+
+    constexpr static ErrorOr<AddressFamily, IPAddressCidrError> from_string(StringView string)
+    {
+        Vector<StringView> const parts = string.split_view('/');
+
+        if (parts.size() != 2)
+            return IPAddressCidrError::StringParsingFailed;
+
+        auto ip_address = IPAddress::from_string(parts[0]);
+        if (!ip_address.has_value())
+            return IPAddressCidrError::StringParsingFailed;
+
+        Optional<u8> length = parts[1].to_number<u8>();
+        if (!length.has_value())
+            return IPAddressCidrError::StringParsingFailed;
+
+        return IPAddressCidr::create(ip_address.value(), length.release_value());
+    }
+
+#ifdef KERNEL
+    ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const
+#else
+    ErrorOr<String> to_string() const
+#endif
+    {
+        StringBuilder builder;
+
+        auto address_string = TRY(m_address.to_string());
+
+#ifdef KERNEL
+        TRY(builder.try_append(address_string->view()));
+#else
+        TRY(builder.try_append(address_string));
+#endif
+
+        TRY(builder.try_append('/'));
+        TRY(builder.try_appendff("{}", m_length));
+
+#ifdef KERNEL
+        return Kernel::KString::try_create(builder.string_view());
+#else
+        return builder.to_string();
+#endif
+    }
+
+    constexpr bool operator==(IPAddressCidr const& other) const = default;
+    constexpr bool operator!=(IPAddressCidr const& other) const = default;
+
+protected:
+    constexpr IPAddressCidr(IPAddress address, u8 length)
+        : m_address(address)
+        , m_length(length)
+    {
+    }
+
+private:
+    IPAddress m_address;
+    u8 m_length;
+};
+
+}
+
+}
+
+#if USING_AK_GLOBALLY
+#endif

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -113,6 +113,8 @@ public:
 
 class IPv4AddressCidr : public Details::IPAddressCidr<IPv4AddressCidr> {
 public:
+    constexpr static u8 MAX_LENGTH = 32;
+
     constexpr IPv4AddressCidr(IPv4Address address, u8 length)
         : IPAddressCidr(address, length)
     {
@@ -153,8 +155,6 @@ public:
         IPv4AddressCidr other_cidr = MUST(IPv4AddressCidr::create(other, length()));
         return first_address_of_subnet() == other_cidr.first_address_of_subnet();
     }
-
-    static u8 const MAX_LENGTH = 32;
 };
 
 template<>

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -21,14 +21,14 @@ namespace Details {
 template<typename Address>
 class AddressTraits;
 
+enum class IPAddressCidrError {
+    CidrTooLong,
+    StringParsingFailed,
+};
+
 template<OneOf<IPv4AddressCidr, IPv6AddressCidr> AddressFamily>
 class IPAddressCidr {
 public:
-    enum class IPAddressCidrError {
-        CidrTooLong,
-        StringParsingFailed,
-    };
-
     using IPAddress = Details::AddressTraits<AddressFamily>::IPAddress;
 
     static constexpr ErrorOr<AddressFamily, IPAddressCidrError> create(IPAddress address, u8 length)
@@ -110,6 +110,24 @@ public:
 };
 
 }
+
+template<>
+struct Formatter<Details::IPAddressCidrError> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Details::IPAddressCidrError error)
+    {
+        StringView value;
+        switch (error) {
+            case Details::IPAddressCidrError::StringParsingFailed:
+                value = "String parsing failed"sv;
+                break;
+            case Details::IPAddressCidrError::CidrTooLong:
+                value = "CIDR too long"sv;
+                break;
+        }
+
+        return Formatter<StringView>::format(builder, value);
+    }
+};
 
 class IPv4AddressCidr : public Details::IPAddressCidr<IPv4AddressCidr> {
 public:

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -117,12 +117,12 @@ struct Formatter<Details::IPAddressCidrError> : Formatter<StringView> {
     {
         StringView value;
         switch (error) {
-            case Details::IPAddressCidrError::StringParsingFailed:
-                value = "String parsing failed"sv;
-                break;
-            case Details::IPAddressCidrError::CidrTooLong:
-                value = "CIDR too long"sv;
-                break;
+        case Details::IPAddressCidrError::StringParsingFailed:
+            value = "String parsing failed"sv;
+            break;
+        case Details::IPAddressCidrError::CidrTooLong:
+            value = "CIDR too long"sv;
+            break;
         }
 
         return Formatter<StringView>::format(builder, value);

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -67,7 +67,7 @@ public:
         if (!length.has_value())
             return IPAddressCidrError::StringParsingFailed;
 
-        return IPAddressCidr::create(ip_address.value(), length.release_value());
+        return IPAddressCidr::create(ip_address.release_value(), length.release_value());
     }
 
 #ifdef KERNEL

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -63,7 +63,7 @@ public:
         if (!ip_address.has_value())
             return IPAddressCidrError::StringParsingFailed;
 
-        Optional<u8> length = parts[1].to_number<u8>();
+        auto length = parts[1].to_number<u8>();
         if (!length.has_value())
             return IPAddressCidrError::StringParsingFailed;
 
@@ -72,29 +72,15 @@ public:
 
 #ifdef KERNEL
     ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const
+    {
+        return Kernel::KString::formatted("{}/{}", m_address, m_length);
+    }
 #else
     ErrorOr<String> to_string() const
-#endif
     {
-        StringBuilder builder;
-
-        auto address_string = TRY(m_address.to_string());
-
-#ifdef KERNEL
-        TRY(builder.try_append(address_string->view()));
-#else
-        TRY(builder.try_append(address_string));
-#endif
-
-        TRY(builder.try_append('/'));
-        TRY(builder.try_appendff("{}", m_length));
-
-#ifdef KERNEL
-        return Kernel::KString::try_create(builder.string_view());
-#else
-        return builder.to_string();
-#endif
+        return String::formatted("{}/{}", m_address, m_length);
     }
+#endif
 
     constexpr bool operator==(IPAddressCidr const& other) const = default;
     constexpr bool operator!=(IPAddressCidr const& other) const = default;

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -9,6 +9,7 @@
 #include <AK/Error.h>
 #include <AK/IPv4Address.h>
 #include <AK/IPv6Address.h>
+#include <AK/UFixedBigInt.h>
 
 namespace AK {
 
@@ -116,6 +117,12 @@ public:
     using IPAddress = IPv4Address;
 };
 
+template<>
+class AddressTraits<IPv6AddressCidr> {
+public:
+    using IPAddress = IPv6Address;
+};
+
 }
 
 class IPv4AddressCidr : public Details::IPAddressCidr<IPv4AddressCidr> {
@@ -191,8 +198,96 @@ struct Formatter<IPv4AddressCidr> : Formatter<StringView> {
 };
 #endif
 
+class IPv6AddressCidr : public Details::IPAddressCidr<IPv6AddressCidr> {
+public:
+    constexpr IPv6AddressCidr(IPv6Address address, u8 length)
+        : IPAddressCidr(address, length)
+    {
+    }
+
+    constexpr IPv6Address first_address_of_subnet() const
+    {
+        u8 address[16] = { 0 };
+        u8 free_bits = MAX_LENGTH - length();
+
+        if (free_bits != 128) {
+            NetworkOrdered<u128> mask = NumericLimits<u128>::max() << free_bits;
+            auto address_mask = bit_cast<Array<u8, 16>>(mask);
+
+            auto const* original_address = ip_address().to_in6_addr_t();
+            for (int i = 0; i < 16; i++) {
+                address[i] = original_address[i] & address_mask[i];
+            }
+        }
+
+        return address;
+    }
+
+    constexpr IPv6Address last_address_of_subnet() const
+    {
+        u8 address[16] = { 0 };
+        u8 free_bits = MAX_LENGTH - length();
+
+        NetworkOrdered<u128> inverse_mask = NumericLimits<u128>::max() >> (128 - free_bits);
+
+        if (free_bits != 128) {
+            NetworkOrdered<u128> mask = NumericLimits<u128>::max() << free_bits;
+            auto address_mask = bit_cast<Array<u8, 16>>(mask);
+
+            auto const* original_address = ip_address().to_in6_addr_t();
+            for (int i = 0; i < 16; i++) {
+                address[i] = original_address[i] & address_mask[i];
+            }
+        }
+
+        auto inverse_address_mask = bit_cast<Array<u8, 16>>(inverse_mask);
+
+        for (int i = 0; i < 16; i++) {
+            address[i] = address[i] | inverse_address_mask[i];
+        }
+
+        return address;
+    }
+
+    bool contains(IPv6Address other) const
+    {
+        IPv6AddressCidr other_cidr = IPv6AddressCidr::create(other, length()).value();
+        return first_address_of_subnet() == other_cidr.first_address_of_subnet();
+    }
+
+    static u8 const MAX_LENGTH = 128;
+};
+
+template<>
+struct Traits<IPv6AddressCidr> : public DefaultTraits<IPv6AddressCidr> {
+    static unsigned hash(IPv6AddressCidr const& address)
+    {
+        IPv6Address ip_address = address.ip_address();
+        return sip_hash_bytes<4, 8>({ &ip_address, address.length() });
+    }
+};
+
+#ifdef KERNEL
+template<>
+struct Formatter<IPv6AddressCidr> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, IPv6AddressCidr value)
+    {
+        return Formatter<StringView>::format(builder, TRY(value.to_string())->view());
+    }
+};
+#else
+template<>
+struct Formatter<IPv6AddressCidr> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, IPv6AddressCidr value)
+    {
+        return Formatter<StringView>::format(builder, TRY(value.to_string()));
+    }
+};
+#endif
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::IPv4AddressCidr;
+using AK::IPv6AddressCidr;
 #endif

--- a/AK/IpAddressCidr.h
+++ b/AK/IpAddressCidr.h
@@ -186,6 +186,8 @@ struct Formatter<IPv4AddressCidr> : Formatter<StringView> {
 
 class IPv6AddressCidr : public Details::IPAddressCidr<IPv6AddressCidr> {
 public:
+    constexpr static u8 MAX_LENGTH = 128;
+
     constexpr IPv6AddressCidr(IPv6Address address, u8 length)
         : IPAddressCidr(address, length)
     {
@@ -206,7 +208,7 @@ public:
             }
         }
 
-        return address;
+        return IPv6Address(address);
     }
 
     constexpr IPv6Address last_address_of_subnet() const
@@ -232,7 +234,7 @@ public:
             address[i] = address[i] | inverse_address_mask[i];
         }
 
-        return address;
+        return IPv6Address(address);
     }
 
     bool contains(IPv6Address other) const
@@ -240,8 +242,6 @@ public:
         IPv6AddressCidr other_cidr = IPv6AddressCidr::create(other, length()).value();
         return first_address_of_subnet() == other_cidr.first_address_of_subnet();
     }
-
-    static u8 const MAX_LENGTH = 128;
 };
 
 template<>

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -44,6 +44,7 @@ set(AK_TEST_SOURCES
     TestIPv4Address.cpp
     TestIPv4AddressCidr.cpp
     TestIPv6Address.cpp
+    TestIPv6AddressCidr.cpp
     TestIndexSequence.cpp
     TestInsertionSort.cpp
     TestIntegerMath.cpp

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -42,6 +42,7 @@ set(AK_TEST_SOURCES
     TestHashTable.cpp
     TestHex.cpp
     TestIPv4Address.cpp
+    TestIPv4AddressCidr.cpp
     TestIPv6Address.cpp
     TestIndexSequence.cpp
     TestInsertionSort.cpp

--- a/Tests/AK/TestIPv4AddressCidr.cpp
+++ b/Tests/AK/TestIPv4AddressCidr.cpp
@@ -13,11 +13,9 @@ TEST_CASE(sanity_check)
 {
     auto address_result = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 32);
 
-    EXPECT(!address_result.is_error());
+    IPv4AddressCidr address = TRY_OR_FAIL(address_result);
 
-    IPv4AddressCidr address = address_result.release_value();
-
-    EXPECT_EQ(address.length(), (u32)32);
+    EXPECT_EQ(address.length(), 32l);
     EXPECT_EQ(address.ip_address(), IPv4Address(192, 0, 2, 1));
     EXPECT_EQ(address.first_address_of_subnet(), IPv4Address(192, 0, 2, 1));
     EXPECT_EQ(address.last_address_of_subnet(), IPv4Address(192, 0, 2, 1));
@@ -29,7 +27,7 @@ TEST_CASE(should_fail_on_invalid_length)
 {
     auto address_result = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 33);
     EXPECT(address_result.is_error());
-    EXPECT_EQ(address_result.error(), IPv4AddressCidr::IPAddressCidrError::CidrTooLong);
+    EXPECT_EQ(address_result.error(), AK::Details::IPAddressCidrError::CidrTooLong);
 }
 
 TEST_CASE(should_find_first_in_subnet)
@@ -44,7 +42,7 @@ TEST_CASE(should_find_last_in_subnet)
     EXPECT_EQ(address.last_address_of_subnet(), IPv4Address(192, 0, 2, 255));
 }
 
-TEST_CASE(should_return_matching_netask)
+TEST_CASE(should_return_matching_netmask)
 {
     IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value();
     EXPECT_EQ(address.netmask(), IPv4Address(255, 255, 255, 0));
@@ -68,10 +66,10 @@ TEST_CASE(should_set_address)
 TEST_CASE(should_set_length)
 {
     IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 32).release_value();
-    EXPECT_EQ(address.length(), (u32)32);
+    EXPECT_EQ(address.length(), 32l);
 
     EXPECT(!address.set_length(24).is_error());
-    EXPECT_EQ(address.length(), (u32)24);
+    EXPECT_EQ(address.length(), 24l);
 }
 
 TEST_CASE(should_not_set_invalid_length)
@@ -103,21 +101,21 @@ TEST_CASE(should_not_parse_invalid_address)
 {
     auto address = IPv4AddressCidr::from_string("256.0.0.1/24"sv);
     EXPECT(address.is_error());
-    EXPECT_EQ(address.error(), IPv4AddressCidr::IPAddressCidrError::StringParsingFailed);
+    EXPECT_EQ(address.error(), AK::Details::IPAddressCidrError::StringParsingFailed);
 }
 
 TEST_CASE(should_not_parse_invalid_length)
 {
     auto address = IPv4AddressCidr::from_string("192.0.2.1/33"sv);
     EXPECT(address.is_error());
-    EXPECT_EQ(address.error(), IPv4AddressCidr::IPAddressCidrError::CidrTooLong);
+    EXPECT_EQ(address.error(), AK::Details::IPAddressCidrError::CidrTooLong);
 }
 
 TEST_CASE(should_not_parse_invalid_cidr_format)
 {
     auto address = IPv4AddressCidr::from_string("192.0.2.1"sv);
     EXPECT(address.is_error());
-    EXPECT_EQ(address.error(), IPv4AddressCidr::IPAddressCidrError::StringParsingFailed);
+    EXPECT_EQ(address.error(), AK::Details::IPAddressCidrError::StringParsingFailed);
 }
 
 TEST_CASE(should_format_cidr)

--- a/Tests/AK/TestIPv4AddressCidr.cpp
+++ b/Tests/AK/TestIPv4AddressCidr.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024, famfo <famfo@famfo.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/IPv4Address.h>
+#include <AK/IpAddressCidr.h>
+
+TEST_CASE(sanity_check)
+{
+    auto address_result = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 32);
+
+    EXPECT(!address_result.is_error());
+
+    IPv4AddressCidr address = address_result.release_value();
+
+    EXPECT_EQ(address.length(), (u32)32);
+    EXPECT_EQ(address.ip_address(), IPv4Address(192, 0, 2, 1));
+    EXPECT_EQ(address.first_address_of_subnet(), IPv4Address(192, 0, 2, 1));
+    EXPECT_EQ(address.last_address_of_subnet(), IPv4Address(192, 0, 2, 1));
+    EXPECT_EQ(address.netmask(), IPv4Address(255, 255, 255, 255));
+    EXPECT(address.contains(IPv4Address(192, 0, 2, 1)));
+}
+
+TEST_CASE(should_fail_on_invalid_length)
+{
+    auto address_result = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 33);
+    EXPECT(address_result.is_error());
+    EXPECT_EQ(address_result.error(), IPv4AddressCidr::IPAddressCidrError::CidrTooLong);
+}
+
+TEST_CASE(should_find_first_in_subnet)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value();
+    EXPECT_EQ(address.first_address_of_subnet(), IPv4Address(192, 0, 2, 0));
+}
+
+TEST_CASE(should_find_last_in_subnet)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value();
+    EXPECT_EQ(address.last_address_of_subnet(), IPv4Address(192, 0, 2, 255));
+}
+
+TEST_CASE(should_return_matching_netask)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value();
+    EXPECT_EQ(address.netmask(), IPv4Address(255, 255, 255, 0));
+}
+
+TEST_CASE(should_contain_other)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value();
+    EXPECT(address.contains(IPv4Address(192, 0, 2, 100)));
+}
+
+TEST_CASE(should_set_address)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 8).release_value();
+    EXPECT_EQ(address.ip_address(), IPv4Address(192, 0, 2, 1));
+
+    address.set_ip_address(IPv4Address(198, 51, 100, 1));
+    EXPECT_EQ(address.ip_address(), IPv4Address(198, 51, 100, 1));
+}
+
+TEST_CASE(should_set_length)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 32).release_value();
+    EXPECT_EQ(address.length(), (u32)32);
+
+    EXPECT(!address.set_length(24).is_error());
+    EXPECT_EQ(address.length(), (u32)24);
+}
+
+TEST_CASE(should_not_set_invalid_length)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 32).release_value();
+    EXPECT(address.set_length(33).is_error());
+}
+
+TEST_CASE(should_not_contain_other)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value();
+    EXPECT(!address.contains(IPv4Address(198, 51, 100, 1)));
+}
+
+TEST_CASE(should_contain_this)
+{
+    IPv4AddressCidr address = IPv4AddressCidr::create(IPv4Address(0, 0, 0, 0), 0).release_value();
+    EXPECT(address.contains(IPv4Address(192, 0, 2, 1)));
+}
+
+TEST_CASE(should_parse_cidr_string)
+{
+    auto address = IPv4AddressCidr::from_string("192.0.2.1/24"sv);
+    EXPECT(!address.is_error());
+    EXPECT_EQ(address.release_value(), IPv4AddressCidr::create(IPv4Address(192, 0, 2, 1), 24).release_value());
+}
+
+TEST_CASE(should_not_parse_invalid_address)
+{
+    auto address = IPv4AddressCidr::from_string("256.0.0.1/24"sv);
+    EXPECT(address.is_error());
+    EXPECT_EQ(address.error(), IPv4AddressCidr::IPAddressCidrError::StringParsingFailed);
+}
+
+TEST_CASE(should_not_parse_invalid_length)
+{
+    auto address = IPv4AddressCidr::from_string("192.0.2.1/33"sv);
+    EXPECT(address.is_error());
+    EXPECT_EQ(address.error(), IPv4AddressCidr::IPAddressCidrError::CidrTooLong);
+}
+
+TEST_CASE(should_not_parse_invalid_cidr_format)
+{
+    auto address = IPv4AddressCidr::from_string("192.0.2.1"sv);
+    EXPECT(address.is_error());
+    EXPECT_EQ(address.error(), IPv4AddressCidr::IPAddressCidrError::StringParsingFailed);
+}
+
+TEST_CASE(should_format_cidr)
+{
+    auto address = IPv4AddressCidr(IPv4Address(192, 0, 2, 1), 24).to_string().release_value();
+    EXPECT_EQ(address.bytes_as_string_view(), "192.0.2.1/24"sv);
+}
+
+TEST_CASE(unaligned_mask)
+{
+    auto address = IPv4AddressCidr::create(IPv4Address(192, 0, 0, 42), 27).release_value();
+    EXPECT_EQ(address.first_address_of_subnet(), IPv4Address(192, 0, 0, 32));
+    EXPECT_EQ(address.last_address_of_subnet(), IPv4Address(192, 0, 0, 63));
+}

--- a/Tests/AK/TestIPv6Address.cpp
+++ b/Tests/AK/TestIPv6Address.cpp
@@ -167,3 +167,14 @@ TEST_CASE(subnets)
     EXPECT(broadcast.is_in_subnet(all_routers.network(12), 12));
     EXPECT(!documentation.is_in_subnet(lla, 4));
 }
+
+TEST_CASE(should_convert_to_u128)
+{
+    constexpr u8 array_address[] = { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+    constexpr IPv6Address addr(array_address);
+    auto addr_u128 = addr.to_u128();
+
+    auto expected = bit_cast<NetworkOrdered<u128>>(array_address);
+
+    EXPECT_EQ((u128)addr_u128, (u128)expected);
+}

--- a/Tests/AK/TestIPv6Address.cpp
+++ b/Tests/AK/TestIPv6Address.cpp
@@ -176,5 +176,5 @@ TEST_CASE(should_convert_to_u128)
 
     auto expected = bit_cast<NetworkOrdered<u128>>(array_address);
 
-    EXPECT_EQ((u128)addr_u128, (u128)expected);
+    EXPECT_EQ(static_cast<u128>(addr_u128), static_cast<u128>(expected));
 }

--- a/Tests/AK/TestIPv6AddressCidr.cpp
+++ b/Tests/AK/TestIPv6AddressCidr.cpp
@@ -13,11 +13,9 @@ TEST_CASE(sanity_check)
 {
     auto address_result = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 128);
 
-    EXPECT(!address_result.is_error());
+    IPv6AddressCidr address = TRY_OR_FAIL(address_result);
 
-    IPv6AddressCidr address = address_result.release_value();
-
-    EXPECT_EQ(address.length(), (u32)128);
+    EXPECT_EQ(address.length(), 128l);
     EXPECT_EQ(address.ip_address(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
     EXPECT_EQ(address.first_address_of_subnet(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
     EXPECT_EQ(address.last_address_of_subnet(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
@@ -27,7 +25,7 @@ TEST_CASE(should_fail_on_invalid_length)
 {
     auto address_result = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 129);
     EXPECT(address_result.is_error());
-    EXPECT_EQ(address_result.error(), IPv6AddressCidr::IPAddressCidrError::CidrTooLong);
+    EXPECT_EQ(address_result.error(), AK::Details::IPAddressCidrError::CidrTooLong);
 }
 
 TEST_CASE(should_find_first_in_subnet)
@@ -60,10 +58,10 @@ TEST_CASE(should_set_address)
 TEST_CASE(should_set_length)
 {
     IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
-    EXPECT_EQ(address.length(), (u32)48);
+    EXPECT_EQ(address.length(), 48l);
 
     EXPECT(!address.set_length(64).is_error());
-    EXPECT_EQ(address.length(), (u32)64);
+    EXPECT_EQ(address.length(), 64l);
 }
 
 TEST_CASE(should_not_set_invalid_length)
@@ -95,21 +93,21 @@ TEST_CASE(should_not_parse_invalid_address)
 {
     auto address = IPv6AddressCidr::from_string("200f:db8:::1/48"sv);
     EXPECT(address.is_error());
-    EXPECT_EQ(address.error(), IPv6AddressCidr::IPAddressCidrError::StringParsingFailed);
+    EXPECT_EQ(address.error(), AK::Details::IPAddressCidrError::StringParsingFailed);
 }
 
 TEST_CASE(should_not_parse_invalid_length)
 {
     auto address = IPv6AddressCidr::from_string("2001:db8::1/129"sv);
     EXPECT(address.is_error());
-    EXPECT_EQ(address.error(), IPv6AddressCidr::IPAddressCidrError::CidrTooLong);
+    EXPECT_EQ(address.error(), AK::Details::IPAddressCidrError::CidrTooLong);
 }
 
 TEST_CASE(should_not_parse_invalid_cidr_format)
 {
     auto address = IPv6AddressCidr::from_string("2001:db8::1"sv);
     EXPECT(address.is_error());
-    EXPECT_EQ(address.error(), IPv6AddressCidr::IPAddressCidrError::StringParsingFailed);
+    EXPECT_EQ(address.error(), AK::Details::IPAddressCidrError::StringParsingFailed);
 }
 
 TEST_CASE(should_format_cidr)

--- a/Tests/AK/TestIPv6AddressCidr.cpp
+++ b/Tests/AK/TestIPv6AddressCidr.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024, famfo <famfo@famfo.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/IPv6Address.h>
+#include <AK/IpAddressCidr.h>
+
+TEST_CASE(sanity_check)
+{
+    auto address_result = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 128);
+
+    EXPECT(!address_result.is_error());
+
+    IPv6AddressCidr address = address_result.release_value();
+
+    EXPECT_EQ(address.length(), (u32)128);
+    EXPECT_EQ(address.ip_address(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
+    EXPECT_EQ(address.first_address_of_subnet(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
+    EXPECT_EQ(address.last_address_of_subnet(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
+    EXPECT(address.contains(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 })));
+}
+TEST_CASE(should_fail_on_invalid_length)
+{
+    auto address_result = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 129);
+    EXPECT(address_result.is_error());
+    EXPECT_EQ(address_result.error(), IPv6AddressCidr::IPAddressCidrError::CidrTooLong);
+}
+
+TEST_CASE(should_find_first_in_subnet)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT_EQ(address.first_address_of_subnet(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
+}
+
+TEST_CASE(should_find_last_in_subnet)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT_EQ(address.last_address_of_subnet(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }));
+}
+
+TEST_CASE(should_contain_other)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT(address.contains(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 1 })));
+}
+
+TEST_CASE(should_set_address)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT_EQ(address.ip_address(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
+
+    address.set_ip_address(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 1 }));
+    EXPECT_EQ(address.ip_address(), IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 1 }));
+}
+
+TEST_CASE(should_set_length)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT_EQ(address.length(), (u32)48);
+
+    EXPECT(!address.set_length(64).is_error());
+    EXPECT_EQ(address.length(), (u32)64);
+}
+
+TEST_CASE(should_not_set_invalid_length)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT(address.set_length(129).is_error());
+}
+
+TEST_CASE(should_not_contain_other)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value();
+    EXPECT(!address.contains(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 })));
+}
+
+TEST_CASE(should_contain_this)
+{
+    IPv6AddressCidr address = IPv6AddressCidr::create(IPv6Address({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }), 0).release_value();
+    EXPECT(address.contains(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 })));
+}
+
+TEST_CASE(should_parse_cidr_string)
+{
+    auto address = IPv6AddressCidr::from_string("2001:db8::1/48"sv);
+    EXPECT(!address.is_error());
+    EXPECT_EQ(address.release_value(), IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value());
+}
+
+TEST_CASE(should_not_parse_invalid_address)
+{
+    auto address = IPv6AddressCidr::from_string("200f:db8:::1/48"sv);
+    EXPECT(address.is_error());
+    EXPECT_EQ(address.error(), IPv6AddressCidr::IPAddressCidrError::StringParsingFailed);
+}
+
+TEST_CASE(should_not_parse_invalid_length)
+{
+    auto address = IPv6AddressCidr::from_string("2001:db8::1/129"sv);
+    EXPECT(address.is_error());
+    EXPECT_EQ(address.error(), IPv6AddressCidr::IPAddressCidrError::CidrTooLong);
+}
+
+TEST_CASE(should_not_parse_invalid_cidr_format)
+{
+    auto address = IPv6AddressCidr::from_string("2001:db8::1"sv);
+    EXPECT(address.is_error());
+    EXPECT_EQ(address.error(), IPv6AddressCidr::IPAddressCidrError::StringParsingFailed);
+}
+
+TEST_CASE(should_format_cidr)
+{
+    auto address = IPv6AddressCidr::create(IPv6Address({ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 48).release_value().to_string().release_value();
+    EXPECT_EQ(address.bytes_as_string_view(), "2001:db8::1/48"sv);
+}
+
+TEST_CASE(unaligned_mask)
+{
+    auto address = IPv6AddressCidr::from_string("2001:db8:0:80::1/57"sv).release_value();
+    EXPECT_EQ(address.first_address_of_subnet(), IPv6Address::from_string("2001:db8:0:80::"sv).release_value());
+    EXPECT_EQ(address.last_address_of_subnet(), IPv6Address::from_string("2001:db8:0:ff:ffff:ffff:ffff:ffff"sv).release_value());
+}


### PR DESCRIPTION
This commit introduces a CIDR datatype which will become handy especially for IPv6 to not have to deal with netmasks. 