### PR TITLE
Kernel/Net: Remove obsolete diagnostic trick

### DIFF
--- a/Kernel/Net/EthernetFrameHeader.h
+++ b/Kernel/Net/EthernetFrameHeader.h
@@ -9,8 +9,6 @@
 #include <AK/Endian.h>
 #include <AK/MACAddress.h>
 
-#pragma GCC diagnostic ignored "-Warray-bounds"
-
 class [[gnu::packed]] EthernetFrameHeader {
 public:
     EthernetFrameHeader() = default;


### PR DESCRIPTION
This PR removes an obsolete gcc directive that is no longer required