### PR TITLE
Chess: Some small usablity improvements

### DIFF
--- a/Userland/Games/Chess/Chess.gml
+++ b/Userland/Games/Chess/Chess.gml
@@ -29,8 +29,7 @@
 
             @GUI::TextEditor {
                 name: "move_display_widget"
-                mode: "DisplayOnly"
-                focus_policy: "NoFocus"
+                mode: "ReadOnly"
             }
 
             @GUI::Label {

--- a/Userland/Games/Chess/Chess.gml
+++ b/Userland/Games/Chess/Chess.gml
@@ -2,7 +2,9 @@
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {}
 
-    @GUI::HorizontalSplitter {
+    @GUI::Frame {
+        layout: @GUI::HorizontalBoxLayout {}
+
         @GUI::Frame {
             name: "chess_widget_frame"
             min_width: 508

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -233,6 +233,8 @@ void ChessWidget::mousedown_event(GUI::MouseEvent& event)
     if (!square.has_value())
         return;
 
+    set_focus(true);
+
     auto piece = board().get_piece(square.value());
     if (drag_enabled() && piece.color == board().turn() && !m_playback) {
         m_dragging_piece = true;


### PR DESCRIPTION
When playing the chess game for the first time, the thing i found most interesting was the move history widget. My first thought was to try and copy the text to write it down somewhere else (at this point I didn't know you could copy it in a more "computer-readable" format with the Ctrl+C keybind) - I was very sad to find that this wasn't possible.

My second thought was to try and resize that weird looking column that changed my cursor when hovered. And, to my despair, it allowed me to! Creating a huge black gap between the board and the moves! Ahhh!

This PR fixes both issues, in a hopefully good way (code wise).