### PR TITLE
Kernel: Be a bit more judicious about how we copy USB structures

### DIFF
--- a/Kernel/Bus/USB/USBConfiguration.cpp
+++ b/Kernel/Bus/USB/USBConfiguration.cpp
@@ -14,6 +14,27 @@
 
 namespace Kernel::USB {
 
+USBConfiguration::USBConfiguration(USBConfiguration const& other)
+    : m_device(other.m_device)
+    , m_descriptor(other.m_descriptor)
+    , m_descriptor_index(other.m_descriptor_index)
+    , m_interfaces(other.m_interfaces)
+{
+    // FIXME: This can definitely OOM
+    for (auto& interface : m_interfaces)
+        interface.set_configuration({}, *this);
+}
+
+USBConfiguration::USBConfiguration(USBConfiguration&& other)
+    : m_device(other.m_device)
+    , m_descriptor(other.m_descriptor)
+    , m_descriptor_index(other.m_descriptor_index)
+    , m_interfaces(move(other.m_interfaces))
+{
+    for (auto& interface : m_interfaces)
+        interface.set_configuration({}, *this);
+}
+
 ErrorOr<void> USBConfiguration::enumerate_interfaces()
 {
     if (m_descriptor.total_length < sizeof(USBConfigurationDescriptor))
@@ -24,7 +45,7 @@ ErrorOr<void> USBConfiguration::enumerate_interfaces()
     // The USB spec is a little bit janky here... Interface and Endpoint descriptors aren't fetched
     // through a `GET_DESCRIPTOR` request to the device. Instead, the _entire_ hierarchy is returned
     // to us in one go.
-    auto transfer_length = TRY(m_device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8) | m_descriptor_index, 0, m_descriptor.total_length, descriptor_hierarchy_buffer.data()));
+    auto transfer_length = TRY(m_device->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8) | m_descriptor_index, 0, m_descriptor.total_length, descriptor_hierarchy_buffer.data()));
 
     FixedMemoryStream stream { descriptor_hierarchy_buffer.span() };
 

--- a/Kernel/Bus/USB/USBConfiguration.h
+++ b/Kernel/Bus/USB/USBConfiguration.h
@@ -19,14 +19,22 @@ class USBConfiguration {
 public:
     USBConfiguration() = delete;
     USBConfiguration(Device& device, USBConfigurationDescriptor const descriptor, u8 descriptor_index)
-        : m_device(device)
+        : m_device(&device)
         , m_descriptor(descriptor)
         , m_descriptor_index(descriptor_index)
     {
         m_interfaces.ensure_capacity(descriptor.number_of_interfaces);
     }
 
-    Device const& device() const { return m_device; }
+private:
+    USBConfiguration(USBConfiguration const&);
+
+public:
+    USBConfiguration(USBConfiguration&&);
+    USBConfiguration copy() const { return USBConfiguration(*this); }
+
+    Device const& device() const { return *m_device; }
+    void set_device(Badge<Device>, Device& device) { m_device = &device; }
     USBConfigurationDescriptor const& descriptor() const { return m_descriptor; }
 
     u8 interface_count() const { return m_descriptor.number_of_interfaces; }
@@ -39,7 +47,7 @@ public:
     ErrorOr<void> enumerate_interfaces();
 
 private:
-    Device& m_device;                              // Reference to the device linked to this configuration
+    Device* m_device;                              // Reference to the device linked to this configuration
     USBConfigurationDescriptor const m_descriptor; // Descriptor that backs this configuration
     u8 m_descriptor_index;                         // Descriptor index for {GET,SET}_DESCRIPTOR
     Vector<USBInterface> m_interfaces;             // Interfaces for this device

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -21,12 +21,12 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController& controller,
 {
     auto device = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) Device(controller, &hub, port, speed)));
     device->set_default_pipe(TRY(ControlPipe::create(controller, device, 0, 8)));
+    TRY(controller.initialize_device(*device));
+
     auto sysfs_node = TRY(SysFSUSBDeviceInformation::create(*device));
     device->m_sysfs_device_info_node.with([&](auto& node) {
         node = move(sysfs_node);
     });
-    TRY(controller.initialize_device(*device));
-
     // Attempt to find a driver for this device. If one is found, we call the driver's
     // "probe" function, which initialises the local state for the device driver.
     // It is currently the driver's responsibility to search the configuration/interface

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -71,10 +71,17 @@ Device::Device(Device const& device)
     , m_address(device.address())
     , m_controller_identifier(device.controller_identifier())
     , m_device_descriptor(device.device_descriptor())
-    , m_configurations(device.configurations())
     , m_controller(device.controller())
     , m_hub(device.hub())
 {
+    // FIXME: This can definitely OOM
+    m_configurations.ensure_capacity(device.configurations().size());
+    for (auto const& configuration : device.configurations()) {
+        m_configurations.unchecked_append(configuration.copy());
+        m_configurations.last().set_device({}, *this);
+    }
+
+    // FIXME: Do we need to enter our selves into the hubs children list or sysfs list?
 }
 
 Device::~Device() = default;

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -31,6 +31,13 @@ class USBConfiguration;
 // https://www.ftdichip.com/Support/Documents/TechnicalNotes/TN_113_Simplified%20Description%20of%20USB%20Device%20Enumeration.pdf
 class Hub;
 class Device : public AtomicRefCounted<Device> {
+    friend class Hub;
+    // Note: This constructor is only used by the USB::Hub class
+    //       As that class inherits from Device, but is usually initialized with a Device object
+    //       needing a copy constructor,
+    // FIXME: Ideally Hub should not inherit from Device, but instead have a Device member
+    Device(Device const& device);
+
 public:
     enum class DeviceSpeed : u8 {
         LowSpeed = 0,
@@ -43,7 +50,6 @@ public:
 
     Device(USBController const&, Hub const*, u8 port, DeviceSpeed);
     Device(USBController const&, Hub const*, u8 port, DeviceSpeed, u8 address, USBDeviceDescriptor const& descriptor);
-    Device(Device const& device);
     virtual ~Device();
 
     u8 port() const { return m_device_port; }

--- a/Kernel/Bus/USB/USBInterface.h
+++ b/Kernel/Bus/USB/USBInterface.h
@@ -18,7 +18,7 @@ class USBInterface final {
 public:
     USBInterface() = delete;
     USBInterface(USBConfiguration const& configuration, USBInterfaceDescriptor const descriptor)
-        : m_configuration(configuration)
+        : m_configuration(&configuration)
         , m_descriptor(descriptor)
     {
     }
@@ -28,10 +28,11 @@ public:
     Vector<USBEndpointDescriptor> const& endpoints() const { return m_endpoint_descriptors; }
 
     USBInterfaceDescriptor const& descriptor() const { return m_descriptor; }
-    USBConfiguration const& configuration() const { return m_configuration; }
+    USBConfiguration const& configuration() const { return *m_configuration; }
+    void set_configuration(Badge<USBConfiguration>, USBConfiguration const& configuration) { m_configuration = &configuration; }
 
 private:
-    USBConfiguration const& m_configuration;              // Configuration that this interface belongs to
+    USBConfiguration const* m_configuration;              // Configuration that this interface belongs to
     USBInterfaceDescriptor const m_descriptor;            // Descriptor backing this interface
     Vector<USBEndpointDescriptor> m_endpoint_descriptors; // Endpoint descriptors for this interface (that we can use to open an endpoint)
 };


### PR DESCRIPTION
A lot of USB structures contain back pointers to their parents, so we need to be careful about how we copy them around, and update the back pointers as necessary.

---

Also Fix lsusb