### PR TITLE
Kernel/Net: Implement SO_LINGER support in TCPSocket close behavior

### DIFF
--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -157,6 +157,7 @@ protected:
     ucred m_acceptor { 0, 0, 0 };
     bool m_routing_disabled { false };
     bool m_broadcast_allowed { false };
+    linger m_linger { 0, 0 };
 
 private:
     virtual bool is_socket() const final { return true; }

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -664,6 +664,30 @@ ErrorOr<void> TCPSocket::close()
 {
     MutexLocker locker(mutex());
     auto result = IPv4Socket::close();
+    if (m_linger.l_onoff != 0) {
+        auto has_unacked_data = m_unacked_packets.with_shared([&](auto const& packets) { return packets.size > 0; });
+        if (m_linger.l_linger > 0) {
+            dbgln_if(TCP_SOCKET_DEBUG, "SO_LINGER enabled. Lingering for {} seconds", m_linger.l_linger);
+            auto deadline = TimeManagement::the().monotonic_time(TimePrecision::Precise) + Duration::from_seconds(m_linger.l_linger);
+            do {
+                has_unacked_data = m_unacked_packets.with_shared([&](auto const& packets) { return packets.size > 0; });
+                (void)Thread::current()->sleep(Duration::from_milliseconds(1));
+            } while (has_unacked_data && TimeManagement::the().monotonic_time(TimePrecision::Precise) < deadline);
+
+            if (has_unacked_data) {
+                dbgln_if(TCP_SOCKET_DEBUG, "SO_LINGER timeout. Some data couldn't make it :(");
+                (void)send_tcp_packet(TCPFlags::RST);
+                set_state(State::Closed);
+                return set_so_error(ETIMEDOUT);
+            }
+        } else {
+            dbgln_if(TCP_SOCKET_DEBUG, "SO_LINGER without timeout, closing immediately");
+            (void)send_tcp_packet(TCPFlags::RST);
+            set_state(State::Closed);
+            return {};
+        }
+    }
+
     if (state() == State::CloseWait) {
         dbgln_if(TCP_SOCKET_DEBUG, " Sending FIN from CloseWait and moving into LastAck");
         [[maybe_unused]] auto rc = send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);


### PR DESCRIPTION
This PR introduces a simple option that changes the behavior of `close()` for connection-oriented protocols, allowing us to specify a timeout interval for packets to be acknowledged or let us forcefully close the socket with a RST.

This feature is particularly useful for the Dropbear and libuv ports and enables more advanced socket operations. I specifically need this for porting a mainframe emulator.