### PR TITLE
Kernel/USBMS: Handle STALLs

### DIFF
--- a/Kernel/Bus/USB/Drivers/HID/MouseDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/HID/MouseDriver.cpp
@@ -67,7 +67,7 @@ ErrorOr<void> MouseDriver::initialize_device(USB::Device& device, USBInterface c
         USB_REQUEST_SET_CONFIGURATION, configuration.configuration_id(), 0, 0, nullptr));
 
     auto const& endpoint_descriptor = interface.endpoints()[0];
-    auto interrupt_in_pipe = TRY(USB::InterruptInPipe::create(device.controller(), device, endpoint_descriptor.endpoint_address, endpoint_descriptor.max_packet_size, 10));
+    auto interrupt_in_pipe = TRY(USB::InterruptInPipe::create(device.controller(), device, endpoint_descriptor.endpoint_address & 0xf, endpoint_descriptor.max_packet_size, 10));
 
     // We only support the boot protocol, so switch to it. By default the report protocol is used (see 7.2.6 Set_Protocol Request).
     TRY(device.control_transfer(

--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -152,7 +152,7 @@ ErrorOr<void> MassStorageDriver::initialise_bulk_only_device(USB::Device& device
         dmesgln("SCSI/BBB: Device is not a Direct Access Block device; Rejecting");
         return ENOTSUP;
     }
-    if (inquiry_data.version < 3 || inquiry_data.version > 7) {
+    if ((inquiry_data.version < 3 || inquiry_data.version > 7) && inquiry_data.version != 0) {
         dmesgln("SCSI/BBB: Device SCSI version not supported ({:#02x}); Rejecting", inquiry_data.version);
         return ENOTSUP;
     }

--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -130,6 +130,7 @@ ErrorOr<void> MassStorageDriver::initialise_bulk_only_device(USB::Device& device
 
     auto bulk_scsi_interface = TRY(BulkSCSIInterface::initialize(
         device,
+        interface,
         move(in_pipe),
         move(out_pipe)));
 

--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -31,7 +31,7 @@ ErrorOr<void> MassStorageDriver::checkout_interface(USB::Device& device, USBInte
     if (descriptor.interface_class_code != USB_CLASS_MASS_STORAGE)
         return ENOTSUP;
 
-    dmesgln("USB MassStorage Interface for device {}:{} found:", device.device_descriptor().vendor_id, device.device_descriptor().product_id);
+    dmesgln("USB MassStorage Interface for device {:04x}:{:04x} found:", device.device_descriptor().vendor_id, device.device_descriptor().product_id);
     dmesgln("    Subclass: {} [{:#02x}]", MassStorage::subclass_string((SubclassCode)descriptor.interface_sub_class_code), descriptor.interface_sub_class_code);
     dmesgln("    Protocol: {} [{:#02x}]", MassStorage::transport_protocol_string((TransportProtocol)descriptor.interface_protocol), descriptor.interface_protocol);
 

--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -11,7 +11,6 @@
 #include <Kernel/Bus/USB/USBRequest.h>
 #include <Kernel/Devices/Storage/USB/BulkSCSIInterface.h>
 #include <Kernel/Devices/Storage/USB/Codes.h>
-#include <Kernel/Devices/Storage/USB/SCSIComands.h>
 
 namespace Kernel::USB {
 
@@ -129,109 +128,12 @@ ErrorOr<void> MassStorageDriver::initialise_bulk_only_device(USB::Device& device
     auto in_pipe = TRY(BulkInPipe::create(device.controller(), device, in_pipe_endpoint_number, in_max_packet_size));
     auto out_pipe = TRY(BulkOutPipe::create(device.controller(), device, out_pipe_endpoint_number, out_max_packet_size));
 
-    SCSI::Inquiry inquiry_command {};
-    inquiry_command.allocation_length = sizeof(SCSI::StandardInquiryData);
-
-    SCSI::StandardInquiryData inquiry_data;
-
-    auto inquiry_response = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, inquiry_command, &inquiry_data, sizeof(inquiry_data)));
-    if (inquiry_response.status != CSWStatus::Passed) {
-        dmesgln("SCSI/BBB: Inquiry failed with code {}", to_underlying(inquiry_response.status));
-        return EIO;
-    }
-    dmesgln("    Device Type: {}", inquiry_data.device_type_string());
-    dmesgln("    Peripheral Qualifier: {:#03b}", (u8)inquiry_data.peripheral_info.qualifier);
-    dmesgln("    Removable: {}", (inquiry_data.removable & 0x80) == 0x80);
-    dmesgln("    Version: {:#02x}", inquiry_data.version);
-    dmesgln("    Vendor: {}", StringView { inquiry_data.vendor_id, 8 });
-    dmesgln("    Product: {}", StringView { inquiry_data.product_id, 16 });
-    dmesgln("    Revision: {}", StringView { inquiry_data.product_revision_level, 4 });
-    if (inquiry_data.peripheral_info.device_type != SCSI::StandardInquiryData::DeviceType::DirectAccessBlockDevice) {
-        dmesgln("SCSI/BBB: Device is not a Direct Access Block device; Rejecting");
-        return ENOTSUP;
-    }
-    if ((inquiry_data.version < 3 || inquiry_data.version > 7) && inquiry_data.version != 0) {
-        dmesgln("SCSI/BBB: Device SCSI version not supported ({:#02x}); Rejecting", inquiry_data.version);
-        return ENOTSUP;
-    }
-    if (inquiry_data.response_data.response_data_format != 2) {
-        // SCSI Commands Reference Manual, Rev. J states that only format 2 is valid,
-        // and that format 1 is obsolete, but does not actually specify what format 1 would have been
-        // so ENOTSUP to be safe
-        dmesgln("SCSI/BBB: Device does not support response data format 2 (got {} instead); Rejecting", (u8)inquiry_data.response_data.response_data_format);
-        return ENOTSUP;
-    }
-
-    // FIXME: Re-query INQUIRY if the DRIVE SERIAL NUMBER field is present (see the ADDITIONAL LENGTH field), to record it
-    //        (bytes 36-43 ~ 8 bytes)
-
-    size_t tries = 0;
-    constexpr size_t max_tries = 5;
-    while (tries < max_tries) {
-        SCSI::TestUnitReady test_unit_ready_command {};
-        auto test_unit_ready_response = TRY(send_scsi_command<SCSIDataDirection::NoData>(*out_pipe, *in_pipe, test_unit_ready_command));
-
-        if (test_unit_ready_response.status == CSWStatus::Passed)
-            break;
-
-        SCSI::RequestSense request_sense_command {};
-        SCSI::FixedFormatSenseData sense_data;
-
-        request_sense_command.allocation_length = sizeof(sense_data);
-
-        auto request_sense_response = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, request_sense_command, &sense_data, sizeof(sense_data)));
-        if (request_sense_response.status != CSWStatus::Passed) {
-            dmesgln("SCSI/BBB: Request Sense failed with code {}, possibly unimplemented", to_underlying(request_sense_response.status));
-            return EIO;
-        }
-        // FIXME: Maybe hide this behind a debug flag, as some hardware fails once after startup
-        dbgln("SCSI/BBB: TestUnitReady Failed:");
-        // FIXME: to_string() these
-        dbgln("    Sense Key: {:#02x}", (u8)sense_data.sense_key);
-        dbgln("    Additional Sense Code: {:#02x}", (u8)sense_data.additional_sense_code);
-        dbgln("    Additional Sense Code Qualifier: {:#02x}", (u8)sense_data.additional_sense_code_qualifier);
-
-        ++tries;
-    }
-    if (tries == max_tries) {
-        dmesgln("SCSI/BBB: TestUnitReady failed too many times");
-        return EIO;
-    }
-
-    SCSI::ReadCapacity10Parameters capacity;
-    auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, SCSI::ReadCapacity10 {}, &capacity, sizeof(capacity)));
-
-    if (status.data_residue != 0) {
-        dmesgln("SCSI/BBB: Read Capacity returned with non-zero data residue; Rejecting");
-        return EIO;
-    }
-
-    if (status.status != CSWStatus::Passed) {
-        dmesgln("SCSI/BBB: Failed to query USB Drive capacity; Rejecting");
-        // FIXME: More error handling
-        return ENOTSUP;
-    }
-
-    dmesgln("    Block Size: {}B", capacity.block_size);
-    dmesgln("    Block Count: {}", capacity.block_count);
-    dmesgln("    Total Size: {}MiB", (u64)capacity.block_size * capacity.block_count / MiB);
-
-    StorageDevice::LUNAddress lun = {
-        device.controller().storage_controller_id(),
-        device.address(),
-        // FIXME: Again, support multiple LUNs per device
-        0
-    };
-
-    auto bulk_scsi_interface = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) BulkSCSIInterface(
-        lun,
-        capacity.block_size,
-        capacity.block_count,
+    auto bulk_scsi_interface = TRY(BulkSCSIInterface::initialize(
         device,
         move(in_pipe),
-        move(out_pipe))));
+        move(out_pipe)));
 
-    m_interfaces.append(bulk_scsi_interface);
+    m_interfaces.append(move(bulk_scsi_interface));
 
     return {};
 }

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -369,7 +369,7 @@ TransferDescriptor* UHCIController::create_transfer_descriptor(Pipe& pipe, Packe
     u16 max_len = (data_len > 0) ? (data_len - 1) : 0x7ff;
     VERIFY(max_len <= 0x4FF || max_len == 0x7FF); // According to the datasheet, anything in the range of 0x500 to 0x7FE are illegal
 
-    td->set_token((max_len << TD_TOKEN_MAXLEN_SHIFT) | ((pipe.data_toggle() ? 1 : 0) << TD_TOKEN_DATA_TOGGLE_SHIFT) | (pipe.endpoint_address() << TD_TOKEN_ENDPOINT_SHIFT) | (pipe.device().address() << TD_TOKEN_DEVICE_ADDR_SHIFT) | (static_cast<u8>(direction)));
+    td->set_token((max_len << TD_TOKEN_MAXLEN_SHIFT) | ((pipe.data_toggle() ? 1 : 0) << TD_TOKEN_DATA_TOGGLE_SHIFT) | (pipe.endpoint_number() << TD_TOKEN_ENDPOINT_SHIFT) | (pipe.device().address() << TD_TOKEN_DEVICE_ADDR_SHIFT) | (static_cast<u8>(direction)));
     pipe.set_toggle(!pipe.data_toggle());
 
     if (pipe.type() == Pipe::Type::Isochronous) {

--- a/Kernel/Bus/USB/USBController.cpp
+++ b/Kernel/Bus/USB/USBController.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Bus/USB/USBRequest.h>
 #include <Kernel/Devices/Storage/StorageManagement.h>
 
 namespace Kernel::USB {
@@ -12,6 +13,17 @@ namespace Kernel::USB {
 USBController::USBController()
     : m_storage_controller_id(StorageManagement::generate_controller_id())
 {
+}
+
+ErrorOr<void> USBController::reset_pipe(Device& device, Pipe& pipe)
+{
+    if (pipe.type() == Pipe::Type::Control)
+        return {};
+
+    TRY(device.control_transfer(USB_REQUEST_TYPE_STANDARD | USB_REQUEST_RECIPIENT_ENDPOINT | USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE,
+        USB_REQUEST_CLEAR_FEATURE, USB_FEATURE_ENDPOINT_HALT, pipe.endpoint_address(), 0, nullptr));
+
+    return {};
 }
 
 }

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -28,6 +28,8 @@ public:
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) = 0;
     virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) = 0;
 
+    virtual ErrorOr<void> reset_pipe(Device&, Pipe&);
+
     virtual ErrorOr<void> initialize_device(Device&) = 0;
 
     u32 storage_controller_id() const { return m_storage_controller_id; }

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -23,6 +23,8 @@ Pipe::Pipe(USBController const& controller, Device& device, Type type, Direction
     , m_data_toggle(false)
     , m_dma_buffer(move(dma_buffer))
 {
+    // Valid endpoint numbers are between 0x0 and 0xf, inclusive.
+    VERIFY(endpoint_number <= 0xf);
 }
 
 ErrorOr<void> Pipe::clear_halt()

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -13,26 +13,26 @@
 
 namespace Kernel::USB {
 
-Pipe::Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+Pipe::Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
     : m_controller(controller)
     , m_device(device)
     , m_type(type)
     , m_direction(direction)
-    , m_endpoint_address(endpoint_address)
+    , m_endpoint_number(endpoint_number)
     , m_max_packet_size(max_packet_size)
     , m_data_toggle(false)
     , m_dma_buffer(move(dma_buffer))
 {
 }
 
-ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB device DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) ControlPipe(controller, device, endpoint_address, max_packet_size, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) ControlPipe(controller, device, endpoint_number, max_packet_size, move(dma_buffer)));
 }
 
-ControlPipe::ControlPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, device, Type::Control, Direction::Bidirectional, endpoint_address, max_packet_size, move(dma_buffer))
+ControlPipe::ControlPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Control, Direction::Bidirectional, endpoint_number, max_packet_size, move(dma_buffer))
 {
 }
 
@@ -64,15 +64,15 @@ ErrorOr<size_t> ControlPipe::submit_control_transfer(u8 request_type, u8 request
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<BulkInPipe>> BulkInPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<BulkInPipe>> BulkInPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BulkInPipe(controller, device, endpoint_address, max_packet_size, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) BulkInPipe(controller, device, endpoint_number, max_packet_size, move(dma_buffer)));
 }
 
-BulkInPipe::BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, device, Pipe::Type::Bulk, Direction::In, endpoint_address, max_packet_size, move(dma_buffer))
+BulkInPipe::BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Pipe::Type::Bulk, Direction::In, endpoint_number, max_packet_size, move(dma_buffer))
 {
 }
 
@@ -110,15 +110,15 @@ ErrorOr<size_t> BulkInPipe::submit_bulk_in_transfer(size_t length, UserOrKernelB
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<BulkOutPipe>> BulkOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<BulkOutPipe>> BulkOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BulkOutPipe(controller, device, endpoint_address, max_packet_size, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) BulkOutPipe(controller, device, endpoint_number, max_packet_size, move(dma_buffer)));
 }
 
-BulkOutPipe::BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, device, Type::Bulk, Direction::Out, endpoint_address, max_packet_size, move(dma_buffer))
+BulkOutPipe::BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Bulk, Direction::Out, endpoint_number, max_packet_size, move(dma_buffer))
 
 {
 }
@@ -156,15 +156,15 @@ ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, UserOrKerne
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<InterruptInPipe>> InterruptInPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<InterruptInPipe>> InterruptInPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptInPipe(controller, device, endpoint_address, max_packet_size, poll_interval, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptInPipe(controller, device, endpoint_number, max_packet_size, poll_interval, move(dma_buffer)));
 }
 
-InterruptInPipe::InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_address, max_packet_size, move(dma_buffer))
+InterruptInPipe::InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_number, max_packet_size, move(dma_buffer))
     , m_poll_interval(poll_interval)
 {
 }
@@ -179,15 +179,15 @@ ErrorOr<NonnullLockRefPtr<Transfer>> InterruptInPipe::submit_interrupt_in_transf
     return transfer;
 }
 
-ErrorOr<NonnullOwnPtr<InterruptOutPipe>> InterruptOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<InterruptOutPipe>> InterruptOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
-    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptOutPipe(controller, device, endpoint_address, max_packet_size, poll_interval, move(dma_buffer)));
+    return adopt_nonnull_own_or_enomem(new (nothrow) InterruptOutPipe(controller, device, endpoint_number, max_packet_size, poll_interval, move(dma_buffer)));
 }
 
-InterruptOutPipe::InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
-    : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_address, max_packet_size, move(dma_buffer))
+InterruptOutPipe::InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
+    : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_number, max_packet_size, move(dma_buffer))
     , m_poll_interval(poll_interval)
 {
 }

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -13,7 +13,7 @@
 
 namespace Kernel::USB {
 
-Pipe::Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+Pipe::Pipe(USBController const& controller, Device& device, Type type, Direction direction, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
     : m_controller(controller)
     , m_device(device)
     , m_type(type)
@@ -25,13 +25,13 @@ Pipe::Pipe(USBController const& controller, Device const& device, Type type, Dir
 {
 }
 
-ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB device DMA buffer"sv, Memory::Region::Access::ReadWrite));
     return adopt_nonnull_own_or_enomem(new (nothrow) ControlPipe(controller, device, endpoint_number, max_packet_size, move(dma_buffer)));
 }
 
-ControlPipe::ControlPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+ControlPipe::ControlPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
     : Pipe(controller, device, Type::Control, Direction::Bidirectional, endpoint_number, max_packet_size, move(dma_buffer))
 {
 }
@@ -64,14 +64,14 @@ ErrorOr<size_t> ControlPipe::submit_control_transfer(u8 request_type, u8 request
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<BulkInPipe>> BulkInPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<BulkInPipe>> BulkInPipe::create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
     return adopt_nonnull_own_or_enomem(new (nothrow) BulkInPipe(controller, device, endpoint_number, max_packet_size, move(dma_buffer)));
 }
 
-BulkInPipe::BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+BulkInPipe::BulkInPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
     : Pipe(controller, device, Pipe::Type::Bulk, Direction::In, endpoint_number, max_packet_size, move(dma_buffer))
 {
 }
@@ -110,14 +110,14 @@ ErrorOr<size_t> BulkInPipe::submit_bulk_in_transfer(size_t length, UserOrKernelB
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<BulkOutPipe>> BulkOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<BulkOutPipe>> BulkOutPipe::create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
     return adopt_nonnull_own_or_enomem(new (nothrow) BulkOutPipe(controller, device, endpoint_number, max_packet_size, move(dma_buffer)));
 }
 
-BulkOutPipe::BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
+BulkOutPipe::BulkOutPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer)
     : Pipe(controller, device, Type::Bulk, Direction::Out, endpoint_number, max_packet_size, move(dma_buffer))
 
 {
@@ -156,14 +156,14 @@ ErrorOr<size_t> BulkOutPipe::submit_bulk_out_transfer(size_t length, UserOrKerne
     return transfer_length;
 }
 
-ErrorOr<NonnullOwnPtr<InterruptInPipe>> InterruptInPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<InterruptInPipe>> InterruptInPipe::create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
     return adopt_nonnull_own_or_enomem(new (nothrow) InterruptInPipe(controller, device, endpoint_number, max_packet_size, poll_interval, move(dma_buffer)));
 }
 
-InterruptInPipe::InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
+InterruptInPipe::InterruptInPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
     : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_number, max_packet_size, move(dma_buffer))
     , m_poll_interval(poll_interval)
 {
@@ -179,14 +179,14 @@ ErrorOr<NonnullLockRefPtr<Transfer>> InterruptInPipe::submit_interrupt_in_transf
     return transfer;
 }
 
-ErrorOr<NonnullOwnPtr<InterruptOutPipe>> InterruptOutPipe::create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
+ErrorOr<NonnullOwnPtr<InterruptOutPipe>> InterruptOutPipe::create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size)
 {
     VERIFY(buffer_size >= max_packet_size);
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB pipe DMA buffer"sv, Memory::Region::Access::ReadWrite));
     return adopt_nonnull_own_or_enomem(new (nothrow) InterruptOutPipe(controller, device, endpoint_number, max_packet_size, poll_interval, move(dma_buffer)));
 }
 
-InterruptOutPipe::InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
+InterruptOutPipe::InterruptOutPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_buffer)
     : Pipe(controller, device, Type::Interrupt, Direction::In, endpoint_number, max_packet_size, move(dma_buffer))
     , m_poll_interval(poll_interval)
 {

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -25,6 +25,11 @@ Pipe::Pipe(USBController const& controller, Device& device, Type type, Direction
 {
 }
 
+ErrorOr<void> Pipe::clear_halt()
+{
+    return m_controller->reset_pipe(m_device, *this);
+}
+
 ErrorOr<NonnullOwnPtr<ControlPipe>> ControlPipe::create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size)
 {
     auto dma_buffer = TRY(MM.allocate_dma_buffer_pages(TRY(Memory::page_round_up(buffer_size)), "USB device DMA buffer"sv, Memory::Region::Access::ReadWrite));

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -48,12 +48,15 @@ public:
     Type type() const { return m_type; }
     Direction direction() const { return m_direction; }
 
+    u8 endpoint_address() const { return (direction() == Direction::In ? 0x80 : 0) | m_endpoint_number; }
     u8 endpoint_number() const { return m_endpoint_number; }
     u16 max_packet_size() const { return m_max_packet_size; }
     bool data_toggle() const { return m_data_toggle; }
 
     void set_max_packet_size(u16 max_size) { m_max_packet_size = max_size; }
     void set_toggle(bool toggle) { m_data_toggle = toggle; }
+
+    ErrorOr<void> clear_halt();
 
 protected:
     friend class Device;

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -43,6 +43,7 @@ public:
     };
 
     Device const& device() const { return m_device; }
+    Device& device() { return m_device; }
 
     Type type() const { return m_type; }
     Direction direction() const { return m_direction; }
@@ -57,10 +58,10 @@ public:
 protected:
     friend class Device;
 
-    Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    Pipe(USBController const& controller, Device& device, Type type, Direction direction, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 
     NonnullLockRefPtr<USBController> m_controller;
-    Device const& m_device;
+    Device& m_device;
 
     Type m_type;
     Direction m_direction;
@@ -76,58 +77,58 @@ protected:
 
 class ControlPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<ControlPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<ControlPipe>> create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_control_transfer(u8 request_type, u8 request, u16 value, u16 index, size_t length, void* data);
 
 private:
-    ControlPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    ControlPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 };
 
 class BulkInPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<BulkInPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<BulkInPipe>> create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_bulk_in_transfer(size_t length, void* data);
     ErrorOr<size_t> submit_bulk_in_transfer(size_t length, UserOrKernelBuffer data);
 
 private:
-    BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    BulkInPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 };
 
 class BulkOutPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_bulk_out_transfer(size_t length, void const* data);
     ErrorOr<size_t> submit_bulk_out_transfer(size_t length, UserOrKernelBuffer const data);
 
 private:
-    BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    BulkOutPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 };
 
 class InterruptInPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<InterruptInPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<InterruptInPipe>> create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<NonnullLockRefPtr<Transfer>> submit_interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback);
 
     u16 poll_interval() const { return m_poll_interval; }
 
 private:
-    InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
+    InterruptInPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
 
     u16 m_poll_interval;
 };
 
 class InterruptOutPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<InterruptOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<InterruptOutPipe>> create(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
 
     u16 poll_interval() const { return m_poll_interval; }
 
 private:
-    InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
+    InterruptOutPipe(USBController const& controller, Device& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
 
     u16 m_poll_interval;
 };

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -47,7 +47,7 @@ public:
     Type type() const { return m_type; }
     Direction direction() const { return m_direction; }
 
-    u8 endpoint_address() const { return m_endpoint_address; }
+    u8 endpoint_number() const { return m_endpoint_number; }
     u16 max_packet_size() const { return m_max_packet_size; }
     bool data_toggle() const { return m_data_toggle; }
 
@@ -57,7 +57,7 @@ public:
 protected:
     friend class Device;
 
-    Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    Pipe(USBController const& controller, Device const& device, Type type, Direction direction, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 
     NonnullLockRefPtr<USBController> m_controller;
     Device const& m_device;
@@ -65,7 +65,7 @@ protected:
     Type m_type;
     Direction m_direction;
 
-    u8 m_endpoint_address { 0 };  // Corresponding endpoint address for this pipe
+    u8 m_endpoint_number { 0 };   // Corresponding endpoint number for this pipe
     u16 m_max_packet_size { 0 };  // Max packet size for this pipe
     bool m_data_toggle { false }; // Data toggle for stuffing bit
 
@@ -76,58 +76,58 @@ protected:
 
 class ControlPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<ControlPipe>> create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<ControlPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_control_transfer(u8 request_type, u8 request, u16 value, u16 index, size_t length, void* data);
 
 private:
-    ControlPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    ControlPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 };
 
 class BulkInPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<BulkInPipe>> create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<BulkInPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_bulk_in_transfer(size_t length, void* data);
     ErrorOr<size_t> submit_bulk_in_transfer(size_t length, UserOrKernelBuffer data);
 
 private:
-    BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    BulkInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 };
 
 class BulkOutPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_bulk_out_transfer(size_t length, void const* data);
     ErrorOr<size_t> submit_bulk_out_transfer(size_t length, UserOrKernelBuffer const data);
 
 private:
-    BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
+    BulkOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, NonnullOwnPtr<Memory::Region> dma_buffer);
 };
 
 class InterruptInPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<InterruptInPipe>> create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<InterruptInPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<NonnullLockRefPtr<Transfer>> submit_interrupt_in_transfer(size_t length, u16 ms_interval, USBAsyncCallback callback);
 
     u16 poll_interval() const { return m_poll_interval; }
 
 private:
-    InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
+    InterruptInPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
 
     u16 m_poll_interval;
 };
 
 class InterruptOutPipe : public Pipe {
 public:
-    static ErrorOr<NonnullOwnPtr<InterruptOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
+    static ErrorOr<NonnullOwnPtr<InterruptOutPipe>> create(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, size_t buffer_size = PAGE_SIZE);
 
     u16 poll_interval() const { return m_poll_interval; }
 
 private:
-    InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_address, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
+    InterruptOutPipe(USBController const& controller, Device const& device, u8 endpoint_number, u16 max_packet_size, u16 poll_interval, NonnullOwnPtr<Memory::Region> dma_pool);
 
     u16 m_poll_interval;
 };

--- a/Kernel/Bus/USB/USBRequest.h
+++ b/Kernel/Bus/USB/USBRequest.h
@@ -42,4 +42,12 @@ static constexpr u8 USB_REQUEST_SET_DESCRIPTOR = 0x07;
 static constexpr u8 USB_REQUEST_GET_CONFIGURATION = 0x08;
 static constexpr u8 USB_REQUEST_SET_CONFIGURATION = 0x09;
 
+// Table 9-6
+static constexpr u16 USB_FEATURE_DEVICE_REMOTE_WAKEUP = 1;
+static constexpr u16 USB_FEATURE_ENDPOINT_HALT = 0;
+static constexpr u16 USB_FEATURE_TEST_MODE = 2;
+
+// Figure 9-6
+static constexpr u16 USB_ENDPOINT_STATUS_HALT = 1 << 0;
+
 }

--- a/Kernel/Bus/USB/xHCI/xHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIController.cpp
@@ -915,6 +915,9 @@ ErrorOr<size_t> xHCIController::submit_bulk_transfer(Transfer& transfer)
     pending_transfer.wait_queue.wait_forever();
     VERIFY(!pending_transfer.endpoint_list_node.is_in_list());
 
+    if (pending_transfer.completion_code == TransferRequestBlock::CompletionCode::Stall_Error)
+        return ESHUTDOWN;
+
     if (pending_transfer.completion_code != TransferRequestBlock::CompletionCode::Success
         && pending_transfer.completion_code != TransferRequestBlock::CompletionCode::Short_Packet)
         return EIO;

--- a/Kernel/Bus/USB/xHCI/xHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIController.cpp
@@ -867,7 +867,8 @@ ErrorOr<size_t> xHCIController::submit_bulk_transfer(Transfer& transfer)
     pending_transfer.wait_queue.wait_forever();
     VERIFY(!pending_transfer.endpoint_list_node.is_in_list());
 
-    if (pending_transfer.completion_code != TransferRequestBlock::CompletionCode::Success)
+    if (pending_transfer.completion_code != TransferRequestBlock::CompletionCode::Success
+        && pending_transfer.completion_code != TransferRequestBlock::CompletionCode::Short_Packet)
         return EIO;
 
     return transfer.transfer_data_size() - pending_transfer.remainder;
@@ -1360,7 +1361,8 @@ void xHCIController::handle_transfer_event(TransferRequestBlock const& transfer_
     auto& endpoint_ring = slot_state.endpoint_rings[endpoint - 1];
     VERIFY(endpoint_ring.region);
 
-    if (transfer_request_block.transfer_event.completion_code != TransferRequestBlock::CompletionCode::Success)
+    if (transfer_request_block.transfer_event.completion_code != TransferRequestBlock::CompletionCode::Success
+        && transfer_request_block.transfer_event.completion_code != TransferRequestBlock::CompletionCode::Short_Packet)
         dmesgln_pci(*this, "Transfer error on slot {} endpoint {}: {}", slot, endpoint, enum_to_string(transfer_request_block.transfer_event.completion_code));
 
     VERIFY(transfer_request_block.transfer_event.event_data == 0); // The Pointer points to the interrupting TRB

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -35,6 +35,8 @@ public:
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) override;
     virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) override;
 
+    virtual ErrorOr<void> reset_pipe(USB::Device&, USB::Pipe&) override;
+
     virtual ErrorOr<void> initialize_device(USB::Device&) override;
 
     ErrorOr<void> initialize_endpoint_if_needed(Pipe const&);
@@ -1145,6 +1147,14 @@ private:
     ErrorOr<void> address_device(u8 slot, u64 input_context_address);
     ErrorOr<void> evaluate_context(u8 slot, u64 input_context_address);
     ErrorOr<void> configure_endpoint(u8 slot, u64 input_context_address);
+
+    enum class TransferStatePreserve {
+        No,
+        Yes,
+    };
+    ErrorOr<void> reset_endpoint(u8 slot, u8 endpoint, TransferStatePreserve);
+
+    ErrorOr<void> set_tr_dequeue_pointer(u8 slot, u8 endpoint, u8 stream_context_type, u16 stream, u64 new_tr_dequeue_pointer, u8 dequeue_cycle_state);
 
     ErrorOr<void> enqueue_transfer(u8 slot, u8 endpoint, Pipe::Direction direction, Span<TransferRequestBlock>, PendingTransfer&);
     void handle_transfer_event(TransferRequestBlock const&);

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -128,6 +128,7 @@ set(KERNEL_SOURCES
     Devices/Storage/SD/SDHostController.cpp
     Devices/Storage/SD/SDMemoryCard.cpp
     Devices/Storage/USB/BulkSCSIInterface.cpp
+    Devices/Storage/USB/BulkSCSIStorageDevice.cpp
     Devices/Storage/VirtIO/VirtIOBlockController.cpp
     Devices/Storage/VirtIO/VirtIOBlockDevice.cpp
     Devices/Storage/StorageController.cpp

--- a/Kernel/Debug.h.in
+++ b/Kernel/Debug.h.in
@@ -358,3 +358,7 @@
 #ifndef XHCI_DEBUG
 #cmakedefine01 XHCI_DEBUG
 #endif
+
+#ifndef USB_MASS_STORAGE_DEBUG
+#cmakedefine01 USB_MASS_STORAGE_DEBUG
+#endif

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
@@ -12,24 +12,128 @@
 
 namespace Kernel::USB {
 
-BulkSCSIInterface::BulkSCSIInterface(StorageDevice::LUNAddress logical_unit_number_address, size_t sector_size, u64 max_addressable_block, USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe)
+BulkSCSIInterface::BulkSCSIInterface(USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe)
     : m_device(device)
     , m_in_pipe(move(in_pipe))
     , m_out_pipe(move(out_pipe))
 {
-    auto storage_device = DeviceManagement::try_create_device<BulkSCSIStorageDevice>(
-        *this,
-        *m_out_pipe,
-        *m_in_pipe,
-        logical_unit_number_address,
-        device.address(), // FIXME: Figure out a better ID to put here
-        sector_size,
-        max_addressable_block)
-                              .release_value_but_fixme_should_propagate_errors();
+}
 
-    m_storage_devices.append(storage_device);
+ErrorOr<NonnullLockRefPtr<BulkSCSIInterface>> BulkSCSIInterface::initialize(USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe)
+{
+    SCSI::Inquiry inquiry_command {};
+    inquiry_command.allocation_length = sizeof(SCSI::StandardInquiryData);
+
+    SCSI::StandardInquiryData inquiry_data;
+
+    auto inquiry_response = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, inquiry_command, &inquiry_data, sizeof(inquiry_data)));
+    if (inquiry_response.status != CSWStatus::Passed) {
+        dmesgln("SCSI/BBB: Inquiry failed with code {}", to_underlying(inquiry_response.status));
+        return EIO;
+    }
+    dmesgln("    Device Type: {}", inquiry_data.device_type_string());
+    dmesgln("    Peripheral Qualifier: {:#03b}", (u8)inquiry_data.peripheral_info.qualifier);
+    dmesgln("    Removable: {}", (inquiry_data.removable & 0x80) == 0x80);
+    dmesgln("    Version: {:#02x}", inquiry_data.version);
+    dmesgln("    Vendor: {}", StringView { inquiry_data.vendor_id, 8 });
+    dmesgln("    Product: {}", StringView { inquiry_data.product_id, 16 });
+    dmesgln("    Revision: {}", StringView { inquiry_data.product_revision_level, 4 });
+    if (inquiry_data.peripheral_info.device_type != SCSI::StandardInquiryData::DeviceType::DirectAccessBlockDevice) {
+        dmesgln("SCSI/BBB: Device is not a Direct Access Block device; Rejecting");
+        return ENOTSUP;
+    }
+    if ((inquiry_data.version < 3 || inquiry_data.version > 7) && inquiry_data.version != 0) {
+        dmesgln("SCSI/BBB: Device SCSI version not supported ({:#02x}); Rejecting", inquiry_data.version);
+        return ENOTSUP;
+    }
+    if (inquiry_data.response_data.response_data_format != 2) {
+        // SCSI Commands Reference Manual, Rev. J states that only format 2 is valid,
+        // and that format 1 is obsolete, but does not actually specify what format 1 would have been
+        // so ENOTSUP to be safe
+        dmesgln("SCSI/BBB: Device does not support response data format 2 (got {} instead); Rejecting", (u8)inquiry_data.response_data.response_data_format);
+        return ENOTSUP;
+    }
+
+    // FIXME: Re-query INQUIRY if the DRIVE SERIAL NUMBER field is present (see the ADDITIONAL LENGTH field), to record it
+    //        (bytes 36-43 ~ 8 bytes)
+
+    size_t tries = 0;
+    constexpr size_t max_tries = 5;
+    while (tries < max_tries) {
+        SCSI::TestUnitReady test_unit_ready_command {};
+        auto test_unit_ready_response = TRY(send_scsi_command<SCSIDataDirection::NoData>(*out_pipe, *in_pipe, test_unit_ready_command));
+
+        if (test_unit_ready_response.status == CSWStatus::Passed)
+            break;
+
+        SCSI::RequestSense request_sense_command {};
+        SCSI::FixedFormatSenseData sense_data;
+
+        request_sense_command.allocation_length = sizeof(sense_data);
+
+        auto request_sense_response = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, request_sense_command, &sense_data, sizeof(sense_data)));
+        if (request_sense_response.status != CSWStatus::Passed) {
+            dmesgln("SCSI/BBB: Request Sense failed with code {}, possibly unimplemented", to_underlying(request_sense_response.status));
+            return EIO;
+        }
+        // FIXME: Maybe hide this behind a debug flag, as some hardware fails once after startup
+        dbgln("SCSI/BBB: TestUnitReady Failed:");
+        // FIXME: to_string() these
+        dbgln("    Sense Key: {:#02x}", (u8)sense_data.sense_key);
+        dbgln("    Additional Sense Code: {:#02x}", (u8)sense_data.additional_sense_code);
+        dbgln("    Additional Sense Code Qualifier: {:#02x}", (u8)sense_data.additional_sense_code_qualifier);
+
+        ++tries;
+    }
+    if (tries == max_tries) {
+        dmesgln("SCSI/BBB: TestUnitReady failed too many times");
+        return EIO;
+    }
+
+    SCSI::ReadCapacity10Parameters capacity;
+    auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*out_pipe, *in_pipe, SCSI::ReadCapacity10 {}, &capacity, sizeof(capacity)));
+
+    if (status.data_residue != 0) {
+        dmesgln("SCSI/BBB: Read Capacity returned with non-zero data residue; Rejecting");
+        return EIO;
+    }
+
+    if (status.status != CSWStatus::Passed) {
+        dmesgln("SCSI/BBB: Failed to query USB Drive capacity; Rejecting");
+        // FIXME: More error handling
+        return ENOTSUP;
+    }
+
+    dmesgln("    Block Size: {}B", capacity.block_size);
+    dmesgln("    Block Count: {}", capacity.block_count);
+    dmesgln("    Total Size: {}MiB", (u64)capacity.block_size * capacity.block_count / MiB);
+
+    auto bulk_scsi_interface = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) BulkSCSIInterface(
+        device,
+        move(in_pipe),
+        move(out_pipe))));
+
+    StorageDevice::LUNAddress lun = {
+        device.controller().storage_controller_id(),
+        device.address(),
+        // FIXME: Support multiple LUNs per device
+        0
+    };
+
+    auto storage_device = TRY(DeviceManagement::try_create_device<BulkSCSIStorageDevice>(
+        *bulk_scsi_interface,
+        *bulk_scsi_interface->m_out_pipe,
+        *bulk_scsi_interface->m_in_pipe,
+        lun,
+        device.address(), // FIXME: Figure out a better ID to put here
+        capacity.block_size,
+        capacity.block_count));
+
+    bulk_scsi_interface->add_storage_device(storage_device);
 
     StorageManagement::the().add_device(storage_device);
+
+    return bulk_scsi_interface;
 }
 
 BulkSCSIInterface::~BulkSCSIInterface()

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
@@ -5,215 +5,37 @@
  */
 
 #include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Devices/DeviceManagement.h>
+#include <Kernel/Devices/Storage/StorageManagement.h>
 #include <Kernel/Devices/Storage/USB/BulkSCSIInterface.h>
 #include <Kernel/Devices/Storage/USB/SCSIComands.h>
 
 namespace Kernel::USB {
 
-BulkSCSIInterface::BulkSCSIInterface(LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block, USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe)
-    : StorageDevice(logical_unit_number_address, hardware_relative_controller_id, sector_size, max_addressable_block)
-    , m_device(device)
+BulkSCSIInterface::BulkSCSIInterface(StorageDevice::LUNAddress logical_unit_number_address, size_t sector_size, u64 max_addressable_block, USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe)
+    : m_device(device)
     , m_in_pipe(move(in_pipe))
     , m_out_pipe(move(out_pipe))
 {
-    // Note: If this fails, it only means that we may be inefficient in our way
-    //       of talking to the device.
-    (void)query_characteristics();
+    auto storage_device = DeviceManagement::try_create_device<BulkSCSIStorageDevice>(
+        *this,
+        *m_out_pipe,
+        *m_in_pipe,
+        logical_unit_number_address,
+        device.address(), // FIXME: Figure out a better ID to put here
+        sector_size,
+        max_addressable_block)
+                              .release_value_but_fixme_should_propagate_errors();
+
+    m_storage_devices.append(storage_device);
+
+    StorageManagement::the().add_device(storage_device);
 }
 
-ErrorOr<void> BulkSCSIInterface::query_characteristics()
+BulkSCSIInterface::~BulkSCSIInterface()
 {
-    SCSI::Inquiry inquiry_command {};
-    inquiry_command.enable_vital_product_data = 1;
-    alignas(SCSI::SupportedVitalProductPages) u8 vital_product_page_buffer[0xfc];
-    SCSI::SupportedVitalProductPages& vital_product_page = *reinterpret_cast<SCSI::SupportedVitalProductPages*>(vital_product_page_buffer);
-
-    inquiry_command.page_code = SCSI::VitalProductDataPageCode::SupportedVitalProductDataPages;
-    inquiry_command.allocation_length = sizeof(vital_product_page_buffer);
-
-    auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*m_out_pipe, *m_in_pipe, inquiry_command, &vital_product_page, sizeof(vital_product_page_buffer)));
-
-    if (status.status != CSWStatus::Passed) {
-        dbgln("SCSI/BBB: Inquiry failed to inquire supported vital product data pages with code {}", to_underlying(status.status));
-        // FIXME: Maybe request sense here
-        // FIXME: Treating this as an error for now
-        // Some HW seems to stall this and/or send garbage...
-        return EIO;
-    }
-    if (vital_product_page.page_code != SCSI::VitalProductDataPageCode::SupportedVitalProductDataPages) {
-        dmesgln("SCSI/BBB: Returned wrong page code for supported vital product data pages: {:#02x}", to_underlying(vital_product_page.page_code));
-        return EIO;
-    }
-
-    if ((vital_product_page.page_length + 4uz) > sizeof(vital_product_page_buffer)) {
-        // Note: This should not be possible, as there are less than 253 page codes allocated
-        dmesgln("SCSI/BBB: Warning: Returned page length for supported vital product data pages is bigger than the allocated buffer, we might be missing some supported pages");
-    }
-
-    // FIXME: Maybe check status.residual_data here
-    auto available_pages = min(vital_product_page.page_length, sizeof(vital_product_page_buffer) - sizeof(SCSI::VitalProductPage));
-    bool found_block_limits = false;
-    for (size_t i = 0; i < available_pages; i++) {
-        if (vital_product_page.supported_pages[i] == SCSI::VitalProductDataPageCode::BlockLimits) {
-            found_block_limits = true;
-            break;
-        }
-        if (to_underlying(vital_product_page.supported_pages[i]) >= to_underlying(SCSI::VitalProductDataPageCode::BlockLimits)) {
-            // The available pages are (supposedly) sorted in ascending order
-            // so we can break here early
-            break;
-        }
-    }
-
-    if (!found_block_limits) {
-        dmesgln("SCSI/BBB: Device does not support block limits page");
-        // This is not an error, we just won't be able to optimize our transfers
-        return {};
-    }
-
-    inquiry_command.page_code = SCSI::VitalProductDataPageCode::BlockLimits;
-    SCSI::BlockLimitsPage block_limits_page {};
-    inquiry_command.allocation_length = sizeof(SCSI::BlockLimitsPage);
-    status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*m_out_pipe, *m_in_pipe, inquiry_command, &block_limits_page, sizeof(SCSI::BlockLimitsPage)));
-    if (status.status != CSWStatus::Passed) {
-        dbgln("SCSI/BBB: Inquiry failed to inquire block limits with code {}", to_underlying(status.status));
-        // FIXME: Maybe request sense here
-    }
-
-    if (block_limits_page.page_code != SCSI::VitalProductDataPageCode::BlockLimits) {
-        dmesgln("SCSI/BBB: Returned wrong page code for block limits {:#02x}", to_underlying(block_limits_page.page_code));
-        return EIO;
-    }
-
-    if (block_limits_page.page_length != sizeof(SCSI::BlockLimitsPage) - 4) {
-        dmesgln("SCSI/BBB: Returned wrong page length for block limits {}", block_limits_page.page_length);
-        return EIO;
-    }
-
-    if (block_limits_page.maximum_transfer_length != 0)
-        m_maximum_transfer_length = block_limits_page.maximum_transfer_length;
-    if (block_limits_page.optimal_transfer_length != 0)
-        m_optimal_transfer_length = block_limits_page.optimal_transfer_length;
-    if (block_limits_page.optimal_transfer_length_granularity != 0)
-        m_optimal_transfer_length_granularity = block_limits_page.optimal_transfer_length_granularity;
-
-    dbgln("SCSI/BBB: Maximum transfer length: {}", m_maximum_transfer_length);
-    dbgln("SCSI/BBB: Optimal transfer length: {}", m_optimal_transfer_length);
-    dbgln("SCSI/BBB: Optimal transfer length granularity: {}", m_optimal_transfer_length_granularity);
-
-    return {};
+    for (auto& storage_device : m_storage_devices)
+        StorageManagement::the().remove_device(storage_device);
 }
 
-u32 BulkSCSIInterface::optimal_block_count(u32 blocks)
-{
-    if (m_maximum_transfer_length.has_value() && blocks > m_maximum_transfer_length.value())
-        return m_maximum_transfer_length.value();
-    // quot. OPTIMAL TRANSFER LENGTH field:
-    // "[...] If a device server receives one of these commands with a transfer size greater than this value,
-    //  then the device server may incur significant delays in processing the command."
-    if (m_optimal_transfer_length.has_value() && blocks > m_optimal_transfer_length.value())
-        return m_optimal_transfer_length.value();
-
-    if (!m_optimal_transfer_length_granularity.has_value())
-        return blocks;
-
-    // quot. OPTIMAL TRANSFER LENGTH GRANULARITY field:
-    // "[...] If a device server receives one of these commands with a transfer size that
-    //  is not equal to a multiple of this value, then the device server may incur significant
-    //  delays in processing the command."
-    // FIXME: This sounds like it may be faster to align up to the granularity in some cases
-    //        But that might be difficult to accomplish in some cases (Ie writing)
-    if (blocks < m_optimal_transfer_length_granularity.value())
-        return blocks;
-
-    return blocks - (blocks % m_optimal_transfer_length_granularity.value());
-}
-
-void BulkSCSIInterface::start_request(AsyncBlockDeviceRequest& request)
-{
-    if (request.request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
-        if (do_read(request.block_index(), request.block_count(), request.buffer(), request.buffer_size()).is_error()) {
-            request.complete(AsyncDeviceRequest::RequestResult::Failure);
-        } else {
-            request.complete(AsyncDeviceRequest::RequestResult::Success);
-        }
-    } else {
-        if (do_write(request.block_index(), request.block_count(), request.buffer(), request.buffer_size()).is_error()) {
-            request.complete(AsyncDeviceRequest::RequestResult::Failure);
-        } else {
-            request.complete(AsyncDeviceRequest::RequestResult::Success);
-        }
-    }
-}
-
-ErrorOr<void> BulkSCSIInterface::do_read(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t)
-{
-    // FIXME: Error Handling and proper device reset on exit
-    SCSI::Read10 read_command;
-
-    u32 block_index_to_read = block_index;
-    u32 blocks_read = 0;
-    UserOrKernelBuffer destination_buffer = buffer;
-    while (blocks_read < block_count) {
-        read_command.logical_block_address = block_index_to_read;
-
-        // FIXME: We only use READ(10) so we only ever read u16::max blocks at a time
-        auto blocks_to_transfer = optimal_block_count(block_count - blocks_read);
-        u16 transfer_length_bytes = min(blocks_to_transfer * block_size(), AK::NumericLimits<u16>::max());
-
-        read_command.transfer_length = transfer_length_bytes / block_size();
-
-        auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(*m_out_pipe, *m_in_pipe, read_command, destination_buffer, transfer_length_bytes));
-
-        if (status.status != CSWStatus::Passed) {
-            // FIXME: Actually handle the error
-            //        See usbmassbulk 5.3, 6.4 and 6.5
-            dmesgln("SCSI/BBB: Read failed with code {}", to_underlying(status.status));
-            return EIO;
-        }
-
-        u32 bytes_transferred = transfer_length_bytes - status.data_residue;
-        u32 blocks_read_in_transfer = bytes_transferred / block_size();
-
-        blocks_read += blocks_read_in_transfer;
-        block_index_to_read += blocks_read_in_transfer;
-    }
-
-    return {};
-}
-
-ErrorOr<void> BulkSCSIInterface::do_write(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t)
-{
-    // FIXME: Error Handling and proper device reset on exit
-    SCSI::Write10 read_command;
-
-    u32 block_index_to_read = block_index;
-    u32 blocks_read = 0;
-    UserOrKernelBuffer source_buffer = buffer;
-    while (blocks_read < block_count) {
-        read_command.logical_block_address = block_index_to_read;
-
-        // FIXME: We only use WRITE(10) so we only ever write u16::max blocks at a time
-        auto blocks_to_transfer = optimal_block_count(block_count - blocks_read);
-        u16 transfer_length_bytes = min(blocks_to_transfer * block_size(), AK::NumericLimits<u16>::max());
-
-        read_command.transfer_length = transfer_length_bytes / block_size();
-
-        auto status = TRY(send_scsi_command<SCSIDataDirection::DataToTarget>(*m_out_pipe, *m_in_pipe, read_command, source_buffer, transfer_length_bytes));
-
-        if (status.status != CSWStatus::Passed) {
-            // FIXME: Actually handle the error
-            //        See usbmassbulk 5.3, 6.4 and 6.5
-            dmesgln("SCSI/BBB: Write failed with code {}", to_underlying(status.status));
-            return EIO;
-        }
-
-        u32 bytes_transferred = transfer_length_bytes - status.data_residue;
-        u32 blocks_read_in_transfer = bytes_transferred / block_size();
-        blocks_read += blocks_read_in_transfer;
-        block_index_to_read += blocks_read_in_transfer;
-    }
-
-    return {};
-}
 }

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
@@ -148,12 +148,17 @@ static ErrorOr<CommandStatusWrapper> send_scsi_command(
 class BulkSCSIInterface : public RefCounted<BulkSCSIInterface> {
     // https://www.usb.org/sites/default/files/usbmassbulk_10.pdf
 public:
-    BulkSCSIInterface(StorageDevice::LUNAddress logical_unit_number_address, size_t sector_size, u64 max_addressable_block, USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe);
+    static ErrorOr<NonnullLockRefPtr<BulkSCSIInterface>> initialize(USB::Device&, NonnullOwnPtr<BulkInPipe>, NonnullOwnPtr<BulkOutPipe>);
+
     ~BulkSCSIInterface();
 
     USB::Device const& device() const { return m_device; }
 
 private:
+    BulkSCSIInterface(USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe);
+
+    void add_storage_device(NonnullLockRefPtr<BulkSCSIStorageDevice> storage_device) { m_storage_devices.append(storage_device); }
+
     BulkSCSIStorageDevice::List m_storage_devices;
 
     USB::Device& m_device;

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
@@ -64,55 +64,6 @@ enum class SCSIDataDirection {
     NoData
 };
 
-template<SCSIDataDirection Direction, typename Command, typename Data = nullptr_t>
-requires(IsNullPointer<Data>
-    || IsPointer<Data>
-    || (Direction == SCSIDataDirection::DataToInitiator && IsSame<Data, UserOrKernelBuffer>)
-    || (Direction == SCSIDataDirection::DataToTarget && IsSameIgnoringCV<Data, UserOrKernelBuffer>))
-static ErrorOr<CommandStatusWrapper> send_scsi_command(
-    USB::BulkOutPipe& out_pipe, USB::BulkInPipe& in_pipe,
-    Command const& command,
-    Data data = nullptr, size_t data_size = 0)
-{
-    CommandBlockWrapper command_block {};
-    command_block.transfer_length = data_size;
-    if constexpr (Direction == SCSIDataDirection::DataToInitiator)
-        command_block.direction = CBWDirection::DataIn;
-    else
-        command_block.direction = CBWDirection::DataOut;
-
-    command_block.set_command(command);
-
-    TRY(out_pipe.submit_bulk_out_transfer(sizeof(command_block), &command_block));
-
-    if constexpr (Direction == SCSIDataDirection::DataToInitiator) {
-        static_assert(!IsNullPointer<Data>);
-        VERIFY(data_size != 0);
-        TRY(in_pipe.submit_bulk_in_transfer(data_size, data));
-    } else if constexpr (Direction == SCSIDataDirection::DataToTarget) {
-        static_assert(!IsNullPointer<Data>);
-        VERIFY(data_size != 0);
-        TRY(out_pipe.submit_bulk_out_transfer(data_size, data));
-    } else {
-        static_assert(IsNullPointer<Data>);
-        VERIFY(data_size == 0);
-    }
-
-    CommandStatusWrapper status;
-    TRY(in_pipe.submit_bulk_in_transfer(sizeof(status), &status));
-    if (status.signature != 0x53425355) {
-        dmesgln("SCSI: Command status signature mismatch, expected 0x53425355, got {:#x}", status.signature);
-        return EIO;
-    }
-
-    if (status.tag != command_block.tag) {
-        dmesgln("SCSI: Command tag mismatch, expected {}, got {}", command_block.tag, status.tag);
-        return EIO;
-    }
-
-    return status;
-}
-
 class BulkSCSIInterface : public RefCounted<BulkSCSIInterface> {
     // https://www.usb.org/sites/default/files/usbmassbulk_10.pdf
 public:
@@ -121,6 +72,54 @@ public:
     ~BulkSCSIInterface();
 
     USB::Device const& device() const { return m_device; }
+
+    template<SCSIDataDirection Direction, typename Command, typename Data = nullptr_t>
+    requires(IsNullPointer<Data>
+        || IsPointer<Data>
+        || (Direction == SCSIDataDirection::DataToInitiator && IsSame<Data, UserOrKernelBuffer>)
+        || (Direction == SCSIDataDirection::DataToTarget && IsSameIgnoringCV<Data, UserOrKernelBuffer>))
+    ErrorOr<CommandStatusWrapper> send_scsi_command(
+        Command const& command,
+        Data data = nullptr, size_t data_size = 0)
+    {
+        CommandBlockWrapper command_block {};
+        command_block.transfer_length = data_size;
+        if constexpr (Direction == SCSIDataDirection::DataToInitiator)
+            command_block.direction = CBWDirection::DataIn;
+        else
+            command_block.direction = CBWDirection::DataOut;
+
+        command_block.set_command(command);
+
+        TRY(m_out_pipe->submit_bulk_out_transfer(sizeof(command_block), &command_block));
+
+        if constexpr (Direction == SCSIDataDirection::DataToInitiator) {
+            static_assert(!IsNullPointer<Data>);
+            VERIFY(data_size != 0);
+            TRY(m_in_pipe->submit_bulk_in_transfer(data_size, data));
+        } else if constexpr (Direction == SCSIDataDirection::DataToTarget) {
+            static_assert(!IsNullPointer<Data>);
+            VERIFY(data_size != 0);
+            TRY(m_out_pipe->submit_bulk_out_transfer(data_size, data));
+        } else {
+            static_assert(IsNullPointer<Data>);
+            VERIFY(data_size == 0);
+        }
+
+        CommandStatusWrapper status;
+        TRY(m_in_pipe->submit_bulk_in_transfer(sizeof(status), &status));
+        if (status.signature != 0x53425355) {
+            dmesgln("SCSI: Command status signature mismatch, expected 0x53425355, got {:#x}", status.signature);
+            return EIO;
+        }
+
+        if (status.tag != command_block.tag) {
+            dmesgln("SCSI: Command tag mismatch, expected {}, got {}", command_block.tag, status.tag);
+            return EIO;
+        }
+
+        return status;
+    }
 
 private:
     BulkSCSIInterface(USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe);

--- a/Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.cpp
+++ b/Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.cpp
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Devices/Storage/USB/BulkSCSIInterface.h>
+#include <Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.h>
+#include <Kernel/Devices/Storage/USB/SCSIComands.h>
+
+namespace Kernel::USB {
+
+BulkSCSIStorageDevice::BulkSCSIStorageDevice(BulkSCSIInterface& interface, BulkOutPipe& out_pipe, BulkInPipe& in_pipe, LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block)
+    : StorageDevice(logical_unit_number_address, hardware_relative_controller_id, sector_size, max_addressable_block)
+    , m_interface(interface)
+    , m_out_pipe(out_pipe)
+    , m_in_pipe(in_pipe)
+{
+    // Note: If this fails, it only means that we may be inefficient in our way
+    //       of talking to the device.
+    (void)query_characteristics();
+}
+
+ErrorOr<void> BulkSCSIStorageDevice::query_characteristics()
+{
+    SCSI::Inquiry inquiry_command {};
+    inquiry_command.enable_vital_product_data = 1;
+    alignas(SCSI::SupportedVitalProductPages) u8 vital_product_page_buffer[0xfc];
+    SCSI::SupportedVitalProductPages& vital_product_page = *reinterpret_cast<SCSI::SupportedVitalProductPages*>(vital_product_page_buffer);
+
+    inquiry_command.page_code = SCSI::VitalProductDataPageCode::SupportedVitalProductDataPages;
+    inquiry_command.allocation_length = sizeof(vital_product_page_buffer);
+
+    auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(m_out_pipe, m_in_pipe, inquiry_command, &vital_product_page, sizeof(vital_product_page_buffer)));
+
+    if (status.status != CSWStatus::Passed) {
+        dbgln("SCSI/BBB: Inquiry failed to inquire supported vital product data pages with code {}", to_underlying(status.status));
+        // FIXME: Maybe request sense here
+        // FIXME: Treating this as an error for now
+        // Some HW seems to stall this and/or send garbage...
+        return EIO;
+    }
+    if (vital_product_page.page_code != SCSI::VitalProductDataPageCode::SupportedVitalProductDataPages) {
+        dmesgln("SCSI/BBB: Returned wrong page code for supported vital product data pages: {:#02x}", to_underlying(vital_product_page.page_code));
+        return EIO;
+    }
+
+    if ((vital_product_page.page_length + 4uz) > sizeof(vital_product_page_buffer)) {
+        // Note: This should not be possible, as there are less than 253 page codes allocated
+        dmesgln("SCSI/BBB: Warning: Returned page length for supported vital product data pages is bigger than the allocated buffer, we might be missing some supported pages");
+    }
+
+    // FIXME: Maybe check status.residual_data here
+    auto available_pages = min(vital_product_page.page_length, sizeof(vital_product_page_buffer) - sizeof(SCSI::VitalProductPage));
+    bool found_block_limits = false;
+    for (size_t i = 0; i < available_pages; i++) {
+        if (vital_product_page.supported_pages[i] == SCSI::VitalProductDataPageCode::BlockLimits) {
+            found_block_limits = true;
+            break;
+        }
+        if (to_underlying(vital_product_page.supported_pages[i]) >= to_underlying(SCSI::VitalProductDataPageCode::BlockLimits)) {
+            // The available pages are (supposedly) sorted in ascending order
+            // so we can break here early
+            break;
+        }
+    }
+
+    if (!found_block_limits) {
+        dmesgln("SCSI/BBB: Device does not support block limits page");
+        // This is not an error, we just won't be able to optimize our transfers
+        return {};
+    }
+
+    inquiry_command.page_code = SCSI::VitalProductDataPageCode::BlockLimits;
+    SCSI::BlockLimitsPage block_limits_page {};
+    inquiry_command.allocation_length = sizeof(SCSI::BlockLimitsPage);
+    status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(m_out_pipe, m_in_pipe, inquiry_command, &block_limits_page, sizeof(SCSI::BlockLimitsPage)));
+    if (status.status != CSWStatus::Passed) {
+        dbgln("SCSI/BBB: Inquiry failed to inquire block limits with code {}", to_underlying(status.status));
+        // FIXME: Maybe request sense here
+    }
+
+    if (block_limits_page.page_code != SCSI::VitalProductDataPageCode::BlockLimits) {
+        dmesgln("SCSI/BBB: Returned wrong page code for block limits {:#02x}", to_underlying(block_limits_page.page_code));
+        return EIO;
+    }
+
+    if (block_limits_page.page_length != sizeof(SCSI::BlockLimitsPage) - 4) {
+        dmesgln("SCSI/BBB: Returned wrong page length for block limits {}", block_limits_page.page_length);
+        return EIO;
+    }
+
+    if (block_limits_page.maximum_transfer_length != 0)
+        m_maximum_transfer_length = block_limits_page.maximum_transfer_length;
+    if (block_limits_page.optimal_transfer_length != 0)
+        m_optimal_transfer_length = block_limits_page.optimal_transfer_length;
+    if (block_limits_page.optimal_transfer_length_granularity != 0)
+        m_optimal_transfer_length_granularity = block_limits_page.optimal_transfer_length_granularity;
+
+    dbgln("SCSI/BBB: Maximum transfer length: {}", m_maximum_transfer_length);
+    dbgln("SCSI/BBB: Optimal transfer length: {}", m_optimal_transfer_length);
+    dbgln("SCSI/BBB: Optimal transfer length granularity: {}", m_optimal_transfer_length_granularity);
+
+    return {};
+}
+
+u32 BulkSCSIStorageDevice::optimal_block_count(u32 blocks)
+{
+    if (m_maximum_transfer_length.has_value() && blocks > m_maximum_transfer_length.value())
+        return m_maximum_transfer_length.value();
+    // quot. OPTIMAL TRANSFER LENGTH field:
+    // "[...] If a device server receives one of these commands with a transfer size greater than this value,
+    //  then the device server may incur significant delays in processing the command."
+    if (m_optimal_transfer_length.has_value() && blocks > m_optimal_transfer_length.value())
+        return m_optimal_transfer_length.value();
+
+    if (!m_optimal_transfer_length_granularity.has_value())
+        return blocks;
+
+    // quot. OPTIMAL TRANSFER LENGTH GRANULARITY field:
+    // "[...] If a device server receives one of these commands with a transfer size that
+    //  is not equal to a multiple of this value, then the device server may incur significant
+    //  delays in processing the command."
+    // FIXME: This sounds like it may be faster to align up to the granularity in some cases
+    //        But that might be difficult to accomplish in some cases (Ie writing)
+    if (blocks < m_optimal_transfer_length_granularity.value())
+        return blocks;
+
+    return blocks - (blocks % m_optimal_transfer_length_granularity.value());
+}
+
+void BulkSCSIStorageDevice::start_request(AsyncBlockDeviceRequest& request)
+{
+    if (request.request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
+        if (do_read(request.block_index(), request.block_count(), request.buffer(), request.buffer_size()).is_error()) {
+            request.complete(AsyncDeviceRequest::RequestResult::Failure);
+        } else {
+            request.complete(AsyncDeviceRequest::RequestResult::Success);
+        }
+    } else {
+        if (do_write(request.block_index(), request.block_count(), request.buffer(), request.buffer_size()).is_error()) {
+            request.complete(AsyncDeviceRequest::RequestResult::Failure);
+        } else {
+            request.complete(AsyncDeviceRequest::RequestResult::Success);
+        }
+    }
+}
+
+ErrorOr<void> BulkSCSIStorageDevice::do_read(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t)
+{
+    // FIXME: Error Handling and proper device reset on exit
+    SCSI::Read10 read_command;
+
+    u32 block_index_to_read = block_index;
+    u32 blocks_read = 0;
+    UserOrKernelBuffer destination_buffer = buffer;
+    while (blocks_read < block_count) {
+        read_command.logical_block_address = block_index_to_read;
+
+        // FIXME: We only use READ(10) so we only ever read u16::max blocks at a time
+        auto blocks_to_transfer = optimal_block_count(block_count - blocks_read);
+        u16 transfer_length_bytes = min(blocks_to_transfer * block_size(), AK::NumericLimits<u16>::max());
+
+        read_command.transfer_length = transfer_length_bytes / block_size();
+
+        auto status = TRY(send_scsi_command<SCSIDataDirection::DataToInitiator>(m_out_pipe, m_in_pipe, read_command, destination_buffer, transfer_length_bytes));
+
+        if (status.status != CSWStatus::Passed) {
+            // FIXME: Actually handle the error
+            //        See usbmassbulk 5.3, 6.4 and 6.5
+            dmesgln("SCSI/BBB: Read failed with code {}", to_underlying(status.status));
+            return EIO;
+        }
+
+        u32 bytes_transferred = transfer_length_bytes - status.data_residue;
+        u32 blocks_read_in_transfer = bytes_transferred / block_size();
+
+        blocks_read += blocks_read_in_transfer;
+        block_index_to_read += blocks_read_in_transfer;
+    }
+
+    return {};
+}
+
+ErrorOr<void> BulkSCSIStorageDevice::do_write(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t)
+{
+    // FIXME: Error Handling and proper device reset on exit
+    SCSI::Write10 read_command;
+
+    u32 block_index_to_read = block_index;
+    u32 blocks_read = 0;
+    UserOrKernelBuffer source_buffer = buffer;
+    while (blocks_read < block_count) {
+        read_command.logical_block_address = block_index_to_read;
+
+        // FIXME: We only use WRITE(10) so we only ever write u16::max blocks at a time
+        auto blocks_to_transfer = optimal_block_count(block_count - blocks_read);
+        u16 transfer_length_bytes = min(blocks_to_transfer * block_size(), AK::NumericLimits<u16>::max());
+
+        read_command.transfer_length = transfer_length_bytes / block_size();
+
+        auto status = TRY(send_scsi_command<SCSIDataDirection::DataToTarget>(m_out_pipe, m_in_pipe, read_command, source_buffer, transfer_length_bytes));
+
+        if (status.status != CSWStatus::Passed) {
+            // FIXME: Actually handle the error
+            //        See usbmassbulk 5.3, 6.4 and 6.5
+            dmesgln("SCSI/BBB: Write failed with code {}", to_underlying(status.status));
+            return EIO;
+        }
+
+        u32 bytes_transferred = transfer_length_bytes - status.data_residue;
+        u32 blocks_read_in_transfer = bytes_transferred / block_size();
+        blocks_read += blocks_read_in_transfer;
+        block_index_to_read += blocks_read_in_transfer;
+    }
+
+    return {};
+}
+
+}

--- a/Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/USB/USBPipe.h>
+#include <Kernel/Devices/Storage/StorageDevice.h>
+
+namespace Kernel::USB {
+
+class BulkSCSIInterface;
+
+class BulkSCSIStorageDevice : public StorageDevice {
+public:
+    BulkSCSIStorageDevice(BulkSCSIInterface&, BulkOutPipe&, BulkInPipe&, LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block);
+
+private:
+    BulkSCSIInterface& m_interface;
+    BulkOutPipe& m_out_pipe;
+    BulkInPipe& m_in_pipe;
+
+    virtual void start_request(AsyncBlockDeviceRequest&) override;
+    virtual CommandSet command_set() const override { return CommandSet::SCSI; }
+
+    u32 optimal_block_count(u32 blocks);
+
+    ErrorOr<void> do_read(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t buffer_size);
+    ErrorOr<void> do_write(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t buffer_size);
+
+    ErrorOr<void> query_characteristics();
+
+    Optional<u16> m_optimal_transfer_length;
+    Optional<u32> m_optimal_transfer_length_granularity;
+    Optional<u32> m_maximum_transfer_length;
+
+    IntrusiveListNode<BulkSCSIStorageDevice, NonnullLockRefPtr<BulkSCSIStorageDevice>> m_list_node;
+
+public:
+    using List = IntrusiveList<&BulkSCSIStorageDevice::m_list_node>;
+};
+
+}

--- a/Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIStorageDevice.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <Kernel/Bus/USB/USBPipe.h>
 #include <Kernel/Devices/Storage/StorageDevice.h>
 
 namespace Kernel::USB {
@@ -16,12 +15,10 @@ class BulkSCSIInterface;
 
 class BulkSCSIStorageDevice : public StorageDevice {
 public:
-    BulkSCSIStorageDevice(BulkSCSIInterface&, BulkOutPipe&, BulkInPipe&, LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block);
+    BulkSCSIStorageDevice(BulkSCSIInterface&, LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block);
 
 private:
     BulkSCSIInterface& m_interface;
-    BulkOutPipe& m_out_pipe;
-    BulkInPipe& m_in_pipe;
 
     virtual void start_request(AsyncBlockDeviceRequest&) override;
     virtual CommandSet command_set() const override { return CommandSet::SCSI; }

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -230,6 +230,7 @@ set(WSMESSAGELOOP_DEBUG ON)
 set(WSSCREEN_DEBUG ON)
 set(XHCI_DEBUG ON)
 set(XML_PARSER_DEBUG ON)
+set(USB_MASS_STORAGE_DEBUG ON)
 
 # False positive: DEBUG is a flag but it works differently.
 # set(DEBUG ON)

--- a/Meta/gn/secondary/Kernel/BUILD.gn
+++ b/Meta/gn/secondary/Kernel/BUILD.gn
@@ -107,6 +107,7 @@ write_cmake_config("kernel_debug_gen") {
     "WAITBLOCK_DEBUG=",
     "WAITQUEUE_DEBUG=",
     "XHCI_DEBUG=",
+    "USB_MASS_STORAGE_DEBUG=",
   ]
 }
 


### PR DESCRIPTION
This makes our USB mass storage driver work with 3 of my USB drives (all SanDisk), which always STALL after a short packet (probably a weird firmware quirk, as it also happens on linux).