### PR TITLE
Tests: Add a (manual) test pdf for paths

### DIFF
--- a/Tests/LibPDF/paths.pdf
+++ b/Tests/LibPDF/paths.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+2 0 obj
+<</Type/Catalog/Pages 1 0 R>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 1 0 R/Contents 4 0 R/MediaBox[0 0 400 300]/Rotate 0>>
+endobj
+
+4 0 obj
+<</Length 334>>
+stream
+/DeviceRGB CS
+
+20 w
+
+0 J
+1 0 0 SC
+20 280 m
+60 280 l
+S
+
+1 J
+1 1 0 SC
+20 250 m
+60 250 l
+S
+
+2 J
+0 0 1 SC
+20 220 m
+60 220 l
+S
+
+0 J
+1 0 0 SC
+100 280 m
+160 280 l
+130 240 l
+100 280 l
+S
+
+0 J
+1 0 0 SC
+180 240 m
+240 240 l
+210 280 l
+180 240 l
+h
+S
+
+0 J
+1 j
+0 1 0 SC
+20 130 50 50 re
+S
+
+0 1 0 SC
+110 130 m
+160 130 l
+160 180 l
+110 180 l
+110 130 l
+S
+
+endstream
+endobj
+
+xref
+0 5
+0000000000 65536 f 
+0000000016 00000 n 
+0000000068 00000 n 
+0000000114 00000 n 
+0000000204 00000 n 
+
+trailer
+<</Size 5/Root 2 0 R>>
+startxref
+588
+%%EOF


### PR DESCRIPTION
Lovingly hand-written. Uses various line cap and line join styles.

Offsets fixed up with:

    mutool clean Tests/LibPDF/paths.pdf Tests/LibPDF/paths.pdf