### PR TITLE
Cherry-pick "LibWeb: Add motion preference"

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -13,6 +13,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/CookieJar.h>
 
@@ -49,6 +50,7 @@
 - (Optional<StringView> const&)webdriverContentIPCPath;
 - (Web::CSS::PreferredColorScheme)preferredColorScheme;
 - (Web::CSS::PreferredContrast)preferredContrast;
+- (Web::CSS::PreferredMotion)preferredMotion;
 - (WebView::SearchEngine const&)searchEngine;
 
 @end

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -31,6 +31,7 @@
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme;
     Web::CSS::PreferredContrast m_preferred_contrast;
+    Web::CSS::PreferredMotion m_preferred_motion;
 
     WebView::SearchEngine m_search_engine;
 
@@ -93,6 +94,7 @@
 
         m_preferred_color_scheme = Web::CSS::PreferredColorScheme::Auto;
         m_preferred_contrast = Web::CSS::PreferredContrast::Auto;
+        m_preferred_motion = Web::CSS::PreferredMotion::Auto;
         m_search_engine = WebView::default_search_engine();
 
         m_allow_popups = allow_popups;
@@ -171,6 +173,11 @@
 - (Web::CSS::PreferredContrast)preferredContrast
 {
     return m_preferred_contrast;
+}
+
+- (Web::CSS::PreferredMotion)preferredMotion
+{
+    return m_preferred_motion;
 }
 
 - (WebView::SearchEngine const&)searchEngine
@@ -299,6 +306,32 @@
     for (TabController* controller in self.managed_tabs) {
         auto* tab = (Tab*)[controller window];
         [[tab web_view] setPreferredContrast:m_preferred_contrast];
+    }
+}
+
+- (void)setAutoPreferredMotion:(id)sender
+{
+    m_preferred_motion = Web::CSS::PreferredMotion::Auto;
+    [self broadcastPreferredMotionUpdate];
+}
+
+- (void)setNoPreferencePreferredMotion:(id)sender
+{
+    m_preferred_motion = Web::CSS::PreferredMotion::NoPreference;
+    [self broadcastPreferredMotionUpdate];
+}
+
+- (void)setReducePreferredMotion:(id)sender
+{
+    m_preferred_motion = Web::CSS::PreferredMotion::Reduce;
+    [self broadcastPreferredMotionUpdate];
+}
+
+- (void)broadcastPreferredMotionUpdate
+{
+    for (TabController* controller in self.managed_tabs) {
+        auto* tab = (Tab*)[controller window];
+        [[tab web_view] setPreferredMotion:m_preferred_motion];
     }
 }
 
@@ -457,6 +490,22 @@
                                                    keyEquivalent:@""];
     [contrast_menu_item setSubmenu:contrast_menu];
 
+    auto* motion_menu = [[NSMenu alloc] init];
+    [motion_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Auto"
+                                                    action:@selector(setAutoPreferredMotion:)
+                                             keyEquivalent:@""]];
+    [motion_menu addItem:[[NSMenuItem alloc] initWithTitle:@"No Preference"
+                                                    action:@selector(setNoPreferencePreferredMotion:)
+                                             keyEquivalent:@""]];
+    [motion_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Reduce"
+                                                    action:@selector(setReducePreferredMotion:)
+                                             keyEquivalent:@""]];
+
+    auto* motion_menu_item = [[NSMenuItem alloc] initWithTitle:@"Motion"
+                                                        action:nil
+                                                 keyEquivalent:@""];
+    [motion_menu_item setSubmenu:motion_menu];
+
     auto* zoom_menu = [[NSMenu alloc] init];
     [zoom_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Zoom In"
                                                   action:@selector(zoomIn:)
@@ -475,6 +524,7 @@
 
     [submenu addItem:color_scheme_menu_item];
     [submenu addItem:contrast_menu_item];
+    [submenu addItem:motion_menu_item];
     [submenu addItem:zoom_menu_item];
     [submenu addItem:[NSMenuItem separatorItem]];
 
@@ -700,6 +750,12 @@
         [item setState:(m_preferred_contrast == Web::CSS::PreferredContrast::More) ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([item action] == @selector(setNoPreferencePreferredContrast:)) {
         [item setState:(m_preferred_contrast == Web::CSS::PreferredContrast::NoPreference) ? NSControlStateValueOn : NSControlStateValueOff];
+    } else if ([item action] == @selector(setAutoPreferredMotion:)) {
+        [item setState:(m_preferred_motion == Web::CSS::PreferredMotion::Auto) ? NSControlStateValueOn : NSControlStateValueOff];
+    } else if ([item action] == @selector(setNoPreferencePreferredMotion:)) {
+        [item setState:(m_preferred_motion == Web::CSS::PreferredMotion::NoPreference) ? NSControlStateValueOn : NSControlStateValueOff];
+    } else if ([item action] == @selector(setReducePreferredMotion:)) {
+        [item setState:(m_preferred_motion == Web::CSS::PreferredMotion::Reduce) ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([item action] == @selector(setSearchEngine:)) {
         auto title = Ladybird::ns_string_to_string([item title]);
         [item setState:(m_search_engine.name == title) ? NSControlStateValueOn : NSControlStateValueOff];

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -11,6 +11,7 @@
 #include <LibURL/Forward.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
@@ -61,6 +62,7 @@
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;
 - (void)setPreferredContrast:(Web::CSS::PreferredContrast)contrast;
+- (void)setPreferredMotion:(Web::CSS::PreferredMotion)motion;
 
 - (void)findInPage:(NSString*)query
     caseSensitivity:(CaseSensitivity)case_sensitivity;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -104,7 +104,7 @@ struct HideCursor {
         // This returns device pixel ratio of the screen the window is opened in
         auto device_pixel_ratio = [[NSScreen mainScreen] backingScaleFactor];
 
-        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, [delegate webContentOptions], [delegate webdriverContentIPCPath], [delegate preferredColorScheme], [delegate preferredContrast]));
+        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, [delegate webContentOptions], [delegate webdriverContentIPCPath], [delegate preferredColorScheme], [delegate preferredContrast], [delegate preferredMotion]));
         [self setWebViewCallbacks];
 
         m_web_view_bridge->initialize_client();
@@ -224,6 +224,11 @@ struct HideCursor {
 - (void)setPreferredContrast:(Web::CSS::PreferredContrast)contrast
 {
     m_web_view_bridge->set_preferred_contrast(contrast);
+}
+
+- (void)setPreferredMotion:(Web::CSS::PreferredMotion)motion
+{
+    m_web_view_bridge->set_preferred_motion(motion);
 }
 
 - (void)debugRequest:(ByteString const&)request argument:(ByteString const&)argument

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -23,17 +23,18 @@ static T scale_for_device(T size, float device_pixel_ratio)
     return size.template to_type<float>().scaled(device_pixel_ratio).template to_type<int>();
 }
 
-ErrorOr<NonnullOwnPtr<WebViewBridge>> WebViewBridge::create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const& web_content_options, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast)
+ErrorOr<NonnullOwnPtr<WebViewBridge>> WebViewBridge::create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const& web_content_options, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast, Web::CSS::PreferredMotion preferred_motion)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) WebViewBridge(move(screen_rects), device_pixel_ratio, web_content_options, move(webdriver_content_ipc_path), preferred_color_scheme, preferred_contrast));
+    return adopt_nonnull_own_or_enomem(new (nothrow) WebViewBridge(move(screen_rects), device_pixel_ratio, web_content_options, move(webdriver_content_ipc_path), preferred_color_scheme, preferred_contrast, preferred_motion));
 }
 
-WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const& web_content_options, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast)
+WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const& web_content_options, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast, Web::CSS::PreferredMotion preferred_motion)
     : m_screen_rects(move(screen_rects))
     , m_web_content_options(web_content_options)
     , m_webdriver_content_ipc_path(move(webdriver_content_ipc_path))
     , m_preferred_color_scheme(preferred_color_scheme)
     , m_preferred_contrast(preferred_contrast)
+    , m_preferred_motion(preferred_motion)
 {
     m_device_pixel_ratio = device_pixel_ratio;
 }
@@ -79,6 +80,12 @@ void WebViewBridge::set_preferred_contrast(Web::CSS::PreferredContrast contrast)
 {
     m_preferred_contrast = contrast;
     client().async_set_preferred_contrast(m_client_state.page_index, contrast);
+}
+
+void WebViewBridge::set_preferred_motion(Web::CSS::PreferredMotion motion)
+{
+    m_preferred_motion = motion;
+    client().async_set_preferred_motion(m_client_state.page_index, motion);
 }
 
 void WebViewBridge::enqueue_input_event(Web::MouseEvent event)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -14,6 +14,7 @@
 #include <LibGfx/StandardCursor.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWebView/ViewImplementation.h>
 
@@ -21,7 +22,7 @@ namespace Ladybird {
 
 class WebViewBridge final : public WebView::ViewImplementation {
 public:
-    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast);
+    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
     virtual ~WebViewBridge() override;
 
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) override;
@@ -43,6 +44,7 @@ public:
     void update_palette();
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
+    void set_preferred_motion(Web::CSS::PreferredMotion);
 
     void enqueue_input_event(Web::MouseEvent);
     void enqueue_input_event(Web::KeyEvent);
@@ -57,7 +59,7 @@ public:
     Function<void()> on_zoom_level_changed;
 
 private:
-    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast);
+    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
 
     virtual void update_zoom() override;
     virtual Web::DevicePixelSize viewport_size() const override;
@@ -72,6 +74,7 @@ private:
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
     Web::CSS::PreferredContrast m_preferred_contrast { Web::CSS::PreferredContrast::Auto };
+    Web::CSS::PreferredMotion m_preferred_motion { Web::CSS::PreferredMotion::Auto };
 };
 
 }

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -20,6 +20,7 @@
 #include <Ladybird/Utilities.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/UserAgent.h>
@@ -259,6 +260,30 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     QObject::connect(no_preference_contrast, &QAction::triggered, this, &BrowserWindow::enable_no_preference_contrast);
 
     auto_contrast->setChecked(true);
+
+    auto* motion_menu = view_menu->addMenu("&Motion");
+
+    auto* motion_group = new QActionGroup(this);
+
+    auto* auto_motion = new QAction("&Auto", this);
+    auto_motion->setCheckable(true);
+    motion_group->addAction(auto_motion);
+    motion_menu->addAction(auto_motion);
+    QObject::connect(auto_motion, &QAction::triggered, this, &BrowserWindow::enable_auto_motion);
+
+    auto* reduce_motion = new QAction("&Reduce", this);
+    reduce_motion->setCheckable(true);
+    motion_group->addAction(reduce_motion);
+    motion_menu->addAction(reduce_motion);
+    QObject::connect(reduce_motion, &QAction::triggered, this, &BrowserWindow::enable_reduce_motion);
+
+    auto* no_preference_motion = new QAction("&No Preference", this);
+    no_preference_motion->setCheckable(true);
+    motion_group->addAction(no_preference_motion);
+    motion_menu->addAction(no_preference_motion);
+    QObject::connect(no_preference_motion, &QAction::triggered, this, &BrowserWindow::enable_no_preference_motion);
+
+    auto_motion->setChecked(true);
 
     auto* show_menubar = new QAction("Show &Menubar", this);
     show_menubar->setCheckable(true);
@@ -928,6 +953,27 @@ void BrowserWindow::enable_no_preference_contrast()
 {
     for_each_tab([](auto& tab) {
         tab.view().set_preferred_contrast(Web::CSS::PreferredContrast::NoPreference);
+    });
+}
+
+void BrowserWindow::enable_auto_motion()
+{
+    for_each_tab([](auto& tab) {
+        tab.view().set_preferred_motion(Web::CSS::PreferredMotion::Auto);
+    });
+}
+
+void BrowserWindow::enable_no_preference_motion()
+{
+    for_each_tab([](auto& tab) {
+        tab.view().set_preferred_motion(Web::CSS::PreferredMotion::NoPreference);
+    });
+}
+
+void BrowserWindow::enable_reduce_motion()
+{
+    for_each_tab([](auto& tab) {
+        tab.view().set_preferred_motion(Web::CSS::PreferredMotion::Reduce);
     });
 }
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -124,6 +124,9 @@ public slots:
     void enable_less_contrast();
     void enable_more_contrast();
     void enable_no_preference_contrast();
+    void enable_auto_motion();
+    void enable_no_preference_motion();
+    void enable_reduce_motion();
     void zoom_in();
     void zoom_out();
     void reset_zoom();

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/BUILD.gn
@@ -48,6 +48,7 @@ source_set("CSS") {
     "PercentageOr.cpp",
     "PreferredColorScheme.cpp",
     "PreferredContrast.cpp",
+    "PreferredMotion.cpp",
     "Ratio.cpp",
     "Resolution.cpp",
     "ResolvedCSSStyleDeclaration.cpp",

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SOURCES
     CSS/PercentageOr.cpp
     CSS/PreferredColorScheme.cpp
     CSS/PreferredContrast.cpp
+    CSS/PreferredMotion.cpp
     CSS/Ratio.cpp
     CSS/Resolution.cpp
     CSS/ResolvedCSSStyleDeclaration.cpp

--- a/Userland/Libraries/LibWeb/CSS/PreferredMotion.cpp
+++ b/Userland/Libraries/LibWeb/CSS/PreferredMotion.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/PreferredMotion.h>
+
+namespace Web::CSS {
+
+PreferredMotion preferred_motion_from_string(StringView value)
+{
+    if (value.equals_ignoring_ascii_case("no-preference"sv))
+        return PreferredMotion::NoPreference;
+    if (value.equals_ignoring_ascii_case("reduce"sv))
+        return PreferredMotion::Reduce;
+    return PreferredMotion::Auto;
+}
+
+StringView preferred_motion_to_string(PreferredMotion value)
+{
+    switch (value) {
+    case PreferredMotion::Auto:
+        return "auto"sv;
+    case PreferredMotion::NoPreference:
+        return "no-preference"sv;
+    case PreferredMotion::Reduce:
+        return "reduce"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/PreferredMotion.h
+++ b/Userland/Libraries/LibWeb/CSS/PreferredMotion.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace Web::CSS {
+
+enum class PreferredMotion {
+    Auto,
+    NoPreference,
+    Reduce,
+};
+
+PreferredMotion preferred_motion_from_string(StringView);
+StringView preferred_motion_to_string(PreferredMotion);
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -356,8 +356,16 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(CSS::MediaFeatureID
         // FIXME: Make this a preference
         return CSS::MediaFeatureValue(CSS::ValueID::NoPreference);
     case CSS::MediaFeatureID::PrefersReducedMotion:
-        // FIXME: Make this a preference
-        return CSS::MediaFeatureValue(CSS::ValueID::NoPreference);
+        switch (page().preferred_motion()) {
+        case CSS::PreferredMotion::NoPreference:
+            return CSS::MediaFeatureValue(CSS::ValueID::NoPreference);
+        case CSS::PreferredMotion::Reduce:
+            return CSS::MediaFeatureValue(CSS::ValueID::Reduce);
+        case CSS::PreferredMotion::Auto:
+        default:
+            // FIXME: Fallback to system settings
+            return CSS::MediaFeatureValue(CSS::ValueID::NoPreference);
+        }
     case CSS::MediaFeatureID::PrefersReducedTransparency:
         // FIXME: Make this a preference
         return CSS::MediaFeatureValue(CSS::ValueID::NoPreference);

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -117,6 +117,11 @@ CSS::PreferredContrast Page::preferred_contrast() const
     return m_client->preferred_contrast();
 }
 
+CSS::PreferredMotion Page::preferred_motion() const
+{
+    return m_client->preferred_motion();
+}
+
 CSSPixelPoint Page::device_to_css_point(DevicePixelPoint point) const
 {
     return {

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -27,6 +27,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
@@ -104,6 +105,7 @@ public:
     CSSPixelRect web_exposed_screen_area() const;
     CSS::PreferredColorScheme preferred_color_scheme() const;
     CSS::PreferredContrast preferred_contrast() const;
+    CSS::PreferredMotion preferred_motion() const;
 
     bool is_same_origin_policy_enabled() const { return m_same_origin_policy_enabled; }
     void set_same_origin_policy_enabled(bool b) { m_same_origin_policy_enabled = b; }
@@ -274,6 +276,7 @@ public:
     virtual double device_pixels_per_css_pixel() const = 0;
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
     virtual CSS::PreferredContrast preferred_contrast() const = 0;
+    virtual CSS::PreferredMotion preferred_motion() const = 0;
     virtual void paint_next_frame() = 0;
     virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, PaintOptions = {}) = 0;
     virtual void page_did_change_title(ByteString const&) { }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -73,6 +73,7 @@ public:
     virtual double device_pixels_per_css_pixel() const override { return 1.0; }
     virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page->client().preferred_color_scheme(); }
     virtual CSS::PreferredContrast preferred_contrast() const override { return m_host_page->client().preferred_contrast(); }
+    virtual CSS::PreferredMotion preferred_motion() const override { return m_host_page->client().preferred_motion(); }
     virtual void request_file(FileRequest) override { }
     virtual void paint_next_frame() override { }
     virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override { }

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -162,6 +162,11 @@ void ViewImplementation::set_preferred_contrast(Web::CSS::PreferredContrast cont
     client().async_set_preferred_contrast(page_id(), contrast);
 }
 
+void ViewImplementation::set_preferred_motion(Web::CSS::PreferredMotion motion)
+{
+    client().async_set_preferred_motion(page_id(), motion);
+}
+
 ByteString ViewImplementation::selected_text()
 {
     return client().get_selected_text(page_id());

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -63,6 +63,7 @@ public:
 
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
+    void set_preferred_motion(Web::CSS::PreferredMotion);
 
     ByteString selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -960,6 +960,12 @@ void ConnectionFromClient::set_preferred_contrast(u64 page_id, Web::CSS::Preferr
         page->set_preferred_contrast(contrast);
 }
 
+void ConnectionFromClient::set_preferred_motion(u64 page_id, Web::CSS::PreferredMotion const& motion)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->set_preferred_motion(motion);
+}
+
 void ConnectionFromClient::set_has_focus(u64 page_id, bool has_focus)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -16,6 +16,7 @@
 #include <LibJS/Heap/Handle.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -91,6 +92,7 @@ private:
     virtual void set_proxy_mappings(u64 page_id, Vector<ByteString> const&, HashMap<ByteString, size_t> const&) override;
     virtual void set_preferred_color_scheme(u64 page_id, Web::CSS::PreferredColorScheme const&) override;
     virtual void set_preferred_contrast(u64 page_id, Web::CSS::PreferredContrast const&) override;
+    virtual void set_preferred_motion(u64 page_id, Web::CSS::PreferredMotion const&) override;
     virtual void set_has_focus(u64 page_id, bool) override;
     virtual void set_is_scripting_enabled(u64 page_id, bool) override;
     virtual void set_device_pixels_per_css_pixel(u64 page_id, float) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -163,6 +163,13 @@ void PageClient::set_preferred_contrast(Web::CSS::PreferredContrast contrast)
         document->invalidate_style();
 }
 
+void PageClient::set_preferred_motion(Web::CSS::PreferredMotion motion)
+{
+    m_preferred_motion = motion;
+    if (auto* document = page().top_level_browsing_context().active_document())
+        document->invalidate_style();
+}
+
 void PageClient::set_is_scripting_enabled(bool is_scripting_enabled)
 {
     page().set_is_scripting_enabled(is_scripting_enabled);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -51,6 +51,7 @@ public:
     void set_device_pixels_per_css_pixel(float device_pixels_per_css_pixel) { m_device_pixels_per_css_pixel = device_pixels_per_css_pixel; }
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
+    void set_preferred_motion(Web::CSS::PreferredMotion);
     void set_should_show_line_box_borders(bool b) { m_should_show_line_box_borders = b; }
     void set_has_focus(bool);
     void set_is_scripting_enabled(bool);
@@ -97,6 +98,7 @@ private:
     virtual Web::DevicePixelRect screen_rect() const override { return m_screen_rect; }
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }
     virtual Web::CSS::PreferredContrast preferred_contrast() const override { return m_preferred_contrast; }
+    virtual Web::CSS::PreferredMotion preferred_motion() const override { return m_preferred_motion; }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;
     virtual void page_did_layout() override;
     virtual void page_did_change_title(ByteString const&) override;
@@ -182,6 +184,7 @@ private:
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
     Web::CSS::PreferredContrast m_preferred_contrast { Web::CSS::PreferredContrast::NoPreference };
+    Web::CSS::PreferredMotion m_preferred_motion { Web::CSS::PreferredMotion::NoPreference };
 
     RefPtr<WebDriverConnection> m_webdriver;
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -5,6 +5,7 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
+#include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/SelectedFile.h>
@@ -80,6 +81,7 @@ endpoint WebContentServer
     set_proxy_mappings(u64 page_id, Vector<ByteString> proxies, HashMap<ByteString, size_t> mappings) =|
     set_preferred_color_scheme(u64 page_id, Web::CSS::PreferredColorScheme color_scheme) =|
     set_preferred_contrast(u64 page_id, Web::CSS::PreferredContrast contrast) =|
+    set_preferred_motion(u64 page_id, Web::CSS::PreferredMotion motion) =|
     set_has_focus(u64 page_id, bool has_focus) =|
     set_is_scripting_enabled(u64 page_id, bool is_scripting_enabled) =|
     set_device_pixels_per_css_pixel(u64 page_id, float device_pixels_per_css_pixel) =|

--- a/Userland/Services/WebWorker/PageHost.cpp
+++ b/Userland/Services/WebWorker/PageHost.cpp
@@ -72,6 +72,11 @@ Web::CSS::PreferredContrast PageHost::preferred_contrast() const
     return Web::CSS::PreferredContrast::Auto;
 }
 
+Web::CSS::PreferredMotion PageHost::preferred_motion() const
+{
+    return Web::CSS::PreferredMotion::Auto;
+}
+
 void PageHost::paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions)
 {
 }

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -30,6 +30,7 @@ public:
     virtual double device_pixels_per_css_pixel() const override;
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
     virtual Web::CSS::PreferredContrast preferred_contrast() const override;
+    virtual Web::CSS::PreferredMotion preferred_motion() const override;
     virtual void paint_next_frame() override {};
     virtual void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;


### PR DESCRIPTION
This adds a motion preference to the browser UI similar to the existing ones for color scheme and contrast.
Both AppKit UI and Qt UI has this new preference.
The auto value is currently the same as NoPreference, follow-ups can address wiring that up to the actual preference for the OS.

(cherry picked from commit 099b77d60f6c30b4d533872fda29ea6d660ed358)

---

https://github.com/LadybirdBrowser/ladybird/pull/151