### PR TITLE
LibWeb: Add a UIEvents/KeyCode.h forwarding header, and cherry-pick using Web::UIEvents::KeyCode in LibWeb

### DIFF
--- a/Ladybird/AppKit/UI/Event.mm
+++ b/Ladybird/AppKit/UI/Event.mm
@@ -13,28 +13,28 @@
 
 namespace Ladybird {
 
-static KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_flags, Optional<Web::UIEvents::MouseButton&> button = {})
+static Web::UIEvents::KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_flags, Optional<Web::UIEvents::MouseButton&> button = {})
 {
-    unsigned modifiers = KeyModifier::Mod_None;
+    unsigned modifiers = Web::UIEvents::KeyModifier::Mod_None;
 
     if ((modifier_flags & NSEventModifierFlagShift) != 0) {
-        modifiers |= KeyModifier::Mod_Shift;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Shift;
     }
     if ((modifier_flags & NSEventModifierFlagControl) != 0) {
         if (button == Web::UIEvents::MouseButton::Primary) {
             *button = Web::UIEvents::MouseButton::Secondary;
         } else {
-            modifiers |= KeyModifier::Mod_Ctrl;
+            modifiers |= Web::UIEvents::KeyModifier::Mod_Ctrl;
         }
     }
     if ((modifier_flags & NSEventModifierFlagOption) != 0) {
-        modifiers |= KeyModifier::Mod_Alt;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Alt;
     }
     if ((modifier_flags & NSEventModifierFlagCommand) != 0) {
-        modifiers |= KeyModifier::Mod_Super;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Super;
     }
 
-    return static_cast<KeyModifier>(modifiers);
+    return static_cast<Web::UIEvents::KeyModifier>(modifiers);
 }
 
 Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* event, NSView* view, NSScrollView* scroll_view, Web::UIEvents::MouseButton button)
@@ -88,120 +88,120 @@ NSEvent* create_context_menu_mouse_event(NSView* view, NSPoint position)
                               pressure:1.0];
 }
 
-static KeyCode ns_key_code_to_key_code(unsigned short key_code, KeyModifier& modifiers)
+static Web::UIEvents::KeyCode ns_key_code_to_key_code(unsigned short key_code, Web::UIEvents::KeyModifier& modifiers)
 {
     auto augment_modifiers_and_return = [&](auto key, auto modifier) {
-        modifiers = static_cast<KeyModifier>(static_cast<unsigned>(modifiers) | modifier);
+        modifiers = static_cast<Web::UIEvents::KeyModifier>(static_cast<unsigned>(modifiers) | modifier);
         return key;
     };
 
     // clang-format off
     switch (key_code) {
-    case kVK_ANSI_0: return KeyCode::Key_0;
-    case kVK_ANSI_1: return KeyCode::Key_1;
-    case kVK_ANSI_2: return KeyCode::Key_2;
-    case kVK_ANSI_3: return KeyCode::Key_3;
-    case kVK_ANSI_4: return KeyCode::Key_4;
-    case kVK_ANSI_5: return KeyCode::Key_5;
-    case kVK_ANSI_6: return KeyCode::Key_6;
-    case kVK_ANSI_7: return KeyCode::Key_7;
-    case kVK_ANSI_8: return KeyCode::Key_8;
-    case kVK_ANSI_9: return KeyCode::Key_9;
-    case kVK_ANSI_A: return KeyCode::Key_A;
-    case kVK_ANSI_B: return KeyCode::Key_B;
-    case kVK_ANSI_C: return KeyCode::Key_C;
-    case kVK_ANSI_D: return KeyCode::Key_D;
-    case kVK_ANSI_E: return KeyCode::Key_E;
-    case kVK_ANSI_F: return KeyCode::Key_F;
-    case kVK_ANSI_G: return KeyCode::Key_G;
-    case kVK_ANSI_H: return KeyCode::Key_H;
-    case kVK_ANSI_I: return KeyCode::Key_I;
-    case kVK_ANSI_J: return KeyCode::Key_J;
-    case kVK_ANSI_K: return KeyCode::Key_K;
-    case kVK_ANSI_L: return KeyCode::Key_L;
-    case kVK_ANSI_M: return KeyCode::Key_M;
-    case kVK_ANSI_N: return KeyCode::Key_N;
-    case kVK_ANSI_O: return KeyCode::Key_O;
-    case kVK_ANSI_P: return KeyCode::Key_P;
-    case kVK_ANSI_Q: return KeyCode::Key_Q;
-    case kVK_ANSI_R: return KeyCode::Key_R;
-    case kVK_ANSI_S: return KeyCode::Key_S;
-    case kVK_ANSI_T: return KeyCode::Key_T;
-    case kVK_ANSI_U: return KeyCode::Key_U;
-    case kVK_ANSI_V: return KeyCode::Key_V;
-    case kVK_ANSI_W: return KeyCode::Key_W;
-    case kVK_ANSI_X: return KeyCode::Key_X;
-    case kVK_ANSI_Y: return KeyCode::Key_Y;
-    case kVK_ANSI_Z: return KeyCode::Key_Z;
-    case kVK_ANSI_Backslash: return KeyCode::Key_Backslash;
-    case kVK_ANSI_Comma: return KeyCode::Key_Comma;
-    case kVK_ANSI_Equal: return KeyCode::Key_Equal;
-    case kVK_ANSI_Grave: return KeyCode::Key_Backtick;
-    case kVK_ANSI_Keypad0: return augment_modifiers_and_return(KeyCode::Key_0, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad1: return augment_modifiers_and_return(KeyCode::Key_1, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad2: return augment_modifiers_and_return(KeyCode::Key_2, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad3: return augment_modifiers_and_return(KeyCode::Key_3, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad4: return augment_modifiers_and_return(KeyCode::Key_4, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad5: return augment_modifiers_and_return(KeyCode::Key_5, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad6: return augment_modifiers_and_return(KeyCode::Key_6, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad7: return augment_modifiers_and_return(KeyCode::Key_7, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad8: return augment_modifiers_and_return(KeyCode::Key_8, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_Keypad9: return augment_modifiers_and_return(KeyCode::Key_9, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadClear: return augment_modifiers_and_return(KeyCode::Key_Delete, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadDecimal: return augment_modifiers_and_return(KeyCode::Key_Period, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadDivide: return augment_modifiers_and_return(KeyCode::Key_Slash, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadEnter: return augment_modifiers_and_return(KeyCode::Key_Return, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadEquals: return augment_modifiers_and_return(KeyCode::Key_Equal, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadMinus: return augment_modifiers_and_return(KeyCode::Key_Minus, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadMultiply: return augment_modifiers_and_return(KeyCode::Key_Asterisk, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_KeypadPlus: return augment_modifiers_and_return(KeyCode::Key_Plus, KeyModifier::Mod_Keypad);
-    case kVK_ANSI_LeftBracket: return KeyCode::Key_LeftBracket;
-    case kVK_ANSI_Minus: return KeyCode::Key_Minus;
-    case kVK_ANSI_Period: return KeyCode::Key_Period;
-    case kVK_ANSI_Quote: return KeyCode::Key_Apostrophe;
-    case kVK_ANSI_RightBracket: return KeyCode::Key_RightBracket;
-    case kVK_ANSI_Semicolon: return KeyCode::Key_Semicolon;
-    case kVK_ANSI_Slash: return KeyCode::Key_Slash;
-    case kVK_CapsLock: return KeyCode::Key_CapsLock;
-    case kVK_Command: return KeyCode::Key_Super;
-    case kVK_Control: return KeyCode::Key_Control;
-    case kVK_Delete: return KeyCode::Key_Backspace;
-    case kVK_DownArrow: return KeyCode::Key_Down;
-    case kVK_End: return KeyCode::Key_End;
-    case kVK_Escape: return KeyCode::Key_Escape;
-    case kVK_F1: return KeyCode::Key_F1;
-    case kVK_F2: return KeyCode::Key_F2;
-    case kVK_F3: return KeyCode::Key_F3;
-    case kVK_F4: return KeyCode::Key_F4;
-    case kVK_F5: return KeyCode::Key_F5;
-    case kVK_F6: return KeyCode::Key_F6;
-    case kVK_F7: return KeyCode::Key_F7;
-    case kVK_F8: return KeyCode::Key_F8;
-    case kVK_F9: return KeyCode::Key_F9;
-    case kVK_F10: return KeyCode::Key_F10;
-    case kVK_F11: return KeyCode::Key_F11;
-    case kVK_F12: return KeyCode::Key_F12;
-    case kVK_ForwardDelete: return KeyCode::Key_Delete;
-    case kVK_Home: return KeyCode::Key_Home;
-    case kVK_LeftArrow: return KeyCode::Key_Left;
-    case kVK_Option: return KeyCode::Key_Alt;
-    case kVK_PageDown: return KeyCode::Key_PageDown;
-    case kVK_PageUp: return KeyCode::Key_PageUp;
-    case kVK_Return: return KeyCode::Key_Return;
-    case kVK_RightArrow: return KeyCode::Key_Right;
-    case kVK_RightCommand: return KeyCode::Key_Super; // FIXME: We do not distinguish left-vs-right.
-    case kVK_RightControl: return KeyCode::Key_Control; // FIXME: We do not distinguish left-vs-right.
-    case kVK_RightOption: return KeyCode::Key_Alt; // FIXME: We do not distinguish left-vs-right.
-    case kVK_RightShift: return KeyCode::Key_RightShift;
-    case kVK_Shift: return KeyCode::Key_Shift;
-    case kVK_Space: return KeyCode::Key_Space;
-    case kVK_Tab: return KeyCode::Key_Tab;
-    case kVK_UpArrow: return KeyCode::Key_Up;
+    case kVK_ANSI_0: return Web::UIEvents::KeyCode::Key_0;
+    case kVK_ANSI_1: return Web::UIEvents::KeyCode::Key_1;
+    case kVK_ANSI_2: return Web::UIEvents::KeyCode::Key_2;
+    case kVK_ANSI_3: return Web::UIEvents::KeyCode::Key_3;
+    case kVK_ANSI_4: return Web::UIEvents::KeyCode::Key_4;
+    case kVK_ANSI_5: return Web::UIEvents::KeyCode::Key_5;
+    case kVK_ANSI_6: return Web::UIEvents::KeyCode::Key_6;
+    case kVK_ANSI_7: return Web::UIEvents::KeyCode::Key_7;
+    case kVK_ANSI_8: return Web::UIEvents::KeyCode::Key_8;
+    case kVK_ANSI_9: return Web::UIEvents::KeyCode::Key_9;
+    case kVK_ANSI_A: return Web::UIEvents::KeyCode::Key_A;
+    case kVK_ANSI_B: return Web::UIEvents::KeyCode::Key_B;
+    case kVK_ANSI_C: return Web::UIEvents::KeyCode::Key_C;
+    case kVK_ANSI_D: return Web::UIEvents::KeyCode::Key_D;
+    case kVK_ANSI_E: return Web::UIEvents::KeyCode::Key_E;
+    case kVK_ANSI_F: return Web::UIEvents::KeyCode::Key_F;
+    case kVK_ANSI_G: return Web::UIEvents::KeyCode::Key_G;
+    case kVK_ANSI_H: return Web::UIEvents::KeyCode::Key_H;
+    case kVK_ANSI_I: return Web::UIEvents::KeyCode::Key_I;
+    case kVK_ANSI_J: return Web::UIEvents::KeyCode::Key_J;
+    case kVK_ANSI_K: return Web::UIEvents::KeyCode::Key_K;
+    case kVK_ANSI_L: return Web::UIEvents::KeyCode::Key_L;
+    case kVK_ANSI_M: return Web::UIEvents::KeyCode::Key_M;
+    case kVK_ANSI_N: return Web::UIEvents::KeyCode::Key_N;
+    case kVK_ANSI_O: return Web::UIEvents::KeyCode::Key_O;
+    case kVK_ANSI_P: return Web::UIEvents::KeyCode::Key_P;
+    case kVK_ANSI_Q: return Web::UIEvents::KeyCode::Key_Q;
+    case kVK_ANSI_R: return Web::UIEvents::KeyCode::Key_R;
+    case kVK_ANSI_S: return Web::UIEvents::KeyCode::Key_S;
+    case kVK_ANSI_T: return Web::UIEvents::KeyCode::Key_T;
+    case kVK_ANSI_U: return Web::UIEvents::KeyCode::Key_U;
+    case kVK_ANSI_V: return Web::UIEvents::KeyCode::Key_V;
+    case kVK_ANSI_W: return Web::UIEvents::KeyCode::Key_W;
+    case kVK_ANSI_X: return Web::UIEvents::KeyCode::Key_X;
+    case kVK_ANSI_Y: return Web::UIEvents::KeyCode::Key_Y;
+    case kVK_ANSI_Z: return Web::UIEvents::KeyCode::Key_Z;
+    case kVK_ANSI_Backslash: return Web::UIEvents::KeyCode::Key_Backslash;
+    case kVK_ANSI_Comma: return Web::UIEvents::KeyCode::Key_Comma;
+    case kVK_ANSI_Equal: return Web::UIEvents::KeyCode::Key_Equal;
+    case kVK_ANSI_Grave: return Web::UIEvents::KeyCode::Key_Backtick;
+    case kVK_ANSI_Keypad0: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_0, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad1: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_1, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad2: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_2, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad3: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_3, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad4: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_4, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad5: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_5, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad6: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_6, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad7: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_7, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad8: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_8, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_Keypad9: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_9, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadClear: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Delete, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadDecimal: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Period, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadDivide: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Slash, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadEnter: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Return, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadEquals: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Equal, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadMinus: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Minus, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadMultiply: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Asterisk, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_KeypadPlus: return augment_modifiers_and_return(Web::UIEvents::KeyCode::Key_Plus, Web::UIEvents::KeyModifier::Mod_Keypad);
+    case kVK_ANSI_LeftBracket: return Web::UIEvents::KeyCode::Key_LeftBracket;
+    case kVK_ANSI_Minus: return Web::UIEvents::KeyCode::Key_Minus;
+    case kVK_ANSI_Period: return Web::UIEvents::KeyCode::Key_Period;
+    case kVK_ANSI_Quote: return Web::UIEvents::KeyCode::Key_Apostrophe;
+    case kVK_ANSI_RightBracket: return Web::UIEvents::KeyCode::Key_RightBracket;
+    case kVK_ANSI_Semicolon: return Web::UIEvents::KeyCode::Key_Semicolon;
+    case kVK_ANSI_Slash: return Web::UIEvents::KeyCode::Key_Slash;
+    case kVK_CapsLock: return Web::UIEvents::KeyCode::Key_CapsLock;
+    case kVK_Command: return Web::UIEvents::KeyCode::Key_Super;
+    case kVK_Control: return Web::UIEvents::KeyCode::Key_Control;
+    case kVK_Delete: return Web::UIEvents::KeyCode::Key_Backspace;
+    case kVK_DownArrow: return Web::UIEvents::KeyCode::Key_Down;
+    case kVK_End: return Web::UIEvents::KeyCode::Key_End;
+    case kVK_Escape: return Web::UIEvents::KeyCode::Key_Escape;
+    case kVK_F1: return Web::UIEvents::KeyCode::Key_F1;
+    case kVK_F2: return Web::UIEvents::KeyCode::Key_F2;
+    case kVK_F3: return Web::UIEvents::KeyCode::Key_F3;
+    case kVK_F4: return Web::UIEvents::KeyCode::Key_F4;
+    case kVK_F5: return Web::UIEvents::KeyCode::Key_F5;
+    case kVK_F6: return Web::UIEvents::KeyCode::Key_F6;
+    case kVK_F7: return Web::UIEvents::KeyCode::Key_F7;
+    case kVK_F8: return Web::UIEvents::KeyCode::Key_F8;
+    case kVK_F9: return Web::UIEvents::KeyCode::Key_F9;
+    case kVK_F10: return Web::UIEvents::KeyCode::Key_F10;
+    case kVK_F11: return Web::UIEvents::KeyCode::Key_F11;
+    case kVK_F12: return Web::UIEvents::KeyCode::Key_F12;
+    case kVK_ForwardDelete: return Web::UIEvents::KeyCode::Key_Delete;
+    case kVK_Home: return Web::UIEvents::KeyCode::Key_Home;
+    case kVK_LeftArrow: return Web::UIEvents::KeyCode::Key_Left;
+    case kVK_Option: return Web::UIEvents::KeyCode::Key_Alt;
+    case kVK_PageDown: return Web::UIEvents::KeyCode::Key_PageDown;
+    case kVK_PageUp: return Web::UIEvents::KeyCode::Key_PageUp;
+    case kVK_Return: return Web::UIEvents::KeyCode::Key_Return;
+    case kVK_RightArrow: return Web::UIEvents::KeyCode::Key_Right;
+    case kVK_RightCommand: return Web::UIEvents::KeyCode::Key_Super; // FIXME: We do not distinguish left-vs-right.
+    case kVK_RightControl: return Web::UIEvents::KeyCode::Key_Control; // FIXME: We do not distinguish left-vs-right.
+    case kVK_RightOption: return Web::UIEvents::KeyCode::Key_Alt; // FIXME: We do not distinguish left-vs-right.
+    case kVK_RightShift: return Web::UIEvents::KeyCode::Key_RightShift;
+    case kVK_Shift: return Web::UIEvents::KeyCode::Key_Shift;
+    case kVK_Space: return Web::UIEvents::KeyCode::Key_Space;
+    case kVK_Tab: return Web::UIEvents::KeyCode::Key_Tab;
+    case kVK_UpArrow: return Web::UIEvents::KeyCode::Key_Up;
     default: break;
     }
     // clang-format on
 
-    return KeyCode::Key_Invalid;
+    return Web::UIEvents::KeyCode::Key_Invalid;
 }
 
 class KeyData : public Web::ChromeInputData {

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -478,7 +478,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     };
 
     m_web_view_bridge->on_link_click = [self](auto const& url, auto const& target, unsigned modifiers) {
-        if (modifiers == Mod_Super) {
+        if (modifiers == Web::UIEvents::KeyModifier::Mod_Super) {
             [self.observer onCreateNewTab:url activateTab:Web::HTML::ActivateTab::No];
         } else if (target == "_blank"sv) {
             [self.observer onCreateNewTab:url activateTab:Web::HTML::ActivateTab::Yes];

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -695,7 +695,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
 
     tab->view().on_link_click = [this](auto url, auto target, unsigned modifiers) {
         // TODO: maybe activate tabs according to some configuration, this is just normal current browser behavior
-        if (modifiers == Mod_Ctrl) {
+        if (modifiers == Web::UIEvents::Mod_Ctrl) {
             m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::No);
         } else if (target == "_blank") {
             m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::Yes);
@@ -705,7 +705,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
     };
 
     tab->view().on_link_middle_click = [this](auto url, auto target, unsigned modifiers) {
-        m_current_tab->view().on_link_click(url, target, Mod_Ctrl);
+        m_current_tab->view().on_link_click(url, target, Web::UIEvents::Mod_Ctrl);
         (void)modifiers;
     };
 

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -14,7 +14,6 @@
 #include <AK/LexicalPath.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Types.h>
-#include <Kernel/API/KeyCode.h>
 #include <Ladybird/HelperProcess.h>
 #include <Ladybird/Utilities.h>
 #include <LibCore/EventLoop.h>
@@ -28,6 +27,7 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/WebContentClient.h>
@@ -151,167 +151,167 @@ static Web::UIEvents::MouseButton get_buttons_from_qt_event(QSinglePointEvent co
     return buttons;
 }
 
-static KeyModifier get_modifiers_from_qt_mouse_event(QSinglePointEvent const& event)
+static Web::UIEvents::KeyModifier get_modifiers_from_qt_mouse_event(QSinglePointEvent const& event)
 {
-    auto modifiers = KeyModifier::Mod_None;
+    auto modifiers = Web::UIEvents::KeyModifier::Mod_None;
     if (event.modifiers().testFlag(Qt::AltModifier))
-        modifiers |= KeyModifier::Mod_Alt;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Alt;
     if (event.modifiers().testFlag(Qt::ControlModifier))
-        modifiers |= KeyModifier::Mod_Ctrl;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Ctrl;
     if (event.modifiers().testFlag(Qt::ShiftModifier))
-        modifiers |= KeyModifier::Mod_Shift;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Shift;
     return modifiers;
 }
 
-static KeyModifier get_modifiers_from_qt_keyboard_event(QKeyEvent const& event)
+static Web::UIEvents::KeyModifier get_modifiers_from_qt_keyboard_event(QKeyEvent const& event)
 {
-    auto modifiers = KeyModifier::Mod_None;
+    auto modifiers = Web::UIEvents::KeyModifier::Mod_None;
     if (event.modifiers().testFlag(Qt::AltModifier))
-        modifiers |= KeyModifier::Mod_Alt;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Alt;
     if (event.modifiers().testFlag(Qt::ControlModifier))
-        modifiers |= KeyModifier::Mod_Ctrl;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Ctrl;
     if (event.modifiers().testFlag(Qt::MetaModifier))
-        modifiers |= KeyModifier::Mod_Super;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Super;
     if (event.modifiers().testFlag(Qt::ShiftModifier))
-        modifiers |= KeyModifier::Mod_Shift;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Shift;
     if (event.modifiers().testFlag(Qt::AltModifier))
-        modifiers |= KeyModifier::Mod_AltGr;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_AltGr;
     if (event.modifiers().testFlag(Qt::KeypadModifier))
-        modifiers |= KeyModifier::Mod_Keypad;
+        modifiers |= Web::UIEvents::KeyModifier::Mod_Keypad;
     return modifiers;
 }
 
-static KeyCode get_keycode_from_qt_keyboard_event(QKeyEvent const& event)
+static Web::UIEvents::KeyCode get_keycode_from_qt_keyboard_event(QKeyEvent const& event)
 {
     struct Mapping {
-        constexpr Mapping(Qt::Key q, KeyCode s)
+        constexpr Mapping(Qt::Key q, Web::UIEvents::KeyCode s)
             : qt_key(q)
             , serenity_key(s)
         {
         }
 
         Qt::Key qt_key;
-        KeyCode serenity_key;
+        Web::UIEvents::KeyCode serenity_key;
     };
 
     // https://doc.qt.io/qt-6/qt.html#Key-enum
     constexpr Mapping mappings[] = {
-        { Qt::Key_0, Key_0 },
-        { Qt::Key_1, Key_1 },
-        { Qt::Key_2, Key_2 },
-        { Qt::Key_3, Key_3 },
-        { Qt::Key_4, Key_4 },
-        { Qt::Key_5, Key_5 },
-        { Qt::Key_6, Key_6 },
-        { Qt::Key_7, Key_7 },
-        { Qt::Key_8, Key_8 },
-        { Qt::Key_9, Key_9 },
-        { Qt::Key_A, Key_A },
-        { Qt::Key_Alt, Key_Alt },
-        { Qt::Key_Ampersand, Key_Ampersand },
-        { Qt::Key_Apostrophe, Key_Apostrophe },
-        { Qt::Key_AsciiCircum, Key_Circumflex },
-        { Qt::Key_AsciiTilde, Key_Tilde },
-        { Qt::Key_Asterisk, Key_Asterisk },
-        { Qt::Key_At, Key_AtSign },
-        { Qt::Key_B, Key_B },
-        { Qt::Key_Backslash, Key_Backslash },
-        { Qt::Key_Backspace, Key_Backspace },
-        { Qt::Key_Bar, Key_Pipe },
-        { Qt::Key_BraceLeft, Key_LeftBrace },
-        { Qt::Key_BraceRight, Key_RightBrace },
-        { Qt::Key_BracketLeft, Key_LeftBracket },
-        { Qt::Key_BracketRight, Key_RightBracket },
-        { Qt::Key_C, Key_C },
-        { Qt::Key_CapsLock, Key_CapsLock },
-        { Qt::Key_Colon, Key_Colon },
-        { Qt::Key_Comma, Key_Comma },
-        { Qt::Key_Control, Key_Control },
-        { Qt::Key_D, Key_D },
-        { Qt::Key_Delete, Key_Delete },
-        { Qt::Key_Dollar, Key_Dollar },
-        { Qt::Key_Down, Key_Down },
-        { Qt::Key_E, Key_E },
-        { Qt::Key_End, Key_End },
-        { Qt::Key_Equal, Key_Equal },
-        { Qt::Key_Enter, Key_Return },
-        { Qt::Key_Escape, Key_Escape },
-        { Qt::Key_Exclam, Key_ExclamationPoint },
-        { Qt::Key_exclamdown, Key_ExclamationPoint },
-        { Qt::Key_F, Key_F },
-        { Qt::Key_F1, Key_F1 },
-        { Qt::Key_F10, Key_F10 },
-        { Qt::Key_F11, Key_F11 },
-        { Qt::Key_F12, Key_F12 },
-        { Qt::Key_F2, Key_F2 },
-        { Qt::Key_F3, Key_F3 },
-        { Qt::Key_F4, Key_F4 },
-        { Qt::Key_F5, Key_F5 },
-        { Qt::Key_F6, Key_F6 },
-        { Qt::Key_F7, Key_F7 },
-        { Qt::Key_F8, Key_F8 },
-        { Qt::Key_F9, Key_F9 },
-        { Qt::Key_G, Key_G },
-        { Qt::Key_Greater, Key_GreaterThan },
-        { Qt::Key_H, Key_H },
-        { Qt::Key_Home, Key_Home },
-        { Qt::Key_I, Key_I },
-        { Qt::Key_Insert, Key_Insert },
-        { Qt::Key_J, Key_J },
-        { Qt::Key_K, Key_K },
-        { Qt::Key_L, Key_L },
-        { Qt::Key_Left, Key_Left },
-        { Qt::Key_Less, Key_LessThan },
-        { Qt::Key_M, Key_M },
-        { Qt::Key_Menu, Key_Menu },
-        { Qt::Key_Meta, Key_Super },
-        { Qt::Key_Minus, Key_Minus },
-        { Qt::Key_N, Key_N },
-        { Qt::Key_NumberSign, Key_Hashtag },
-        { Qt::Key_NumLock, Key_NumLock },
-        { Qt::Key_O, Key_O },
-        { Qt::Key_P, Key_P },
-        { Qt::Key_PageDown, Key_PageDown },
-        { Qt::Key_PageUp, Key_PageUp },
-        { Qt::Key_ParenLeft, Key_LeftParen },
-        { Qt::Key_ParenRight, Key_RightParen },
-        { Qt::Key_Percent, Key_Percent },
-        { Qt::Key_Period, Key_Period },
-        { Qt::Key_Plus, Key_Plus },
-        { Qt::Key_Print, Key_PrintScreen },
-        { Qt::Key_Q, Key_Q },
-        { Qt::Key_Question, Key_QuestionMark },
-        { Qt::Key_QuoteDbl, Key_DoubleQuote },
-        { Qt::Key_QuoteLeft, Key_Backtick },
-        { Qt::Key_R, Key_R },
-        { Qt::Key_Return, Key_Return },
-        { Qt::Key_Right, Key_Right },
-        { Qt::Key_S, Key_S },
-        { Qt::Key_ScrollLock, Key_ScrollLock },
-        { Qt::Key_Semicolon, Key_Semicolon },
-        { Qt::Key_Shift, Key_LeftShift },
-        { Qt::Key_Slash, Key_Slash },
-        { Qt::Key_Space, Key_Space },
-        { Qt::Key_Super_L, Key_Super },
-        { Qt::Key_Super_R, Key_Super },
-        { Qt::Key_SysReq, Key_SysRq },
-        { Qt::Key_T, Key_T },
-        { Qt::Key_Tab, Key_Tab },
-        { Qt::Key_U, Key_U },
-        { Qt::Key_Underscore, Key_Underscore },
-        { Qt::Key_Up, Key_Up },
-        { Qt::Key_V, Key_V },
-        { Qt::Key_W, Key_W },
-        { Qt::Key_X, Key_X },
-        { Qt::Key_Y, Key_Y },
-        { Qt::Key_Z, Key_Z },
+        { Qt::Key_0, Web::UIEvents::Key_0 },
+        { Qt::Key_1, Web::UIEvents::Key_1 },
+        { Qt::Key_2, Web::UIEvents::Key_2 },
+        { Qt::Key_3, Web::UIEvents::Key_3 },
+        { Qt::Key_4, Web::UIEvents::Key_4 },
+        { Qt::Key_5, Web::UIEvents::Key_5 },
+        { Qt::Key_6, Web::UIEvents::Key_6 },
+        { Qt::Key_7, Web::UIEvents::Key_7 },
+        { Qt::Key_8, Web::UIEvents::Key_8 },
+        { Qt::Key_9, Web::UIEvents::Key_9 },
+        { Qt::Key_A, Web::UIEvents::Key_A },
+        { Qt::Key_Alt, Web::UIEvents::Key_Alt },
+        { Qt::Key_Ampersand, Web::UIEvents::Key_Ampersand },
+        { Qt::Key_Apostrophe, Web::UIEvents::Key_Apostrophe },
+        { Qt::Key_AsciiCircum, Web::UIEvents::Key_Circumflex },
+        { Qt::Key_AsciiTilde, Web::UIEvents::Key_Tilde },
+        { Qt::Key_Asterisk, Web::UIEvents::Key_Asterisk },
+        { Qt::Key_At, Web::UIEvents::Key_AtSign },
+        { Qt::Key_B, Web::UIEvents::Key_B },
+        { Qt::Key_Backslash, Web::UIEvents::Key_Backslash },
+        { Qt::Key_Backspace, Web::UIEvents::Key_Backspace },
+        { Qt::Key_Bar, Web::UIEvents::Key_Pipe },
+        { Qt::Key_BraceLeft, Web::UIEvents::Key_LeftBrace },
+        { Qt::Key_BraceRight, Web::UIEvents::Key_RightBrace },
+        { Qt::Key_BracketLeft, Web::UIEvents::Key_LeftBracket },
+        { Qt::Key_BracketRight, Web::UIEvents::Key_RightBracket },
+        { Qt::Key_C, Web::UIEvents::Key_C },
+        { Qt::Key_CapsLock, Web::UIEvents::Key_CapsLock },
+        { Qt::Key_Colon, Web::UIEvents::Key_Colon },
+        { Qt::Key_Comma, Web::UIEvents::Key_Comma },
+        { Qt::Key_Control, Web::UIEvents::Key_Control },
+        { Qt::Key_D, Web::UIEvents::Key_D },
+        { Qt::Key_Delete, Web::UIEvents::Key_Delete },
+        { Qt::Key_Dollar, Web::UIEvents::Key_Dollar },
+        { Qt::Key_Down, Web::UIEvents::Key_Down },
+        { Qt::Key_E, Web::UIEvents::Key_E },
+        { Qt::Key_End, Web::UIEvents::Key_End },
+        { Qt::Key_Equal, Web::UIEvents::Key_Equal },
+        { Qt::Key_Enter, Web::UIEvents::Key_Return },
+        { Qt::Key_Escape, Web::UIEvents::Key_Escape },
+        { Qt::Key_Exclam, Web::UIEvents::Key_ExclamationPoint },
+        { Qt::Key_exclamdown, Web::UIEvents::Key_ExclamationPoint },
+        { Qt::Key_F, Web::UIEvents::Key_F },
+        { Qt::Key_F1, Web::UIEvents::Key_F1 },
+        { Qt::Key_F10, Web::UIEvents::Key_F10 },
+        { Qt::Key_F11, Web::UIEvents::Key_F11 },
+        { Qt::Key_F12, Web::UIEvents::Key_F12 },
+        { Qt::Key_F2, Web::UIEvents::Key_F2 },
+        { Qt::Key_F3, Web::UIEvents::Key_F3 },
+        { Qt::Key_F4, Web::UIEvents::Key_F4 },
+        { Qt::Key_F5, Web::UIEvents::Key_F5 },
+        { Qt::Key_F6, Web::UIEvents::Key_F6 },
+        { Qt::Key_F7, Web::UIEvents::Key_F7 },
+        { Qt::Key_F8, Web::UIEvents::Key_F8 },
+        { Qt::Key_F9, Web::UIEvents::Key_F9 },
+        { Qt::Key_G, Web::UIEvents::Key_G },
+        { Qt::Key_Greater, Web::UIEvents::Key_GreaterThan },
+        { Qt::Key_H, Web::UIEvents::Key_H },
+        { Qt::Key_Home, Web::UIEvents::Key_Home },
+        { Qt::Key_I, Web::UIEvents::Key_I },
+        { Qt::Key_Insert, Web::UIEvents::Key_Insert },
+        { Qt::Key_J, Web::UIEvents::Key_J },
+        { Qt::Key_K, Web::UIEvents::Key_K },
+        { Qt::Key_L, Web::UIEvents::Key_L },
+        { Qt::Key_Left, Web::UIEvents::Key_Left },
+        { Qt::Key_Less, Web::UIEvents::Key_LessThan },
+        { Qt::Key_M, Web::UIEvents::Key_M },
+        { Qt::Key_Menu, Web::UIEvents::Key_Menu },
+        { Qt::Key_Meta, Web::UIEvents::Key_Super },
+        { Qt::Key_Minus, Web::UIEvents::Key_Minus },
+        { Qt::Key_N, Web::UIEvents::Key_N },
+        { Qt::Key_NumberSign, Web::UIEvents::Key_Hashtag },
+        { Qt::Key_NumLock, Web::UIEvents::Key_NumLock },
+        { Qt::Key_O, Web::UIEvents::Key_O },
+        { Qt::Key_P, Web::UIEvents::Key_P },
+        { Qt::Key_PageDown, Web::UIEvents::Key_PageDown },
+        { Qt::Key_PageUp, Web::UIEvents::Key_PageUp },
+        { Qt::Key_ParenLeft, Web::UIEvents::Key_LeftParen },
+        { Qt::Key_ParenRight, Web::UIEvents::Key_RightParen },
+        { Qt::Key_Percent, Web::UIEvents::Key_Percent },
+        { Qt::Key_Period, Web::UIEvents::Key_Period },
+        { Qt::Key_Plus, Web::UIEvents::Key_Plus },
+        { Qt::Key_Print, Web::UIEvents::Key_PrintScreen },
+        { Qt::Key_Q, Web::UIEvents::Key_Q },
+        { Qt::Key_Question, Web::UIEvents::Key_QuestionMark },
+        { Qt::Key_QuoteDbl, Web::UIEvents::Key_DoubleQuote },
+        { Qt::Key_QuoteLeft, Web::UIEvents::Key_Backtick },
+        { Qt::Key_R, Web::UIEvents::Key_R },
+        { Qt::Key_Return, Web::UIEvents::Key_Return },
+        { Qt::Key_Right, Web::UIEvents::Key_Right },
+        { Qt::Key_S, Web::UIEvents::Key_S },
+        { Qt::Key_ScrollLock, Web::UIEvents::Key_ScrollLock },
+        { Qt::Key_Semicolon, Web::UIEvents::Key_Semicolon },
+        { Qt::Key_Shift, Web::UIEvents::Key_LeftShift },
+        { Qt::Key_Slash, Web::UIEvents::Key_Slash },
+        { Qt::Key_Space, Web::UIEvents::Key_Space },
+        { Qt::Key_Super_L, Web::UIEvents::Key_Super },
+        { Qt::Key_Super_R, Web::UIEvents::Key_Super },
+        { Qt::Key_SysReq, Web::UIEvents::Key_SysRq },
+        { Qt::Key_T, Web::UIEvents::Key_T },
+        { Qt::Key_Tab, Web::UIEvents::Key_Tab },
+        { Qt::Key_U, Web::UIEvents::Key_U },
+        { Qt::Key_Underscore, Web::UIEvents::Key_Underscore },
+        { Qt::Key_Up, Web::UIEvents::Key_Up },
+        { Qt::Key_V, Web::UIEvents::Key_V },
+        { Qt::Key_W, Web::UIEvents::Key_W },
+        { Qt::Key_X, Web::UIEvents::Key_X },
+        { Qt::Key_Y, Web::UIEvents::Key_Y },
+        { Qt::Key_Z, Web::UIEvents::Key_Z },
     };
 
     for (auto const& mapping : mappings) {
         if (event.key() == mapping.qt_key)
             return mapping.serenity_key;
     }
-    return Key_Invalid;
+    return Web::UIEvents::Key_Invalid;
 }
 
 void WebContentView::keyPressEvent(QKeyEvent* event)
@@ -752,12 +752,12 @@ void WebContentView::enqueue_native_event(Web::KeyEvent::Type type, QKeyEvent co
     auto to_web_event = [&]() -> Web::KeyEvent {
         if (event.key() == Qt::Key_Backtab) {
             // Qt transforms Shift+Tab into a "Backtab", so we undo that transformation here.
-            return { type, KeyCode::Key_Tab, Mod_Shift, '\t', make<KeyData>(event) };
+            return { type, Web::UIEvents::KeyCode::Key_Tab, Web::UIEvents::Mod_Shift, '\t', make<KeyData>(event) };
         }
 
         if (event.key() == Qt::Key_Enter || event.key() == Qt::Key_Return) {
             // This ensures consistent behavior between systems that treat Enter as '\n' and '\r\n'
-            return { type, KeyCode::Key_Return, Mod_Shift, '\n', make<KeyData>(event) };
+            return { type, Web::UIEvents::KeyCode::Key_Return, Web::UIEvents::Mod_Shift, '\n', make<KeyData>(event) };
         }
 
         return { type, keycode, modifiers, code_point, make<KeyData>(event) };

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/StringBuilder.h>
-#include <Kernel/API/KeyCode.h>
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
@@ -34,6 +33,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/UIEvents/EventNames.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/KeyboardEvent.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 
@@ -774,7 +774,7 @@ bool EventTarget::dispatch_event(Event& event)
 
         // keydown, provided the key is neither the Esc key nor a shortcut key reserved by the user agent.
         if (event.type() == UIEvents::EventNames::keydown)
-            return static_cast<UIEvents::KeyboardEvent*>(&event)->key_code() != KeyCode::Key_Escape;
+            return static_cast<UIEvents::KeyboardEvent*>(&event)->key_code() != UIEvents::KeyCode::Key_Escape;
 
         // mousedown.
         if (event.type() == UIEvents::EventNames::mousedown)

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1914,26 +1914,26 @@ void HTMLMediaElement::reject_pending_play_promises(ReadonlySpan<JS::NonnullGCPt
         WebIDL::reject_promise(realm, promise, error);
 }
 
-WebIDL::ExceptionOr<void> HTMLMediaElement::handle_keydown(Badge<Web::EventHandler>, KeyCode key)
+WebIDL::ExceptionOr<void> HTMLMediaElement::handle_keydown(Badge<Web::EventHandler>, UIEvents::KeyCode key)
 {
     switch (key) {
-    case KeyCode::Key_Space:
+    case UIEvents::KeyCode::Key_Space:
         TRY(toggle_playback());
         break;
 
-    case KeyCode::Key_Home:
+    case UIEvents::KeyCode::Key_Home:
         set_current_time(0);
         break;
-    case KeyCode::Key_End:
+    case UIEvents::KeyCode::Key_End:
         set_current_time(duration());
         break;
 
-    case KeyCode::Key_Left:
-    case KeyCode::Key_Right: {
+    case UIEvents::KeyCode::Key_Left:
+    case UIEvents::KeyCode::Key_Right: {
         static constexpr double time_skipped_per_key_press = 5.0;
         auto current_time = this->current_time();
 
-        if (key == KeyCode::Key_Left)
+        if (key == UIEvents::KeyCode::Key_Left)
             current_time = max(0.0, current_time - time_skipped_per_key_press);
         else
             current_time = min(duration(), current_time + time_skipped_per_key_press);
@@ -1942,12 +1942,12 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::handle_keydown(Badge<Web::EventHandl
         break;
     }
 
-    case KeyCode::Key_Up:
-    case KeyCode::Key_Down: {
+    case UIEvents::KeyCode::Key_Up:
+    case UIEvents::KeyCode::Key_Down: {
         static constexpr double volume_change_per_key_press = 0.1;
         auto volume = this->volume();
 
-        if (key == KeyCode::Key_Up)
+        if (key == UIEvents::KeyCode::Key_Up)
             volume = min(1.0, volume + volume_change_per_key_press);
         else
             volume = max(0.0, volume - volume_change_per_key_press);
@@ -1956,7 +1956,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::handle_keydown(Badge<Web::EventHandl
         break;
     }
 
-    case KeyCode::Key_M:
+    case UIEvents::KeyCode::Key_M:
         set_muted(!muted());
         break;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -11,7 +11,6 @@
 #include <AK/Optional.h>
 #include <AK/Time.h>
 #include <AK/Variant.h>
-#include <Kernel/API/KeyCode.h>
 #include <LibGfx/Rect.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibJS/SafeFunction.h>
@@ -20,6 +19,7 @@
 #include <LibWeb/HTML/EventLoop/Task.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <math.h>
 
@@ -109,7 +109,7 @@ public:
 
     JS::NonnullGCPtr<TextTrack> add_text_track(Bindings::TextTrackKind kind, String const& label, String const& language);
 
-    WebIDL::ExceptionOr<void> handle_keydown(Badge<Web::EventHandler>, KeyCode);
+    WebIDL::ExceptionOr<void> handle_keydown(Badge<Web::EventHandler>, UIEvents::KeyCode);
 
     enum class MouseTrackingComponent {
         Timeline,

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -68,12 +68,12 @@ void Internals::send_text(HTML::HTMLElement& target, String const& text)
     target.focus();
 
     for (auto code_point : text.code_points())
-        page.handle_keydown(code_point_to_key_code(code_point), 0, code_point);
+        page.handle_keydown(UIEvents::code_point_to_key_code(code_point), 0, code_point);
 }
 
 void Internals::commit_text()
 {
-    global_object().browsing_context()->page().handle_keydown(Key_Return, 0, 0);
+    global_object().browsing_context()->page().handle_keydown(UIEvents::Key_Return, 0, 0);
 }
 
 void Internals::click(double x, double y)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -793,7 +793,7 @@ bool EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u32 code
         return focus_next_element();
     }
 
-    if (key == KeyCode::Key_Escape)
+    if (key == UIEvents::KeyCode::Key_Escape)
         return document->window()->close_watcher_manager()->process_close_watchers();
 
     auto& realm = document->realm();

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -9,13 +9,13 @@
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/WeakPtr.h>
-#include <Kernel/API/KeyCode.h>
 #include <LibGfx/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/EditEventHandler.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 
 namespace Web {
 
@@ -30,8 +30,8 @@ public:
     bool handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
     bool handle_doubleclick(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 
-    bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
-    bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);
+    bool handle_keydown(UIEvents::KeyCode, unsigned modifiers, u32 code_point);
+    bool handle_keyup(UIEvents::KeyCode, unsigned modifiers, u32 code_point);
 
     void set_mouse_event_tracking_paintable(Painting::Paintable*);
 
@@ -45,7 +45,7 @@ private:
     bool focus_next_element();
     bool focus_previous_element();
 
-    bool fire_keyboard_event(FlyString const& event_name, HTML::Navigable&, KeyCode, unsigned modifiers, u32 code_point);
+    bool fire_keyboard_event(FlyString const& event_name, HTML::Navigable&, UIEvents::KeyCode, unsigned modifiers, u32 code_point);
     CSSPixelPoint compute_mouse_event_client_offset(CSSPixelPoint event_page_position) const;
     CSSPixelPoint compute_mouse_event_page_offset(CSSPixelPoint event_client_offset) const;
     CSSPixelPoint compute_mouse_event_movement(CSSPixelPoint event_client_offset) const;

--- a/Userland/Libraries/LibWeb/Page/InputEvent.cpp
+++ b/Userland/Libraries/LibWeb/Page/InputEvent.cpp
@@ -36,8 +36,8 @@ template<>
 ErrorOr<Web::KeyEvent> IPC::decode(Decoder& decoder)
 {
     auto type = TRY(decoder.decode<Web::KeyEvent::Type>());
-    auto key = TRY(decoder.decode<KeyCode>());
-    auto modifiers = TRY(decoder.decode<KeyModifier>());
+    auto key = TRY(decoder.decode<Web::UIEvents::KeyCode>());
+    auto modifiers = TRY(decoder.decode<Web::UIEvents::KeyModifier>());
     auto code_point = TRY(decoder.decode<u32>());
 
     return Web::KeyEvent { type, key, modifiers, code_point, nullptr };
@@ -65,7 +65,7 @@ ErrorOr<Web::MouseEvent> IPC::decode(Decoder& decoder)
     auto screen_position = TRY(decoder.decode<Web::DevicePixelPoint>());
     auto button = TRY(decoder.decode<Web::UIEvents::MouseButton>());
     auto buttons = TRY(decoder.decode<Web::UIEvents::MouseButton>());
-    auto modifiers = TRY(decoder.decode<KeyModifier>());
+    auto modifiers = TRY(decoder.decode<Web::UIEvents::KeyModifier>());
     auto wheel_delta_x = TRY(decoder.decode<int>());
     auto wheel_delta_y = TRY(decoder.decode<int>());
 

--- a/Userland/Libraries/LibWeb/Page/InputEvent.h
+++ b/Userland/Libraries/LibWeb/Page/InputEvent.h
@@ -11,11 +11,8 @@
 #include <LibGfx/Point.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
-
-// FIXME: This should not be included outside of Serenity. This FIXME appears in several locations across the Ladybird
-//        chromes. The classes in this file provide a good opportunity to remove Kernel types from LibWeb.
-#include <Kernel/API/KeyCode.h>
 
 namespace Web {
 
@@ -33,8 +30,8 @@ public:
     KeyEvent clone_without_chrome_data() const;
 
     Type type;
-    KeyCode key { KeyCode::Key_Invalid };
-    KeyModifier modifiers { KeyModifier::Mod_None };
+    UIEvents::KeyCode key { UIEvents::KeyCode::Key_Invalid };
+    UIEvents::KeyModifier modifiers { UIEvents::KeyModifier::Mod_None };
     u32 code_point { 0 };
 
     OwnPtr<ChromeInputData> chrome_data;
@@ -57,7 +54,7 @@ public:
     Web::DevicePixelPoint screen_position;
     UIEvents::MouseButton button { UIEvents::MouseButton::None };
     UIEvents::MouseButton buttons { UIEvents::MouseButton::None };
-    KeyModifier modifiers { KeyModifier::Mod_None };
+    UIEvents::KeyModifier modifiers { UIEvents::KeyModifier::Mod_None };
     int wheel_delta_x { 0 };
     int wheel_delta_y { 0 };
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -212,12 +212,12 @@ bool Page::handle_doubleclick(DevicePixelPoint position, DevicePixelPoint screen
     return top_level_traversable()->event_handler().handle_doubleclick(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
 }
 
-bool Page::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)
+bool Page::handle_keydown(UIEvents::KeyCode key, unsigned modifiers, u32 code_point)
 {
     return focused_navigable().event_handler().handle_keydown(key, modifiers, code_point);
 }
 
-bool Page::handle_keyup(KeyCode key, unsigned modifiers, u32 code_point)
+bool Page::handle_keyup(UIEvents::KeyCode key, unsigned modifiers, u32 code_point)
 {
     return focused_navigable().event_handler().handle_keyup(key, modifiers, code_point);
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -14,7 +14,6 @@
 #include <AK/RefPtr.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
-#include <Kernel/API/KeyCode.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
@@ -40,6 +39,7 @@
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 
 #ifdef HAS_ACCELERATED_GRAPHICS
 #    include <LibAccelGfx/Context.h>
@@ -98,8 +98,8 @@ public:
     bool handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, DevicePixels wheel_delta_x, DevicePixels wheel_delta_y);
     bool handle_doubleclick(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 
-    bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
-    bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);
+    bool handle_keydown(UIEvents::KeyCode, unsigned modifiers, u32 code_point);
+    bool handle_keyup(UIEvents::KeyCode, unsigned modifiers, u32 code_point);
 
     Gfx::Palette palette() const;
     CSSPixelRect web_exposed_screen_area() const;

--- a/Userland/Libraries/LibWeb/UIEvents/KeyCode.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyCode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// FIXME: Stop including Kernel here eventually.
+#include <Kernel/API/KeyCode.h>
+
+namespace Web::UIEvents {
+
+using KeyCode = ::KeyCode;
+using enum KeyCode;
+
+using KeyModifier = ::KeyModifier;
+using enum KeyModifier;
+
+inline KeyCode code_point_to_key_code(u32 code_point)
+{
+    return ::code_point_to_key_code(code_point);
+}
+
+}

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -8,8 +8,8 @@
 
 #include <AK/FlyString.h>
 #include <AK/TypeCasts.h>
-#include <Kernel/API/KeyCode.h>
 #include <LibWeb/UIEvents/EventModifier.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/UIEvent.h>
 
 namespace Web::UIEvents {

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/API/KeyCode.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MouseEventPrototype.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/API/KeyCode.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WheelEventPrototype.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
+#include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/WheelEvent.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 


### PR DESCRIPTION
Cherry-picks most of the second commit from https://github.com/LadybirdBrowser/ladybird/pull/86, which will make future cherry-picks easier.

No intended behavior change.