### PR TITLE
Utilities/du: Fix displaying size on devices that don't report blocks

### DIFF
--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -228,11 +228,12 @@ u64 print_space_usage(ByteString const& path, DuOption const& du_option, size_t 
             return 0;
     }
 
-    if (!du_option.apparent_size) {
+    // If the underlying FS reports 0 used blocks, apparent size may be more accurate
+    if (du_option.apparent_size || path_stat.st_blocks == 0) {
+        size += path_stat.st_size;
+    } else {
         constexpr auto block_size = 512;
         size += path_stat.st_blocks * block_size;
-    } else {
-        size += path_stat.st_size;
     }
 
     bool is_beyond_depth = current_depth > du_option.max_depth;


### PR DESCRIPTION
Certain virtual filesystems (RAMFS) always report 0 used blocks, even for files that are not empty. In this case, we should fall back to reporting the apparent size, as showing zero is somewhat misleading.

Before:

![image](https://github.com/user-attachments/assets/7eb8e9f1-c1a8-4b19-82d0-e373ed7639cf)

After:

![image](https://github.com/user-attachments/assets/617dbe38-eb03-4a62-9bc6-9788d1903ec1)

Alternatively, we could make RAMFS report some fake block size. I'm open for discussion and suggestions.