### PR TITLE
Cherry-pick "Everywhere: Include <LibGfx/Painter.h> in fewer places" + prep

### DIFF
--- a/Tests/LibGfx/TestScalingFunctions.cpp
+++ b/Tests/LibGfx/TestScalingFunctions.cpp
@@ -37,11 +37,11 @@ TEST_CASE(test_painter_scaling_uses_premultiplied_alpha)
         EXPECT_EQ(bottom_right_pixel, Color::Transparent);
     };
 
-    test_scaling_mode(Gfx::Painter::ScalingMode::BilinearBlend);
+    test_scaling_mode(Gfx::ScalingMode::BilinearBlend);
     // FIXME: Include ScalingMode::SmoothPixels as part of this test
     //        This mode does not currently pass this test, as it  behave according to the spec
     //        defined here: https://drafts.csswg.org/css-images/#valdef-image-rendering-pixelated
-    // test_scaling_mode(Gfx::Painter::ScalingMode::SmoothPixels);
+    // test_scaling_mode(Gfx::ScalingMode::SmoothPixels);
 }
 
 TEST_CASE(test_bitmap_scaling_uses_premultiplied_alpha)

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -642,13 +642,13 @@ void Painter::blit_canvas(Gfx::IntRect const& dst_rect, Canvas const& canvas, fl
 void Painter::blit_canvas(Gfx::FloatRect const& dst_rect, Canvas const& canvas, float opacity, Optional<Gfx::AffineTransform> affine_transform)
 {
     auto texture = GL::Texture(canvas.framebuffer().texture);
-    blit_scaled_texture(dst_rect, texture, { { 0, 0 }, canvas.size() }, Painter::ScalingMode::NearestNeighbor, opacity, move(affine_transform));
+    blit_scaled_texture(dst_rect, texture, { { 0, 0 }, canvas.size() }, ScalingMode::NearestNeighbor, opacity, move(affine_transform));
 }
 
 void Painter::blit_canvas(Gfx::FloatRect const& dst_rect, Canvas const& canvas, Gfx::FloatRect const& src_rect, float opacity, Optional<Gfx::AffineTransform> affine_transform, BlendingMode blending_mode)
 {
     auto texture = GL::Texture(canvas.framebuffer().texture);
-    blit_scaled_texture(dst_rect, texture, src_rect, Painter::ScalingMode::NearestNeighbor, opacity, move(affine_transform), blending_mode);
+    blit_scaled_texture(dst_rect, texture, src_rect, ScalingMode::NearestNeighbor, opacity, move(affine_transform), blending_mode);
 }
 
 void Painter::blit_scaled_texture(Gfx::FloatRect const& dst_rect, GL::Texture const& texture, Gfx::FloatRect const& src_rect, ScalingMode scaling_mode, float opacity, Optional<Gfx::AffineTransform> affine_transform, BlendingMode blending_mode)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -17,10 +17,10 @@
 
 namespace Gfx {
 
-void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPoint actual_to, Color color, float thickness, Painter::LineStyle style, Color, LineLengthMode line_length_mode)
+void AntiAliasingPainter::draw_anti_aliased_line(FloatPoint actual_from, FloatPoint actual_to, Color color, float thickness, LineStyle style, Color, LineLengthMode line_length_mode)
 {
     // FIXME: Implement this :P
-    VERIFY(style == Painter::LineStyle::Solid);
+    VERIFY(style == LineStyle::Solid);
 
     if (color.alpha() == 0)
         return;
@@ -142,7 +142,7 @@ void AntiAliasingPainter::draw_dotted_line(IntPoint point1, IntPoint point2, Col
 {
     // AA circles don't really work below a radius of 2px.
     if (thickness < 4)
-        return m_underlying_painter.draw_line(point1, point2, color, thickness, Painter::LineStyle::Dotted);
+        return m_underlying_painter.draw_line(point1, point2, color, thickness, LineStyle::Dotted);
 
     auto draw_spaced_dots = [&](int start, int end, auto to_point) {
         int step = thickness * 2;
@@ -180,14 +180,14 @@ void AntiAliasingPainter::draw_dotted_line(IntPoint point1, IntPoint point2, Col
     }
 }
 
-void AntiAliasingPainter::draw_line(IntPoint actual_from, IntPoint actual_to, Color color, float thickness, Painter::LineStyle style, Color alternate_color, LineLengthMode line_length_mode)
+void AntiAliasingPainter::draw_line(IntPoint actual_from, IntPoint actual_to, Color color, float thickness, LineStyle style, Color alternate_color, LineLengthMode line_length_mode)
 {
     draw_line(actual_from.to_type<float>(), actual_to.to_type<float>(), color, thickness, style, alternate_color, line_length_mode);
 }
 
-void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to, Color color, float thickness, Painter::LineStyle style, Color alternate_color, LineLengthMode line_length_mode)
+void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to, Color color, float thickness, LineStyle style, Color alternate_color, LineLengthMode line_length_mode)
 {
-    if (style == Painter::LineStyle::Dotted)
+    if (style == LineStyle::Dotted)
         return draw_dotted_line(actual_from.to_rounded<int>(), actual_to.to_rounded<int>(), color, static_cast<int>(round(thickness)));
     draw_anti_aliased_line(actual_from, actual_to, color, thickness, style, alternate_color, line_length_mode);
 }

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -14,6 +14,7 @@
 #include <AK/NumericLimits.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Line.h>
+#include <LibGfx/Painter.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -10,6 +10,7 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Quad.h>
+#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 
@@ -34,8 +35,8 @@ public:
         draw_line(line.a(), line.b(), color, thickness, style, alternate_color, line_length_mode);
     }
 
-    void fill_path(Path const&, Color, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
-    void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
+    void fill_path(Path const&, Color, WindingRule rule = WindingRule::Nonzero);
+    void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, WindingRule rule = WindingRule::Nonzero);
 
     void stroke_path(Path const&, Color, float thickness, Path::CapStyle cap_style = Path::CapStyle::Round);
     void stroke_path(Path const&, PaintStyle const& paint_style, float thickness, float opacity = 1.0f, Path::CapStyle cap_style = Path::CapStyle::Round);

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -28,9 +28,9 @@ public:
         Distance
     };
 
-    void draw_line(IntPoint, IntPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
-    void draw_line(FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
-    void draw_line(FloatLine line, Color color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint)
+    void draw_line(IntPoint, IntPoint, Color, float thickness = 1, LineStyle style = LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
+    void draw_line(FloatPoint, FloatPoint, Color, float thickness = 1, LineStyle style = LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
+    void draw_line(FloatLine line, Color color, float thickness = 1, LineStyle style = LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint)
     {
         draw_line(line.a(), line.b(), color, thickness, style, alternate_color, line_length_mode);
     }
@@ -75,7 +75,7 @@ private:
 
     Range draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color alternate_color, bool flip_x_and_y, Optional<Range> x_clip, BlendMode blend_mode);
 
-    void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, Painter::LineStyle, Color, LineLengthMode);
+    void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, LineStyle, Color, LineLengthMode);
     void draw_dotted_line(IntPoint, IntPoint, Gfx::Color, int thickness);
 
     Painter& m_underlying_painter;

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -6,8 +6,11 @@
 
 #pragma once
 
+#include <LibGfx/Color.h>
 #include <LibGfx/CornerRadius.h>
-#include <LibGfx/Painter.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/LineStyle.h>
+#include <LibGfx/PaintStyle.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Quad.h>
 #include <LibGfx/WindingRule.h>

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -10,6 +10,7 @@
 #include <AK/Types.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/EdgeFlagPathRasterizer.h>
+#include <LibGfx/Painter.h>
 
 #if defined(AK_COMPILER_GCC)
 #    pragma GCC optimize("O3")

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -99,13 +99,13 @@ EdgeFlagPathRasterizer<SamplesPerPixel>::EdgeFlagPathRasterizer(IntSize size)
 }
 
 template<unsigned SamplesPerPixel>
-void EdgeFlagPathRasterizer<SamplesPerPixel>::fill(Painter& painter, Path const& path, Color color, Painter::WindingRule winding_rule, FloatPoint offset)
+void EdgeFlagPathRasterizer<SamplesPerPixel>::fill(Painter& painter, Path const& path, Color color, WindingRule winding_rule, FloatPoint offset)
 {
     fill_internal(painter, path, color, winding_rule, offset);
 }
 
 template<unsigned SamplesPerPixel>
-void EdgeFlagPathRasterizer<SamplesPerPixel>::fill(Painter& painter, Path const& path, PaintStyle const& style, float opacity, Painter::WindingRule winding_rule, FloatPoint offset)
+void EdgeFlagPathRasterizer<SamplesPerPixel>::fill(Painter& painter, Path const& path, PaintStyle const& style, float opacity, WindingRule winding_rule, FloatPoint offset)
 {
     style.paint(enclosing_int_rect(path.bounding_box()), [&](PaintStyle::SamplerFunction sampler) {
         if (opacity == 0.0f)
@@ -122,7 +122,7 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::fill(Painter& painter, Path const&
 }
 
 template<unsigned SamplesPerPixel>
-void EdgeFlagPathRasterizer<SamplesPerPixel>::fill_internal(Painter& painter, Path const& path, auto color_or_function, Painter::WindingRule winding_rule, FloatPoint offset)
+void EdgeFlagPathRasterizer<SamplesPerPixel>::fill_internal(Painter& painter, Path const& path, auto color_or_function, WindingRule winding_rule, FloatPoint offset)
 {
     // FIXME: Figure out how painter scaling works here...
     VERIFY(painter.scale() == 1);
@@ -190,7 +190,7 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::fill_internal(Painter& painter, Pa
 
     Detail::Edge* active_edges = nullptr;
 
-    if (winding_rule == Painter::WindingRule::EvenOdd) {
+    if (winding_rule == WindingRule::EvenOdd) {
         auto plot_edge = [&](Detail::Edge& edge, int start_subpixel_y, int end_subpixel_y, EdgeExtent& edge_extent) {
             for_each_sample(edge, start_subpixel_y, end_subpixel_y, edge_extent, [&](int xi, int, SampleType sample) {
                 m_scanline[xi] ^= sample;
@@ -199,10 +199,10 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::fill_internal(Painter& painter, Pa
         for (int scanline = min_scanline; scanline <= max_scanline; scanline++) {
             auto edge_extent = empty_edge_extent();
             active_edges = plot_edges_for_scanline(scanline, plot_edge, edge_extent, active_edges);
-            write_scanline<Painter::WindingRule::EvenOdd>(painter, scanline, edge_extent, color_or_function);
+            write_scanline<WindingRule::EvenOdd>(painter, scanline, edge_extent, color_or_function);
         }
     } else {
-        VERIFY(winding_rule == Painter::WindingRule::Nonzero);
+        VERIFY(winding_rule == WindingRule::Nonzero);
         // Only allocate the winding buffer if needed.
         // NOTE: non-zero fills are a fair bit less efficient. So if you can do an even-odd fill do that :^)
         if (m_windings.is_empty())
@@ -217,7 +217,7 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::fill_internal(Painter& painter, Pa
         for (int scanline = min_scanline; scanline <= max_scanline; scanline++) {
             auto edge_extent = empty_edge_extent();
             active_edges = plot_edges_for_scanline(scanline, plot_edge, edge_extent, active_edges);
-            write_scanline<Painter::WindingRule::Nonzero>(painter, scanline, edge_extent, color_or_function);
+            write_scanline<WindingRule::Nonzero>(painter, scanline, edge_extent, color_or_function);
         }
     }
 }
@@ -348,10 +348,10 @@ auto EdgeFlagPathRasterizer<SamplesPerPixel>::accumulate_non_zero_scanline(EdgeE
 }
 
 template<unsigned SamplesPerPixel>
-template<Painter::WindingRule WindingRule, typename Callback>
+template<WindingRule WindingRule, typename Callback>
 auto EdgeFlagPathRasterizer<SamplesPerPixel>::accumulate_scanline(EdgeExtent edge_extent, auto init, Callback callback)
 {
-    if constexpr (WindingRule == Painter::WindingRule::EvenOdd)
+    if constexpr (WindingRule == WindingRule::EvenOdd)
         return accumulate_even_odd_scanline(edge_extent, init, callback);
     else
         return accumulate_non_zero_scanline(edge_extent, init, callback);
@@ -377,7 +377,7 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::fast_fill_solid_color_span(ARGB32*
 }
 
 template<unsigned SamplesPerPixel>
-template<Painter::WindingRule WindingRule>
+template<WindingRule WindingRule>
 FLATTEN __attribute__((hot)) void EdgeFlagPathRasterizer<SamplesPerPixel>::write_scanline(Painter& painter, int scanline, EdgeExtent edge_extent, auto& color_or_function)
 {
     // Handle scanline clipping.
@@ -386,7 +386,7 @@ FLATTEN __attribute__((hot)) void EdgeFlagPathRasterizer<SamplesPerPixel>::write
     if (clipped_extent.min_x > clipped_extent.max_x) {
         // Fully clipped. Unfortunately we still need to zero the scanline data.
         edge_extent.memset_extent(m_scanline.data(), 0);
-        if constexpr (WindingRule == Painter::WindingRule::Nonzero)
+        if constexpr (WindingRule == WindingRule::Nonzero)
             edge_extent.memset_extent(m_windings.data(), 0);
         return;
     }
@@ -448,19 +448,19 @@ void Painter::fill_path(Path const& path, Color color, WindingRule winding_rule)
     rasterizer.fill(*this, path, color, winding_rule);
 }
 
-void Painter::fill_path(Path const& path, PaintStyle const& paint_style, float opacity, Painter::WindingRule winding_rule)
+void Painter::fill_path(Path const& path, PaintStyle const& paint_style, float opacity, WindingRule winding_rule)
 {
     EdgeFlagPathRasterizer<8> rasterizer(path_bounds(path));
     rasterizer.fill(*this, path, paint_style, opacity, winding_rule);
 }
 
-void AntiAliasingPainter::fill_path(Path const& path, Color color, Painter::WindingRule winding_rule)
+void AntiAliasingPainter::fill_path(Path const& path, Color color, WindingRule winding_rule)
 {
     EdgeFlagPathRasterizer<32> rasterizer(path_bounds(path));
     rasterizer.fill(m_underlying_painter, path, color, winding_rule, m_transform.translation());
 }
 
-void AntiAliasingPainter::fill_path(Path const& path, PaintStyle const& paint_style, float opacity, Painter::WindingRule winding_rule)
+void AntiAliasingPainter::fill_path(Path const& path, PaintStyle const& paint_style, float opacity, WindingRule winding_rule)
 {
     EdgeFlagPathRasterizer<32> rasterizer(path_bounds(path));
     rasterizer.fill(m_underlying_painter, path, paint_style, opacity, winding_rule, m_transform.translation());

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -10,8 +10,8 @@
 #include <AK/GenericShorthands.h>
 #include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Forward.h>
 #include <LibGfx/PaintStyle.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -145,8 +145,8 @@ class EdgeFlagPathRasterizer {
 public:
     EdgeFlagPathRasterizer(IntSize);
 
-    void fill(Painter&, Path const&, Color, Painter::WindingRule, FloatPoint offset = {});
-    void fill(Painter&, Path const&, PaintStyle const&, float opacity, Painter::WindingRule, FloatPoint offset = {});
+    void fill(Painter&, Path const&, Color, WindingRule, FloatPoint offset = {});
+    void fill(Painter&, Path const&, PaintStyle const&, float opacity, WindingRule, FloatPoint offset = {});
 
 private:
     using SubpixelSample = Detail::Sample<SamplesPerPixel>;
@@ -172,16 +172,16 @@ private:
         }
     };
 
-    void fill_internal(Painter&, Path const&, auto color_or_function, Painter::WindingRule, FloatPoint offset);
+    void fill_internal(Painter&, Path const&, auto color_or_function, WindingRule, FloatPoint offset);
     Detail::Edge* plot_edges_for_scanline(int scanline, auto plot_edge, EdgeExtent&, Detail::Edge* active_edges = nullptr);
 
-    template<Painter::WindingRule>
+    template<WindingRule>
     FLATTEN void write_scanline(Painter&, int scanline, EdgeExtent, auto& color_or_function);
     Color scanline_color(int scanline, int offset, u8 alpha, auto& color_or_function);
     void write_pixel(BitmapFormat format, ARGB32* scanline_ptr, int scanline, int offset, SampleType sample, auto& color_or_function);
     void fast_fill_solid_color_span(ARGB32* scanline_ptr, int start, int end, Color color);
 
-    template<Painter::WindingRule, typename Callback>
+    template<WindingRule, typename Callback>
     auto accumulate_scanline(EdgeExtent, auto, Callback);
     auto accumulate_even_odd_scanline(EdgeExtent, auto, auto sample_callback);
     auto accumulate_non_zero_scanline(EdgeExtent, auto, auto sample_callback);
@@ -196,10 +196,10 @@ private:
         WindingCounts winding;
     };
 
-    template<Painter::WindingRule WindingRule>
+    template<WindingRule WindingRule>
     constexpr auto initial_acc() const
     {
-        if constexpr (WindingRule == Painter::WindingRule::EvenOdd)
+        if constexpr (WindingRule == WindingRule::EvenOdd)
             return SampleType {};
         else
             return NonZeroAcc {};

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -19,6 +19,7 @@
 #include <LibGfx/Font/OpenType/Glyf.h>
 #include <LibGfx/Font/OpenType/Tables.h>
 #include <LibGfx/ImageFormats/PNGLoader.h>
+#include <LibGfx/Painter.h>
 #include <math.h>
 #include <sys/mman.h>
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -11,6 +11,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/StringView.h>
+#include <LibCore/Resource.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/OpenType/Cmap.h>

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -13,7 +13,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/OpenType/Tables.h>
-#include <LibGfx/Painter.h>
+#include <LibGfx/Path.h>
 #include <LibGfx/Size.h>
 #include <math.h>
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -483,10 +483,10 @@ void TinyVGDecodedImageData::draw_transformed(Painter& painter, AffineTransform 
             auto fill_path = draw_path;
             fill_path.close_all_subpaths();
             command.fill->visit(
-                [&](Color color) { aa_painter.fill_path(fill_path, color, Painter::WindingRule::EvenOdd); },
+                [&](Color color) { aa_painter.fill_path(fill_path, color, WindingRule::EvenOdd); },
                 [&](NonnullRefPtr<SVGGradientPaintStyle> style) {
                     const_cast<SVGGradientPaintStyle&>(*style).set_gradient_transform(transform);
-                    aa_painter.fill_path(fill_path, style, 1.0f, Painter::WindingRule::EvenOdd);
+                    aa_painter.fill_path(fill_path, style, 1.0f, WindingRule::EvenOdd);
                 });
         }
         if (command.stroke.has_value()) {

--- a/Userland/Libraries/LibGfx/LineStyle.h
+++ b/Userland/Libraries/LibGfx/LineStyle.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx {
+
+enum class LineStyle {
+    Solid,
+    Dotted,
+    Dashed,
+};
+
+}

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1185,7 +1185,7 @@ ALWAYS_INLINE static void do_draw_box_sampled_scaled_bitmap(Gfx::Bitmap& target,
     }
 }
 
-template<bool has_alpha_channel, Painter::ScalingMode scaling_mode, typename GetPixel>
+template<bool has_alpha_channel, ScalingMode scaling_mode, typename GetPixel>
 ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity)
 {
     auto int_src_rect = enclosing_int_rect(src_rect);
@@ -1193,7 +1193,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
     if (clipped_src_rect.is_empty())
         return;
 
-    if constexpr (scaling_mode == Painter::ScalingMode::NearestNeighbor || scaling_mode == Painter::ScalingMode::SmoothPixels) {
+    if constexpr (scaling_mode == ScalingMode::NearestNeighbor || scaling_mode == ScalingMode::SmoothPixels) {
         if (dst_rect == clipped_rect && int_src_rect == src_rect && !(dst_rect.width() % int_src_rect.width()) && !(dst_rect.height() % int_src_rect.height())) {
             int hfactor = dst_rect.width() / int_src_rect.width();
             int vfactor = dst_rect.height() / int_src_rect.height();
@@ -1207,7 +1207,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
         }
     }
 
-    if constexpr (scaling_mode == Painter::ScalingMode::BoxSampling)
+    if constexpr (scaling_mode == ScalingMode::BoxSampling)
         return do_draw_box_sampled_scaled_bitmap<has_alpha_channel>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
 
     bool has_opacity = opacity != 1.f;
@@ -1228,7 +1228,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
             auto desired_x = (x - dst_rect.x()) * hscale + src_left;
 
             Color src_pixel;
-            if constexpr (scaling_mode == Painter::ScalingMode::BilinearBlend) {
+            if constexpr (scaling_mode == ScalingMode::BilinearBlend) {
                 auto shifted_x = desired_x + bilinear_offset_x;
                 auto shifted_y = desired_y + bilinear_offset_y;
 
@@ -1249,7 +1249,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
                 auto bottom = bottom_left.mixed_with(bottom_right, x_ratio);
 
                 src_pixel = top.mixed_with(bottom, y_ratio);
-            } else if constexpr (scaling_mode == Painter::ScalingMode::SmoothPixels) {
+            } else if constexpr (scaling_mode == ScalingMode::SmoothPixels) {
                 auto scaled_x1 = clamp(desired_x >> 32, clipped_src_rect.left(), clipped_src_rect.right() - 1);
                 auto scaled_x0 = clamp(scaled_x1 - 1, clipped_src_rect.left(), clipped_src_rect.right() - 1);
                 auto scaled_y1 = clamp(desired_y >> 32, clipped_src_rect.top(), clipped_src_rect.bottom() - 1);
@@ -1288,23 +1288,23 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
 }
 
 template<bool has_alpha_channel, typename GetPixel>
-ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity, Painter::ScalingMode scaling_mode)
+ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity, ScalingMode scaling_mode)
 {
     switch (scaling_mode) {
-    case Painter::ScalingMode::NearestNeighbor:
-        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::NearestNeighbor>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+    case ScalingMode::NearestNeighbor:
+        do_draw_scaled_bitmap<has_alpha_channel, ScalingMode::NearestNeighbor>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
-    case Painter::ScalingMode::SmoothPixels:
-        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::SmoothPixels>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+    case ScalingMode::SmoothPixels:
+        do_draw_scaled_bitmap<has_alpha_channel, ScalingMode::SmoothPixels>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
-    case Painter::ScalingMode::BilinearBlend:
-        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::BilinearBlend>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+    case ScalingMode::BilinearBlend:
+        do_draw_scaled_bitmap<has_alpha_channel, ScalingMode::BilinearBlend>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
-    case Painter::ScalingMode::BoxSampling:
-        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::BoxSampling>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+    case ScalingMode::BoxSampling:
+        do_draw_scaled_bitmap<has_alpha_channel, ScalingMode::BoxSampling>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
-    case Painter::ScalingMode::None:
-        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::None>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+    case ScalingMode::None:
+        do_draw_scaled_bitmap<has_alpha_channel, ScalingMode::None>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
     }
 }
@@ -2445,7 +2445,7 @@ void Painter::draw_text_run(FloatPoint baseline_start, Utf8View const& string, F
     });
 }
 
-void Painter::draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Bitmap const& bitmap, FloatRect const& src_rect, AffineTransform const& transform, float opacity, Painter::ScalingMode scaling_mode)
+void Painter::draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Bitmap const& bitmap, FloatRect const& src_rect, AffineTransform const& transform, float opacity, ScalingMode scaling_mode)
 {
     if (transform.is_identity_or_translation_or_scale()) {
         draw_scaled_bitmap(transform.map(dst_rect.to_type<float>()).to_rounded<int>(), bitmap, src_rect, opacity, scaling_mode);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -19,6 +19,7 @@
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
+#include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/TextAlignment.h>
 #include <LibGfx/TextDirection.h>
@@ -53,13 +54,8 @@ public:
         Dashed,
     };
 
-    enum class ScalingMode {
-        NearestNeighbor,
-        SmoothPixels,
-        BilinearBlend,
-        BoxSampling,
-        None,
-    };
+    // FIXME: Remove this after replacing all uses with Gfx::ScalingMode.
+    using ScalingMode = ::Gfx::ScalingMode;
 
     void clear_rect(IntRect const&, Color);
     void fill_rect(IntRect const&, Color);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -16,6 +16,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>
 #include <LibGfx/GrayscaleBitmap.h>
+#include <LibGfx/LineStyle.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
@@ -49,11 +50,8 @@ public:
     explicit Painter(Gfx::Bitmap&);
     ~Painter() = default;
 
-    enum class LineStyle {
-        Solid,
-        Dotted,
-        Dashed,
-    };
+    // FIXME: Remove this after replacing all uses with Gfx::LineStyle.
+    using LineStyle = ::Gfx::LineStyle;
 
     // FIXME: Remove this after replacing all uses with Gfx::ScalingMode.
     using ScalingMode = ::Gfx::ScalingMode;

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -25,6 +25,7 @@
 #include <LibGfx/TextDirection.h>
 #include <LibGfx/TextElision.h>
 #include <LibGfx/TextWrapping.h>
+#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 
@@ -147,10 +148,8 @@ public:
 
     void stroke_path(Path const&, Color, int thickness);
 
-    enum class WindingRule {
-        Nonzero,
-        EvenOdd,
-    };
+    // FIXME: Remove this after replacing all uses with Gfx::WindingRule.
+    using WindingRule = ::Gfx::WindingRule;
 
     void fill_path(Path const&, Color, WindingRule rule = WindingRule::Nonzero);
     void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, WindingRule rule = WindingRule::Nonzero);

--- a/Userland/Libraries/LibGfx/PathClipper.cpp
+++ b/Userland/Libraries/LibGfx/PathClipper.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/AntiAliasingPainter.h>
+#include <LibGfx/Painter.h>
 #include <LibGfx/PathClipper.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/PathClipper.h
+++ b/Userland/Libraries/LibGfx/PathClipper.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include <LibGfx/Painter.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Forward.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/PathClipper.h
+++ b/Userland/Libraries/LibGfx/PathClipper.h
@@ -13,7 +13,7 @@ namespace Gfx {
 
 struct ClipPath {
     Path path;
-    Painter::WindingRule winding_rule;
+    WindingRule winding_rule;
 };
 
 class PathClipper {

--- a/Userland/Libraries/LibGfx/ScalingMode.h
+++ b/Userland/Libraries/LibGfx/ScalingMode.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx {
+
+enum class ScalingMode {
+    NearestNeighbor,
+    SmoothPixels,
+    BilinearBlend,
+    BoxSampling,
+    None,
+};
+
+}

--- a/Userland/Libraries/LibGfx/WindingRule.h
+++ b/Userland/Libraries/LibGfx/WindingRule.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx {
+
+enum class WindingRule {
+    Nonzero,
+    EvenOdd,
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -9,7 +9,7 @@
 #include <AK/FlyString.h>
 #include <AK/Optional.h>
 #include <LibGfx/FontCascadeList.h>
-#include <LibGfx/Painter.h>
+#include <LibGfx/ScalingMode.h>
 #include <LibWeb/CSS/BackdropFilter.h>
 #include <LibWeb/CSS/CalculatedOr.h>
 #include <LibWeb/CSS/Clip.h>
@@ -329,19 +329,19 @@ struct BorderRadiusData {
 };
 
 // FIXME: Find a better place for this helper.
-inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_value, Gfx::IntRect source, Gfx::IntRect target)
+inline Gfx::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_value, Gfx::IntRect source, Gfx::IntRect target)
 {
     switch (css_value) {
     case CSS::ImageRendering::Auto:
     case CSS::ImageRendering::HighQuality:
     case CSS::ImageRendering::Smooth:
         if (target.width() < source.width() || target.height() < source.height())
-            return Gfx::Painter::ScalingMode::BoxSampling;
-        return Gfx::Painter::ScalingMode::BilinearBlend;
+            return Gfx::ScalingMode::BoxSampling;
+        return Gfx::ScalingMode::BilinearBlend;
     case CSS::ImageRendering::CrispEdges:
-        return Gfx::Painter::ScalingMode::NearestNeighbor;
+        return Gfx::ScalingMode::NearestNeighbor;
     case CSS::ImageRendering::Pixelated:
-        return Gfx::Painter::ScalingMode::SmoothPixels;
+        return Gfx::ScalingMode::SmoothPixels;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -10,6 +10,7 @@
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
+#include <LibGfx/Font/VectorFont.h>
 #include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -11,6 +11,7 @@
 #include <AK/Vector.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/PathClipper.h>
 #include <LibWeb/Bindings/CanvasRenderingContext2DPrototype.h>

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -155,10 +155,10 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
 
     // 6. Paint the region of the image argument specified by the source rectangle on the region of the rendering context's output bitmap specified by the destination rectangle, after applying the current transformation matrix to the destination rectangle.
     draw_clipped([&](auto& painter) {
-        auto scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
+        auto scaling_mode = Gfx::ScalingMode::NearestNeighbor;
         if (drawing_state().image_smoothing_enabled) {
             // FIXME: Honor drawing_state().image_smoothing_quality
-            scaling_mode = Gfx::Painter::ScalingMode::BilinearBlend;
+            scaling_mode = Gfx::ScalingMode::BilinearBlend;
         }
 
         painter.underlying_painter().draw_scaled_bitmap_with_transform(destination_rect.to_rounded<int>(), *bitmap, source_rect, drawing_state().transform, drawing_state().global_alpha, scaling_mode);

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -92,7 +92,7 @@ Gfx::Path CanvasRenderingContext2D::rect_path(float x, float y, float width, flo
 
 void CanvasRenderingContext2D::fill_rect(float x, float y, float width, float height)
 {
-    return fill_internal(rect_path(x, y, width, height), Gfx::Painter::WindingRule::EvenOdd);
+    return fill_internal(rect_path(x, y, width, height), Gfx::WindingRule::EvenOdd);
 }
 
 void CanvasRenderingContext2D::clear_rect(float x, float y, float width, float height)
@@ -300,7 +300,7 @@ void CanvasRenderingContext2D::fill_text(StringView text, float x, float y, Opti
 {
     if (is<Gfx::BitmapFont>(*current_font()))
         return bitmap_font_fill_text(text, x, y, max_width);
-    fill_internal(text_path(text, x, y, max_width), Gfx::Painter::WindingRule::Nonzero);
+    fill_internal(text_path(text, x, y, max_width), Gfx::WindingRule::Nonzero);
 }
 
 void CanvasRenderingContext2D::stroke_text(StringView text, float x, float y, Optional<double> max_width)
@@ -351,17 +351,17 @@ void CanvasRenderingContext2D::stroke(Path2D const& path)
     stroke_internal(transformed_path);
 }
 
-static Gfx::Painter::WindingRule parse_fill_rule(StringView fill_rule)
+static Gfx::WindingRule parse_fill_rule(StringView fill_rule)
 {
     if (fill_rule == "evenodd"sv)
-        return Gfx::Painter::WindingRule::EvenOdd;
+        return Gfx::WindingRule::EvenOdd;
     if (fill_rule == "nonzero"sv)
-        return Gfx::Painter::WindingRule::Nonzero;
+        return Gfx::WindingRule::Nonzero;
     dbgln("Unrecognized fillRule for CRC2D.fill() - this problem goes away once we pass an enum instead of a string");
-    return Gfx::Painter::WindingRule::Nonzero;
+    return Gfx::WindingRule::Nonzero;
 }
 
-void CanvasRenderingContext2D::fill_internal(Gfx::Path const& path, Gfx::Painter::WindingRule winding_rule)
+void CanvasRenderingContext2D::fill_internal(Gfx::Path const& path, Gfx::WindingRule winding_rule)
 {
     draw_clipped([&, this](auto& painter) mutable {
         auto path_to_fill = path;
@@ -597,7 +597,7 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(By
     return prepared_text;
 }
 
-void CanvasRenderingContext2D::clip_internal(Gfx::Path& path, Gfx::Painter::WindingRule winding_rule)
+void CanvasRenderingContext2D::clip_internal(Gfx::Path& path, Gfx::WindingRule winding_rule)
 {
     // FIXME: This should calculate the new clip path by intersecting the given path with the current one.
     // See: https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-clip-dev

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -13,7 +13,6 @@
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/PathClipper.h>
 #include <LibWeb/Bindings/PlatformObject.h>

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -145,8 +145,8 @@ private:
     void bitmap_font_fill_text(StringView text, float x, float y, Optional<double> max_width);
 
     void stroke_internal(Gfx::Path const&);
-    void fill_internal(Gfx::Path const&, Gfx::Painter::WindingRule);
-    void clip_internal(Gfx::Path&, Gfx::Painter::WindingRule);
+    void fill_internal(Gfx::Path const&, Gfx::WindingRule);
+    void clip_internal(Gfx::Path&, Gfx::WindingRule);
 
     JS::NonnullGCPtr<HTMLCanvasElement> m_element;
     OwnPtr<Gfx::Painter> m_painter;

--- a/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.cpp
@@ -117,7 +117,7 @@ CommandResult AffineCommandExecutorCPU::fill_rect(FillRect const& command)
     // FIXME: Support clip_paths.
     Gfx::Path path;
     path.rect(command.rect.to_type<float>());
-    aa_painter().fill_path(path.copy_transformed(stacking_context().transform), command.color, Gfx::Painter::WindingRule::EvenOdd);
+    aa_painter().fill_path(path.copy_transformed(stacking_context().transform), command.color, Gfx::WindingRule::EvenOdd);
     return CommandResult::Continue;
 }
 
@@ -254,7 +254,7 @@ CommandResult AffineCommandExecutorCPU::fill_rect_with_rounded_corners(FillRectW
     Gfx::Path path;
     path.rounded_rect(command.rect.to_type<float>(), command.top_left_radius, command.top_right_radius, command.bottom_right_radius, command.bottom_left_radius);
     path = path.copy_transformed(stacking_context().transform);
-    aa_painter().fill_path(path, command.color, Gfx::Painter::WindingRule::EvenOdd);
+    aa_painter().fill_path(path, command.color, Gfx::WindingRule::EvenOdd);
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/AffineCommandExecutorCPU.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Painter.h>
 #include <LibGfx/Quad.h>
 #include <LibWeb/Painting/RecordingPainter.h>
 

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -100,19 +100,19 @@ void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect co
         }
     };
 
-    auto gfx_line_style = Gfx::Painter::LineStyle::Solid;
+    auto gfx_line_style = Gfx::LineStyle::Solid;
     switch (border_style) {
     case CSS::LineStyle::None:
     case CSS::LineStyle::Hidden:
         return;
     case CSS::LineStyle::Dotted:
-        gfx_line_style = Gfx::Painter::LineStyle::Dotted;
+        gfx_line_style = Gfx::LineStyle::Dotted;
         break;
     case CSS::LineStyle::Dashed:
-        gfx_line_style = Gfx::Painter::LineStyle::Dashed;
+        gfx_line_style = Gfx::LineStyle::Dashed;
         break;
     case CSS::LineStyle::Solid:
-        gfx_line_style = Gfx::Painter::LineStyle::Solid;
+        gfx_line_style = Gfx::LineStyle::Solid;
         break;
     case CSS::LineStyle::Double:
     case CSS::LineStyle::Groove:
@@ -123,7 +123,7 @@ void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect co
         break;
     }
 
-    if (gfx_line_style != Gfx::Painter::LineStyle::Solid) {
+    if (gfx_line_style != Gfx::LineStyle::Solid) {
         auto [p1, p2] = points_for_edge(edge, rect);
         switch (edge) {
         case BorderEdge::Top:

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -191,7 +191,7 @@ void paint_border(RecordingPainter& painter, BorderEdge edge, DevicePixelRect co
             path.close_all_subpaths();
             painter.fill_path({ .path = path,
                 .color = color,
-                .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+                .winding_rule = Gfx::WindingRule::EvenOdd });
             path.clear();
         }
     };

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -18,7 +18,6 @@
 #include <LibGfx/GrayscaleBitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -186,7 +186,7 @@ struct FillPathUsingColor {
     Gfx::IntRect path_bounding_rect;
     Gfx::Path path;
     Color color;
-    Gfx::Painter::WindingRule winding_rule;
+    Gfx::WindingRule winding_rule;
     Gfx::FloatPoint aa_translation;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return path_bounding_rect; }
@@ -202,7 +202,7 @@ struct FillPathUsingPaintStyle {
     Gfx::IntRect path_bounding_rect;
     Gfx::Path path;
     PaintStyle paint_style;
-    Gfx::Painter::WindingRule winding_rule;
+    Gfx::WindingRule winding_rule;
     float opacity;
     Gfx::FloatPoint aa_translation;
 

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -22,6 +22,7 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
+#include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/StylePainter.h>
 #include <LibGfx/TextAlignment.h>
@@ -76,7 +77,7 @@ struct DrawScaledBitmap {
     Gfx::IntRect dst_rect;
     NonnullRefPtr<Gfx::Bitmap> bitmap;
     Gfx::IntRect src_rect;
-    Gfx::Painter::ScalingMode scaling_mode;
+    Gfx::ScalingMode scaling_mode;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }
     void translate_by(Gfx::IntPoint const& offset) { dst_rect.translate_by(offset); }
@@ -86,7 +87,7 @@ struct DrawScaledImmutableBitmap {
     Gfx::IntRect dst_rect;
     NonnullRefPtr<Gfx::ImmutableBitmap> bitmap;
     Gfx::IntRect src_rect;
-    Gfx::Painter::ScalingMode scaling_mode;
+    Gfx::ScalingMode scaling_mode;
     Vector<Gfx::Path> clip_paths;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -278,7 +278,7 @@ struct DrawLine {
     Gfx::IntPoint from;
     Gfx::IntPoint to;
     int thickness;
-    Gfx::Painter::LineStyle style;
+    Gfx::LineStyle style;
     Color alternate_color;
 
     void translate_by(Gfx::IntPoint const& offset)

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -375,7 +375,7 @@ CommandResult CommandExecutorCPU::fill_ellipse(FillEllipse const& command)
 
 CommandResult CommandExecutorCPU::draw_line(DrawLine const& command)
 {
-    if (command.style == Gfx::Painter::LineStyle::Dotted) {
+    if (command.style == Gfx::LineStyle::Dotted) {
         Gfx::AntiAliasingPainter aa_painter(painter());
         aa_painter.draw_line(command.from, command.to, command.color, command.thickness, command.style, command.alternate_color);
     } else {

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -156,7 +156,7 @@ CommandResult CommandExecutorCPU::push_stacking_context(PushStackingContext cons
             .painter = AK::make<Gfx::Painter>(bitmap),
             .opacity = 1,
             .destination = command.source_paintable_rect.translated(command.post_transform_translation),
-            .scaling_mode = Gfx::Painter::ScalingMode::None,
+            .scaling_mode = Gfx::ScalingMode::None,
             .mask = command.mask });
         painter().translate(-command.source_paintable_rect.location());
         return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/MaybeOwned.h>
+#include <LibGfx/ScalingMode.h>
 #include <LibWeb/Painting/AffineCommandExecutorCPU.h>
 #include <LibWeb/Painting/RecordingPainter.h>
 
@@ -70,7 +71,7 @@ private:
         MaybeOwned<Gfx::Painter> painter;
         float opacity;
         Gfx::IntRect destination;
-        Gfx::Painter::ScalingMode scaling_mode;
+        Gfx::ScalingMode scaling_mode;
         Optional<StackingContextMask> mask = {};
     };
 

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorGPU.cpp
@@ -61,15 +61,15 @@ CommandResult CommandExecutorGPU::fill_rect(FillRect const& command)
     return CommandResult::Continue;
 }
 
-static AccelGfx::Painter::ScalingMode to_accelgfx_scaling_mode(Gfx::Painter::ScalingMode scaling_mode)
+static AccelGfx::Painter::ScalingMode to_accelgfx_scaling_mode(Gfx::ScalingMode scaling_mode)
 {
     switch (scaling_mode) {
-    case Gfx::Painter::ScalingMode::NearestNeighbor:
-    case Gfx::Painter::ScalingMode::BoxSampling:
-    case Gfx::Painter::ScalingMode::SmoothPixels:
-    case Gfx::Painter::ScalingMode::None:
+    case Gfx::ScalingMode::NearestNeighbor:
+    case Gfx::ScalingMode::BoxSampling:
+    case Gfx::ScalingMode::SmoothPixels:
+    case Gfx::ScalingMode::None:
         return AccelGfx::Painter::ScalingMode::NearestNeighbor;
-    case Gfx::Painter::ScalingMode::BilinearBlend:
+    case Gfx::ScalingMode::BilinearBlend:
         return AccelGfx::Painter::ScalingMode::Bilinear;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -18,7 +18,6 @@
 #include <LibGfx/GrayscaleBitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -89,7 +89,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         path.line_to({ left + sin_60_deg * (right - left), (top + bottom) / 2 });
         path.line_to({ left, bottom });
         path.close();
-        context.recording_painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+        context.recording_painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::WindingRule::EvenOdd });
         break;
     }
     case CSS::ListStyleType::DisclosureOpen: {
@@ -103,7 +103,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         path.line_to({ right, top });
         path.line_to({ (left + right) / 2, top + sin_60_deg * (bottom - top) });
         path.close();
-        context.recording_painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+        context.recording_painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::WindingRule::EvenOdd });
         break;
     }
     case CSS::ListStyleType::Decimal:

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -54,7 +54,7 @@ void MediaPaintable::fill_triangle(RecordingPainter& painter, Gfx::IntPoint loca
     painter.fill_path({
         .path = path,
         .color = color,
-        .winding_rule = Gfx::Painter::WindingRule::EvenOdd,
+        .winding_rule = Gfx::WindingRule::EvenOdd,
     });
 }
 
@@ -227,7 +227,7 @@ void MediaPaintable::paint_control_bar_speaker(PaintContext& context, HTML::HTML
     path.line_to(device_point(0, 11));
     path.line_to(device_point(0, 4));
     path.close();
-    context.recording_painter().fill_path({ .path = path, .color = speaker_button_color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+    context.recording_painter().fill_path({ .path = path, .color = speaker_button_color, .winding_rule = Gfx::WindingRule::EvenOdd });
 
     path.clear();
     path.move_to(device_point(13, 3));

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/GenericShorthands.h>
 #include <LibGfx/Font/ScaledFont.h>
+#include <LibGfx/Painter.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -625,7 +625,7 @@ void paint_text_decoration(PaintContext& context, TextPaintable const& paintable
 
         switch (paintable.computed_values().text_decoration_style()) {
         case CSS::TextDecorationStyle::Solid:
-            painter.draw_line(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value(), Gfx::Painter::LineStyle::Solid);
+            painter.draw_line(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value(), Gfx::LineStyle::Solid);
             break;
         case CSS::TextDecorationStyle::Double:
             switch (line) {
@@ -647,10 +647,10 @@ void paint_text_decoration(PaintContext& context, TextPaintable const& paintable
             painter.draw_line(line_start_point.translated(0, device_line_thickness + 1).to_type<int>(), line_end_point.translated(0, device_line_thickness + 1).to_type<int>(), line_color, device_line_thickness.value());
             break;
         case CSS::TextDecorationStyle::Dashed:
-            painter.draw_line(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value(), Gfx::Painter::LineStyle::Dashed);
+            painter.draw_line(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value(), Gfx::LineStyle::Dashed);
             break;
         case CSS::TextDecorationStyle::Dotted:
-            painter.draw_line(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value(), Gfx::Painter::LineStyle::Dotted);
+            painter.draw_line(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value(), Gfx::LineStyle::Dotted);
             break;
         case CSS::TextDecorationStyle::Wavy:
             painter.draw_triangle_wave(line_start_point.to_type<int>(), line_end_point.to_type<int>(), line_color, device_line_thickness.value() + 1, device_line_thickness.value());

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -210,7 +210,7 @@ void RecordingPainter::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect
     });
 }
 
-void RecordingPainter::draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness, Gfx::Painter::LineStyle style, Color alternate_color)
+void RecordingPainter::draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness, Gfx::LineStyle style, Color alternate_color)
 {
     append(DrawLine {
         .color = color,

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -185,7 +185,7 @@ void RecordingPainter::draw_rect(Gfx::IntRect const& rect, Color color, bool rou
         .rough = rough });
 }
 
-void RecordingPainter::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
+void RecordingPainter::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode)
 {
     if (dst_rect.is_empty())
         return;
@@ -197,7 +197,7 @@ void RecordingPainter::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bit
     });
 }
 
-void RecordingPainter::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode, Vector<Gfx::Path> const& clip_paths)
+void RecordingPainter::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode, Vector<Gfx::Path> const& clip_paths)
 {
     if (dst_rect.is_empty())
         return;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -18,7 +18,6 @@
 #include <LibGfx/GrayscaleBitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -95,7 +95,7 @@ public:
     void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor, Vector<Gfx::Path> const& clip_paths = {});
 
-    void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::Painter::LineStyle style = Gfx::Painter::LineStyle::Solid, Color alternate_color = Color::Transparent);
+    void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::LineStyle style = Gfx::LineStyle::Solid, Color alternate_color = Color::Transparent);
 
     void draw_text(Gfx::IntRect const&, String, Gfx::Font const&, Gfx::TextAlignment = Gfx::TextAlignment::TopLeft, Color = Color::Black, Gfx::TextElision = Gfx::TextElision::None, Gfx::TextWrapping = Gfx::TextWrapping::DontWrap);
 

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -51,7 +51,7 @@ public:
     struct FillPathUsingColorParams {
         Gfx::Path path;
         Gfx::Color color;
-        Gfx::Painter::WindingRule winding_rule = Gfx::Painter::WindingRule::EvenOdd;
+        Gfx::WindingRule winding_rule = Gfx::WindingRule::EvenOdd;
         Optional<Gfx::FloatPoint> translation = {};
     };
     void fill_path(FillPathUsingColorParams params);
@@ -59,7 +59,7 @@ public:
     struct FillPathUsingPaintStyleParams {
         Gfx::Path path;
         PaintStyle paint_style;
-        Gfx::Painter::WindingRule winding_rule = Gfx::Painter::WindingRule::EvenOdd;
+        Gfx::WindingRule winding_rule = Gfx::WindingRule::EvenOdd;
         float opacity;
         Optional<Gfx::FloatPoint> translation = {};
     };

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -22,6 +22,7 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
+#include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/StylePainter.h>
 #include <LibGfx/TextAlignment.h>
@@ -91,8 +92,8 @@ public:
 
     void draw_rect(Gfx::IntRect const& rect, Color color, bool rough = false);
 
-    void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor);
-    void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor, Vector<Gfx::Path> const& clip_paths = {});
+    void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
+    void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor, Vector<Gfx::Path> const& clip_paths = {});
 
     void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::Painter::LineStyle style = Gfx::Painter::LineStyle::Solid, Color alternate_color = Color::Transparent);
 

--- a/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -38,13 +38,13 @@ TraversalDecision SVGPathPaintable::hit_test(CSSPixelPoint position, HitTestType
     return SVGGraphicsPaintable::hit_test(position, type, callback);
 }
 
-static Gfx::Painter::WindingRule to_gfx_winding_rule(SVG::FillRule fill_rule)
+static Gfx::WindingRule to_gfx_winding_rule(SVG::FillRule fill_rule)
 {
     switch (fill_rule) {
     case SVG::FillRule::Nonzero:
-        return Gfx::Painter::WindingRule::Nonzero;
+        return Gfx::WindingRule::Nonzero;
     case SVG::FillRule::Evenodd:
-        return Gfx::Painter::WindingRule::EvenOdd;
+        return Gfx::WindingRule::EvenOdd;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/Painting/TableBordersPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/TableBordersPainting.cpp
@@ -284,9 +284,9 @@ static void paint_collected_edges(PaintContext& context, Vector<BorderEdgePainti
             : border_edge_painting_info.rect.bottom_left();
 
         if (border_style == CSS::LineStyle::Dotted) {
-            context.recording_painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::Painter::LineStyle::Dotted);
+            context.recording_painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::LineStyle::Dotted);
         } else if (border_style == CSS::LineStyle::Dashed) {
-            context.recording_painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::Painter::LineStyle::Dashed);
+            context.recording_painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::LineStyle::Dashed);
         } else {
             // FIXME: Support the remaining line styles instead of rendering them as solid.
             context.recording_painter().fill_rect(Gfx::IntRect(border_edge_painting_info.rect.location(), border_edge_painting_info.rect.size()), color);


### PR DESCRIPTION
Cherry-picks the middle 4 commits from https://github.com/LadybirdBrowser/ladybird/pull/50, with the motivation that this allows cherry-picking other things with fewer conflicts.

This keeps forwarding enums for Path::{LineStyle,ScalingMode,WindingRule} in place until the rest of the code is migrated to the new global enums. Help with that is appreciated!