### PR TITLE
Kernel/syscalls: Require `inet` promise for AF_INET6 domain

### DIFF
--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -16,6 +16,8 @@ namespace Kernel {
     do {                                          \
         if (domain == AF_INET)                    \
             TRY(require_promise(Pledge::inet));   \
+        else if (domain == AF_INET6)              \
+            TRY(require_promise(Pledge::inet));   \
         else if (domain == AF_LOCAL)              \
             TRY(require_promise(Pledge::unix));   \
     } while (0)


### PR DESCRIPTION
This goes in accordance with OpenBSD specification
https://man.openbsd.org/pledge.2#inet