### PR TITLE
Kernel/Filesystem+Tests: Fix RAMFS block count reporting, introduce a test

### DIFF
--- a/Kernel/FileSystem/RAMFS/Inode.cpp
+++ b/Kernel/FileSystem/RAMFS/Inode.cpp
@@ -122,6 +122,7 @@ ErrorOr<void> RAMFSInode::ensure_allocated_blocks(size_t offset, size_t io_size)
         }
     }
     clean_allocated_blocks_on_failure.disarm();
+    m_metadata.block_count = m_blocks.size();
     return {};
 }
 

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIBTEST_BASED_SOURCES
     TestEmptySharedInodeVMObject.cpp
     TestExt2FS.cpp
     TestFileSystemDirentTypes.cpp
+    TestFileSystemReportedSize.cpp
     TestInvalidUIDSet.cpp
     TestSharedInodeVMObject.cpp
     TestPosixFallocate.cpp

--- a/Tests/Kernel/TestFileSystemReportedSize.cpp
+++ b/Tests/Kernel/TestFileSystemReportedSize.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, sdomi <ja@sdomi.pl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static void test_write_path(char const* path)
+{
+    struct stat st;
+
+    auto fd = open(path, O_RDWR | O_CREAT);
+    EXPECT_NE(fd, -1);
+
+    EXPECT_NE(fstat(fd, &st), -1);
+    EXPECT(st.st_blocks == 0);
+    EXPECT_EQ(st.st_size, 0);
+
+    auto rc = write(fd, "meow", 4);
+    EXPECT_NE(rc, 0);
+
+    EXPECT_NE(fstat(fd, &st), -1);
+
+    EXPECT(st.st_blocks > 0);
+    EXPECT(st.st_size > 0);
+    close(fd);
+    unlink(path);
+}
+
+TEST_CASE(reported_blocksize_ramfs)
+{
+    test_write_path("/tmp/asdf");
+}
+
+TEST_CASE(reported_blocksize_ext2fs)
+{
+    test_write_path("/home/anon/asdf");
+}
+
+// TODO: automate testing of FatFS/FUSE/...


### PR DESCRIPTION
I tried making the test for this as generic as possible, so we can extend it onto more FSes (once we start testing those more widely in the future). Currently it runs against RAMFS itself and Ext2FS, because that was the easiest to set up.

L21 from TestFileSystemReportedSize.cpp isn't an EXPECT_EQ due to the macro complaining about not being able to compare between two types; maybe this is something we should look into fixing in the future?