### PR TITLE
Cherry-pick "LibGfx: Make Painter::target() return a Bitmap&"

### DIFF
--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -132,15 +132,15 @@ void MagnifierWidget::second_paint_event(GUI::PaintEvent&)
 
     GUI::Painter painter(*this);
 
-    auto target = painter.target();
-    auto bitmap_clone_or_error = target->clone();
+    auto& target = painter.target();
+    auto bitmap_clone_or_error = target.clone();
     if (bitmap_clone_or_error.is_error())
         return;
 
     auto clone = bitmap_clone_or_error.release_value();
-    auto rect = target->rect();
+    auto rect = target.rect();
 
-    m_color_filter->apply(*target, rect, *clone, rect);
+    m_color_filter->apply(target, rect, *clone, rect);
 }
 
 void MagnifierWidget::mousemove_event(GUI::MouseEvent& event)

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -133,15 +133,15 @@ void PreviewWidget::second_paint_event(GUI::PaintEvent&)
     if (!m_color_filter)
         return;
 
-    auto target = painter.target();
-    auto bitmap_clone_or_error = target->clone();
+    auto& target = painter.target();
+    auto bitmap_clone_or_error = target.clone();
     if (bitmap_clone_or_error.is_error())
         return;
 
     auto clone = bitmap_clone_or_error.release_value();
-    auto rect = target->rect();
+    auto rect = target.rect();
 
-    m_color_filter->apply(*target, rect, *clone, rect);
+    m_color_filter->apply(target, rect, *clone, rect);
 }
 
 void PreviewWidget::resize_event(GUI::ResizeEvent&)

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -398,8 +398,8 @@ FLATTEN __attribute__((hot)) void EdgeFlagPathRasterizer<SamplesPerPixel>::write
     });
 
     // Get pointer to current scanline pixels.
-    auto dest_format = painter.target()->format();
-    auto dest_ptr = painter.target()->scanline(scanline + m_blit_origin.y());
+    auto dest_format = painter.target().format();
+    auto dest_ptr = painter.target().scanline(scanline + m_blit_origin.y());
 
     // Simple case: Handle each pixel individually.
     // Used for PaintStyle fills and semi-transparent colors.

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -74,8 +74,8 @@ void Painter::fill_rect_with_draw_op(IntRect const& a_rect, Color color)
     if (rect.is_empty())
         return;
 
-    ARGB32* dst = m_target->scanline(rect.top()) + rect.left();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(rect.top()) + rect.left();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     for (int i = rect.height() - 1; i >= 0; --i) {
         for (int j = 0; j < rect.width(); ++j)
@@ -90,11 +90,11 @@ void Painter::clear_rect(IntRect const& a_rect, Color color)
     if (rect.is_empty())
         return;
 
-    VERIFY(m_target->rect().contains(rect));
+    VERIFY(target().rect().contains(rect));
     rect *= scale();
 
-    ARGB32* dst = m_target->scanline(rect.top()) + rect.left();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(rect.top()) + rect.left();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     for (int i = rect.height() - 1; i >= 0; --i) {
         fast_u32_fill(dst, color.value(), rect.width());
@@ -105,10 +105,10 @@ void Painter::clear_rect(IntRect const& a_rect, Color color)
 void Painter::fill_physical_rect(IntRect const& physical_rect, Color color)
 {
     // Callers must do clipping.
-    ARGB32* dst = m_target->scanline(physical_rect.top()) + physical_rect.left();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(physical_rect.top()) + physical_rect.left();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
-    auto dst_format = target()->format();
+    auto dst_format = target().format();
     for (int i = physical_rect.height() - 1; i >= 0; --i) {
         for (int j = 0; j < physical_rect.width(); ++j)
             dst[j] = color_for_format(dst_format, dst[j]).blend(color).value();
@@ -134,7 +134,7 @@ void Painter::fill_rect(IntRect const& a_rect, Color color)
     auto rect = a_rect.translated(translation()).intersected(clip_rect());
     if (rect.is_empty())
         return;
-    VERIFY(m_target->rect().contains(rect));
+    VERIFY(target().rect().contains(rect));
 
     fill_physical_rect(rect * scale(), color);
 }
@@ -166,8 +166,8 @@ void Painter::fill_rect_with_dither_pattern(IntRect const& a_rect, Color color_a
     if (rect.is_empty())
         return;
 
-    ARGB32* dst = m_target->scanline(rect.top()) + rect.left();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(rect.top()) + rect.left();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     for (int i = 0; i < rect.height(); ++i) {
         for (int j = 0; j < rect.width(); ++j) {
@@ -191,8 +191,8 @@ void Painter::fill_rect_with_checkerboard(IntRect const& a_rect, IntSize cell_si
     if (rect.is_empty())
         return;
 
-    ARGB32* dst = m_target->scanline(rect.top()) + rect.left();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(rect.top()) + rect.left();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     int first_cell_column = (rect.x() - translated_rect.x()) / cell_size.width();
     int prologue_length = min(rect.width(), cell_size.width() - ((rect.x() - translated_rect.x()) % cell_size.width()));
@@ -348,7 +348,7 @@ void Painter::fill_rounded_corner(IntRect const& a_rect, int radius, Color color
 
     if (rect.is_empty())
         return;
-    VERIFY(m_target->rect().contains(rect));
+    VERIFY(target().rect().contains(rect));
 
     // We got cut on the top!
     // FIXME: Also account for clipping on the x-axis
@@ -360,8 +360,8 @@ void Painter::fill_rounded_corner(IntRect const& a_rect, int radius, Color color
     rect *= scale();
     clip_offset *= scale();
 
-    ARGB32* dst = m_target->scanline(rect.top()) + rect.left();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(rect.top()) + rect.left();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     IntPoint circle_center;
     switch (orientation) {
@@ -389,7 +389,7 @@ void Painter::fill_rounded_corner(IntRect const& a_rect, int radius, Color color
         return distance2 <= (radius2 + radius + 0.25);
     };
 
-    auto dst_format = target()->format();
+    auto dst_format = target().format();
     for (int i = rect.height() - 1; i >= 0; --i) {
         for (int j = 0; j < rect.width(); ++j)
             if (is_in_circle(j, rect.height() - i + clip_offset))
@@ -409,7 +409,7 @@ void Painter::draw_circle_arc_intersecting(IntRect const& a_rect, IntPoint cente
 
     if (rect.is_empty())
         return;
-    VERIFY(m_target->rect().contains(rect));
+    VERIFY(target().rect().contains(rect));
 
     // We got cut on the top!
     // FIXME: Also account for clipping on the x-axis
@@ -428,9 +428,9 @@ void Painter::draw_circle_arc_intersecting(IntRect const& a_rect, IntPoint cente
         return distance2 <= (radius2 + radius + 0.25) && distance2 >= (radius2 - radius + 0.25);
     };
 
-    ARGB32* dst = m_target->scanline(rect.top()) + rect.left();
-    auto dst_format = target()->format();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(rect.top()) + rect.left();
+    auto dst_format = target().format();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     for (int i = rect.height() - 1; i >= 0; --i) {
         for (int j = 0; j < rect.width(); ++j)
@@ -499,7 +499,7 @@ void Painter::fill_ellipse(IntRect const& a_rect, Color color)
     if (rect.is_empty())
         return;
 
-    VERIFY(m_target->rect().contains(rect));
+    VERIFY(target().rect().contains(rect));
 
     auto const center = a_rect.center();
 
@@ -594,7 +594,7 @@ void Painter::draw_rect(IntRect const& a_rect, Color color, bool rough)
     if (draw_left_side && draw_right_side) {
         // Specialized loop when drawing both sides.
         for (int y = min_y * scale; y <= max_y * scale; ++y) {
-            auto* bits = m_target->scanline(y);
+            auto* bits = target().scanline(y);
             for (int i = 0; i < scale; ++i)
                 set_physical_pixel_with_draw_op(bits[rect.left() * scale + i], color);
             for (int i = 0; i < scale; ++i)
@@ -602,7 +602,7 @@ void Painter::draw_rect(IntRect const& a_rect, Color color, bool rough)
         }
     } else {
         for (int y = min_y * scale; y <= max_y * scale; ++y) {
-            auto* bits = m_target->scanline(y);
+            auto* bits = target().scanline(y);
             if (draw_left_side)
                 for (int i = 0; i < scale; ++i)
                     set_physical_pixel_with_draw_op(bits[rect.left() * scale + i], color);
@@ -641,8 +641,8 @@ void Painter::draw_bitmap(IntPoint p, CharacterBitmap const& bitmap, Color color
     int const last_row = clipped_rect.bottom() - rect.top();
     int const first_column = clipped_rect.left() - rect.left();
     int const last_column = clipped_rect.right() - rect.left();
-    ARGB32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(clipped_rect.y()) + clipped_rect.x();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
     char const* bitmap_row = &bitmap.bits()[first_row * bitmap.width() + first_column];
     size_t const bitmap_skip = bitmap.width();
 
@@ -669,9 +669,9 @@ void Painter::draw_bitmap(IntPoint p, GlyphBitmap const& bitmap, Color color)
     int const last_column = clipped_rect.right() - dst_rect.left();
 
     int scale = this->scale();
-    ARGB32* dst = m_target->scanline(clipped_rect.y() * scale) + clipped_rect.x() * scale;
-    auto dst_format = target()->format();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(clipped_rect.y() * scale) + clipped_rect.x() * scale;
+    auto dst_format = target().format();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     if (scale == 1) {
         for (int row = first_row; row < last_row; ++row) {
@@ -800,7 +800,7 @@ void Painter::draw_triangle(IntPoint a, IntPoint b, IntPoint c, Color color)
 
         int left_bound = result_a, right_bound = result_b;
 
-        ARGB32* scanline = m_target->scanline(y);
+        ARGB32* scanline = target().scanline(y);
         for (int x = max(left_bound, clip.left()); x <= min(right_bound, clip.right() - 1); x++)
             scanline[x] = rgba;
     }
@@ -890,9 +890,9 @@ void Painter::blit_with_opacity(IntPoint position, Gfx::Bitmap const& source, In
 
     BlitState blit_state {
         .src = source.scanline(src_rect.top() + first_row) + src_rect.left() + first_column,
-        .dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x(),
+        .dst = target().scanline(clipped_rect.y()) + clipped_rect.x(),
         .src_pitch = source.pitch() / sizeof(ARGB32),
-        .dst_pitch = m_target->pitch() / sizeof(ARGB32),
+        .dst_pitch = target().pitch() / sizeof(ARGB32),
         .row_count = last_row - first_row,
         .column_count = last_column - first_column,
         .opacity = opacity,
@@ -900,12 +900,12 @@ void Painter::blit_with_opacity(IntPoint position, Gfx::Bitmap const& source, In
     };
 
     if (source.has_alpha_channel() && apply_alpha) {
-        if (m_target->has_alpha_channel())
+        if (target().has_alpha_channel())
             do_blit_with_opacity<BlitState::BothAlpha>(blit_state);
         else
             do_blit_with_opacity<BlitState::SrcAlpha>(blit_state);
     } else {
-        if (m_target->has_alpha_channel())
+        if (target().has_alpha_channel())
             do_blit_with_opacity<BlitState::DstAlpha>(blit_state);
         else
             do_blit_with_opacity<BlitState::NoAlpha>(blit_state);
@@ -931,9 +931,9 @@ void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRec
     int const last_row = clipped_rect.bottom() - dst_rect.top();
     int const first_column = clipped_rect.left() - dst_rect.left();
     int const last_column = clipped_rect.right() - dst_rect.left();
-    ARGB32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
-    auto dst_format = target()->format();
+    ARGB32* dst = target().scanline(clipped_rect.y()) + clipped_rect.x();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
+    auto dst_format = target().format();
     auto src_format = source.format();
 
     int s = scale / source.scale();
@@ -1003,8 +1003,8 @@ void Painter::draw_tiled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& so
     int const first_row = clipped_rect.top() - dst_rect.top();
     int const last_row = clipped_rect.bottom() - dst_rect.top();
     int const first_column = clipped_rect.left() - dst_rect.left();
-    ARGB32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(clipped_rect.y()) + clipped_rect.x();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     if (source.format() == BitmapFormat::BGRx8888 || source.format() == BitmapFormat::BGRA8888) {
         int s = scale / source.scale();
@@ -1073,8 +1073,8 @@ void Painter::blit(IntPoint position, Gfx::Bitmap const& source, IntRect const& 
     int const first_row = clipped_rect.top() - dst_rect.top();
     int const last_row = clipped_rect.bottom() - dst_rect.top();
     int const first_column = clipped_rect.left() - dst_rect.left();
-    ARGB32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    size_t const dst_skip = m_target->pitch() / sizeof(ARGB32);
+    ARGB32* dst = target().scanline(clipped_rect.y()) + clipped_rect.x();
+    size_t const dst_skip = target().pitch() / sizeof(ARGB32);
 
     if (source.format() == BitmapFormat::BGRx8888 || source.format() == BitmapFormat::BGRA8888) {
         ARGB32 const* src = source.scanline(src_rect.top() + first_row) + src_rect.left() + first_column;
@@ -1822,11 +1822,11 @@ void Painter::set_physical_pixel(IntPoint physical_point, Color color, bool blen
 {
     // This function should only be called after translation, clipping, etc has been handled elsewhere
     // if not use set_pixel().
-    auto& dst = m_target->scanline(physical_point.y())[physical_point.x()];
+    auto& dst = target().scanline(physical_point.y())[physical_point.x()];
     if (!blend || color.alpha() == 255)
         dst = color.value();
     else if (color.alpha())
-        dst = color_for_format(target()->format(), dst).blend(color).value();
+        dst = color_for_format(target().format(), dst).blend(color).value();
 }
 
 Optional<Color> Painter::get_pixel(IntPoint p)
@@ -1835,16 +1835,16 @@ Optional<Color> Painter::get_pixel(IntPoint p)
     point.translate_by(state().translation);
     if (!clip_rect().contains(point / scale()))
         return {};
-    return m_target->get_pixel(point);
+    return target().get_pixel(point);
 }
 
 ErrorOr<NonnullRefPtr<Bitmap>> Painter::get_region_bitmap(IntRect const& region, BitmapFormat format, Optional<IntRect&> actual_region)
 {
     VERIFY(scale() == 1);
-    auto bitmap_region = region.translated(state().translation).intersected(m_target->rect());
+    auto bitmap_region = region.translated(state().translation).intersected(target().rect());
     if (actual_region.has_value())
         actual_region.value() = bitmap_region.translated(-state().translation);
-    return m_target->cropped(bitmap_region, format);
+    return target().cropped(bitmap_region, format);
 }
 
 ALWAYS_INLINE void Painter::set_physical_pixel_with_draw_op(u32& pixel, Color color)
@@ -1869,13 +1869,13 @@ ALWAYS_INLINE void Painter::fill_physical_scanline_with_draw_op(int y, int x, in
 {
     // This always draws a single physical scanline, independent of scale().
     // This should only be called by routines that already handle scale.
-    auto dst_format = m_target->format();
+    auto dst_format = target().format();
     switch (draw_op()) {
     case DrawOp::Copy:
-        fast_u32_fill(m_target->scanline(y) + x, color.value(), width);
+        fast_u32_fill(target().scanline(y) + x, color.value(), width);
         break;
     case DrawOp::Xor: {
-        auto* pixel = m_target->scanline(y) + x;
+        auto* pixel = target().scanline(y) + x;
         auto* end = pixel + width;
         while (pixel < end) {
             *pixel = color_for_format(dst_format, *pixel).xored(color).value();
@@ -1884,7 +1884,7 @@ ALWAYS_INLINE void Painter::fill_physical_scanline_with_draw_op(int y, int x, in
         break;
     }
     case DrawOp::Invert: {
-        auto* pixel = m_target->scanline(y) + x;
+        auto* pixel = target().scanline(y) + x;
         auto* end = pixel + width;
         while (pixel < end) {
             *pixel = color_for_format(dst_format, *pixel).inverted().value();
@@ -1906,8 +1906,8 @@ void Painter::draw_physical_pixel(IntPoint physical_position, Color color, int t
         return;
 
     if (thickness == 1) { // Implies scale() == 1.
-        auto& pixel = m_target->scanline(physical_position.y())[physical_position.x()];
-        return set_physical_pixel_with_draw_op(pixel, color_for_format(m_target->format(), pixel).blend(color));
+        auto& pixel = target().scanline(physical_position.y())[physical_position.x()];
+        return set_physical_pixel_with_draw_op(pixel, color_for_format(target().format(), pixel).blend(color));
     }
 
     IntRect rect { physical_position, { thickness, thickness } };
@@ -2316,7 +2316,7 @@ void Painter::draw_elliptical_arc(IntPoint p1, IntPoint p2, IntPoint center, Flo
 void Painter::add_clip_rect(IntRect const& rect)
 {
     state().clip_rect.intersect(rect.translated(translation()));
-    state().clip_rect.intersect(m_target->rect()); // FIXME: This shouldn't be necessary?
+    state().clip_rect.intersect(target().rect()); // FIXME: This shouldn't be necessary?
 }
 
 void Painter::clear_clip_rect()

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -176,7 +176,7 @@ public:
 
     IntPoint translation() const { return state().translation; }
 
-    Gfx::Bitmap* target() { return m_target.ptr(); }
+    [[nodiscard]] Gfx::Bitmap& target() { return *m_target; }
 
     void save() { m_state_stack.append(m_state_stack.last()); }
     void restore()

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -447,7 +447,7 @@ void CanvasRenderingContext2D::reset_to_default_state()
 
     // 1. Clear canvas's bitmap to transparent black.
     if (painter)
-        painter->clear_rect(painter->target()->rect(), Color::Transparent);
+        painter->clear_rect(painter->target().rect(), Color::Transparent);
 
     // 2. Empty the list of subpaths in context's current default path.
     path().clear();
@@ -459,7 +459,7 @@ void CanvasRenderingContext2D::reset_to_default_state()
     reset_drawing_state();
 
     if (painter)
-        did_draw(painter->target()->rect().to_type<float>());
+        did_draw(painter->target().rect().to_type<float>());
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-measuretext

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -78,7 +78,7 @@ void BorderRadiusCornerClipper::sample_under_corners(Gfx::Painter& page_painter)
                     position.translate_by(translation);
                     if (!clip_rect.contains(position))
                         continue;
-                    auto page_pixel = page_painter.target()->get_pixel<Gfx::StorageFormat::BGRA8888>(position.x(), position.y());
+                    auto page_pixel = page_painter.target().get_pixel<Gfx::StorageFormat::BGRA8888>(position.x(), position.y());
                     final_pixel = page_pixel.with_alpha(mask_alpha);
                 }
                 m_corner_bitmap->set_pixel<Gfx::StorageFormat::BGRA8888>(corner_location.x(), corner_location.y(), final_pixel);

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerCPU.cpp
@@ -125,7 +125,7 @@ CommandResult DisplayListPlayerCPU::push_stacking_context(PushStackingContext co
 
     if (m_enable_affine_command_executor && !affine_transform.is_identity_or_translation()) {
         auto offset = command.is_fixed_position ? Gfx::IntPoint {} : painter().translation();
-        m_affine_display_list_player = AffineDisplayListPlayerCPU(*painter().target(),
+        m_affine_display_list_player = AffineDisplayListPlayerCPU(painter().target(),
             Gfx::AffineTransform {}.set_translation(offset.to_type<float>()), painter().clip_rect());
         if (m_affine_display_list_player->push_stacking_context(command) == CommandResult::SkipStackingContext)
             return CommandResult::SkipStackingContext;
@@ -221,14 +221,14 @@ CommandResult DisplayListPlayerCPU::pop_stacking_context(PopStackingContext cons
     auto stacking_context = stacking_contexts.take_last();
     // Stacking contexts that don't own their painter are simple translations, and don't need to blit anything back.
     if (stacking_context.painter.is_owned()) {
-        auto bitmap = stacking_context.painter->target();
+        auto& bitmap = stacking_context.painter->target();
         if (stacking_context.mask.has_value())
-            bitmap->apply_mask(*stacking_context.mask->mask_bitmap, stacking_context.mask->mask_kind);
+            bitmap.apply_mask(*stacking_context.mask->mask_bitmap, stacking_context.mask->mask_kind);
         auto destination_rect = stacking_context.destination;
-        if (destination_rect.size() == bitmap->size()) {
-            painter().blit(destination_rect.location(), *bitmap, bitmap->rect(), stacking_context.opacity);
+        if (destination_rect.size() == bitmap.size()) {
+            painter().blit(destination_rect.location(), bitmap, bitmap.rect(), stacking_context.opacity);
         } else {
-            painter().draw_scaled_bitmap(destination_rect, *bitmap, bitmap->rect(), stacking_context.opacity, stacking_context.scaling_mode);
+            painter().draw_scaled_bitmap(destination_rect, bitmap, bitmap.rect(), stacking_context.opacity, stacking_context.scaling_mode);
         }
     }
     return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -488,7 +488,7 @@ void paint_outer_box_shadow(Gfx::Painter& painter, PaintBoxShadowParams params)
     // FIXME: Could reduce the shadow paints from 8 to 4 for shadows with all corner radii 50%.
 
     // FIXME: We use this since we want the clip rect to include everything after a certain x or y.
-    // Note: Using painter.target()->width() or height() does not work, when the painter is a small
+    // Note: Using painter.target().width() or height() does not work, when the painter is a small
     // translated bitmap rather than full screen, as the clip rect may not intersect.
     constexpr auto really_large_number = NumericLimits<int>::max() / 2;
 


### PR DESCRIPTION
Painter always has a target bitmap, so let's return a reference.

(cherry picked from commit f42c18bc4c4a5d49fccbfab996bf04d77476b366; amended to resolve conflicts in Painter due to us having more APIs, and to update code no longer in ladybird: DisplayListPlayerCPU, and Magnifier and ThemeEditor)

---

Cherry-picks another commit from https://github.com/LadybirdBrowser/ladybird/pull/50