### PR TITLE
Cherry-pick "Everywhere: Limit layout text fragments to use one font for all glyphs"

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -407,7 +407,7 @@ void Painter::draw_scaled_bitmap(Gfx::FloatRect const& dst_rect, Gfx::Bitmap con
     GL::delete_texture(texture);
 }
 
-void Painter::draw_glyph_run(Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color const& color)
+void Painter::draw_glyph_run(Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Gfx::Font const& font, Color const& color)
 {
     bind_target_canvas();
 
@@ -420,7 +420,6 @@ void Painter::draw_glyph_run(Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color 
         if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
             auto const& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
 
-            auto const& font = *glyph.font;
             auto code_point = glyph.code_point;
             auto point = glyph.position;
 

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -70,7 +70,7 @@ public:
     void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_scaled_immutable_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::FloatRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
 
-    void draw_glyph_run(Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color const& color);
+    void draw_glyph_run(Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Gfx::Font const&, Color const& color);
 
     void set_clip_rect(Gfx::IntRect);
     void clear_clip_rect();

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1410,10 +1410,10 @@ void Painter::draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIterator& it, F
     auto draw_glyph_or_emoji = prepare_draw_glyph_or_emoji(point, it, font);
     if (draw_glyph_or_emoji.has<DrawGlyph>()) {
         auto& glyph = draw_glyph_or_emoji.get<DrawGlyph>();
-        draw_glyph(glyph.position, glyph.code_point, *glyph.font, color);
+        draw_glyph(glyph.position, glyph.code_point, font, color);
     } else {
         auto& emoji = draw_glyph_or_emoji.get<DrawEmoji>();
-        draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *emoji.font);
+        draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, font);
     }
 }
 
@@ -2432,15 +2432,13 @@ void Painter::draw_text_run(IntPoint baseline_start, Utf8View const& string, Fon
 
 void Painter::draw_text_run(FloatPoint baseline_start, Utf8View const& string, Font const& font, Color color)
 {
-    auto font_list = Gfx::FontCascadeList::create();
-    font_list->add(font);
-    for_each_glyph_position(baseline_start, string, font_list, [&](DrawGlyphOrEmoji glyph_or_emoji) {
+    for_each_glyph_position(baseline_start, string, font, [&](DrawGlyphOrEmoji glyph_or_emoji) {
         if (glyph_or_emoji.has<DrawGlyph>()) {
             auto& glyph = glyph_or_emoji.get<DrawGlyph>();
-            draw_glyph(glyph.position, glyph.code_point, *glyph.font, color);
+            draw_glyph(glyph.position, glyph.code_point, font, color);
         } else {
             auto& emoji = glyph_or_emoji.get<DrawEmoji>();
-            draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *emoji.font);
+            draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, font);
         }
     });
 }

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -218,10 +218,8 @@ void Path::text(Utf8View text, Font const& font)
     }
 
     auto& scaled_font = static_cast<ScaledFont const&>(font);
-    auto font_list = Gfx::FontCascadeList::create();
-    font_list->add(scaled_font);
     for_each_glyph_position(
-        last_point(), text, font_list, [&](DrawGlyphOrEmoji glyph_or_emoji) {
+        last_point(), text, scaled_font, [&](DrawGlyphOrEmoji glyph_or_emoji) {
             if (glyph_or_emoji.has<DrawGlyph>()) {
                 auto& glyph = glyph_or_emoji.get<DrawGlyph>();
                 move_to(glyph.position);
@@ -259,13 +257,10 @@ Path Path::place_text_along(Utf8View text, Font const& font) const
         return lines[line_index].a();
     };
 
-    auto font_list = Gfx::FontCascadeList::create();
-    font_list->add(font);
     auto& scaled_font = static_cast<Gfx::ScaledFont const&>(font);
-
     Gfx::Path result_path;
     Gfx::for_each_glyph_position(
-        {}, text, font_list, [&](Gfx::DrawGlyphOrEmoji glyph_or_emoji) {
+        {}, text, font, [&](Gfx::DrawGlyphOrEmoji glyph_or_emoji) {
             auto* glyph = glyph_or_emoji.get_pointer<Gfx::DrawGlyph>();
             if (!glyph)
                 return;

--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -227,7 +227,6 @@ DrawGlyphOrEmoji prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIter
         return DrawGlyph {
             .position = point,
             .code_point = code_point,
-            .font = font,
         };
     }
 
@@ -236,7 +235,6 @@ DrawGlyphOrEmoji prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIter
         return DrawEmoji {
             .position = point,
             .emoji = emoji,
-            .font = font,
         };
     }
 
@@ -245,7 +243,6 @@ DrawGlyphOrEmoji prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIter
         return DrawGlyph {
             .position = point,
             .code_point = code_point,
-            .font = font,
         };
     }
 
@@ -254,7 +251,6 @@ DrawGlyphOrEmoji prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIter
     return DrawGlyph {
         .position = point,
         .code_point = 0xFFFD,
-        .font = font,
     };
 }
 

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -198,7 +198,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
         Vector<Gfx::DrawGlyphOrEmoji> glyph_run;
         float glyph_run_width = 0;
         Gfx::for_each_glyph_position(
-            { 0, 0 }, chunk.view, text_node.computed_values().font_list(), [&](Gfx::DrawGlyphOrEmoji const& glyph_or_emoji) {
+            { 0, 0 }, chunk.view, chunk.font, [&](Gfx::DrawGlyphOrEmoji const& glyph_or_emoji) {
                 glyph_run.append(glyph_or_emoji);
                 return IterationDecision::Continue;
             },
@@ -215,7 +215,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
         Item item {
             .type = Item::Type::Text,
             .node = &text_node,
-            .glyph_run = move(glyph_run),
+            .glyph_run = adopt_ref(*new Gfx::GlyphRun(move(glyph_run), chunk.font)),
             .offset_in_node = chunk.start,
             .length_in_node = chunk.length,
             .width = chunk_width,
@@ -324,7 +324,7 @@ void InlineLevelIterator::enter_text_node(Layout::TextNode const& text_node)
         .do_respect_linebreaks = do_respect_linebreaks,
         .is_first_chunk = true,
         .is_last_chunk = false,
-        .chunk_iterator = TextNode::ChunkIterator { text_node.text_for_rendering(), do_wrap_lines, do_respect_linebreaks },
+        .chunk_iterator = TextNode::ChunkIterator { text_node.text_for_rendering(), do_wrap_lines, do_respect_linebreaks, text_node.computed_values().font_list() },
     };
     m_text_node_context->next_chunk = m_text_node_context->chunk_iterator.next();
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -32,7 +32,7 @@ public:
         };
         Type type {};
         JS::GCPtr<Layout::Node const> node {};
-        Vector<Gfx::DrawGlyphOrEmoji> glyph_run {};
+        RefPtr<Gfx::GlyphRun> glyph_run {};
         size_t offset_in_node { 0 };
         size_t length_in_node { 0 };
         CSSPixels width { 0.0f };

--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -15,16 +15,16 @@
 
 namespace Web::Layout {
 
-void LineBox::add_fragment(Node const& layout_node, int start, int length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, Vector<Gfx::DrawGlyphOrEmoji> glyph_run)
+void LineBox::add_fragment(Node const& layout_node, int start, int length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run)
 {
     bool text_align_is_justify = layout_node.computed_values().text_align() == CSS::TextAlign::Justify;
-    if (!text_align_is_justify && !m_fragments.is_empty() && &m_fragments.last().layout_node() == &layout_node) {
+    if (glyph_run && !text_align_is_justify && !m_fragments.is_empty() && &m_fragments.last().layout_node() == &layout_node && &m_fragments.last().m_glyph_run->font() == &glyph_run->font()) {
         auto const fragment_width = m_fragments.last().width();
         // The fragment we're adding is from the last Layout::Node on the line.
         // Expand the last fragment instead of adding a new one with the same Layout::Node.
         m_fragments.last().m_length = (start - m_fragments.last().m_start) + length;
         m_fragments.last().set_width(m_fragments.last().width() + content_width);
-        for (auto& glyph : glyph_run) {
+        for (auto& glyph : glyph_run->glyphs()) {
             glyph.visit([&](auto& glyph) { glyph.position.translate_by(fragment_width.to_float(), 0); });
             m_fragments.last().m_glyph_run->append(glyph);
         }

--- a/Userland/Libraries/LibWeb/Layout/LineBox.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.h
@@ -20,7 +20,7 @@ public:
     CSSPixels bottom() const { return m_bottom; }
     CSSPixels baseline() const { return m_baseline; }
 
-    void add_fragment(Node const& layout_node, int start, int length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, Vector<Gfx::DrawGlyphOrEmoji> = {});
+    void add_fragment(Node const& layout_node, int start, int length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run = {});
 
     Vector<LineBoxFragment> const& fragments() const { return m_fragments; }
     Vector<LineBoxFragment>& fragments() { return m_fragments; }

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -19,14 +19,14 @@ class LineBoxFragment {
     friend class LineBox;
 
 public:
-    LineBoxFragment(Node const& layout_node, int start, int length, CSSPixelPoint offset, CSSPixelSize size, CSSPixels border_box_top, Vector<Gfx::DrawGlyphOrEmoji> glyphs)
+    LineBoxFragment(Node const& layout_node, int start, int length, CSSPixelPoint offset, CSSPixelSize size, CSSPixels border_box_top, RefPtr<Gfx::GlyphRun> glyph_run)
         : m_layout_node(layout_node)
         , m_start(start)
         , m_length(length)
         , m_offset(offset)
         , m_size(size)
         , m_border_box_top(border_box_top)
-        , m_glyph_run(adopt_ref(*new Gfx::GlyphRun(move(glyphs))))
+        , m_glyph_run(move(glyph_run))
     {
     }
 
@@ -59,7 +59,7 @@ public:
 
     bool is_atomic_inline() const;
 
-    Gfx::GlyphRun const& glyph_run() const { return *m_glyph_run; }
+    RefPtr<Gfx::GlyphRun> glyph_run() const { return m_glyph_run; }
 
 private:
     JS::NonnullGCPtr<Node const> m_layout_node;
@@ -69,7 +69,7 @@ private:
     CSSPixelSize m_size;
     CSSPixels m_border_box_top { 0 };
     CSSPixels m_baseline { 0 };
-    NonnullRefPtr<Gfx::GlyphRun> m_glyph_run;
+    RefPtr<Gfx::GlyphRun> m_glyph_run;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -97,7 +97,7 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
     };
 }
 
-void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, Vector<Gfx::DrawGlyphOrEmoji> glyph_run)
+void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun> glyph_run)
 {
     ensure_last_line_box().add_fragment(text_node, offset_in_node, length_in_node, leading_size, trailing_size, leading_margin, trailing_margin, content_width, content_height, 0, 0, move(glyph_run));
     m_max_height_on_current_line = max(m_max_height_on_current_line, content_height);

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.h
@@ -25,7 +25,7 @@ public:
 
     void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
-    void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, Vector<Gfx::DrawGlyphOrEmoji>);
+    void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
 
     // Returns whether a line break occurred.
     bool break_if_needed(CSSPixels next_item_width)

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -28,6 +28,7 @@ public:
 
     struct Chunk {
         Utf8View view;
+        NonnullRefPtr<Gfx::Font> font;
         size_t start { 0 };
         size_t length { 0 };
         bool has_breaking_newline { false };
@@ -36,16 +37,17 @@ public:
 
     class ChunkIterator {
     public:
-        ChunkIterator(StringView text, bool wrap_lines, bool respect_linebreaks);
+        ChunkIterator(StringView text, bool wrap_lines, bool respect_linebreaks, Gfx::FontCascadeList const&);
         Optional<Chunk> next();
 
     private:
-        Optional<Chunk> try_commit_chunk(Utf8View::Iterator const& start, Utf8View::Iterator const& end, bool has_breaking_newline) const;
+        Optional<Chunk> try_commit_chunk(Utf8View::Iterator const& start, Utf8View::Iterator const& end, bool has_breaking_newline, Gfx::Font const&) const;
 
         bool const m_wrap_lines;
         bool const m_respect_linebreaks;
         Utf8View m_utf8_view;
         Utf8View::Iterator m_iterator;
+        Gfx::FontCascadeList const& m_font_cascade_list;
     };
 
     void invalidate_text_for_rendering();

--- a/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.cpp
@@ -84,11 +84,12 @@ CommandResult AffineDisplayListPlayerCPU::draw_glyph_run(DrawGlyphRun const& com
     auto scale = Gfx::AffineTransform {}.scale(command.scale, command.scale);
     auto const& glyphs = command.glyph_run->glyphs();
     Gfx::Path path;
-    for (auto& glyph_or_emoji : glyphs) {
+    auto const& font = command.glyph_run->font();
+    for (auto const& glyph_or_emoji : glyphs) {
         if (auto* glyph = glyph_or_emoji.get_pointer<Gfx::DrawGlyph>()) {
-            if (!is<Gfx::ScaledFont>(glyph->font))
+            if (!is<Gfx::ScaledFont>(font))
                 return CommandResult::Continue;
-            auto& scaled_font = static_cast<Gfx::ScaledFont const&>(*glyph->font);
+            auto& scaled_font = static_cast<Gfx::ScaledFont const&>(font);
             auto position = glyph->position.translated(scaled_font.glyph_left_bearing(glyph->code_point), 0);
             auto glyph_id = scaled_font.glyph_id_for_code_point(glyph->code_point);
             Gfx::Path glyph_path;

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -62,11 +62,16 @@ static Vector<Gfx::Path> compute_text_clip_paths(PaintContext& context, Paintabl
 {
     Vector<Gfx::Path> text_clip_paths;
     auto add_text_clip_path = [&](PaintableFragment const& fragment) {
+        auto glyph_run = fragment.glyph_run();
+        if (!glyph_run || glyph_run->glyphs().is_empty())
+            return;
         // Scale to the device pixels.
         Gfx::Path glyph_run_path;
-        for (auto glyph : fragment.glyph_run().glyphs()) {
+        auto const& font = fragment.glyph_run()->font();
+        auto resized_font = font.with_size(font.point_size() * static_cast<float>(context.device_pixels_per_css_pixel()));
+        auto const* scaled_font = static_cast<Gfx::ScaledFont const*>(resized_font.ptr());
+        for (auto glyph : fragment.glyph_run()->glyphs()) {
             glyph.visit([&](auto& glyph) {
-                glyph.font = glyph.font->with_size(glyph.font->point_size() * static_cast<float>(context.device_pixels_per_css_pixel()));
                 glyph.position = glyph.position.scaled(context.device_pixels_per_css_pixel());
             });
 
@@ -75,13 +80,12 @@ static Vector<Gfx::Path> compute_text_clip_paths(PaintContext& context, Paintabl
 
                 // Get the path for the glyph.
                 Gfx::Path glyph_path;
-                auto const& scaled_font = static_cast<Gfx::ScaledFont const&>(*draw_glyph.font);
-                auto glyph_id = scaled_font.glyph_id_for_code_point(draw_glyph.code_point);
-                scaled_font.append_glyph_path_to(glyph_path, glyph_id);
+                auto glyph_id = scaled_font->glyph_id_for_code_point(draw_glyph.code_point);
+                scaled_font->append_glyph_path_to(glyph_path, glyph_id);
 
                 // Transform the path to the fragment's position.
                 // FIXME: Record glyphs and use Painter::draw_glyphs() instead to avoid this duplicated code.
-                auto top_left = draw_glyph.position + Gfx::FloatPoint(scaled_font.glyph_left_bearing(draw_glyph.code_point), 0);
+                auto top_left = draw_glyph.position + Gfx::FloatPoint(scaled_font->glyph_left_bearing(draw_glyph.code_point), 0);
                 auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(top_left);
                 auto transform = Gfx::AffineTransform {}.translate(glyph_position.blit_position.to_type<float>());
                 glyph_run_path.append_path(glyph_path.copy_transformed(transform));

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -86,11 +86,12 @@ void DisplayList::execute(DisplayListPlayer& executor)
             auto& command = command_with_scroll_id.command;
             if (command.has<DrawGlyphRun>()) {
                 auto scale = command.get<DrawGlyphRun>().scale;
+                auto const& font = command.get<DrawGlyphRun>().glyph_run->font();
+                auto scaled_font = font.with_size(font.point_size() * static_cast<float>(scale));
                 for (auto const& glyph_or_emoji : command.get<DrawGlyphRun>().glyph_run->glyphs()) {
                     if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
                         auto const& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
-                        auto font = glyph.font->with_size(glyph.font->point_size() * static_cast<float>(scale));
-                        unique_glyphs.ensure(font, [] { return HashTable<u32> {}; }).set(glyph.code_point);
+                        unique_glyphs.ensure(scaled_font, [] { return HashTable<u32> {}; }).set(glyph.code_point);
                     }
                 }
             }

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerCPU.cpp
@@ -31,18 +31,19 @@ CommandResult DisplayListPlayerCPU::draw_glyph_run(DrawGlyphRun const& command)
 {
     auto& painter = this->painter();
     auto const& glyphs = command.glyph_run->glyphs();
-    for (auto& glyph_or_emoji : glyphs) {
+    auto const& font = command.glyph_run->font();
+    auto scaled_font = font.with_size(font.point_size() * static_cast<float>(command.scale));
+    for (auto const& glyph_or_emoji : glyphs) {
         auto transformed_glyph = glyph_or_emoji;
         transformed_glyph.visit([&](auto& glyph) {
             glyph.position = glyph.position.scaled(command.scale).translated(command.translation);
-            glyph.font = glyph.font->with_size(glyph.font->point_size() * static_cast<float>(command.scale));
         });
         if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
             auto& glyph = transformed_glyph.get<Gfx::DrawGlyph>();
-            painter.draw_glyph(glyph.position, glyph.code_point, *glyph.font, command.color);
+            painter.draw_glyph(glyph.position, glyph.code_point, *scaled_font, command.color);
         } else {
             auto& emoji = transformed_glyph.get<Gfx::DrawEmoji>();
-            painter.draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *emoji.font);
+            painter.draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *scaled_font);
         }
     }
     return CommandResult::Continue;
@@ -279,18 +280,19 @@ CommandResult DisplayListPlayerCPU::paint_text_shadow(PaintTextShadow const& com
     Gfx::IntPoint const baseline_start(command.text_rect.x(), command.text_rect.y());
     shadow_painter.translate(baseline_start);
     auto const& glyphs = command.glyph_run->glyphs();
+    auto const& font = command.glyph_run->font();
+    auto scaled_font = font.with_size(font.point_size() * static_cast<float>(command.glyph_run_scale));
     for (auto const& glyph_or_emoji : glyphs) {
         auto transformed_glyph = glyph_or_emoji;
         transformed_glyph.visit([&](auto& glyph) {
             glyph.position = glyph.position.scaled(command.glyph_run_scale);
-            glyph.font = glyph.font->with_size(glyph.font->point_size() * static_cast<float>(command.glyph_run_scale));
         });
         if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
             auto& glyph = transformed_glyph.get<Gfx::DrawGlyph>();
-            shadow_painter.draw_glyph(glyph.position, glyph.code_point, *glyph.font, command.color);
+            shadow_painter.draw_glyph(glyph.position, glyph.code_point, *scaled_font, command.color);
         } else {
             auto& emoji = transformed_glyph.get<Gfx::DrawEmoji>();
-            shadow_painter.draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *emoji.font);
+            shadow_painter.draw_emoji(emoji.position.to_type<int>(), *emoji.emoji, *scaled_font);
         }
     }
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -227,12 +227,10 @@ void DisplayListRecorder::draw_text(Gfx::IntRect const& rect, String raw_text, G
     if (rect.is_empty())
         return;
 
-    auto glyph_run = adopt_ref(*new Gfx::GlyphRun);
-    auto font_cascade_list = Gfx::FontCascadeList::create();
-    font_cascade_list->add(font);
+    auto glyph_run = adopt_ref(*new Gfx::GlyphRun({}, font));
     float glyph_run_width = 0;
     Gfx::for_each_glyph_position(
-        { 0, 0 }, raw_text.code_points(), font_cascade_list, [&](Gfx::DrawGlyphOrEmoji const& glyph_or_emoji) {
+        { 0, 0 }, raw_text.code_points(), font, [&](Gfx::DrawGlyphOrEmoji const& glyph_or_emoji) {
             glyph_run->append(glyph_or_emoji);
             return IterationDecision::Continue;
         },

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -673,16 +673,20 @@ void paint_text_fragment(PaintContext& context, TextPaintable const& paintable, 
 
         auto text = paintable.text_for_rendering();
 
+        auto glyph_run = fragment.glyph_run();
+        if (!glyph_run)
+            return;
+
         DevicePixelPoint baseline_start { fragment_absolute_device_rect.x(), fragment_absolute_device_rect.y() + context.rounded_device_pixels(fragment.baseline()) };
         auto scale = context.device_pixels_per_css_pixel();
-        painter.draw_text_run(baseline_start.to_type<int>(), fragment.glyph_run(), paintable.computed_values().webkit_text_fill_color(), fragment_absolute_device_rect.to_type<int>(), scale);
+        painter.draw_text_run(baseline_start.to_type<int>(), *glyph_run, paintable.computed_values().webkit_text_fill_color(), fragment_absolute_device_rect.to_type<int>(), scale);
 
         auto selection_rect = context.enclosing_device_rect(fragment.selection_rect(paintable.layout_node().first_available_font())).to_type<int>();
         if (!selection_rect.is_empty()) {
             painter.fill_rect(selection_rect, CSS::SystemColor::highlight());
             DisplayListRecorderStateSaver saver(painter);
             painter.add_clip_rect(selection_rect);
-            painter.draw_text_run(baseline_start.to_type<int>(), fragment.glyph_run(), CSS::SystemColor::highlight_text(), fragment_absolute_device_rect.to_type<int>(), scale);
+            painter.draw_text_run(baseline_start.to_type<int>(), *glyph_run, CSS::SystemColor::highlight_text(), fragment_absolute_device_rect.to_type<int>(), scale);
         }
 
         paint_text_decoration(context, paintable, fragment);

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -39,7 +39,7 @@ public:
 
     CSSPixelRect const absolute_rect() const;
 
-    Gfx::GlyphRun const& glyph_run() const { return *m_glyph_run; }
+    RefPtr<Gfx::GlyphRun> glyph_run() const { return m_glyph_run; }
 
     CSSPixelRect selection_rect(Gfx::Font const&) const;
 
@@ -58,7 +58,7 @@ private:
     int m_start;
     int m_length;
     Painting::BorderRadiiData m_border_radii_data;
-    NonnullRefPtr<Gfx::GlyphRun> m_glyph_run;
+    RefPtr<Gfx::GlyphRun> m_glyph_run;
     Vector<ShadowData> m_shadows;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -579,7 +579,11 @@ void paint_box_shadow(PaintContext& context,
 
 void paint_text_shadow(PaintContext& context, PaintableFragment const& fragment, Vector<ShadowData> const& shadow_layers)
 {
-    if (shadow_layers.is_empty() || fragment.glyph_run().is_empty())
+    if (shadow_layers.is_empty())
+        return;
+
+    auto glyph_run = fragment.glyph_run();
+    if (!glyph_run || glyph_run->glyphs().is_empty())
         return;
 
     auto fragment_width = context.enclosing_device_pixels(fragment.width()).value();
@@ -610,7 +614,7 @@ void paint_text_shadow(PaintContext& context, PaintableFragment const& fragment,
             draw_rect.y() + offset_y - margin
         };
 
-        context.display_list_recorder().paint_text_shadow(blur_radius, bounding_rect, text_rect.translated(0, fragment_baseline), fragment.glyph_run(), context.device_pixels_per_css_pixel(), layer.color, draw_location);
+        context.display_list_recorder().paint_text_shadow(blur_radius, bounding_rect, text_rect.translated(0, fragment_baseline), *glyph_run, context.device_pixels_per_css_pixel(), layer.color, draw_location);
     }
 }
 


### PR DESCRIPTION
The ChunkIterator now limits a chunk to using only one font (before, it was possible to have a chunk with >1 font, when `unicode-range` CSS property is used).

This change allows us to reduce some complexity in the text shaping and painting code and makes us compatible with the APIs in Skia and HarfBuzz.

(cherry picked from commit 7181c3f2ea5fba73e77d98acbf9e46640b4a9015, minorly amended to fix conflicts caused by:
* Our VectorFont not being renamed to Typeface
* Us cherry-picking https://github.com/LadybirdBrowser/ladybird/pull/502 first
* Us still having bitmap fonts, and hence needing glyph_spacing()

Also amended for:
* AffineDisplayListPlayerCPU changes
* Removing pure virtuals for glyph_id_for_code_point and glyph_id_for_code_point in Font.h again since we still have BitmapFont which can't implement them
* Updating more Painter methods that we still had (Painter::draw_glyph_or_emoji(), Painter::draw_text_run()) )

---

Cherry-picks https://github.com/LadybirdBrowser/ladybird/pull/320