### PR TITLE
Ports: Link LibCoreBasic when included

### DIFF
--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -11,7 +11,7 @@ configopts=(
     "-DPULSEAUDIO=OFF"
     "-DJACK=OFF"
     "-DSDL_LIBSAMPLERATE=OFF" # Disabled to prevent potential collision with host libsamplerate
-    "-DEXTRA_LDFLAGS=-laudio;-liconv;-ldl"
+    "-DEXTRA_LDFLAGS=-lcorebasic;-laudio;-liconv"
 )
 depends=("libiconv")
 

--- a/Ports/xmp-cli/patches/0001-Add-support-for-Serenity-LibAudio.patch
+++ b/Ports/xmp-cli/patches/0001-Add-support-for-Serenity-LibAudio.patch
@@ -29,7 +29,7 @@ index b65eb85244acec722b2f240976f184f06db11a27..6745ed1d04cde08b9811781c2bfe552d
  endif
  
 +xmp_SOURCES += sound_serenity.cpp
-+xmp_LDADD   += -lcore -lcoreminimal -lipc -laudio -lstdc++
++xmp_LDADD   += -lcore -lcoreminimal -lcorebasic -lipc -laudio -lstdc++
 +
  man_MANS = xmp.1
  


### PR DESCRIPTION
Due to the LibCoreBasic split it is now needed to add -lcorebasic when the EventLoop is used, this will fix at least 2 ports from building: SDL2 and xmp-cli