### PR TITLE
Cherry-pick "LibWeb: Fix OOB access in "text-overflow: ellipsis" clip"

### DIFF
--- a/Tests/LibWeb/Ref/text-overflow.html
+++ b/Tests/LibWeb/Ref/text-overflow.html
@@ -15,3 +15,4 @@
 </style>
 <div class="clip">This text gets clipped</div>
 <div class="ellipsis">This text gets an ellipsis</div>
+<div class="ellipsis" style="width: 0px">Invisible</div>

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -351,7 +351,7 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
                     auto max_text_width = available_width - ellipsis_width;
 
                     auto& glyphs = glyph_run->glyphs();
-                    auto last_glyph_index = 0;
+                    size_t last_glyph_index = 0;
                     auto last_glyph_position = Gfx::FloatPoint();
 
                     for (auto const& glyph_or_emoji : glyphs) {
@@ -370,10 +370,13 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
                         last_glyph_position = this_position;
                     }
 
-                    auto remove_item_count = glyphs.size() - last_glyph_index;
-                    glyphs.remove(last_glyph_index - 1, remove_item_count);
-
-                    glyphs.append(Gfx::DrawGlyph(last_glyph_position, ellipsis_codepoint));
+                    if (last_glyph_index > 1) {
+                        auto remove_item_count = glyphs.size() - last_glyph_index;
+                        glyphs.remove(last_glyph_index - 1, remove_item_count);
+                        glyphs.append(Gfx::DrawGlyph {
+                            .position = last_glyph_position,
+                            .code_point = ellipsis_codepoint });
+                    }
                 }
             }
             line_builder.append_text_chunk(


### PR DESCRIPTION
Fixes out of bound access to glyph run when `last_glyph_index` is 0.

Fixes crashing on https://github.com/LadybirdBrowser/ladybird/pulls

(cherry picked from commit fa605ef22577d92bbfc3f4a809bb1b4072bb0048)

---

https://github.com/LadybirdBrowser/ladybird/pull/944