### PR TITLE
Cherry-pick "LibWeb: Don't crash when parsing `HTMLInputElement` invalid time values"

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-invalid-time-digits.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-invalid-time-digits.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/HTMLInputElement-invalid-time-digits.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLInputElement-invalid-time-digits.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const inputElement = document.createElement("input");
+        inputElement.type = "time";
+        inputElement.value = "invalid";
+        inputElement.value = "xx:34:56";
+        inputElement.value = "12:xx:56";
+        inputElement.value = "12:34:xx";
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Dates.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Dates.cpp
@@ -183,10 +183,14 @@ bool is_valid_time_string(StringView value)
         return false;
     if (parts[0].length() != 2)
         return false;
+    if (!(is_ascii_digit(parts[0][0]) && is_ascii_digit(parts[0][1])))
+        return false;
     auto hour = (parse_ascii_digit(parts[0][0]) * 10) + parse_ascii_digit(parts[0][1]);
     if (hour > 23)
         return false;
     if (parts[1].length() != 2)
+        return false;
+    if (!(is_ascii_digit(parts[1][0]) && is_ascii_digit(parts[1][1])))
         return false;
     auto minute = (parse_ascii_digit(parts[1][0]) * 10) + parse_ascii_digit(parts[1][1]);
     if (minute > 59)
@@ -195,6 +199,8 @@ bool is_valid_time_string(StringView value)
         return true;
 
     if (parts[2].length() < 2)
+        return false;
+    if (!(is_ascii_digit(parts[2][0]) && is_ascii_digit(parts[2][1])))
         return false;
     auto second = (parse_ascii_digit(parts[2][0]) * 10) + parse_ascii_digit(parts[2][1]);
     if (second > 59)


### PR DESCRIPTION
(cherry picked from commit fe42e2719f1ba92e04a530ca3910a7c8bfbbf1af)

---

https://github.com/LadybirdBrowser/ladybird/pull/1150