### PR TITLE
E1000NetworkAdapter: Fix incorrect cast of RX buffer descriptor pointer

### DIFF
--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -326,7 +326,7 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::read_mac_address()
 
 UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_rx_descriptors()
 {
-    auto* rx_descriptors = (e1000_tx_desc*)m_rx_descriptors_region->vaddr().as_ptr();
+    auto* rx_descriptors = (e1000_rx_desc*)m_rx_descriptors_region->vaddr().as_ptr();
     constexpr auto rx_buffer_page_count = rx_buffer_size / PAGE_SIZE;
     for (size_t i = 0; i < number_of_rx_descriptors; ++i) {
         auto& descriptor = rx_descriptors[i];
@@ -432,7 +432,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
 
 void E1000NetworkAdapter::receive()
 {
-    auto* rx_descriptors = (e1000_tx_desc*)m_rx_descriptors_region->vaddr().as_ptr();
+    auto* rx_descriptors = (e1000_rx_desc*)m_rx_descriptors_region->vaddr().as_ptr();
     u32 rx_current;
     for (;;) {
         rx_current = in32(REG_RXDESCTAIL) % number_of_rx_descriptors;


### PR DESCRIPTION
Fix incorrect casts of (e1000_rx_desc*) to (e1000_tx_desc*) in functions related to frame receive path.

Previous code appears to work because only fields common to both the TX and RX descriptor types are used in the affected code and happen to be at the same offset inside the packed structs.
