### PR TITLE
Cherry-pick 'LibJS: Allow date format "YYYY-M-DD"'

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -180,6 +180,7 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%a%t%b%t%e%t%T%t%Y"sv,                // "Wed Apr 17 23:08:53 2019"
         "%Y-%m-%eT%T%X%z"sv,                   // "2024-01-26T22:10:11.306+0000"
         "%m/%e/%Y,%t%T%t%p"sv,                 // "1/27/2024, 9:28:30 AM"
+        "%Y-%m-%e"sv,                          // "2024-1-15"
     };
 
     for (auto const& format : extra_formats) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -16,6 +16,8 @@ test("basic functionality", () => {
 
     const originalTimeZone = setTimeZone("UTC");
 
+    expect(Date.parse("1980-5-30")).toBe(328492800000);
+
     setTimeZone("America/Chicago");
     expect(Date.parse("Jan 01 1970 GMT")).toBe(0);
     expect(Date.parse("Wed Apr 17 23:08:53 2019 +0000")).toBe(1555542533000);
@@ -42,7 +44,6 @@ test("basic functionality", () => {
     expect(Date.parse("1980-05-00T")).toBe(NaN);
     expect(Date.parse("1980-05-00T15:15:")).toBe(NaN);
     expect(Date.parse("1980-05-00T15:15:15.")).toBe(NaN);
-    expect(Date.parse("1980-5-30")).toBe(NaN);
     expect(Date.parse("1980-05-30T13")).toBe(NaN);
     expect(Date.parse("1980-05-30T13:4")).toBe(NaN);
     expect(Date.parse("1980-05-30T13:40+")).toBe(NaN);


### PR DESCRIPTION
(cherry picked from commit b4d996680a24e6ecb8d0dc755e1208838ee88601)

---

https://github.com/LadybirdBrowser/ladybird/pull/1398