### PR TITLE
Ports/RetroArch: Enable unix platform

### DIFF
--- a/Ports/RetroArch/patches/0002-Add-strlcat.patch
+++ b/Ports/RetroArch/patches/0002-Add-strlcat.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Add strlcat()
  1 file changed, 4 insertions(+)
 
 diff --git a/Makefile.common b/Makefile.common
-index 40c3ad2d5a077dc8f84932506d4253c7d98e326f..f2d6bcf526a1c7d3aba90bdd4ef6cd1ebc3ca91c 100644
+index 2a715f4786a2714f32cb127691e6ed1a390b5188..3b0b4ca0b8f63d3ab79938005934df178e9c446f 100644
 --- a/Makefile.common
 +++ b/Makefile.common
-@@ -186,6 +186,10 @@ ifneq ($(findstring Linux,$(OS)),)
+@@ -184,6 +184,10 @@ ifneq ($(findstring Linux,$(OS)),)
     HAVE_UNIX = 1
  endif
  

--- a/Ports/RetroArch/patches/0003-Disable-pthread_attr_setschedpolicy.patch
+++ b/Ports/RetroArch/patches/0003-Disable-pthread_attr_setschedpolicy.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Disable pthread_attr_setschedpolicy()
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libretro-common/rthreads/rthreads.c b/libretro-common/rthreads/rthreads.c
-index b611a3e443148f1471d3de7aa6f11b4a62e9ba4a..76800cbdaedf31fcc409456b69ae366a58026163 100644
+index 2a748edd53a19304de81faade4bd28e3014df713..2660345dfb76688922c1300630d603f90d9164cd 100644
 --- a/libretro-common/rthreads/rthreads.c
 +++ b/libretro-common/rthreads/rthreads.c
-@@ -161,7 +161,7 @@ sthread_t *sthread_create(void (*thread_func)(void*), void *userdata)
+@@ -158,7 +158,7 @@ sthread_t *sthread_create(void (*thread_func)(void*), void *userdata)
  }
  
  /* TODO/FIXME - this needs to be implemented for Switch/3DS */

--- a/Ports/RetroArch/patches/0004-Use-SDL-software-instead-of-hardware-rendering.patch
+++ b/Ports/RetroArch/patches/0004-Use-SDL-software-instead-of-hardware-rendering.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Use SDL software instead of hardware rendering
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/gfx/drivers/sdl2_gfx.c b/gfx/drivers/sdl2_gfx.c
-index 4dbe33f446815aa212daf0dbb58c3d2e183e88ec..dd67b4aaec550cf375ea3da088363e266dc5aa31 100644
+index 9168a0e77d38f2f6dda991a6f15df294ceba4ba5..4f11b7a3e727f4d632c0dd77ef67c719b740c637 100644
 --- a/gfx/drivers/sdl2_gfx.c
 +++ b/gfx/drivers/sdl2_gfx.c
-@@ -182,7 +182,7 @@ static void sdl2_render_msg(sdl2_video_t *vid, const char *msg)
+@@ -186,7 +186,7 @@ static void sdl2_render_msg(sdl2_video_t *vid, const char *msg)
  
  static void sdl2_init_renderer(sdl2_video_t *vid)
  {

--- a/Ports/RetroArch/patches/0005-Set-default-options-for-SerenityOS.patch
+++ b/Ports/RetroArch/patches/0005-Set-default-options-for-SerenityOS.patch
@@ -16,17 +16,17 @@ Set some config paths to home directory
  create mode 100644 pkg/serenityos/retroarch.cfg
 
 diff --git a/Makefile b/Makefile
-index 63c7eda4aa9ac2acf7ec7dfe9c04fcd5d8919a74..2aed29f89cf3709186fcd7c13400e34f1c90c299 100644
+index c0c3a6c1d3f6351235a1cdc0afa0e17b1328465b..f7ab2104baa8a41b4243d685acb76d75dc3518c4 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -235,7 +235,7 @@ install: $(TARGET)
+@@ -238,7 +238,7 @@ install: $(TARGET)
  	mkdir -p $(DESTDIR)$(DATA_DIR)/pixmaps 2>/dev/null || /bin/true
  	cp $(TARGET) $(DESTDIR)$(BIN_DIR)
  	cp tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 -	cp retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)
 +	cp pkg/serenityos/retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)
  	cp com.libretro.RetroArch.appdata.xml $(DESTDIR)$(DATA_DIR)/metainfo
- 	cp retroarch.desktop $(DESTDIR)$(DATA_DIR)/applications
+ 	cp org.libretro.RetroArch.desktop $(DESTDIR)$(DATA_DIR)/applications
  	cp docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
 diff --git a/pkg/serenityos/retroarch.cfg b/pkg/serenityos/retroarch.cfg
 new file mode 100644

--- a/Ports/RetroArch/patches/0006-Enable-unix-platform.patch
+++ b/Ports/RetroArch/patches/0006-Enable-unix-platform.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chocolateimage <chocolateimage@protonmail.com>
+Date: Tue, 15 Oct 2024 21:09:31 +0200
+Subject: [PATCH] Enable unix platform
+
+This will make arguments from shell (like `--help`) work
+---
+ Makefile.common            | 1 +
+ frontend/frontend_driver.c | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.common b/Makefile.common
+index 3b0b4ca0b8f63d3ab79938005934df178e9c446f..7a6da1658a4a80da8733e9229a2dbd7393b6fdc0 100644
+--- a/Makefile.common
++++ b/Makefile.common
+@@ -186,6 +186,7 @@ endif
+ 
+ ifneq ($(findstring SerenityOS,$(OS)),)
+ 	OBJ += $(LIBRETRO_COMM_DIR)/compat/compat_strl.o
++   HAVE_UNIX = 1
+ endif
+ 
+ ifeq ($(HAVE_UNIX), 1)
+diff --git a/frontend/frontend_driver.c b/frontend/frontend_driver.c
+index 047d14218e229c65b365a2af68354ba9af61f251..01e2a5e500f4b575059ac9329b7344d7876b7dbf 100644
+--- a/frontend/frontend_driver.c
++++ b/frontend/frontend_driver.c
+@@ -98,7 +98,7 @@ static frontend_ctx_driver_t *frontend_ctx_drivers[] = {
+ #if defined(__APPLE__) && defined(__MACH__)
+    &frontend_ctx_darwin,
+ #endif
+-#if defined(__linux__) || (defined(BSD) && !defined(__MACH__))
++#if defined(__linux__) || (defined(BSD) && !defined(__MACH__)) || defined(__serenity__)
+    &frontend_ctx_unix,
+ #endif
+ #if defined(PSP) || defined(VITA)

--- a/Ports/RetroArch/patches/ReadMe.md
+++ b/Ports/RetroArch/patches/ReadMe.md
@@ -31,3 +31,9 @@ The libretro core won't keep running in the background when we are in the menu.
 Don't pause gameplay when window focus is lost
 Set some config paths to home directory
 
+## `0006-Enable-unix-platform.patch`
+
+Enable unix platform
+
+This will make arguments from shell (like `--help`) work
+


### PR DESCRIPTION
This will make arguments from shell (like `--help`) work.

The commit also changes other patches' hashes but that is probably because the patches weren't updated when RetroArch was updated to v1.19.1