### PR TITLE
Meta: Port recent changes to the GN build

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibTextCodec/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibTextCodec/BUILD.gn
@@ -30,6 +30,9 @@ shared_library("LibTextCodec") {
     "//AK",
     "//Userland/Libraries/LibUnicode",
   ]
-  sources = [ "Decoder.cpp" ]
+  sources = [
+    "Decoder.cpp",
+    "Encoder.cpp",
+  ]
   sources += get_target_outputs(":generate_encoding_indexes")
 }

--- a/Meta/gn/secondary/Userland/Libraries/LibURL/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibURL/BUILD.gn
@@ -10,6 +10,7 @@ shared_library("LibURL") {
   ]
   deps = [
     "//AK",
+    "//Userland/Libraries/LibTextCodec",
     "//Userland/Libraries/LibUnicode",
   ]
 }


### PR DESCRIPTION
4167d1214aa LibTextCodec+LibURL: Implement `utf-8` and `euc-jp` encoders