### PR TITLE
LibPDF: Don't fail on files where object 0 is not in the xref table

### DIFF
--- a/Tests/LibPDF/CMakeLists.txt
+++ b/Tests/LibPDF/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_FILES
     jbig2-globals.pdf
     linearized.pdf
     non-linearized.pdf
+    offset.pdf
     oss-fuzz-testcase-62065.pdf
     password-is-sup.pdf
     pattern.pdf

--- a/Tests/LibPDF/CMakeLists.txt
+++ b/Tests/LibPDF/CMakeLists.txt
@@ -18,10 +18,14 @@ set(TEST_FILES
     offset.pdf
     oss-fuzz-testcase-62065.pdf
     password-is-sup.pdf
+    paths.pdf
     pattern.pdf
+    rotate.pdf
+    standard-14-fonts.pdf
     text.pdf
     type1.pdf
     type3.pdf
+    wide-gamut-only.pdf
 )
 install(FILES ${TEST_FILES} DESTINATION home/anon/Documents/pdf)
 install(FILES ${TEST_FILES} DESTINATION usr/Tests/LibPDF)

--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -70,7 +70,7 @@ TEST_CASE(empty_file_issue_10702)
     EXPECT(document.is_error());
 }
 
-TEST_CASE(encodig)
+TEST_CASE(encoding)
 {
     auto file = MUST(Core::MappedFile::map("encoding.pdf"sv));
     auto document = MUST(PDF::Document::create(file->bytes()));

--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -89,6 +89,14 @@ TEST_CASE(encoding)
     EXPECT_EQ(outline_dict->children[2]->title, (char const*)u8"Titlè 3");
 }
 
+TEST_CASE(offset)
+{
+    auto file = MUST(Core::MappedFile::map("offset.pdf"sv));
+    auto document = MUST(PDF::Document::create(file->bytes()));
+    MUST(document->initialize());
+    EXPECT_EQ(document->get_page_count(), 1U);
+}
+
 TEST_CASE(truncated_pdf_header_issue_10717)
 {
     AK::ByteString string { "%PDF-2.11%" };

--- a/Tests/LibPDF/offset.pdf
+++ b/Tests/LibPDF/offset.pdf
@@ -1,0 +1,45 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 300]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>
+endobj
+
+4 0 obj
+<</Length 55>>
+stream
+BT
+/F1 25 Tf
+40 200 Td
+[ (Should not crash) ] TJ T*
+ET
+
+endstream
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/Name/F1/BaseFont/Helvetica/Encoding/MacRomanEncoding>>
+endobj
+
+xref
+1 6
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000227 00000 n 
+0000000331 00000 n 
+0000000000 00000 f 
+
+trailer
+<</Size 6/Root 1 0 R>>
+startxref
+429
+%%EOF

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -372,7 +372,7 @@ PDFErrorOr<void> DocumentParser::validate_xref_table_and_fix_if_necessary()
        Like most other PDF parsers seem to do, we still try to salvage the situation.
        NOTE: This is probably not spec-compliant behavior.*/
     size_t first_valid_index = 0;
-    while (m_xref_table->byte_offset_for_object(first_valid_index) == invalid_byte_offset)
+    while (!m_xref_table->has_object(first_valid_index))
         first_valid_index++;
 
     if (first_valid_index) {

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -428,6 +428,7 @@ static PDFErrorOr<NonnullRefPtr<StreamObject>> indirect_value_as_stream(NonnullR
 
 PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
 {
+    // PDF 1.7 spec, 3.4.7 "Cross-Reference Streams"
     auto xref_stream = TRY(parse_indirect_value());
     auto stream = TRY(indirect_value_as_stream(xref_stream));
 

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -495,9 +495,9 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
                 byte_index += field_size;
             }
 
-            u8 type = fields[0];
-            if (field_sizes->at(0).get_u32() == 0)
-                type = 1;
+            u8 type = 1;
+            if (field_sizes->at(0).get_u32() != 0)
+                type = fields[0];
 
             entries.append({ fields[1], static_cast<u16>(fields[2]), type != 0, type == 2 });
         }

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -437,7 +437,7 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
     if (type != "XRef")
         return error("Malformed xref dictionary");
 
-    auto field_sizes = TRY(dict->get_array(m_document, "W"));
+    auto field_sizes = TRY(dict->get_array(m_document, CommonNames::W));
     if (field_sizes->size() != 3)
         return error("Malformed xref dictionary");
     if (field_sizes->at(1).get_u32() == 0)


### PR DESCRIPTION
History:

* https://github.com/SerenityOS/serenity/commit/72f693e9ed6b106e0760a3b1869f92d3267ddd41 from https://github.com/SerenityOS/serenity/pull/6974 added the initial XRefTable. Here, -1
  was used for byte_offset of invalid entries. has_object() compared
  byte_offset to -1.

* https://github.com/SerenityOS/serenity/commit/e23bfd72521258921978134bfef88285dcb2f9ec from https://github.com/SerenityOS/serenity/pull/7675 added invalid_byte_offset (equal to
  LONG_MAX) and initialized byte_offset with it, but forgot to update
  has_object(). has_object() still compared to -1, so has_object would
  now never return false.

* https://github.com/SerenityOS/serenity/commit/d1bc89e30b962d2e4805c0fcc7f2caf4d51267b7 from https://github.com/SerenityOS/serenity/pull/16150 added validate_xref_table_and_fix_if_necessary,
  which used `byte_offset_for_object(index) == invalid_byte_offset` to
  detect if an object was in the xref table. `byte_offset_for_object`
  internally did `VERIFY(has_object(index))`, which due to the previous
  bullet was always true. It ran this for all object numbers from 0
  up to the first object with byte_offset != invalid_byte_offset.

* https://github.com/SerenityOS/serenity/commit/d458471e094f1c9ae3407eb2c6248278ae37cac3 from https://github.com/SerenityOS/serenity/pull/24099 updated has_object() to check against
  invalid_byte_offset instead of -1, making it work again -- but causing
  a VERIFY in validate_xref_table_and_fix_if_necessary(). This caused
  validate_xref_table_and_fix_if_necessary() to VERIFY if object 0
  was not in the xref table.

* The fix is to make validate_xref_table_and_fix_if_necessary() call
  has_object() to find out if an object exists in the xref table.
  (When validate_xref_table_and_fix_if_necessary(), that didn't work,
  because has_object() was broken then.)

This is hit 4 times in my 1000 file test set. For these three files,
the xref is valid:

* 0000200.pdf
* 0000567.pdf
* 0000651.pdf

For https://github.com/SerenityOS/serenity/commit/0000900af3d030f28ddc54bee4a366500a461a76.pdf, validate_xref_table_and_fix_if_necessary() actually
fixes up the xref table.

Fixes https://github.com/SerenityOS/serenity/issues/25079.

---

Also some minor cleanups while I was in the area, and a test for the above.