### PR TITLE
Cherry-pick changes to Tests/LibWeb/TestConfig.ini

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,4 +1,5 @@
 [Skipped]
+Text/input/HTML/cross-origin-window-properties.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/WebAnimations/misc/DocumentTimeline.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -6,7 +6,10 @@ Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-crypto.html
 Text/input/Worker/Worker-echo.html
+Text/input/Worker/Worker-importScripts.html
 Text/input/Worker/Worker-location.html
+Text/input/Worker/Worker-module.html
+Text/input/Worker/Worker-performance.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html
 Ref/css-keyframe-fill-forwards.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -3,6 +3,7 @@ Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-blob.html
+Text/input/Worker/Worker-crypto.html
 Text/input/Worker/Worker-echo.html
 Text/input/Worker/Worker-location.html
 Text/input/window-scrollTo.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -5,3 +5,4 @@ Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html
+Ref/css-keyframe-fill-forwards.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -2,7 +2,9 @@
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
+Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-echo.html
+Text/input/Worker/Worker-location.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html
 Ref/css-keyframe-fill-forwards.html


### PR DESCRIPTION
Mac CI is currently timing out. Downstream disabled all worker tests; @trflynn89 says that helped there. Let's try doing that over here too.

https://github.com/LadybirdBrowser/ladybird/pull/297
https://github.com/LadybirdBrowser/ladybird/pull/1305
https://github.com/LadybirdBrowser/ladybird/pull/1567
https://github.com/LadybirdBrowser/ladybird/pull/1626 (even though we don't have the commit that motivated that yet)
First commit of https://github.com/LadybirdBrowser/ladybird/pull/1627