### PR TITLE
DisplaySettings+LibEDID: Automatically generate monitor resolution list

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -50,6 +50,13 @@ ErrorOr<void> MonitorSettingsWidget::create_resolution_list()
     TRY(m_resolutions.try_append({ 2560, 1440 }));
     TRY(m_resolutions.try_append({ 3440, 1440 }));
 
+    TRY(generate_resolution_strings());
+
+    return {};
+}
+
+ErrorOr<void> MonitorSettingsWidget::generate_resolution_strings()
+{
     for (auto resolution : m_resolutions) {
         // Use Euclid's Algorithm to calculate greatest common factor
         i32 a = resolution.width();

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -22,36 +22,57 @@ namespace DisplaySettings {
 ErrorOr<NonnullRefPtr<MonitorSettingsWidget>> MonitorSettingsWidget::try_create()
 {
     auto monitor_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) MonitorSettingsWidget()));
+
+    TRY(monitor_settings_widget->load_current_settings());
     TRY(monitor_settings_widget->create_resolution_list());
     TRY(monitor_settings_widget->create_frame());
-    TRY(monitor_settings_widget->load_current_settings());
+
     return monitor_settings_widget;
 }
 
 ErrorOr<void> MonitorSettingsWidget::create_resolution_list()
 {
-    // TODO: Find a better way to get the default resolution
-    TRY(m_resolutions.try_append({ 640, 480 }));
-    TRY(m_resolutions.try_append({ 800, 600 }));
-    TRY(m_resolutions.try_append({ 1024, 768 }));
-    TRY(m_resolutions.try_append({ 1280, 720 }));
-    TRY(m_resolutions.try_append({ 1280, 768 }));
-    TRY(m_resolutions.try_append({ 1280, 960 }));
-    TRY(m_resolutions.try_append({ 1280, 1024 }));
-    TRY(m_resolutions.try_append({ 1360, 768 }));
-    TRY(m_resolutions.try_append({ 1368, 768 }));
-    TRY(m_resolutions.try_append({ 1440, 900 }));
-    TRY(m_resolutions.try_append({ 1600, 900 }));
-    TRY(m_resolutions.try_append({ 1600, 1200 }));
-    TRY(m_resolutions.try_append({ 1920, 1080 }));
-    TRY(m_resolutions.try_append({ 2048, 1152 }));
-    TRY(m_resolutions.try_append({ 2256, 1504 }));
-    TRY(m_resolutions.try_append({ 2560, 1080 }));
-    TRY(m_resolutions.try_append({ 2560, 1440 }));
-    TRY(m_resolutions.try_append({ 3440, 1440 }));
+    m_resolutions.clear();
+    m_resolution_strings.clear();
+
+    auto edid = m_screen_edids[m_selected_screen_index];
+    if (edid.has_value()) {
+        // Try to collect all supported resolutions for the main screen
+        auto resolutions = TRY(edid.value().supported_resolutions());
+        for (auto& resolution : resolutions) {
+            dbgln("Adding EDID supported resolution: {}x{}", resolution.width, resolution.height);
+            TRY(m_resolutions.try_append({ resolution.width, resolution.height }));
+        }
+
+        // Manually create resolution list if no resolutions were collected
+        if (m_resolutions.is_empty())
+            edid = {};
+    }
+
+    if (!edid.has_value()) {
+        // Manually create resolutions list, as the device has failed to provide valid EDID data
+        TRY(m_resolutions.try_append({ 640, 480 }));
+        TRY(m_resolutions.try_append({ 800, 600 }));
+        TRY(m_resolutions.try_append({ 1024, 768 }));
+        TRY(m_resolutions.try_append({ 1280, 720 }));
+        TRY(m_resolutions.try_append({ 1280, 768 }));
+        TRY(m_resolutions.try_append({ 1280, 960 }));
+        TRY(m_resolutions.try_append({ 1280, 1024 }));
+        TRY(m_resolutions.try_append({ 1360, 768 }));
+        TRY(m_resolutions.try_append({ 1368, 768 }));
+        TRY(m_resolutions.try_append({ 1440, 900 }));
+        TRY(m_resolutions.try_append({ 1600, 900 }));
+        TRY(m_resolutions.try_append({ 1600, 1200 }));
+        TRY(m_resolutions.try_append({ 1920, 1080 }));
+        TRY(m_resolutions.try_append({ 2048, 1152 }));
+        TRY(m_resolutions.try_append({ 2256, 1504 }));
+        TRY(m_resolutions.try_append({ 2560, 1080 }));
+        TRY(m_resolutions.try_append({ 2560, 1440 }));
+        TRY(m_resolutions.try_append({ 3440, 1440 }));
+        dbgln("EDID unavailable; Adding resolutions manually");
+    }
 
     TRY(generate_resolution_strings());
-
     return {};
 }
 
@@ -139,6 +160,8 @@ ErrorOr<void> MonitorSettingsWidget::create_frame()
 
     m_dpi_label = *find_descendant_of_type_named<GUI::Label>("display_dpi");
 
+    m_screen_combo->set_selected_index(m_selected_screen_index);
+    TRY(selected_screen_index_or_resolution_changed());
     return {};
 }
 
@@ -191,14 +214,18 @@ ErrorOr<void> MonitorSettingsWidget::load_current_settings()
             TRY(m_screens.try_append(TRY(String::formatted("{}: {}", i + 1, screen_display_name))));
     }
     m_selected_screen_index = m_screen_layout.main_screen_index;
-    m_screen_combo->set_selected_index(m_selected_screen_index);
-    TRY(selected_screen_index_or_resolution_changed());
 
+    if (!m_screen_combo.is_null()) {
+        m_screen_combo->set_selected_index(m_selected_screen_index);
+        TRY(selected_screen_index_or_resolution_changed());
+    }
     return {};
 }
 
 ErrorOr<void> MonitorSettingsWidget::selected_screen_index_or_resolution_changed()
 {
+    TRY(create_resolution_list());
+
     auto& screen = m_screen_layout.screens[m_selected_screen_index];
 
     // Let's attempt to find the current resolution based on the screen layout settings

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -18,6 +18,11 @@
 
 namespace DisplaySettings {
 
+enum class DidScreenIndexChange {
+    No,
+    Yes
+};
+
 class MonitorSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT(MonitorSettingsWidget);
 
@@ -43,7 +48,7 @@ private:
     ErrorOr<void> create_resolution_list();
     ErrorOr<void> load_current_settings();
     ErrorOr<void> generate_resolution_strings();
-    ErrorOr<void> selected_screen_index_or_resolution_changed();
+    ErrorOr<void> selected_screen_index_or_resolution_changed(DidScreenIndexChange screen_index_changed);
 
     size_t m_selected_screen_index { 0 };
 

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -42,6 +42,7 @@ private:
     ErrorOr<void> create_frame();
     ErrorOr<void> create_resolution_list();
     ErrorOr<void> load_current_settings();
+    ErrorOr<void> generate_resolution_strings();
     ErrorOr<void> selected_screen_index_or_resolution_changed();
 
     size_t m_selected_screen_index { 0 };


### PR DESCRIPTION
Before, the DisplaySettings app hardcoded a bunch of resolutions without checking what the monitor supports. This PR makes it so that they're parsed directly from the selected monitor's EDID, which up to this point had only been used for getting the monitor's name.

Additionally, it changes the way LibEDID handles incorrect or truncated data. Before this, the data would be deemed as invalid and thrown out unless it could parse all established timings, standard timings, detailed timings, short video descriptors and coordinated video timings. This, coupled with the buffer being seemingly too small to capture the entire EDID descriptor that QEMU provides, would result in the parser failing to provide any resolutions at all no matter what. 

For now, I made it so that failing to parse the established timing and standard timing sources will return an error, while everything else just prints a message to the debug output and gets ignored.