### PR TITLE
LibGfx+Clients: Remove Painter::{WindingRule,LineStyle} forwarding declarations

### DIFF
--- a/Userland/Applications/AnalogClock/AnalogClock.cpp
+++ b/Userland/Applications/AnalogClock/AnalogClock.cpp
@@ -80,7 +80,7 @@ void AnalogClock::draw_hand(GUI::Painter& painter, double angle, double length, 
     hand_fill.line_to(static_cast<Gfx::FloatPoint>(right_wing_point));
     hand_fill.close();
 
-    painter.fill_path(hand_fill, hand_color, Gfx::Painter::WindingRule::Nonzero);
+    painter.fill_path(hand_fill, hand_color, Gfx::WindingRule::Nonzero);
 
     // Draw highlight depending on the angle, this creates a subtle 3d effect.
     // remember the angle value is offset by half pi.

--- a/Userland/Applications/PixelPaint/HistogramWidget.cpp
+++ b/Userland/Applications/PixelPaint/HistogramWidget.cpp
@@ -111,7 +111,7 @@ void HistogramWidget::paint_event(GUI::PaintEvent& event)
     brightness_path.line_to({ last_drawn_x, bottom_line });
     brightness_path.close();
 
-    painter.fill_path(brightness_path, Color::MidGray, Gfx::Painter::WindingRule::EvenOdd);
+    painter.fill_path(brightness_path, Color::MidGray, Gfx::WindingRule::EvenOdd);
     painter.stroke_path(red_channel_path, Color(Color::NamedColor::Red).with_alpha(90), 2);
     painter.stroke_path(green_channel_path, Color(Color::NamedColor::Green).with_alpha(90), 2);
     painter.stroke_path(blue_channel_path, Color(Color::NamedColor::Blue).with_alpha(90), 2);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -189,10 +189,10 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
         for (auto& guide : m_guides) {
             if (guide->orientation() == Guide::Orientation::Horizontal) {
                 int y_coordinate = (int)content_to_frame_position({ 0.0f, guide->offset() }).y();
-                painter.draw_line({ 0, y_coordinate }, { rect().width(), y_coordinate }, Color::Cyan, 1, Gfx::Painter::LineStyle::Dashed, Color::LightGray);
+                painter.draw_line({ 0, y_coordinate }, { rect().width(), y_coordinate }, Color::Cyan, 1, Gfx::LineStyle::Dashed, Color::LightGray);
             } else if (guide->orientation() == Guide::Orientation::Vertical) {
                 int x_coordinate = (int)content_to_frame_position({ guide->offset(), 0.0f }).x();
-                painter.draw_line({ x_coordinate, 0 }, { x_coordinate, rect().height() }, Color::Cyan, 1, Gfx::Painter::LineStyle::Dashed, Color::LightGray);
+                painter.draw_line({ x_coordinate, 0 }, { x_coordinate, rect().height() }, Color::Cyan, 1, Gfx::LineStyle::Dashed, Color::LightGray);
             }
         }
     }

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -447,12 +447,12 @@ void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, Gf
                                          icon_line3_rotated_offset.a(),
                                          icon_line4_rotated_offset.a(),
                                          icon_line5_rotated_offset.a()),
-                    Color(Color::MidGray).with_alpha(alpha), Gfx::Painter::WindingRule::EvenOdd);
+                    Color(Color::MidGray).with_alpha(alpha), Gfx::WindingRule::EvenOdd);
                 aa_painter.fill_path(make_triangle_path(
                                          icon_line3_rotated_offset.b(),
                                          icon_line4_rotated_offset.b(),
                                          icon_line5_rotated_offset.b()),
-                    Color(Color::MidGray).with_alpha(alpha), Gfx::Painter::WindingRule::EvenOdd);
+                    Color(Color::MidGray).with_alpha(alpha), Gfx::WindingRule::EvenOdd);
             }
         };
 

--- a/Userland/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Userland/Applications/SystemMonitor/GraphWidget.cpp
@@ -94,7 +94,7 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
                         path.line_to({ current_point->x() - 1, inner_rect.bottom() });
                         path.line_to({ first_point->x() + 1, inner_rect.bottom() });
                         path.close();
-                        painter.fill_path(path, background_color, Gfx::Painter::WindingRule::EvenOdd);
+                        painter.fill_path(path, background_color, Gfx::WindingRule::EvenOdd);
                     } else if (points_in_path == 1 && current_point) {
                         // Can't fill any area, we only have one data point.
                         // Just draw a vertical line as a "fill"...

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -126,7 +126,7 @@ void Canvas::draw()
     path.line_to({ 90, 460 });
     path.elliptical_arc_to({ 260, 540 }, { 40, 30 }, 0, true, false);
     path.close();
-    painter.fill_path(path, Color::Yellow, Gfx::Painter::WindingRule::EvenOdd);
+    painter.fill_path(path, Color::Yellow, Gfx::WindingRule::EvenOdd);
 
     auto buggie = Gfx::Bitmap::load_from_file("/res/graphics/buggie.png"sv).release_value_but_fixme_should_propagate_errors();
     painter.blit({ 280, 280 }, *buggie, buggie->rect(), 0.5);

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -76,36 +76,36 @@ void Canvas::draw()
     painter.draw_triangle({ 430, 240 }, { 480, 140 }, { 480, 240 }, Color::Red);
     painter.draw_rect({ 380, 140, 100, 100 }, Color::Yellow);
 
-    painter.draw_line({ 500, 20 }, { 750, 20 }, Color::Green, 1, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 500, 30 }, { 750, 30 }, Color::Red, 5, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 500, 45 }, { 750, 45 }, Color::Blue, 10, Gfx::Painter::LineStyle::Solid);
+    painter.draw_line({ 500, 20 }, { 750, 20 }, Color::Green, 1, Gfx::LineStyle::Solid);
+    painter.draw_line({ 500, 30 }, { 750, 30 }, Color::Red, 5, Gfx::LineStyle::Solid);
+    painter.draw_line({ 500, 45 }, { 750, 45 }, Color::Blue, 10, Gfx::LineStyle::Solid);
 
-    painter.draw_line({ 500, 60 }, { 750, 60 }, Color::Green, 1, Gfx::Painter::LineStyle::Dotted);
-    painter.draw_line({ 500, 70 }, { 750, 70 }, Color::Red, 5, Gfx::Painter::LineStyle::Dotted);
-    painter.draw_line({ 500, 85 }, { 750, 85 }, Color::Blue, 10, Gfx::Painter::LineStyle::Dotted);
+    painter.draw_line({ 500, 60 }, { 750, 60 }, Color::Green, 1, Gfx::LineStyle::Dotted);
+    painter.draw_line({ 500, 70 }, { 750, 70 }, Color::Red, 5, Gfx::LineStyle::Dotted);
+    painter.draw_line({ 500, 85 }, { 750, 85 }, Color::Blue, 10, Gfx::LineStyle::Dotted);
 
-    painter.draw_line({ 500, 100 }, { 750, 100 }, Color::Green, 1, Gfx::Painter::LineStyle::Dashed);
-    painter.draw_line({ 500, 110 }, { 750, 110 }, Color::Red, 5, Gfx::Painter::LineStyle::Dashed);
-    painter.draw_line({ 500, 125 }, { 750, 125 }, Color::Blue, 10, Gfx::Painter::LineStyle::Dashed);
+    painter.draw_line({ 500, 100 }, { 750, 100 }, Color::Green, 1, Gfx::LineStyle::Dashed);
+    painter.draw_line({ 500, 110 }, { 750, 110 }, Color::Red, 5, Gfx::LineStyle::Dashed);
+    painter.draw_line({ 500, 125 }, { 750, 125 }, Color::Blue, 10, Gfx::LineStyle::Dashed);
 
-    painter.draw_line({ 500, 140 }, { 500, 240 }, Color::Green, 1, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 510, 140 }, { 510, 240 }, Color::Red, 5, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 525, 140 }, { 525, 240 }, Color::Blue, 10, Gfx::Painter::LineStyle::Solid);
+    painter.draw_line({ 500, 140 }, { 500, 240 }, Color::Green, 1, Gfx::LineStyle::Solid);
+    painter.draw_line({ 510, 140 }, { 510, 240 }, Color::Red, 5, Gfx::LineStyle::Solid);
+    painter.draw_line({ 525, 140 }, { 525, 240 }, Color::Blue, 10, Gfx::LineStyle::Solid);
 
-    painter.draw_line({ 540, 140 }, { 540, 240 }, Color::Green, 1, Gfx::Painter::LineStyle::Dotted);
-    painter.draw_line({ 550, 140 }, { 550, 240 }, Color::Red, 5, Gfx::Painter::LineStyle::Dotted);
-    painter.draw_line({ 565, 140 }, { 565, 240 }, Color::Blue, 10, Gfx::Painter::LineStyle::Dotted);
+    painter.draw_line({ 540, 140 }, { 540, 240 }, Color::Green, 1, Gfx::LineStyle::Dotted);
+    painter.draw_line({ 550, 140 }, { 550, 240 }, Color::Red, 5, Gfx::LineStyle::Dotted);
+    painter.draw_line({ 565, 140 }, { 565, 240 }, Color::Blue, 10, Gfx::LineStyle::Dotted);
 
-    painter.draw_line({ 580, 140 }, { 580, 240 }, Color::Green, 1, Gfx::Painter::LineStyle::Dashed);
-    painter.draw_line({ 590, 140 }, { 590, 240 }, Color::Red, 5, Gfx::Painter::LineStyle::Dashed);
-    painter.draw_line({ 605, 140 }, { 605, 240 }, Color::Blue, 10, Gfx::Painter::LineStyle::Dashed);
+    painter.draw_line({ 580, 140 }, { 580, 240 }, Color::Green, 1, Gfx::LineStyle::Dashed);
+    painter.draw_line({ 590, 140 }, { 590, 240 }, Color::Red, 5, Gfx::LineStyle::Dashed);
+    painter.draw_line({ 605, 140 }, { 605, 240 }, Color::Blue, 10, Gfx::LineStyle::Dashed);
 
-    painter.draw_line({ 640, 190 }, { 740, 240 }, Color::Green, 1, Gfx::Painter::LineStyle::Dashed);
-    painter.draw_line({ 640, 140 }, { 740, 240 }, Color::Red, 5, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 690, 140 }, { 740, 240 }, Color::Blue, 10, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 740, 190 }, { 640, 240 }, Color::Green, 1, Gfx::Painter::LineStyle::Dotted);
-    painter.draw_line({ 740, 140 }, { 640, 240 }, Color::Red, 5, Gfx::Painter::LineStyle::Solid);
-    painter.draw_line({ 690, 140 }, { 640, 240 }, Color::Blue, 10, Gfx::Painter::LineStyle::Solid);
+    painter.draw_line({ 640, 190 }, { 740, 240 }, Color::Green, 1, Gfx::LineStyle::Dashed);
+    painter.draw_line({ 640, 140 }, { 740, 240 }, Color::Red, 5, Gfx::LineStyle::Solid);
+    painter.draw_line({ 690, 140 }, { 740, 240 }, Color::Blue, 10, Gfx::LineStyle::Solid);
+    painter.draw_line({ 740, 190 }, { 640, 240 }, Color::Green, 1, Gfx::LineStyle::Dotted);
+    painter.draw_line({ 740, 140 }, { 640, 240 }, Color::Red, 5, Gfx::LineStyle::Solid);
+    painter.draw_line({ 690, 140 }, { 640, 240 }, Color::Blue, 10, Gfx::LineStyle::Solid);
 
     auto bg = Gfx::Bitmap::load_from_file("/res/html/misc/90s-bg.png"sv).release_value_but_fixme_should_propagate_errors();
     painter.draw_tiled_bitmap({ 20, 260, 480, 320 }, *bg);

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -148,7 +148,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
         path.line_to(A);
         path.close();
 
-        painter.fill_path(path, color, Gfx::Painter::WindingRule::EvenOdd);
+        painter.fill_path(path, color, Gfx::WindingRule::EvenOdd);
     };
 
     for (auto& m : m_board_markings) {

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -292,7 +292,7 @@ void TabWidget::paint_event(PaintEvent& event)
             } else {
                 painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-2), palette().button_text());
                 painter.draw_line(icon_rect.top_right().moved_left(2), icon_rect.bottom_left().translated(1, -2), palette().button_text());
-                painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
+                painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Gfx::LineStyle::Dotted);
             }
         }
     }
@@ -369,7 +369,7 @@ void TabWidget::paint_event(PaintEvent& event)
         } else {
             painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-2, -2), palette().button_text());
             painter.draw_line(icon_rect.top_right().moved_left(2), icon_rect.bottom_left().translated(1, -2), palette().button_text());
-            painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
+            painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Gfx::LineStyle::Dotted);
         }
     }
 }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2227,7 +2227,7 @@ void Painter::for_each_line_segment_on_cubic_bezier_curve(FloatPoint control_poi
     }
 }
 
-void Painter::draw_cubic_bezier_curve(IntPoint control_point_0, IntPoint control_point_1, IntPoint p1, IntPoint p2, Color color, int thickness, Painter::LineStyle style)
+void Painter::draw_cubic_bezier_curve(IntPoint control_point_0, IntPoint control_point_1, IntPoint p1, IntPoint p2, Color color, int thickness, LineStyle style)
 {
     for_each_line_segment_on_cubic_bezier_curve(FloatPoint(control_point_0), FloatPoint(control_point_1), FloatPoint(p1), FloatPoint(p2), [&](FloatPoint fp1, FloatPoint fp2) {
         draw_line(IntPoint(fp1.x(), fp1.y()), IntPoint(fp2.x(), fp2.y()), color, thickness, style);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -146,9 +146,6 @@ public:
 
     void stroke_path(Path const&, Color, int thickness);
 
-    // FIXME: Remove this after replacing all uses with Gfx::WindingRule.
-    using WindingRule = ::Gfx::WindingRule;
-
     void fill_path(Path const&, Color, WindingRule rule = WindingRule::Nonzero);
     void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, WindingRule rule = WindingRule::Nonzero);
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -50,9 +50,6 @@ public:
     explicit Painter(Gfx::Bitmap&);
     ~Painter() = default;
 
-    // FIXME: Remove this after replacing all uses with Gfx::LineStyle.
-    using LineStyle = ::Gfx::LineStyle;
-
     // FIXME: Remove this after replacing all uses with Gfx::ScalingMode.
     using ScalingMode = ::Gfx::ScalingMode;
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -360,9 +360,9 @@ RENDERER_HANDLER(path_fill_nonzero)
     begin_path_paint();
     m_current_path.close_all_subpaths();
     if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::Painter::WindingRule::Nonzero);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::WindingRule::Nonzero);
     } else {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::Painter::WindingRule::Nonzero);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::WindingRule::Nonzero);
     }
     end_path_paint();
     return {};
@@ -378,9 +378,9 @@ RENDERER_HANDLER(path_fill_evenodd)
     begin_path_paint();
     m_current_path.close_all_subpaths();
     if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::Painter::WindingRule::EvenOdd);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::WindingRule::EvenOdd);
     } else {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::Painter::WindingRule::EvenOdd);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::WindingRule::EvenOdd);
     }
     end_path_paint();
     return {};
@@ -396,9 +396,9 @@ RENDERER_HANDLER(path_fill_stroke_nonzero)
     }
     m_current_path.close_all_subpaths();
     if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::Painter::WindingRule::Nonzero);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::WindingRule::Nonzero);
     } else {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::Painter::WindingRule::Nonzero);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::WindingRule::Nonzero);
     }
     end_path_paint();
     return {};
@@ -414,9 +414,9 @@ RENDERER_HANDLER(path_fill_stroke_evenodd)
     }
     m_current_path.close_all_subpaths();
     if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::Painter::WindingRule::EvenOdd);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), 1.0, Gfx::WindingRule::EvenOdd);
     } else {
-        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::Painter::WindingRule::EvenOdd);
+        m_anti_aliasing_painter.fill_path(m_current_path, state().paint_style.get<Color>(), Gfx::WindingRule::EvenOdd);
     }
     end_path_paint();
     return {};

--- a/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.cpp
@@ -45,7 +45,7 @@ void AffineDisplayListPlayerCPU::prepare_clipping(Gfx::IntRect bounding_rect)
     set_target(clip_bounds.top_left(), *m_expensive_clipping_mask);
     Gfx::Path clip_path;
     clip_path.quad(current_stacking_context.clip.quad);
-    aa_painter().fill_path(clip_path, Gfx::Color::Black, Gfx::Painter::WindingRule::EvenOdd);
+    aa_painter().fill_path(clip_path, Gfx::Color::Black, Gfx::WindingRule::EvenOdd);
 
     // Prepare painter:
     set_target(clip_bounds.top_left(), *m_expensive_clipping_target);


### PR DESCRIPTION
No behavior change. Follow-up to #25065.