### PR TITLE
Meta/run.py: Prefer `spicevmc` over `qemu-vdagent`

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -491,13 +491,13 @@ def set_up_spice(config: Configuration):
             capture_output=True,
             encoding="utf-8",
         ).stdout.lower()
-        if "qemu-vdagent" in chardev_info:
+        if "spicevmc" in chardev_info:
+            config.spice_arguments = ["-chardev", "spicevmc,id=vdagent,name=vdagent"]
+        elif "qemu-vdagent" in chardev_info:
             config.spice_arguments = [
                 "-chardev",
                 "qemu-vdagent,clipboard=on,mouse=off,id=vdagent,name=vdagent",
             ]
-        elif "spicevmc" in chardev_info:
-            config.spice_arguments = ["-chardev", "spicevmc,id=vdagent,name=vdagent"]
         else:
             raise RunError("No compatible SPICE character device was found")
 


### PR DESCRIPTION
This restores the behaviour to that of the old run.sh and allows the spice agent to _somewhat_ work again, though file transfers are currently fairly unreliable.

