### PR TITLE
LibGfx+Clients: Remove Painter::ScalingMode forwarding declaration

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -140,7 +140,7 @@ void MonitorWidget::redraw_desktop_if_needed()
     } else if (m_desktop_wallpaper_mode == "Tile"sv) {
         painter.draw_tiled_bitmap(m_desktop_bitmap->rect(), *scaled_bitmap);
     } else if (m_desktop_wallpaper_mode == "Stretch"sv) {
-        painter.draw_scaled_bitmap(m_desktop_bitmap->rect(), *m_wallpaper_bitmap, m_wallpaper_bitmap->rect(), 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
+        painter.draw_scaled_bitmap(m_desktop_bitmap->rect(), *m_wallpaper_bitmap, m_wallpaper_bitmap->rect(), 1.f, Gfx::ScalingMode::BilinearBlend);
     } else {
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -224,7 +224,7 @@ void ChessGamePreview::paint_event(GUI::PaintEvent& event)
             bitmap,
             bitmap.rect(),
             1.0f,
-            Gfx::Painter::ScalingMode::BilinearBlend);
+            Gfx::ScalingMode::BilinearBlend);
     };
 
     draw_piece({ Chess::Color::White, Chess::Type::King }, { 0, 0 });

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -45,7 +45,7 @@ void VectorImage::rotate(Gfx::RotationDirection rotation_direction)
     m_size = { m_size.height(), m_size.width() };
 }
 
-void VectorImage::draw_into(Gfx::Painter& painter, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const
+void VectorImage::draw_into(Gfx::Painter& painter, Gfx::IntRect const& dest, Gfx::ScalingMode) const
 {
     m_vector->draw_into(painter, dest, m_transform);
 }
@@ -65,7 +65,7 @@ void BitmapImage::rotate(Gfx::RotationDirection rotation)
     m_bitmap = m_bitmap->rotated(rotation).release_value_but_fixme_should_propagate_errors();
 }
 
-void BitmapImage::draw_into(Gfx::Painter& painter, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode scaling_mode) const
+void BitmapImage::draw_into(Gfx::Painter& painter, Gfx::IntRect const& dest, Gfx::ScalingMode scaling_mode) const
 {
     painter.draw_scaled_bitmap(dest, *m_bitmap, m_bitmap->rect(), 1.0f, scaling_mode);
 }
@@ -370,7 +370,7 @@ void ViewWidget::animate()
     }
 }
 
-void ViewWidget::set_scaling_mode(Gfx::Painter::ScalingMode scaling_mode)
+void ViewWidget::set_scaling_mode(Gfx::ScalingMode scaling_mode)
 {
     m_scaling_mode = scaling_mode;
     update();

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -27,7 +27,7 @@ public:
     virtual void flip(Gfx::Orientation) = 0;
     virtual void rotate(Gfx::RotationDirection) = 0;
 
-    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const = 0;
+    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::ScalingMode) const = 0;
 
     virtual ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(Optional<Gfx::IntSize> ideal_size) const = 0;
 
@@ -43,7 +43,7 @@ public:
     virtual void flip(Gfx::Orientation) override;
     virtual void rotate(Gfx::RotationDirection) override;
 
-    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const override;
+    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::ScalingMode) const override;
 
     virtual ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(Optional<Gfx::IntSize> ideal_size) const override;
 
@@ -73,7 +73,7 @@ public:
     virtual void flip(Gfx::Orientation) override;
     virtual void rotate(Gfx::RotationDirection) override;
 
-    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const override;
+    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::ScalingMode) const override;
 
     virtual ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(Optional<Gfx::IntSize>) const override
     {
@@ -112,7 +112,7 @@ public:
     void set_path(String const& path);
     void resize_window();
     void scale_image_for_window();
-    void set_scaling_mode(Gfx::Painter::ScalingMode);
+    void set_scaling_mode(Gfx::ScalingMode);
 
     bool is_next_available() const;
     bool is_previous_available() const;
@@ -166,7 +166,7 @@ private:
     bool m_scaled_for_first_image { false };
     Vector<ByteString> m_files_in_same_dir;
     Optional<size_t> m_current_index;
-    Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::BoxSampling };
+    Gfx::ScalingMode m_scaling_mode { Gfx::ScalingMode::BoxSampling };
 };
 
 }

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -254,19 +254,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
 
     auto nearest_neighbor_action = GUI::Action::create_checkable("&Nearest Neighbor", [&](auto&) {
-        widget.set_scaling_mode(Gfx::Painter::ScalingMode::NearestNeighbor);
+        widget.set_scaling_mode(Gfx::ScalingMode::NearestNeighbor);
     });
 
     auto smooth_pixels_action = GUI::Action::create_checkable("&Smooth Pixels", [&](auto&) {
-        widget.set_scaling_mode(Gfx::Painter::ScalingMode::SmoothPixels);
+        widget.set_scaling_mode(Gfx::ScalingMode::SmoothPixels);
     });
 
     auto bilinear_action = GUI::Action::create_checkable("&Bilinear", [&](auto&) {
-        widget.set_scaling_mode(Gfx::Painter::ScalingMode::BilinearBlend);
+        widget.set_scaling_mode(Gfx::ScalingMode::BilinearBlend);
     });
 
     auto box_sampling_action = GUI::Action::create_checkable("B&ox Sampling", [&](auto&) {
-        widget.set_scaling_mode(Gfx::Painter::ScalingMode::BoxSampling);
+        widget.set_scaling_mode(Gfx::ScalingMode::BoxSampling);
     });
     box_sampling_action->set_checked(true);
 

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -108,7 +108,7 @@ void MagnifierWidget::paint_event(GUI::PaintEvent& event)
         painter.fill_rect(frame_inner_rect, Gfx::Color::Black);
 
     if (m_grabbed_bitmap)
-        painter.draw_scaled_bitmap(bitmap_rect, *m_grabbed_bitmap, m_grabbed_bitmap->rect(), 1.0, Gfx::Painter::ScalingMode::NearestNeighbor);
+        painter.draw_scaled_bitmap(bitmap_rect, *m_grabbed_bitmap, m_grabbed_bitmap->rect(), 1.0, Gfx::ScalingMode::NearestNeighbor);
 
     if (m_show_grid) {
         int start_y = bitmap_rect.top();

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -492,7 +492,7 @@ void MapWidget::paint_map(GUI::Painter& painter)
                     if ((child_tile_y & 1) > 0)
                         target_rect.translate_by(0, TILE_SIZE / 2);
 
-                    painter.draw_scaled_bitmap(target_rect, *child_tile.release_value(), tile_source, 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
+                    painter.draw_scaled_bitmap(target_rect, *child_tile.release_value(), tile_source, 1.f, Gfx::ScalingMode::BilinearBlend);
                     ++cached_tiles_used;
                 }
             }
@@ -510,7 +510,7 @@ void MapWidget::paint_map(GUI::Painter& painter)
                     source_rect.translate_by(TILE_SIZE / 2, 0);
                 if ((tile_y & 1) > 0)
                     source_rect.translate_by(0, TILE_SIZE / 2);
-                painter.draw_scaled_bitmap(tile_rect, *larger_tile.release_value(), source_rect, 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
+                painter.draw_scaled_bitmap(tile_rect, *larger_tile.release_value(), source_rect, 1.f, Gfx::ScalingMode::BilinearBlend);
             }
         }
     }

--- a/Userland/Applications/PixelPaint/Filters/Median.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Median.cpp
@@ -8,6 +8,7 @@
 #include <AK/QuickSort.h>
 #include <Applications/PixelPaint/Filters/MedianSettingsGML.h>
 #include <LibGUI/SpinBox.h>
+#include <LibGfx/Painter.h>
 
 namespace PixelPaint::Filters {
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -674,7 +674,7 @@ Optional<Gfx::IntRect> Image::nonempty_content_bounding_rect() const
     return bounding_rect;
 }
 
-ErrorOr<void> Image::resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode)
+ErrorOr<void> Image::resize(Gfx::IntSize new_size, Gfx::ScalingMode scaling_mode)
 {
     float scale_x = 1.0f;
     float scale_y = 1.0f;
@@ -687,7 +687,7 @@ ErrorOr<void> Image::resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode sca
         scale_y = new_size.height() / static_cast<float>(size().height());
     }
 
-    if (scaling_mode != Gfx::Painter::ScalingMode::None) {
+    if (scaling_mode != Gfx::ScalingMode::None) {
         Vector<NonnullRefPtr<Layer>> scaled_layers;
         TRY(scaled_layers.try_ensure_capacity(m_layers.size()));
 

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -19,8 +19,8 @@
 #include <LibGUI/Forward.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Rect.h>
+#include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
 
 namespace PixelPaint {
@@ -100,7 +100,7 @@ public:
     ErrorOr<void> flip(Gfx::Orientation orientation);
     ErrorOr<void> rotate(Gfx::RotationDirection direction);
     ErrorOr<void> crop(Gfx::IntRect const& rect);
-    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode scaling_mode);
+    ErrorOr<void> resize(Gfx::IntSize new_size, Gfx::ScalingMode scaling_mode);
 
     Optional<Gfx::IntRect> nonempty_content_bounding_rect() const;
 

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -238,7 +238,7 @@ ErrorOr<void> Layer::crop(Gfx::IntRect const& rect, NotifyClients notify_clients
     return {};
 }
 
-ErrorOr<void> Layer::scale(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients)
+ErrorOr<void> Layer::scale(Gfx::IntRect const& new_rect, Gfx::ScalingMode scaling_mode, NotifyClients notify_clients)
 {
     auto src_rect = Gfx::IntRect({}, size());
     auto dst_rect = Gfx::IntRect({}, new_rect.size());
@@ -247,7 +247,7 @@ ErrorOr<void> Layer::scale(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMo
     {
         Gfx::Painter painter(scaled_content_bitmap);
 
-        if (scaling_mode == Gfx::Painter::ScalingMode::None) {
+        if (scaling_mode == Gfx::ScalingMode::None) {
             painter.blit(src_rect.top_left(), *m_content_bitmap, src_rect, 1.0f);
         } else {
             painter.draw_scaled_bitmap(dst_rect, *m_content_bitmap, src_rect, 1.0f, scaling_mode);
@@ -258,7 +258,7 @@ ErrorOr<void> Layer::scale(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMo
         auto dst = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, new_rect.size()));
         Gfx::Painter painter(dst);
 
-        if (scaling_mode == Gfx::Painter::ScalingMode::None) {
+        if (scaling_mode == Gfx::ScalingMode::None) {
             painter.blit(src_rect.top_left(), *m_content_bitmap, src_rect, 1.0f);
         } else {
             painter.draw_scaled_bitmap(dst_rect, *m_mask_bitmap, src_rect, 1.0f, scaling_mode);

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -15,7 +15,7 @@
 #include <AK/Weakable.h>
 #include <LibGUI/Event.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Painter.h>
+#include <LibGfx/ScalingMode.h>
 
 namespace PixelPaint {
 
@@ -79,7 +79,7 @@ public:
     ErrorOr<void> flip(Gfx::Orientation orientation, NotifyClients notify_clients = NotifyClients::Yes);
     ErrorOr<void> rotate(Gfx::RotationDirection direction, NotifyClients notify_clients = NotifyClients::Yes);
     ErrorOr<void> crop(Gfx::IntRect const& rect, NotifyClients notify_clients = NotifyClients::Yes);
-    ErrorOr<void> scale(Gfx::IntRect const& new_rect, Gfx::Painter::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::Yes);
+    ErrorOr<void> scale(Gfx::IntRect const& new_rect, Gfx::ScalingMode scaling_mode, NotifyClients notify_clients = NotifyClients::Yes);
 
     Optional<Gfx::IntRect> nonempty_content_bounding_rect() const;
     Optional<Gfx::IntRect> editing_mask_bounding_rect() const;

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -142,10 +142,10 @@ void LayerListWidget::paint_event(GUI::PaintEvent& event)
         }
 
         painter.draw_rect(adjusted_rect, palette().color(ColorRole::BaseText));
-        painter.draw_scaled_bitmap(inner_thumbnail_rect, layer.display_bitmap(), layer.display_bitmap().rect(), 1.f, Gfx::Painter::ScalingMode::BoxSampling);
+        painter.draw_scaled_bitmap(inner_thumbnail_rect, layer.display_bitmap(), layer.display_bitmap().rect(), 1.f, Gfx::ScalingMode::BoxSampling);
 
         if (is_masked)
-            painter.draw_scaled_bitmap(inner_mask_thumbnail_rect, *layer.mask_bitmap(), layer.mask_bitmap()->rect(), 1.f, Gfx::Painter::ScalingMode::BoxSampling);
+            painter.draw_scaled_bitmap(inner_mask_thumbnail_rect, *layer.mask_bitmap(), layer.mask_bitmap()->rect(), 1.f, Gfx::ScalingMode::BoxSampling);
 
         Color border_color = layer.is_visible() ? palette().color(ColorRole::BaseText) : palette().color(ColorRole::DisabledText);
 

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -78,29 +78,29 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
     VERIFY(box_sampling_radio);
     VERIFY(resize_canvas_radio);
 
-    m_scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
+    m_scaling_mode = Gfx::ScalingMode::NearestNeighbor;
     if (bilinear_radio->is_checked())
-        m_scaling_mode = Gfx::Painter::ScalingMode::BilinearBlend;
+        m_scaling_mode = Gfx::ScalingMode::BilinearBlend;
 
     nearest_neighbor_radio->on_checked = [this](bool is_checked) {
         if (is_checked)
-            m_scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
+            m_scaling_mode = Gfx::ScalingMode::NearestNeighbor;
     };
     smooth_pixels_radio->on_checked = [this](bool is_checked) {
         if (is_checked)
-            m_scaling_mode = Gfx::Painter::ScalingMode::SmoothPixels;
+            m_scaling_mode = Gfx::ScalingMode::SmoothPixels;
     };
     bilinear_radio->on_checked = [this](bool is_checked) {
         if (is_checked)
-            m_scaling_mode = Gfx::Painter::ScalingMode::BilinearBlend;
+            m_scaling_mode = Gfx::ScalingMode::BilinearBlend;
     };
     box_sampling_radio->on_checked = [this](bool is_checked) {
         if (is_checked)
-            m_scaling_mode = Gfx::Painter::ScalingMode::BoxSampling;
+            m_scaling_mode = Gfx::ScalingMode::BoxSampling;
     };
     resize_canvas_radio->on_checked = [this](bool is_checked) {
         if (is_checked)
-            m_scaling_mode = Gfx::Painter::ScalingMode::None;
+            m_scaling_mode = Gfx::ScalingMode::None;
     };
 
     auto ok_button = main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.h
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <LibGUI/Dialog.h>
-#include <LibGfx/Painter.h>
+#include <LibGfx/ScalingMode.h>
 
 namespace PixelPaint {
 
@@ -16,14 +16,14 @@ class ResizeImageDialog final : public GUI::Dialog {
 
 public:
     Gfx::IntSize desired_size() const { return m_desired_size; }
-    Gfx::Painter::ScalingMode scaling_mode() const { return m_scaling_mode; }
+    Gfx::ScalingMode scaling_mode() const { return m_scaling_mode; }
     bool should_rescale() const { return m_rescale_image; }
 
 private:
     ResizeImageDialog(Gfx::IntSize starting_size, GUI::Window* parent_window);
 
     Gfx::IntSize m_desired_size;
-    Gfx::Painter::ScalingMode m_scaling_mode;
+    Gfx::ScalingMode m_scaling_mode;
     float m_starting_aspect_ratio;
     bool m_rescale_image;
 };

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -124,7 +124,7 @@ void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
         return;
 
     if (m_scaling) {
-        auto scaled_layer_or_error = m_editor->active_layer()->scale(m_new_layer_rect, Gfx::Painter::ScalingMode::BilinearBlend);
+        auto scaled_layer_or_error = m_editor->active_layer()->scale(m_new_layer_rect, Gfx::ScalingMode::BilinearBlend);
         if (scaled_layer_or_error.is_error())
             GUI::MessageBox::show_error(m_editor->window(), MUST(String::formatted("Failed to resize layer: {}", scaled_layer_or_error.release_error())));
         else
@@ -199,7 +199,7 @@ void MoveTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
     if (m_scaling && (!m_cached_preview_bitmap.is_null() || !update_cached_preview_bitmap(layer).is_error())) {
         Gfx::PainterStateSaver saver(painter);
         painter.add_clip_rect(m_editor->content_rect());
-        painter.draw_scaled_bitmap(rect_in_editor, *m_cached_preview_bitmap, m_cached_preview_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+        painter.draw_scaled_bitmap(rect_in_editor, *m_cached_preview_bitmap, m_cached_preview_bitmap->rect(), 1.0f, Gfx::ScalingMode::BilinearBlend);
     }
     painter.draw_rect_with_thickness(rect_in_editor, Color::Black, 3);
     painter.draw_rect_with_thickness(rect_in_editor, Color::White, 1);
@@ -247,7 +247,7 @@ ErrorOr<void> MoveTool::update_cached_preview_bitmap(Layer const* layer)
 
     m_cached_preview_bitmap = TRY(Gfx::Bitmap::create(source_bitmap.format(), preview_bitmap_size));
     GUI::Painter preview_painter(*m_cached_preview_bitmap);
-    preview_painter.draw_scaled_bitmap(m_cached_preview_bitmap->rect(), source_bitmap, source_bitmap.rect(), 0.8f, Gfx::Painter::ScalingMode::BilinearBlend);
+    preview_painter.draw_scaled_bitmap(m_cached_preview_bitmap->rect(), source_bitmap, source_bitmap.rect(), 0.8f, Gfx::ScalingMode::BilinearBlend);
     Gfx::ContrastFilter preview_filter(0.5f);
     preview_filter.apply(*m_cached_preview_bitmap, m_cached_preview_bitmap->rect(), *m_cached_preview_bitmap, m_cached_preview_bitmap->rect());
     return {};

--- a/Userland/Applications/VideoPlayer/VideoFrameWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoFrameWidget.cpp
@@ -71,7 +71,7 @@ void VideoFrameWidget::paint_event(GUI::PaintEvent& event)
         return;
 
     if (m_sizing_mode == VideoSizingMode::Stretch) {
-        painter.draw_scaled_bitmap(frame_inner_rect(), *m_bitmap, m_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+        painter.draw_scaled_bitmap(frame_inner_rect(), *m_bitmap, m_bitmap->rect(), 1.0f, Gfx::ScalingMode::BilinearBlend);
         return;
     }
 
@@ -101,7 +101,7 @@ void VideoFrameWidget::paint_event(GUI::PaintEvent& event)
     }
 
     auto display_rect = Gfx::IntRect(center.translated(-display_size.width() / 2, -display_size.height() / 2), display_size);
-    painter.draw_scaled_bitmap(display_rect, *m_bitmap, m_bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+    painter.draw_scaled_bitmap(display_rect, *m_bitmap, m_bitmap->rect(), 1.0f, Gfx::ScalingMode::BilinearBlend);
 }
 
 }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -112,7 +112,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
         if (!(m_dragging_piece && sq == m_moving_square)) {
             auto bmp = get_piece_graphic(active_board.get_piece(sq));
             if (bmp) {
-                painter.draw_scaled_bitmap(tile_rect.shrunken(square_margin, square_margin, square_margin, square_margin), *bmp, bmp->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+                painter.draw_scaled_bitmap(tile_rect.shrunken(square_margin, square_margin, square_margin, square_margin), *bmp, bmp->rect(), 1.0f, Gfx::ScalingMode::BilinearBlend);
             }
         }
 
@@ -197,7 +197,7 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
         auto bmp = get_piece_graphic(active_board.get_piece(m_moving_square));
         if (bmp) {
             auto center = m_drag_point - Gfx::IntPoint(square_width / 2, square_height / 2);
-            painter.draw_scaled_bitmap({ center, { square_width, square_height } }, *bmp, bmp->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+            painter.draw_scaled_bitmap({ center, { square_width, square_height } }, *bmp, bmp->rect(), 1.0f, Gfx::ScalingMode::BilinearBlend);
         }
     }
 

--- a/Userland/Games/ColorLines/ColorLines.cpp
+++ b/Userland/Games/ColorLines/ColorLines.cpp
@@ -194,7 +194,7 @@ void ColorLines::paint_event(GUI::PaintEvent& event)
         if (color >= 0 && color < Marble::number_of_colors) {
             auto const source_rect = Gfx::IntRect { animation_frame * marble_pixel_size, 0, marble_pixel_size, marble_pixel_size };
             painter.draw_scaled_bitmap(rect, *m_marble_bitmaps[color], source_rect,
-                1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+                1.0f, Gfx::ScalingMode::BilinearBlend);
         }
     };
 
@@ -320,7 +320,7 @@ void ColorLines::paint_event(GUI::PaintEvent& event)
                 return 2;
             };
             painter.draw_scaled_bitmap(destination_rect, *m_trace_bitmaps[get_direction_bitmap_index()], source_rect,
-                1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+                1.0f, Gfx::ScalingMode::BilinearBlend);
         }
     }
 }

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -732,7 +732,7 @@ static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_thumbnail(StringView path)
     auto destination = Gfx::IntRect(0, 0, (int)(bitmap->width() * scale), (int)(bitmap->height() * scale)).centered_within(thumbnail->rect());
 
     Painter painter(thumbnail);
-    painter.draw_scaled_bitmap(destination, *bitmap, bitmap->rect(), 1.f, Painter::ScalingMode::BoxSampling);
+    painter.draw_scaled_bitmap(destination, *bitmap, bitmap->rect(), 1.f, Gfx::ScalingMode::BoxSampling);
     return thumbnail;
 }
 

--- a/Userland/Libraries/LibGUI/RangeSlider.h
+++ b/Userland/Libraries/LibGUI/RangeSlider.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGUI/AbstractSlider.h>
+#include <LibGfx/Gradients.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -50,9 +50,6 @@ public:
     explicit Painter(Gfx::Bitmap&);
     ~Painter() = default;
 
-    // FIXME: Remove this after replacing all uses with Gfx::ScalingMode.
-    using ScalingMode = ::Gfx::ScalingMode;
-
     void clear_rect(IntRect const&, Color);
     void fill_rect(IntRect const&, Color);
     void fill_rect(IntRect const&, PaintStyle const&);

--- a/Userland/Libraries/LibSoftGPU/Image.cpp
+++ b/Userland/Libraries/LibSoftGPU/Image.cpp
@@ -190,7 +190,7 @@ void Image::regenerate_mipmaps()
             higher_level_bitmap,
             higher_level_bitmap->rect(),
             1.f,
-            Gfx::Painter::ScalingMode::BilinearBlend);
+            Gfx::ScalingMode::BilinearBlend);
 
         copy_bitmap_into_level(current_level_bitmap, level);
     }

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -859,7 +859,7 @@ void Compositor::update_wallpaper_bitmap()
             auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, screen.size(), screen.scale_factor()).release_value_but_fixme_should_propagate_errors();
 
             Gfx::Painter painter(*bitmap);
-            painter.draw_scaled_bitmap(bitmap->rect(), *m_wallpaper, m_wallpaper->rect(), 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
+            painter.draw_scaled_bitmap(bitmap->rect(), *m_wallpaper, m_wallpaper->rect(), 1.f, Gfx::ScalingMode::BilinearBlend);
 
             screen_data.m_wallpaper_bitmap = move(bitmap);
         }

--- a/Userland/Services/WindowServer/WindowSwitcher.cpp
+++ b/Userland/Services/WindowServer/WindowSwitcher.cpp
@@ -198,7 +198,7 @@ void WindowSwitcher::draw()
         item_rect.shrink(item_padding(), 0);
         Gfx::IntRect thumbnail_rect = { item_rect.location().translated(0, 5), { thumbnail_width(), thumbnail_height() } };
         if (window.backing_store())
-            painter.draw_scaled_bitmap(thumbnail_rect, *window.backing_store(), window.backing_store()->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+            painter.draw_scaled_bitmap(thumbnail_rect, *window.backing_store(), window.backing_store()->rect(), 1.0f, Gfx::ScalingMode::BilinearBlend);
         Gfx::IntRect icon_rect = { thumbnail_rect.bottom_right().translated(-window.icon().width() - 1, -window.icon().height() - 1), { window.icon().width(), window.icon().height() } };
         painter.blit(icon_rect.location(), window.icon(), window.icon().rect());
         painter.draw_text(item_rect.translated(thumbnail_width() + 12, 0).translated(1), window.computed_title(), WindowManager::the().window_title_font(), Gfx::TextAlignment::CenterLeft, text_color.inverted());


### PR DESCRIPTION
No behavior change. Follow-up to #25065.