### PR TITLE
LibGfx: Clean up geometry when stroking closed paths

### DIFF
--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -646,6 +646,17 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         shape_idx = 1;
 
+        auto add_round_join = [&] {
+            add_vertex(shape[shape_idx] + pen_vertices[active]);
+            auto slope_now = slope();
+            auto range = active_ranges[active];
+            while (!range.in_range(slope_now)) {
+                active = mod(active + (clockwise(slope_now, range.end) ? 1 : -1), pen_vertices.size());
+                add_vertex(shape[shape_idx] + pen_vertices[active]);
+                range = active_ranges[active];
+            }
+        };
+
         auto trace_path_until_index = [&](size_t index) {
             while (shape_idx < index) {
                 add_vertex(shape[shape_idx] + pen_vertices[active]);
@@ -688,14 +699,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
                 shape_idx++;
             } else {
                 // Round linecap.
-                add_vertex(shape[shape_idx] + pen_vertices[active]);
-                auto slope_now = slope();
-                auto range = active_ranges[active];
-                while (!range.in_range(slope_now)) {
-                    active = mod(active + (clockwise(slope_now, range.end) ? 1 : -1), pen_vertices.size());
-                    add_vertex(shape[shape_idx] + pen_vertices[active]);
-                    range = active_ranges[active];
-                }
+                add_round_join();
             }
         };
 

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -646,9 +646,9 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         shape_idx = 1;
 
-        auto add_round_join = [&] {
+        auto add_round_join = [&](unsigned next_index) {
             add_vertex(shape[shape_idx] + pen_vertices[active]);
-            auto slope_now = angle_between(shape[shape_idx], shape[shape_idx + 1]);
+            auto slope_now = angle_between(shape[shape_idx], shape[next_index]);
             auto range = active_ranges[active];
             while (!range.in_range(slope_now)) {
                 active = mod(active + (clockwise(slope_now, range.end) ? 1 : -1), pen_vertices.size());
@@ -659,7 +659,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         auto trace_path_until_index = [&](size_t index) {
             while (shape_idx < index) {
-                add_round_join();
+                add_round_join(shape_idx + 1);
                 shape_idx++;
             }
         };
@@ -694,7 +694,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
                 shape_idx++;
             } else {
                 // Round linecap.
-                add_round_join();
+                add_round_join(shape_idx + 1);
             }
         };
 

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -692,7 +692,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
                 add_vertex(p2);
                 shape_idx++;
             } else {
-                // Round linecap.
+                VERIFY(cap_style == CapStyle::Round);
                 add_round_join(shape_idx + 1);
             }
         };

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -659,13 +659,8 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         auto trace_path_until_index = [&](size_t index) {
             while (shape_idx < index) {
-                add_vertex(shape[shape_idx] + pen_vertices[active]);
-                auto slope_now = slope();
-                auto range = active_ranges[active];
-                if (range.in_range(slope_now))
-                    shape_idx++;
-                else
-                    active = mod(active + (clockwise(slope_now, range.end) ? 1 : -1), pen_vertices.size());
+                add_round_join();
+                shape_idx++;
             }
         };
 

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -648,7 +648,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         auto add_round_join = [&] {
             add_vertex(shape[shape_idx] + pen_vertices[active]);
-            auto slope_now = slope();
+            auto slope_now = angle_between(shape[shape_idx], shape[shape_idx + 1]);
             auto range = active_ranges[active];
             while (!range.in_range(slope_now)) {
                 active = mod(active + (clockwise(slope_now, range.end) ? 1 : -1), pen_vertices.size());


### PR DESCRIPTION
Previously, when stroking closed paths, we'd create a single
path where the inner stroke and the outer stroke were connected
with round linecaps. Since we currently only support round line joins,
this looked ok.

Now, we don't draw caps when stroking closed paths, but instead
generate a closed inner path and an independent closed outer path.

This has the advantage that it produces slightly less geometry, and
it's a prerequisite for implementing non-round line joins.

No visual difference.