### PR TITLE
LibGfx+LibPDF+Tests: Add support for miter line joins and janky bevel line joins

### DIFF
--- a/Tests/LibGfx/TestPath.cpp
+++ b/Tests/LibGfx/TestPath.cpp
@@ -89,6 +89,32 @@ TEST_CASE(path_to_fill_two_single_points)
     }
 }
 
+TEST_CASE(path_to_fill_miter_linejoin)
+{
+    float line_width = 2;
+    {
+        Gfx::Path path;
+        path.move_to({ 0, 0 });
+        path.line_to({ 2, 0 });
+        path.line_to({ 2, 2 });
+        auto fill = path.stroke_to_fill(line_width, Gfx::Path::CapStyle::Butt, Gfx::Path::JoinStyle::Miter);
+        EXPECT_EQ(fill.bounding_box(), Gfx::FloatRect({ 0, -1 }, { 3, 3 }));
+        EXPECT_EQ(fill.to_byte_string(), "M 1,1 L 1,2 L 3,2 L 3,-1 L 0,-1 L 0,1 L 1,1 Z");
+    }
+
+    {
+        Gfx::Path path;
+        path.move_to({ 1, 1 });
+        path.line_to({ 4, 1 });
+        path.line_to({ 4, 4 });
+        path.line_to({ 1, 4 });
+        path.close();
+        auto fill = path.stroke_to_fill(line_width, Gfx::Path::CapStyle::Butt, Gfx::Path::JoinStyle::Miter);
+        EXPECT_EQ(fill.bounding_box(), Gfx::FloatRect({ 0, 0 }, { 5, 5 }));
+        EXPECT_EQ(fill.to_byte_string(), "M 3,2 L 3,3 L 2,3 L 2,2 L 3,2 Z M 0,5 L 5,5 L 5,0 L 0,0 L 0,5 Z");
+    }
+}
+
 TEST_CASE(path_to_string)
 {
     {

--- a/Tests/LibPDF/paths.pdf
+++ b/Tests/LibPDF/paths.pdf
@@ -14,7 +14,7 @@ endobj
 endobj
 
 4 0 obj
-<</Length 2117>>
+<</Length 2149>>
 stream
 /DeviceRGB CS
 
@@ -170,8 +170,7 @@ Q
 
 % Closed lines.
 q
-1 j
-
+0 j
 0 J
 1 0 0 SC
 290 280 m
@@ -179,6 +178,7 @@ q
 h
 S
 
+1 j
 1 J
 1 1 0 SC
 290 250 m
@@ -186,6 +186,7 @@ S
 h
 S
 
+2 j
 2 J
 0 0 1 SC
 290 220 m
@@ -204,14 +205,17 @@ Q
 200 170 l
 S
 
-% Open triangle, facing down, opposite winding order.
+% Open triangle, facing down, opposite winding order. Bevel linejoins.
+q
 0 J
+2 j
 1 0 0 SC
 200 90 m
 230 50 l
 260 90 l
 200 90 l
 S
+Q
 
 % Closed triangle, facing up.
 0 J
@@ -288,7 +292,7 @@ endobj
 
 xref
 0 5
-0000000000 00003 f 
+0000000000 65536 f 
 0000000016 00000 n 
 0000000068 00000 n 
 0000000114 00000 n 
@@ -297,5 +301,5 @@ xref
 trailer
 <</Size 5/Root 2 0 R>>
 startxref
-2372
+2404
 %%EOF

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -193,20 +193,20 @@ void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to
     draw_anti_aliased_line(actual_from, actual_to, color, thickness, style, alternate_color, line_length_mode);
 }
 
-void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thickness, Path::CapStyle cap_style)
+void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thickness, Path::CapStyle cap_style, Path::JoinStyle join_style)
 {
     if (thickness <= 0)
         return;
     // FIXME: Cache this? Probably at a higher level such as in LibWeb?
-    fill_path(path.stroke_to_fill(thickness, cap_style), color);
+    fill_path(path.stroke_to_fill(thickness, cap_style, join_style), color);
 }
 
-void AntiAliasingPainter::stroke_path(Path const& path, Gfx::PaintStyle const& paint_style, float thickness, float opacity, Path::CapStyle cap_style)
+void AntiAliasingPainter::stroke_path(Path const& path, Gfx::PaintStyle const& paint_style, float thickness, float opacity, Path::CapStyle cap_style, Path::JoinStyle join_style)
 {
     if (thickness <= 0)
         return;
     // FIXME: Cache this? Probably at a higher level such as in LibWeb?
-    fill_path(path.stroke_to_fill(thickness, cap_style), paint_style, opacity);
+    fill_path(path.stroke_to_fill(thickness, cap_style, join_style), paint_style, opacity);
 }
 
 void AntiAliasingPainter::fill_rect(FloatRect const& float_rect, Color color)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -41,8 +41,8 @@ public:
     void fill_path(Path const&, Color, WindingRule rule = WindingRule::Nonzero);
     void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, WindingRule rule = WindingRule::Nonzero);
 
-    void stroke_path(Path const&, Color, float thickness, Path::CapStyle cap_style = Path::CapStyle::Round);
-    void stroke_path(Path const&, PaintStyle const& paint_style, float thickness, float opacity = 1.0f, Path::CapStyle cap_style = Path::CapStyle::Round);
+    void stroke_path(Path const&, Color, float thickness, Path::CapStyle cap_style = Path::CapStyle::Round, Path::JoinStyle join_style = Path::JoinStyle::Round);
+    void stroke_path(Path const&, PaintStyle const& paint_style, float thickness, float opacity = 1.0f, Path::CapStyle cap_style = Path::CapStyle::Round, Path::JoinStyle join_style = Path::JoinStyle::Round);
 
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint delta) { m_transform.translate(delta); }

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -657,9 +657,13 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
             }
         };
 
+        auto add_linejoin = [&](unsigned next_index) {
+            add_round_join(next_index);
+        };
+
         auto trace_path_until_index = [&](size_t index) {
             while (shape_idx < index) {
-                add_round_join(shape_idx + 1);
+                add_linejoin(shape_idx + 1);
                 shape_idx++;
             }
         };
@@ -705,7 +709,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         // Close outer stroke for closed paths, or draw cap 1 for open paths.
         if (current_segment_is_closed) {
-            add_round_join(1);
+            add_linejoin(1);
 
             // Start an independent path for the inner stroke.
             convolution.close();
@@ -728,7 +732,7 @@ Path Path::stroke_to_fill(float thickness, CapStyle cap_style) const
 
         // Close inner stroke for closed paths, or draw cap 2 for open paths.
         if (current_segment_is_closed) {
-            add_round_join(segment.size());
+            add_linejoin(segment.size());
         } else {
             add_linecap();
         }

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -215,7 +215,13 @@ public:
         Square,
     };
 
-    Path stroke_to_fill(float thickness, CapStyle cap_style = CapStyle::Round) const;
+    enum class JoinStyle {
+        // FIXME: Miter,
+        Round,
+        Bevel,
+    };
+
+    Path stroke_to_fill(float thickness, CapStyle cap_style = CapStyle::Round, JoinStyle join_style = JoinStyle::Round) const;
 
     Path place_text_along(Utf8View text, Font const&) const;
 

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -216,7 +216,7 @@ public:
     };
 
     enum class JoinStyle {
-        // FIXME: Miter,
+        Miter,
         Round,
         Bevel,
     };

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -340,9 +340,9 @@ RENDERER_HANDLER(path_stroke)
 {
     begin_path_paint();
     if (state().stroke_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), line_width(), 1.0f, line_cap_style());
+        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), line_width(), 1.0f, line_cap_style(), line_join_style());
     } else {
-        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<Color>(), line_width(), line_cap_style());
+        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<Color>(), line_width(), line_cap_style(), line_join_style());
     }
     end_path_paint();
     return {};
@@ -390,9 +390,9 @@ RENDERER_HANDLER(path_fill_stroke_nonzero)
 {
     begin_path_paint();
     if (state().stroke_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), line_width(), 1.0f, line_cap_style());
+        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), line_width(), 1.0f, line_cap_style(), line_join_style());
     } else {
-        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<Color>(), line_width(), line_cap_style());
+        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<Color>(), line_width(), line_cap_style(), line_join_style());
     }
     m_current_path.close_all_subpaths();
     if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
@@ -408,9 +408,9 @@ RENDERER_HANDLER(path_fill_stroke_evenodd)
 {
     begin_path_paint();
     if (state().stroke_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), line_width(), 1.0f, line_cap_style());
+        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), line_width(), 1.0f, line_cap_style(), line_join_style());
     } else {
-        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<Color>(), line_width(), line_cap_style());
+        m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_style.get<Color>(), line_width(), line_cap_style(), line_join_style());
     }
     m_current_path.close_all_subpaths();
     if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
@@ -1011,6 +1011,20 @@ Gfx::Path::CapStyle Renderer::line_cap_style() const
         return Gfx::Path::CapStyle::Round;
     case LineCapStyle::SquareCap:
         return Gfx::Path::CapStyle::Square;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Gfx::Path::JoinStyle Renderer::line_join_style() const
+{
+    switch (state().line_join_style) {
+    case LineJoinStyle::Miter:
+        // FIXME: JoinStyle::Miter once it exists
+        return Gfx::Path::JoinStyle::Round;
+    case LineJoinStyle::Round:
+        return Gfx::Path::JoinStyle::Round;
+    case LineJoinStyle::Bevel:
+        return Gfx::Path::JoinStyle::Bevel;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1019,8 +1019,7 @@ Gfx::Path::JoinStyle Renderer::line_join_style() const
 {
     switch (state().line_join_style) {
     case LineJoinStyle::Miter:
-        // FIXME: JoinStyle::Miter once it exists
-        return Gfx::Path::JoinStyle::Round;
+        return Gfx::Path::JoinStyle::Miter;
     case LineJoinStyle::Round:
         return Gfx::Path::JoinStyle::Round;
     case LineJoinStyle::Bevel:

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -184,6 +184,7 @@ private:
 
     float line_width() const;
     Gfx::Path::CapStyle line_cap_style() const;
+    Gfx::Path::JoinStyle line_join_style() const;
 
     Gfx::AffineTransform calculate_image_space_transformation(Gfx::IntSize);
 


### PR DESCRIPTION
Both are implemented by still walking the round linejoin pen. The bevel line join adds the last pen vertex, which looks a bit janky. The miter join looks good due to using math, but it also still does the silly pen walking. We can improve this later on.