### PR TITLE
Cherry-pick "LibWeb/CSS: Mark grid-[gap, column-gap, row-gap] properties as aliases"

### DIFF
--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -113,15 +113,13 @@ grid-auto-columns: auto
 grid-auto-flow: row
 grid-auto-rows: auto
 grid-column-end: auto
-grid-column-gap: auto
 grid-column-start: auto
 grid-row-end: auto
-grid-row-gap: auto
 grid-row-start: auto
 grid-template-areas: 
 grid-template-columns: 
 grid-template-rows: 
-height: 2091px
+height: 2057px
 inline-size: auto
 inset-block-end: auto
 inset-block-start: auto

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1382,17 +1382,7 @@
     ]
   },
   "grid-column-gap": {
-    "animation-type": "by-computed-value",
-    "inherited": false,
-    "initial": "auto",
-    "valid-types": [
-      "length [0,∞]",
-      "percentage [0,∞]"
-    ],
-    "valid-identifiers": [
-      "auto"
-    ],
-    "percentages-resolve-to": "length"
+    "legacy-alias-for": "column-gap"
   },
   "grid-column-start": {
     "animation-type": "discrete",
@@ -1406,21 +1396,7 @@
     ]
   },
   "grid-gap": {
-    "inherited": false,
-    "initial": "auto",
-    "valid-types": [
-      "length [0,∞]",
-      "percentage [0,∞]"
-    ],
-    "max-values": 2,
-    "valid-identifiers": [
-      "auto"
-    ],
-    "percentages-resolve-to": "length",
-    "longhands": [
-      "grid-row-gap",
-      "grid-column-gap"
-    ]
+    "legacy-alias-for": "gap"
   },
   "grid-row": {
     "inherited": false,
@@ -1448,17 +1424,7 @@
     ]
   },
   "grid-row-gap": {
-    "animation-type": "by-computed-value",
-    "inherited": false,
-    "initial": "auto",
-    "valid-types": [
-      "length [0,∞]",
-      "percentage [0,∞]"
-    ],
-    "valid-identifiers": [
-      "auto"
-    ],
-    "percentages-resolve-to": "length"
+    "legacy-alias-for": "row-gap"
   },
   "grid-row-start": {
     "animation-type": "discrete",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -675,7 +675,7 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
         return;
     }
 
-    if (property_id == CSS::PropertyID::Gap || property_id == CSS::PropertyID::GridGap) {
+    if (property_id == CSS::PropertyID::Gap) {
         if (value.is_value_list()) {
             auto const& values_list = value.as_value_list();
             set_longhand_property(CSS::PropertyID::RowGap, values_list.values()[0]);
@@ -683,16 +683,6 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
             return;
         }
         set_longhand_property(CSS::PropertyID::RowGap, value);
-        set_longhand_property(CSS::PropertyID::ColumnGap, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::RowGap || property_id == CSS::PropertyID::GridRowGap) {
-        set_longhand_property(CSS::PropertyID::RowGap, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::ColumnGap || property_id == CSS::PropertyID::GridColumnGap) {
         set_longhand_property(CSS::PropertyID::ColumnGap, value);
         return;
     }


### PR DESCRIPTION
These are legacy name aliases for the properties without the 'grid-' prefix. See https://drafts.csswg.org/css-align-3/#gap-legacy

(cherry picked from commit c79f261bec40a61373d45508c1935f839454c95d)

---

https://github.com/LadybirdBrowser/ladybird/pull/1785