### PR TITLE
Cherry-pick "LibWeb/CSS: Tweak in CSSRGB::to_color() to avoid floating point errors"

### DIFF
--- a/Tests/LibWeb/Ref/css-color-functions.html
+++ b/Tests/LibWeb/Ref/css-color-functions.html
@@ -36,6 +36,9 @@
 <div style="background-color: rgba(-20%, 0%, 300%, -50%);">
     <p>legacy rgba with out-of-range percentages (should be clamped)</p>
 </div>
+<div style="background-color: rgb(10% 50% 90%);">
+    <p>modern rgb with percentages (round away from 0)</p>
+</div>
 <div style="background-color: rgb(10 20% 30);">
     <p>modern rgb with mixed types</p>
 </div>

--- a/Tests/LibWeb/Ref/reference/css-color-functions-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-color-functions-ref.html
@@ -38,6 +38,9 @@
 <div style="background-color: #ffffff;">
     <p>legacy rgba with out-of-range percentages (should be clamped)</p>
 </div>
+<div style="background-color: #1a80e6;">
+    <p>modern rgb with percentages (round away from 0)</p>
+</div>
 <div style="background-color: #0a331e;">
     <p>modern rgb with mixed types</p>
 </div>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -25,14 +25,14 @@ Color CSSRGB::to_color(Optional<Layout::NodeWithStyle const&>) const
             return normalized(style_value.as_number().number());
 
         if (style_value.is_percentage())
-            return normalized(style_value.as_percentage().value() * 2.55);
+            return normalized(style_value.as_percentage().value() * 255 / 100);
 
         if (style_value.is_math()) {
             auto const& calculated = style_value.as_math();
             if (calculated.resolves_to_number())
                 return normalized(calculated.resolve_number().value());
             if (calculated.resolves_to_percentage())
-                return normalized(calculated.resolve_percentage().value().value() * 2.55);
+                return normalized(calculated.resolve_percentage().value().value() * 255 / 100);
         }
 
         if (style_value.is_keyword() && style_value.to_keyword() == Keyword::None)


### PR DESCRIPTION
Example of the difference:

    50 * 2.55      --> 127.4999 --> round towards +∞ --> 127
    50 * 255 / 100 --> 127.5000 --> round towards +∞ --> 128

Now, 9 failing WPT tests in /css/css-color/ pass.

(cherry picked from commit 6c3ecf6a342cbc0a83c1deac89e1a7edf6d959c4; amended because css-color-functions.html is a reftest for us, not a screenshot test)

---

https://github.com/LadybirdBrowser/ladybird/pull/1857