### PR TITLE
Kernel: Introduce a new model for writing devicetree drivers

### DIFF
--- a/Kernel/Arch/aarch64/InterruptManagement.cpp
+++ b/Kernel/Arch/aarch64/InterruptManagement.cpp
@@ -5,11 +5,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NeverDestroyed.h>
 #include <Kernel/Arch/aarch64/InterruptManagement.h>
 #include <Kernel/Arch/aarch64/RPi/InterruptController.h>
+#include <Kernel/Library/Panic.h>
 
 namespace Kernel {
 
+static NeverDestroyed<Vector<DeviceTree::DeviceRecipe<NonnullLockRefPtr<IRQController>>>> s_recipes;
 static InterruptManagement* s_interrupt_management;
 
 bool InterruptManagement::initialized()
@@ -31,10 +34,25 @@ void InterruptManagement::initialize()
     the().find_controllers();
 }
 
+void InterruptManagement::add_recipe(DeviceTree::DeviceRecipe<NonnullLockRefPtr<IRQController>> recipe)
+{
+    s_recipes->append(move(recipe));
+}
+
 void InterruptManagement::find_controllers()
 {
-    // TODO: Once device tree support is in place, find interrupt controllers using that.
-    m_interrupt_controllers.append(adopt_lock_ref(*new (nothrow) RPi::InterruptController));
+    for (auto& recipe : *s_recipes) {
+        auto device_or_error = recipe.create_device();
+        if (device_or_error.is_error()) {
+            dmesgln("InterruptManagement: Failed to create interrupt controller for device \"{}\" with driver {}: {}", recipe.node_name, recipe.driver_name, device_or_error.release_error());
+            continue;
+        }
+
+        m_interrupt_controllers.append(device_or_error.release_value());
+    }
+
+    if (m_interrupt_controllers.is_empty())
+        PANIC("InterruptManagement: No supported interrupt controller found in devicetree");
 }
 
 u8 InterruptManagement::acquire_mapped_interrupt_number(u8 interrupt_number)

--- a/Kernel/Arch/aarch64/InterruptManagement.h
+++ b/Kernel/Arch/aarch64/InterruptManagement.h
@@ -8,6 +8,7 @@
 
 #include <AK/Vector.h>
 #include <Kernel/Arch/aarch64/IRQController.h>
+#include <Kernel/Firmware/DeviceTree/DeviceRecipe.h>
 #include <Kernel/Library/LockRefPtr.h>
 
 namespace Kernel {
@@ -17,6 +18,8 @@ public:
     static InterruptManagement& the();
     static void initialize();
     static bool initialized();
+
+    static void add_recipe(DeviceTree::DeviceRecipe<NonnullLockRefPtr<IRQController>>);
 
     static u8 acquire_mapped_interrupt_number(u8 original_irq);
 

--- a/Kernel/Arch/aarch64/RPi/Timer.h
+++ b/Kernel/Arch/aarch64/RPi/Timer.h
@@ -18,9 +18,8 @@ struct TimerRegisters;
 
 class Timer final : public HardwareTimer<IRQHandler> {
 public:
+    Timer();
     virtual ~Timer();
-
-    static NonnullLockRefPtr<Timer> initialize();
 
     virtual HardwareTimerType timer_type() const override { return HardwareTimerType::RPiTimer; }
     virtual StringView model() const override { return "RPi Timer"sv; }
@@ -65,8 +64,6 @@ public:
     static u32 get_clock_rate(ClockID);
 
 private:
-    Timer();
-
     enum class TimerID : u32 {
         Timer0 = 0,
         Timer1 = 1,

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -78,6 +78,10 @@
 #    include <Kernel/Arch/riscv64/Delay.h>
 #endif
 
+#if ARCH(AARCH64) || ARCH(RISCV64)
+#    include <Kernel/Firmware/DeviceTree/Management.h>
+#endif
+
 // Defined in the linker script
 typedef void (*ctor_func_t)();
 extern ctor_func_t start_heap_ctors[];
@@ -261,11 +265,16 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
     for (ctor_func_t* ctor = start_ctors; ctor < end_ctors; ctor++)
         (*ctor)();
 
+    for (auto* init_function = driver_init_table_start; init_function != driver_init_table_end; init_function++)
+        (*init_function)();
+
 #if ARCH(AARCH64) || ARCH(RISCV64)
     MUST(DeviceTree::unflatten_fdt());
 
     if (kernel_command_line().contains("dump_fdt"sv))
         DeviceTree::dump_fdt();
+
+    DeviceTree::Management::initialize();
 #endif
 
 #if ARCH(RISCV64)
@@ -415,10 +424,6 @@ void init_stage2(void*)
     PTYMultiplexer::initialize();
 
     AudioManagement::the().initialize();
-
-    // Initialize all USB Drivers
-    for (auto* init_function = driver_init_table_start; init_function != driver_init_table_end; init_function++)
-        (*init_function)();
 
     StorageManagement::the().initialize(kernel_command_line().is_nvme_polling_enabled());
     for (int i = 0; i < 5; ++i) {

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -31,7 +31,7 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController& controller,
     // "probe" function, which initialises the local state for the device driver.
     // It is currently the driver's responsibility to search the configuration/interface
     // and take the appropriate action.
-    for (auto& driver : USBManagement::the().available_drivers()) {
+    for (auto& driver : USBManagement::available_drivers()) {
         // FIXME: Some devices have multiple configurations, for which we may have a better driver,
         //        than the first we find, or we have a vendor specific driver for the device,
         //        so we want a prioritization mechanism here

--- a/Kernel/Bus/USB/USBManagement.h
+++ b/Kernel/Bus/USB/USBManagement.h
@@ -25,13 +25,12 @@ public:
     static LockRefPtr<Driver> get_driver_by_name(StringView name);
     static void unregister_driver(NonnullLockRefPtr<Driver> driver);
 
-    Vector<NonnullLockRefPtr<Driver>>& available_drivers() { return m_available_drivers; }
+    static Vector<NonnullLockRefPtr<Driver>>& available_drivers();
 
 private:
     void enumerate_controllers();
 
     USBController::List m_controllers;
-    Vector<NonnullLockRefPtr<Driver>> m_available_drivers;
 };
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -235,6 +235,7 @@ set(KERNEL_SOURCES
     Firmware/ACPI/Parser.cpp
     Firmware/ACPI/StaticParsing.cpp
     Firmware/DeviceTree/DeviceTree.cpp
+    Firmware/DeviceTree/Management.cpp
     Interrupts/GenericInterruptHandler.cpp
     Interrupts/IRQHandler.cpp
     Interrupts/PCIIRQHandler.cpp

--- a/Kernel/Firmware/DeviceTree/Device.h
+++ b/Kernel/Firmware/DeviceTree/Device.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/Noncopyable.h>
+#include <LibDeviceTree/DeviceTree.h>
+
+namespace Kernel::DeviceTree {
+
+class Driver;
+class Management;
+
+class Device {
+    AK_MAKE_NONCOPYABLE(Device);
+    AK_MAKE_DEFAULT_MOVABLE(Device);
+
+public:
+    Device(::DeviceTree::DeviceTreeNodeView const& node, StringView node_name)
+        : m_node(&node)
+        , m_node_name(node_name)
+    {
+    }
+
+    ::DeviceTree::DeviceTreeNodeView const& node() const { return *m_node; }
+    StringView node_name() const { return m_node_name; }
+
+    Driver const* driver() const { return m_driver; }
+    void set_driver(Badge<Management>, Driver const& driver)
+    {
+        VERIFY(m_driver == nullptr);
+        m_driver = &driver;
+    }
+
+private:
+    // This needs to be a pointer for the class to be movable.
+    ::DeviceTree::DeviceTreeNodeView const* m_node;
+    StringView m_node_name;
+    Driver const* m_driver { nullptr };
+};
+
+}

--- a/Kernel/Firmware/DeviceTree/DeviceRecipe.h
+++ b/Kernel/Firmware/DeviceTree/DeviceRecipe.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace Kernel::DeviceTree {
+
+template<typename DevicePtr>
+struct DeviceRecipe {
+    StringView driver_name;
+    StringView node_name;
+    Function<ErrorOr<DevicePtr>()> create_device;
+};
+
+}

--- a/Kernel/Firmware/DeviceTree/Driver.h
+++ b/Kernel/Firmware/DeviceTree/Driver.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/StringView.h>
+#include <Kernel/Firmware/DeviceTree/Device.h>
+
+namespace Kernel::DeviceTree {
+
+using DriverInitFunction = void (*)();
+
+class Driver {
+    AK_MAKE_NONCOPYABLE(Driver);
+    AK_MAKE_NONMOVABLE(Driver);
+
+public:
+    Driver(StringView name)
+        : m_driver_name(name)
+    {
+    }
+
+    virtual ~Driver() = default;
+    virtual Span<StringView const> compatibles() const = 0;
+    virtual ErrorOr<void> probe(Device const&, StringView compatible_entry) const = 0;
+
+    StringView name() const { return m_driver_name; }
+
+private:
+    StringView const m_driver_name;
+};
+
+#define DEVICETREE_DRIVER(driver_name, compatibles_array)                                                          \
+    class driver_name final : public Kernel::DeviceTree::Driver {                                                  \
+    public:                                                                                                        \
+        driver_name()                                                                                              \
+            : Kernel::DeviceTree::Driver(#driver_name##sv)                                                         \
+        {                                                                                                          \
+        }                                                                                                          \
+                                                                                                                   \
+        static void init();                                                                                        \
+        Span<StringView const> compatibles() const override { return compatibles_array; }                          \
+        ErrorOr<void> probe(Kernel::DeviceTree::Device const& device, StringView compatible_entry) const override; \
+    };                                                                                                             \
+                                                                                                                   \
+    void driver_name::init()                                                                                       \
+    {                                                                                                              \
+        auto driver = MUST(adopt_nonnull_own_or_enomem(new (nothrow) driver_name()));                              \
+        MUST(Kernel::DeviceTree::Management::register_driver(move(driver)));                                       \
+    }                                                                                                              \
+                                                                                                                   \
+    static Kernel::DeviceTree::DriverInitFunction driver_init_function_ptr_##driver_name [[gnu::section(".driver_init"), gnu::used]] = &driver_name::init
+
+}

--- a/Kernel/Firmware/DeviceTree/Management.cpp
+++ b/Kernel/Firmware/DeviceTree/Management.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Singleton.h>
+#include <Kernel/Firmware/DeviceTree/DeviceTree.h>
+#include <Kernel/Firmware/DeviceTree/Management.h>
+
+namespace Kernel::DeviceTree {
+
+static Singleton<Management> s_the;
+
+void Management::initialize()
+{
+    auto maybe_model = DeviceTree::get().get_property("model"sv);
+    if (maybe_model.has_value())
+        dmesgln("DeviceTree: System board model: {}", maybe_model->as_string());
+
+    MUST(the().scan_node_for_devices(DeviceTree::get()));
+}
+
+Management& Management::the()
+{
+    return *s_the;
+}
+
+ErrorOr<void> Management::register_driver(NonnullOwnPtr<DeviceTree::Driver>&& driver)
+{
+    for (auto compatible_entry : driver->compatibles()) {
+        VERIFY(!s_the->m_drivers.contains(compatible_entry));
+        TRY(the().m_drivers.try_set(compatible_entry, move(driver)));
+    }
+
+    return {};
+}
+
+ErrorOr<void> Management::scan_node_for_devices(::DeviceTree::DeviceTreeNodeView const& node)
+{
+    for (auto const& [child_name, child] : node.children()) {
+        if (TRY(m_devices.try_set(&child, Device { child, child_name })) != HashSetResult::InsertedNewEntry)
+            continue;
+
+        auto& device = m_devices.get(&child).release_value();
+
+        if (child.is_compatible_with("simple-bus"sv)) {
+            TRY(scan_node_for_devices(child));
+            continue;
+        }
+
+        auto maybe_compatible = child.get_property("compatible"sv);
+        if (!maybe_compatible.has_value())
+            continue;
+
+        // The compatible property is ordered from most specific to least specific, so choose the first compatible we have a driver for.
+        TRY(maybe_compatible->for_each_string([this, &device](StringView compatible_entry) -> ErrorOr<IterationDecision> {
+            auto maybe_driver = m_drivers.get(compatible_entry);
+            if (!maybe_driver.has_value())
+                return IterationDecision::Continue;
+
+            return attach_device_to_driver(device, *maybe_driver.release_value(), compatible_entry) ? IterationDecision::Break : IterationDecision::Continue;
+        }));
+    }
+
+    return {};
+}
+
+bool Management::attach_device_to_driver(Device& device, Driver const& driver, StringView compatible_entry)
+{
+    if (auto result = driver.probe(device, compatible_entry); result.is_error()) {
+        dbgln("DeviceTree: Failed to attach device \"{}\" to driver {}: {}", device.node_name(), driver.name(), result.release_error());
+        return false;
+    }
+
+    device.set_driver({}, driver);
+    dbgln("DeviceTree: Attached device \"{}\" to driver {}", device.node_name(), driver.name());
+
+    return true;
+}
+
+}

--- a/Kernel/Firmware/DeviceTree/Management.h
+++ b/Kernel/Firmware/DeviceTree/Management.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <Kernel/Firmware/DeviceTree/Driver.h>
+#include <Libraries/LibDeviceTree/DeviceTree.h>
+
+namespace Kernel::DeviceTree {
+
+class Management {
+public:
+    static void initialize();
+    static Management& the();
+
+    static ErrorOr<void> register_driver(NonnullOwnPtr<DeviceTree::Driver>&&);
+
+    ErrorOr<void> scan_node_for_devices(::DeviceTree::DeviceTreeNodeView const& node);
+
+private:
+    static bool attach_device_to_driver(Device&, Driver const&, StringView compatible_entry);
+
+    HashMap<StringView, NonnullOwnPtr<Driver>> m_drivers;
+    HashMap<::DeviceTree::DeviceTreeNodeView const*, Device> m_devices;
+};
+
+}

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -14,6 +14,7 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/API/TimePage.h>
+#include <Kernel/Firmware/DeviceTree/DeviceRecipe.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UnixTypes.h>
@@ -37,6 +38,8 @@ public:
     static void initialize(u32 cpu);
     static bool is_initialized();
     static TimeManagement& the();
+
+    static void add_recipe(DeviceTree::DeviceRecipe<NonnullLockRefPtr<HardwareTimerBase>>);
 
     static u64 scheduler_current_time();
 

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.cpp
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.cpp
@@ -73,4 +73,24 @@ ErrorOr<NonnullOwnPtr<DeviceTree>> DeviceTree::parse(ReadonlyBytes flattened_dev
     return device_tree;
 }
 
+bool DeviceTreeNodeView::is_compatible_with(StringView wanted_compatible_string) const
+{
+    auto maybe_compatible = get_property("compatible"sv);
+    if (!maybe_compatible.has_value())
+        return false;
+
+    bool is_compatible = false;
+
+    maybe_compatible->for_each_string([&is_compatible, wanted_compatible_string](StringView compatible_entry) {
+        if (compatible_entry == wanted_compatible_string) {
+            is_compatible = true;
+            return IterationDecision::Break;
+        }
+
+        return IterationDecision::Continue;
+    });
+
+    return is_compatible;
+}
+
 }

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -115,6 +115,10 @@ public:
 
     DeviceTreeNodeView const* parent() const { return m_parent; }
 
+    // NOTE: When checking for multiple drivers, prefer iterating over the string array instead,
+    //       as the compatible strings are sorted by preference, which this function cannot account for.
+    bool is_compatible_with(StringView) const;
+
     // FIXME: Add convenience functions for common properties like "reg" and "compatible"
     // Note: The "reg" property is a list of address and size pairs, but the address is not always a u32 or u64
     //       In pci devices the #address-size is 3 cells: (phys.lo phys.mid phys.hi)


### PR DESCRIPTION
This PR should make writing devicetree drivers a lot simpler and keep code duplication minimal.

This PR does *not* depend on #25103. But we will need that PR to actually get the physical addresses from the 'reg' properties.