### PR TITLE
Kernel/riscv64+crash: Use '.option arch'

### DIFF
--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -189,6 +189,8 @@ ALWAYS_INLINE Thread* ProcessorBase<T>::current_thread()
 template<typename T>
 ALWAYS_INLINE void ProcessorBase<T>::pause()
 {
+    // PAUSE is a HINT defined by the Zihintpause extension.
+    // We don't have to check if that extension is supported, since HINTs effectively behave like NOPs if they are not implemented.
     asm volatile(R"(
         .option push
         .option arch, +zihintpause

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -189,9 +189,12 @@ ALWAYS_INLINE Thread* ProcessorBase<T>::current_thread()
 template<typename T>
 ALWAYS_INLINE void ProcessorBase<T>::pause()
 {
-    // FIXME: Use the pause instruction directly (via .option arch, +zihintpause)
-    //        when we upgrade our toolchain to clang 17
-    asm volatile(".word 0x0100000f");
+    asm volatile(R"(
+        .option push
+        .option arch, +zihintpause
+            pause
+        .option pop
+    )" :);
 }
 
 template<typename T>

--- a/Kernel/Arch/riscv64/boot.S
+++ b/Kernel/Arch/riscv64/boot.S
@@ -11,7 +11,7 @@
 // Booting via booti causes U-Boot to pass us the boot hart ID and a flattened devicetree (https://www.kernel.org/doc/html/latest/arch/riscv/boot.html).
 linux_header:
 .option push
-.option norvc
+.option arch, -c
   j start                                   // u32 code0
   j start                                   // u32 code1
 .option pop

--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
             // gets expanded to, is required to cause an illegal-instruction exception.
             asm volatile(R"(
                 .option push
-                .option norvc
+                .option arch, -c
                     unimp
                 .option pop
             )" :);


### PR DESCRIPTION
This option is now available on both our toolchains.