### PR TITLE
Cherry-pick "Documentation: Remove unnecessary newline in documentation"

### DIFF
--- a/Documentation/Browser/ProcessArchitecture.md
+++ b/Documentation/Browser/ProcessArchitecture.md
@@ -32,8 +32,7 @@ This process can decode images (PNG, JPEG, BMP, ICO, PBM, etc.) into bitmaps. Ea
 
 To get a fresh **WebContent** process, anyone with the suitable file system permissions can spawn one by connecting to
 the socket at `/tmp/session/%sid/portal/webcontent`, with `%sid` being the current login session id. This socket is managed
-by **
-SystemServer** and will spawn a new instance of **WebContent** for every connection.
+by **SystemServer** and will spawn a new instance of **WebContent** for every connection.
 
 The same basic concept applies to **RequestServer** and **ImageDecoder** as well, except that those services are spawned
 by **WebContent** as needed, not by **Browser**.


### PR DESCRIPTION
The commit removes an unnecessary newline character in the documentation that was breaking the bold formatting.

(cherry picked from commit 23428c0b9ace27e989ee90109d336852786e3155)

---

https://github.com/LadybirdBrowser/ladybird/pull/29