### PR TITLE
Cherry-pick "LibWeb: Ensure `ParentNode.getElementsByClassName()` matches all classes"

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/getElementsByClassName-multiple.txt
+++ b/Tests/LibWeb/Text/expected/DOM/getElementsByClassName-multiple.txt
@@ -1,0 +1,4 @@
+       document.getElementsByClassName("te st").length: 3
+<DIV id="1" >
+<DIV id="2" >
+<DIV id="3" >

--- a/Tests/LibWeb/Text/input/DOM/getElementsByClassName-multiple.html
+++ b/Tests/LibWeb/Text/input/DOM/getElementsByClassName-multiple.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="1" class="te st"></div>
+<div id="2" class="st te"></div>
+<div id="3" class="te te st"></div>
+<div id="4" class="te te"></div>
+<div id="5" class="st st"></div>
+<div id="6" class="test"></div>
+<script>
+    test(() => {
+        let elements = document.getElementsByClassName("te st");
+        println(`document.getElementsByClassName("te st").length: ${elements.length}`);
+        for (let element of elements) {
+            printElement(element);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -227,6 +227,7 @@ WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<JS::Handle
     return {};
 }
 
+// https://dom.spec.whatwg.org/#dom-document-getelementsbyclassname
 JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_class_name(StringView class_names)
 {
     Vector<FlyString> list_of_class_names;
@@ -235,10 +236,10 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_class_name(StringVi
     }
     return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
         for (auto& name : list_of_class_names) {
-            if (element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
-                return true;
+            if (!element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
+                return false;
         }
-        return false;
+        return !list_of_class_names.is_empty();
     });
 }
 


### PR DESCRIPTION
(cherry picked from commit 96c0cbf584e99d5c1c9b894d0317d8c2887ade83)

---

https://github.com/LadybirdBrowser/ladybird/pull/947