### PR TITLE
Cherry-pick "LibXML: Include line and column numbers in parse error messages"

### DIFF
--- a/Tests/LibWeb/Text/data/bad.xml
+++ b/Tests/LibWeb/Text/data/bad.xml
@@ -1,1 +1,2 @@
-<this-will-not-parse
+<?xml version="1.0" encoding="UTF-8"?>
+<this-will-not-parse</this-will-not-parse>

--- a/Tests/LibWeb/Text/expected/XML/error-page.txt
+++ b/Tests/LibWeb/Text/expected/XML/error-page.txt
@@ -1,3 +1,3 @@
   Got load event
 [object HTMLDocument]
-Failed to parse XML document: Expected '>' at offset 21
+Failed to parse XML document: Expected '>' at line: 1, col: 20 (offset 59)

--- a/Userland/Libraries/LibXML/Parser/Parser.h
+++ b/Userland/Libraries/LibXML/Parser/Parser.h
@@ -22,7 +22,7 @@
 namespace XML {
 
 struct ParseError {
-    size_t offset;
+    LineTrackingLexer::Position position {};
     ByteString error;
 };
 
@@ -185,7 +185,7 @@ private:
             if (rule_name.starts_with("parse_"sv))
                 rule_name = rule_name.substring_view(6);
             m_parse_errors.append({
-                error.offset,
+                error.position,
                 ByteString::formatted("{}: {}", rule_name, error.error),
             });
         }
@@ -219,6 +219,6 @@ template<>
 struct AK::Formatter<XML::ParseError> : public AK::Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, XML::ParseError const& error)
     {
-        return Formatter<FormatString>::format(builder, "{} at offset {}"sv, error.error, error.offset);
+        return Formatter<FormatString>::format(builder, "{} at line: {}, col: {} (offset {})"sv, error.error, error.position.line, error.position.column, error.position.offset);
     }
 };


### PR DESCRIPTION
(cherry picked from commit c0f30f31d109ba1420421b3de9e47560fcb3e65f)

---

https://github.com/LadybirdBrowser/ladybird/pull/943