### PR TITLE
Cherry-pick "LibWeb: Match class selectors case insensitively in quirks mode"

### DIFF
--- a/Tests/LibWeb/Text/expected/quirks-mode-case-insensitive-class-selector.txt
+++ b/Tests/LibWeb/Text/expected/quirks-mode-case-insensitive-class-selector.txt
@@ -1,0 +1,1 @@
+  ParentNode.querySelector matches class selectors case-insensitively in quirks mode: true

--- a/Tests/LibWeb/Text/input/quirks-mode-case-insensitive-class-selector.html
+++ b/Tests/LibWeb/Text/input/quirks-mode-case-insensitive-class-selector.html
@@ -1,0 +1,9 @@
+<!-- Quirks mode -->
+<script src="include.js"></script>
+<div class="tEsT"></div>
+<script>
+    test(() => {
+        let divElement = document.querySelector(".test");
+        println(`ParentNode.querySelector matches class selectors case-insensitively in quirks mode: ${divElement instanceof Element}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -702,8 +702,12 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, Optio
     }
     case CSS::Selector::SimpleSelector::Type::Id:
         return component.name() == element.id();
-    case CSS::Selector::SimpleSelector::Type::Class:
-        return element.has_class(component.name());
+    case CSS::Selector::SimpleSelector::Type::Class: {
+        // Class selectors are matched case insensitively in quirks mode.
+        // See: https://drafts.csswg.org/selectors-4/#class-html
+        auto case_sensitivity = element.document().in_quirks_mode() ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive;
+        return element.has_class(component.name(), case_sensitivity);
+    }
     case CSS::Selector::SimpleSelector::Type::Attribute:
         return matches_attribute(component.attribute(), style_sheet_for_rule, element);
     case CSS::Selector::SimpleSelector::Type::PseudoClass:
@@ -788,8 +792,12 @@ static bool fast_matches_simple_selector(CSS::Selector::SimpleSelector const& si
             return false;
         }
         return matches_namespace(simple_selector.qualified_name(), element, style_sheet_for_rule);
-    case CSS::Selector::SimpleSelector::Type::Class:
-        return element.has_class(simple_selector.name());
+    case CSS::Selector::SimpleSelector::Type::Class: {
+        // Class selectors are matched case insensitively in quirks mode.
+        // See: https://drafts.csswg.org/selectors-4/#class-html
+        auto case_sensitivity = element.document().in_quirks_mode() ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive;
+        return element.has_class(simple_selector.name(), case_sensitivity);
+    }
     case CSS::Selector::SimpleSelector::Type::Id:
         return simple_selector.name() == element.id();
     case CSS::Selector::SimpleSelector::Type::Attribute:


### PR DESCRIPTION
This align our implementation with the CSSWG Selectors Level 4 specification.

(cherry picked from commit 82ed2534776406872337b34ddf2dfaa0b3332c32)

---

https://github.com/LadybirdBrowser/ladybird/pull/937