### PR TITLE
Cherry-pick "LibWeb: Cache the Document's node navigable when possible"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5325,4 +5325,14 @@ void Document::reset_cursor_blink_cycle()
         m_cursor_position->node()->paintable()->set_needs_display();
 }
 
+JS::GCPtr<HTML::Navigable> Document::cached_navigable()
+{
+    return m_cached_navigable.ptr();
+}
+
+void Document::set_cached_navigable(JS::GCPtr<HTML::Navigable> navigable)
+{
+    m_cached_navigable = navigable.ptr();
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -695,6 +695,10 @@ public:
     bool cursor_blink_state() const { return m_cursor_blink_state; }
 
     void user_did_edit_document_text(Badge<EditEventHandler>);
+    // Cached pointer to the last known node navigable.
+    // If this document is currently the "active document" of the cached navigable, the cache is still valid.
+    JS::GCPtr<HTML::Navigable> cached_navigable();
+    void set_cached_navigable(JS::GCPtr<HTML::Navigable>);
 
 protected:
     virtual void initialize(JS::Realm&) override;
@@ -964,6 +968,9 @@ private:
     JS::GCPtr<DOM::Position> m_cursor_position;
     RefPtr<Core::Timer> m_cursor_blink_timer;
     bool m_cursor_blink_state { false };
+
+    // NOTE: This is WeakPtr, not GCPtr, on purpose. We don't want the document to keep some old detached navigable alive.
+    WeakPtr<HTML::Navigable> m_cached_navigable;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -362,9 +362,17 @@ void Node::set_node_value(Optional<String> const& maybe_value)
 // https://html.spec.whatwg.org/multipage/document-sequences.html#node-navigable
 JS::GCPtr<HTML::Navigable> Node::navigable() const
 {
+    auto& document = const_cast<Document&>(this->document());
+    if (auto cached_navigable = document.cached_navigable()) {
+        if (cached_navigable->active_document() == &document)
+            return cached_navigable;
+    }
+
     // To get the node navigable of a node node, return the navigable whose active document is node's node document,
     // or null if there is no such navigable.
-    return HTML::Navigable::navigable_with_active_document(const_cast<Document&>(document()));
+    auto navigable = HTML::Navigable::navigable_with_active_document(document);
+    document.set_cached_navigable(navigable);
+    return navigable;
 }
 
 [[maybe_unused]] static StringView to_string(StyleInvalidationReason reason)


### PR DESCRIPTION
To avoid expensive lookups, we now cache a weak pointer from document to the last known node navigable. Before using the cache, we validate that the document is still the navigable's active document.

(cherry picked from commit e746b2b133758b3552ae07941cc6d14332c64d59)

---

https://github.com/LadybirdBrowser/ladybird/pull/936