### PR TITLE
Cherry-pick "LibWeb: Bucket CSS rules by pseudo-element"

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -213,7 +213,7 @@ private:
         HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
         HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
         HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
-        Vector<MatchingRule> pseudo_element_rules;
+        Array<Vector<MatchingRule>, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)> rules_by_pseudo_element;
         Vector<MatchingRule> root_rules;
         Vector<MatchingRule> other_rules;
 


### PR DESCRIPTION
Instead of throwing all pseudo-element rules in one bucket, let's have one bucket per pseudo-element.

This means we only run ::before rules for ::before pseudo-elements, only ::after rules for ::after, etc.

Average style update time on https://tailwindcss.com/ 250ms -> 215ms.

(cherry picked from commit 87056ee0d2505c26149a36fc5b69446504b172bb)

---

https://github.com/LadybirdBrowser/ladybird/pull/1362