### PR TITLE
Cherry-pick "LibWeb/CSS: Implement revert-layer"

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSKeyword.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSKeyword.cpp
@@ -77,6 +77,7 @@ inline bool is_css_wide_keyword(StringView name)
     return name.equals_ignoring_ascii_case("inherit"sv)
         || name.equals_ignoring_ascii_case("initial"sv)
         || name.equals_ignoring_ascii_case("revert"sv)
+        || name.equals_ignoring_ascii_case("revert-layer"sv)
         || name.equals_ignoring_ascii_case("unset"sv);
 }
 

--- a/Tests/LibWeb/Text/expected/css/revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/css/revert-layer.txt
@@ -1,0 +1,4 @@
+    PASS: revert to base (first target)
+PASS: revert to base (second target)
+PASS: double revert (first target)
+PASS: double revert (second target)

--- a/Tests/LibWeb/Text/input/css/revert-layer.html
+++ b/Tests/LibWeb/Text/input/css/revert-layer.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<target class="first"></target>
+<target class="second"></target>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        // In all test cases, the rule specified as "color: green" should win.
+        var testCases = [
+            {
+                title: 'revert to base',
+                style: `
+                    @layer base, special;
+                    @layer special { target { color: revert-layer; } target.second { color: green; } }
+                    @layer base { target { color: green; } target.second { color: red; } }
+                `,
+            },
+            {
+                title: 'double revert',
+                style: `
+                    @layer layer1, layer2, layer3;
+                    @layer layer3 { target { color: revert-layer; } target.second { color: revert-layer; } }
+                    @layer layer2 { target { color: revert-layer; } target.second { color: green; } }
+                    @layer layer1 { target { color: green; } target.second { color: revert-layer; } }
+                `,
+            },
+        ];
+
+        for (let testCase of testCases) {
+            const styleElement = document.createElement('style');
+            styleElement.textContent = testCase['style'];
+            document.head.append(styleElement);
+
+            var targets = document.querySelectorAll('target');
+            for (let target of targets) {
+                let actual = window.getComputedStyle(target).color;
+                if (actual === 'rgb(0, 128, 0)') {
+                    println(`PASS: ${testCase['title']} (${target.classList[0]} target)`);
+                } else {
+                    println(`FAIL: ${testCase['title']} (${target.classList[0]} target) - Expected 'rgb(0, 128, 0)', got '${actual}'`);
+                }
+            }
+
+            styleElement.remove();
+        }
+
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -331,10 +331,11 @@ public:
 
     // https://www.w3.org/TR/css-values-4/#common-keywords
     // https://drafts.csswg.org/css-cascade-4/#valdef-all-revert
-    bool is_css_wide_keyword() const { return is_inherit() || is_initial() || is_revert() || is_unset(); }
+    bool is_css_wide_keyword() const { return is_inherit() || is_initial() || is_revert() || is_unset() || is_revert_layer(); }
     bool is_inherit() const { return to_keyword() == Keyword::Inherit; }
     bool is_initial() const { return to_keyword() == Keyword::Initial; }
     bool is_revert() const { return to_keyword() == Keyword::Revert; }
+    bool is_revert_layer() const { return to_keyword() == Keyword::RevertLayer; }
     bool is_unset() const { return to_keyword() == Keyword::Unset; }
 
     bool has_auto() const;

--- a/Userland/Libraries/LibWeb/CSS/Keywords.json
+++ b/Userland/Libraries/LibWeb/CSS/Keywords.json
@@ -308,6 +308,7 @@
   "repeat-y",
   "reverse",
   "revert",
+  "revert-layer",
   "ridge",
   "right",
   "round",

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1757,7 +1757,10 @@ RefPtr<CSSStyleValue> Parser::parse_builtin_value(TokenStream<ComponentValue>& t
             transaction.commit();
             return CSSKeywordValue::create(Keyword::Revert);
         }
-        // FIXME: Implement `revert-layer` from CSS-CASCADE-5.
+        if (ident.equals_ignoring_ascii_case("revert-layer"sv)) {
+            transaction.commit();
+            return CSSKeywordValue::create(Keyword::RevertLayer);
+        }
     }
 
     return nullptr;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
@@ -33,6 +33,10 @@ public:
             static ValueComparingNonnullRefPtr<CSSKeywordValue> const revert_instance = adopt_ref(*new (nothrow) CSSKeywordValue(Keyword::Revert));
             return revert_instance;
         }
+        case Keyword::RevertLayer: {
+            static ValueComparingNonnullRefPtr<CSSKeywordValue> const revert_layer_instance = adopt_ref(*new (nothrow) CSSKeywordValue(Keyword::RevertLayer));
+            return revert_layer_instance;
+        }
         case Keyword::Unset: {
             static ValueComparingNonnullRefPtr<CSSKeywordValue> const unset_instance = adopt_ref(*new (nothrow) CSSKeywordValue(Keyword::Unset));
             return unset_instance;


### PR DESCRIPTION
With the introduction of the cascade layer, the 5th CSS-wide keyword, `revert-layer`, has been added.

(cherry picked from commit bea7eec5183a816a100d190e409a622f429d7405)

---

https://github.com/LadybirdBrowser/ladybird/pull/1371