### PR TITLE
Cherry-pick "UI/Qt: Ensure we don't add the same zoom shortcut key more than once"

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -188,7 +188,10 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     auto* zoom_in_action = new QAction("Zoom &In", this);
     zoom_in_action->setIcon(load_icon_from_uri("resource://icons/16x16/zoom-in.png"sv));
     auto zoom_in_shortcuts = QKeySequence::keyBindings(QKeySequence::StandardKey::ZoomIn);
-    zoom_in_shortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal));
+    auto secondary_zoom_shortcut = QKeySequence(Qt::CTRL | Qt::Key_Equal);
+    if (!zoom_in_shortcuts.contains(secondary_zoom_shortcut))
+        zoom_in_shortcuts.append(AK::move(secondary_zoom_shortcut));
+
     zoom_in_action->setShortcuts(zoom_in_shortcuts);
     m_zoom_menu->addAction(zoom_in_action);
     QObject::connect(zoom_in_action, &QAction::triggered, this, &BrowserWindow::zoom_in);


### PR DESCRIPTION
On my system `QKeySequence::StandardKey::ZoomIn` includes both `Ctrl++` and `Ctrl+=`, so explicitly adding the secondary `Ctrl+=` shortcut ourselves results in an ambiguous shortcut error message being shown.

According to the Qt documentation the key bindings returned by `QKeySequence::StandardKey::*` are platform specific, so we may still need to add the secondary shortcut on some systems. Therefore, we now check whether our secondary shortcut is already in the shortcut list before adding it.

(cherry picked from commit ebfb847d347b40e377900658795442797c7e14e9)

---

https://github.com/LadybirdBrowser/ladybird/pull/122