### PR TITLE
Cherry-pick "LibWeb: Ensure a repaint occurs when the current selection is cleared"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -96,12 +96,13 @@ void Range::set_associated_selection(Badge<Selection::Selection>, JS::GCPtr<Sele
 
 void Range::update_associated_selection()
 {
-    if (!m_associated_selection)
-        return;
-    if (auto* viewport = m_associated_selection->document()->paintable()) {
+    if (auto* viewport = m_start_container->document().paintable()) {
         viewport->recompute_selection_states();
         viewport->set_needs_display();
     }
+
+    if (!m_associated_selection)
+        return;
 
     // https://w3c.github.io/selection-api/#selectionchange-event
     // When the selection is dissociated with its range, associated with a new range or the associated range's boundary


### PR DESCRIPTION
This fixes an issue where clearing the find in page query would not always visually clear the selection.

(cherry picked from commit 0b33331f3678eb69bc3448949dfc2c1e1e7671e6)

---

https://github.com/LadybirdBrowser/ladybird/pull/263