### PR TITLE
Cherry-pick "UI/Qt: Don't show URL when a new tab is initially focused"

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -644,8 +644,11 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab, Tab& par
     }
 
     m_tabs_container->addTab(tab, "New Tab");
-    if (activate_tab == Web::HTML::ActivateTab::Yes)
+    if (activate_tab == Web::HTML::ActivateTab::Yes) {
         m_tabs_container->setCurrentWidget(tab);
+        if (m_tabs_container->count() != 1)
+            tab->set_url_is_hidden(true);
+    }
     initialize_tab(tab);
     return *tab;
 }
@@ -659,8 +662,11 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
     }
 
     m_tabs_container->addTab(tab, "New Tab");
-    if (activate_tab == Web::HTML::ActivateTab::Yes)
+    if (activate_tab == Web::HTML::ActivateTab::Yes) {
         m_tabs_container->setCurrentWidget(tab);
+        if (m_tabs_container->count() != 1)
+            tab->set_url_is_hidden(true);
+    }
     initialize_tab(tab);
 
     return *tab;

--- a/Ladybird/Qt/LocationEdit.cpp
+++ b/Ladybird/Qt/LocationEdit.cpp
@@ -37,7 +37,7 @@ LocationEdit::LocationEdit(QWidget* parent)
         auto query = ak_string_from_qstring(text());
 
         if (auto url = WebView::sanitize_url(query, search_engine_url); url.has_value())
-            setText(qstring_from_ak_string(url->serialize()));
+            set_url(url.release_value());
     });
 
     connect(this, &QLineEdit::textEdited, [this] {
@@ -65,6 +65,11 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 void LocationEdit::focusOutEvent(QFocusEvent* event)
 {
     QLineEdit::focusOutEvent(event);
+    if (m_url_is_hidden) {
+        m_url_is_hidden = false;
+        if (text().isEmpty())
+            setText(qstring_from_ak_string(m_url.serialize()));
+    }
     highlight_location();
 }
 
@@ -107,6 +112,16 @@ void LocationEdit::highlight_location()
 
     QInputMethodEvent event(QString(), attributes);
     QCoreApplication::sendEvent(this, &event);
+}
+
+void LocationEdit::set_url(URL::URL const& url)
+{
+    m_url = url;
+    if (m_url_is_hidden) {
+        clear();
+    } else {
+        setText(qstring_from_ak_string(url.serialize()));
+    }
 }
 
 }

--- a/Ladybird/Qt/LocationEdit.h
+++ b/Ladybird/Qt/LocationEdit.h
@@ -17,12 +17,21 @@ class LocationEdit final : public QLineEdit {
 public:
     explicit LocationEdit(QWidget*);
 
+    URL::URL url() const { return m_url; }
+    void set_url(URL::URL const&);
+
+    bool url_is_hidden() const { return m_url_is_hidden; }
+    void set_url_is_hidden(bool url_is_hidden) { m_url_is_hidden = url_is_hidden; }
+
 private:
     virtual void focusInEvent(QFocusEvent* event) override;
     virtual void focusOutEvent(QFocusEvent* event) override;
 
     void highlight_location();
     AK::OwnPtr<AutoComplete> m_autocomplete;
+
+    URL::URL m_url;
+    bool m_url_is_hidden { false };
 };
 
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -145,7 +145,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_favicon = default_favicon();
         emit favicon_changed(tab_index(), m_favicon);
 
-        m_location_edit->setText(url_serialized);
+        m_location_edit->set_url(url);
         m_location_edit->setCursorPosition(0);
     };
 
@@ -155,7 +155,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     };
 
     view().on_url_change = [this](auto const& url) {
-        m_location_edit->setText(qstring_from_ak_string(url.serialize()));
+        m_location_edit->set_url(url);
     };
 
     QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
@@ -863,7 +863,7 @@ void Tab::copy_link_url(URL::URL const& url)
 
 void Tab::location_edit_return_pressed()
 {
-    navigate(ak_url_from_qstring(m_location_edit->text()));
+    navigate(m_location_edit->url());
 }
 
 void Tab::open_file()

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -67,6 +67,9 @@ public:
 
     void set_line_box_borders(bool);
 
+    bool url_is_hidden() const { return m_location_edit->url_is_hidden(); }
+    void set_url_is_hidden(bool url_is_hidden) { m_location_edit->set_url_is_hidden(url_is_hidden); }
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();


### PR DESCRIPTION
The URL is now not shown when a new tab is initially activated until the location bar loses focus. This allows the user to see the location bar placeholder text when opening a new tab. It also makes it easier to paste URLs into the location bar after opening a new tab.

(cherry picked from commit 808784092c552518fe1d9a83543c40cd13e8ac09)

---

https://github.com/LadybirdBrowser/ladybird/pull/137