### PR TITLE
Cherry-pick "LibWebView: Append remaining source after consuming all tokens"

### DIFF
--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -60,7 +60,7 @@ String highlight_source(URL::URL const& url, StringView source)
         previous_position = end_position;
     };
 
-    for (auto token = tokenizer.next_token(); token.has_value() && !token->is_end_of_file(); token = tokenizer.next_token()) {
+    for (auto token = tokenizer.next_token(); token.has_value(); token = tokenizer.next_token()) {
         if (token->is_comment()) {
             append_source(token->start_position().byte_offset);
             append_source(token->end_position().byte_offset, "comment"sv);
@@ -83,6 +83,8 @@ String highlight_source(URL::URL const& url, StringView source)
             append_source(token->end_position().byte_offset);
         } else {
             append_source(token->end_position().byte_offset);
+            if (token->is_end_of_file())
+                break;
         }
     }
 


### PR DESCRIPTION
Since "Character" tokens do not have an "end position", viewing source drops the source contents following the final non-"Character" token.

By handling the EOF token and breaking out of the loop, we avoid this issue.

(cherry picked from commit 7de669dc07956c402e0ddec76e3f214f622cf2c4)

---

https://github.com/LadybirdBrowser/ladybird/pull/353