### PR TITLE
Cherry-pick "LibWeb: Save float-intrusion for marker before list elements layout"

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -77,7 +77,8 @@ private:
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
 
-    void layout_list_item_marker(ListItemBox const&);
+    void ensure_sizes_correct_for_left_offset_calculation(ListItemBox const&);
+    void layout_list_item_marker(ListItemBox const&, CSSPixels const& left_space_before_list_item_elements_formatted);
 
     void measure_scrollable_overflow(Box const&, CSSPixels& bottom_edge, CSSPixels& right_edge) const;
 


### PR DESCRIPTION
... to prevent that left-floating elements inside the list element push the list marker into the (non-floating) content of the list element.

(cherry picked from commit b7e505365c768b70ce830fbe3a6eac93b2364cd8)

---

https://github.com/LadybirdBrowser/ladybird/pull/396