### PR TITLE
Cherry-pick "WebDriver: Launch Ladybird with `--force-new-process`"

### DIFF
--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -46,6 +46,7 @@ static ErrorOr<pid_t> launch_browser(ByteString const& socket_path)
     }
 
     arguments.append("--allow-popups");
+    arguments.append("--force-new-process");
 
     arguments.append("about:blank");
 


### PR DESCRIPTION
This allows multiple WPT tests to be run in parallel with using the `--processes` option.

(cherry picked from commit c14dc77349eca6f9cddd7fbb1d8e216cc9fa6cf8)

---

https://github.com/LadybirdBrowser/ladybird/pull/196