### PR TITLE
Meta: Add DragEvent to GN build

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
@@ -33,6 +33,7 @@ source_set("HTML") {
     "DecodedImageData.cpp",
     "DedicatedWorkerGlobalScope.cpp",
     "DocumentState.cpp",
+    "DragEvent.cpp",
     "ElementInternals.cpp",
     "EmbedderPolicy.cpp",
     "ErrorEvent.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/idl_files.gni
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/idl_files.gni
@@ -123,6 +123,7 @@ standard_idl_files = [
   "//Userland/Libraries/LibWeb/HTML/CloseWatcher.idl",
   "//Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.idl",
   "//Userland/Libraries/LibWeb/HTML/DataTransfer.idl",
+  "//Userland/Libraries/LibWeb/HTML/DragEvent.idl",
   "//Userland/Libraries/LibWeb/HTML/DOMParser.idl",
   "//Userland/Libraries/LibWeb/HTML/DOMStringList.idl",
   "//Userland/Libraries/LibWeb/HTML/DOMStringMap.idl",


### PR DESCRIPTION
This should've been in #24721.

Makes Text/input/all-window-properties.html pass with the GN build.