### PR TITLE
Cherry-pick "LibWeb: Implement popover property and attribute"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -214,6 +214,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(ping)                       \
     __ENUMERATE_HTML_ATTRIBUTE(placeholder)                \
     __ENUMERATE_HTML_ATTRIBUTE(playsinline)                \
+    __ENUMERATE_HTML_ATTRIBUTE(popover)                    \
     __ENUMERATE_HTML_ATTRIBUTE(poster)                     \
     __ENUMERATE_HTML_ATTRIBUTE(preload)                    \
     __ENUMERATE_HTML_ATTRIBUTE(readonly)                   \

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -681,6 +681,34 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInternals>> HTMLElement::attach_inte
     return { internals };
 }
 
+// https://html.spec.whatwg.org/multipage/popover.html#dom-popover
+Optional<String> HTMLElement::popover() const
+{
+    // FIXME: This should probably be `Reflect` in the IDL.
+    // The popover IDL attribute must reflect the popover attribute, limited to only known values.
+    auto value = get_attribute(HTML::AttributeNames::popover);
+
+    if (!value.has_value())
+        return {};
+
+    if (value.value().is_empty() || value.value().equals_ignoring_ascii_case("auto"sv))
+        return "auto"_string;
+
+    return "manual"_string;
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#dom-popover
+WebIDL::ExceptionOr<void> HTMLElement::set_popover(Optional<String> value)
+{
+    // FIXME: This should probably be `Reflect` in the IDL.
+    // The popover IDL attribute must reflect the popover attribute, limited to only known values.
+    if (value.has_value())
+        return set_attribute(HTML::AttributeNames::popover, value.release_value());
+
+    remove_attribute(HTML::AttributeNames::popover);
+    return {};
+}
+
 void HTMLElement::did_receive_focus()
 {
     if (m_content_editable_state != ContentEditableState::True)

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -77,6 +77,9 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInternals>> attach_internals();
 
+    WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
+    Optional<String> popover() const;
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -35,7 +35,7 @@ interface HTMLElement : Element {
     [FIXME] undefined showPopover();
     [FIXME] undefined hidePopover();
     [FIXME] boolean togglePopover(optional boolean force);
-    [FIXME, CEReactions] attribute DOMString? popover;
+    [CEReactions] attribute DOMString? popover;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
     readonly attribute Element? offsetParent;


### PR DESCRIPTION
The popover property now reflects the attribute.

It cannot currently use the Reflect IDL concept because the empty string value is special cased.

(cherry picked from commit a9669639cee27e81640fe7a37d9d1f319db6b666)

---

https://github.com/LadybirdBrowser/ladybird/pull/336, except for the unintentional change to Tests/LibWeb/rebaseline-libweb-test