### PR TITLE
Meta: Make GN build actually refer to StorageAPI

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -331,6 +331,7 @@ shared_library("LibWeb") {
            "SVG",
            "SecureContexts",
            "Selection",
+           "StorageAPI",
            "Streams",
            "UIEvents",
            "UserTiming",


### PR DESCRIPTION
This should have been part of #25241.