### PR TITLE
Cherry-pick "LibWeb: Don't crash on getClientRects() in document without navigable"

### DIFF
--- a/Tests/LibWeb/Text/expected/CSSOMView/getClientRects-in-detached-document.txt
+++ b/Tests/LibWeb/Text/expected/CSSOMView/getClientRects-in-detached-document.txt
@@ -1,0 +1,3 @@
+[object CSSStyleDeclaration]
+[object DOMRectList]
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/CSSOMView/getClientRects-in-detached-document.html
+++ b/Tests/LibWeb/Text/input/CSSOMView/getClientRects-in-detached-document.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let doc = document.implementation.createHTMLDocument();
+        let div = doc.createElement("div");
+        doc.body.appendChild(div);
+
+        // NOTE: We do a getComputedStyle() to trick the document into doing some style/layout work.
+        //       In the future, we may optimize away some of this work, which would potentially
+        //       make the test not work as intended anymore.
+        println(getComputedStyle(div));
+
+        println(div.getClientRects());
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
I previously believed there was no way a detached document should have layout information, but it turns out there is a way: getComputedStyle().

So we need to account for cases where we have a layout node, but no navigable, since that is a state we can get into at this moment.

Fixes #354

(cherry picked from commit 1e7b17f15024d0618f1a1e17e3e927856febde28)

---

https://github.com/LadybirdBrowser/ladybird/pull/971