### PR TITLE
Meta: Enable `qemu-vdagent` (for copy/paste support) by default on Linux

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -486,26 +486,27 @@ def set_up_cpu_count(config: Configuration):
 
 
 def set_up_spice(config: Configuration):
-    if environ.get("SERENITY_SPICE") == "1":
-        chardev_info = run(
-            [str(config.qemu_binary), "-chardev", "help"],
-            capture_output=True,
-            encoding="utf-8",
-        ).stdout.lower()
-        if "spicevmc" in chardev_info:
-            config.spice_arguments = ["-chardev", "spicevmc,id=vdagent,name=vdagent"]
-        elif "qemu-vdagent" in chardev_info:
-            config.spice_arguments = [
-                "-chardev",
-                "qemu-vdagent,clipboard=on,mouse=off,id=vdagent,name=vdagent",
-            ]
-        else:
-            raise RunError("No compatible SPICE character device was found")
+    # Only the default machine has virtio-serial (required for the spice agent).
+    if config.machine_type != MachineType.Default:
+        return
+    use_non_qemu_spice = environ.get("SERENITY_SPICE") == "1"
+    chardev_info = run(
+        [str(config.qemu_binary), "-chardev", "help"],
+        capture_output=True,
+        encoding="utf-8",
+    ).stdout.lower()
+    if use_non_qemu_spice and "spicevmc" in chardev_info:
+        config.spice_arguments = ["-chardev", "spicevmc,id=vdagent,name=vdagent"]
+    elif "qemu-vdagent" in chardev_info:
+        config.extra_arguments.extend([
+            "-chardev",
+            "qemu-vdagent,clipboard=on,mouse=off,id=vdagent,name=vdagent",
+        ])
 
-        if "spice" in chardev_info:
-            config.spice_arguments.extend(["-spice", "port=5930,agent-mouse=off,disable-ticketing=on"])
-        if "spice" in chardev_info or "vdagent" in chardev_info:
-            config.spice_arguments.extend(["-device", "virtserialport,chardev=vdagent,nr=1"])
+    if use_non_qemu_spice and "spice" in chardev_info:
+        config.spice_arguments.extend(["-spice", "port=5930,agent-mouse=off,disable-ticketing=on"])
+    if "spice" in chardev_info or "vdagent" in chardev_info:
+        config.extra_arguments.extend(["-device", "virtserialport,chardev=vdagent,nr=1"])
 
 
 def set_up_audio_backend(config: Configuration):
@@ -583,6 +584,8 @@ def set_up_screens(config: Configuration):
             config.display_backend = "sdl,gl=off"
         elif config.screen_count > 1 and "sdl" in qemu_display_info:
             config.display_backend = "sdl,gl=off"
+        elif "gtk" in qemu_display_info and has_virgl():
+            config.display_backend = "gtk,gl=on"
         elif "sdl" in qemu_display_info and has_virgl():
             config.display_backend = "sdl,gl=on"
         elif "cocoa" in qemu_display_info:

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -60,6 +60,8 @@ then
     EXTRA_ARGS="--disable-sdl"
 else
     UI_LIB=gtk
+    # Allows copy pasting between Serenity and the host.
+    EXTRA_ARGS="--enable-gtk-clipboard"
 fi
 
 echo Using $UI_LIB based UI


### PR DESCRIPTION
This updates `run.py` so that it will configure the `qemu-vdagent` (QEMU's built-in spice agent for clipboard support) when it's available.

Setting `SERENITY_SPICE=1` is only needed to use `spicevmc`, which implements more features (such as file transfers), but requires more setup to get working (see Documentation/SpiceIntegration.md).

This matches the behaviour of the old `run.sh` script, the logic was changed (perhaps unintentionally) in the `run.py` rewrite.

Note: For copy/paste to work you may need to rebuild QEMU with `--enable-gtk-clipboard` (which is added to `Toolchain/BuildQemu.sh` for Linux as part of this patch).