### PR TITLE
Cherry-pick "LibWeb: Readonly input element's arrow buttons don't change the value"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -867,8 +867,10 @@ void HTMLInputElement::create_text_input_shadow_tree()
 
         auto up_callback_function = JS::NativeFunction::create(
             realm(), [this](JS::VM&) {
-                MUST(step_up());
-                user_interaction_did_change_input_value();
+                if (m_is_mutable) {
+                    MUST(step_up());
+                    user_interaction_did_change_input_value();
+                }
                 return JS::js_undefined();
             },
             0, "", &realm());
@@ -887,8 +889,10 @@ void HTMLInputElement::create_text_input_shadow_tree()
 
         auto down_callback_function = JS::NativeFunction::create(
             realm(), [this](JS::VM&) {
-                MUST(step_down());
-                user_interaction_did_change_input_value();
+                if (m_is_mutable) {
+                    MUST(step_down());
+                    user_interaction_did_change_input_value();
+                }
                 return JS::js_undefined();
             },
             0, "", &realm());


### PR DESCRIPTION
(cherry picked from commit c31f9815b46a12c931f7d446f7e4e42c71eacf5d)

---

https://github.com/LadybirdBrowser/ladybird/pull/1602