### PR TITLE
Meta: Add a SSH server to the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,9 @@
             "password": "vscode",
             "webPort": "6080",
             "vncPort": "5901"
+        },
+        "ghcr.io/devcontainers/features/sshd:1": {
+            "version": "latest"
         }
     },
 


### PR DESCRIPTION
This patch fixes this error when trying to SSH into the devcontainer with [`gh codespaces ssh`](https://cli.github.com/manual/gh_codespace_ssh):

```
error getting ssh server details: failed to start SSH server: Please check if an SSH server is installed in the container.
```