### PR TITLE
Cherry-pick "LibWeb: Ensure Elements don't need style update after computing style"

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2222,6 +2222,8 @@ RefPtr<StyleProperties> StyleComputer::compute_style_impl(DOM::Element& element,
         return style;
     }
 
+    ScopeGuard guard { [&element]() { element.set_needs_style_update(false); } };
+
     auto style = StyleProperties::create();
     // 1. Perform the cascade. This produces the "specified style"
     bool did_match_any_pseudo_element_rules = false;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -533,7 +533,6 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
 
 CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
 {
-    set_needs_style_update(false);
     VERIFY(parent());
 
     auto& style_computer = document().style_computer();


### PR DESCRIPTION
Previously, we set the "needs style update" flag to false at the beginning of recomputing the style. This meant that if any code within the cascade set this flag to true, then we would end style computation thinking the element still needed its style updating. This could occur when starting a transition, and would make TreeBuilder crash.

By ensuring that we always set the flag to false at the very end of style computation, this is avoided, along with any similar issues - I noticed a comment in `Animation::cancel()` which sounds like a workaround was needed for a similar problem previously.

(cherry picked from commit 8c79edac085ee164aca5ca7cf287e68e93e03217)

---

https://github.com/LadybirdBrowser/ladybird/pull/1573