### PR TITLE
Tests: Remove unused Kernel/ include

### DIFF
--- a/Tests/LibCore/TestLibCoreFileWatcher.cpp
+++ b/Tests/LibCore/TestLibCoreFileWatcher.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/API/InodeWatcherEvent.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/FileWatcher.h>
 #include <LibCore/Timer.h>


### PR DESCRIPTION
This include was unused when it was added in #6993, probably copy-pasta from Tests/LibC/TestLibCInodeWatcher.cpp where it is used.

No behavior change.