### PR TITLE
Cherry-pick "UI/Qt: Set a minimum size policy for the navigation control toolbar"

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -91,6 +91,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_toolbar->addAction(&m_window->reload_action());
     m_toolbar->addWidget(m_location_edit);
     m_toolbar->addAction(&m_window->new_tab_action());
+    m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
     m_hamburger_button_action = m_toolbar->addWidget(m_hamburger_button);
     m_toolbar->setIconSize({ 16, 16 });
     // This is a little awkward, but without this Qt shrinks the button to the size of the icon.


### PR DESCRIPTION
This prevents the user being able to shrink the window to the point that the location bar and other controls are no longer visible.

(cherry picked from commit 4ed46adeeec4860b55d455da49aa93aff26bf1a3)

---

https://github.com/LadybirdBrowser/ladybird/pull/516