### PR TITLE
Cherry-pick "UI/Qt: Don't hide the location bar URL when creating a tab from a URL"

### DIFF
--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -67,6 +67,13 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Web
     auto* window = new BrowserWindow(initial_urls, cookie_jar, web_content_options, webdriver_content_ipc_path, allow_popups, parent_tab, move(page_index));
     set_active_window(*window);
     window->show();
+    if (initial_urls.is_empty()) {
+        auto* tab = window->current_tab();
+        if (tab) {
+            tab->set_url_is_hidden(true);
+            tab->focus_location_editor();
+        }
+    }
     window->activateWindow();
     window->raise();
     return *window;

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -66,11 +66,6 @@ static Vector<URL::URL> sanitize_urls(Vector<ByteString> const& raw_urls)
         if (auto url = WebView::sanitize_url(raw_url); url.has_value())
             sanitized_urls.append(url.release_value());
     }
-
-    if (sanitized_urls.is_empty()) {
-        auto new_tab_page = Ladybird::Settings::the()->new_tab_page();
-        sanitized_urls.append(ak_string_from_qstring(new_tab_page));
-    }
     return sanitized_urls;
 }
 


### PR DESCRIPTION
The location bar URL is no longer hidden when creating a new tab or opening a new window that has an associated URL. Conversely, the location bar is now always focused and the URL hidden when creating a window or tab without an associated URL.

The location bar is focused when:
* Opening the browser from the command line with no URL arguments
* Opening a new tab (Ctrl+T)
* Opening a new window (Ctrl+N)

The location bar is not focused when:
* Opening the browser from the command line with one or more URLs
* Opening hyperlinks in a new tab
* Clicking a hyperlink with `target="_blank"`

This matches the behavior of other major browsers.

(cherry picked from commit efce3d967183f7071d47f27ce93310662217ef5e)

---

https://github.com/LadybirdBrowser/ladybird/pull/228