### PR TITLE
Cherry-pick "LibWeb: Don't extrapolate transition properties for unknown properties"

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAnimations/transition-unknown-property.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/transition-unknown-property.txt
@@ -1,0 +1,1 @@
+   PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/WebAnimations/transition-unknown-property.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/transition-unknown-property.html
@@ -1,0 +1,15 @@
+<style>
+#foo {
+    transition-property: filter;
+    transition-timing-function: linear;
+    transition-duration:.3s;
+}
+</style>
+<div id="foo"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        foo.offsetWidth;
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
If we don't recognize a given transition-property value as a known CSS property (one that we know about, not necessarily an invalid one), we should not extrapolate the other transition-foo values for it.

Fixes #1480

(cherry picked from commit 9765a733d0bc297815fc1a7fce562e3d8f69cd84)

---

https://github.com/LadybirdBrowser/ladybird/pull/1514