### PR TITLE
LibGfx+LibPDF: Add support for stroke dash patterns 

### DIFF
--- a/Tests/LibGfx/TestPath.cpp
+++ b/Tests/LibGfx/TestPath.cpp
@@ -115,6 +115,25 @@ TEST_CASE(path_to_fill_miter_linejoin)
     }
 }
 
+TEST_CASE(path_to_fill_dash)
+{
+    {
+        Gfx::Path path;
+        path.move_to({ 0, 0.5 });
+        path.line_to({ 13, 0.5 });
+        auto fill = path.stroke_to_fill({ .thickness = 1, .cap_style = Gfx::Path::CapStyle::Butt, .dash_pattern = { 3, 3 }, .dash_offset = 0 });
+        EXPECT_EQ(fill.to_byte_string(), "M 3,1 L 3,0 L 0,0 L 0,1 L 3,1 Z M 9,1 L 9,0 L 6,0 L 6,1 L 9,1 Z M 13,1 L 13,0 L 12,0 L 12,1 L 13,1 Z");
+    }
+
+    {
+        Gfx::Path path;
+        path.move_to({ 0, 0.5 });
+        path.line_to({ 13, 0.5 });
+        auto fill = path.stroke_to_fill({ .thickness = 1, .cap_style = Gfx::Path::CapStyle::Butt, .dash_pattern = { 2, 3 }, .dash_offset = 11 });
+        EXPECT_EQ(fill.to_byte_string(), "M 1,1 L 1,0 L 0,0 L 0,1 L 1,1 Z M 6,1 L 6,0 L 4,0 L 4,1 L 6,1 Z M 11,1 L 11,0 L 9,0 L 9,1 L 11,1 Z");
+    }
+}
+
 TEST_CASE(path_to_string)
 {
     {

--- a/Tests/LibPDF/paths.pdf
+++ b/Tests/LibPDF/paths.pdf
@@ -14,7 +14,7 @@ endobj
 endobj
 
 4 0 obj
-<</Length 2313>>
+<</Length 2981>>
 stream
 /DeviceRGB CS
 
@@ -210,10 +210,10 @@ q
 0 J
 2 j
 1 0 0 SC
-200 90 m
-230 50 l
-260 90 l
-200 90 l
+240 90 m
+270 50 l
+300 90 l
+240 90 l
 S
 Q
 
@@ -307,6 +307,71 @@ q
 S
 Q
 
+% PDF 1.7 spec, TABLE 4.6 Examples of line dash patterns
+
+q
+0 J
+1 0 0 SC
+3 0 0 3 100 60 cm
+1 w
+
+[] 0 d
+0 0 m 13 0 l S
+
+1 0 0 1 0 -3 cm
+[3] 0 d
+0 0 m 13 0 l S
+
+1 0 0 1 0 -3 cm
+[2] 1 d
+0 0 m 13 0 l S
+
+1 0 0 1 0 -3 cm
+[2 1] 0 d
+0 0 m 13 0 l S
+
+1 0 0 1 0 -3 cm
+[3 5] 6 d
+0 0 m 13 0 l S
+
+1 0 0 1 0 -3 cm
+[2 3] 11 d
+0 0 m 13 0 l S
+Q
+
+% Dashed rect with 0 dash length
+
+[ 0 10 ] 0 d
+1 J
+0 1 0 SC
+155 45 30 30 re
+S
+
+% Dashed rects with different cap styles. The last one also has a no-op negative
+% scale factor.
+
+1 w
+[ 2 2 ] 1 d
+0 J
+0 1 0 SC
+195 45 30 30 re
+S
+
+1 w
+[ 2 2 ] 1 d
+1 J
+0 1 0 SC
+155 5 30 30 re
+S
+
+-1 0 0 -1 0 0 cm
+1 w
+[ 2 2 ] 1 d
+2 J
+0 1 0 SC
+-195 -5 -30 -30 re
+S
+
 endstream
 endobj
 
@@ -321,5 +386,5 @@ xref
 trailer
 <</Size 5/Root 2 0 R>>
 startxref
-2568
+3236
 %%EOF

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -232,6 +232,9 @@ public:
         // The default value of 10 matches the PDF and <canvas> default value, which corresponds to 11.48 degrees.
         // (SVG uses a default of 4, which corresponds to 28.96 degrees.)
         float miter_limit { 10 };
+
+        Vector<float> dash_pattern {};
+        float dash_offset { 0 };
     };
     Path stroke_to_fill(StrokeStyle const&) const;
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -210,10 +210,10 @@ RENDERER_HANDLER(set_miter_limit)
 RENDERER_HANDLER(set_dash_pattern)
 {
     auto dash_array = MUST(m_document->resolve_to<ArrayObject>(args[0]));
-    Vector<int> pattern;
+    Vector<float> pattern;
     for (auto& element : *dash_array)
-        pattern.append(element.to_int());
-    state().line_dash_pattern = LineDashPattern { pattern, args[1].to_int() };
+        pattern.append(element.to_float());
+    state().line_dash_pattern = LineDashPattern { pattern, args[1].to_float() };
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -37,8 +37,8 @@ enum class LineJoinStyle : u8 {
 };
 
 struct LineDashPattern {
-    Vector<int> pattern;
-    int phase;
+    Vector<float> pattern;
+    float phase;
 };
 
 enum class TextRenderingMode : u8 {


### PR DESCRIPTION
This adds support for dash patterns to Path::stroke_to_fill().
This is used in PDFs, `<canvas>`, and `<svg>`.

The implementation is based on the <canvas> spec. It seems to do
the right thing for PDF files too.

This is hooked up in LibPDF. Future commits will do `<canvas>` and `<svg>`.