### PR TITLE
Kernel/aarch64: Don't use the memory before .text as the initial stack (+ some linker script fixes)

### DIFF
--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -182,25 +182,16 @@ static void build_mappings(PageBumpAllocator& allocator, u64* root_table)
     auto start_of_mmio_range = VirtualAddress(mmio_base + KERNEL_MAPPING_BASE);
     auto end_of_mmio_range = VirtualAddress(mmio_end + KERNEL_MAPPING_BASE);
 
-    // FIXME: don't use the memory before `start` as the initial stack
-    auto start_of_stack_range = start_of_kernel_range.offset(-128 * KiB);
-    auto end_of_stack_range = start_of_kernel_range;
-
     auto start_of_physical_kernel_range = PhysicalAddress(start_of_kernel_range.get()).offset(-calculate_physical_to_link_time_address_offset());
     auto start_of_physical_mmio_range = PhysicalAddress(mmio_base);
-    auto start_of_physical_stack_range = PhysicalAddress { start_of_stack_range.get() }.offset(-calculate_physical_to_link_time_address_offset());
 
     // Insert identity mappings
     insert_entries_for_memory_range(allocator, root_table, start_of_kernel_range.offset(-calculate_physical_to_link_time_address_offset()), end_of_kernel_range.offset(-calculate_physical_to_link_time_address_offset()), start_of_physical_kernel_range, normal_memory_flags);
     insert_entries_for_memory_range(allocator, root_table, VirtualAddress(mmio_base), VirtualAddress(mmio_end), start_of_physical_mmio_range, device_memory_flags);
-    insert_entries_for_memory_range(allocator, root_table, start_of_stack_range.offset(-calculate_physical_to_link_time_address_offset()), end_of_stack_range.offset(-calculate_physical_to_link_time_address_offset()), start_of_physical_stack_range, device_memory_flags);
 
     // Map kernel and MMIO into high virtual memory
     insert_entries_for_memory_range(allocator, root_table, start_of_kernel_range, end_of_kernel_range, start_of_physical_kernel_range, normal_memory_flags);
     insert_entries_for_memory_range(allocator, root_table, start_of_mmio_range, end_of_mmio_range, start_of_physical_mmio_range, device_memory_flags);
-
-    // Map the initial stack
-    insert_entries_for_memory_range(allocator, root_table, start_of_stack_range, end_of_stack_range, start_of_physical_stack_range, normal_memory_flags);
 }
 
 static void switch_to_page_table(u8* page_table)

--- a/Kernel/Arch/aarch64/boot.S
+++ b/Kernel/Arch/aarch64/boot.S
@@ -18,11 +18,9 @@ start:
   and x13, x13, 0xff
   cbnz x13, halt
 
-  // Let stack start before .text for now.
-  // 512 kiB (0x80000) of stack are probably not sufficient, especially once we give the other cores some stack too,
-  // but for now it's ok.
-  adrp x14, start
-  add x14, x14, :lo12:start
+  // Set the stack pointer register to the location defined in the linker script.
+  adrp x14, end_of_initial_stack
+  add x14, x14, :lo12:end_of_initial_stack
   mov sp, x14
 
   // Clear BSS.

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -19,6 +19,7 @@ SECTIONS
 
     .text ALIGN(4K) : AT (ADDR(.text))
     {
+        start_of_kernel_text = .;
         *(.text.first)
 
         start_of_safemem_text = .;
@@ -29,6 +30,7 @@ SECTIONS
         end_of_safemem_atomic_text = .;
 
         *(.text*)
+        end_of_kernel_text = .;
     } :text
 
     .driver_init ALIGN(4K) : AT (ADDR(.driver_init))
@@ -53,7 +55,9 @@ SECTIONS
 
     .data ALIGN(4K) : AT (ADDR(.data))
     {
+        start_of_kernel_data = .;
         *(.data*)
+        end_of_kernel_data = .;
     } :data
 
     .ksyms ALIGN(4K) : AT (ADDR(.ksyms))
@@ -85,14 +89,10 @@ SECTIONS
     */
 
     /* FIXME: Placeholder to satisfy linker */
-    start_of_kernel_text = .;
-    end_of_kernel_text = .;
     start_of_unmap_after_init = .;
     end_of_unmap_after_init = .;
     start_of_ro_after_init = .;
     end_of_ro_after_init = .;
-    start_of_kernel_data = .;
-    end_of_kernel_data = .;
 
     . = ALIGN(4K);
     page_tables_phys_start = .;

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -30,7 +30,6 @@ SECTIONS
         end_of_safemem_atomic_text = .;
 
         *(.text*)
-        end_of_kernel_text = .;
     } :text
 
     .driver_init ALIGN(4K) : AT (ADDR(.driver_init))
@@ -38,6 +37,15 @@ SECTIONS
         driver_init_table_start = .;
         *(.driver_init)
         driver_init_table_end = .;
+    } :text
+
+    .unmap_after_init ALIGN(4K) : AT (ADDR(.unmap_after_init))
+    {
+        start_of_unmap_after_init = .;
+        *(.unmap_after_init*);
+        end_of_unmap_after_init = .;
+
+        end_of_kernel_text = .;
     } :text
 
     .rodata ALIGN(4K) : AT (ADDR(.rodata))
@@ -58,6 +66,13 @@ SECTIONS
         start_of_kernel_data = .;
         *(.data*)
         end_of_kernel_data = .;
+    } :data
+
+    .ro_after_init ALIGN(4K) : AT(ADDR(.ro_after_init))
+    {
+        start_of_ro_after_init = .;
+        *(.ro_after_init);
+        end_of_ro_after_init = .;
     } :data
 
     .ksyms ALIGN(4K) : AT (ADDR(.ksyms))
@@ -87,12 +102,6 @@ SECTIONS
         FIXME: 8MB is enough space for all of the tables required to identity map
                physical memory. 8M is wasteful, so this should be properly calculated.
     */
-
-    /* FIXME: Placeholder to satisfy linker */
-    start_of_unmap_after_init = .;
-    end_of_unmap_after_init = .;
-    start_of_ro_after_init = .;
-    end_of_ro_after_init = .;
 
     . = ALIGN(4K);
     page_tables_phys_start = .;

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -5,10 +5,10 @@ KERNEL_MAPPING_BASE = 0x2000000000;
 /* TODO: Add FLAGS to the program headers */
 PHDRS
 {
-  text PT_LOAD ;
-  data PT_LOAD ;
-  ksyms PT_LOAD ;
-  bss PT_LOAD ;
+    text PT_LOAD ;
+    data PT_LOAD ;
+    ksyms PT_LOAD ;
+    bss PT_LOAD ;
 }
 
 SECTIONS
@@ -80,10 +80,10 @@ SECTIONS
     end_of_initial_stack = .;
 
     /*
-        FIXME: 8MB is enough space for all of the tables required to identity map 
+        FIXME: 8MB is enough space for all of the tables required to identity map
                physical memory. 8M is wasteful, so this should be properly calculated.
     */
-    
+
     /* FIXME: Placeholder to satisfy linker */
     start_of_kernel_text = .;
     end_of_kernel_text = .;
@@ -96,7 +96,7 @@ SECTIONS
 
     . = ALIGN(4K);
     page_tables_phys_start = .;
-    
+
     . += 8M;
     page_tables_phys_end = .;
 

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -73,6 +73,12 @@ SECTIONS
         *(.heap)
     } :bss
 
+    . = ALIGN(4K);
+    start_of_initial_stack = .;
+
+    . += 32K;
+    end_of_initial_stack = .;
+
     /*
         FIXME: 8MB is enough space for all of the tables required to identity map 
                physical memory. 8M is wasteful, so this should be properly calculated.

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -92,12 +92,10 @@ extern ctor_func_t end_ctors[];
 extern uintptr_t __stack_chk_guard;
 READONLY_AFTER_INIT uintptr_t __stack_chk_guard __attribute__((used));
 
-#if ARCH(X86_64)
 extern "C" u8 start_of_safemem_text[];
 extern "C" u8 end_of_safemem_text[];
 extern "C" u8 start_of_safemem_atomic_text[];
 extern "C" u8 end_of_safemem_atomic_text[];
-#endif
 
 extern "C" USB::DriverInitFunction driver_init_table_start[];
 extern "C" USB::DriverInitFunction driver_init_table_end[];
@@ -217,11 +215,11 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init([[maybe_
 
 #if ARCH(X86_64)
     MM.unmap_prekernel();
+#endif
 
     // Ensure that the safemem sections are not empty. This could happen if the linker accidentally discards the sections.
     VERIFY(+start_of_safemem_text != +end_of_safemem_text);
     VERIFY(+start_of_safemem_atomic_text != +end_of_safemem_atomic_text);
-#endif
 
     // Invoke all static global constructors in the kernel.
     // Note that we want to do this as early as possible.

--- a/Kernel/Arch/x86_64/linker.ld
+++ b/Kernel/Arch/x86_64/linker.ld
@@ -6,13 +6,13 @@ ENTRY(init)
 
 PHDRS
 {
-  elf_headers PT_LOAD FILEHDR PHDRS FLAGS(PF_R) ;
-  text PT_LOAD FLAGS(PF_R | PF_X) ;
-  data PT_LOAD FLAGS(PF_R | PF_W) ;
-  bss PT_LOAD FLAGS(PF_R | PF_W) ;
-  dynamic_segment PT_LOAD FLAGS(PF_R | PF_W) ;
-  dynamic PT_DYNAMIC FLAGS(PF_R | PF_W) ;
-  ksyms PT_LOAD FLAGS(PF_R) ;
+    elf_headers PT_LOAD FILEHDR PHDRS FLAGS(PF_R) ;
+    text PT_LOAD FLAGS(PF_R | PF_X) ;
+    data PT_LOAD FLAGS(PF_R | PF_W) ;
+    bss PT_LOAD FLAGS(PF_R | PF_W) ;
+    dynamic_segment PT_LOAD FLAGS(PF_R | PF_W) ;
+    dynamic PT_DYNAMIC FLAGS(PF_R | PF_W) ;
+    ksyms PT_LOAD FLAGS(PF_R) ;
 }
 
 SECTIONS


### PR DESCRIPTION
This moves the initial aarch64 stack similar to how #23205 moved it for RISC-V.

I also included some small improvements to the aarch64 linker script while I'm here.