### PR TITLE
Meta: Add a virtio-serial device to the RISC-V machine

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -747,6 +747,7 @@ def set_up_machine_devices(config: Configuration):
             [
                 "virtio-keyboard",
                 "virtio-tablet",
+                "virtio-serial,max_ports=2",
             ]
         )
         return


### PR DESCRIPTION
This unbreaks `Meta/serenity.sh run riscv64`, since 36a2826 enabled SPICE by default (which requires a virtio-serial device).