### PR TITLE
Cherry-pick "LibWeb/DOM: Implement Node.lookupPrefix", reloaded

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Node-lookupPrefix.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Node-lookupPrefix.txt
@@ -1,0 +1,9 @@
+Prefix for namespace "test" on document: ex
+Prefix for namespace "test" on document fragment: null
+Prefix for namespace "test" on comment node 0: ex
+Prefix null on document: null
+Prefix for absent namespace "no" on document: null
+Prefix for namespace "def" on child: abc
+Prefix null on child: null
+Prefix for namespace "test" (in parent) on child: ex
+Prefix for namespace "def" (from attribute "x") on child: abc

--- a/Tests/LibWeb/Text/input/DOM/Node-lookupPrefix.html
+++ b/Tests/LibWeb/Text/input/DOM/Node-lookupPrefix.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const xmlDoc = new DOMParser().parseFromString(`<root xmlns:ex="test"><!--abc--><child xmlns:abc="def" x="1"></child></root>`, "application/xml");
+        const fragment = document.createDocumentFragment();
+        println(`Prefix for namespace "test" on document: ${xmlDoc.lookupPrefix("test")}`);
+        println(`Prefix for namespace "test" on document fragment: ${fragment.lookupPrefix("test")}`);
+        println(`Prefix for namespace "test" on comment node 0: ${xmlDoc.childNodes[0].lookupPrefix("test")}`);
+        println(`Prefix null on document: ${xmlDoc.lookupPrefix(null)}`);
+        println(`Prefix for absent namespace "no" on document: ${xmlDoc.lookupPrefix("no")}`);
+
+        const child = xmlDoc.querySelector("child");
+        println(`Prefix for namespace "def" on child: ${child.lookupPrefix("def")}`);
+        println(`Prefix null on child: ${child.lookupPrefix(null)}`);
+        println(`Prefix for namespace "test" (in parent) on child: ${child.lookupPrefix("test")}`);
+
+        const attrX = child.getAttributeNode("x");
+        println(`Prefix for namespace "def" (from attribute "x") on child: ${attrX.lookupPrefix("def")}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2216,6 +2216,30 @@ void Element::set_prefix(Optional<FlyString> value)
     m_qualified_name.set_prefix(move(value));
 }
 
+// https://dom.spec.whatwg.org/#locate-a-namespace-prefix
+Optional<String> Element::locate_a_namespace_prefix(Optional<String> const& namespace_) const
+{
+    // 1. If element’s namespace is namespace and its namespace prefix is non-null, then return its namespace prefix.
+    if (this->namespace_uri() == namespace_ && this->prefix().has_value())
+        return this->prefix()->to_string();
+
+    // 2. If element has an attribute whose namespace prefix is "xmlns" and value is namespace, then return element’s first such attribute’s local name.
+    if (auto* attributes = this->attributes()) {
+        for (size_t i = 0; i < attributes->length(); ++i) {
+            auto& attr = *attributes->item(i);
+            if (attr.prefix() == "xmlns" && attr.value() == namespace_)
+                return attr.local_name().to_string();
+        }
+    }
+
+    // 3. If element’s parent element is not null, then return the result of running locate a namespace prefix on that element using namespace.
+    if (auto* parent = this->parent_element())
+        return parent->locate_a_namespace_prefix(namespace_);
+
+    // 4. Return null
+    return {};
+}
+
 void Element::for_each_attribute(Function<void(Attr const&)> callback) const
 {
     for (size_t i = 0; i < m_attributes->length(); ++i)

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -106,6 +106,8 @@ public:
 
     void set_prefix(Optional<FlyString> value);
 
+    Optional<String> locate_a_namespace_prefix(Optional<String> const& namespace_) const;
+
     // NOTE: This is for the JS bindings
     Optional<FlyString> const& namespace_uri() const { return m_qualified_name.namespace_(); }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -732,6 +732,7 @@ public:
 
     Optional<String> locate_a_namespace(Optional<String> const& prefix) const;
     Optional<String> lookup_namespace_uri(Optional<String> prefix) const;
+    Optional<String> lookup_prefix(Optional<String> namespace_) const;
     bool is_default_namespace(Optional<String> namespace_) const;
 
 protected:

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -54,7 +54,7 @@ interface Node : EventTarget {
     unsigned short compareDocumentPosition(Node? otherNode);
     boolean contains(Node? other);
 
-    [FIXME] DOMString? lookupPrefix(DOMString? namespace);
+    DOMString? lookupPrefix(DOMString? namespace);
     DOMString? lookupNamespaceURI(DOMString? prefix);
     boolean isDefaultNamespace(DOMString? namespace);
 


### PR DESCRIPTION
https://github.com/LadybirdBrowser/ladybird/pull/870

Previously at #24859, but back then the new test didn't pass yet. Now it does.