### PR TITLE
text pr (LibWebView: Do floating-point-error-free zoom calculation using rounding)

### DIFF
--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -104,7 +104,7 @@ void ViewImplementation::zoom_in()
 {
     if (m_zoom_level >= ZOOM_MAX_LEVEL)
         return;
-    m_zoom_level += ZOOM_STEP;
+    m_zoom_level = round_to<int>((m_zoom_level + ZOOM_STEP) * 100) / 100.0f;
     update_zoom();
 }
 
@@ -112,7 +112,7 @@ void ViewImplementation::zoom_out()
 {
     if (m_zoom_level <= ZOOM_MIN_LEVEL)
         return;
-    m_zoom_level -= ZOOM_STEP;
+    m_zoom_level = round_to<int>((m_zoom_level - ZOOM_STEP) * 100) / 100.0f;
     update_zoom();
 }
 


### PR DESCRIPTION
The current min/max zoom levels are supposed to be: 30% and 500%. Before, due to floating point error accumulation in incremental addition of zoom-step into zoom-level, one extra zoom step would get allowed, enabling user to zoom 20%-to-510%.

Now, using rounding, the intermediate zoom-level values should be as close to the theoretical value as FP32 can represent. E.g. zoom-level of 70% (theoretical multiplier 0.7) is 0.69... .

(cherry picked from commit 96335f31d5a8c6180a4cc0254585bc01ba6742fa)