### PR TITLE
Jakt fixes

### DIFF
--- a/Meta/CMake/jakt.cmake
+++ b/Meta/CMake/jakt.cmake
@@ -23,10 +23,10 @@ if(${PROJECT_NAME} STREQUAL "Lagom")
     set(JAKT_TARGET_TRIPLE ${arch}-unknown-${os}-unknown)
     set(JAKT_LIBRARY_BASE "${SerenityOS_SOURCE_DIR}/Toolchain/Local/jakt/lib")
 else()
-    set(JAKT_LIBRARY_BASE "${CMAKE_SYSROOT}/usr/local/lib")
+    set(JAKT_LIBRARY_BASE "${SerenityOS_SOURCE_DIR}/Toolchain/Local/jakt/usr/local/lib")
 endif()
 set(JAKT_LIBRARY_DIR "${JAKT_LIBRARY_BASE}/${JAKT_TARGET_TRIPLE}")
-set(JAKT_INCLUDE_DIR "${CMAKE_SYSROOT}/usr/local/include/runtime")
+set(JAKT_INCLUDE_DIR "${SerenityOS_SOURCE_DIR}/Toolchain/Local/jakt/usr/local/include/runtime")
 
 # Make sure the jakt compiler:
 # - exists

--- a/Toolchain/BuildJakt.sh
+++ b/Toolchain/BuildJakt.sh
@@ -255,15 +255,15 @@ build_for() {
 
         buildstep "jakt/support/build/$TOOLCHAIN" "$PREFIX/bin/jakt" cross \
                                                             --only-support-libs \
-                                                            --install-root "$SYSROOT/usr/local" \
+                                                            --install-root "$PREFIX/usr/local" \
                                                             --target-triple "$JAKT_TARGET" \
                                                             --target-links-ak \
                                                             -C "$TARGET_CXX" \
                                                             -O \
                                                             -J "$NPROC"
 
-        buildstep "jakt/support/build/$TOOLCHAIN/ranlib" "$TARGET_RANLIB" "$SYSROOT/usr/local/lib/$JAKT_TARGET/libjakt_runtime_$JAKT_TARGET.a"
-        buildstep "jakt/support/build/$TOOLCHAIN/ranlib" "$TARGET_RANLIB" "$SYSROOT/usr/local/lib/$JAKT_TARGET/libjakt_main_$JAKT_TARGET.a"
+        buildstep "jakt/support/build/$TOOLCHAIN/ranlib" "$TARGET_RANLIB" "$PREFIX/usr/local/lib/$JAKT_TARGET/libjakt_runtime_$JAKT_TARGET.a"
+        buildstep "jakt/support/build/$TOOLCHAIN/ranlib" "$TARGET_RANLIB" "$PREFIX/usr/local/lib/$JAKT_TARGET/libjakt_main_$JAKT_TARGET.a"
     popd
 }
 

--- a/Userland/Libraries/LibShell/Shell.h
+++ b/Userland/Libraries/LibShell/Shell.h
@@ -29,6 +29,7 @@
     __ENUMERATE_SHELL_BUILTIN(where, InAllModes)             \
     __ENUMERATE_SHELL_BUILTIN(cd, InAllModes)                \
     __ENUMERATE_SHELL_BUILTIN(cdh, InAllModes)               \
+    __ENUMERATE_SHELL_BUILTIN(command, InAllModes)           \
     __ENUMERATE_SHELL_BUILTIN(pwd, InAllModes)               \
     __ENUMERATE_SHELL_BUILTIN(type, InAllModes)              \
     __ENUMERATE_SHELL_BUILTIN(exec, InAllModes)              \


### PR DESCRIPTION
Unrelated Shell commit, plus fix for `serenity.sh recreate` deleting the jakt runtime with no way to get it back automatically.