### PR TITLE
Games/BrickGame: Bind `Key_Z` to rotate left

### DIFF
--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -532,6 +532,7 @@ void BrickGame::keydown_event(GUI::KeyEvent& event)
         render_request = m_brick_game->rotate_right();
         break;
     case KeyCode::Key_E:
+    case KeyCode::Key_Z:
         render_request = m_brick_game->rotate_left();
         break;
     case KeyCode::Key_S:


### PR DESCRIPTION
This is for people who prefer to play with the arrow keys.

Using Z for rotating the piece left is also the default binding on [tetris.com](https://tetris.com).

![image](https://github.com/user-attachments/assets/88cfea4e-3f61-4bdd-a756-530905132dc8)
