### PR TITLE
Cherry-pick "LibWeb: Stub out SVGGraphicsElement.getScreenCTM()"

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -316,4 +316,10 @@ JS::NonnullGCPtr<SVGAnimatedTransformList> SVGGraphicsElement::transform() const
     return SVGAnimatedTransformList::create(realm(), base_val, anim_val);
 }
 
+JS::GCPtr<Geometry::DOMMatrix> SVGGraphicsElement::get_screen_ctm()
+{
+    dbgln("(STUBBED) SVGGraphicsElement::get_screen_ctm(). Called on: {}", debug_description());
+    return Geometry::DOMMatrix::create(realm());
+}
+
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -63,6 +63,8 @@ public:
     JS::NonnullGCPtr<Geometry::DOMRect> get_b_box(Optional<SVGBoundingBoxOptions>);
     JS::NonnullGCPtr<SVGAnimatedTransformList> transform() const;
 
+    JS::GCPtr<Geometry::DOMMatrix> get_screen_ctm();
+
 protected:
     SVGGraphicsElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.idl
@@ -15,5 +15,5 @@ interface SVGGraphicsElement : SVGElement {
 
     DOMRect getBBox(optional SVGBoundingBoxOptions options = {});
     [FIXME] DOMMatrix? getCTM();
-    [FIXME] DOMMatrix? getScreenCTM();
+    DOMMatrix? getScreenCTM();
 };


### PR DESCRIPTION
This allows us to run Speedometer 3.0 to completion. :^)

(cherry picked from commit 72320be1240039822693aa1659c4adbb24cde87f)

---

Another sneaky PR-less commit, https://github.com/LadybirdBrowser/ladybird/commit/72320be1240039822693aa1659c4adbb24cde87f