### PR TITLE
Terminal: Add option to change font size independently of window size

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -55,6 +55,8 @@ public:
                 m_parent_terminal.set_show_scrollbar(value);
             else if (key == "ConfirmClose" && on_confirm_close_changed)
                 on_confirm_close_changed(value);
+            else if (key == "ResizeOnZoom")
+                m_parent_terminal.set_resize_on_zoom(value);
         } else if (group == "Cursor" && key == "Blinking") {
             m_parent_terminal.set_cursor_blinking(value);
         }
@@ -413,9 +415,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto& font = terminal->font();
         auto new_size = max(5, font.presentation_size() + adjustment);
         if (auto new_font = Gfx::FontDatabase::the().get(font.family(), new_size, font.weight(), font.width(), font.slope(), preference)) {
-            terminal->set_font_and_resize_to_fit(*new_font);
-            terminal->apply_size_increments_to_window(*window);
-            window->resize(terminal->size());
+            if (terminal->should_resize_on_zoom()) {
+                terminal->set_font_and_resize_to_fit(*new_font);
+                terminal->apply_size_increments_to_window(*window);
+                window->resize(terminal->size());
+            } else {
+                terminal->set_font(*new_font);
+                terminal->apply_size_increments_to_window(*window);
+            }
         }
     };
 

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -106,6 +106,15 @@ ErrorOr<void> MainWidget::setup()
         set_modified(true);
     };
     confirm_close_checkbox.set_checked(m_confirm_close, GUI::AllowCallback::No);
+
+    m_window_resize_on_zoom = Config::read_bool("Terminal"sv, "Terminal"sv, "ResizeOnZoom"sv, true);
+    auto& window_resize_on_zoom_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("window_resize_on_zoom");
+    window_resize_on_zoom_checkbox.on_checked = [&](bool window_resize_on_zoom) {
+        m_window_resize_on_zoom = window_resize_on_zoom;
+        Config::write_bool("Terminal"sv, "Terminal"sv, "ResizeOnZoom"sv, window_resize_on_zoom);
+        set_modified(true);
+    };
+    window_resize_on_zoom_checkbox.set_checked(m_window_resize_on_zoom, GUI::AllowCallback::No);
     return {};
 }
 
@@ -120,6 +129,7 @@ void MainWidget::write_back_settings() const
     Config::write_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, m_orignal_confirm_close);
     Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_original_bell_mode));
     Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
+    Config::write_bool("Terminal"sv, "Terminal"sv, "ResizeOnZoom"sv, m_window_resize_on_zoom);
 }
 
 void MainWidget::cancel_settings()

--- a/Userland/Applications/TerminalSettings/MainWidget.h
+++ b/Userland/Applications/TerminalSettings/MainWidget.h
@@ -35,5 +35,7 @@ private:
     VT::TerminalWidget::BellMode m_original_bell_mode;
     VT::TerminalWidget::AutoMarkMode m_original_automark_mode;
     bool m_orignal_confirm_close { true };
+
+    bool m_window_resize_on_zoom;
 };
 }

--- a/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
@@ -66,4 +66,17 @@
             text: "Auto-mark on interactive shell prompts"
         }
     }
+
+    @GUI::GroupBox {
+        title: "Window resize"
+        preferred_height: "fit"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [8]
+        }
+
+        @GUI::CheckBox {
+            name: "window_resize_on_zoom"
+            text: "Resize the window on zoom in/out"
+        }
+    }
 }

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -136,6 +136,8 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy)
 
     m_terminal.set_size(Config::read_i32("Terminal"sv, "Window"sv, "Width"sv, 80), Config::read_i32("Terminal"sv, "Window"sv, "Height"sv, 25));
 
+    m_resize_on_zoom = Config::read_bool("Terminal"sv, "Terminal"sv, "ResizeOnZoom"sv, true);
+
     m_copy_action = GUI::Action::create("&Copy", { Mod_Ctrl | Mod_Shift, Key_C }, Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"sv).release_value_but_fixme_should_propagate_errors(), [this](auto&) {
         copy();
     });

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -121,6 +121,9 @@ public:
     static ByteString stringify_bell(BellMode);
     static ByteString stringify_automark_mode(AutoMarkMode);
 
+    bool should_resize_on_zoom() const { return m_resize_on_zoom; }
+    void set_resize_on_zoom(bool value) { m_resize_on_zoom = value; }
+
 private:
     TerminalWidget(int ptm_fd, bool automatic_size_policy);
 
@@ -262,6 +265,8 @@ private:
 
     bool m_startup_process_owns_pty { false };
     pid_t m_startup_process_id { -1 };
+
+    bool m_resize_on_zoom { true };
 };
 
 }


### PR DESCRIPTION
Introduced a new option in the Terminal application to adjust the font size without affecting the window dimensions.

Demo:

![TerminalResize](https://github.com/user-attachments/assets/edc37003-c6cb-4b9d-b21b-d8e391a83f9a)
