### PR TITLE
Terminal: Set alpha channel to 0xFF

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -89,8 +89,9 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy)
     : m_terminal(*this)
     , m_automatic_size_policy(automatic_size_policy)
 {
-    static_assert(sizeof(m_colors) == sizeof(xterm_colors));
-    memcpy(m_colors, xterm_colors, sizeof(m_colors));
+    VERIFY(m_colors.size() == xterm_colors.size());
+    for (size_t i = 0; i < xterm_colors.size(); i++)
+        m_colors[i] = Gfx::Color::from_rgb(xterm_colors[i]);
 
     set_override_cursor(Gfx::StandardCursor::IBeam);
     set_focus_policy(GUI::FocusPolicy::StrongFocus);

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -195,7 +195,7 @@ private:
     // Snapshot of m_hovered_href when opening a context menu for a hyperlink.
     ByteString m_context_menu_href;
 
-    Gfx::Color m_colors[256];
+    Array<Gfx::Color, 256> m_colors;
     Gfx::Color m_default_foreground_color;
     Gfx::Color m_default_background_color;
     bool m_show_bold_text_as_bright { true };

--- a/Userland/Libraries/LibVT/XtermColors.h
+++ b/Userland/Libraries/LibVT/XtermColors.h
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
+
 #pragma once
 
-static constexpr unsigned xterm_colors[256] = {
+static constexpr Array<unsigned, 256> xterm_colors = to_array<unsigned>({
     0x000000,
     0xcc0000,
     0x3e9a06,
@@ -263,4 +265,4 @@ static constexpr unsigned xterm_colors[256] = {
     0xdadada,
     0xe4e4e4,
     0xeeeeee,
-};
+});


### PR DESCRIPTION
This fixes a bug where `VT::Color::Kind::Indexed` colors from index 16 to 255 were not being rendered because their alpha channel was set to zero.

Before:
![XTermColors](https://github.com/user-attachments/assets/e7aec7b9-23f9-4068-9c34-2d277278698d)

After:
![image](https://github.com/user-attachments/assets/4aa784ef-d301-4cfa-b0a0-20a0aa810614)

Testing script:

```python
for i in range(16, 256):
   print(f"Index: {i}: \033[38;5;{i}mWHF :^)\033[0m")
```

