### PR TITLE
TerminalSettings: Optimize TerminalSettings config writes and fix cancel behavior for `m_automark_mode`

### DIFF
--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -63,17 +63,14 @@ ErrorOr<void> MainWidget::setup()
 
     beep_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::AudibleBeep;
-        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_bell_mode));
         set_modified(true);
     };
     visual_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::Visible;
-        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_bell_mode));
         set_modified(true);
     };
     no_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::Disabled;
-        Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_bell_mode));
         set_modified(true);
     };
 
@@ -88,12 +85,10 @@ ErrorOr<void> MainWidget::setup()
 
     automark_off_radio.on_checked = [this](bool) {
         m_automark_mode = VT::TerminalWidget::AutoMarkMode::MarkNothing;
-        Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
         set_modified(true);
     };
     automark_on_interactive_prompt_radio.on_checked = [this](bool) {
         m_automark_mode = VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt;
-        Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
         set_modified(true);
     };
 
@@ -102,7 +97,6 @@ ErrorOr<void> MainWidget::setup()
     auto& confirm_close_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("terminal_confirm_close");
     confirm_close_checkbox.on_checked = [&](bool confirm_close) {
         m_confirm_close = confirm_close;
-        Config::write_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, confirm_close);
         set_modified(true);
     };
     confirm_close_checkbox.set_checked(m_confirm_close, GUI::AllowCallback::No);

--- a/Userland/Applications/TerminalSettings/MainWidget.cpp
+++ b/Userland/Applications/TerminalSettings/MainWidget.cpp
@@ -113,13 +113,14 @@ void MainWidget::apply_settings()
 {
     m_original_bell_mode = m_bell_mode;
     m_orignal_confirm_close = m_confirm_close;
+    m_original_automark_mode = m_automark_mode;
     write_back_settings();
 }
 void MainWidget::write_back_settings() const
 {
     Config::write_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, m_orignal_confirm_close);
     Config::write_string("Terminal"sv, "Window"sv, "Bell"sv, VT::TerminalWidget::stringify_bell(m_original_bell_mode));
-    Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_automark_mode));
+    Config::write_string("Terminal"sv, "Terminal"sv, "AutoMark"sv, VT::TerminalWidget::stringify_automark_mode(m_original_automark_mode));
 }
 
 void MainWidget::cancel_settings()


### PR DESCRIPTION
Before:
![TerminalSettingsBug](https://github.com/user-attachments/assets/5fe1ebe4-0d6f-4446-9d31-539459d2f103)
After:
![TerminalSettingsBugFix](https://github.com/user-attachments/assets/a185806b-84be-429a-865d-7c94f0732aad)
