### PR TITLE
Cherry-pick "HTMLEncodingDetection: Use mime type in encoding sniffing"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -19,6 +19,7 @@ bool prescan_skip_whitespace_and_slashes(ByteBuffer const& input, size_t& positi
 Optional<StringView> extract_character_encoding_from_meta_element(ByteString const&);
 JS::GCPtr<DOM::Attr> prescan_get_attribute(DOM::Document&, ByteBuffer const& input, size_t& position);
 Optional<ByteString> run_prescan_byte_stream_algorithm(DOM::Document&, ByteBuffer const& input);
-ByteString run_encoding_sniffing_algorithm(DOM::Document&, ByteBuffer const& input);
+Optional<ByteString> run_bom_sniff(ByteBuffer const& input);
+ByteString run_encoding_sniffing_algorithm(DOM::Document&, ByteBuffer const& input, Optional<MimeSniff::MimeType> maybe_mime_type = {});
 
 }


### PR DESCRIPTION
Also added proper spec comments.
Fixes at least one WPT test that was failing previously: https://wpt.live/encoding/single-byte-decoder.window.html?document

(cherry picked from commit c1a14f66adf4b5e55a0e2a78068749e7d8b3ed98)

---

https://github.com/LadybirdBrowser/ladybird/pull/1707