### PR TITLE
Everywhere: Convert from_string_view -> from_string_literal where static

### DIFF
--- a/Ladybird/Qt/AutoComplete.cpp
+++ b/Ladybird/Qt/AutoComplete.cpp
@@ -41,18 +41,18 @@ AutoComplete::AutoComplete(QWidget* parent)
 ErrorOr<Vector<String>> AutoComplete::parse_google_autocomplete(Vector<JsonValue> const& json)
 {
     if (json.size() != 5)
-        return Error::from_string_view("Invalid JSON, expected 5 elements in array"sv);
+        return Error::from_string_literal("Invalid JSON, expected 5 elements in array");
 
     if (!json[0].is_string())
-        return Error::from_string_view("Invalid JSON, expected first element to be a string"sv);
+        return Error::from_string_literal("Invalid JSON, expected first element to be a string");
     auto query = TRY(String::from_byte_string(json[0].as_string()));
 
     if (!json[1].is_array())
-        return Error::from_string_view("Invalid JSON, expected second element to be an array"sv);
+        return Error::from_string_literal("Invalid JSON, expected second element to be an array");
     auto suggestions_array = json[1].as_array().values();
 
     if (query != m_query)
-        return Error::from_string_view("Invalid JSON, query does not match"sv);
+        return Error::from_string_literal("Invalid JSON, query does not match");
 
     Vector<String> results;
     results.ensure_capacity(suggestions_array.size());
@@ -86,13 +86,13 @@ ErrorOr<Vector<String>> AutoComplete::parse_yahoo_autocomplete(JsonObject const&
     auto suggestions_object = json.get("r"sv)->as_array().values();
 
     if (query != m_query)
-        return Error::from_string_view("Invalid JSON, query does not match"sv);
+        return Error::from_string_literal("Invalid JSON, query does not match");
 
     Vector<String> results;
     results.ensure_capacity(suggestions_object.size());
     for (auto& suggestion_object : suggestions_object) {
         if (!suggestion_object.is_object())
-            return Error::from_string_view("Invalid JSON, expected value to be an object"sv);
+            return Error::from_string_literal("Invalid JSON, expected value to be an object");
         auto suggestion = suggestion_object.as_object();
 
         if (!suggestion.get("k"sv).has_value() || !suggestion.get("k"sv)->is_string())
@@ -121,7 +121,7 @@ ErrorOr<void> AutoComplete::got_network_response(QNetworkReply* reply)
     } else if (engine_name == "Yahoo")
         results = TRY(parse_yahoo_autocomplete(json.as_object()));
     else {
-        return Error::from_string_view("Invalid engine name"sv);
+        return Error::from_string_literal("Invalid engine name");
     }
 
     constexpr size_t MAX_AUTOCOMPLETE_RESULTS = 6;

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<ByteString> find_certificates(StringView serenity_resource_root)
 {
     auto cert_path = ByteString::formatted("{}/ladybird/cacert.pem", serenity_resource_root);
     if (!FileSystem::exists(cert_path))
-        return Error::from_string_view("Don't know how to load certs!"sv);
+        return Error::from_string_literal("Don't know how to load certs!");
     return cert_path;
 }
 

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -362,7 +362,7 @@ TEST_CASE(fallible_json_object_for_each)
     }));
 
     auto result1 = object.try_for_each_member([](auto const&, auto const&) -> ErrorOr<void> {
-        return Error::from_string_view("nanananana"sv);
+        return Error::from_string_literal("nanananana");
     });
     EXPECT(result1.is_error());
     EXPECT_EQ(result1.error().string_literal(), "nanananana"sv);
@@ -402,7 +402,7 @@ TEST_CASE(fallible_json_array_for_each)
     }));
 
     auto result1 = array.try_for_each([](auto const&) -> ErrorOr<void> {
-        return Error::from_string_view("nanananana"sv);
+        return Error::from_string_literal("nanananana");
     });
     EXPECT(result1.is_error());
     EXPECT_EQ(result1.error().string_literal(), "nanananana"sv);

--- a/Userland/Libraries/LibAudio/FlacWriter.cpp
+++ b/Userland/Libraries/LibAudio/FlacWriter.cpp
@@ -40,7 +40,7 @@ FlacWriter::~FlacWriter()
 ErrorOr<void> FlacWriter::finalize()
 {
     if (m_state == WriteState::FullyFinalized)
-        return Error::from_string_view("File is already finalized"sv);
+        return Error::from_string_literal("File is already finalized");
 
     if (m_state == WriteState::HeaderUnwritten)
         TRY(finalize_header_format());
@@ -74,7 +74,7 @@ ErrorOr<void> FlacWriter::finalize()
 ErrorOr<void> FlacWriter::finalize_header_format()
 {
     if (m_state != WriteState::HeaderUnwritten)
-        return Error::from_string_view("Header format is already finalized"sv);
+        return Error::from_string_literal("Header format is already finalized");
     TRY(write_header());
     m_state = WriteState::FormatFinalized;
     return {};
@@ -83,9 +83,9 @@ ErrorOr<void> FlacWriter::finalize_header_format()
 ErrorOr<void> FlacWriter::set_num_channels(u8 num_channels)
 {
     if (m_state != WriteState::HeaderUnwritten)
-        return Error::from_string_view("Header format is already finalized"sv);
+        return Error::from_string_literal("Header format is already finalized");
     if (num_channels > 8)
-        return Error::from_string_view("FLAC doesn't support more than 8 channels"sv);
+        return Error::from_string_literal("FLAC doesn't support more than 8 channels");
 
     m_num_channels = num_channels;
     return {};
@@ -94,7 +94,7 @@ ErrorOr<void> FlacWriter::set_num_channels(u8 num_channels)
 ErrorOr<void> FlacWriter::set_sample_rate(u32 sample_rate)
 {
     if (m_state != WriteState::HeaderUnwritten)
-        return Error::from_string_view("Header format is already finalized"sv);
+        return Error::from_string_literal("Header format is already finalized");
 
     m_sample_rate = sample_rate;
     return {};
@@ -103,9 +103,9 @@ ErrorOr<void> FlacWriter::set_sample_rate(u32 sample_rate)
 ErrorOr<void> FlacWriter::set_bits_per_sample(u16 bits_per_sample)
 {
     if (m_state != WriteState::HeaderUnwritten)
-        return Error::from_string_view("Header format is already finalized"sv);
+        return Error::from_string_literal("Header format is already finalized");
     if (bits_per_sample < 8 || bits_per_sample > 32)
-        return Error::from_string_view("FLAC only supports bits per sample between 8 and 32"sv);
+        return Error::from_string_literal("FLAC only supports bits per sample between 8 and 32");
 
     m_bits_per_sample = bits_per_sample;
     return {};
@@ -246,7 +246,7 @@ ErrorOr<void> FlacWriter::write_header()
 ErrorOr<void> FlacWriter::add_metadata_block(FlacRawMetadataBlock block, Optional<size_t> insertion_index)
 {
     if (m_state != WriteState::HeaderUnwritten)
-        return Error::from_string_view("Metadata blocks can only be added before the header is finalized"sv);
+        return Error::from_string_literal("Metadata blocks can only be added before the header is finalized");
 
     if (insertion_index.has_value())
         TRY(m_cached_metadata_blocks.try_insert(insertion_index.value(), move(block)));
@@ -260,11 +260,11 @@ ErrorOr<void> FlacWriter::write_metadata_block(FlacRawMetadataBlock& block)
 {
     if (m_state == WriteState::FormatFinalized) {
         if (!m_last_padding.has_value())
-            return Error::from_string_view("No (more) padding available to write block into"sv);
+            return Error::from_string_literal("No (more) padding available to write block into");
 
         auto const last_padding = m_last_padding.release_value();
         if (block.length > last_padding.size)
-            return Error::from_string_view("Late metadata block doesn't fit in available padding"sv);
+            return Error::from_string_literal("Late metadata block doesn't fit in available padding");
 
         auto const current_position = TRY(m_stream->tell());
         ScopeGuard guard = [&] { (void)m_stream->seek(current_position, SeekMode::SetPosition); };
@@ -294,7 +294,7 @@ ErrorOr<void> FlacWriter::write_metadata_block(FlacRawMetadataBlock& block)
             };
             TRY(m_stream->write_value(new_padding_block));
         } else if (new_size != 0) {
-            return Error::from_string_view("Remaining padding is not divisible by 4, there will be some stray zero bytes!"sv);
+            return Error::from_string_literal("Remaining padding is not divisible by 4, there will be some stray zero bytes!");
         }
 
         return {};
@@ -482,7 +482,7 @@ ErrorOr<void> FlacFrameHeader::write_to_stream(Stream& stream) const
 ErrorOr<void> FlacWriter::write_samples(ReadonlySpan<Sample> samples)
 {
     if (m_state == WriteState::FullyFinalized)
-        return Error::from_string_view("File is already finalized"sv);
+        return Error::from_string_literal("File is already finalized");
 
     auto remaining_samples = samples;
     while (remaining_samples.size() > 0) {

--- a/Userland/Libraries/LibAudio/MultiChannel.h
+++ b/Userland/Libraries/LibAudio/MultiChannel.h
@@ -26,7 +26,7 @@ template<ArrayLike<i64> ChannelType, ArrayLike<ChannelType> InputType>
 ErrorOr<FixedArray<Sample>> downmix_surround_to_stereo(InputType const& input, float sample_scale_factor)
 {
     if (input.size() == 0)
-        return Error::from_string_view("Cannot resample from 0 channels"sv);
+        return Error::from_string_literal("Cannot resample from 0 channels");
 
     auto channel_count = input.size();
     auto sample_count = input[0].size();
@@ -94,7 +94,7 @@ ErrorOr<FixedArray<Sample>> downmix_surround_to_stereo(InputType const& input, f
         }
         break;
     default:
-        return Error::from_string_view("Invalid number of channels greater than 8"sv);
+        return Error::from_string_literal("Invalid number of channels greater than 8");
     }
 
     return output;

--- a/Userland/Libraries/LibAudio/VorbisComment.cpp
+++ b/Userland/Libraries/LibAudio/VorbisComment.cpp
@@ -33,7 +33,7 @@ static ErrorOr<void> read_vorbis_field(Metadata& metadata_to_write_into, String 
     auto field_name_and_contents = TRY(unparsed_user_comment.split_limit('=', 2));
 
     if (field_name_and_contents.size() != 2)
-        return Error::from_string_view("User comment does not contain '='"sv);
+        return Error::from_string_literal("User comment does not contain '='");
     auto contents = field_name_and_contents.take_last();
     auto field_name = TRY(field_name_and_contents.take_first().to_uppercase());
 

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -292,7 +292,7 @@ ErrorOr<bool> Process::is_being_debugged()
 #    endif
 #endif
     // FIXME: Implement this for more platforms.
-    return Error::from_string_view("Platform does not support checking for debugger"sv);
+    return Error::from_string_literal("Platform does not support checking for debugger");
 }
 
 // Forces the process to sleep until a debugger is attached, then breaks.

--- a/Userland/Libraries/LibCore/ResourceImplementation.cpp
+++ b/Userland/Libraries/LibCore/ResourceImplementation.cpp
@@ -59,7 +59,7 @@ ErrorOr<NonnullRefPtr<Resource>> ResourceImplementation::load_from_uri(StringVie
     }
 
     dbgln("ResourceImplementation: Unknown scheme for {}", uri);
-    return Error::from_string_view("Invalid scheme"sv);
+    return Error::from_string_literal("Invalid scheme");
 }
 
 Vector<String> ResourceImplementation::child_names(Resource const& resource)

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1876,16 +1876,16 @@ ErrorOr<ByteString> current_executable_path()
     for (int32 cookie { 0 }; get_next_image_info(B_CURRENT_TEAM, &cookie, &info) == B_OK && info.type != B_APP_IMAGE;)
         ;
     if (info.type != B_APP_IMAGE)
-        return Error::from_string_view("current_executable_path() failed"sv);
+        return Error::from_string_literal("current_executable_path() failed");
     if (sizeof(info.name) > sizeof(path))
         return Error::from_errno(ENAMETOOLONG);
     strlcpy(path, info.name, sizeof(path) - 1);
 #elif defined(AK_OS_EMSCRIPTEN)
-    return Error::from_string_view("current_executable_path() unknown on this platform"sv);
+    return Error::from_string_literal("current_executable_path() unknown on this platform");
 #else
 #    warning "Not sure how to get current_executable_path on this platform!"
     // GetModuleFileName on Windows, unsure about OpenBSD.
-    return Error::from_string_view("current_executable_path unknown"sv);
+    return Error::from_string_literal("current_executable_path unknown");
 #endif
     path[sizeof(path) - 1] = '\0';
     return ByteString { path, strlen(path) };

--- a/Userland/Libraries/LibCrypto/ASN1/DER.h
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.h
@@ -77,10 +77,10 @@ public:
     ErrorOr<void> rewrite_tag(Kind kind)
     {
         if (m_stack.is_empty())
-            return Error::from_string_view("Nothing on stack to rewrite"sv);
+            return Error::from_string_literal("Nothing on stack to rewrite");
 
         if (eof())
-            return Error::from_string_view("Stream is empty"sv);
+            return Error::from_string_literal("Stream is empty");
 
         if (m_current_tag.has_value()) {
             m_current_tag->kind = kind;

--- a/Userland/Libraries/LibCrypto/Hash/MGF.h
+++ b/Userland/Libraries/LibCrypto/Hash/MGF.h
@@ -26,7 +26,7 @@ public:
         // 1. If length > 2^32(hLen), output "mask too long" and stop.
         if constexpr (sizeof(size_t) > 32) {
             if (length > (h_len << 32))
-                return Error::from_string_view("mask too long"sv);
+                return Error::from_string_literal("mask too long");
         }
 
         // 2. Let T be the empty octet string.

--- a/Userland/Libraries/LibCrypto/Hash/PBKDF2.h
+++ b/Userland/Libraries/LibCrypto/Hash/PBKDF2.h
@@ -27,7 +27,7 @@ public:
 
         // 1. If dkLen > (2^32 - 1) * hLen, output "derived key too long" and stop.
         if (key_length_bytes > (AK::pow(2.0, 32.0) - 1) * h_len)
-            return Error::from_string_view("derived key too long"sv);
+            return Error::from_string_literal("derived key too long");
 
         // 2 . Let l be the number of hLen-octet blocks in the derived key rounding up,
         //     and let r be the number of octets in the last block

--- a/Userland/Libraries/LibCrypto/Padding/OAEP.h
+++ b/Userland/Libraries/LibCrypto/Padding/OAEP.h
@@ -30,7 +30,7 @@ public:
         auto h_len = HashFunction::digest_size();
         auto max_message_size = length - (2 * h_len) - 1;
         if (message.size() > max_message_size)
-            return Error::from_string_view("message too long"sv);
+            return Error::from_string_literal("message too long");
 
         // 3. Generate an octet string PS consisting of emLen-||M||-2hLen-1 zero octets. The length of PS may be 0.
         auto padding_size = length - message.size() - (2 * h_len) - 1;

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -82,7 +82,7 @@ static ErrorOr<SupportedGroup> oid_to_curve(Vector<int> curve)
     else if (curve == curve_prime256)
         return SupportedGroup::SECP256R1;
 
-    return Error::from_string_view("Unknown curve oid"sv);
+    return Error::from_string_literal("Unknown curve oid");
 }
 
 static ErrorOr<Crypto::UnsignedBigInteger> parse_certificate_version(Crypto::ASN1::Decoder& decoder, Vector<StringView> current_scope)

--- a/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
@@ -147,7 +147,7 @@ ErrorOr<void> RoleType::serialize_as_json(JsonObjectSerializer<StringBuilder>& o
 ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool focusable, AriaData const& data)
 {
     if (is_abstract_role(role))
-        return Error::from_string_view("Cannot construct a role object for an abstract role."sv);
+        return Error::from_string_literal("Cannot construct a role object for an abstract role.");
 
     switch (role) {
     case Role::alert:

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -1106,7 +1106,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
     // NOTE: Spec jumps to 6 here for some reason
     // 6. If performing the key generation operation results in an error, then throw an OperationError.
     auto maybe_private_key_data = curve.visit(
-        [](Empty const&) -> ErrorOr<ByteBuffer> { return Error::from_string_view("noop error"sv); },
+        [](Empty const&) -> ErrorOr<ByteBuffer> { return Error::from_string_literal("noop error"); },
         [](auto instance) { return instance.generate_private_key(); });
 
     if (maybe_private_key_data.is_error())
@@ -1115,7 +1115,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
     auto private_key_data = maybe_private_key_data.release_value();
 
     auto maybe_public_key_data = curve.visit(
-        [](Empty const&) -> ErrorOr<ByteBuffer> { return Error::from_string_view("noop error"sv); },
+        [](Empty const&) -> ErrorOr<ByteBuffer> { return Error::from_string_literal("noop error"); },
         [&](auto instance) { return instance.generate_public_key(private_key_data); });
 
     if (maybe_public_key_data.is_error())
@@ -1290,7 +1290,7 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::
         auto encoded_signature = encoder.finish();
 
         auto maybe_result = curve.visit(
-            [](Empty const&) -> ErrorOr<bool> { return Error::from_string_view("Failed to create valid crypto instance"sv); },
+            [](Empty const&) -> ErrorOr<bool> { return Error::from_string_literal("Failed to create valid crypto instance"); },
             [&](auto instance) { return instance.verify(M, Q, encoded_signature); });
 
         if (maybe_result.is_error()) {
@@ -1517,7 +1517,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> PBKDF2::derive_bits(Algor
     // the contents of the salt attribute of normalizedAlgorithm as the salt, S,
     // the value of the iterations attribute of normalizedAlgorithm as the iteration count, c,
     // and length divided by 8 as the intended key length, dkLen.
-    ErrorOr<ByteBuffer> result = Error::from_string_view("noop error"sv);
+    ErrorOr<ByteBuffer> result = Error::from_string_literal("noop error");
 
     auto password = key->handle().get<ByteBuffer>();
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1915,7 +1915,7 @@ ErrorOr<void> Element::scroll_into_view(Optional<Variant<bool, ScrollIntoViewOpt
     // 6. If the element does not have any associated box, or is not available to user-agent features, then return.
     document().update_layout();
     if (!layout_node())
-        return Error::from_string_view("Element has no associated box"sv);
+        return Error::from_string_literal("Element has no associated box");
 
     // 7. Scroll the element into view with behavior, block, and inline.
     TRY(scroll_an_element_into_view(*this, behavior, block, inline_));

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -136,7 +136,7 @@ ErrorOr<Optional<URL::URL>> Response::location_url(Optional<String> const& reque
     // 3. If location is a header value, then set location to the result of parsing location with response’s URL.
     auto location = DOMURL::parse(location_values.first(), url().copy());
     if (!location.is_valid())
-        return Error::from_string_view("Invalid 'Location' header URL"sv);
+        return Error::from_string_literal("Invalid 'Location' header URL");
 
     // 4. If location is a URL whose fragment is null, then set location’s fragment to requestFragment.
     if (!location.fragment().has_value())

--- a/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -308,26 +308,26 @@ static JsonValue match_capabilities(JsonObject const& capabilities)
         if (name == "browserName"sv) {
             // If value is not a string equal to the "browserName" entry in matched capabilities, return success with data null.
             if (value.as_string() != matched_capabilities.get_byte_string(name).value())
-                return AK::Error::from_string_view("browserName"sv);
+                return AK::Error::from_string_literal("browserName");
         }
         // -> "browserVersion"
         else if (name == "browserVersion"sv) {
             // Compare value to the "browserVersion" entry in matched capabilities using an implementation-defined comparison algorithm. The comparison is to accept a value that places constraints on the version using the "<", "<=", ">", and ">=" operators.
             // If the two values do not match, return success with data null.
             if (!matches_browser_version(value.as_string(), matched_capabilities.get_byte_string(name).value()))
-                return AK::Error::from_string_view("browserVersion"sv);
+                return AK::Error::from_string_literal("browserVersion");
         }
         // -> "platformName"
         else if (name == "platformName"sv) {
             // If value is not a string equal to the "platformName" entry in matched capabilities, return success with data null.
             if (!matches_platform_name(value.as_string(), matched_capabilities.get_byte_string(name).value()))
-                return AK::Error::from_string_view("platformName"sv);
+                return AK::Error::from_string_literal("platformName");
         }
         // -> "acceptInsecureCerts"
         else if (name == "acceptInsecureCerts"sv) {
             // If value is true and the endpoint node does not support insecure TLS certificates, return success with data null.
             if (value.as_bool())
-                return AK::Error::from_string_view("acceptInsecureCerts"sv);
+                return AK::Error::from_string_literal("acceptInsecureCerts");
         }
         // -> "proxy"
         else if (name == "proxy"sv) {
@@ -342,11 +342,11 @@ static JsonValue match_capabilities(JsonObject const& capabilities)
             if (name == "webSocketUrl"sv) {
                 // 1. If value is false, return success with data null.
                 if (!value.as_bool())
-                    return AK::Error::from_string_view("webSocketUrl"sv);
+                    return AK::Error::from_string_literal("webSocketUrl");
 
                 // 2. Return success with data value.
                 // FIXME: Remove this when we support BIDI communication.
-                return AK::Error::from_string_view("webSocketUrl"sv);
+                return AK::Error::from_string_literal("webSocketUrl");
             }
         }
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -505,7 +505,7 @@ void ViewImplementation::handle_web_content_process_crash()
 static ErrorOr<LexicalPath> save_screenshot(Gfx::ShareableBitmap const& bitmap)
 {
     if (!bitmap.is_valid())
-        return Error::from_string_view("Failed to take a screenshot"sv);
+        return Error::from_string_literal("Failed to take a screenshot");
 
     LexicalPath path { Core::StandardPaths::downloads_directory() };
     path = path.append(TRY(Core::DateTime::now().to_string("screenshot-%Y-%m-%d-%H-%M-%S.png"sv)));

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -25,7 +25,7 @@ HashMap<unsigned, NonnullRefPtr<Session>> Client::s_sessions;
 ErrorOr<NonnullRefPtr<Client>> Client::try_create(NonnullOwnPtr<Core::BufferedTCPSocket> socket, LaunchBrowserCallbacks callbacks, Core::EventReceiver* parent)
 {
     if (!callbacks.launch_browser || !callbacks.launch_headless_browser)
-        return Error::from_string_view("All callbacks to launch a browser must be provided"sv);
+        return Error::from_string_literal("All callbacks to launch a browser must be provided");
 
     TRY(socket->set_blocking(true));
     return adopt_nonnull_ref_or_enomem(new (nothrow) Client(move(socket), move(callbacks), parent));

--- a/Userland/Utilities/aconv.cpp
+++ b/Userland/Utilities/aconv.cpp
@@ -19,12 +19,12 @@
 static ErrorOr<StringView> guess_format_from_extension(StringView path)
 {
     if (path == "-"sv)
-        return Error::from_string_view("Cannot guess format for standard stream, please specify format manually"sv);
+        return Error::from_string_literal("Cannot guess format for standard stream, please specify format manually");
 
     LexicalPath lexical_path { path };
     auto extension = lexical_path.extension();
     if (extension.is_empty())
-        return Error::from_string_view("Cannot guess format for file without file extension"sv);
+        return Error::from_string_literal("Cannot guess format for file without file extension");
 
     // Note: Do not return the `extension` StringView in any case, since that will possibly lead to UAF.
     if (extension == "wav"sv || extension == "wave"sv)
@@ -36,7 +36,7 @@ static ErrorOr<StringView> guess_format_from_extension(StringView path)
     if (extension == "qoa"sv)
         return "qoa"sv;
 
-    return Error::from_string_view("Cannot guess format for the given file extension"sv);
+    return Error::from_string_literal("Cannot guess format for the given file extension");
 }
 
 static ErrorOr<Audio::PcmSampleFormat> parse_sample_format(StringView textual_format)
@@ -53,7 +53,7 @@ static ErrorOr<Audio::PcmSampleFormat> parse_sample_format(StringView textual_fo
         return Audio::PcmSampleFormat::Float32;
     if (textual_format == "f64le"sv)
         return Audio::PcmSampleFormat::Float64;
-    return Error::from_string_view("Unknown sample format"sv);
+    return Error::from_string_literal("Unknown sample format");
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -76,10 +76,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     if (input.is_empty())
-        return Error::from_string_view("Input file is required, use '-' to read from standard input"sv);
+        return Error::from_string_literal("Input file is required, use '-' to read from standard input");
 
     if (output_format.is_empty() && output == "-"sv)
-        return Error::from_string_view("Output format must be specified manually when writing to standard output"sv);
+        return Error::from_string_literal("Output format must be specified manually when writing to standard output");
 
     if (input != "-"sv)
         TRY(Core::System::unveil(TRY(FileSystem::absolute_path(input)), "r"sv));

--- a/Userland/Utilities/animation.cpp
+++ b/Userland/Utilities/animation.cpp
@@ -39,7 +39,7 @@ static ErrorOr<Options> parse_options(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     if (options.out_path.is_empty())
-        return Error::from_string_view("-o is required "sv);
+        return Error::from_string_literal("-o is required ");
 
     if (inter_frame_compression_full + inter_frame_compression_clip + inter_frame_compression_none > 1)
         return Error::from_string_view("Only one of --inter-frame-compression=full, --inter-frame-compression=clip-rect, --inter-frame-compression=none can be specified"sv);
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto file = TRY(Core::MappedFile::map(options.in_path));
     auto decoder = TRY(Gfx::ImageDecoder::try_create_for_raw_bytes(file->bytes()));
     if (!decoder)
-        return Error::from_string_view("Could not find decoder for input file"sv);
+        return Error::from_string_literal("Could not find decoder for input file");
 
     auto output_file = TRY(Core::File::open(options.out_path, Core::File::OpenMode::Write));
     auto output_stream = TRY(Core::OutputBufferedFile::create(move(output_file)));


### PR DESCRIPTION
(cherry picked from commit 229b64a4b723a391c21f247d72d78cd575ace6ff; minorly amended to fix conflict in image.cpp due to serenity in the meantime adding webp writing support, and due to changes in Android and Vulkan-related files that serenity doesn't have)

---

https://github.com/LadybirdBrowser/ladybird/pull/457