### PR TITLE
Cherry-pick "LibWeb: Let determine_the_origin() take an optional URL after all", second commit

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -59,15 +59,17 @@ bool url_matches_about_srcdoc(URL::URL const& url)
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#determining-the-origin
-HTML::Origin determine_the_origin(URL::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin)
+HTML::Origin determine_the_origin(Optional<URL::URL const&> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin)
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
     if (has_flag(sandbox_flags, SandboxingFlagSet::SandboxedOrigin)) {
         return HTML::Origin {};
     }
 
-    // FIXME: 2. If url is null, then return a new opaque origin.
-    // FIXME: There appears to be no way to get a null URL here, so it might be a spec bug.
+    // 2. If url is null, then return a new opaque origin.
+    if (!url.has_value()) {
+        return HTML::Origin {};
+    }
 
     // 3. If url is about:srcdoc, then:
     if (url == "about:srcdoc"sv) {
@@ -79,11 +81,11 @@ HTML::Origin determine_the_origin(URL::URL const& url, SandboxingFlagSet sandbox
     }
 
     // 4. If url matches about:blank and sourceOrigin is non-null, then return sourceOrigin.
-    if (url_matches_about_blank(url) && source_origin.has_value())
+    if (url_matches_about_blank(*url) && source_origin.has_value())
         return source_origin.release_value();
 
     // 5. Return url's origin.
-    return DOMURL::url_origin(url);
+    return DOMURL::url_origin(*url);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-auxiliary-browsing-context

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -168,7 +168,7 @@ private:
     JS::GCPtr<BrowsingContext> m_previous_sibling;
 };
 
-HTML::Origin determine_the_origin(URL::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin);
+HTML::Origin determine_the_origin(Optional<URL::URL const&>, SandboxingFlagSet, Optional<HTML::Origin> source_origin);
 
 SandboxingFlagSet determine_the_creation_sandboxing_flags(BrowsingContext const&, JS::GCPtr<DOM::Element> embedder);
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -608,7 +608,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<NavigationParams>> create_navigation
     response->set_body(TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, document_resource.get<String>().bytes())));
 
     // 3. Let responseOrigin be the result of determining the origin given response's URL, targetSnapshotParams's sandboxing flags, and entry's document state's origin.
-    auto response_origin = determine_the_origin(*response->url(), target_snapshot_params.sandboxing_flags, entry->document_state()->origin());
+    auto response_origin = determine_the_origin(response->url(), target_snapshot_params.sandboxing_flags, entry->document_state()->origin());
 
     // 4. Let coop be a new cross-origin opener policy.
     CrossOriginOpenerPolicy coop = {};
@@ -879,7 +879,7 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
         // FIXME 10. Set finalSandboxFlags to the union of targetSnapshotParams's sandboxing flags and responsePolicyContainer's CSP list's CSP-derived sandboxing flags.
 
         // 11. Set responseOrigin to the result of determining the origin given response's URL, finalSandboxFlags, and entry's document state's initiator origin.
-        response_origin = determine_the_origin(*response_holder->response()->url(), final_sandbox_flags, entry->document_state()->initiator_origin());
+        response_origin = determine_the_origin(response_holder->response()->url(), final_sandbox_flags, entry->document_state()->initiator_origin());
 
         // 12. If navigable is a top-level traversable, then:
         if (navigable->is_top_level_traversable()) {


### PR DESCRIPTION
I originally believed that this could never receive a null URL and the spec was inaccurate, but it seems like it can indeed.

I don't have a distilled test, but this makes logging in with GitHub work on https://v0.dev/

(cherry picked from commit 1a4b0ded1f802fdcc3ef9b919b5749b086471fc2; amended to also cherry-pick LadybirdBrowser/ladybird#2358)

---

https://github.com/LadybirdBrowser/ladybird/pull/1537 (first commit was in #25345).