### PR TITLE
Cherry-pick "UI/Qt: Process drag-and-drop events through the web view"

### DIFF
--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -59,6 +59,8 @@ public:
     virtual void wheelEvent(QWheelEvent*) override;
     virtual void mouseDoubleClickEvent(QMouseEvent*) override;
     virtual void dragEnterEvent(QDragEnterEvent*) override;
+    virtual void dragMoveEvent(QDragMoveEvent*) override;
+    virtual void dragLeaveEvent(QDragLeaveEvent*) override;
     virtual void dropEvent(QDropEvent*) override;
     virtual void keyPressEvent(QKeyEvent* event) override;
     virtual void keyReleaseEvent(QKeyEvent* event) override;
@@ -102,8 +104,13 @@ private:
     void update_cursor(Gfx::StandardCursor cursor);
 
     void enqueue_native_event(Web::MouseEvent::Type, QSinglePointEvent const& event);
+
+    void enqueue_native_event(Web::DragEvent::Type, QDropEvent const& event);
+    void finish_handling_drag_event(Web::DragEvent const&);
+
     void enqueue_native_event(Web::KeyEvent::Type, QKeyEvent const& event);
     void finish_handling_key_event(Web::KeyEvent const&);
+
     void update_screen_rects();
 
     bool m_tooltip_override { false };


### PR DESCRIPTION
This forwards all drag-and-drop events from the UI to the WebContent process. If the page accepts the events, the UI does not handle them. Otherwise, we will open the dropped files as file:// URLs.

(cherry picked from commit 4833ba06eaef20053f85343a13c0307394d67ded)

---

Last commit of https://github.com/LadybirdBrowser/ladybird/pull/1111 (first 13 were in #25243).