### PR TITLE
SpiceAgent: Send notification when file transfer is complete 

### DIFF
--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -43,7 +43,7 @@ void Notification::show()
     VERIFY(!m_shown && !m_destroyed);
     auto icon = m_icon ? m_icon->to_shareable_bitmap() : Gfx::ShareableBitmap();
     m_connection = ConnectionToNotificationServer::try_create(this).release_value_but_fixme_should_propagate_errors();
-    m_connection->show_notification(m_text, m_title, icon);
+    m_connection->show_notification(m_text, m_title, icon, m_launch_url);
     m_shown = true;
 }
 
@@ -73,6 +73,11 @@ bool Notification::update()
     if (m_icon_dirty) {
         m_connection->update_notification_icon(m_icon ? m_icon->to_shareable_bitmap() : Gfx::ShareableBitmap());
         m_icon_dirty = false;
+    }
+
+    if (m_launch_url_dirty) {
+        m_connection->update_notification_launch_url(m_launch_url);
+        m_launch_url_dirty = false;
     }
 
     return true;

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <LibCore/EventReceiver.h>
 #include <LibGfx/Bitmap.h>
+#include <LibURL/URL.h>
 
 namespace GUI {
 
@@ -43,6 +44,13 @@ public:
         m_icon = icon;
     }
 
+    URL::URL const& launch_url() const { return m_launch_url; }
+    void set_launch_url(URL::URL const& launch_url)
+    {
+        m_launch_url_dirty = true;
+        m_launch_url = launch_url;
+    }
+
     void show();
     bool update();
     void close();
@@ -60,6 +68,8 @@ private:
     bool m_text_dirty { false };
     RefPtr<Gfx::Bitmap const> m_icon;
     bool m_icon_dirty { false };
+    URL::URL m_launch_url;
+    bool m_launch_url_dirty { false };
 
     bool m_destroyed { false };
     bool m_shown { false };

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -55,11 +55,11 @@ private:
     void connection_closed();
 
     String m_title;
-    bool m_title_dirty;
+    bool m_title_dirty { false };
     String m_text;
-    bool m_text_dirty;
+    bool m_text_dirty { false };
     RefPtr<Gfx::Bitmap const> m_icon;
-    bool m_icon_dirty;
+    bool m_icon_dirty { false };
 
     bool m_destroyed { false };
     bool m_shown { false };

--- a/Userland/Services/NotificationServer/CMakeLists.txt
+++ b/Userland/Services/NotificationServer/CMakeLists.txt
@@ -21,4 +21,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_bin(NotificationServer)
-target_link_libraries(NotificationServer PRIVATE LibCore LibGfx LibGUI LibIPC LibMain)
+target_link_libraries(NotificationServer PRIVATE LibCore LibDesktop LibGfx LibGUI LibIPC LibMain LibURL)

--- a/Userland/Services/NotificationServer/ConnectionFromClient.cpp
+++ b/Userland/Services/NotificationServer/ConnectionFromClient.cpp
@@ -24,9 +24,9 @@ void ConnectionFromClient::die()
     s_connections.remove(client_id());
 }
 
-void ConnectionFromClient::show_notification(String const& text, String const& title, Gfx::ShareableBitmap const& icon)
+void ConnectionFromClient::show_notification(String const& text, String const& title, Gfx::ShareableBitmap const& icon, URL::URL const& launch_url)
 {
-    auto window = NotificationWindow::construct(client_id(), text, title, icon);
+    auto window = NotificationWindow::construct(client_id(), text, title, icon, launch_url);
     window->show();
 }
 
@@ -53,6 +53,15 @@ Messages::NotificationServer::UpdateNotificationTextResponse ConnectionFromClien
     if (window) {
         window->set_text(text);
         window->set_title(title);
+    }
+    return !!window;
+}
+
+Messages::NotificationServer::UpdateNotificationLaunchUrlResponse ConnectionFromClient::update_notification_launch_url(URL::URL const& launch_url)
+{
+    auto window = NotificationWindow::get_window_by_id(client_id());
+    if (window) {
+        window->set_launch_url(launch_url);
     }
     return !!window;
 }

--- a/Userland/Services/NotificationServer/ConnectionFromClient.h
+++ b/Userland/Services/NotificationServer/ConnectionFromClient.h
@@ -23,10 +23,11 @@ public:
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>, int client_id);
 
-    virtual void show_notification(String const&, String const&, Gfx::ShareableBitmap const&) override;
+    virtual void show_notification(String const&, String const&, Gfx::ShareableBitmap const&, URL::URL const&) override;
     virtual void close_notification() override;
     virtual Messages::NotificationServer::UpdateNotificationIconResponse update_notification_icon(Gfx::ShareableBitmap const&) override;
     virtual Messages::NotificationServer::UpdateNotificationTextResponse update_notification_text(String const&, String const&) override;
+    virtual Messages::NotificationServer::UpdateNotificationLaunchUrlResponse update_notification_launch_url(URL::URL const&) override;
     virtual Messages::NotificationServer::IsShowingResponse is_showing() override;
 };
 

--- a/Userland/Services/NotificationServer/NotificationServer.ipc
+++ b/Userland/Services/NotificationServer/NotificationServer.ipc
@@ -2,11 +2,13 @@
 
 endpoint NotificationServer
 {
-    show_notification(String text, String title, Gfx::ShareableBitmap icon) => ()
+    show_notification(String text, String title, Gfx::ShareableBitmap icon, URL::URL launch_url) => ()
 
     update_notification_text(String text, String title) => (bool still_showing)
 
     update_notification_icon(Gfx::ShareableBitmap icon) => (bool still_showing)
+
+    update_notification_launch_url(URL::URL launch_url) => (bool still_showing)
 
     is_showing() => (bool still_showing)
 

--- a/Userland/Services/NotificationServer/NotificationWidget.h
+++ b/Userland/Services/NotificationServer/NotificationWidget.h
@@ -14,7 +14,15 @@ class NotificationWidget : public GUI::Widget {
     C_OBJECT_ABSTRACT(NotificationWidget)
 public:
     static ErrorOr<NonnullRefPtr<NotificationWidget>> try_create();
+
     virtual ~NotificationWidget() override = default;
+
+    Function<void()> on_click;
+    virtual void mousedown_event(GUI::MouseEvent&) override
+    {
+        if (on_click)
+            on_click();
+    }
 
 private:
     NotificationWidget() = default;

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -8,6 +8,7 @@
 
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Window.h>
+#include <LibURL/URL.h>
 
 namespace NotificationServer {
 
@@ -20,6 +21,10 @@ public:
     void set_text(String const&);
     void set_title(String const&);
     void set_image(Gfx::ShareableBitmap const&);
+    void set_launch_url(URL::URL const& launch_url)
+    {
+        m_launch_url = launch_url;
+    }
 
     static RefPtr<NotificationWindow> get_window_by_id(i32 id);
 
@@ -28,7 +33,7 @@ protected:
     virtual void leave_event(Core::Event&) override;
 
 private:
-    NotificationWindow(i32 client_id, String const& text, String const& title, Gfx::ShareableBitmap const&);
+    NotificationWindow(i32 client_id, String const& text, String const& title, Gfx::ShareableBitmap const&, URL::URL const& launch_url);
 
     virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
 
@@ -40,6 +45,7 @@ private:
     GUI::Label* m_text_label;
     GUI::Label* m_title_label;
     GUI::ImageWidget* m_image;
+    URL::URL m_launch_url;
     bool m_hovering { false };
 };
 

--- a/Userland/Services/NotificationServer/main.cpp
+++ b/Userland/Services/NotificationServer/main.cpp
@@ -18,8 +18,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto server = TRY(IPC::MultiServer<NotificationServer::ConnectionFromClient>::try_create());
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio recvfd sendfd accept rpath"));
+    TRY(Core::System::pledge("unix stdio recvfd sendfd accept rpath"));
 
     return app->exec();
 }

--- a/Userland/Services/SpiceAgent/CMakeLists.txt
+++ b/Userland/Services/SpiceAgent/CMakeLists.txt
@@ -11,5 +11,5 @@ set(SOURCES
 )
 
 serenity_bin(SpiceAgent)
-target_link_libraries(SpiceAgent PRIVATE LibCore LibDesktop LibFileSystem LibGfx LibGUI LibMain LibURL)
+target_link_libraries(SpiceAgent PRIVATE LibCore LibFileSystem LibGfx LibGUI LibMain LibURL)
 add_dependencies(SpiceAgent Clipboard)

--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -8,7 +8,6 @@
 #include "SpiceAgent.h"
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
-#include <LibDesktop/Launcher.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
@@ -28,11 +27,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // We use the application to be able to easily write to the user's clipboard.
     auto app = TRY(GUI::Application::create(arguments));
 
-    TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory())));
-    TRY(Desktop::Launcher::seal_allowlist());
-
     TRY(Core::System::pledge("unix rpath wpath cpath stdio sendfd recvfd"));
     TRY(Core::System::unveil(SPICE_DEVICE, "rw"sv));
+    TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/notify", "rw"));
     TRY(Core::System::unveil(Core::StandardPaths::downloads_directory(), "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
Rather than (re-)open the Downloads folder on every completed file transfer, send a notification when a transfer is complete. The notification includes the file's name, and clicking it will open the Downloads folder (with the file highlighted).
![image](https://github.com/user-attachments/assets/6deec8b7-8eb6-4f9b-b936-3a74c7db72fa)
