### PR TITLE
LibGfx: Fix crash when calling draw_triangle_wave() offscreen

### DIFF
--- a/Tests/LibGfx/TestPainter.cpp
+++ b/Tests/LibGfx/TestPainter.cpp
@@ -53,3 +53,11 @@ TEST_CASE(draw_rect_rough_bounds)
     painter.draw_rect(Gfx::IntRect(0, 0, 1, 1), Color::Black, true);
     painter.draw_rect(Gfx::IntRect(9, 9, 1, 1), Color::Black, true);
 }
+
+TEST_CASE(draw_triangle_wave)
+{
+    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { 10, 10 }));
+    Gfx::Painter painter(*bitmap);
+    for (int y = -3; y < bitmap->height() + 3; ++y)
+        painter.draw_triangle_wave({ 0, y }, { bitmap->width(), y }, Gfx::Color::Red, 3, 2);
+}

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1912,6 +1912,8 @@ void Painter::draw_physical_pixel(IntPoint physical_position, Color color, int t
 
     IntRect rect { physical_position, { thickness, thickness } };
     rect.intersect(clip_rect() * scale());
+    if (rect.is_empty())
+        return;
     fill_physical_rect(rect, color);
 }
 


### PR DESCRIPTION
I think this regressed in #5018. It easily triggered when scrolling a page that uses `text-decoration-style: wavy`.