### PR TITLE
Kernel: Add and use TypedMapping<T*[]*>

### DIFF
--- a/Kernel/Bus/VirtIO/Queue.cpp
+++ b/Kernel/Bus/VirtIO/Queue.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Atomic.h>
 #include <Kernel/Bus/VirtIO/Queue.h>
+#include <Kernel/Library/MiniStdLib.h>
 
 namespace Kernel::VirtIO {
 

--- a/Kernel/Bus/VirtIO/Queue.h
+++ b/Kernel/Bus/VirtIO/Queue.h
@@ -8,7 +8,6 @@
 
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/MemoryManager.h>
-#include <Kernel/Memory/ScatterGatherList.h>
 
 namespace Kernel::VirtIO {
 

--- a/Kernel/Memory/TypedMapping.h
+++ b/Kernel/Memory/TypedMapping.h
@@ -22,6 +22,35 @@ struct TypedMapping {
     T* operator->() { return ptr(); }
     T const& operator*() const { return *ptr(); }
     T& operator*() { return *ptr(); }
+
+    OwnPtr<Region> region;
+    PhysicalAddress paddr;
+    size_t offset { 0 };
+    size_t length { 0 };
+};
+
+template<typename T>
+struct TypedMapping<T[]> {
+    T const* ptr() const { return reinterpret_cast<T const*>(region->vaddr().offset(offset).as_ptr()); }
+    T* ptr() { return reinterpret_cast<T*>(region->vaddr().offset(offset).as_ptr()); }
+    VirtualAddress base_address() const { return region->vaddr().offset(offset); }
+    T const* operator->() const { return ptr(); }
+    T* operator->() { return ptr(); }
+    T const& operator*() const { return *ptr(); }
+    T& operator*() { return *ptr(); }
+
+    size_t size() const { return length / sizeof(T); }
+    T const& operator[](size_t index) const
+    {
+        VERIFY(index < size());
+        return ptr()[index];
+    }
+    T& operator[](size_t index)
+    {
+        VERIFY(index < size());
+        return ptr()[index];
+    }
+
     OwnPtr<Region> region;
     PhysicalAddress paddr;
     size_t offset { 0 };
@@ -63,6 +92,43 @@ template<typename T>
 static ErrorOr<TypedMapping<T>> map_typed_writable(PhysicalAddress paddr)
 {
     return map_typed<T>(paddr, sizeof(T), Region::Access::Read | Region::Access::Write);
+}
+
+template<typename T>
+static ErrorOr<NonnullOwnPtr<TypedMapping<T[]>>> adopt_new_nonnull_own_typed_mapping_array(PhysicalAddress paddr, size_t items, Region::Access access = Region::Access::Read)
+{
+    size_t length_in_bytes = items * sizeof(T);
+    auto mapping_length = TRY(page_round_up(paddr.offset_in_page() + length_in_bytes));
+    auto region = TRY(MM.allocate_mmio_kernel_region(paddr.page_base(), mapping_length, {}, access));
+    auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Memory::TypedMapping<T[]>()));
+    table->region = move(region);
+    table->offset = paddr.offset_in_page();
+    table->paddr = paddr;
+    table->length = length_in_bytes;
+    return table;
+}
+
+template<typename T>
+static ErrorOr<TypedMapping<T[]>> map_typed_array(PhysicalAddress paddr, size_t items, Region::Access access = Region::Access::Read)
+{
+    size_t length_in_bytes = items * sizeof(T);
+    return map_typed<T[]>(paddr, length_in_bytes, access);
+}
+
+template<typename T>
+static ErrorOr<TypedMapping<T[]>> allocate_dma_region_as_typed_array(size_t items, StringView name, Region::Access access)
+{
+    size_t length_in_bytes = items * sizeof(T);
+    size_t mapping_length = TRY(page_round_up(length_in_bytes));
+    auto region = TRY(MM.allocate_dma_buffer_pages(mapping_length, name, access));
+
+    Memory::TypedMapping<T[]> table;
+    table.paddr = region->physical_page(0)->paddr();
+    table.region = move(region);
+    table.offset = 0;
+    table.length = length_in_bytes;
+
+    return table;
 }
 
 }

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -31,8 +31,8 @@ public:
 private:
     E1000ENetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const&, u8 irq,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
-        NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
-        NonnullOwnPtr<Memory::Region> tx_descriptors_region);
+        NonnullOwnPtr<Memory::Region> tx_buffer_region, Memory::TypedMapping<RxDescriptor volatile[]> rx_descriptors,
+        Memory::TypedMapping<TxDescriptor volatile[]> tx_descriptors);
 
     virtual StringView class_name() const override { return "E1000ENetworkAdapter"sv; }
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -40,35 +40,38 @@ protected:
     static constexpr size_t rx_buffer_size = 8192;
     static constexpr size_t tx_buffer_size = 8192;
 
+    struct RxDescriptor {
+        uint64_t addr { 0 };
+        uint16_t length { 0 };
+        uint16_t checksum { 0 };
+        uint8_t status { 0 };
+        uint8_t errors { 0 };
+        uint16_t special { 0 };
+    };
+    static_assert(AssertSize<RxDescriptor, 16>());
+
+    struct TxDescriptor {
+        uint64_t addr { 0 };
+        uint16_t length { 0 };
+        uint8_t cso { 0 };
+        uint8_t cmd { 0 };
+        uint8_t status { 0 };
+        uint8_t css { 0 };
+        uint16_t special { 0 };
+    };
+    static_assert(AssertSize<TxDescriptor, 16>());
+
     void setup_interrupts();
     void setup_link();
 
     E1000NetworkAdapter(StringView, PCI::DeviceIdentifier const&, u8 irq,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
-        NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
-        NonnullOwnPtr<Memory::Region> tx_descriptors_region);
+        NonnullOwnPtr<Memory::Region> tx_buffer_region,
+        Memory::TypedMapping<RxDescriptor volatile[]> rx_descriptors,
+        Memory::TypedMapping<TxDescriptor volatile[]> tx_descriptors);
 
     virtual bool handle_irq() override;
     virtual StringView class_name() const override { return "E1000NetworkAdapter"sv; }
-
-    struct [[gnu::packed]] e1000_rx_desc {
-        uint64_t volatile addr { 0 };
-        uint16_t volatile length { 0 };
-        uint16_t volatile checksum { 0 };
-        uint8_t volatile status { 0 };
-        uint8_t volatile errors { 0 };
-        uint16_t volatile special { 0 };
-    };
-
-    struct [[gnu::packed]] e1000_tx_desc {
-        uint64_t volatile addr { 0 };
-        uint16_t volatile length { 0 };
-        uint8_t volatile cso { 0 };
-        uint8_t volatile cmd { 0 };
-        uint8_t volatile status { 0 };
-        uint8_t volatile css { 0 };
-        uint16_t volatile special { 0 };
-    };
 
     virtual void detect_eeprom();
     virtual u32 read_eeprom(u8 address);
@@ -91,8 +94,9 @@ protected:
 
     NonnullOwnPtr<IOWindow> m_registers_io_window;
 
-    NonnullOwnPtr<Memory::Region> m_rx_descriptors_region;
-    NonnullOwnPtr<Memory::Region> m_tx_descriptors_region;
+    Memory::TypedMapping<RxDescriptor volatile[]> m_rx_descriptors;
+    Memory::TypedMapping<TxDescriptor volatile[]> m_tx_descriptors;
+
     NonnullOwnPtr<Memory::Region> m_rx_buffer_region;
     NonnullOwnPtr<Memory::Region> m_tx_buffer_region;
     Array<void*, number_of_rx_descriptors> m_rx_buffers;

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -49,13 +49,13 @@ private:
 
     bool determine_supported_version() const;
 
-    struct [[gnu::packed]] TXDescriptor {
-        u16 volatile frame_length; // top 2 bits are reserved
-        u16 volatile flags;
-        u16 volatile vlan_tag;
-        u16 volatile vlan_flags;
-        u32 volatile buffer_address_low;
-        u32 volatile buffer_address_high;
+    struct TXDescriptor {
+        u16 frame_length; // top 2 bits are reserved
+        u16 flags;
+        u16 vlan_tag;
+        u16 vlan_flags;
+        u32 buffer_address_low;
+        u32 buffer_address_high;
 
         // flags bit field
         static constexpr u16 Ownership = 0x8000u;
@@ -67,13 +67,13 @@ private:
 
     static_assert(AssertSize<TXDescriptor, 16u>());
 
-    struct [[gnu::packed]] RXDescriptor {
-        u16 volatile buffer_size; // top 2 bits are reserved
-        u16 volatile flags;
-        u16 volatile vlan_tag;
-        u16 volatile vlan_flags;
-        u32 volatile buffer_address_low;
-        u32 volatile buffer_address_high;
+    struct RXDescriptor {
+        u16 buffer_size; // top 2 bits are reserved
+        u16 flags;
+        u16 vlan_tag;
+        u16 vlan_flags;
+        u32 buffer_address_low;
+        u32 buffer_address_high;
 
         // flags bit field
         static constexpr u16 Ownership = 0x8000u;
@@ -211,10 +211,10 @@ private:
     bool m_version_uncertain { true };
     NonnullOwnPtr<IOWindow> m_registers_io_window;
     u32 m_ocp_base_address { 0 };
-    OwnPtr<Memory::Region> m_rx_descriptors_region;
+    Memory::TypedMapping<RXDescriptor volatile[]> m_rx_descriptors;
     Vector<NonnullOwnPtr<Memory::Region>> m_rx_buffers_regions;
     u16 m_rx_free_index { 0 };
-    OwnPtr<Memory::Region> m_tx_descriptors_region;
+    Memory::TypedMapping<TXDescriptor volatile[]> m_tx_descriptors;
     Vector<NonnullOwnPtr<Memory::Region>> m_tx_buffers_regions;
     u16 m_tx_free_index { 0 };
     bool m_link_up { false };


### PR DESCRIPTION
This mainly adds users of this in the Network code, as those were the easiest to find
Other places in the kernel may profit off of this in the future, like the ring buffers across other drivers