### PR TITLE
Cherry-pick "LibWeb: Skip DedicatedWorkerGlobalScope-instanceof test"

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,8 +1,12 @@
 [Skipped]
-Text/input/HTML/cross-origin-window-properties.html
+Ref/css-keyframe-fill-forwards.html
+Ref/unicode-range.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
+Text/input/HTML/cross-origin-window-properties.html
+Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
+Text/input/window-scrollTo.html
 Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-crypto.html
 Text/input/Worker/Worker-echo.html
@@ -10,6 +14,3 @@ Text/input/Worker/Worker-importScripts.html
 Text/input/Worker/Worker-location.html
 Text/input/Worker/Worker-module.html
 Text/input/Worker/Worker-performance.html
-Text/input/window-scrollTo.html
-Ref/unicode-range.html
-Ref/css-keyframe-fill-forwards.html


### PR DESCRIPTION
It is consistently hanging on mac. See LadybirdBrowser/ladybird#1306 for details.

(cherry picked from commit feaf2feab8fbd855f526a5a4eec2395fdec6a749)

---

https://github.com/LadybirdBrowser/ladybird/pull/1867

#25390 brought the test in, and it's failing on our CI too: https://github.com/SerenityOS/serenity/actions/runs/11872575369/job/33086444958?pr=25410