### PR TITLE
Cherry-pick "LibWeb: Don't discard PostedMessage tasks when closing a worker"

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -9,6 +9,7 @@ Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/window-scrollTo.html
 Text/input/Worker/Worker-blob.html
+Text/input/Worker/Worker-close-after-postMessage.html
 Text/input/Worker/Worker-crypto.html
 Text/input/Worker/Worker-echo.html
 Text/input/Worker/Worker-importScripts.html

--- a/Tests/LibWeb/Text/expected/Worker/Worker-close-after-postMessage.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-close-after-postMessage.txt
@@ -1,0 +1,1 @@
+PASS (didn't hang)

--- a/Tests/LibWeb/Text/input/Worker/Worker-close-after-postMessage.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-close-after-postMessage.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let work = new Worker("worker-close-after-postMessage.js");
+        work.onmessage = (evt) => {
+            println(evt.data);
+            done();
+        };
+        work.postMessage("")
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Worker/worker-close-after-postMessage.js
+++ b/Tests/LibWeb/Text/input/Worker/worker-close-after-postMessage.js
@@ -1,0 +1,4 @@
+self.onmessage = function () {
+    postMessage("PASS (didn't hang)");
+    self.close();
+};

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -68,8 +68,9 @@ void WorkerGlobalScope::set_internal_port(JS::NonnullGCPtr<MessagePort> port)
 void WorkerGlobalScope::close_a_worker()
 {
     // 1. Discard any tasks that have been added to workerGlobal's relevant agent's event loop's task queues.
-    relevant_settings_object(*this).responsible_event_loop().task_queue().remove_tasks_matching([](HTML::Task const&) {
-        return true;
+    relevant_settings_object(*this).responsible_event_loop().task_queue().remove_tasks_matching([](HTML::Task const& task) {
+        // NOTE: We don't discard tasks with the PostedMessage source, as the spec expects PostMessage() to act as if it is invoked immediately
+        return task.source() != HTML::Task::Source::PostedMessage;
     });
 
     // 2. Set workerGlobal's closing flag to true. (This prevents any further tasks from being queued.)


### PR DESCRIPTION
The spec expects `postMessage()` to act as if it is invoked immediately. Since `postMessage()` isn't actually invoked immediately, keep tasks with source `PostedMessage` in the task queue, so that these tasks are processed. Fixes a hang when `WorkerGlobalScope.close()` is called immediately after `postMessage()`.

(cherry picked from commit fd8d350b4756817598ee49a11b9efc3b953dbb00)

---

https://github.com/LadybirdBrowser/ladybird/pull/1661
