### PR TITLE
Cherry-pick "LibWeb: Make empty media query lists evaluate to true"

### DIFF
--- a/Tests/LibWeb/Layout/expected/media-query-empty.txt
+++ b/Tests/LibWeb/Layout/expected/media-query-empty.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
+      BlockContainer <div.first> at (8,8) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17] baseline: 13.296875
+            "First"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.second> at (8,25) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 6, rect: [8,25 57.40625x17] baseline: 13.296875
+            "Second"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+        TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
+      PaintableWithLines (BlockContainer<DIV>.first) [8,8 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
+      PaintableWithLines (BlockContainer<DIV>.second) [8,25 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]

--- a/Tests/LibWeb/Layout/input/media-query-empty.html
+++ b/Tests/LibWeb/Layout/input/media-query-empty.html
@@ -1,0 +1,15 @@
+<style>
+div { display: none; }
+@media {
+    div.first { display: block; }
+}
+@media{
+    div.second { display: block; }
+}
+@media ,, {
+    div.invalid { display: block; }
+}
+</style>
+<div class="first">First</div>
+<div class="second">Second</div>
+<div class="invalid">Invalid</div>

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -100,9 +100,8 @@ bool MediaList::evaluate(HTML::Window const& window)
 
 bool MediaList::matches() const
 {
-    if (m_media.is_empty()) {
+    if (m_media.is_empty())
         return true;
-    }
 
     for (auto& media : m_media) {
         if (media->matches())

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -51,10 +51,14 @@ String MediaQueryList::media() const
 // https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-matches
 bool MediaQueryList::matches() const
 {
+    if (m_media.is_empty())
+        return true;
+
     for (auto& media : m_media) {
         if (media->matches())
             return true;
     }
+
     return false;
 }
 
@@ -63,6 +67,9 @@ bool MediaQueryList::evaluate()
     auto window = m_document->window();
     if (!window)
         return false;
+
+    if (m_media.is_empty())
+        return true;
 
     bool now_matches = false;
     for (auto& media : m_media) {


### PR DESCRIPTION
(cherry picked from commit 16f2f6aa4230ad7f2e4b502c1b5fabd53215220c)

---

https://github.com/LadybirdBrowser/ladybird/pull/1611
