### PR TITLE
Cherry-pick "LibWeb/CSS: Bring TokenStream in line with spec"

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
@@ -97,15 +97,15 @@ namespace Web::CSS::Parser {
 static Optional<RoundingStrategy> parse_rounding_strategy(Vector<ComponentValue> const& tokens)
 {
     auto stream = TokenStream { tokens };
-    stream.skip_whitespace();
+    stream.discard_whitespace();
     if (!stream.has_next_token())
         return {};
 
-    auto& ident = stream.next_token();
+    auto& ident = stream.consume_a_token();
     if (!ident.is(Token::Type::Ident))
         return {};
 
-    stream.skip_whitespace();
+    stream.discard_whitespace();
     if (stream.has_next_token())
         return {};
 

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestCSSIDSpeed.cpp
     TestCSSPixels.cpp
+    TestCSSTokenStream.cpp
     TestFetchInfrastructure.cpp
     TestFetchURL.cpp
     TestHTMLTokenizer.cpp

--- a/Tests/LibWeb/TestCSSTokenStream.cpp
+++ b/Tests/LibWeb/TestCSSTokenStream.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/FlyString.h>
+#include <AK/Vector.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/CSS/Parser/TokenStream.h>
+
+namespace Web::CSS::Parser {
+
+TEST_CASE(basic)
+{
+    Vector<Token> tokens {
+        Token::create_ident("hello"_fly_string),
+    };
+
+    TokenStream stream { tokens };
+    EXPECT(!stream.is_empty());
+    EXPECT(stream.has_next_token());
+    EXPECT_EQ(stream.remaining_token_count(), 1u);
+
+    // next_token() doesn't consume it
+    auto const& next = stream.next_token();
+    EXPECT(!stream.is_empty());
+    EXPECT(stream.has_next_token());
+    EXPECT_EQ(stream.remaining_token_count(), 1u);
+    // Check what the token is
+    EXPECT(next.is(Token::Type::Ident));
+    EXPECT_EQ(next.ident(), "hello"_fly_string);
+
+    // consume_a_token() does consume it
+    auto const& consumed = stream.consume_a_token();
+    EXPECT(stream.is_empty());
+    EXPECT(!stream.has_next_token());
+    EXPECT_EQ(stream.remaining_token_count(), 0u);
+    // Check what the token is
+    EXPECT(consumed.is(Token::Type::Ident));
+    EXPECT_EQ(consumed.ident(), "hello"_fly_string);
+
+    // Now, any further tokens should be EOF
+    EXPECT(stream.next_token().is(Token::Type::EndOfFile));
+    EXPECT(stream.consume_a_token().is(Token::Type::EndOfFile));
+}
+
+TEST_CASE(marks)
+{
+    Vector<Token> tokens {
+        Token::create_ident("a"_fly_string),
+        Token::create_ident("b"_fly_string),
+        Token::create_ident("c"_fly_string),
+        Token::create_ident("d"_fly_string),
+        Token::create_ident("e"_fly_string),
+        Token::create_ident("f"_fly_string),
+        Token::create_ident("g"_fly_string),
+    };
+    TokenStream stream { tokens };
+
+    stream.mark(); // 0
+
+    EXPECT_EQ(stream.remaining_token_count(), 7u);
+
+    stream.discard_a_token();
+    stream.discard_a_token();
+    stream.discard_a_token();
+
+    EXPECT_EQ(stream.remaining_token_count(), 4u);
+
+    stream.mark(); // 3
+
+    stream.discard_a_token();
+
+    EXPECT_EQ(stream.remaining_token_count(), 3u);
+
+    stream.restore_a_mark(); // Back to 3
+
+    EXPECT_EQ(stream.remaining_token_count(), 4u);
+
+    stream.discard_a_token();
+    stream.discard_a_token();
+    stream.discard_a_token();
+
+    EXPECT_EQ(stream.remaining_token_count(), 1u);
+
+    stream.mark(); // 6
+
+    stream.discard_a_mark();
+
+    EXPECT_EQ(stream.remaining_token_count(), 1u);
+
+    stream.restore_a_mark(); // Back to 0
+
+    EXPECT_EQ(stream.remaining_token_count(), 7u);
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -27,20 +27,20 @@ Optional<Vector<TElement>> Parser::parse_color_stop_list(TokenStream<ComponentVa
     };
 
     auto parse_color_stop_list_element = [&](TElement& element) -> ElementType {
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (!tokens.has_next_token())
             return ElementType::Garbage;
 
         RefPtr<CSSStyleValue> color;
         Optional<typename TElement::PositionType> position;
         Optional<typename TElement::PositionType> second_position;
-        if (auto dimension = parse_dimension(tokens.peek_token()); dimension.has_value() && is_position(*dimension)) {
+        if (auto dimension = parse_dimension(tokens.next_token()); dimension.has_value() && is_position(*dimension)) {
             // [<T-percentage> <color>] or [<T-percentage>]
             position = get_position(*dimension);
-            (void)tokens.next_token(); // dimension
-            tokens.skip_whitespace();
+            tokens.discard_a_token(); // dimension
+            tokens.discard_whitespace();
             // <T-percentage>
-            if (!tokens.has_next_token() || tokens.peek_token().is(Token::Type::Comma)) {
+            if (!tokens.has_next_token() || tokens.next_token().is(Token::Type::Comma)) {
                 element.transition_hint = typename TElement::ColorHint { *position };
                 return ElementType::ColorHint;
             }
@@ -55,16 +55,16 @@ Optional<Vector<TElement>> Parser::parse_color_stop_list(TokenStream<ComponentVa
             if (!maybe_color)
                 return ElementType::Garbage;
             color = maybe_color.release_nonnull();
-            tokens.skip_whitespace();
+            tokens.discard_whitespace();
             // Allow up to [<color> <T-percentage> <T-percentage>] (double-position color stops)
             // Note: Double-position color stops only appear to be valid in this order.
             for (auto stop_position : Array { &position, &second_position }) {
-                if (tokens.has_next_token() && !tokens.peek_token().is(Token::Type::Comma)) {
-                    auto dimension = parse_dimension(tokens.next_token());
+                if (tokens.has_next_token() && !tokens.next_token().is(Token::Type::Comma)) {
+                    auto dimension = parse_dimension(tokens.consume_a_token());
                     if (!dimension.has_value() || !is_position(*dimension))
                         return ElementType::Garbage;
                     *stop_position = get_position(*dimension);
-                    tokens.skip_whitespace();
+                    tokens.discard_whitespace();
                 }
             }
         }
@@ -83,14 +83,14 @@ Optional<Vector<TElement>> Parser::parse_color_stop_list(TokenStream<ComponentVa
     Vector<TElement> color_stops { first_element };
     while (tokens.has_next_token()) {
         TElement list_element {};
-        tokens.skip_whitespace();
-        if (!tokens.next_token().is(Token::Type::Comma))
+        tokens.discard_whitespace();
+        if (!tokens.consume_a_token().is(Token::Type::Comma))
             return {};
         auto element_type = parse_color_stop_list_element(list_element);
         if (element_type == ElementType::ColorHint) {
             // <color-hint>, <color-stop>
-            tokens.skip_whitespace();
-            if (!tokens.next_token().is(Token::Type::Comma))
+            tokens.discard_whitespace();
+            if (!tokens.consume_a_token().is(Token::Type::Comma))
                 return {};
             // Note: This fills in the color stop on the same list_element as the color hint (it does not overwrite it).
             if (parse_color_stop_list_element(list_element) != ElementType::ColorStop)
@@ -140,7 +140,7 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
     using GradientType = LinearGradientStyleValue::GradientType;
 
     auto transaction = outer_tokens.begin_transaction();
-    auto& component_value = outer_tokens.next_token();
+    auto& component_value = outer_tokens.consume_a_token();
 
     if (!component_value.is_function())
         return nullptr;
@@ -164,7 +164,7 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
     // linear-gradient() = linear-gradient([ <angle> | to <side-or-corner> ]?, <color-stop-list>)
 
     TokenStream tokens { component_value.function().values() };
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
 
     if (!tokens.has_next_token())
         return nullptr;
@@ -194,10 +194,10 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
         return token.token().ident().equals_ignoring_ascii_case("to"sv);
     };
 
-    auto const& first_param = tokens.peek_token();
+    auto const& first_param = tokens.next_token();
     if (first_param.is(Token::Type::Dimension)) {
         // <angle>
-        tokens.next_token();
+        tokens.discard_a_token();
         auto angle_value = first_param.token().dimension_value();
         auto unit_string = first_param.token().dimension_unit();
         auto angle_type = Angle::unit_from_name(unit_string);
@@ -211,23 +211,23 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
 
         // Note: -webkit-linear-gradient does not include to the "to" prefix on the side or corner
         if (gradient_type == GradientType::Standard) {
-            tokens.next_token();
-            tokens.skip_whitespace();
+            tokens.discard_a_token();
+            tokens.discard_whitespace();
 
             if (!tokens.has_next_token())
                 return nullptr;
         }
 
         // [left | right] || [top | bottom]
-        auto const& first_side = tokens.next_token();
+        auto const& first_side = tokens.consume_a_token();
         if (!first_side.is(Token::Type::Ident))
             return nullptr;
 
         auto side_a = to_side(first_side.token().ident());
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         Optional<SideOrCorner> side_b;
-        if (tokens.has_next_token() && tokens.peek_token().is(Token::Type::Ident))
-            side_b = to_side(tokens.next_token().token().ident());
+        if (tokens.has_next_token() && tokens.next_token().is(Token::Type::Ident))
+            side_b = to_side(tokens.consume_a_token().token().ident());
 
         if (side_a.has_value() && !side_b.has_value()) {
             gradient_direction = *side_a;
@@ -252,11 +252,11 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
         has_direction_param = false;
     }
 
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
     if (!tokens.has_next_token())
         return nullptr;
 
-    if (has_direction_param && !tokens.next_token().is(Token::Type::Comma))
+    if (has_direction_param && !tokens.consume_a_token().is(Token::Type::Comma))
         return nullptr;
 
     auto color_stops = parse_linear_color_stop_list(tokens);
@@ -270,7 +270,7 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
 RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<ComponentValue>& outer_tokens)
 {
     auto transaction = outer_tokens.begin_transaction();
-    auto& component_value = outer_tokens.next_token();
+    auto& component_value = outer_tokens.consume_a_token();
 
     if (!component_value.is_function())
         return nullptr;
@@ -287,7 +287,7 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
         return nullptr;
 
     TokenStream tokens { component_value.function().values() };
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
 
     if (!tokens.has_next_token())
         return nullptr;
@@ -297,7 +297,7 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
 
     // conic-gradient( [ [ from <angle> ]? [ at <position> ]? ]  ||
     // <color-interpolation-method> , <angular-color-stop-list> )
-    auto token = tokens.peek_token();
+    auto token = tokens.next_token();
     bool got_from_angle = false;
     bool got_color_interpolation_method = false;
     bool got_at_position = false;
@@ -305,8 +305,8 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
         auto consume_identifier = [&](auto identifier) {
             auto token_string = token.token().ident();
             if (token_string.equals_ignoring_ascii_case(identifier)) {
-                (void)tokens.next_token();
-                tokens.skip_whitespace();
+                tokens.discard_a_token();
+                tokens.discard_whitespace();
                 return true;
             }
             return false;
@@ -319,7 +319,7 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
             if (!tokens.has_next_token())
                 return nullptr;
 
-            auto angle_token = tokens.next_token();
+            auto angle_token = tokens.consume_a_token();
             if (!angle_token.is(Token::Type::Dimension))
                 return nullptr;
             auto angle = angle_token.token().dimension_value();
@@ -348,16 +348,16 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
         } else {
             break;
         }
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (!tokens.has_next_token())
             return nullptr;
-        token = tokens.peek_token();
+        token = tokens.next_token();
     }
 
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
     if (!tokens.has_next_token())
         return nullptr;
-    if ((got_from_angle || got_at_position || got_color_interpolation_method) && !tokens.next_token().is(Token::Type::Comma))
+    if ((got_from_angle || got_at_position || got_color_interpolation_method) && !tokens.consume_a_token().is(Token::Type::Comma))
         return nullptr;
 
     auto color_stops = parse_angular_color_stop_list(tokens);
@@ -380,7 +380,7 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
     using Size = RadialGradientStyleValue::Size;
 
     auto transaction = outer_tokens.begin_transaction();
-    auto& component_value = outer_tokens.next_token();
+    auto& component_value = outer_tokens.consume_a_token();
 
     if (!component_value.is_function())
         return nullptr;
@@ -397,7 +397,7 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
         return nullptr;
 
     TokenStream tokens { component_value.function().values() };
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
     if (!tokens.has_next_token())
         return nullptr;
 
@@ -416,8 +416,8 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
 
     auto parse_ending_shape = [&]() -> Optional<EndingShape> {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
-        auto& token = tokens.next_token();
+        tokens.discard_whitespace();
+        auto& token = tokens.consume_a_token();
         if (!token.is(Token::Type::Ident))
             return {};
         auto ident = token.token().ident();
@@ -446,11 +446,11 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
         //      <length [0,∞]>                |
         //      <length-percentage [0,∞]>{2}
         auto transaction_size = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (!tokens.has_next_token())
             return {};
-        if (tokens.peek_token().is(Token::Type::Ident)) {
-            auto extent = parse_extent_keyword(tokens.next_token().token().ident());
+        if (tokens.next_token().is(Token::Type::Ident)) {
+            auto extent = parse_extent_keyword(tokens.consume_a_token().token().ident());
             if (!extent.has_value())
                 return {};
             return commit_value(*extent, transaction_size);
@@ -459,7 +459,7 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
         if (!first_radius.has_value())
             return {};
         auto transaction_second_dimension = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (tokens.has_next_token()) {
             auto second_radius = parse_length_percentage(tokens);
             if (second_radius.has_value())
@@ -494,13 +494,13 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
         }
     }
 
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
     if (!tokens.has_next_token())
         return nullptr;
 
-    auto& token = tokens.peek_token();
+    auto& token = tokens.next_token();
     if (token.is_ident("at"sv)) {
-        (void)tokens.next_token();
+        tokens.discard_a_token();
         auto position = parse_position_value(tokens);
         if (!position)
             return nullptr;
@@ -508,10 +508,10 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
         expect_comma = true;
     }
 
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
     if (!tokens.has_next_token())
         return nullptr;
-    if (expect_comma && !tokens.next_token().is(Token::Type::Comma))
+    if (expect_comma && !tokens.consume_a_token().is(Token::Type::Comma))
         return nullptr;
 
     // <color-stop-list>

--- a/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -29,7 +29,7 @@ Vector<NonnullRefPtr<MediaQuery>> Parser::parse_a_media_query_list(TokenStream<T
 
     // AD-HOC: Ignore whitespace-only queries
     // to make `@media {..}` equivalent to `@media all {..}`
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
     if (!tokens.has_next_token())
         return {};
 
@@ -64,8 +64,8 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
     // `[ not | only ]?`, Returns whether to negate the query
     auto parse_initial_modifier = [](auto& tokens) -> Optional<bool> {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
-        auto& token = tokens.next_token();
+        tokens.discard_whitespace();
+        auto& token = tokens.consume_a_token();
         if (!token.is(Token::Type::Ident))
             return {};
 
@@ -92,11 +92,11 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
     };
 
     auto media_query = MediaQuery::create();
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
 
     // `<media-condition>`
     if (auto media_condition = parse_media_condition(tokens, MediaCondition::AllowOr::Yes)) {
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (tokens.has_next_token())
             return invalid_media_query();
         media_query->m_media_condition = move(media_condition);
@@ -106,13 +106,13 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
     // `[ not | only ]?`
     if (auto modifier = parse_initial_modifier(tokens); modifier.has_value()) {
         media_query->m_negated = modifier.value();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
     }
 
     // `<media-type>`
     if (auto media_type = parse_media_type(tokens); media_type.has_value()) {
         media_query->m_media_type = media_type.value();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
     } else {
         return invalid_media_query();
     }
@@ -121,9 +121,9 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
         return media_query;
 
     // `[ and <media-condition-without-or> ]?`
-    if (auto maybe_and = tokens.next_token(); maybe_and.is_ident("and"sv)) {
+    if (auto maybe_and = tokens.consume_a_token(); maybe_and.is_ident("and"sv)) {
         if (auto media_condition = parse_media_condition(tokens, MediaCondition::AllowOr::No)) {
-            tokens.skip_whitespace();
+            tokens.discard_whitespace();
             if (tokens.has_next_token())
                 return invalid_media_query();
             media_query->m_media_condition = move(media_condition);
@@ -142,14 +142,14 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
 {
     // `<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]`
     auto transaction = tokens.begin_transaction();
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
 
     // `<media-not> = not <media-in-parens>`
     auto parse_media_not = [&](auto& tokens) -> OwnPtr<MediaCondition> {
         auto local_transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
 
-        auto& first_token = tokens.next_token();
+        auto& first_token = tokens.consume_a_token();
         if (first_token.is_ident("not"sv)) {
             if (auto child_condition = parse_media_condition(tokens, MediaCondition::AllowOr::Yes)) {
                 local_transaction.commit();
@@ -162,11 +162,11 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
 
     auto parse_media_with_combinator = [&](auto& tokens, StringView combinator) -> OwnPtr<MediaCondition> {
         auto local_transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
 
-        auto& first = tokens.next_token();
+        auto& first = tokens.consume_a_token();
         if (first.is_ident(combinator)) {
-            tokens.skip_whitespace();
+            tokens.discard_whitespace();
             if (auto media_in_parens = parse_media_in_parens(tokens)) {
                 local_transaction.commit();
                 return media_in_parens;
@@ -189,7 +189,7 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
 
     // `<media-in-parens> [ <media-and>* | <media-or>* ]`
     if (auto maybe_media_in_parens = parse_media_in_parens(tokens)) {
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         // Only `<media-in-parens>`
         if (!tokens.has_next_token()) {
             transaction.commit();
@@ -203,11 +203,11 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
         if (auto media_and = parse_media_and(tokens)) {
             child_conditions.append(media_and.release_nonnull());
 
-            tokens.skip_whitespace();
+            tokens.discard_whitespace();
             while (tokens.has_next_token()) {
                 if (auto next_media_and = parse_media_and(tokens)) {
                     child_conditions.append(next_media_and.release_nonnull());
-                    tokens.skip_whitespace();
+                    tokens.discard_whitespace();
                     continue;
                 }
                 // We failed - invalid syntax!
@@ -223,11 +223,11 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
             if (auto media_or = parse_media_or(tokens)) {
                 child_conditions.append(media_or.release_nonnull());
 
-                tokens.skip_whitespace();
+                tokens.discard_whitespace();
                 while (tokens.has_next_token()) {
                     if (auto next_media_or = parse_media_or(tokens)) {
                         child_conditions.append(next_media_or.release_nonnull());
-                        tokens.skip_whitespace();
+                        tokens.discard_whitespace();
                         continue;
                     }
                     // We failed - invalid syntax!
@@ -247,7 +247,7 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
 Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& tokens)
 {
     // `[ <mf-plain> | <mf-boolean> | <mf-range> ]`
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
 
     // `<mf-name> = <ident>`
     struct MediaFeatureName {
@@ -260,7 +260,7 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
     };
     auto parse_mf_name = [](auto& tokens, bool allow_min_max_prefix) -> Optional<MediaFeatureName> {
         auto transaction = tokens.begin_transaction();
-        auto& token = tokens.next_token();
+        auto& token = tokens.consume_a_token();
         if (token.is(Token::Type::Ident)) {
             auto name = token.token().ident();
             if (auto id = media_feature_id_from_string(name); id.has_value()) {
@@ -285,10 +285,10 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
     // `<mf-boolean> = <mf-name>`
     auto parse_mf_boolean = [&](auto& tokens) -> Optional<MediaFeature> {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
 
         if (auto maybe_name = parse_mf_name(tokens, false); maybe_name.has_value()) {
-            tokens.skip_whitespace();
+            tokens.discard_whitespace();
             if (!tokens.has_next_token()) {
                 transaction.commit();
                 return MediaFeature::boolean(maybe_name->id);
@@ -301,14 +301,14 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
     // `<mf-plain> = <mf-name> : <mf-value>`
     auto parse_mf_plain = [&](auto& tokens) -> Optional<MediaFeature> {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
 
         if (auto maybe_name = parse_mf_name(tokens, true); maybe_name.has_value()) {
-            tokens.skip_whitespace();
-            if (tokens.next_token().is(Token::Type::Colon)) {
-                tokens.skip_whitespace();
+            tokens.discard_whitespace();
+            if (tokens.consume_a_token().is(Token::Type::Colon)) {
+                tokens.discard_whitespace();
                 if (auto maybe_value = parse_media_feature_value(maybe_name->id, tokens); maybe_value.has_value()) {
-                    tokens.skip_whitespace();
+                    tokens.discard_whitespace();
                     if (!tokens.has_next_token()) {
                         transaction.commit();
                         switch (maybe_name->type) {
@@ -333,9 +333,9 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
     //  <mf-comparison> = <mf-lt> | <mf-gt> | <mf-eq>`
     auto parse_comparison = [](auto& tokens) -> Optional<MediaFeature::Comparison> {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
 
-        auto& first = tokens.next_token();
+        auto& first = tokens.consume_a_token();
         if (first.is(Token::Type::Delim)) {
             auto first_delim = first.token().delim();
             if (first_delim == '=') {
@@ -343,9 +343,9 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
                 return MediaFeature::Comparison::Equal;
             }
             if (first_delim == '<') {
-                auto& second = tokens.peek_token();
+                auto& second = tokens.next_token();
                 if (second.is_delim('=')) {
-                    tokens.next_token();
+                    tokens.discard_a_token();
                     transaction.commit();
                     return MediaFeature::Comparison::LessThanOrEqual;
                 }
@@ -353,9 +353,9 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
                 return MediaFeature::Comparison::LessThan;
             }
             if (first_delim == '>') {
-                auto& second = tokens.peek_token();
+                auto& second = tokens.next_token();
                 if (second.is_delim('=')) {
-                    tokens.next_token();
+                    tokens.discard_a_token();
                     transaction.commit();
                     return MediaFeature::Comparison::GreaterThanOrEqual;
                 }
@@ -403,16 +403,16 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
     //             | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>`
     auto parse_mf_range = [&](auto& tokens) -> Optional<MediaFeature> {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
 
         // `<mf-name> <mf-comparison> <mf-value>`
         // NOTE: We have to check for <mf-name> first, since all <mf-name>s will also parse as <mf-value>.
         if (auto maybe_name = parse_mf_name(tokens, false); maybe_name.has_value() && media_feature_type_is_range(maybe_name->id)) {
-            tokens.skip_whitespace();
+            tokens.discard_whitespace();
             if (auto maybe_comparison = parse_comparison(tokens); maybe_comparison.has_value()) {
-                tokens.skip_whitespace();
+                tokens.discard_whitespace();
                 if (auto maybe_value = parse_media_feature_value(maybe_name->id, tokens); maybe_value.has_value()) {
-                    tokens.skip_whitespace();
+                    tokens.discard_whitespace();
                     if (!tokens.has_next_token() && !maybe_value->is_ident()) {
                         transaction.commit();
                         return MediaFeature::half_range(maybe_value.release_value(), flip(maybe_comparison.release_value()), maybe_name->id);
@@ -435,23 +435,23 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
             while (tokens.has_next_token() && !maybe_name.has_value()) {
                 if (auto maybe_comparison = parse_comparison(tokens); maybe_comparison.has_value()) {
                     // We found a comparison, so the next non-whitespace token should be the <mf-name>
-                    tokens.skip_whitespace();
+                    tokens.discard_whitespace();
                     maybe_name = parse_mf_name(tokens, false);
                     break;
                 }
-                tokens.next_token();
-                tokens.skip_whitespace();
+                tokens.discard_a_token();
+                tokens.discard_whitespace();
             }
         }
 
         // Now, we can parse the range properly.
         if (maybe_name.has_value() && media_feature_type_is_range(maybe_name->id)) {
             if (auto maybe_left_value = parse_media_feature_value(maybe_name->id, tokens); maybe_left_value.has_value()) {
-                tokens.skip_whitespace();
+                tokens.discard_whitespace();
                 if (auto maybe_left_comparison = parse_comparison(tokens); maybe_left_comparison.has_value()) {
-                    tokens.skip_whitespace();
-                    tokens.next_token(); // The <mf-name> which we already parsed above.
-                    tokens.skip_whitespace();
+                    tokens.discard_whitespace();
+                    tokens.discard_a_token(); // The <mf-name> which we already parsed above.
+                    tokens.discard_whitespace();
 
                     if (!tokens.has_next_token()) {
                         transaction.commit();
@@ -459,9 +459,9 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
                     }
 
                     if (auto maybe_right_comparison = parse_comparison(tokens); maybe_right_comparison.has_value()) {
-                        tokens.skip_whitespace();
+                        tokens.discard_whitespace();
                         if (auto maybe_right_value = parse_media_feature_value(maybe_name->id, tokens); maybe_right_value.has_value()) {
-                            tokens.skip_whitespace();
+                            tokens.discard_whitespace();
                             // For this to be valid, the following must be true:
                             // - Comparisons must either both be >/>= or both be </<=.
                             // - Neither comparison can be `=`.
@@ -500,8 +500,8 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
 Optional<MediaQuery::MediaType> Parser::parse_media_type(TokenStream<ComponentValue>& tokens)
 {
     auto transaction = tokens.begin_transaction();
-    tokens.skip_whitespace();
-    auto const& token = tokens.next_token();
+    tokens.discard_whitespace();
+    auto const& token = tokens.consume_a_token();
 
     if (!token.is(Token::Type::Ident))
         return {};
@@ -517,19 +517,19 @@ OwnPtr<MediaCondition> Parser::parse_media_in_parens(TokenStream<ComponentValue>
 {
     // `<media-in-parens> = ( <media-condition> ) | ( <media-feature> ) | <general-enclosed>`
     auto transaction = tokens.begin_transaction();
-    tokens.skip_whitespace();
+    tokens.discard_whitespace();
 
     // `( <media-condition> ) | ( <media-feature> )`
-    auto const& first_token = tokens.peek_token();
+    auto const& first_token = tokens.next_token();
     if (first_token.is_block() && first_token.block().is_paren()) {
         TokenStream inner_token_stream { first_token.block().values() };
         if (auto maybe_media_condition = parse_media_condition(inner_token_stream, MediaCondition::AllowOr::Yes)) {
-            tokens.next_token();
+            tokens.discard_a_token();
             transaction.commit();
             return maybe_media_condition.release_nonnull();
         }
         if (auto maybe_media_feature = parse_media_feature(inner_token_stream); maybe_media_feature.has_value()) {
-            tokens.next_token();
+            tokens.discard_a_token();
             transaction.commit();
             return MediaCondition::from_feature(maybe_media_feature.release_value());
         }
@@ -553,10 +553,10 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     // NOTE: Calculations are not allowed for media feature values, at least in the current spec, so we reject them.
 
     // Identifiers
-    if (tokens.peek_token().is(Token::Type::Ident)) {
+    if (tokens.next_token().is(Token::Type::Ident)) {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
-        auto keyword = keyword_from_string(tokens.next_token().token().ident());
+        tokens.discard_whitespace();
+        auto keyword = keyword_from_string(tokens.consume_a_token().token().ident());
         if (keyword.has_value() && media_feature_accepts_keyword(media_feature, keyword.value())) {
             transaction.commit();
             return MediaFeatureValue(keyword.value());
@@ -568,7 +568,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     // Boolean (<mq-boolean> in the spec: a 1 or 0)
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Boolean)) {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (auto integer = parse_integer(tokens); integer.has_value() && !integer->is_calculated()) {
             auto integer_value = integer->value();
             if (integer_value == 0 || integer_value == 1) {
@@ -590,7 +590,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     // Length
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Length)) {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (auto length = parse_length(tokens); length.has_value() && !length->is_calculated()) {
             transaction.commit();
             return MediaFeatureValue(length->value());
@@ -600,7 +600,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     // Ratio
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Ratio)) {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (auto ratio = parse_ratio(tokens); ratio.has_value()) {
             transaction.commit();
             return MediaFeatureValue(ratio.release_value());
@@ -610,7 +610,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     // Resolution
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Resolution)) {
         auto transaction = tokens.begin_transaction();
-        tokens.skip_whitespace();
+        tokens.discard_whitespace();
         if (auto resolution = parse_resolution(tokens); resolution.has_value() && !resolution->is_calculated()) {
             transaction.commit();
             return MediaFeatureValue(resolution->value());


### PR DESCRIPTION
When the TokenStream code was originally written, there was no such concept in the CSS Syntax spec. But since then, it's been officially added, (https://drafts.csswg.org/css-syntax/#css-token-stream) and the parsing algorithms are described in terms of it. This patch brings our implementation in line with the spec. A few deprecated TokenStream methods are left around until their users are also updated to match the newer spec.

There are a few differences:

- They name things differently. The main confusing one is we had `next_token()` which consumed a token and returned it, but the spec has a `next_token()` which peeks the next token. The spec names are honestly better than what I'd come up with. (`discard_a_token()` is a nice addition too!)

- We used to store the index of the token that was just consumed, and they instead store the index of the token that will be consumed next. This is a perfect breeding ground for off-by-one errors, so I've finally added a test suite for TokenStream itself.

- We use a transaction system for rewinding, and the spec uses a stack of "marks", which can be manually rewound to. These should be able to coexist as long as we stick with marks in the parser spec algorithms, and stick with transactions elsewhere.

(cherry picked from commit b645e26e9b29437c0e248b5e43e3ec76aacf960d)

---

https://github.com/LadybirdBrowser/ladybird/pull/1694
