### PR TITLE
AK: Don't define IsFloatingPoint and the FloatingPoint concept in KERNEL

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -15,8 +15,10 @@ namespace AK::Concepts {
 template<typename T>
 concept Integral = IsIntegral<T>;
 
+#ifndef KERNEL
 template<typename T>
 concept FloatingPoint = IsFloatingPoint<T>;
+#endif
 
 template<typename T>
 concept Fundamental = IsFundamental<T>;
@@ -168,7 +170,9 @@ using AK::Concepts::ConvertibleTo;
 using AK::Concepts::DerivedFrom;
 using AK::Concepts::Enum;
 using AK::Concepts::FallibleFunction;
+#ifndef KERNEL
 using AK::Concepts::FloatingPoint;
+#endif
 using AK::Concepts::Fundamental;
 using AK::Concepts::Indexable;
 using AK::Concepts::Integral;

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -403,6 +403,7 @@ public:
         return *this < other || *this == other;
     }
 
+#ifndef KERNEL
     // Casting from a float should be faster than casting to a float
     template<FloatingPoint F>
     bool operator==(F other) const { return *this == (This)other; }
@@ -416,6 +417,7 @@ public:
     bool operator<(F other) const { return *this < (This)other; }
     template<FloatingPoint F>
     bool operator<=(F other) const { return *this <= (This)other; }
+#endif
 
     template<size_t P, typename U>
     operator FixedPoint<P, U>() const

--- a/AK/SIMD.h
+++ b/AK/SIMD.h
@@ -97,6 +97,7 @@ struct IndexVectorFor<T> {
     using Type = T;
 };
 
+#ifndef KERNEL
 template<SIMDVector T>
 requires(IsFloatingPoint<ElementOf<T>>)
 struct IndexVectorFor<T> {
@@ -105,6 +106,7 @@ struct IndexVectorFor<T> {
         u32 __attribute__((vector_size(sizeof(T)))),
         u64 __attribute__((vector_size(sizeof(T))))>;
 };
+#endif
 
 }
 
@@ -114,10 +116,13 @@ using IndexVectorFor = typename Detail::IndexVectorFor<T>::Type;
 static_assert(IsSame<IndexVectorFor<i8x16>, i8x16>);
 static_assert(IsSame<IndexVectorFor<u32x4>, u32x4>);
 static_assert(IsSame<IndexVectorFor<u64x4>, u64x4>);
-#if defined(AK_COMPILER_CLANG)
+
+#ifndef KERNEL
+#    if defined(AK_COMPILER_CLANG)
 // FIXME: GCC silently ignores the dependent vector_size attribute, this seems to be a bug
 //        https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68703
 static_assert(IsSame<IndexVectorFor<f32x4>, u32x4>);
 static_assert(IsSame<IndexVectorFor<f64x4>, u64x4>);
+#    endif
 #endif
 }

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -342,6 +342,7 @@ inline constexpr bool __IsIntegral<unsigned long long> = true;
 template<typename T>
 inline constexpr bool IsIntegral = __IsIntegral<MakeUnsigned<RemoveCV<T>>>;
 
+#ifndef KERNEL
 template<typename T>
 inline constexpr bool __IsFloatingPoint = false;
 template<>
@@ -353,6 +354,7 @@ inline constexpr bool __IsFloatingPoint<long double> = true;
 
 template<typename T>
 inline constexpr bool IsFloatingPoint = __IsFloatingPoint<RemoveCV<T>>;
+#endif
 
 template<typename ReferenceType, typename T>
 using CopyConst = Conditional<IsConst<ReferenceType>, AddConst<T>, RemoveConst<T>>;
@@ -369,8 +371,13 @@ inline constexpr bool IsSigned = IsSame<T, MakeSigned<T>>;
 template<typename T>
 inline constexpr bool IsUnsigned = IsSame<T, MakeUnsigned<T>>;
 
+#ifndef KERNEL
 template<typename T>
 inline constexpr bool IsArithmetic = IsIntegral<T> || IsFloatingPoint<T>;
+#else
+template<typename T>
+inline constexpr bool IsArithmetic = IsIntegral<T>;
+#endif
 
 template<typename T>
 inline constexpr bool IsFundamental = IsArithmetic<T> || IsVoid<T> || IsNullPointer<T>;
@@ -634,7 +641,9 @@ using AK::Detail::IsCopyAssignable;
 using AK::Detail::IsCopyConstructible;
 using AK::Detail::IsDestructible;
 using AK::Detail::IsEnum;
+#ifndef KERNEL
 using AK::Detail::IsFloatingPoint;
+#endif
 using AK::Detail::IsFunction;
 using AK::Detail::IsFundamental;
 using AK::Detail::IsHashCompatible;


### PR DESCRIPTION
We build KERNEL without floats, so that context switches don't have to save float registers. As a side effect of that, _Float16 results in a "_Float16 is not supported on this target" diagnostic.

Having IsFloatingPoint<> be false for the upcoming f16 type, but true for other floating point types seems strange, so just stop having these concepts in kernel code altogether.

---

Prerequisite for #25434.