### PR TITLE
Cherry-pick "LibWeb: Rename 'cross-origin opener policy' to 'opener policy'"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -143,8 +143,8 @@ JS_DEFINE_ALLOCATOR(Document);
 static JS::NonnullGCPtr<HTML::BrowsingContext> obtain_a_browsing_context_to_use_for_a_navigation_response(
     HTML::BrowsingContext& browsing_context,
     HTML::SandboxingFlagSet sandbox_flags,
-    HTML::CrossOriginOpenerPolicy navigation_coop,
-    HTML::CrossOriginOpenerPolicyEnforcementResult coop_enforcement_result)
+    HTML::OpenerPolicy navigation_coop,
+    HTML::OpenerPolicyEnforcementResult coop_enforcement_result)
 {
     // 1. If browsingContext is not a top-level browsing context, return browsingContext.
     if (!browsing_context.is_top_level())
@@ -169,7 +169,7 @@ static JS::NonnullGCPtr<HTML::BrowsingContext> obtain_a_browsing_context_to_use_
     // 5. If sandboxFlags is not empty, then:
     if (!is_empty(sandbox_flags)) {
         // 1. Assert navigationCOOP's value is "unsafe-none".
-        VERIFY(navigation_coop.value == HTML::CrossOriginOpenerPolicyValue::UnsafeNone);
+        VERIFY(navigation_coop.value == HTML::OpenerPolicyValue::UnsafeNone);
 
         // 2. Assert: newBrowsingContext's popup sandboxing flag set is empty.
 
@@ -187,11 +187,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
     auto browsing_context = navigation_params.navigable->active_browsing_context();
 
     // 2. Set browsingContext to the result of the obtaining a browsing context to use for a navigation response given browsingContext, navigationParams's final sandboxing flag set,
-    //    navigationParams's cross-origin opener policy, and navigationParams's COOP enforcement result.
+    //    navigationParams's opener policy, and navigationParams's COOP enforcement result.
     browsing_context = obtain_a_browsing_context_to_use_for_a_navigation_response(
         *browsing_context,
         navigation_params.final_sandboxing_flag_set,
-        navigation_params.cross_origin_opener_policy,
+        navigation_params.opener_policy,
         navigation_params.coop_enforcement_result);
 
     // FIXME: 3. Let permissionsPolicy be the result of creating a permissions policy from a response
@@ -289,7 +289,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
     //     policy container: navigationParams's policy container
     //     FIXME: permissions policy: permissionsPolicy
     //     active sandboxing flag set: navigationParams's final sandboxing flag set
-    //     FIXME: cross-origin opener policy: navigationParams's cross-origin opener policy
+    //     FIXME: opener policy: navigationParams's opener policy
     //     FIXME: load timing info: loadTimingInfo
     //     FIXME: was created via cross-origin redirects: navigationParams's response's has cross-origin redirects
     //     during-loading navigation ID for WebDriver BiDi: navigationParams's id

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -25,7 +25,7 @@
 #include <LibWeb/DOM/NonElementParentNode.h>
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/HTML/BrowsingContext.h>
-#include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
+#include <LibWeb/HTML/CrossOrigin/OpenerPolicy.h>
 #include <LibWeb/HTML/DocumentReadyState.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
 #include <LibWeb/HTML/History.h>
@@ -149,8 +149,8 @@ public:
     HTML::Origin origin() const;
     void set_origin(HTML::Origin const& origin);
 
-    HTML::CrossOriginOpenerPolicy const& cross_origin_opener_policy() const { return m_cross_origin_opener_policy; }
-    void set_cross_origin_opener_policy(HTML::CrossOriginOpenerPolicy policy) { m_cross_origin_opener_policy = move(policy); }
+    HTML::OpenerPolicy const& opener_policy() const { return m_opener_policy; }
+    void set_opener_policy(HTML::OpenerPolicy policy) { m_opener_policy = move(policy); }
 
     URL::URL parse_url(StringView) const;
 
@@ -845,7 +845,7 @@ private:
     Optional<URL::URL> m_about_base_url;
 
     // https://html.spec.whatwg.org/multipage/dom.html#concept-document-coop
-    HTML::CrossOriginOpenerPolicy m_cross_origin_opener_policy;
+    HTML::OpenerPolicy m_opener_policy;
 
     // https://html.spec.whatwg.org/multipage/dom.html#the-document's-referrer
     String m_referrer;

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -25,17 +25,17 @@ JS::NonnullGCPtr<DOM::Document> create_document_for_inline_content(JS::GCPtr<HTM
     // 1. Let origin be a new opaque origin.
     HTML::Origin origin {};
 
-    // 2. Let coop be a new cross-origin opener policy.
-    auto coop = HTML::CrossOriginOpenerPolicy {};
+    // 2. Let coop be a new opener policy.
+    auto coop = HTML::OpenerPolicy {};
 
-    // 3. Let coopEnforcementResult be a new cross-origin opener policy enforcement result with
+    // 3. Let coopEnforcementResult be a new opener policy enforcement result with
     //    url: response's URL
     //    origin: origin
-    //    cross-origin opener policy: coop
-    HTML::CrossOriginOpenerPolicyEnforcementResult coop_enforcement_result {
+    //    opener policy: coop
+    HTML::OpenerPolicyEnforcementResult coop_enforcement_result {
         .url = URL::URL("about:error"), // AD-HOC
         .origin = origin,
-        .cross_origin_opener_policy = coop
+        .opener_policy = coop
     };
 
     // 4. Let navigationParams be a new navigation params with
@@ -50,7 +50,7 @@ JS::NonnullGCPtr<DOM::Document> create_document_for_inline_content(JS::GCPtr<HTM
     //    reserved environment: null
     //    policy container: a new policy container
     //    final sandboxing flag set: an empty set
-    //    cross-origin opener policy: coop
+    //    opener policy: coop
     //    FIXME: navigation timing type: navTimingType
     //    about base URL: null
     auto response = Fetch::Infrastructure::Response::create(vm);
@@ -67,7 +67,7 @@ JS::NonnullGCPtr<DOM::Document> create_document_for_inline_content(JS::GCPtr<HTM
     navigation_params->origin = move(origin);
     navigation_params->policy_container = HTML::PolicyContainer {};
     navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
-    navigation_params->cross_origin_opener_policy = move(coop);
+    navigation_params->opener_policy = move(coop);
     navigation_params->about_base_url = {};
 
     // 5. Let document be the result of creating and initializing a Document object given "html", "text/html", and navigationParams.

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -528,8 +528,8 @@ enum class AllowMultipleFiles;
 enum class MediaSeekMode;
 enum class SandboxingFlagSet;
 
-struct CrossOriginOpenerPolicy;
-struct CrossOriginOpenerPolicyEnforcementResult;
+struct OpenerPolicy;
+struct OpenerPolicyEnforcementResult;
 struct Environment;
 struct EnvironmentSettingsObject;
 struct NavigationParams;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -13,7 +13,7 @@
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/BrowsingContextGroup.h>
-#include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
+#include <LibWeb/HTML/CrossOrigin/OpenerPolicy.h>
 #include <LibWeb/HTML/DocumentState.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLDocument.h>
@@ -261,10 +261,10 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
 
         // 3. If creator's origin is same origin with creator's relevant settings object's top-level origin,
         if (creator->origin().is_same_origin(creator->relevant_settings_object().top_level_origin)) {
-            // then set document's cross-origin opener policy to creator's browsing context's top-level browsing context's active document's cross-origin opener policy.
+            // then set document's opener policy to creator's browsing context's top-level browsing context's active document's opener policy.
             VERIFY(creator->browsing_context());
             VERIFY(creator->browsing_context()->top_level_browsing_context()->active_document());
-            document->set_cross_origin_opener_policy(creator->browsing_context()->top_level_browsing_context()->active_document()->cross_origin_opener_policy());
+            document->set_opener_policy(creator->browsing_context()->top_level_browsing_context()->active_document()->opener_policy());
         }
     }
 

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/OpenerPolicy.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/OpenerPolicy.h
@@ -11,7 +11,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policy-value
-enum class CrossOriginOpenerPolicyValue {
+enum class OpenerPolicyValue {
     UnsafeNone,
     SameOriginAllowPopups,
     SameOrigin,
@@ -19,15 +19,15 @@ enum class CrossOriginOpenerPolicyValue {
 };
 
 // https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policy
-struct CrossOriginOpenerPolicy {
-    // A value, which is a cross-origin opener policy value, initially "unsafe-none".
-    CrossOriginOpenerPolicyValue value { CrossOriginOpenerPolicyValue::UnsafeNone };
+struct OpenerPolicy {
+    // A value, which is an opener policy value, initially "unsafe-none".
+    OpenerPolicyValue value { OpenerPolicyValue::UnsafeNone };
 
     // A reporting endpoint, which is string or null, initially null.
     Optional<String> reporting_endpoint;
 
-    // A report-only value, which is a cross-origin opener policy value, initially "unsafe-none".
-    CrossOriginOpenerPolicyValue report_only_value { CrossOriginOpenerPolicyValue::UnsafeNone };
+    // A report-only value, which is an opener policy value, initially "unsafe-none".
+    OpenerPolicyValue report_only_value { OpenerPolicyValue::UnsafeNone };
 
     // A report-only reporting endpoint, which is a string or null, initially null.
     Optional<String> report_only_reporting_endpoint;

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/OpenerPolicyEnforcementResult.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/OpenerPolicyEnforcementResult.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include <LibURL/URL.h>
-#include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
+#include <LibWeb/HTML/CrossOrigin/OpenerPolicy.h>
 #include <LibWeb/HTML/Origin.h>
 
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#coop-enforcement-result
-struct CrossOriginOpenerPolicyEnforcementResult {
+struct OpenerPolicyEnforcementResult {
     // A boolean needs a browsing context group switch, initially false.
     bool needs_a_browsing_context_group_switch { false };
 
@@ -26,8 +26,8 @@ struct CrossOriginOpenerPolicyEnforcementResult {
     // An origin origin.
     Origin origin;
 
-    // A cross-origin opener policy cross-origin opener policy.
-    CrossOriginOpenerPolicy cross_origin_opener_policy;
+    // An opener policy.
+    OpenerPolicy opener_policy;
 
     // A boolean current context is navigation source.
     bool current_context_is_navigation_source { false };

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
@@ -84,7 +84,7 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(
     if (accessed->is_ancestor_of(*accessor.top_level_browsing_context()->opener_browsing_context()))
         accessor_accessed_relationship = AccessorAccessedRelationship::AccessorIsOpener;
 
-    // 12. Queue violation reports for accesses, given accessorAccessedRelationship, accessorTopDocument's cross-origin opener policy, accessedTopDocument's cross-origin opener policy, accessor's active document's URL, accessed's active document's URL, accessor's top-level browsing context's initial URL, accessed's top-level browsing context's initial URL, accessor's active document's origin, accessed's active document's origin, accessor's top-level browsing context's opener origin at creation, accessed's top-level browsing context's opener origin at creation, accessorTopDocument's referrer, accessedTopDocument's referrer, propertyKey, and environment.
+    // 12. Queue violation reports for accesses, given accessorAccessedRelationship, accessorTopDocument's opener policy, accessedTopDocument's opener policy, accessor's active document's URL, accessed's active document's URL, accessor's top-level browsing context's initial URL, accessed's top-level browsing context's initial URL, accessor's active document's origin, accessed's active document's origin, accessor's top-level browsing context's opener origin at creation, accessed's top-level browsing context's opener origin at creation, accessorTopDocument's referrer, accessedTopDocument's referrer, propertyKey, and environment.
     (void)environment;
     (void)accessor_accessed_relationship;
 }

--- a/Userland/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigationParams.h
@@ -12,8 +12,8 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicy.h>
-#include <LibWeb/HTML/CrossOrigin/CrossOriginOpenerPolicyEnforcementResult.h>
+#include <LibWeb/HTML/CrossOrigin/OpenerPolicy.h>
+#include <LibWeb/HTML/CrossOrigin/OpenerPolicyEnforcementResult.h>
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
@@ -43,8 +43,8 @@ struct NavigationParams : JS::Cell {
     // null or an algorithm accepting a Document, once it has been created
     Function<void(DOM::Document&)> commit_early_hints { nullptr };
 
-    // a cross-origin opener policy enforcement result, used for reporting and potentially for causing a browsing context group switch
-    CrossOriginOpenerPolicyEnforcementResult coop_enforcement_result;
+    // an opener policy enforcement result, used for reporting and potentially for causing a browsing context group switch
+    OpenerPolicyEnforcementResult coop_enforcement_result;
 
     // null or an environment reserved for the new Document
     Fetch::Infrastructure::Request::ReservedClientType reserved_environment;
@@ -58,8 +58,8 @@ struct NavigationParams : JS::Cell {
     // a sandboxing flag set to impose on the new Document
     SandboxingFlagSet final_sandboxing_flag_set = {};
 
-    // a cross-origin opener policy to use for the new Document
-    CrossOriginOpenerPolicy cross_origin_opener_policy;
+    // an opener policy to use for the new Document
+    OpenerPolicy opener_policy;
 
     // FIXME: a NavigationTimingType used for creating the navigation timing entry for the new Document
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -41,7 +41,7 @@ ErrorOr<JS::NonnullGCPtr<SVGDecodedImageData>> SVGDecodedImageData::create(JS::R
     navigation_params->origin = HTML::Origin {};
     navigation_params->policy_container = HTML::PolicyContainer {};
     navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
-    navigation_params->cross_origin_opener_policy = HTML::CrossOriginOpenerPolicy {};
+    navigation_params->opener_policy = HTML::OpenerPolicy {};
 
     // FIXME: Use Navigable::navigate() instead of manually replacing the navigable's document.
     auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params).release_value_but_fixme_should_propagate_errors();


### PR DESCRIPTION
(cherry picked from commit de31ea5852e3fc0aca1e86e06c6bc019f27824de)

---

https://github.com/LadybirdBrowser/ladybird/pull/1399