### PR TITLE
Cherry-pick "LibWeb: Unify scroll handling between viewport and scrollable boxes"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2012,8 +2012,11 @@ void Navigable::perform_scroll_of_viewport(CSSPixelPoint new_position)
         scroll_offset_did_change();
         set_needs_display();
 
-        if (auto document = active_document())
+        if (auto document = active_document()) {
+            document->set_needs_to_refresh_scroll_state(true);
+            document->set_needs_to_refresh_clip_state(true);
             document->inform_all_viewport_clients_about_the_current_viewport_rect();
+        }
     }
 
     // Schedule the HTML event loop to ensure that a `resize` event gets fired.

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -174,8 +174,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint viewport_position, CSS
     if (!m_navigable->active_document()->is_fully_active())
         return EventResult::Dropped;
 
-    auto scroll_offset = m_navigable->active_document()->navigable()->viewport_scroll_offset();
-    auto position = viewport_position.translated(scroll_offset);
+    auto position = viewport_position;
 
     m_navigable->active_document()->update_layout();
 
@@ -244,8 +243,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
     if (!m_navigable->active_document()->is_fully_active())
         return EventResult::Dropped;
 
-    auto scroll_offset = m_navigable->active_document()->navigable()->viewport_scroll_offset();
-    auto position = viewport_position.translated(scroll_offset);
+    auto position = viewport_position;
 
     m_navigable->active_document()->update_layout();
 
@@ -375,8 +373,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint viewport_position, CSSP
     if (!m_navigable->active_document()->is_fully_active())
         return EventResult::Dropped;
 
-    auto scroll_offset = m_navigable->active_document()->navigable()->viewport_scroll_offset();
-    auto position = viewport_position.translated(scroll_offset);
+    auto position = viewport_position;
 
     m_navigable->active_document()->update_layout();
 
@@ -488,8 +485,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint viewport_position, CSSP
     if (!m_navigable->active_document()->is_fully_active())
         return EventResult::Dropped;
 
-    auto scroll_offset = m_navigable->active_document()->navigable()->viewport_scroll_offset();
-    auto position = viewport_position.translated(scroll_offset);
+    auto position = viewport_position;
 
     m_navigable->active_document()->update_layout();
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -296,9 +296,6 @@ Optional<CSSPixelRect> PaintableBox::scroll_thumb_rect(ScrollDirection direction
         };
     }
 
-    if (is_viewport())
-        thumb_rect.translate_by(this->scroll_offset());
-
     return thumb_rect;
 }
 
@@ -796,14 +793,10 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mousedown(Badge<EventHan
     auto vertical_scroll_thumb_rect = scroll_thumb_rect(ScrollDirection::Vertical);
     auto horizontal_scroll_thumb_rect = scroll_thumb_rect(ScrollDirection::Horizontal);
     if (vertical_scroll_thumb_rect.has_value() && vertical_scroll_thumb_rect.value().contains(position)) {
-        if (is_viewport())
-            position.translate_by(-scroll_offset());
         m_last_mouse_tracking_position = position;
         m_scroll_thumb_dragging_direction = ScrollDirection::Vertical;
         const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
     } else if (horizontal_scroll_thumb_rect.has_value() && horizontal_scroll_thumb_rect.value().contains(position)) {
-        if (is_viewport())
-            position.translate_by(-scroll_offset());
         m_last_mouse_tracking_position = position;
         m_scroll_thumb_dragging_direction = ScrollDirection::Horizontal;
         const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
@@ -824,9 +817,6 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mouseup(Badge<EventHandl
 Paintable::DispatchEventOfSameName PaintableBox::handle_mousemove(Badge<EventHandler>, CSSPixelPoint position, unsigned, unsigned)
 {
     if (m_last_mouse_tracking_position.has_value()) {
-        if (is_viewport())
-            position.translate_by(-scroll_offset());
-
         Gfx::Point<double> scroll_delta;
         if (m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal)
             scroll_delta.set_x((position.x() - m_last_mouse_tracking_position->x()).to_double());

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -340,11 +340,6 @@ TraversalDecision StackingContext::hit_test(CSSPixelPoint position, HitTestType 
     };
     auto transformed_position = affine_transform_matrix().inverse().value_or({}).map(offset_position).to_type<CSSPixels>() + transform_origin;
 
-    if (paintable().is_fixed_position()) {
-        auto scroll_offset = paintable().document().navigable()->viewport_scroll_offset();
-        transformed_position.translate_by(-scroll_offset);
-    }
-
     // NOTE: Hit testing basically happens in reverse painting order.
     // https://www.w3.org/TR/CSS22/visuren.html#z-index
 


### PR DESCRIPTION
This change causes the viewport to be treated as a "scroll frame," similar to how it already works for boxes with "overflow: scroll." This means that, instead of encoding the viewport translation into a display list, the items will be assigned the scroll frame id of the viewport and then shifted by the scroll offset before execution. In the future it will allow us to reuse a display list for repainting if only scroll offset has changed.

As a side effect, it also removes the need for special handling of "position: fixed" because compensating for the viewport offset while painting or hit-testing is no longer necessary. Instead, anything contained within a "position: fixed" element is simply not assigned a scroll frame id, which means it is not shifted by the scroll offset.

(cherry picked from commit dd8c6937254045251d910951c6b3ad49e27f0626)

---

https://github.com/LadybirdBrowser/ladybird/pull/1026