### PR TITLE
Kernel/Ext2FS: Add full support for large inodes

### DIFF
--- a/.github/workflows/serenity-template.yml
+++ b/.github/workflows/serenity-template.yml
@@ -167,6 +167,9 @@ jobs:
           echo "::group::ninja run # Qemu output"
           ninja run
           echo "::endgroup::"
+          echo "::group::Check Filesystem Consistency"
+          e2fsck -f -y _disk_image
+          echo "::endgroup::"
           echo "::group::Verify Output File"
           mkdir fsmount
           sudo mount -t ext2 -o loop,rw _disk_image fsmount

--- a/Kernel/FileSystem/Ext2FS/Definitions.h
+++ b/Kernel/FileSystem/Ext2FS/Definitions.h
@@ -409,6 +409,7 @@ struct ext2_inode_large {
     __u32 i_crtime;       /* File creation time */
     __u32 i_crtime_extra; /* extra File creation time (nsec << 2 | epoch)*/
     __u32 i_version_hi;   /* high 32 bits for 64-bit version */
+    __u32 i_projid;       /* Project ID */
 };
 
 #define i_size_high i_dir_acl

--- a/Kernel/FileSystem/Ext2FS/Definitions.h
+++ b/Kernel/FileSystem/Ext2FS/Definitions.h
@@ -414,6 +414,10 @@ struct ext2_inode_large {
 
 #define i_size_high i_dir_acl
 
+#define EXT4_EPOCH_BITS 2
+#define EXT4_EPOCH_MASK ((1 << EXT4_EPOCH_BITS) - 1)
+#define EXT4_NSEC_MASK (~0UL << EXT4_EPOCH_BITS)
+
 #if defined(__KERNEL__) || defined(__linux__)
 #    define i_reserved1 osd1.linux1.l_i_reserved1
 #    define i_frag osd2.linux2.l_i_frag

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -79,7 +79,10 @@ private:
 
     ErrorOr<NonnullRefPtr<Ext2FSInode>> build_root_inode() const;
 
-    ErrorOr<void> write_ext2_inode(InodeIndex, ext2_inode const&);
+    // NOTE: The large Ext2 inode structure is strictly superset of the classic 128-byte inode structure,
+    // so the this function simply ignores all the extra data if the filesystem doesn't support large inodes.
+    ErrorOr<void> write_ext2_inode(InodeIndex, ext2_inode_large const&);
+
     bool find_block_containing_inode(InodeIndex, BlockIndex& block_index, unsigned& offset) const;
 
     ErrorOr<void> flush_super_block();

--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -417,10 +417,10 @@ InodeMetadata Ext2FSInode::metadata() const
     metadata.uid = inode_uid(m_raw_inode);
     metadata.gid = inode_gid(m_raw_inode);
     metadata.link_count = m_raw_inode.i_links_count;
-    metadata.atime = UnixDateTime::from_seconds_since_epoch(m_raw_inode.i_atime);
-    metadata.ctime = UnixDateTime::from_seconds_since_epoch(m_raw_inode.i_ctime);
-    metadata.mtime = UnixDateTime::from_seconds_since_epoch(m_raw_inode.i_mtime);
-    metadata.dtime = UnixDateTime::from_seconds_since_epoch(m_raw_inode.i_dtime);
+    metadata.atime = UnixDateTime::from_seconds_since_epoch(static_cast<i32>(m_raw_inode.i_atime));
+    metadata.ctime = UnixDateTime::from_seconds_since_epoch(static_cast<i32>(m_raw_inode.i_ctime));
+    metadata.mtime = UnixDateTime::from_seconds_since_epoch(static_cast<i32>(m_raw_inode.i_mtime));
+    metadata.dtime = UnixDateTime::from_seconds_since_epoch(static_cast<i32>(m_raw_inode.i_dtime));
     metadata.block_size = fs().logical_block_size();
     metadata.block_count = m_raw_inode.i_blocks;
 

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -47,6 +47,12 @@ private:
     virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<int> get_block_address(int) override;
 
+    bool is_within_inode_bounds(FlatPtr base, FlatPtr value_offset, size_t value_size) const;
+
+    static time_t decode_seconds_with_extra(i32 seconds, u32 extra) { return (extra & EXT4_EPOCH_MASK) ? static_cast<time_t>(seconds) + (static_cast<time_t>(extra & EXT4_EPOCH_MASK) << 32) : static_cast<time_t>(seconds); }
+    static u32 decode_nanoseconds_from_extra(u32 extra) { return (extra & EXT4_NSEC_MASK) >> EXT4_EPOCH_BITS; }
+    static u32 encode_time_to_extra(time_t seconds, u32 nanoseconds) { return (((static_cast<time_t>(seconds) - static_cast<i32>(seconds)) >> 32) & EXT4_EPOCH_MASK) | (nanoseconds << EXT4_EPOCH_BITS); }
+
     ErrorOr<BlockBasedFileSystem::BlockIndex> allocate_block(BlockBasedFileSystem::BlockIndex, bool zero_newly_allocated_block, bool allow_cache);
     ErrorOr<u32> allocate_and_zero_block();
 
@@ -86,7 +92,7 @@ private:
 
     mutable Ext2FSBlockView m_block_view;
     HashMap<NonnullOwnPtr<KString>, InodeIndex> m_lookup_cache;
-    ext2_inode m_raw_inode {};
+    ext2_inode_large m_raw_inode {};
 };
 
 inline Ext2FS& Ext2FSInode::fs()

--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -75,7 +75,7 @@ dd if=/dev/zero of="${dev}${partition_number}" bs=1M count=1 status=none || die 
 echo "done"
 
 printf "creating new filesystem... "
-mke2fs -q -I 128 "${dev}${partition_number}" || die "couldn't create filesystem"
+mke2fs -q "${dev}${partition_number}" || die "couldn't create filesystem"
 echo "done"
 
 printf "mounting filesystem... "

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -93,7 +93,7 @@ dd if=/dev/zero of="${dev}${partition_number}" bs=1M count=1 status=none || die 
 echo "done"
 
 printf "creating new filesystem... "
-mke2fs -q -I 128 "${dev}${partition_number}" || die "couldn't create filesystem"
+mke2fs -q "${dev}${partition_number}" || die "couldn't create filesystem"
 echo "done"
 
 printf "mounting filesystem... "

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -77,7 +77,7 @@ echo "done"
 
 printf "creating new filesystems... "
 mkfs.vfat -F 32 "${dev}p1" || die "couldn't create efi filesystem"
-mke2fs -q -I 128 "${dev}p2" || die "couldn't create root filesystem"
+mke2fs -q "${dev}p2" || die "couldn't create root filesystem"
 echo "done"
 
 printf "mounting filesystems... "

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -33,7 +33,7 @@ fi
 # Prepend the toolchain qemu directory so we pick up QEMU from there
 PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
 
-INODE_SIZE=128
+INODE_SIZE=256
 INODE_COUNT=$(($(inode_usage "$SERENITY_SOURCE_DIR/Base") + $(inode_usage Root)))
 INODE_COUNT=$((INODE_COUNT + 2000))  # Some additional inodes for toolchain files, could probably also be calculated
 DISK_SIZE_BYTES=$((($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) ) * 1024 * 1024))
@@ -180,8 +180,8 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 if [ $use_genext2fs = 1 ]; then
     # regenerate new image, since genext2fs is unable to reuse the previously written image.
     # genext2fs is very slow in generating big images, so I use a smaller image here. size can be updated
-    # if it's not enough.
-    # not using "-I $INODE_SIZE" since it hangs. Serenity handles whatever default this uses instead.
+    # if it's not enough. this also accounts for the fact that genext2fs only supports 128-byte inodes.
+    DISK_SIZE_BYTES=$((DISK_SIZE_BYTES - INODE_COUNT * 128))
     genext2fs -B 4096 -b $((DISK_SIZE_BYTES / 4096)) -N "${INODE_COUNT}" -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
     # if using docker with shared mount, file is created as root, so make it writable for users
     chmod 0666 _disk_image


### PR DESCRIPTION
The extra data provided by large inodes has almost exclusively to do with timestamps, which means that you can now get nanosecond precision on your root file system, and the capability to support dates beyond 2038 or so in a standards-compliant way. This is also basically a pre-requisite for ext3/ext4, since the 128-byte inodes we've been using are more-or-less deprecated.

This PR also fixes up serialization of epoch offsets, so if you have a filesystem that has inodes with negative timestamps, then those should now be reported correctly.

Lastly, this also adds a CI step to validate filesystem consistency after running tests, since we shouldn't be seeing any filesystem corruption after all the recent work that's been put into `Ext2FS`.