### PR TITLE
LibUnicode+LibWeb: Rework bidirectional_class() API a bit

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -843,7 +843,7 @@ namespace Unicode {
     generate_enum("WordBreakProperty"sv, {}, unicode_data.word_break_props.keys());
     generate_enum("SentenceBreakProperty"sv, {}, unicode_data.sentence_break_props.keys());
     generate_enum("CompatibilityFormattingTag"sv, "Canonical"sv, unicode_data.compatibility_tags);
-    generate_enum("BidirectionalClass"sv, {}, unicode_data.bidirectional_classes.values(), unicode_data.bidirectional_class_aliases);
+    generate_enum("BidirectionalClassInternal"sv, {}, unicode_data.bidirectional_classes.values(), unicode_data.bidirectional_class_aliases);
 
     generator.append(R"~~~(
 struct SpecialCasing {
@@ -1038,7 +1038,7 @@ struct CodePointNameComparator : public CodePointRangeComparator {
 
 struct BidiClassData {
     CodePointRange code_point_range {};
-    BidirectionalClass bidi_class {};
+    BidirectionalClassInternal bidi_class {};
 };
 
 struct CodePointBidiClassComparator : public CodePointRangeComparator {
@@ -1303,7 +1303,7 @@ static constexpr Array<BidiClassData, @size@> s_bidirectional_classes { {
             generator.set("first", ByteString::formatted("{:#x}", data.code_point_range.first));
             generator.set("last", ByteString::formatted("{:#x}", data.code_point_range.last));
             generator.set("bidi_class", data.bidi_class);
-            generator.append("{ { @first@, @last@ }, BidirectionalClass::@bidi_class@ }");
+            generator.append("{ { @first@, @last@ }, BidirectionalClassInternal::@bidi_class@ }");
 
             if (bidi_classes_in_current_row == max_bidi_classes_per_row) {
                 bidi_classes_in_current_row = 0;
@@ -1445,7 +1445,7 @@ Optional<u32> code_point_composition(u32 first_code_point, u32 second_code_point
     return {};
 }
 
-Optional<BidirectionalClass> bidirectional_class(u32 code_point)
+Optional<BidirectionalClassInternal> bidirectional_class_internal(u32 code_point)
 {
     if (auto const* entry = binary_search(s_bidirectional_classes, code_point, nullptr, CodePointBidiClassComparator {}))
         return entry->bidi_class;
@@ -1512,8 +1512,6 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
     TRY(append_prop_search("GraphemeBreakProperty"sv, "grapheme_break_property"sv, "s_grapheme_break_properties"sv));
     TRY(append_prop_search("WordBreakProperty"sv, "word_break_property"sv, "s_word_break_properties"sv));
     TRY(append_prop_search("SentenceBreakProperty"sv, "sentence_break_property"sv, "s_sentence_break_properties"sv));
-
-    TRY(append_from_string("BidirectionalClass"sv, "bidirectional_class"sv, unicode_data.bidirectional_classes, {}));
 
     generator.append(R"~~~(
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -198,6 +198,7 @@ struct UnicodeData {
 
     HashTable<ByteString> bidirectional_classes;
     Vector<CodePointBidiClass> code_point_bidirectional_classes;
+    Vector<Alias> bidirectional_class_aliases;
 };
 
 static ByteString sanitize_entry(ByteString const& entry)
@@ -842,7 +843,7 @@ namespace Unicode {
     generate_enum("WordBreakProperty"sv, {}, unicode_data.word_break_props.keys());
     generate_enum("SentenceBreakProperty"sv, {}, unicode_data.sentence_break_props.keys());
     generate_enum("CompatibilityFormattingTag"sv, "Canonical"sv, unicode_data.compatibility_tags);
-    generate_enum("BidirectionalClass"sv, {}, unicode_data.bidirectional_classes.values());
+    generate_enum("BidirectionalClass"sv, {}, unicode_data.bidirectional_classes.values(), unicode_data.bidirectional_class_aliases);
 
     generator.append(R"~~~(
 struct SpecialCasing {
@@ -1916,6 +1917,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     populate_general_category_unions(unicode_data.general_categories);
     TRY(parse_unicode_data(*unicode_data_file, unicode_data));
+    TRY(parse_value_alias_list(*prop_value_alias_file, "bc"sv, unicode_data.bidirectional_classes.values(), unicode_data.bidirectional_class_aliases));
     TRY(parse_value_alias_list(*prop_value_alias_file, "gc"sv, unicode_data.general_categories.keys(), unicode_data.general_category_aliases));
     TRY(parse_value_alias_list(*prop_value_alias_file, "sc"sv, unicode_data.script_list.keys(), unicode_data.script_aliases, false));
     TRY(normalize_script_extensions(unicode_data.script_extensions, unicode_data.script_list, unicode_data.script_aliases));

--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -416,25 +416,13 @@ TEST_CASE(code_point_display_name)
 
 TEST_CASE(code_point_bidirectional_character_type)
 {
-    auto code_point_bidi_class = [](u32 code_point) {
-        auto bidi_class = Unicode::bidirectional_class(code_point);
-        VERIFY(bidi_class.has_value());
-        return bidi_class.release_value();
-    };
-
-    auto bidi_class_from_string = [](StringView name) {
-        auto result = Unicode::bidirectional_class_from_string(name);
-        VERIFY(result.has_value());
-        return result.release_value();
-    };
-
     // Left-to-right
-    EXPECT_EQ(code_point_bidi_class('A'), bidi_class_from_string("L"sv));
-    EXPECT_EQ(code_point_bidi_class('z'), bidi_class_from_string("L"sv));
+    EXPECT_EQ(Unicode::bidirectional_class('A'), Unicode::BidiClass::LeftToRight);
+    EXPECT_EQ(Unicode::bidirectional_class('z'), Unicode::BidiClass::LeftToRight);
     // European number
-    EXPECT_EQ(code_point_bidi_class('7'), bidi_class_from_string("EN"sv));
+    EXPECT_EQ(Unicode::bidirectional_class('7'), Unicode::BidiClass::EuropeanNumber);
     // Whitespace
-    EXPECT_EQ(code_point_bidi_class(' '), bidi_class_from_string("WS"sv));
+    EXPECT_EQ(Unicode::bidirectional_class(' '), Unicode::BidiClass::WhiteSpaceNeutral);
     // Arabic right-to-left (U+FEB4 ARABIC LETTER SEEN MEDIAL FORM)
-    EXPECT_EQ(code_point_bidi_class(0xFEB4), bidi_class_from_string("AL"sv));
+    EXPECT_EQ(Unicode::bidirectional_class(0xFEB4), Unicode::BidiClass::RightToLeftArabic);
 }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -228,7 +228,71 @@ bool __attribute__((weak)) code_point_has_grapheme_break_property(u32, GraphemeB
 bool __attribute__((weak)) code_point_has_word_break_property(u32, WordBreakProperty) { return {}; }
 bool __attribute__((weak)) code_point_has_sentence_break_property(u32, SentenceBreakProperty) { return {}; }
 
-Optional<BidirectionalClass> __attribute__((weak)) bidirectional_class_from_string(StringView) { return {}; }
-Optional<BidirectionalClass> __attribute__((weak)) bidirectional_class(u32) { return {}; }
+Optional<BidirectionalClassInternal> __attribute__((weak)) bidirectional_class_internal(u32) { return {}; }
+
+#if ENABLE_UNICODE_DATA
+static constexpr BidiClass bidi_class_from_bidirectional_class_interal(BidirectionalClassInternal direction)
+{
+    switch (direction) {
+    case BidirectionalClassInternal::Arabic_Number:
+        return BidiClass::ArabicNumber;
+    case BidirectionalClassInternal::Paragraph_Separator:
+        return BidiClass::BlockSeparator;
+    case BidirectionalClassInternal::Boundary_Neutral:
+        return BidiClass::BoundaryNeutral;
+    case BidirectionalClassInternal::Common_Separator:
+        return BidiClass::CommonNumberSeparator;
+    case BidirectionalClassInternal::Nonspacing_Mark:
+        return BidiClass::DirNonSpacingMark;
+    case BidirectionalClassInternal::European_Number:
+        return BidiClass::EuropeanNumber;
+    case BidirectionalClassInternal::European_Separator:
+        return BidiClass::EuropeanNumberSeparator;
+    case BidirectionalClassInternal::European_Terminator:
+        return BidiClass::EuropeanNumberTerminator;
+    case BidirectionalClassInternal::First_Strong_Isolate:
+        return BidiClass::FirstStrongIsolate;
+    case BidirectionalClassInternal::Left_To_Right:
+        return BidiClass::LeftToRight;
+    case BidirectionalClassInternal::Left_To_Right_Embedding:
+        return BidiClass::LeftToRightEmbedding;
+    case BidirectionalClassInternal::Left_To_Right_Isolate:
+        return BidiClass::LeftToRightIsolate;
+    case BidirectionalClassInternal::Left_To_Right_Override:
+        return BidiClass::LeftToRightOverride;
+    case BidirectionalClassInternal::Other_Neutral:
+        return BidiClass::OtherNeutral;
+    case BidirectionalClassInternal::Pop_Directional_Format:
+        return BidiClass::PopDirectionalFormat;
+    case BidirectionalClassInternal::Pop_Directional_Isolate:
+        return BidiClass::PopDirectionalIsolate;
+    case BidirectionalClassInternal::Right_To_Left:
+        return BidiClass::RightToLeft;
+    case BidirectionalClassInternal::Arabic_Letter:
+        return BidiClass::RightToLeftArabic;
+    case BidirectionalClassInternal::Right_To_Left_Embedding:
+        return BidiClass::RightToLeftEmbedding;
+    case BidirectionalClassInternal::Right_To_Left_Isolate:
+        return BidiClass::RightToLeftIsolate;
+    case BidirectionalClassInternal::Right_To_Left_Override:
+        return BidiClass::RightToLeftOverride;
+    case BidirectionalClassInternal::Segment_Separator:
+        return BidiClass::SegmentSeparator;
+    case BidirectionalClassInternal::White_Space:
+        return BidiClass::WhiteSpaceNeutral;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+#endif
+
+BidiClass bidirectional_class([[maybe_unused]] u32 code_point)
+{
+#if ENABLE_UNICODE_DATA
+    if (auto bidi_class_internal = bidirectional_class_internal(code_point); bidi_class_internal.has_value())
+        return bidi_class_from_bidirectional_class_interal(bidi_class_internal.value());
+#endif
+    return BidiClass::LeftToRight;
+}
 
 }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -69,7 +69,35 @@ bool code_point_has_grapheme_break_property(u32 code_point, GraphemeBreakPropert
 bool code_point_has_word_break_property(u32 code_point, WordBreakProperty property);
 bool code_point_has_sentence_break_property(u32 code_point, SentenceBreakProperty property);
 
-Optional<BidirectionalClass> bidirectional_class_from_string(StringView);
-Optional<BidirectionalClass> bidirectional_class(u32 code_point);
+enum class BidirectionalClassInternal : u8;
+Optional<BidirectionalClassInternal> bidirectional_class_internal(u32 code_point);
+
+enum class BidiClass {
+    ArabicNumber,             // AN
+    BlockSeparator,           // B
+    BoundaryNeutral,          // BN
+    CommonNumberSeparator,    // CS
+    DirNonSpacingMark,        // NSM
+    EuropeanNumber,           // EN
+    EuropeanNumberSeparator,  // ES
+    EuropeanNumberTerminator, // ET
+    FirstStrongIsolate,       // FSI
+    LeftToRight,              // L
+    LeftToRightEmbedding,     // LRE
+    LeftToRightIsolate,       // LRI
+    LeftToRightOverride,      // LRO
+    OtherNeutral,             // ON
+    PopDirectionalFormat,     // PDF
+    PopDirectionalIsolate,    // PDI
+    RightToLeft,              // R
+    RightToLeftArabic,        // AL
+    RightToLeftEmbedding,     // RLE
+    RightToLeftIsolate,       // RLI
+    RightToLeftOverride,      // RLO
+    SegmentSeparator,         // S
+    WhiteSpaceNeutral,        // WS
+};
+
+BidiClass bidirectional_class(u32 code_point);
 
 }

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -10,7 +10,7 @@
 
 namespace Unicode {
 
-enum class BidirectionalClass : u8;
+enum class BidiClass;
 enum class Block : u16;
 enum class EmojiGroup : u8;
 enum class GeneralCategory : u8;


### PR DESCRIPTION
Before this commit, GenerateUnicodeData generated a
`BidirectionalClass` enum directly from UnicodeData.txt.

Now, GenerateUnicodeData instead generates `BidirectionalClassInternal`
and CharacterTypes.h has an explicit enum `BidiClass` with nicer names
-- no underscores, but also names more similar to ICUs names.

(Since CharacterTypes.h is included in some of LibUnicode's generators,
it can't refer to generated `BidirectionalClassInternal`, so we instead
have a big manual mapping switch in UnicodeData.cpp.)

`bidirectional_class()` used to return an `Optional<BidirectionalClass>`
for when unicode data was disabled. Now we return `BidiClass` and
just return `BidiClass::LeftToRight` instead of making every client
do this.

It also updates LibWeb's Element.cpp to this new system.

Also remove now-unused `bidirectional_class_from_string()`.

This kind of cherry-picks the 4th commit of
LadybirdBrowser/ladybird#239 (aa3a30870b58c47cb37bce1418d7e6bee7af71d9):
The CharacterTypes.h, Element.cpp and TestUnicodeCharacterTypes.cpp changes are
by trflynn.

Co-authored-by: Tim Flynn <trflynn89@serenityos.org>