### PR TITLE
Cherry-pick "LibWeb: Begin implementing FontFaceSet.prototype.load"

### DIFF
--- a/Tests/LibWeb/Text/expected/css/FontFaceSet-load.txt
+++ b/Tests/LibWeb/Text/expected/css/FontFaceSet-load.txt
@@ -1,0 +1,3 @@
+Load invalid font: PASS
+Load CSS keyword as font: PASS
+Load valid font: PASS

--- a/Tests/LibWeb/Text/input/css/FontFaceSet-load.html
+++ b/Tests/LibWeb/Text/input/css/FontFaceSet-load.html
@@ -1,0 +1,33 @@
+<script src="../include.js"></script>
+<script type="text/javascript">
+    asyncTest(async done => {
+        const fontFaceSet = document.fonts;
+
+        const fontFace = new FontFace("Hash Sans", "url(../../../../Ref/assets/HashSans.woff)");
+        fontFaceSet.add(fontFace);
+
+        try {
+            await fontFaceSet.load("invalid");
+            println("Load invalid font: FAIL");
+        } catch (e) {
+            println("Load invalid font: PASS");
+        }
+
+        try {
+            await fontFaceSet.load("revert");
+            println("Load CSS keyword as font: FAIL");
+        } catch (e) {
+            println("Load CSS keyword as font: PASS");
+        }
+
+        try {
+            await fontFaceSet.load("1em Hash Sans");
+            println("Load valid font: PASS");
+        } catch (e) {
+            println("Load valid font: FAIL");
+            println(e);
+        }
+
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -79,6 +79,8 @@ public:
 
     void load_font_source();
 
+    JS::NonnullGCPtr<WebIDL::Promise> font_status_promise() { return m_font_status_promise; }
+
 private:
     FontFace(JS::Realm&, JS::NonnullGCPtr<WebIDL::Promise> font_status_promise, Vector<ParsedFontFace::Source> urls, ByteBuffer data, String family, FontFaceDescriptors const& descriptors);
 


### PR DESCRIPTION
This implementation is incomplete in that we do not fully implement the steps to match the given font against the fonts in the set.

This is used by fonts.google.com to load the fonts used for sample text.

(cherry picked from commit 9bdf2e928c448585a6349bef36d7cb98ccc0607b)

---

https://github.com/LadybirdBrowser/ladybird/pull/1937