### PR TITLE
Meta: Make LibIDL depend on LibCoreMinimal in GN build

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibIDL/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibIDL/BUILD.gn
@@ -7,7 +7,7 @@ shared_library("LibIDL") {
   ]
   deps = [
     "//AK",
-    "//Userland/Libraries/LibCore",
+    "//Userland/Libraries/LibCore:minimal",
     "//Userland/Libraries/LibFileSystem",
   ]
 }


### PR DESCRIPTION
Reduces the number of build steps after touching a file in LibUnicode from 915 to 87.

---

Ports the LibIDL cmake change in #25121 to the GN build.