### PR TITLE
Remove `std::` prefixes

### DIFF
--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -339,8 +339,7 @@ In C++ implementation files, do not use "using" declarations of any kind to impo
 ```cpp
 // File.cpp
 
-std::swap(a, b);
-c = std::numeric_limits<int>::max()
+Core::ArgsParser args_parser;
 ```
 
 ###### Wrong:
@@ -348,8 +347,8 @@ c = std::numeric_limits<int>::max()
 ```cpp
 // File.cpp
 
-using std::swap;
-swap(a, b);
+using Core::ArgsParser;
+ArgsParser args_parser;
 ```
 
 ###### Wrong:
@@ -357,8 +356,8 @@ swap(a, b);
 ```cpp
 // File.cpp
 
-using namespace std;
-swap(a, b);
+using namespace Core;
+ArgsParser args_parser;
 ```
 
 ### Types

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -611,7 +611,7 @@ Tab::Tab(BrowserWindow& window)
         if (auto path = GUI::FilePicker::get_open_filepath(&window, "Select file", Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::CenterWithinParent, move(accepted_file_filters)); path.has_value())
             create_selected_file(path.release_value());
 
-        view().file_picker_closed(std::move(selected_files));
+        view().file_picker_closed(move(selected_files));
     };
 
     m_select_dropdown = GUI::Menu::construct();

--- a/Userland/Services/WindowServer/Overlays.cpp
+++ b/Userland/Services/WindowServer/Overlays.cpp
@@ -431,7 +431,7 @@ WindowStackSwitchOverlay::WindowStackSwitchOverlay(Screen& screen, WindowStack& 
 TileWindowOverlay::TileWindowOverlay(Window& window, Gfx::IntRect const& tiled_frame_rect, Gfx::Palette&& palette)
     : m_window(window)
     , m_tiled_frame_rect(tiled_frame_rect)
-    , m_palette(std::move(palette))
+    , m_palette(move(palette))
 {
 }
 


### PR DESCRIPTION
We don't use the STL and things in std:: (except were the language forces us).

This gets rid of offenders in `git grep std:: | rg -v initializer | rg -iv Patches | rg -v corou | rg -v ClangPlugin | rg -v 'operator new' | rg -v 'operator delete'` (except in Ladybird/Qt, where std:: is fine).