### PR TITLE
Add Locale::Segmenter, and cherry-pick two ladybird PRs

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibLocale/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibLocale/BUILD.gn
@@ -178,6 +178,7 @@ source_set("LibLocale") {
     "NumberFormat.cpp",
     "PluralRules.cpp",
     "RelativeTimeFormat.cpp",
+    "Segmenter.cpp",
   ]
   deps = [
     "//AK",

--- a/Tests/LibLocale/CMakeLists.txt
+++ b/Tests/LibLocale/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestDateTimeFormat.cpp
     TestLocale.cpp
+    TestSegmenter.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibLocale/TestSegmenter.cpp
+++ b/Tests/LibLocale/TestSegmenter.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Array.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+#include <LibLocale/Segmenter.h>
+
+template<size_t N>
+static void test_grapheme_segmentation(StringView string, size_t const (&expected_boundaries)[N])
+{
+    Vector<size_t> boundaries;
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Grapheme);
+
+    segmenter->for_each_boundary(MUST(String::from_utf8(string)), [&](auto boundary) {
+        boundaries.append(boundary);
+        return IterationDecision::Continue;
+    });
+
+    EXPECT_EQ(boundaries, ReadonlySpan<size_t> { expected_boundaries });
+}
+
+TEST_CASE(grapheme_segmentation)
+{
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Grapheme);
+
+    segmenter->for_each_boundary(String {}, [&](auto i) {
+        dbgln("{}", i);
+        VERIFY_NOT_REACHED();
+        return IterationDecision::Break;
+    });
+
+    test_grapheme_segmentation("a"sv, { 0u, 1u });
+    test_grapheme_segmentation("ab"sv, { 0u, 1u, 2u });
+    test_grapheme_segmentation("abc"sv, { 0u, 1u, 2u, 3u });
+
+    test_grapheme_segmentation("a\nb"sv, { 0u, 1u, 2u, 3u });
+    test_grapheme_segmentation("a\n\rb"sv, { 0u, 1u, 2u, 3u, 4u });
+    test_grapheme_segmentation("a\r\nb"sv, { 0u, 1u, 3u, 4u });
+
+    test_grapheme_segmentation("aᄀb"sv, { 0u, 1u, 4u, 5u });
+    test_grapheme_segmentation("aᄀᄀb"sv, { 0u, 1u, 7u, 8u });
+    test_grapheme_segmentation("aᄀᆢb"sv, { 0u, 1u, 7u, 8u });
+    test_grapheme_segmentation("aᄀ가b"sv, { 0u, 1u, 7u, 8u });
+    test_grapheme_segmentation("aᄀ각b"sv, { 0u, 1u, 7u, 8u });
+
+    test_grapheme_segmentation("a😀b"sv, { 0u, 1u, 5u, 6u });
+    test_grapheme_segmentation("a👨‍👩‍👧‍👦b"sv, { 0u, 1u, 26u, 27u });
+    test_grapheme_segmentation("a👩🏼‍❤️‍👨🏻b"sv, { 0u, 1u, 29u, 30u });
+}
+
+TEST_CASE(grapheme_segmentation_indic_conjunct_break)
+{
+    test_grapheme_segmentation("\u0915"sv, { 0u, 3u });
+    test_grapheme_segmentation("\u0915a"sv, { 0u, 3u, 4u });
+    test_grapheme_segmentation("\u0915\u0916"sv, { 0u, 3u, 6u });
+
+    test_grapheme_segmentation("\u0915\u094D\u0916"sv, { 0u, 9u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u094D\u0916"sv, { 0u, 15u });
+    test_grapheme_segmentation("\u0915\u094D\u09BC\u09CD\u0916"sv, { 0u, 15u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u094D\u09BC\u09CD\u0916"sv, { 0u, 21u });
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u09BC\u09CD\u094D\u0916"sv, { 0u, 21u });
+    test_grapheme_segmentation("\u0915\u094D\u09BC\u09CD\u09BC\u09CD\u0916"sv, { 0u, 21u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u09BC\u09CD\u094D\u09BC\u09CD\u0916"sv, { 0u, 27u });
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u094D\u09BC\u09CD\u09BC\u09CD\u0916"sv, { 0u, 27u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u09BC\u09CD\u094D\u09BC\u09CD\u09BC\u09CD\u0916"sv, { 0u, 33u });
+}
+
+template<size_t N>
+static void test_word_segmentation(StringView string, size_t const (&expected_boundaries)[N])
+{
+    Vector<size_t> boundaries;
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
+
+    segmenter->for_each_boundary(MUST(String::from_utf8(string)), [&](auto boundary) {
+        boundaries.append(boundary);
+        return IterationDecision::Continue;
+    });
+
+    EXPECT_EQ(boundaries, ReadonlySpan<size_t> { expected_boundaries });
+}
+
+TEST_CASE(word_segmentation)
+{
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
+
+    segmenter->for_each_boundary(String {}, [&](auto) {
+        VERIFY_NOT_REACHED();
+        return IterationDecision::Break;
+    });
+
+    test_word_segmentation("a"sv, { 0u, 1u });
+    test_word_segmentation("ab"sv, { 0u, 2u });
+    test_word_segmentation("abc"sv, { 0u, 3u });
+
+    test_word_segmentation("ab cd"sv, { 0u, 2u, 3u, 5u });
+    test_word_segmentation("ab  cd"sv, { 0u, 2u, 4u, 6u });
+    test_word_segmentation("ab\tcd"sv, { 0u, 2u, 3u, 5u });
+    test_word_segmentation("ab\ncd"sv, { 0u, 2u, 3u, 5u });
+    test_word_segmentation("ab\n\rcd"sv, { 0u, 2u, 3u, 4u, 6u });
+    test_word_segmentation("ab\r\ncd"sv, { 0u, 2u, 4u, 6u });
+
+    test_word_segmentation("a😀b"sv, { 0u, 1u, 5u, 6u });
+    test_word_segmentation("a👨‍👩‍👧‍👦b"sv, { 0u, 1u, 26u, 27u });
+    test_word_segmentation("a👩🏼‍❤️‍👨🏻b"sv, { 0u, 1u, 29u, 30u });
+
+    test_word_segmentation("ab 12 cd"sv, { 0u, 2u, 3u, 5u, 6u, 8u });
+    test_word_segmentation("ab 1.2 cd"sv, { 0u, 2u, 3u, 6u, 7u, 9u });
+    test_word_segmentation("ab 12.34 cd"sv, { 0u, 2u, 3u, 8u, 9u, 11u });
+    test_word_segmentation("ab example.com cd"sv, { 0u, 2u, 3u, 14u, 15u, 17u });
+
+    test_word_segmentation("ab can't cd"sv, { 0u, 2u, 3u, 8u, 9u, 11u });
+    test_word_segmentation("ab \"can't\" cd"sv, { 0u, 2u, 3u, 4u, 9u, 10u, 11u, 13u });
+
+    test_word_segmentation(
+        "The quick (“brown”) fox can’t jump 32.3 feet, right?"sv,
+        { 0u, 3u, 4u, 9u, 10u, 11u, 14u, 19u, 22u, 23u, 24u, 27u, 28u, 35u, 36u, 40u, 41u, 45u, 46u, 50u, 51u, 52u, 57u, 58u });
+}

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -877,8 +877,6 @@ ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Seg
     TRY(print_type(print_context, "Segments"sv));
     out("\n  string: ");
     TRY(print_value(print_context, JS::PrimitiveString::create(segments.vm(), move(segments_string)), seen_objects));
-    out("\n  segmenter: ");
-    TRY(print_value(print_context, &segments.segments_segmenter(), seen_objects));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
@@ -13,7 +13,7 @@ namespace JS::Intl {
 JS_DEFINE_ALLOCATOR(SegmentIterator);
 
 // 18.6.1 CreateSegmentIterator ( segmenter, string ), https://tc39.es/ecma402/#sec-createsegmentsobject
-NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, Segmenter& segmenter, Utf16View const& string, Segments const& segments)
+NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, ::Locale::Segmenter const& segmenter, Utf16View const& string, Segments const& segments)
 {
     // 1. Let internalSlotsList be « [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] ».
     // 2. Let iterator be OrdinaryObjectCreate(%SegmentIteratorPrototype%, internalSlotsList).
@@ -21,22 +21,22 @@ NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, Segmenter& s
     // 4. Set iterator.[[IteratedString]] to string.
     // 5. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to 0.
     // 6. Return iterator.
-    return realm.heap().allocate<SegmentIterator>(realm, realm, segmenter, move(string), segments);
+    return realm.heap().allocate<SegmentIterator>(realm, realm, segmenter, string, segments);
 }
 
 // 18.6 Segment Iterator Objects, https://tc39.es/ecma402/#sec-segment-iterator-objects
-SegmentIterator::SegmentIterator(Realm& realm, Segmenter& segmenter, Utf16View const& string, Segments const& segments)
+SegmentIterator::SegmentIterator(Realm& realm, ::Locale::Segmenter const& segmenter, Utf16View const& string, Segments const& segments)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().intl_segment_iterator_prototype())
-    , m_iterating_segmenter(segmenter)
+    , m_iterating_segmenter(segmenter.clone())
     , m_iterated_string(string)
     , m_segments(segments)
 {
+    m_iterating_segmenter->set_segmented_text(m_iterated_string);
 }
 
 void SegmentIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_iterating_segmenter);
     visitor.visit(m_segments);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
@@ -9,6 +9,7 @@
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/Intl/Segmenter.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibLocale/Segmenter.h>
 
 namespace JS::Intl {
 
@@ -17,25 +18,23 @@ class SegmentIterator final : public Object {
     JS_DECLARE_ALLOCATOR(SegmentIterator);
 
 public:
-    static NonnullGCPtr<SegmentIterator> create(Realm&, Segmenter&, Utf16View const&, Segments const&);
+    static NonnullGCPtr<SegmentIterator> create(Realm&, ::Locale::Segmenter const&, Utf16View const&, Segments const&);
 
     virtual ~SegmentIterator() override = default;
 
-    Segmenter const& iterating_segmenter() const { return m_iterating_segmenter; }
+    ::Locale::Segmenter& iterating_segmenter() { return *m_iterating_segmenter; }
     Utf16View const& iterated_string() const { return m_iterated_string; }
-    size_t iterated_string_next_segment_code_unit_index() const { return m_iterated_string_next_segment_code_unit_index; }
-    void set_iterated_string_next_segment_code_unit_index(size_t index) { m_iterated_string_next_segment_code_unit_index = index; }
+    size_t iterated_string_next_segment_code_unit_index() const { return m_iterating_segmenter->current_boundary(); }
 
     Segments const& segments() { return m_segments; }
 
 private:
-    SegmentIterator(Realm&, Segmenter&, Utf16View const&, Segments const&);
+    SegmentIterator(Realm&, ::Locale::Segmenter const&, Utf16View const&, Segments const&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    NonnullGCPtr<Segmenter> m_iterating_segmenter;               // [[IteratingSegmenter]]
-    Utf16View m_iterated_string;                                 // [[IteratedString]]
-    size_t m_iterated_string_next_segment_code_unit_index { 0 }; // [[IteratedStringNextSegmentCodeUnitIndex]]
+    NonnullOwnPtr<::Locale::Segmenter> m_iterating_segmenter; // [[IteratingSegmenter]]
+    Utf16View m_iterated_string;                              // [[IteratedString]]
 
     NonnullGCPtr<Segments const> m_segments;
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
@@ -41,7 +41,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentIteratorPrototype::next)
     auto iterator = TRY(typed_this_object(vm));
 
     // 3. Let segmenter be iterator.[[IteratingSegmenter]].
-    auto const& segmenter = iterator->iterating_segmenter();
+    auto& segmenter = iterator->iterating_segmenter();
 
     // 4. Let string be iterator.[[IteratedString]].
     auto const& string = iterator->iterated_string();
@@ -49,22 +49,25 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentIteratorPrototype::next)
     // 5. Let startIndex be iterator.[[IteratedStringNextSegmentCodeUnitIndex]].
     auto start_index = iterator->iterated_string_next_segment_code_unit_index();
 
-    // 6. Let endIndex be ! FindBoundary(segmenter, string, startIndex, after).
-    auto end_index = find_boundary(segmenter, string, start_index, Direction::After);
+    // 6. Let len be the length of string.
+    auto length = string.length_in_code_units();
 
-    // 7. If endIndex is not finite, then
-    if (!Value(end_index).is_finite_number()) {
+    // 7. If startIndex ≥ len, then
+    if (start_index >= length) {
         // a. Return CreateIterResultObject(undefined, true).
         return create_iterator_result_object(vm, js_undefined(), true);
     }
 
-    // 8. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to endIndex.
-    iterator->set_iterated_string_next_segment_code_unit_index(end_index);
+    // 8. Let endIndex be FindBoundary(segmenter, string, startIndex, after).
+    auto end_index = find_boundary(segmenter, string, start_index, Direction::After);
 
-    // 9. Let segmentData be ! CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
+    // 9. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to endIndex.
+    // NOTE: This is already handled by LibLocale.
+
+    // 10. Let segmentData be CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
     auto segment_data = TRY(create_segment_data_object(vm, segmenter, string, start_index, end_index));
 
-    // 10. Return CreateIterResultObject(segmentData, false).
+    // 11. Return CreateIterResultObject(segmentData, false).
     return create_iterator_result_object(vm, segment_data, false);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
@@ -9,6 +9,7 @@
 
 #include <AK/String.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibLocale/Segmenter.h>
 
 namespace JS::Intl {
 
@@ -17,34 +18,34 @@ class Segmenter final : public Object {
     JS_DECLARE_ALLOCATOR(Segmenter);
 
 public:
-    enum class SegmenterGranularity {
-        Grapheme,
-        Word,
-        Sentence,
-    };
-
     virtual ~Segmenter() override = default;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
-    SegmenterGranularity segmenter_granularity() const { return m_segmenter_granularity; }
-    void set_segmenter_granularity(StringView);
-    StringView segmenter_granularity_string() const;
+    ::Locale::SegmenterGranularity segmenter_granularity() const { return m_segmenter_granularity; }
+    void set_segmenter_granularity(StringView segmenter_granularity) { m_segmenter_granularity = ::Locale::segmenter_granularity_from_string(segmenter_granularity); }
+    StringView segmenter_granularity_string() const { return ::Locale::segmenter_granularity_to_string(m_segmenter_granularity); }
+
+    ::Locale::Segmenter const& segmenter() const { return *m_segmenter; }
+    void set_segmenter(NonnullOwnPtr<::Locale::Segmenter> segmenter) { m_segmenter = move(segmenter); }
 
 private:
     explicit Segmenter(Object& prototype);
 
-    String m_locale;                                                                 // [[Locale]]
-    SegmenterGranularity m_segmenter_granularity { SegmenterGranularity::Grapheme }; // [[SegmenterGranularity]]
+    String m_locale;                                                                                     // [[Locale]]
+    ::Locale::SegmenterGranularity m_segmenter_granularity { ::Locale::SegmenterGranularity::Grapheme }; // [[SegmenterGranularity]]
+
+    // Non-standard. Stores the segmenter for the Intl object's segmentation options.
+    OwnPtr<::Locale::Segmenter> m_segmenter;
 };
 
-ThrowCompletionOr<NonnullGCPtr<Object>> create_segment_data_object(VM&, Segmenter const&, Utf16View const&, double start_index, double end_index);
+ThrowCompletionOr<NonnullGCPtr<Object>> create_segment_data_object(VM&, ::Locale::Segmenter const&, Utf16View const&, size_t start_index, size_t end_index);
 
 enum class Direction {
     Before,
     After,
 };
-double find_boundary(Segmenter const&, Utf16View const&, double start_index, Direction);
+size_t find_boundary(::Locale::Segmenter&, Utf16View const&, size_t start_index, Direction);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -71,21 +71,22 @@ ThrowCompletionOr<NonnullGCPtr<Object>> SegmenterConstructor::construct(Function
     // 8. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 9. Let localeData be %Segmenter%.[[LocaleData]].
-
-    // 10. Let r be ResolveLocale(%Segmenter%.[[AvailableLocales]], requestedLocales, opt, %Segmenter%.[[RelevantExtensionKeys]], localeData).
+    // 9. Let r be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], requestedLocales, opt, %Intl.Segmenter%.[[RelevantExtensionKeys]], %Intl.Segmenter%.[[LocaleData]]).
     auto result = resolve_locale(requested_locales, opt, {});
 
-    // 11. Set segmenter.[[Locale]] to r.[[locale]].
+    // 10. Set segmenter.[[Locale]] to r.[[locale]].
     segmenter->set_locale(move(result.locale));
 
-    // 12. Let granularity be ? GetOption(options, "granularity", string, « "grapheme", "word", "sentence" », "grapheme").
+    // 11. Let granularity be ? GetOption(options, "granularity", string, « "grapheme", "word", "sentence" », "grapheme").
     auto granularity = TRY(get_option(vm, *options, vm.names.granularity, OptionType::String, { "grapheme"sv, "word"sv, "sentence"sv }, "grapheme"sv));
 
-    // 13. Set segmenter.[[SegmenterGranularity]] to granularity.
+    // 12. Set segmenter.[[SegmenterGranularity]] to granularity.
     segmenter->set_segmenter_granularity(granularity.as_string().utf8_string_view());
 
-    // 14. Return segmenter.
+    auto locale_segmenter = ::Locale::Segmenter::create(segmenter->locale(), segmenter->segmenter_granularity());
+    segmenter->set_segmenter(move(locale_segmenter));
+
+    // 13. Return segmenter.
     return segmenter;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
@@ -70,7 +70,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmenterPrototype::segment)
     auto string = TRY(vm.argument(0).to_utf16_string(vm));
 
     // 4. Return ! CreateSegmentsObject(segmenter, string).
-    return Segments::create(realm, segmenter, move(string));
+    return Segments::create(realm, segmenter->segmenter(), move(string));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
@@ -13,7 +13,7 @@ namespace JS::Intl {
 JS_DEFINE_ALLOCATOR(Segments);
 
 // 18.5.1 CreateSegmentsObject ( segmenter, string ), https://tc39.es/ecma402/#sec-createsegmentsobject
-NonnullGCPtr<Segments> Segments::create(Realm& realm, Segmenter& segmenter, Utf16String string)
+NonnullGCPtr<Segments> Segments::create(Realm& realm, ::Locale::Segmenter const& segmenter, Utf16String string)
 {
     // 1. Let internalSlotsList be « [[SegmentsSegmenter]], [[SegmentsString]] ».
     // 2. Let segments be OrdinaryObjectCreate(%SegmentsPrototype%, internalSlotsList).
@@ -24,17 +24,12 @@ NonnullGCPtr<Segments> Segments::create(Realm& realm, Segmenter& segmenter, Utf1
 }
 
 // 18.5 Segments Objects, https://tc39.es/ecma402/#sec-segments-objects
-Segments::Segments(Realm& realm, Segmenter& segmenter, Utf16String string)
+Segments::Segments(Realm& realm, ::Locale::Segmenter const& segmenter, Utf16String string)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().intl_segments_prototype())
-    , m_segments_segmenter(segmenter)
+    , m_segments_segmenter(segmenter.clone())
     , m_segments_string(move(string))
 {
-}
-
-void Segments::visit_edges(Cell::Visitor& visitor)
-{
-    Base::visit_edges(visitor);
-    visitor.visit(m_segments_segmenter);
+    m_segments_segmenter->set_segmented_text(m_segments_string.view());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
@@ -9,6 +9,7 @@
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/Intl/Segmenter.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibLocale/Segmenter.h>
 
 namespace JS::Intl {
 
@@ -17,21 +18,19 @@ class Segments final : public Object {
     JS_DECLARE_ALLOCATOR(Segments);
 
 public:
-    static NonnullGCPtr<Segments> create(Realm&, Segmenter&, Utf16String);
+    static NonnullGCPtr<Segments> create(Realm&, ::Locale::Segmenter const&, Utf16String);
 
     virtual ~Segments() override = default;
 
-    Segmenter& segments_segmenter() const { return m_segments_segmenter; }
+    ::Locale::Segmenter& segments_segmenter() const { return *m_segments_segmenter; }
 
     Utf16View segments_string() const { return m_segments_string.view(); }
 
 private:
-    Segments(Realm&, Segmenter&, Utf16String);
+    Segments(Realm&, ::Locale::Segmenter const&, Utf16String);
 
-    virtual void visit_edges(Cell::Visitor&) override;
-
-    NonnullGCPtr<Segmenter> m_segments_segmenter; // [[SegmentsSegmenter]]
-    Utf16String m_segments_string;                // [[SegmentsString]]
+    NonnullOwnPtr<::Locale::Segmenter> m_segments_segmenter; // [[SegmentsSegmenter]]
+    Utf16String m_segments_string;                           // [[SegmentsString]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
@@ -38,10 +38,10 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentsPrototype::containing)
     auto segments = TRY(typed_this_object(vm));
 
     // 3. Let segmenter be segments.[[SegmentsSegmenter]].
-    auto const& segmenter = segments->segments_segmenter();
+    auto& segmenter = segments->segments_segmenter();
 
     // 4. Let string be segments.[[SegmentsString]].
-    auto string = segments->segments_string();
+    auto const& string = segments->segments_string();
 
     // 5. Let len be the length of string.
     auto length = string.length_in_code_units();
@@ -50,16 +50,16 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentsPrototype::containing)
     auto n = TRY(vm.argument(0).to_integer_or_infinity(vm));
 
     // 7. If n < 0 or n ≥ len, return undefined.
-    if (n < 0 || n >= length)
+    if (n < 0 || n >= static_cast<double>(length))
         return js_undefined();
 
-    // 8. Let startIndex be ! FindBoundary(segmenter, string, n, before).
-    auto start_index = find_boundary(segmenter, string, n, Direction::Before);
+    // 8. Let startIndex be FindBoundary(segmenter, string, n, before).
+    auto start_index = find_boundary(segmenter, string, static_cast<size_t>(n), Direction::Before);
 
-    // 9. Let endIndex be ! FindBoundary(segmenter, string, n, after).
-    auto end_index = find_boundary(segmenter, string, n, Direction::After);
+    // 9. Let endIndex be FindBoundary(segmenter, string, n, after).
+    auto end_index = find_boundary(segmenter, string, static_cast<size_t>(n), Direction::After);
 
-    // 10. Return ! CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
+    // 10. Return CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
     return TRY(create_segment_data_object(vm, segmenter, string, start_index, end_index));
 }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Segmenter/Segmenter.prototype.segment.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Segmenter/Segmenter.prototype.segment.js
@@ -139,6 +139,7 @@ describe("correct behavior", () => {
         for (const segment of segments) {
             expect(segment.segment).toBe(expectedSegments[index].segment);
             expect(segment.index).toBe(expectedSegments[index].index);
+            // FIXME: expect(segment.isWordLike).toBe(expectedSegments[index].isWordLike);
             expect(segment.input).toBe(string);
             index++;
         }

--- a/Userland/Libraries/LibLocale/CMakeLists.txt
+++ b/Userland/Libraries/LibLocale/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     NumberFormat.cpp
     PluralRules.cpp
     RelativeTimeFormat.cpp
+    Segmenter.cpp
 )
 
 serenity_lib(LibLocale locale)

--- a/Userland/Libraries/LibLocale/Forward.h
+++ b/Userland/Libraries/LibLocale/Forward.h
@@ -45,6 +45,8 @@ enum class Weekday : u8;
 enum class WeekendEndRegion : u8;
 enum class WeekendStartRegion : u8;
 
+class Segmenter;
+
 struct CalendarFormat;
 struct CalendarPattern;
 struct CalendarRangePattern;

--- a/Userland/Libraries/LibLocale/Segmenter.cpp
+++ b/Userland/Libraries/LibLocale/Segmenter.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Utf16View.h>
+#include <AK/Utf32View.h>
+#include <LibLocale/Locale.h>
+#include <LibLocale/Segmenter.h>
+#include <LibUnicode/Segmentation.h>
+
+namespace Locale {
+
+SegmenterGranularity segmenter_granularity_from_string(StringView segmenter_granularity)
+{
+    if (segmenter_granularity == "grapheme"sv)
+        return SegmenterGranularity::Grapheme;
+    if (segmenter_granularity == "sentence"sv)
+        return SegmenterGranularity::Sentence;
+    if (segmenter_granularity == "word"sv)
+        return SegmenterGranularity::Word;
+    VERIFY_NOT_REACHED();
+}
+
+StringView segmenter_granularity_to_string(SegmenterGranularity segmenter_granularity)
+{
+    switch (segmenter_granularity) {
+    case SegmenterGranularity::Grapheme:
+        return "grapheme"sv;
+    case SegmenterGranularity::Sentence:
+        return "sentence"sv;
+    case SegmenterGranularity::Word:
+        return "word"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+class SegmenterImpl : public Segmenter {
+public:
+    SegmenterImpl(SegmenterGranularity segmenter_granularity)
+        : Segmenter(segmenter_granularity)
+    {
+    }
+
+    virtual ~SegmenterImpl() override = default;
+
+    virtual NonnullOwnPtr<Segmenter> clone() const override
+    {
+        return make<SegmenterImpl>(m_segmenter_granularity);
+    }
+
+    virtual void set_segmented_text(String text) override
+    {
+        m_string_storage = move(text);
+        m_segmented_text = Utf8View { m_string_storage.code_points() };
+    }
+
+    virtual void set_segmented_text(Utf16View const& text) override
+    {
+        m_segmented_text = text;
+    }
+
+    void set_segmented_text(Utf32View const& text)
+    {
+        m_segmented_text = text;
+    }
+
+    virtual size_t current_boundary() override
+    {
+        return m_current_boundary;
+    }
+
+    virtual Optional<size_t> previous_boundary(size_t boundary, Inclusive inclusive) override
+    {
+        if (inclusive == Inclusive::Yes)
+            ++boundary;
+        auto new_boundary = m_segmented_text.visit([&](auto const& text) { return previous_segmentation_boundary(text, boundary); });
+        if (new_boundary.has_value())
+            m_current_boundary = new_boundary.value();
+        return new_boundary;
+    }
+
+    virtual Optional<size_t> next_boundary(size_t boundary, Inclusive inclusive) override
+    {
+        if (inclusive == Inclusive::Yes)
+            --boundary;
+        auto new_boundary = m_segmented_text.visit([&](auto const& text) { return next_segmentation_boundary(text, boundary); });
+        if (new_boundary.has_value())
+            m_current_boundary = new_boundary.value();
+        return new_boundary;
+    }
+
+    virtual void for_each_boundary(String text, SegmentationCallback callback) override
+    {
+        for_each_segmentation_boundary(text.code_points(), move(callback));
+    }
+
+    virtual void for_each_boundary(Utf16View const& text, SegmentationCallback callback) override
+    {
+        for_each_segmentation_boundary(text, move(callback));
+    }
+
+    virtual void for_each_boundary(Utf32View const& text, SegmentationCallback callback) override
+    {
+        for_each_segmentation_boundary(text, move(callback));
+    }
+
+    virtual bool is_current_boundary_word_like() const override
+    {
+        // FIXME: Implement one day.
+        return false;
+    }
+
+private:
+    template<class T>
+    Optional<size_t> previous_segmentation_boundary(T const& text, size_t boundary)
+    {
+        switch (segmenter_granularity()) {
+        case SegmenterGranularity::Grapheme:
+            return Unicode::previous_grapheme_segmentation_boundary(text, boundary);
+        case SegmenterGranularity::Sentence:
+            return Unicode::previous_sentence_segmentation_boundary(text, boundary);
+        case SegmenterGranularity::Word:
+            return Unicode::previous_word_segmentation_boundary(text, boundary);
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    template<class T>
+    Optional<size_t> next_segmentation_boundary(T const& text, size_t boundary)
+    {
+        switch (segmenter_granularity()) {
+        case SegmenterGranularity::Grapheme:
+            return Unicode::next_grapheme_segmentation_boundary(text, boundary);
+        case SegmenterGranularity::Sentence:
+            return Unicode::next_sentence_segmentation_boundary(text, boundary);
+        case SegmenterGranularity::Word:
+            return Unicode::next_word_segmentation_boundary(text, boundary);
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    template<class T>
+    void for_each_segmentation_boundary(T const& text, SegmentationCallback callback)
+    {
+        switch (segmenter_granularity()) {
+        case SegmenterGranularity::Grapheme:
+            Unicode::for_each_grapheme_segmentation_boundary(text, move(callback));
+            break;
+        case SegmenterGranularity::Sentence:
+            Unicode::for_each_sentence_segmentation_boundary(text, move(callback));
+            break;
+        case SegmenterGranularity::Word:
+            Unicode::for_each_word_segmentation_boundary(text, move(callback));
+            break;
+        }
+    }
+
+    size_t m_current_boundary { 0 };
+    String m_string_storage;
+    Variant<Utf8View, Utf16View, Utf32View> m_segmented_text { Utf8View {} };
+};
+
+NonnullOwnPtr<Segmenter> Segmenter::create(SegmenterGranularity segmenter_granularity)
+{
+    return Segmenter::create(default_locale(), segmenter_granularity);
+}
+
+NonnullOwnPtr<Segmenter> Segmenter::create(StringView locale, SegmenterGranularity segmenter_granularity)
+{
+    // FIXME: Implement locale-specific segmentation.
+    (void)locale;
+    return make<SegmenterImpl>(segmenter_granularity);
+}
+
+}

--- a/Userland/Libraries/LibLocale/Segmenter.h
+++ b/Userland/Libraries/LibLocale/Segmenter.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+
+namespace Locale {
+
+enum class SegmenterGranularity {
+    Grapheme,
+    Sentence,
+    Word,
+};
+SegmenterGranularity segmenter_granularity_from_string(StringView);
+StringView segmenter_granularity_to_string(SegmenterGranularity);
+
+class Segmenter {
+public:
+    static NonnullOwnPtr<Segmenter> create(SegmenterGranularity segmenter_granularity);
+    static NonnullOwnPtr<Segmenter> create(StringView locale, SegmenterGranularity segmenter_granularity);
+    virtual ~Segmenter() = default;
+
+    SegmenterGranularity segmenter_granularity() const { return m_segmenter_granularity; }
+
+    virtual NonnullOwnPtr<Segmenter> clone() const = 0;
+
+    virtual void set_segmented_text(String) = 0;
+    virtual void set_segmented_text(Utf16View const&) = 0;
+
+    virtual size_t current_boundary() = 0;
+
+    enum class Inclusive {
+        No,
+        Yes,
+    };
+    virtual Optional<size_t> previous_boundary(size_t index, Inclusive = Inclusive::No) = 0;
+    virtual Optional<size_t> next_boundary(size_t index, Inclusive = Inclusive::No) = 0;
+
+    using SegmentationCallback = Function<IterationDecision(size_t)>;
+    virtual void for_each_boundary(String, SegmentationCallback) = 0;
+    virtual void for_each_boundary(Utf16View const&, SegmentationCallback) = 0;
+    virtual void for_each_boundary(Utf32View const&, SegmentationCallback) = 0;
+
+    virtual bool is_current_boundary_word_like() const = 0;
+
+protected:
+    explicit Segmenter(SegmenterGranularity segmenter_granularity)
+        : m_segmenter_granularity(segmenter_granularity)
+    {
+    }
+
+    SegmenterGranularity m_segmenter_granularity { SegmenterGranularity::Grapheme };
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -8,6 +8,7 @@
 
 #include <AK/String.h>
 #include <AK/Utf16View.h>
+#include <LibLocale/Forward.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
@@ -23,7 +24,7 @@ class CharacterData
     JS_DECLARE_ALLOCATOR(CharacterData);
 
 public:
-    virtual ~CharacterData() override = default;
+    virtual ~CharacterData() override;
 
     String const& data() const { return m_data; }
     void set_data(String const&);
@@ -39,6 +40,8 @@ public:
     WebIDL::ExceptionOr<void> delete_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units);
     WebIDL::ExceptionOr<void> replace_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units, String const&);
 
+    Locale::Segmenter& segmenter();
+
 protected:
     CharacterData(Document&, NodeType, String const&);
 
@@ -46,6 +49,8 @@ protected:
 
 private:
     String m_data;
+
+    OwnPtr<Locale::Segmenter> m_segmenter;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Position.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Position.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <AK/Utf8View.h>
-#include <LibUnicode/Segmentation.h>
+#include <LibLocale/Segmenter.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/Text.h>
@@ -40,9 +40,8 @@ bool Position::increment_offset()
         return false;
 
     auto& node = verify_cast<DOM::Text>(*m_node);
-    auto text = Utf8View(node.data());
 
-    if (auto offset = Unicode::next_grapheme_segmentation_boundary(text, m_offset); offset.has_value()) {
+    if (auto offset = node.segmenter().next_boundary(m_offset); offset.has_value()) {
         m_offset = *offset;
         return true;
     }
@@ -57,9 +56,8 @@ bool Position::decrement_offset()
         return false;
 
     auto& node = verify_cast<DOM::Text>(*m_node);
-    auto text = Utf8View(node.data());
 
-    if (auto offset = Unicode::previous_grapheme_segmentation_boundary(text, m_offset); offset.has_value()) {
+    if (auto offset = node.segmenter().previous_boundary(m_offset); offset.has_value()) {
         m_offset = *offset;
         return true;
     }

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
-#include <LibUnicode/Segmentation.h>
+#include <LibLocale/Segmenter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/Range.h>
@@ -22,15 +22,15 @@ void EditEventHandler::handle_delete_character_after(JS::NonnullGCPtr<DOM::Docum
     auto& node = verify_cast<DOM::Text>(*cursor_position->node());
     auto& text = node.data();
 
-    auto next_grapheme_offset = Unicode::next_grapheme_segmentation_boundary(Utf8View { text }, cursor_position->offset());
-    if (!next_grapheme_offset.has_value()) {
+    auto next_offset = node.segmenter().next_boundary(cursor_position->offset());
+    if (!next_offset.has_value()) {
         // FIXME: Move to the next node and delete the first character there.
         return;
     }
 
     StringBuilder builder;
     builder.append(text.bytes_as_string_view().substring_view(0, cursor_position->offset()));
-    builder.append(text.bytes_as_string_view().substring_view(*next_grapheme_offset));
+    builder.append(text.bytes_as_string_view().substring_view(*next_offset));
     node.set_data(MUST(builder.to_string()));
 
     document->user_did_edit_document_text({});


### PR DESCRIPTION
This in a way cherry-picks the first three commits of https://github.com/LadybirdBrowser/ladybird/pull/218 – except it doesn't use ICU for it.

This is behavior-preserving for now (in the future we can make Segmenter locale-dependent and improve it). The main motivation is that this makes it easier to cherry-pick later ladybird patches.