### PR TITLE
Cherry-pick "LibWeb: Use a Unicode text segmenter to select words on double-click"

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibLocale/Segmenter.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -691,30 +692,16 @@ EventResult EventHandler::handle_doubleclick(CSSPixelPoint viewport_position, CS
             auto& hit_dom_node = const_cast<DOM::Text&>(verify_cast<DOM::Text>(*hit_paintable.dom_node()));
             auto const& text_for_rendering = hit_paintable.text_for_rendering();
 
-            int first_word_break_before = [&] {
-                // Start from one before the index position to prevent selecting only spaces between words, caused by the addition below.
-                // This also helps us dealing with cases where index is equal to the string length.
-                for (int i = result->index_in_node - 1; i >= 0; --i) {
-                    if (is_ascii_space(text_for_rendering.bytes_as_string_view()[i])) {
-                        // Don't include the space in the selection
-                        return i + 1;
-                    }
-                }
-                return 0;
-            }();
+            auto& segmenter = word_segmenter();
+            segmenter.set_segmented_text(text_for_rendering);
 
-            int first_word_break_after = [&] {
-                for (size_t i = result->index_in_node; i < text_for_rendering.bytes().size(); ++i) {
-                    if (is_ascii_space(text_for_rendering.bytes_as_string_view()[i]))
-                        return i;
-                }
-                return text_for_rendering.bytes().size();
-            }();
+            auto previous_boundary = segmenter.previous_boundary(result->index_in_node, Locale::Segmenter::Inclusive::Yes).value_or(0);
+            auto next_boundary = segmenter.next_boundary(result->index_in_node).value_or(text_for_rendering.byte_count());
 
             auto& realm = node->document().realm();
-            document.set_cursor_position(DOM::Position::create(realm, hit_dom_node, first_word_break_after));
+            document.set_cursor_position(DOM::Position::create(realm, hit_dom_node, next_boundary));
             if (auto selection = node->document().get_selection()) {
-                (void)selection->set_base_and_extent(hit_dom_node, first_word_break_before, hit_dom_node, first_word_break_after);
+                (void)selection->set_base_and_extent(hit_dom_node, previous_boundary, hit_dom_node, next_boundary);
             }
             update_selection_range_for_input_or_textarea();
         }
@@ -1216,6 +1203,13 @@ void EventHandler::update_selection_range_for_input_or_textarea()
 
     if (target.has_value())
         target.value().set_the_selection_range(selection_start, selection_end, direction, HTML::SelectionSource::UI);
+}
+
+Locale::Segmenter& EventHandler::word_segmenter()
+{
+    if (!m_word_segmenter)
+        m_word_segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
+    return *m_word_segmenter;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -12,6 +12,7 @@
 #include <LibGfx/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/GCPtr.h>
+#include <LibLocale/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -41,6 +42,8 @@ public:
     void handle_paste(String const& text);
 
     void visit_edges(JS::Cell::Visitor& visitor) const;
+
+    Locale::Segmenter& word_segmenter();
 
 private:
     bool focus_next_element();
@@ -75,6 +78,8 @@ private:
     WeakPtr<DOM::EventTarget> m_mousedown_target;
 
     Optional<CSSPixelPoint> m_mousemove_previous_screen_position;
+
+    OwnPtr<Locale::Segmenter> m_word_segmenter;
 };
 
 }


### PR DESCRIPTION
We currently use a naive word segmentation, looking for ASCII spaces to mark a word boundary. Use LibUnicode's complete implementation instead.

(cherry picked from commit 430c9d3e3fb6ec9e2aa3d962381672b70957c395; amended to use Locale::Segmenter instead of Unicode::Segmenter due to LibLocale and LibUnicode being two distinct libraries in serenity)

---

https://github.com/LadybirdBrowser/ladybird/pull/1205 1st commit; the other commits were in #25371 already)