### PR TITLE
LibLocale: Make Segmenter store segment boundaries

### DIFF
--- a/Tests/LibLocale/BenchmarkSegmenter.cpp
+++ b/Tests/LibLocale/BenchmarkSegmenter.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibLocale/Segmenter.h>
+#include <LibTest/TestCase.h>
+
+constexpr size_t N = 10'000;
+
+static auto make_string()
+{
+    return MUST(String::repeated("hello "_string, N));
+}
+
+auto long_string = make_string();
+
+BENCHMARK_CASE(for_each_boundary)
+{
+    Vector<size_t> boundaries;
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
+
+    segmenter->for_each_boundary(long_string, [&](auto boundary) {
+        boundaries.append(boundary);
+        return IterationDecision::Continue;
+    });
+
+    EXPECT_EQ(boundaries.size(), 2 * N + 1);
+}
+
+BENCHMARK_CASE(forward)
+{
+    Vector<size_t> boundaries;
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
+    segmenter->set_segmented_text(long_string);
+
+    size_t boundary = 0;
+    boundaries.append(boundary);
+    while (true) {
+        auto next_boundary = segmenter->next_boundary(boundary);
+        if (!next_boundary.has_value())
+            break;
+
+        boundary = next_boundary.value();
+        boundaries.append(boundary);
+    }
+
+    EXPECT_EQ(boundaries.size(), 2 * N + 1);
+}
+
+BENCHMARK_CASE(backward)
+{
+    Vector<size_t> boundaries;
+    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
+    segmenter->set_segmented_text(long_string);
+
+    size_t boundary = long_string.bytes_as_string_view().length();
+    boundaries.append(boundary);
+    while (true) {
+        auto next_boundary = segmenter->previous_boundary(boundary);
+        if (!next_boundary.has_value())
+            break;
+
+        boundary = next_boundary.value();
+        boundaries.append(boundary);
+    }
+
+    EXPECT_EQ(boundaries.size(), 2 * N + 1);
+}

--- a/Tests/LibLocale/CMakeLists.txt
+++ b/Tests/LibLocale/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    BenchmarkSegmenter.cpp
     TestDateTimeFormat.cpp
     TestLocale.cpp
     TestSegmenter.cpp

--- a/Tests/LibLocale/TestSegmenter.cpp
+++ b/Tests/LibLocale/TestSegmenter.cpp
@@ -13,10 +13,10 @@
 #include <LibLocale/Segmenter.h>
 
 template<size_t N>
-static void test_grapheme_segmentation(StringView string, size_t const (&expected_boundaries)[N])
+static void test_segmentation(Locale::SegmenterGranularity granularity, StringView string, size_t const (&expected_boundaries)[N])
 {
     Vector<size_t> boundaries;
-    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Grapheme);
+    auto segmenter = Locale::Segmenter::create(granularity);
 
     segmenter->for_each_boundary(MUST(String::from_utf8(string)), [&](auto boundary) {
         boundaries.append(boundary);
@@ -24,6 +24,12 @@ static void test_grapheme_segmentation(StringView string, size_t const (&expecte
     });
 
     EXPECT_EQ(boundaries, ReadonlySpan<size_t> { expected_boundaries });
+}
+
+template<size_t N>
+static void test_grapheme_segmentation(StringView string, size_t const (&expected_boundaries)[N])
+{
+    test_segmentation(Locale::SegmenterGranularity::Grapheme, string, expected_boundaries);
 }
 
 TEST_CASE(grapheme_segmentation)
@@ -79,15 +85,7 @@ TEST_CASE(grapheme_segmentation_indic_conjunct_break)
 template<size_t N>
 static void test_word_segmentation(StringView string, size_t const (&expected_boundaries)[N])
 {
-    Vector<size_t> boundaries;
-    auto segmenter = Locale::Segmenter::create(Locale::SegmenterGranularity::Word);
-
-    segmenter->for_each_boundary(MUST(String::from_utf8(string)), [&](auto boundary) {
-        boundaries.append(boundary);
-        return IterationDecision::Continue;
-    });
-
-    EXPECT_EQ(boundaries, ReadonlySpan<size_t> { expected_boundaries });
+    test_segmentation(Locale::SegmenterGranularity::Word, string, expected_boundaries);
 }
 
 TEST_CASE(word_segmentation)


### PR DESCRIPTION
Instead of recomputing boundaries on every iteration, this now
computes boundaries once and then searches that vector.

This is still O(n^2) for now, but already much faster (at the expense
of using O(n) memory): `BenchmarkSegmenter.for_each_boundary` stays
at around 3ms, but `forward` and `backward` go from ~13s to ~60ms
on my system.

Also add BenchmarkSegmenter, and improve test coverage a bit.

Note that code that still uses LibUnicode/Segmentation.h directly still has the slower behavior.