### PR TITLE
EFIPrekernel: Don't depend on `install_libc_headers`

### DIFF
--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -28,7 +28,6 @@ add_compile_definitions(PREKERNEL)
 add_executable(EFIPrekernel ${SOURCES})
 
 add_dependencies(EFIPrekernel Kernel)
-add_dependencies(EFIPrekernel install_libc_headers)
 
 target_compile_options(EFIPrekernel PRIVATE -fno-threadsafe-statics)
 target_link_options(EFIPrekernel PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld LINKER:--no-dynamic-linker -nostdlib)


### PR DESCRIPTION
This target was removed in 175f9dc5c3, but the dependency on it wasn't removed from faeb9ff521 before PR #24995 was merged. This should make everything build again.