### PR TITLE
Kernel/VFS: Make filesystem implementations responsible for renames

### DIFF
--- a/Kernel/FileSystem/DevLoopFS/FileSystem.cpp
+++ b/Kernel/FileSystem/DevLoopFS/FileSystem.cpp
@@ -52,6 +52,11 @@ Inode& DevLoopFS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> DevLoopFS::rename(Inode&, StringView, Inode&, StringView)
+{
+    return EROFS;
+}
+
 ErrorOr<NonnullRefPtr<Inode>> DevLoopFS::get_inode(InodeIdentifier inode_id) const
 {
     if (inode_id.index() == 1)

--- a/Kernel/FileSystem/DevLoopFS/FileSystem.h
+++ b/Kernel/FileSystem/DevLoopFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
 private:
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 

--- a/Kernel/FileSystem/DevLoopFS/Inode.cpp
+++ b/Kernel/FileSystem/DevLoopFS/Inode.cpp
@@ -106,11 +106,6 @@ ErrorOr<void> DevLoopFSInode::remove_child(StringView)
     return EROFS;
 }
 
-ErrorOr<void> DevLoopFSInode::replace_child(StringView, Inode&)
-{
-    return EROFS;
-}
-
 ErrorOr<void> DevLoopFSInode::chmod(mode_t)
 {
     return EROFS;

--- a/Kernel/FileSystem/DevLoopFS/Inode.h
+++ b/Kernel/FileSystem/DevLoopFS/Inode.h
@@ -38,7 +38,6 @@ private:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
 

--- a/Kernel/FileSystem/DevPtsFS/FileSystem.cpp
+++ b/Kernel/FileSystem/DevPtsFS/FileSystem.cpp
@@ -45,6 +45,11 @@ Inode& DevPtsFS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> DevPtsFS::rename(Inode&, StringView, Inode&, StringView)
+{
+    return EROFS;
+}
+
 u8 DevPtsFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
 {
     return ram_backed_file_type_to_directory_entry_type(entry);

--- a/Kernel/FileSystem/DevPtsFS/FileSystem.h
+++ b/Kernel/FileSystem/DevPtsFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
 private:
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 

--- a/Kernel/FileSystem/DevPtsFS/Inode.cpp
+++ b/Kernel/FileSystem/DevPtsFS/Inode.cpp
@@ -112,11 +112,6 @@ ErrorOr<void> DevPtsFSInode::remove_child(StringView)
     return EROFS;
 }
 
-ErrorOr<void> DevPtsFSInode::replace_child(StringView, Inode&)
-{
-    return EROFS;
-}
-
 ErrorOr<void> DevPtsFSInode::chmod(mode_t)
 {
     return EROFS;

--- a/Kernel/FileSystem/DevPtsFS/Inode.h
+++ b/Kernel/FileSystem/DevPtsFS/Inode.h
@@ -38,7 +38,6 @@ private:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
 

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -38,7 +38,7 @@ ErrorOr<void> Ext2FS::rename(Inode& old_parent_inode, StringView old_basename, I
     auto old_inode = TRY(old_parent_inode.lookup(old_basename));
 
     TRY(new_parent_inode.add_child(old_inode, new_basename, old_inode->mode()));
-    TRY(old_parent_inode.remove_child(old_basename));
+    TRY(static_cast<Ext2FSInode&>(old_parent_inode).remove_child_impl(old_basename, Ext2FSInode::RemoveDotEntries::No));
 
     // If the inode that we moved is a directory and we changed parent
     // directories, then we also have to make .. point to the new parent inode,

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -50,6 +50,8 @@ public:
     virtual bool supports_watchers() const override { return true; }
     virtual bool supports_backing_loop_devices() const override { return true; }
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 
     FeaturesOptional get_features_optional() const;

--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -829,64 +829,6 @@ ErrorOr<void> Ext2FSInode::remove_child(StringView name)
     return {};
 }
 
-ErrorOr<void> Ext2FSInode::replace_child(StringView name, Inode& child)
-{
-    MutexLocker locker(m_inode_lock);
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::replace_child(): Replacing '{}' with inode {}", identifier(), name, child.index());
-    VERIFY(is_directory());
-
-    TRY(populate_lookup_cache());
-
-    if (name.length() > EXT2_NAME_LEN)
-        return ENAMETOOLONG;
-
-    Vector<Ext2FSDirectoryEntry> entries;
-    bool has_file_type_attribute = has_flag(fs().get_features_optional(), Ext2FS::FeaturesOptional::ExtendedAttributes);
-
-    Optional<InodeIndex> old_child_index;
-    TRY(traverse_as_directory([&](auto& entry) -> ErrorOr<void> {
-        auto is_replacing_this_inode = name == entry.name;
-        auto inode_index = is_replacing_this_inode ? child.index() : entry.inode.index();
-
-        auto entry_name = TRY(KString::try_create(entry.name));
-        TRY(entries.try_empend(move(entry_name), inode_index, has_file_type_attribute ? to_ext2_file_type(child.mode()) : (u8)EXT2_FT_UNKNOWN));
-        if (is_replacing_this_inode)
-            old_child_index = entry.inode.index();
-
-        return {};
-    }));
-
-    if (!old_child_index.has_value())
-        return ENOENT;
-
-    auto old_child = TRY(fs().get_inode({ fsid(), *old_child_index }));
-
-    auto old_index_it = m_lookup_cache.find(name);
-    VERIFY(old_index_it != m_lookup_cache.end());
-    old_index_it->value = child.index();
-
-    // NOTE: Between this line and the write_directory line, all operations must
-    //       be atomic. Any changes made should be reverted.
-    TRY(child.increment_link_count());
-
-    auto maybe_decrement_error = old_child->decrement_link_count();
-    if (maybe_decrement_error.is_error()) {
-        old_index_it->value = *old_child_index;
-        MUST(child.decrement_link_count());
-        return maybe_decrement_error;
-    }
-
-    // FIXME: The filesystem is left in an inconsistent state if this fails.
-    //        Revert the changes made above if we can't write_directory.
-    //        Ideally, decrement should be the last operation, but we currently
-    //        can't "un-write" a directory entry list.
-    TRY(write_directory(entries));
-
-    // TODO: Emit a did_replace_child event.
-
-    return {};
-}
-
 ErrorOr<void> Ext2FSInode::populate_lookup_cache()
 {
     VERIFY(m_inode_lock.is_exclusively_locked_by_current_thread());

--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -19,21 +19,21 @@ namespace Kernel {
 
 static constexpr size_t max_inline_symlink_length = 60;
 
-static u8 to_ext2_file_type(mode_t mode)
+u8 Ext2FSInode::to_ext2_file_type(mode_t mode)
 {
-    if (is_regular_file(mode))
+    if (Kernel::is_regular_file(mode))
         return EXT2_FT_REG_FILE;
-    if (is_directory(mode))
+    if (Kernel::is_directory(mode))
         return EXT2_FT_DIR;
-    if (is_character_device(mode))
+    if (Kernel::is_character_device(mode))
         return EXT2_FT_CHRDEV;
-    if (is_block_device(mode))
+    if (Kernel::is_block_device(mode))
         return EXT2_FT_BLKDEV;
-    if (is_fifo(mode))
+    if (Kernel::is_fifo(mode))
         return EXT2_FT_FIFO;
-    if (is_socket(mode))
+    if (Kernel::is_socket(mode))
         return EXT2_FT_SOCK;
-    if (is_symlink(mode))
+    if (Kernel::is_symlink(mode))
         return EXT2_FT_SYMLINK;
     return EXT2_FT_UNKNOWN;
 }

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -57,6 +57,12 @@ private:
     ErrorOr<BlockBasedFileSystem::BlockIndex> allocate_block(BlockBasedFileSystem::BlockIndex, bool zero_newly_allocated_block, bool allow_cache);
     ErrorOr<u32> allocate_and_zero_block();
 
+    enum class RemoveDotEntries {
+        Yes,
+        No,
+    };
+
+    ErrorOr<void> remove_child_impl(StringView name, RemoveDotEntries);
     ErrorOr<void> write_directory(Vector<Ext2FSDirectoryEntry>&);
     ErrorOr<void> populate_lookup_cache();
     ErrorOr<void> resize(u64);

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -49,6 +49,8 @@ private:
 
     bool is_within_inode_bounds(FlatPtr base, FlatPtr value_offset, size_t value_size) const;
 
+    static u8 to_ext2_file_type(mode_t mode);
+
     static time_t decode_seconds_with_extra(i32 seconds, u32 extra) { return (extra & EXT4_EPOCH_MASK) ? static_cast<time_t>(seconds) + (static_cast<time_t>(extra & EXT4_EPOCH_MASK) << 32) : static_cast<time_t>(seconds); }
     static u32 decode_nanoseconds_from_extra(u32 extra) { return (extra & EXT4_NSEC_MASK) >> EXT4_EPOCH_BITS; }
     static u32 encode_time_to_extra(time_t seconds, u32 nanoseconds) { return (((static_cast<time_t>(seconds) - static_cast<i32>(seconds)) >> 32) & EXT4_EPOCH_MASK) | (nanoseconds << EXT4_EPOCH_BITS); }

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -38,7 +38,6 @@ private:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode& child, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> update_timestamps(Optional<UnixDateTime> atime, Optional<UnixDateTime> ctime, Optional<UnixDateTime> mtime) override;
     virtual ErrorOr<void> increment_link_count() override;
     virtual ErrorOr<void> decrement_link_count() override;

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -65,6 +65,7 @@ public:
     virtual ~FATFS() override = default;
     virtual StringView class_name() const override { return "FATFS"sv; }
     virtual Inode& root_inode() override;
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 
 private:

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -725,7 +725,7 @@ ErrorOr<void> FATInode::add_child(Inode& inode, StringView name, mode_t mode)
 
     Vector<FATLongFileNameEntry> lfn_entries = {};
     if (!valid_sfn)
-        auto lfn_entries = TRY(create_lfn_entries(name, lfn_entry_checksum(entry)));
+        lfn_entries = TRY(create_lfn_entries(name, lfn_entry_checksum(entry)));
 
     MutexLocker locker(m_inode_lock);
 

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -25,7 +25,7 @@ ErrorOr<NonnullRefPtr<FATInode>> FATInode::create(FATFS& fs, FATEntry entry, FAT
 }
 
 FATInode::FATInode(FATFS& fs, FATEntry entry, FATEntryLocation inode_metadata_location, NonnullOwnPtr<KString> filename)
-    : Inode(fs, first_cluster(fs.m_fat_version))
+    : Inode(fs, first_cluster(fs.m_fat_version, entry.first_cluster_low, entry.first_cluster_high))
     , m_entry(entry)
     , m_inode_metadata_location(inode_metadata_location)
     , m_filename(move(filename))
@@ -353,18 +353,18 @@ StringView FATInode::byte_terminated_string(StringView string, u8 fill_byte)
 
 u32 FATInode::first_cluster() const
 {
-    return first_cluster(fs().m_fat_version);
+    return first_cluster(fs().m_fat_version, m_entry.first_cluster_low, m_entry.first_cluster_high);
 }
 
-u32 FATInode::first_cluster(FATVersion const version) const
+u32 FATInode::first_cluster(FATVersion const version, u16 first_cluster_low, u16 first_cluster_high)
 {
     if (version == FATVersion::FAT32) {
-        return (static_cast<u32>(m_entry.first_cluster_high) << 16) | m_entry.first_cluster_low;
+        return (static_cast<u32>(first_cluster_high) << 16) | first_cluster_low;
     }
     // The space occupied in a directory entry by `first_cluster_high` (0x14)
     // is reserved in FAT12/16, and may be used to store file meta-data.
     // As a result, do not include it on FAT12/16 file systems.
-    return m_entry.first_cluster_low;
+    return first_cluster_low;
 }
 
 ErrorOr<void> FATInode::allocate_and_add_cluster_to_chain()

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -78,6 +78,13 @@ private:
 
     ErrorOr<Vector<ByteBuffer>> collect_sfns();
 
+    enum class FreeClusters {
+        Yes,
+        No,
+    };
+
+    ErrorOr<void> remove_child_impl(StringView name, FreeClusters free_clusters);
+
     // ^Inode
     virtual ErrorOr<size_t> write_bytes_locked(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*) override;
     virtual ErrorOr<size_t> read_bytes_locked(off_t, size_t, UserOrKernelBuffer& buffer, OpenFileDescription*) const override;
@@ -88,7 +95,6 @@ private:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate_locked(u64) override;

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -69,7 +69,7 @@ private:
     // This overload of `first_cluster` does not rely on the base Inode
     // already being created to determine the FAT version. It is used
     // during FATInode creation (create()).
-    u32 first_cluster(FATVersion const version) const;
+    static u32 first_cluster(FATVersion const version, u16 first_cluster_low, u16 first_cluster_high);
     ErrorOr<void> allocate_and_add_cluster_to_chain();
     ErrorOr<void> remove_last_cluster_from_chain();
     ErrorOr<Vector<FATEntryLocation>> allocate_entries(u32 count);

--- a/Kernel/FileSystem/FUSE/FileSystem.cpp
+++ b/Kernel/FileSystem/FUSE/FileSystem.cpp
@@ -70,6 +70,11 @@ Inode& FUSE::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> FUSE::rename(Inode&, StringView, Inode&, StringView)
+{
+    return ENOTIMPL;
+}
+
 u8 FUSE::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
 {
     return ram_backed_file_type_to_directory_entry_type(entry);

--- a/Kernel/FileSystem/FUSE/FileSystem.h
+++ b/Kernel/FileSystem/FUSE/FileSystem.h
@@ -31,6 +31,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
 private:
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 

--- a/Kernel/FileSystem/FUSE/Inode.cpp
+++ b/Kernel/FileSystem/FUSE/Inode.cpp
@@ -265,11 +265,6 @@ ErrorOr<void> FUSEInode::remove_child(StringView)
     return ENOTIMPL;
 }
 
-ErrorOr<void> FUSEInode::replace_child(StringView, Inode&)
-{
-    return ENOTIMPL;
-}
-
 ErrorOr<void> FUSEInode::chmod(mode_t)
 {
     return ENOTIMPL;

--- a/Kernel/FileSystem/FUSE/Inode.h
+++ b/Kernel/FileSystem/FUSE/Inode.h
@@ -35,7 +35,6 @@ private:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate_locked(u64) override;

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -32,6 +32,8 @@ public:
     virtual Inode& root_inode() = 0;
     virtual bool supports_watchers() const { return false; }
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) = 0;
+
     // FIXME: We should aim to provide more concise mechanism to ensure
     // that backing Inodes from the FileSystem are kept intact so we can
     // attach them to a loop device.

--- a/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
@@ -53,6 +53,11 @@ Inode& ISO9660FS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> ISO9660FS::rename(Inode&, StringView, Inode&, StringView)
+{
+    return EROFS;
+}
+
 unsigned ISO9660FS::total_block_count() const
 {
     return LittleEndian { m_primary_volume->volume_space_size.little };

--- a/Kernel/FileSystem/ISO9660FS/FileSystem.h
+++ b/Kernel/FileSystem/ISO9660FS/FileSystem.h
@@ -36,6 +36,8 @@ public:
     virtual StringView class_name() const override { return "ISO9660FS"sv; }
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
     virtual unsigned total_block_count() const override;
     virtual unsigned total_inode_count() const override;
 

--- a/Kernel/FileSystem/ISO9660FS/Inode.cpp
+++ b/Kernel/FileSystem/ISO9660FS/Inode.cpp
@@ -70,11 +70,6 @@ ErrorOr<void> ISO9660Inode::traverse_as_directory(Function<ErrorOr<void>(FileSys
     });
 }
 
-ErrorOr<void> ISO9660Inode::replace_child(StringView, Inode&)
-{
-    return EROFS;
-}
-
 ErrorOr<NonnullRefPtr<Inode>> ISO9660Inode::lookup(StringView name)
 {
     RefPtr<Inode> inode;

--- a/Kernel/FileSystem/ISO9660FS/Inode.h
+++ b/Kernel/FileSystem/ISO9660FS/Inode.h
@@ -28,7 +28,6 @@ public:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate_locked(u64) override;

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -66,9 +66,6 @@ public:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) = 0;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) = 0;
     virtual ErrorOr<void> remove_child(StringView name) = 0;
-    /// Replace child atomically, incrementing the link count of the replacement
-    /// inode and decrementing the older inode's.
-    virtual ErrorOr<void> replace_child(StringView name, Inode&) = 0;
     virtual ErrorOr<void> chmod(mode_t) = 0;
     virtual ErrorOr<void> chown(UserID, GroupID) = 0;
 

--- a/Kernel/FileSystem/Plan9FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FS/FileSystem.cpp
@@ -91,6 +91,12 @@ Inode& Plan9FS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> Plan9FS::rename(Inode&, StringView, Inode&, StringView)
+{
+    // TODO
+    return ENOTIMPL;
+}
+
 Plan9FS::ReceiveCompletion::ReceiveCompletion(u16 tag)
     : tag(tag)
 {

--- a/Kernel/FileSystem/Plan9FS/FileSystem.h
+++ b/Kernel/FileSystem/Plan9FS/FileSystem.h
@@ -29,6 +29,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
     u16 allocate_tag() { return m_next_tag++; }
     u32 allocate_fid() { return m_next_fid++; }
 

--- a/Kernel/FileSystem/Plan9FS/Inode.cpp
+++ b/Kernel/FileSystem/Plan9FS/Inode.cpp
@@ -96,12 +96,6 @@ ErrorOr<size_t> Plan9FSInode::read_bytes_locked(off_t offset, size_t size, UserO
     return nread;
 }
 
-ErrorOr<void> Plan9FSInode::replace_child(StringView, Inode&)
-{
-    // TODO
-    return ENOTIMPL;
-}
-
 ErrorOr<size_t> Plan9FSInode::write_bytes_locked(off_t offset, size_t size, UserOrKernelBuffer const& data, OpenFileDescription*)
 {
     TRY(ensure_open_for_mode(O_WRONLY));

--- a/Kernel/FileSystem/Plan9FS/Inode.h
+++ b/Kernel/FileSystem/Plan9FS/Inode.h
@@ -30,7 +30,6 @@ public:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate_locked(u64) override;

--- a/Kernel/FileSystem/ProcFS/FileSystem.cpp
+++ b/Kernel/FileSystem/ProcFS/FileSystem.cpp
@@ -43,4 +43,9 @@ Inode& ProcFS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> ProcFS::rename(Inode&, StringView, Inode&, StringView)
+{
+    return EROFS;
+}
+
 }

--- a/Kernel/FileSystem/ProcFS/FileSystem.h
+++ b/Kernel/FileSystem/ProcFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
 private:
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 

--- a/Kernel/FileSystem/ProcFS/Inode.h
+++ b/Kernel/FileSystem/ProcFS/Inode.h
@@ -46,7 +46,6 @@ private:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView, mode_t, dev_t, UserID, GroupID) override { return EROFS; }
     virtual ErrorOr<void> add_child(Inode&, StringView, mode_t) override { return EROFS; }
     virtual ErrorOr<void> remove_child(StringView) override { return EROFS; }
-    virtual ErrorOr<void> replace_child(StringView, Inode&) override { return EROFS; }
     virtual ErrorOr<void> chmod(mode_t) override { return EROFS; }
     virtual ErrorOr<void> chown(UserID, GroupID) override { return EROFS; }
     virtual ErrorOr<size_t> write_bytes_locked(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*) override { return EROFS; }

--- a/Kernel/FileSystem/RAMFS/FileSystem.h
+++ b/Kernel/FileSystem/RAMFS/FileSystem.h
@@ -29,6 +29,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 
 private:

--- a/Kernel/FileSystem/RAMFS/Inode.cpp
+++ b/Kernel/FileSystem/RAMFS/Inode.cpp
@@ -71,26 +71,6 @@ ErrorOr<void> RAMFSInode::traverse_as_directory(Function<ErrorOr<void>(FileSyste
     return {};
 }
 
-ErrorOr<void> RAMFSInode::replace_child(StringView name, Inode& new_child)
-{
-    MutexLocker locker(m_inode_lock);
-    VERIFY(is_directory());
-    VERIFY(new_child.fsid() == fsid());
-
-    auto* child = find_child_by_name(name);
-    if (!child)
-        return ENOENT;
-
-    auto old_child = child->inode;
-    child->inode = static_cast<RAMFSInode&>(new_child);
-
-    old_child->did_delete_self();
-
-    // TODO: Emit a did_replace_child event.
-
-    return {};
-}
-
 ErrorOr<NonnullOwnPtr<RAMFSInode::DataBlock>> RAMFSInode::DataBlock::create()
 {
     auto data_block_buffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_with_size(DataBlock::block_size, AllocationStrategy::AllocateNow));

--- a/Kernel/FileSystem/RAMFS/Inode.h
+++ b/Kernel/FileSystem/RAMFS/Inode.h
@@ -31,7 +31,6 @@ public:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate_locked(u64) override;

--- a/Kernel/FileSystem/SysFS/FileSystem.cpp
+++ b/Kernel/FileSystem/SysFS/FileSystem.cpp
@@ -36,4 +36,9 @@ Inode& SysFS::root_inode()
     return *m_root_inode;
 }
 
+ErrorOr<void> SysFS::rename(Inode&, StringView, Inode&, StringView)
+{
+    return EROFS;
+}
+
 }

--- a/Kernel/FileSystem/SysFS/FileSystem.h
+++ b/Kernel/FileSystem/SysFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual ErrorOr<void> rename(Inode& old_parent_inode, StringView old_basename, Inode& new_parent_inode, StringView new_basename) override;
+
 private:
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 

--- a/Kernel/FileSystem/SysFS/Inode.cpp
+++ b/Kernel/FileSystem/SysFS/Inode.cpp
@@ -90,11 +90,6 @@ ErrorOr<void> SysFSInode::remove_child(StringView)
     return EROFS;
 }
 
-ErrorOr<void> SysFSInode::replace_child(StringView, Inode&)
-{
-    return EROFS;
-}
-
 ErrorOr<void> SysFSInode::chmod(mode_t)
 {
     return EPERM;

--- a/Kernel/FileSystem/SysFS/Inode.h
+++ b/Kernel/FileSystem/SysFS/Inode.h
@@ -31,7 +31,6 @@ protected:
     virtual ErrorOr<NonnullRefPtr<Inode>> create_child(StringView name, mode_t, dev_t, UserID, GroupID) override;
     virtual ErrorOr<void> add_child(Inode&, StringView name, mode_t) override;
     virtual ErrorOr<void> remove_child(StringView name) override;
-    virtual ErrorOr<void> replace_child(StringView name, Inode& child) override;
     virtual ErrorOr<void> chmod(mode_t) override;
     virtual ErrorOr<void> chown(UserID, GroupID) override;
     virtual ErrorOr<void> truncate_locked(u64) override;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -812,18 +812,9 @@ ErrorOr<void> VirtualFileSystem::rename(VFSRootContext const& vfs_root_context, 
         }
         if (new_inode.is_directory() && !old_inode.is_directory())
             return EISDIR;
-        TRY(new_parent_inode.remove_child(new_basename));
     }
 
-    TRY(new_parent_inode.add_child(old_inode, new_basename, old_inode.mode()));
-    TRY(old_parent_inode.remove_child(old_basename));
-
-    // If the inode that we moved is a directory and we changed parent
-    // directories, then we also have to make .. point to the new parent inode,
-    // because .. is its own inode.
-    if (old_inode.is_directory() && old_parent_inode.index() != new_parent_inode.index()) {
-        TRY(old_inode.replace_child(".."sv, new_parent_inode));
-    }
+    TRY(new_parent_inode.fs().rename(old_parent_inode, old_basename, new_parent_inode, new_basename));
 
     return {};
 }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -1038,9 +1038,6 @@ ErrorOr<void> VirtualFileSystem::rmdir(VFSRootContext const& vfs_root_context, C
     if (custody->is_readonly())
         return EROFS;
 
-    TRY(inode.remove_child("."sv));
-    TRY(inode.remove_child(".."sv));
-
     return parent_inode.remove_child(KLexicalPath::basename(path));
 }
 

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -272,10 +272,14 @@ ErrorOr<void> copy_directory(StringView destination_path, StringView source_path
     auto my_umask = umask(0);
     umask(my_umask);
 
-    TRY(Core::System::chmod(destination_path, source_stat.st_mode & ~my_umask));
+    if (auto result = Core::System::chmod(destination_path, source_stat.st_mode & ~my_umask); result.is_error())
+        if (result.error().is_errno() && result.error().code() != ENOTSUP)
+            return result.release_error();
 
     if (has_flag(preserve_mode, PreserveMode::Ownership))
-        TRY(Core::System::chown(destination_path, source_stat.st_uid, source_stat.st_gid));
+        if (auto result = Core::System::chown(destination_path, source_stat.st_uid, source_stat.st_gid); result.is_error())
+            if (result.error().is_errno() && result.error().code() != ENOTSUP)
+                return result.release_error();
 
     if (has_flag(preserve_mode, PreserveMode::Timestamps)) {
         struct timespec times[2] = {


### PR DESCRIPTION
This PR hands over the responsibility for rename operations to the respective filesystem implementation, which allows for several improvements, including:
- renaming actually working properly on FATFS
- it being easier to optimize rename logic (FATFS kind of takes advantage of this)
- being able to implement a rename operation in the FUSE driver (not in this PR though)

This also fixes two issues I found in FATFS while testing the rename logic :P