### PR TITLE
LibELF+Kernel: Don't define SERENITY_PAGE_SIZE in ELFABI.h

### DIFF
--- a/Kernel/API/serenity_limits.h
+++ b/Kernel/API/serenity_limits.h
@@ -7,3 +7,9 @@
 #pragma once
 
 #define PTHREAD_STACK_MAX (32 * 1024 * 1024) // 32MiB
+
+#ifdef __serenity__
+#    define SERENITY_PAGE_SIZE PAGE_SIZE
+#else
+#    define SERENITY_PAGE_SIZE 4096
+#endif

--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -39,17 +39,9 @@
 #    include <AK/Types.h>
 #endif
 
-#include <AK/Platform.h>
-
 #define ElfW(type) Elf64_##type
 
 #define ELFSIZE 64
-
-#if defined(AK_OS_SERENITY)
-#    define SERENITY_PAGE_SIZE PAGE_SIZE
-#else
-#    define SERENITY_PAGE_SIZE 4096
-#endif
 
 typedef uint8_t Elf_Byte;
 


### PR DESCRIPTION
ELFABI.h gets included during the toolchain build, so we shouldn't
include AK headers from that file.
SERENITY_PAGE_SIZE also isn't really related to ELF ABI, so move it to
the serenity_limits.h header.