### PR TITLE
WindowServer: Handle flipped submenus during safe submenu navigation

### DIFF
--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -156,6 +156,8 @@ private:
 
     void start_activation_animation(MenuItem&);
 
+    bool opens_to_the_left() const { return m_opens_to_the_left; }
+
     ConnectionFromClient* m_client { nullptr };
     int m_menu_id { 0 };
     String m_name;
@@ -171,6 +173,7 @@ private:
     Gfx::IntPoint m_last_position_in_hover;
     int m_theme_index_at_last_paint { -1 };
     int m_hovered_item_index { -1 };
+    bool m_opens_to_the_left { false };
 
     bool m_scrollable { false };
     int m_scroll_offset { 0 };


### PR DESCRIPTION
The old calculation was unnecessarily complicated and didn't handle flipped menus correctly. To determine the two triangle corners at the submenu, we can simply use the submenu's rect() and subtract the position of the parent menu to get the correct relative coordinates.

If the submenu is flipped at its vertical axis, we need to use the opposite corners of the window rect.

Before:
[Screencast_20241208_010239.webm](https://github.com/user-attachments/assets/10720d38-6fd1-415e-aeb7-a90ff3147fe4)

After:
[Screencast_20241208_010106.webm](https://github.com/user-attachments/assets/05627a31-c9c0-447b-8cf6-b419d80aa060)