### PR TITLE
Kernel/USB: Remove never-initialized USB::Device::m_{vendor,product}_id

### DIFF
--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -38,7 +38,7 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController& controller,
         auto result = driver->probe(device);
         if (result.is_error())
             continue;
-        dbgln_if(USB_DEBUG, "Found driver {} for device {:04x}:{:04x}!", driver->name(), device->m_vendor_id, device->m_product_id);
+        dbgln_if(USB_DEBUG, "Found driver {} for device {:04x}:{:04x}!", driver->name(), device->device_descriptor().vendor_id, device->device_descriptor().product_id);
         device->set_driver(driver);
         break;
     }

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -116,8 +116,6 @@ protected:
     size_t m_controller_identifier { 0 };
 
     // Device description
-    u16 m_vendor_id { 0 };                      // This device's vendor ID assigned by the USB group
-    u16 m_product_id { 0 };                     // This device's product ID assigned by the USB group
     USBDeviceDescriptor m_device_descriptor {}; // Device Descriptor obtained from USB Device
     Vector<USBConfiguration> m_configurations;  // Configurations for this device
 

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -93,7 +93,7 @@ ErrorOr<void> Hub::enumerate_and_power_on_hub()
     }
 
     if constexpr (USB_DEBUG) {
-        dbgln("USB Hub Descriptor for {:04x}:{:04x}", m_vendor_id, m_product_id);
+        dbgln("USB Hub Descriptor for {:04x}:{:04x}", m_device_descriptor.vendor_id, m_device_descriptor.product_id);
         dbgln("Number of Downstream Ports: {}", descriptor.number_of_downstream_ports);
         dbgln("Hub Characteristics: {:#04x}", static_cast<u16>(descriptor.hub_characteristics.raw));
         dbgln("Power On to Power Good Time: {} ms ({} * 2ms)", descriptor.power_on_to_power_good_time * 2, descriptor.power_on_to_power_good_time);


### PR DESCRIPTION
These members were never set and are redundant because you can just read them directly from the device descriptor.