### PR TITLE
Kernel/aarch64: Implement basic PCI support

### DIFF
--- a/Kernel/Arch/aarch64/Dummy.cpp
+++ b/Kernel/Arch/aarch64/Dummy.cpp
@@ -23,17 +23,3 @@ void microseconds_delay(u32)
 }
 
 }
-
-// Initializer.cpp
-namespace Kernel::PCI {
-
-SetOnce g_pci_access_io_probe_failed;
-SetOnce g_pci_access_is_disabled_from_commandline;
-
-void initialize()
-{
-    dbgln("PCI: FIXME: Enable PCI for aarch64 platforms");
-    g_pci_access_io_probe_failed.set();
-}
-
-}

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -8,6 +8,7 @@
 #include <AK/Format.h>
 #include <AK/Vector.h>
 
+#include <Kernel/Arch/Interrupts.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/TrapFrame.h>
 #include <Kernel/Arch/aarch64/ASM_wrapper.h>
@@ -51,6 +52,8 @@ void ProcessorBase<T>::initialize(u32)
         dmesgln("CPU[{}]: {} not detected, randomness will be poor", m_cpu, cpu_feature_to_description(CPUFeature::RNG));
 
     store_fpu_state(&s_clean_fpu_state);
+
+    initialize_interrupts();
 }
 
 template<typename T>

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -521,6 +521,8 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/PlatformInit/Virt.cpp
 
         Arch/aarch64/Serial/PL011.cpp
+
+        Bus/PCI/DeviceTreeInitializer.cpp
     )
 
     # Otherwise linker errors e.g undefined reference to `__aarch64_cas8_acq_rel'
@@ -558,7 +560,6 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/Interrupts/PLIC.cpp
         Arch/riscv64/MMU.cpp
         Arch/riscv64/PageDirectory.cpp
-        Arch/riscv64/PCI/Initializer.cpp
         Arch/riscv64/PowerState.cpp
         Arch/riscv64/pre_init.cpp
         Arch/riscv64/Processor.cpp
@@ -567,6 +568,8 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/SmapDisabler.cpp
         Arch/riscv64/Timer.cpp
         Arch/riscv64/trap_handler.S
+
+        Bus/PCI/DeviceTreeInitializer.cpp
     )
 
     # NOTE: These files cannot use a stack protector and sanitizers, as these will cause accesses to global variables to be inserted

--- a/Kernel/Devices/Storage/AHCI/Definitions.h
+++ b/Kernel/Devices/Storage/AHCI/Definitions.h
@@ -37,7 +37,7 @@ enum HeaderAttributes : u8 {
     C = (1 << 7), /* Updates Command register */
 };
 
-struct [[gnu::packed]] Header {
+struct Header {
     u8 fis_type;
     u8 port_muliplier;
 };
@@ -47,7 +47,7 @@ static_assert(AssertSize<Header, 2>());
 
 namespace Kernel::FIS::HostToDevice {
 
-struct [[gnu::packed]] Register {
+struct Register {
     Header header;
     u8 command;
     u8 features_low;
@@ -66,7 +66,7 @@ static_assert(AssertSize<Register, 5 * 4>());
 
 namespace Kernel::FIS::DeviceToHost {
 
-struct [[gnu::packed]] Register {
+struct Register {
     Header header;
     u8 status;
     u8 error;
@@ -79,7 +79,7 @@ struct [[gnu::packed]] Register {
 };
 static_assert(AssertSize<Register, 5 * 4>());
 
-struct [[gnu::packed]] SetDeviceBits {
+struct SetDeviceBits {
     Header header;
     u8 status;
     u8 error;
@@ -87,13 +87,13 @@ struct [[gnu::packed]] SetDeviceBits {
 };
 static_assert(AssertSize<SetDeviceBits, 2 * 4>());
 
-struct [[gnu::packed]] DMAActivate {
+struct DMAActivate {
     Header header;
     u16 reserved;
 };
 static_assert(AssertSize<DMAActivate, 1 * 4>());
 
-struct [[gnu::packed]] PIOSetup {
+struct PIOSetup {
     Header header;
     u8 status;
     u8 error;
@@ -113,16 +113,16 @@ static_assert(AssertSize<PIOSetup, 5 * 4>());
 
 namespace Kernel::FIS::BiDirectional {
 
-struct [[gnu::packed]] Data {
+struct Data {
     Header header;
     u16 reserved;
     u32 data[];
 };
 static_assert(AssertSize<Data, 1 * 4>());
 
-struct [[gnu::packed]] BISTActivate {
+struct BISTActivate {
 };
-struct [[gnu::packed]] DMASetup {
+struct DMASetup {
     Header header;
     u16 reserved;
     u32 dma_buffer_identifier_low;
@@ -246,7 +246,7 @@ enum HBACapabilitiesExtended : u32 {
 };
 
 // This structure is not defined by the AHCI spec, but is used within the code
-struct [[gnu::packed]] HBADefinedCapabilities {
+struct HBADefinedCapabilities {
     size_t ports_count { 1 };
     size_t max_command_list_entries_count { 1 };
     u8 interface_speed_generation { 1 };
@@ -274,7 +274,6 @@ struct [[gnu::packed]] HBADefinedCapabilities {
     bool aggressive_device_sleep_management_supported : 1 { false };
     bool devsleep_entrance_from_slumber_only : 1 { false };
 };
-static_assert(AssertSize<HBADefinedCapabilities, 20>());
 
 enum class DeviceDetectionInitialization {
     NoActionRequested,
@@ -371,7 +370,7 @@ private:
     u32 volatile& m_bitfield;
 };
 
-struct [[gnu::packed]] PortRegisters {
+struct PortRegisters {
     u32 clb;  /* Port x Command List Base Address */
     u32 clbu; /* Port x Command List Base Address Upper 32-Bits */
     u32 fb;   /* Port x FIS Base Address */
@@ -395,7 +394,7 @@ struct [[gnu::packed]] PortRegisters {
 };
 static_assert(AssertSize<PortRegisters, 0x80>());
 
-struct [[gnu::packed]] GenericHostControl {
+struct GenericHostControl {
     u32 cap; /* Host Capabilities */
     u32 ghc; /* Global Host Control */
     u32 is;  /* Interrupt Status */
@@ -410,7 +409,7 @@ struct [[gnu::packed]] GenericHostControl {
 };
 static_assert(AssertSize<GenericHostControl, 0x2c>());
 
-struct [[gnu::packed]] HBA {
+struct HBA {
     GenericHostControl control_regs;
     u8 reserved[52];
     u8 nvmhci[64];
@@ -420,7 +419,7 @@ struct [[gnu::packed]] HBA {
 static_assert(AssertSize<HBA, 0x100>());
 static_assert(__builtin_offsetof(HBA, port_regs[32]) == 0x1100);
 
-struct [[gnu::packed]] CommandHeader {
+struct CommandHeader {
     u16 attributes;
     u16 prdtl; /* Physical Region Descriptor Table Length */
     u32 prdbc; /* Physical Region Descriptor Byte Count */
@@ -430,7 +429,7 @@ struct [[gnu::packed]] CommandHeader {
 };
 static_assert(AssertSize<CommandHeader, 8 * 4>());
 
-struct [[gnu::packed]] PhysicalRegionDescriptor {
+struct PhysicalRegionDescriptor {
     u32 base_low;
     u32 base_high;
     u32 reserved;
@@ -438,7 +437,7 @@ struct [[gnu::packed]] PhysicalRegionDescriptor {
 };
 static_assert(AssertSize<PhysicalRegionDescriptor, 4 * 4>());
 
-struct [[gnu::packed]] CommandTable {
+struct CommandTable {
     u8 command_fis[64];
     u8 atapi_command[32];
     u8 reserved[32];
@@ -660,5 +659,6 @@ struct [[gnu::packed]] ATAIdentifyBlock {
     u16 reserved10[19];
     u16 integrity;
 };
+static_assert(AssertSize<ATAIdentifyBlock, 512>());
 
 };


### PR DESCRIPTION
This is enough to enumerate PCI devices, and to read/write from/to the PCI configuration space on the virt machine.

I did try to get PCI interrupts working, and so I've included a few commits that resulted from that, but ultimately it seems that we'd need to support the GICv2m extension if we want to get MSI(-X) working, or then we'd need to figure out how to get pin-based interrupts to work with the plain GICv2.

Also, I couldn't really find any specs for the aarch64 devicetree stuff included here (I mostly worked off of [this blog post](https://michael2012z.medium.com/understanding-pci-node-in-fdt-769a894a13cc) and some trial and error), so do take this with a grain of salt.