### PR TITLE
LibC: Don't push a fake return address in `create_thread` on non-x86

### DIFF
--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -106,8 +106,10 @@ static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argumen
 
     VERIFY((uintptr_t)stack % 16 == 0);
 
+#if ARCH(X86_64)
     // Push a fake return address
     push_on_stack(nullptr);
+#endif
 
     int rc = syscall(SC_create_thread, pthread_create_helper, thread_params);
     if (rc >= 0)


### PR DESCRIPTION
The AArch64 and RISC-V ABI use a caller-saved register to store the return address instead of (always) storing it on the stack. All non-special registers of newly created threads are zero by default, so we don't need to anything special for those architectures here.

This change also causes the stack pointer to no longer be misaligned for secondary threads on those architectures.