### PR TITLE
Kernel: Recognize a stack pointer pointing to the top of stack as valid

### DIFF
--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -1455,7 +1455,15 @@ bool MemoryManager::validate_user_stack(AddressSpace& space, VirtualAddress vadd
         return false;
 
     auto* region = find_user_region_from_vaddr(space, vaddr);
-    return region && region->is_user() && region->is_stack();
+    bool is_valid_user_stack = region && region->is_user() && region->is_stack();
+
+    // The stack pointer initially points to the exclusive end of the stack region.
+    if (!is_valid_user_stack) {
+        region = find_user_region_from_vaddr(space, vaddr.offset(-1));
+        is_valid_user_stack = region && region->range().end() == vaddr && region->is_user() && region->is_stack();
+    }
+
+    return is_valid_user_stack;
 }
 
 void MemoryManager::unregister_kernel_region(Region& region)

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -28,7 +28,7 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<Sys
         return EOVERFLOW;
 
     TRY(address_space().with([&](auto& space) -> ErrorOr<void> {
-        if (!MM.validate_user_stack(*space, VirtualAddress(user_sp.value() - 4)))
+        if (!MM.validate_user_stack(*space, VirtualAddress(user_sp.value())))
             return EFAULT;
         return {};
     }));


### PR DESCRIPTION
This also removes the explicit decrementing of the stack pointer in `sys$create_thread` before passing it to `validate_user_stack`, as it's unnecessary now.

This unbreaks programs using threads on AArch64 and RISC-V after 070534c3ee74995d5fb82ca9f9ffd86ad814305d (oops).