### PR TITLE
Kernel/aarch64: Make the kernel boot on the virt machine

### DIFF
--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -143,7 +143,7 @@ public:
     void idle_begin() const;
     void idle_end() const;
     u64 time_spent_idle() const;
-    ALWAYS_INLINE static u64 read_cycle_count();
+    ALWAYS_INLINE static Optional<u64> read_cycle_count();
 
     void check_invoke_scheduler();
     void invoke_scheduler_async() { m_invoke_scheduler_async = true; }

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -143,7 +143,7 @@ public:
     void idle_begin() const;
     void idle_end() const;
     u64 time_spent_idle() const;
-    ALWAYS_INLINE static u64 read_cpu_counter();
+    ALWAYS_INLINE static u64 read_cycle_count();
 
     void check_invoke_scheduler();
     void invoke_scheduler_async() { m_invoke_scheduler_async = true; }

--- a/Kernel/Arch/aarch64/PlatformInit/RaspberryPi.cpp
+++ b/Kernel/Arch/aarch64/PlatformInit/RaspberryPi.cpp
@@ -60,6 +60,18 @@ void raspberry_pi_platform_init(StringView compatible_string)
     dmesgln("RPi: Firmware version: {}", firmware_version);
 
     RPi::Framebuffer::initialize();
+
+    // The BCM's SDHC is alternate function 3 on pins 21-27.
+    gpio.set_pin_function(21, RPi::GPIO::PinFunction::Alternate3); // CD
+    gpio.set_pin_high_detect_enable(21, true);
+
+    gpio.set_pin_function(22, RPi::GPIO::PinFunction::Alternate3); // SD1_CLK
+    gpio.set_pin_function(23, RPi::GPIO::PinFunction::Alternate3); // SD1_CMD
+
+    gpio.set_pin_function(24, RPi::GPIO::PinFunction::Alternate3); // SD1_DAT0
+    gpio.set_pin_function(25, RPi::GPIO::PinFunction::Alternate3); // SD1_DAT1
+    gpio.set_pin_function(26, RPi::GPIO::PinFunction::Alternate3); // SD1_DAT2
+    gpio.set_pin_function(27, RPi::GPIO::PinFunction::Alternate3); // SD1_DAT3
 }
 
 }

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -45,6 +45,9 @@ void ProcessorBase<T>::initialize(u32)
 {
     m_deferred_call_pool.init();
 
+    // FIXME: Actually set the correct count when we support SMP on AArch64.
+    g_total_processors.store(1, AK::MemoryOrder::memory_order_release);
+
     dmesgln("CPU[{}]: Supports {}", m_cpu, build_cpu_feature_names(m_features));
     dmesgln("CPU[{}]: Physical address bit width: {}", m_cpu, m_physical_address_bit_width);
     dmesgln("CPU[{}]: Virtual address bit width: {}", m_cpu, m_virtual_address_bit_width);

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -203,7 +203,7 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 }
 
 template<typename T>
-ALWAYS_INLINE u64 ProcessorBase<T>::read_cpu_counter()
+ALWAYS_INLINE u64 ProcessorBase<T>::read_cycle_count()
 {
     TODO_AARCH64();
     return 0;

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -203,7 +203,7 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 }
 
 template<typename T>
-ALWAYS_INLINE u64 ProcessorBase<T>::read_cycle_count()
+ALWAYS_INLINE Optional<u64> ProcessorBase<T>::read_cycle_count()
 {
     TODO_AARCH64();
     return 0;

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -205,8 +205,9 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 template<typename T>
 ALWAYS_INLINE Optional<u64> ProcessorBase<T>::read_cycle_count()
 {
-    TODO_AARCH64();
-    return 0;
+    if (Processor::current().has_feature(CPUFeature::PMUv3))
+        return Aarch64::PMCCNTR_EL0::read().CCNT;
+    return {};
 }
 
 }

--- a/Kernel/Arch/aarch64/RPi/SDHostController.h
+++ b/Kernel/Arch/aarch64/RPi/SDHostController.h
@@ -14,8 +14,7 @@ namespace Kernel::RPi {
 
 class SDHostController : public ::SDHostController {
 public:
-    static SDHostController& the();
-    SDHostController();
+    SDHostController(Memory::TypedMapping<SD::HostControlRegisterMap volatile>);
     virtual ~SDHostController() override = default;
 
 protected:

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -342,7 +342,9 @@ void init_stage2(void*)
     (void)SerialDevice::must_create(2).leak_ref();
     (void)SerialDevice::must_create(3).leak_ref();
 #elif ARCH(AARCH64)
-    (void)MUST(RPi::MiniUART::create()).leak_ref();
+    // FIXME: Make MiniUART a DeviceTree::Driver.
+    if (DeviceTree::get().is_compatible_with("raspberrypi,3-model-b"sv) || DeviceTree::get().is_compatible_with("raspberrypi,4-model-b"sv))
+        (void)MUST(RPi::MiniUART::create()).leak_ref();
 #endif
 
     (void)PCSpeakerDevice::must_create().leak_ref();

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -207,7 +207,7 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 }
 
 template<typename T>
-ALWAYS_INLINE u64 ProcessorBase<T>::read_cpu_counter()
+ALWAYS_INLINE u64 ProcessorBase<T>::read_cycle_count()
 {
     return RISCV64::CSR::read(RISCV64::CSR::Address::CYCLE);
 }

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -207,7 +207,7 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 }
 
 template<typename T>
-ALWAYS_INLINE u64 ProcessorBase<T>::read_cycle_count()
+ALWAYS_INLINE Optional<u64> ProcessorBase<T>::read_cycle_count()
 {
     return RISCV64::CSR::read(RISCV64::CSR::Address::CYCLE);
 }

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -270,7 +270,7 @@ ALWAYS_INLINE bool ProcessorBase<T>::has_pat() const
 }
 
 template<typename T>
-ALWAYS_INLINE u64 ProcessorBase<T>::read_cpu_counter()
+ALWAYS_INLINE u64 ProcessorBase<T>::read_cycle_count()
 {
     return read_tsc();
 }

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -270,7 +270,7 @@ ALWAYS_INLINE bool ProcessorBase<T>::has_pat() const
 }
 
 template<typename T>
-ALWAYS_INLINE u64 ProcessorBase<T>::read_cycle_count()
+ALWAYS_INLINE Optional<u64> ProcessorBase<T>::read_cycle_count()
 {
     return read_tsc();
 }

--- a/Kernel/Devices/Storage/StorageManagement.h
+++ b/Kernel/Devices/Storage/StorageManagement.h
@@ -14,6 +14,7 @@
 #include <Kernel/Devices/Storage/StorageDevice.h>
 #include <Kernel/Devices/Storage/StorageDevicePartition.h>
 #include <Kernel/FileSystem/FileSystem.h>
+#include <Kernel/Firmware/DeviceTree/DeviceRecipe.h>
 #include <Kernel/Library/NonnullLockRefPtr.h>
 #include <LibPartition/PartitionTable.h>
 
@@ -43,6 +44,8 @@ public:
 
     void add_device(StorageDevice&);
     void remove_device(StorageDevice&);
+
+    static void add_recipe(DeviceTree::DeviceRecipe<NonnullRefPtr<StorageController>>);
 
 private:
     void enumerate_pci_controllers(bool nvme_poll);

--- a/Kernel/Security/Random.h
+++ b/Kernel/Security/Random.h
@@ -163,8 +163,16 @@ public:
     {
         auto& kernel_rng = KernelRng::the();
         SpinlockLocker lock(kernel_rng.get_lock());
+
+        u64 timestamp = 0;
+        auto maybe_cycle_count = Processor::read_cycle_count();
+        if (maybe_cycle_count.has_value())
+            timestamp = maybe_cycle_count.release_value();
+        else
+            timestamp = static_cast<u64>(TimeManagement::now().milliseconds_since_epoch());
+
         // We don't lock this because on the off chance a pool is corrupted, entropy isn't lost.
-        Event<T> event = { Processor::read_cycle_count(), m_source, event_data };
+        Event<T> event = { timestamp, m_source, event_data };
         kernel_rng.add_random_event(event, m_pool);
         m_pool++;
         kernel_rng.wake_if_ready();

--- a/Kernel/Security/Random.h
+++ b/Kernel/Security/Random.h
@@ -164,7 +164,7 @@ public:
         auto& kernel_rng = KernelRng::the();
         SpinlockLocker lock(kernel_rng.get_lock());
         // We don't lock this because on the off chance a pool is corrupted, entropy isn't lost.
-        Event<T> event = { Processor::read_cpu_counter(), m_source, event_data };
+        Event<T> event = { Processor::read_cycle_count(), m_source, event_data };
         kernel_rng.add_random_event(event, m_pool);
         m_pool++;
         kernel_rng.wake_if_ready();


### PR DESCRIPTION
You can try booting it with the following command:
`qemu-system-aarch64 -s -m 2G -cpu max -M virt -serial mon:stdio -d guest_errors,unimp -kernel Build/aarch64/Kernel/kernel8.img -drive file=Build/aarch64/_disk_image,format=raw,if=none,id=boot-drive -device nvme,drive=boot-drive,serial=deadbeef -append 'serial_debug nvme_poll root=block3:0' -device VGA -device virtio-tablet -device virtio-keyboard`

Even virtio keyboard and mouse work!

We should probably split the init section into a non-early and early section and add a devicetree driver for the MiniUART in the future. This would also allow us to get rid of the `DeviceRecipe` for the RPi::SDHostController.