### PR TITLE
AK: Make Function a little bit constexpr

### DIFF
--- a/AK/ScopeGuard.h
+++ b/AK/ScopeGuard.h
@@ -13,12 +13,12 @@ namespace AK {
 template<typename Callback>
 class ScopeGuard {
 public:
-    ScopeGuard(Callback callback)
+    constexpr ScopeGuard(Callback callback)
         : m_callback(move(callback))
     {
     }
 
-    ~ScopeGuard()
+    constexpr ~ScopeGuard()
     {
         m_callback();
     }

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -35,6 +35,7 @@ set(AK_TEST_SOURCES
     TestFloatingPointParsing.cpp
     TestFlyString.cpp
     TestFormat.cpp
+    TestFunction.cpp
     TestFuzzyMatch.cpp
     TestGeneratorAK.cpp
     TestGenericLexer.cpp

--- a/Tests/AK/TestFunction.cpp
+++ b/Tests/AK/TestFunction.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Function.h>
+
+constexpr int const_call(Function<int(int)> f, int i)
+{
+    return f(i);
+}
+
+constinit int i = const_call([](int i) { return i; }, 4);


### PR DESCRIPTION
Just enough to make it possible to pass a lambda to a constexpr function
taking an AK::Function parameter and have that constexpr function call
the passed-in AK::Function.

The main thing is that bit_cast<>s of pointers aren't ok in constexpr
functions, and neither is placement new. So add a union with stronger
typing for the constexpr case.

The body of the `if (is_constexpr_evaluated())` in
`init_with_callable()` is identical to the `if constexpr` right
after it. But `if constexpr (is_constexpr_evaluated())` always
evaluates `is_constexpr_evaluated()` in a constexpr context, so
this can't just add ` || is_constexpr_evaluated()` to that
`if constexpr`.