### PR TITLE
Meta: Use response file for linking shared libraries in GN build

### DIFF
--- a/Meta/gn/build/toolchain/BUILD.gn
+++ b/Meta/gn/build/toolchain/BUILD.gn
@@ -91,11 +91,13 @@ template("unix_toolchain") {
 
     tool("solink") {
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
+      rspfile = outfile + ".rsp"
+      rspfile_content = "{{inputs}}"
       if (current_os == "ios" || current_os == "mac") {
-        command = "$ld -shared {{ldflags}} -o $outfile {{inputs}} {{libs}} {{frameworks}} -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"
+        command = "$ld -shared {{ldflags}} -o $outfile @\"$rspfile\" {{libs}} {{frameworks}} -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"
         default_output_extension = ".dylib"
       } else {
-        command = "$ld -shared {{ldflags}} -Wl,-soname,{{target_output_name}}{{output_extension}} -Wl,-rpath,\\\$ORIGIN -o $outfile {{inputs}} {{libs}}"
+        command = "$ld -shared {{ldflags}} -Wl,-soname,{{target_output_name}}{{output_extension}} -Wl,-rpath,\\\$ORIGIN -o $outfile @\"$rspfile\" {{libs}}"
         default_output_extension = ".so"
       }
       description = "SOLINK $outfile"


### PR DESCRIPTION
Linking liblagom-web.so produces a ~132K long command line. Ninja passes the whole command line as a single arg to `sh -c <arg>`, and the limit for single arguments (`MAX_ARG_STRLEN`) on Linux is `PAGE_SIZE * 32` == 128K.

A response file passes the list of files in a file on disk, which lets us sidestep this problem. Ninja writes response files before invoking commands, and deletes them after (unless `-d keeprsp` is passed to ninja, then it keeps them on disk).