### PR TITLE
Kernel+Userland: Add immutable mounts

### DIFF
--- a/Base/etc/fstab
+++ b/Base/etc/fstab
@@ -1,14 +1,14 @@
 # Root file system. This is a fake entry which gets ignored by `mount -a`;
 # the actual logic for mounting root is in the kernel.
-/dev/hda	/	ext2	nodev,nosuid,ro
+/dev/hda	/	ext2	immutable,nodev,nosuid,ro
 # Remount /bin, /root, and /home while adding the appropriate permissions.
-/bin	/bin	bind	bind,nodev,ro
-/etc	/etc	bind	bind,nodev,nosuid
-/home	/home	bind	bind,nodev,nosuid
-/root	/root	bind	bind,nodev,nosuid
-/var	/var	bind	bind,nodev,nosuid
-/www	/www	bind	bind,nodev,nosuid
-/usr/Tests	/usr/Tests	bind	bind,nodev,ro
-/usr/local	/usr/local	bind	bind,nodev,nosuid
-/usr/Ports	/usr/Ports	bind	bind,nodev,nosuid
+/bin	/bin	bind	immutable,bind,nodev,ro
+/etc	/etc	bind	immutable,bind,nodev,nosuid
+/home	/home	bind	immutable,bind,nodev,nosuid
+/root	/root	bind	immutable,bind,nodev,nosuid
+/var	/var	bind	immutable,bind,nodev,nosuid
+/www	/www	bind	immutable,bind,nodev,nosuid
+/usr/Tests	/usr/Tests	bind	immutable,bind,nodev,ro
+/usr/local	/usr/local	bind	immutable,bind,nodev,nosuid
+/usr/Ports	/usr/Ports	bind	immutable,bind,nodev,nosuid
 

--- a/Base/usr/share/man/man2/mount.md
+++ b/Base/usr/share/man/man2/mount.md
@@ -67,6 +67,13 @@ in mount flags of the underlying file system. To "refresh" the working directory
 to use the new mount flags after remounting a filesystem, a process can call
 `chdir()` with the path to the same directory.
 
+## Immutable mounts
+
+When passing the `MS_IMMUTABLE` flag, it will set a mount as immutable.
+An immutable mount cannot change (e.g. changing flags), nor be removed, if the associated VFS root context with mount is being used by a process.
+
+Be extremely careful on setting this flag for mounts on the main VFS root context (i.e. the VFS root context the system starts with) - naturally, you will not be able to remove or change such mount until a complete reboot.
+
 ## Errors
 
 -   `EINVAL`: The `flags` value contains deprecated flags such as `MS_REMOUNT` or `MS_BIND`.

--- a/Kernel/API/POSIX/unistd.h
+++ b/Kernel/API/POSIX/unistd.h
@@ -31,6 +31,7 @@ extern "C" {
 #define MS_AXALLOWED (1 << 7)
 #define MS_NOREGULAR (1 << 8)
 #define MS_SRCHIDDEN (1 << 9)
+#define MS_IMMUTABLE (1 << 10)
 
 enum {
     _SC_MONOTONIC_CLOCK,

--- a/Kernel/FileSystem/VFSRootContext.cpp
+++ b/Kernel/FileSystem/VFSRootContext.cpp
@@ -50,8 +50,8 @@ Custody const& VFSRootContext::empty_context_custody_for_kernel_processes()
 
 ErrorOr<void> VFSRootContext::for_each_mount(Function<ErrorOr<void>(Mount const&)> callback) const
 {
-    return mounts().with([&](auto& mounts) -> ErrorOr<void> {
-        for (auto& mount : mounts)
+    return m_details.with([&](auto& details) -> ErrorOr<void> {
+        for (auto& mount : details.mounts)
             TRY(callback(mount));
         return {};
     });
@@ -98,14 +98,14 @@ ErrorOr<NonnullRefPtr<VFSRootContext>> VFSRootContext::create_with_empty_ramfs()
     auto root_custody = TRY(Custody::try_create(nullptr, ""sv, fs->root_inode(), 0));
     auto context = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) VFSRootContext(root_custody)));
     auto new_mount = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Mount(fs->root_inode(), 0)));
-    TRY(context->mounts().with([&](auto& mounts) -> ErrorOr<void> {
+    TRY(context->m_details.with([&](auto& details) -> ErrorOr<void> {
         dbgln("VFSRootContext({}): Root (\"/\") FileSystemID {}, Mounting {} at inode {} with flags {}",
             context->id(),
             fs->fsid(),
             fs->class_name(),
             root_custody->inode().identifier(),
             0);
-        add_to_mounts_list_and_increment_fs_mounted_count(DoBindMount::No, mounts, move(new_mount));
+        add_to_mounts_list_and_increment_fs_mounted_count(DoBindMount::No, details.mounts, move(new_mount));
         return {};
     }));
 
@@ -116,32 +116,225 @@ ErrorOr<NonnullRefPtr<VFSRootContext>> VFSRootContext::create_with_empty_ramfs()
     return context;
 }
 
-void VFSRootContext::set_attached(Badge<Process>)
+ErrorOr<void> VFSRootContext::pivot_root(FileBackedFileSystem::List& file_backed_file_systems_list, FileSystem& fs, NonnullOwnPtr<Mount> new_mount, NonnullRefPtr<Custody> root_mount_point, int root_mount_flags)
 {
-    m_attributes.with([](auto& attributes) {
-        attributes.attached_by_process.set();
+    return m_details.with([&](auto& details) -> ErrorOr<void> {
+        return fs.mounted_count().with([&](auto& mounted_count) -> ErrorOr<void> {
+            // NOTE: If the mounted count is 0, then this filesystem is about to be
+            // deleted, so this must be a kernel bug as we don't include such filesystem
+            // in the VirtualFileSystem s_details->file_backed_file_systems_list list anymore.
+            VERIFY(mounted_count > 0);
+
+            // NOTE: The mounts table should not be empty as it always need
+            // to have at least one mount!
+            VERIFY(!details.mounts.is_empty());
+
+            // NOTE: If we have many mounts in the table, then simply don't allow
+            // userspace to override them but instead require to unmount everything except
+            // the root mount first.
+            if (details.mounts.size_slow() != 1)
+                return EPERM;
+
+            auto& mount = *details.mounts.first();
+            TRY(VirtualFileSystem::remove_mount(mount, file_backed_file_systems_list));
+            VERIFY(details.mounts.is_empty());
+
+            dbgln("VFSRootContext({}): Root mount set to FileSystemID {}, Mounting {} at inode {} with flags {}",
+                id(),
+                new_mount->guest_fs().fsid(),
+                new_mount->guest_fs().class_name(),
+                root_mount_point->inode().identifier(),
+                root_mount_flags);
+
+            // NOTE: Leak the mount pointer so it can be added to the mount list, but it won't be
+            // deleted after being added.
+            details.mounts.append(*new_mount.leak_ptr());
+
+            // NOTE: We essentially do the same thing like VFSRootContext::add_to_mounts_list_and_increment_fs_mounted_count function
+            // but because we already locked the spinlock of the attach count, we can't call that function here.
+            mounted_count++;
+            // NOTE: Now fill the root custody with a valid custody for the new root mount.
+            m_root_custody.with([&root_mount_point](auto& custody) {
+                custody = move(root_mount_point);
+            });
+            return {};
+        });
+    });
+}
+
+ErrorOr<void> VFSRootContext::do_full_teardown(Badge<PowerStateSwitchTask>)
+{
+    // NOTE: We are going to tear down the entire VFS root context from its mounts.
+    // To do this properly, we swap out the original root custody with the empty
+    // root custody for vfs root context of kernel processes.
+    m_root_custody.with([](auto& custody) {
+        custody = VFSRootContext::empty_context_custody_for_kernel_processes();
+    });
+
+    auto unmount_was_successful = true;
+    while (unmount_was_successful) {
+        unmount_was_successful = false;
+        Vector<Mount&, 16> mounts;
+        TRY(m_details.with([&mounts](auto& details) -> ErrorOr<void> {
+            for (auto& mount : details.mounts) {
+                TRY(mounts.try_append(const_cast<Mount&>(mount)));
+            }
+            return {};
+        }));
+        if (mounts.is_empty())
+            break;
+        auto const remaining_mounts = mounts.size();
+
+        while (!mounts.is_empty()) {
+            auto& mount = mounts.take_last();
+            TRY(mount.guest_fs().flush_writes());
+
+            auto mount_path = TRY(mount.absolute_path());
+            auto& mount_inode = mount.guest();
+            auto const result = VirtualFileSystem::unmount(*this, mount_inode, mount_path->view());
+            if (result.is_error()) {
+                dbgln("Error during unmount of {}: {}", mount_path, result.error());
+                // FIXME: For unknown reasons the root FS stays busy even after everything else has shut down and was unmounted.
+                //        Until we find the underlying issue, allow an unclean shutdown here.
+                if (remaining_mounts <= 1)
+                    dbgln("BUG! One mount remaining; the root file system may not be unmountable at all. Shutting down anyways.");
+            } else {
+                unmount_was_successful = true;
+            }
+        }
+    }
+    return {};
+}
+
+ErrorOr<void> VFSRootContext::unmount(FileBackedFileSystem::List& file_backed_file_systems_list, Inode& guest_inode, StringView custody_path)
+{
+    return m_details.with([&](auto& details) -> ErrorOr<void> {
+        bool did_unmount = false;
+        for (auto& mount : details.mounts) {
+            if (&mount.guest() != &guest_inode)
+                continue;
+            auto mountpoint_path = TRY(mount.absolute_path());
+            if (custody_path != mountpoint_path->view())
+                continue;
+
+            TRY(VFSRootContext::validate_mount_not_immutable_while_being_used(details, mount));
+            dbgln("VFSRootContext({}): Unmounting {}...", id(), custody_path);
+            TRY(VirtualFileSystem::remove_mount(mount, file_backed_file_systems_list));
+            did_unmount = true;
+            break;
+        }
+        if (!did_unmount) {
+            dbgln("VFSRootContext: Nothing mounted on inode {}", guest_inode.identifier());
+            return ENODEV;
+        }
+
+        // NOTE: The VFSRootContext mount table is not empty and we
+        // successfully deleted the desired mount from it, so return
+        // a success now.
+        if (!details.mounts.is_empty())
+            return {};
+
+        // NOTE: If the mount table is empty, then the VFSRootContext
+        // is no longer in valid state (each VFSRootContext at least should
+        // have a root mount), so remove it now.
+        VFSRootContext::all_root_contexts_list().with([this](auto& list) {
+            dbgln("VFSRootContext: Nothing mounted in VFSRootContext({}), removing it", id());
+            list.remove(*this);
+        });
+        return {};
+    });
+}
+
+void VFSRootContext::detach(Badge<Process>)
+{
+    m_details.with([](auto& details) {
+        VERIFY(details.attached_by_process.was_set());
+        VERIFY(details.attach_count > 0);
+        details.attach_count--;
+    });
+}
+
+void VFSRootContext::attach(Badge<Process>)
+{
+    m_details.with([](auto& details) {
+        details.attached_by_process.set();
+        details.attach_count++;
     });
 }
 
 bool VFSRootContext::mount_point_exists_at_custody(Custody& mount_point)
 {
-    return m_mounts.with([&](auto& mounts) -> bool {
-        return any_of(mounts, [&mount_point](auto const& existing_mount) {
+    return m_details.with([&](auto& details) -> bool {
+        return any_of(details.mounts, [&mount_point](auto const& existing_mount) {
             return existing_mount.host_custody() && VirtualFileSystem::check_matching_absolute_path_hierarchy(*existing_mount.host_custody(), mount_point);
         });
     });
 }
 
+ErrorOr<void> VFSRootContext::do_on_mount_for_host_custody(ValidateImmutableFlag validate_immutable_flag, Custody const& current_custody, Function<void(Mount&)> callback) const
+{
+    VERIFY(validate_immutable_flag == ValidateImmutableFlag::Yes || validate_immutable_flag == ValidateImmutableFlag::No);
+    return m_details.with([&](auto& details) -> ErrorOr<void> {
+        // NOTE: We either search for the root mount or for a mount that has a parent custody!
+        if (!current_custody.parent()) {
+            for (auto& mount : details.mounts) {
+                if (!mount.host_custody()) {
+                    if (validate_immutable_flag == ValidateImmutableFlag::Yes)
+                        TRY(VFSRootContext::validate_mount_not_immutable_while_being_used(details, mount));
+
+                    callback(mount);
+                    return {};
+                }
+            }
+            // NOTE: There must be a root mount entry, so fail if we don't find it.
+            VERIFY_NOT_REACHED();
+        } else {
+            for (auto& mount : details.mounts) {
+                if (mount.host_custody() && VirtualFileSystem::check_matching_absolute_path_hierarchy(*mount.host_custody(), current_custody)) {
+                    if (validate_immutable_flag == ValidateImmutableFlag::Yes)
+                        TRY(VFSRootContext::validate_mount_not_immutable_while_being_used(details, mount));
+
+                    callback(mount);
+                    return {};
+                }
+            }
+        }
+        return Error::from_errno(ENODEV);
+    });
+}
+
+ErrorOr<void> VFSRootContext::apply_to_mount_for_host_custody(Custody const& current_custody, Function<void(Mount&)> callback)
+{
+    return do_on_mount_for_host_custody(ValidateImmutableFlag::Yes, current_custody, move(callback));
+}
+
+ErrorOr<VFSRootContext::CurrentMountState> VFSRootContext::current_mount_state_for_host_custody(Custody const& current_custody) const
+{
+    RefPtr<FileSystem> guest_fs;
+    RefPtr<Inode> guest;
+    int mount_flags_for_child { 0 };
+    TRY(do_on_mount_for_host_custody(ValidateImmutableFlag::No, current_custody, [&guest, &guest_fs, &mount_flags_for_child](auto const& mount) {
+        guest = mount.guest();
+        guest_fs = mount.guest_fs();
+        mount_flags_for_child = mount.flags();
+    }));
+
+    return VFSRootContext::CurrentMountState {
+        Mount::Details { guest_fs.release_nonnull(), guest.release_nonnull() },
+        mount_flags_for_child
+    };
+}
+
 ErrorOr<void> VFSRootContext::add_new_mount(DoBindMount do_bind_mount, Inode& source, Custody& mount_point, int flags)
 {
     auto new_mount = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Mount(source, mount_point, flags)));
-    return m_mounts.with([&](auto& mounts) -> ErrorOr<void> {
+    return m_details.with([&](auto& details) -> ErrorOr<void> {
         // NOTE: The VFSRootContext should be attached to the list if there's
         // at least one mount in the mount table.
         // We also should have at least one mount in the table because
         // this method shouldn't be called for new contexts when adding
         // their root mounts.
-        VERIFY(!mounts.is_empty());
+        VERIFY(!details.mounts.is_empty());
         VFSRootContext::all_root_contexts_list().with([&](auto& list) {
             VERIFY(list.contains(*this));
         });
@@ -163,7 +356,7 @@ ErrorOr<void> VFSRootContext::add_new_mount(DoBindMount do_bind_mount, Inode& so
             dbgln("VFSRootContext({}): Mounting unsuccessful - inode {} is already a mount-point.", id(), mount_point.inode().identifier());
             return EBUSY;
         }
-        add_to_mounts_list_and_increment_fs_mounted_count(do_bind_mount, mounts, move(new_mount));
+        add_to_mounts_list_and_increment_fs_mounted_count(do_bind_mount, details.mounts, move(new_mount));
         return {};
     });
 }

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -56,6 +56,8 @@ bool check_matching_absolute_path_hierarchy(Custody const& first_custody, Custod
 
 ErrorOr<FileSystemInitializer const*> find_filesystem_type_initializer(StringView fs_type);
 
+ErrorOr<void> remove_mount(Mount& mount, FileBackedFileSystem::List& file_backed_fs_list);
+
 ErrorOr<void> mount(VFSRootContext&, MountFile&, OpenFileDescription*, Custody& mount_point, int flags);
 ErrorOr<void> pivot_root_by_copying_mounted_fs_instance(VFSRootContext&, FileSystem& fs, int root_mount_flags);
 

--- a/Kernel/Syscalls/unshare.cpp
+++ b/Kernel/Syscalls/unshare.cpp
@@ -82,7 +82,7 @@ ErrorOr<FlatPtr> Process::sys$unshare_attach(Userspace<Syscall::SC_unshare_attac
         m_attached_vfs_root_context.with([vfs_root_context](auto& context) {
             context = vfs_root_context;
         });
-        vfs_root_context->set_attached({});
+        vfs_root_context->attach({});
         return 0;
     }
     case UnshareType::HostnameContext: {

--- a/Kernel/Tasks/PowerStateSwitchTask.cpp
+++ b/Kernel/Tasks/PowerStateSwitchTask.cpp
@@ -57,50 +57,6 @@ void PowerStateSwitchTask::spawn(PowerStateCommand command)
     g_power_state_switch_task = move(power_state_switch_task_thread);
 }
 
-static ErrorOr<void> unmount_mounts_on_vfs_root_context(VFSRootContext& vfs_root_context)
-{
-    // NOTE: We are going to tear down the entire VFS root context from its mounts.
-    // To do this properly, we swap out the original root custody with the empty
-    // root custody for vfs root context of kernel processes.
-    vfs_root_context.root_custody().with([](auto& custody) {
-        custody = VFSRootContext::empty_context_custody_for_kernel_processes();
-    });
-
-    auto unmount_was_successful = true;
-    while (unmount_was_successful) {
-        unmount_was_successful = false;
-        Vector<Mount&, 16> mounts;
-        TRY(vfs_root_context.mounts().with([&mounts](auto& list) -> ErrorOr<void> {
-            for (auto& mount : list) {
-                TRY(mounts.try_append(const_cast<Mount&>(mount)));
-            }
-            return {};
-        }));
-        if (mounts.is_empty())
-            break;
-        auto const remaining_mounts = mounts.size();
-
-        while (!mounts.is_empty()) {
-            auto& mount = mounts.take_last();
-            TRY(mount.guest_fs().flush_writes());
-
-            auto mount_path = TRY(mount.absolute_path());
-            auto& mount_inode = mount.guest();
-            auto const result = VirtualFileSystem::unmount(vfs_root_context, mount_inode, mount_path->view());
-            if (result.is_error()) {
-                dbgln("Error during unmount of {}: {}", mount_path, result.error());
-                // FIXME: For unknown reasons the root FS stays busy even after everything else has shut down and was unmounted.
-                //        Until we find the underlying issue, allow an unclean shutdown here.
-                if (remaining_mounts <= 1)
-                    dbgln("BUG! One mount remaining; the root file system may not be unmountable at all. Shutting down anyways.");
-            } else {
-                unmount_was_successful = true;
-            }
-        }
-    }
-    return {};
-}
-
 ErrorOr<void> PowerStateSwitchTask::perform_shutdown(PowerStateSwitchTask::DoReboot do_reboot)
 {
     // We assume that by this point userland has tried as much as possible to shut down everything in an orderly fashion.
@@ -146,7 +102,7 @@ ErrorOr<void> PowerStateSwitchTask::perform_shutdown(PowerStateSwitchTask::DoReb
         });
         for (size_t index = 0; index < collected_contexts_count; index++) {
             VERIFY(contexts[index]);
-            TRY(unmount_mounts_on_vfs_root_context(*contexts[index]));
+            TRY(contexts[index]->do_full_teardown({}));
         }
     } while (collected_contexts_count > 0);
 

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -352,7 +352,7 @@ Process::Process(StringView name, NonnullRefPtr<Credentials> credentials, Proces
     }
 
     m_attached_vfs_root_context.with([](auto& context) {
-        context->set_attached({});
+        context->attach({});
     });
 
     m_attached_hostname_context.with([](auto& context) {
@@ -888,6 +888,11 @@ void Process::finalize()
     m_environment.clear();
 
     m_attached_hostname_context.with([](auto& context) {
+        context->detach({});
+        context = nullptr;
+    });
+
+    m_attached_vfs_root_context.with([](auto& context) {
         context->detach({});
         context = nullptr;
     });

--- a/Userland/Utilities/init.cpp
+++ b/Userland/Utilities/init.cpp
@@ -18,11 +18,11 @@
 
 static ErrorOr<void> prepare_bare_minimum_filesystem_mounts()
 {
-    TRY(Core::System::remount({}, "/"sv, MS_NODEV | MS_NOSUID | MS_RDONLY));
-    TRY(Core::System::mount({}, -1, "/proc"sv, "proc"sv, MS_NOSUID));
-    TRY(Core::System::mount({}, -1, "/sys"sv, "sys"sv, 0));
-    TRY(Core::System::mount({}, -1, "/dev"sv, "ram"sv, MS_NOSUID | MS_NOEXEC | MS_NOREGULAR));
-    TRY(Core::System::mount({}, -1, "/tmp"sv, "ram"sv, MS_NOSUID | MS_NODEV));
+    TRY(Core::System::remount({}, "/"sv, MS_IMMUTABLE | MS_NODEV | MS_NOSUID | MS_RDONLY));
+    TRY(Core::System::mount({}, -1, "/proc"sv, "proc"sv, MS_IMMUTABLE | MS_NOSUID));
+    TRY(Core::System::mount({}, -1, "/sys"sv, "sys"sv, MS_IMMUTABLE));
+    TRY(Core::System::mount({}, -1, "/dev"sv, "ram"sv, MS_IMMUTABLE | MS_NOSUID | MS_NOEXEC | MS_NOREGULAR));
+    TRY(Core::System::mount({}, -1, "/tmp"sv, "ram"sv, MS_IMMUTABLE | MS_NOSUID | MS_NODEV));
     // NOTE: Set /tmp to have a sticky bit with 0777 permissions.
     TRY(Core::System::chmod("/tmp"sv, 01777));
     return {};
@@ -55,7 +55,7 @@ static ErrorOr<void> prepare_tmpfs_system_devicemap_directory()
 
     TRY(Core::System::mkdir("/tmp/system/"sv, 0755));
     TRY(Core::System::mkdir("/tmp/system/devicemap/"sv, 0755));
-    TRY(Core::System::mount({}, -1, "/tmp/system/devicemap/"sv, "ram"sv, MS_NOEXEC | MS_NOSUID | MS_NODEV));
+    TRY(Core::System::mount({}, -1, "/tmp/system/devicemap/"sv, "ram"sv, MS_IMMUTABLE | MS_NOEXEC | MS_NOSUID | MS_NODEV));
     TRY(Core::System::mkdir("/tmp/system/devicemap/nodes/"sv, 0755));
     TRY(Core::System::mkdir("/tmp/system/devicemap/nodes/block/"sv, 0755));
     TRY(Core::System::mkdir("/tmp/system/devicemap/nodes/char/"sv, 0755));
@@ -114,9 +114,9 @@ static ErrorOr<void> prepare_bare_minimum_devtmpfs_directory_structure()
     TRY(Core::System::symlink("/proc/self/fd/2"sv, "/dev/stderr"sv));
     TRY(Core::System::mkdir("/dev/gpu"sv, 0755));
     TRY(Core::System::mkdir("/dev/pts"sv, 0755));
-    TRY(Core::System::mount({}, -1, "/dev/pts"sv, "devpts"sv, 0));
+    TRY(Core::System::mount({}, -1, "/dev/pts"sv, "devpts"sv, MS_IMMUTABLE));
     TRY(Core::System::mkdir("/dev/loop"sv, 0755));
-    TRY(Core::System::mount({}, -1, "/dev/loop"sv, "devloop"sv, 0));
+    TRY(Core::System::mount({}, -1, "/dev/loop"sv, "devloop"sv, MS_IMMUTABLE));
 
     mode_t old_mask = umask(0);
     TRY(populate_device_node_with_symlink(DeviceNodeType::Character, "/dev/devctl"sv, 0660, 2, 10));

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -45,6 +45,8 @@ static int parse_options(StringView options)
             flags |= MS_NOREGULAR;
         else if (part == "srchidden")
             flags |= MS_SRCHIDDEN;
+        else if (part == "immutable")
+            flags |= MS_IMMUTABLE;
         else
             warnln("Ignoring invalid option: {}", part);
     }
@@ -179,6 +181,8 @@ static ErrorOr<void> print_mounts()
         else
             out("rw");
 
+        if (mount_flags & MS_IMMUTABLE)
+            out(",immutable");
         if (mount_flags & MS_NODEV)
             out(",nodev");
         if (mount_flags & MS_NOREGULAR)


### PR DESCRIPTION
I decided to try #24915 again. This should be part of security hardening in the `VFSRootContext` mechanism, and prevent unmounting crucial filesystems or changing their mountpoints' flags while the system runs.