### PR TITLE
Meta: Pass compiler's builtin includes to jakt too

### DIFF
--- a/Meta/CMake/get_cxx_includes.py
+++ b/Meta/CMake/get_cxx_includes.py
@@ -1,0 +1,109 @@
+import argparse
+import os
+import subprocess
+import sys
+
+
+def get_includes_from_version_output(compiler, target_args):
+    try:
+        output = subprocess.check_output(
+            [compiler, *target_args, "-xc++", "/dev/null", "-E", "-Wp,-v"], stderr=subprocess.STDOUT
+        )
+    except subprocess.CalledProcessError as e:
+        print("Error getting includes from compiler version output: " + e.output)
+        sys.exit(1)
+
+    includes = []
+    in_search_list = False
+    for line in output.splitlines():
+        line = line.strip()
+        if not in_search_list:
+            if line == "#include <...> search starts here:":
+                in_search_list = True
+                continue
+            continue
+        if line == "End of search list.":
+            break
+        includes.append(line)
+
+    return includes
+
+
+def get_includes_from_preprocessor_output(compiler, test_file, target_args):
+    try:
+        output = subprocess.check_output(
+            [compiler, *target_args, "-E", test_file], stderr=subprocess.STDOUT
+        )
+    except subprocess.CalledProcessError as e:
+        print(b"Error getting includes from preprocessor output: " + e.output)
+        sys.exit(1)
+
+    includes = []
+    for line in output.splitlines():
+        if not line.startswith(b"# 1 "):
+            continue
+        include = line.removeprefix(b"# 1 ")
+        include = include[1:-1]  # Remove quotes
+        includes.append(include)
+
+    return includes
+
+
+def convert_includes_to_dirs(includes):
+    dirs = []
+    for include in includes:
+        if not os.path.isabs(include):
+            continue
+        include_dir = os.path.dirname(include)
+        if include_dir.endswith(b"/bits"):
+            include_dir = os.path.dirname(include_dir)
+
+        while not os.path.isdir(include_dir):
+            include_dir = os.path.dirname(include_dir)
+
+        if os.path.basename(include_dir).startswith(b"_"):
+            continue
+
+        dirs.append(include_dir)
+
+    return dirs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract System Includes from C++ Compiler"
+    )
+
+    parser.add_argument("--compiler", required=True, help="Specify C++ compiler to extract includes from")
+    parser.add_argument("--target", help="Specify target platform for compiler")
+
+    parser.add_argument(
+        "--test-file", required=True, help="Specify the path to the test file containing '#include' directives"
+    )
+
+    args = parser.parse_args()
+    compiler = args.compiler
+    test_file = args.test_file
+    target = args.target
+
+    target_args = []
+    if target is not None and target != "":
+        target_args = [f"--target={target}"]
+
+    includes = get_includes_from_version_output(compiler, target_args)
+    system_includes = get_includes_from_preprocessor_output(compiler, test_file, target_args)
+    system_includes = convert_includes_to_dirs(system_includes)
+
+    out = []
+    seen = set()
+    for p in system_includes + includes:
+        if p in seen:
+            continue
+        seen.add(p)
+        out.append(p.decode("utf-8"))
+
+    print(";".join(out), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/Toolchain/BuildJakt.sh
+++ b/Toolchain/BuildJakt.sh
@@ -90,7 +90,7 @@ buildstep_ninja() {
 
 mkdir -p "$DIR/Tarballs"
 
-JAKT_COMMIT_HASH="1fed928d0abf08188e48fe765ab68e5047c05ec2"
+JAKT_COMMIT_HASH="bf6e9ce89206fb744d8acc6e700e31e4330a5f25"
 JAKT_NAME="jakt-${JAKT_COMMIT_HASH}"
 JAKT_TARBALL="${JAKT_NAME}.tar.gz"
 JAKT_GIT_URL="https://github.com/serenityos/jakt"


### PR DESCRIPTION
This is not an issue with clang, but when gcc is used as the c++ compiler, jakt can't know its builtin include paths; so come up with a nice and hacky cmake blob to fix the problem.

Warning: hacky!