### PR TITLE
AK: Add implementations of exp2() and exp() on non-x86

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -862,6 +862,32 @@ constexpr T log10(T x)
 }
 
 template<FloatingPoint T>
+constexpr T exp2(T exponent)
+{
+    CONSTEXPR_STATE(exp2, exponent);
+
+#if ARCH(X86_64)
+    T res;
+    asm("fld1\n"
+        "fld %%st(1)\n"
+        "fprem\n"
+        "f2xm1\n"
+        "faddp\n"
+        "fscale\n"
+        "fstp %%st(1)"
+        : "=t"(res)
+        : "0"(exponent));
+    return res;
+#else
+#    if defined(AK_OS_SERENITY)
+    // TODO: Add implementation for this function.
+    TODO();
+#    endif
+    return __builtin_exp2(exponent);
+#endif
+}
+
+template<FloatingPoint T>
 constexpr T exp(T exponent)
 {
     CONSTEXPR_STATE(exp, exponent);
@@ -886,32 +912,6 @@ constexpr T exp(T exponent)
     TODO();
 #    endif
     return __builtin_exp(exponent);
-#endif
-}
-
-template<FloatingPoint T>
-constexpr T exp2(T exponent)
-{
-    CONSTEXPR_STATE(exp2, exponent);
-
-#if ARCH(X86_64)
-    T res;
-    asm("fld1\n"
-        "fld %%st(1)\n"
-        "fprem\n"
-        "f2xm1\n"
-        "faddp\n"
-        "fscale\n"
-        "fstp %%st(1)"
-        : "=t"(res)
-        : "0"(exponent));
-    return res;
-#else
-#    if defined(AK_OS_SERENITY)
-    // TODO: Add implementation for this function.
-    TODO();
-#    endif
-    return __builtin_exp2(exponent);
 #endif
 }
 


### PR DESCRIPTION
This is a pretty naive implementation of exp2() that can be improved
a lot, but hey, it beats the sin() and cos() implementation on non-x86.

It also implements exp(x) as exp2(x * log2(e)), with the same
disclaimer.

---

With this, it's possible to open Text Editor and Video Player (and probably more, but not yet Browser) in aarch64 builds.