### PR TITLE
AK: Implement asin(), atan(), tan() on non-x86

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -726,9 +726,7 @@ constexpr T tan(T angle)
     return ret;
 #else
 #    if defined(AK_OS_SERENITY)
-    // FIXME: This is a very naive implementation, and is only valid for small x.
-    //        Probably a good idea to use a better algorithm in the future, such as a taylor approximation.
-    return angle;
+    return sin(angle) / cos(angle);
 #    else
     return __builtin_tan(angle);
 #    endif

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -739,10 +739,20 @@ template<FloatingPoint T>
 constexpr T asin(T x)
 {
     CONSTEXPR_STATE(asin, x);
-    if (x > 1 || x < -1)
+
+    if (x < 0)
+        return -asin(-x);
+
+    if (x > 1)
         return NaN<T>;
-    if (x > (T)0.5 || x < (T)-0.5)
-        return 2 * atan<T>(x / (1 + sqrt<T>(1 - x * x)));
+
+    if (x > (T)0.5) {
+        // asin(x) = pi/2 - 2 * asin(sqrt((1 - x) / 2))
+        // If 0.5 < x <= 1, then sqrt((1 - x) / 2 ) < 0.5,
+        // and the recursion will go down the `<= 0.5` branch.
+        return Pi<T> / 2 - 2 * asin(sqrt((1 - x) / 2));
+    }
+
     T squared = x * x;
     T value = x;
     T i = x * squared;

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -736,28 +736,6 @@ constexpr T tan(T angle)
 }
 
 template<FloatingPoint T>
-constexpr T atan(T value)
-{
-    CONSTEXPR_STATE(atan, value);
-
-#if ARCH(X86_64)
-    T ret;
-    asm(
-        "fld1\n"
-        "fpatan\n"
-        : "=t"(ret)
-        : "0"(value));
-    return ret;
-#else
-#    if defined(AK_OS_SERENITY)
-    // TODO: Add implementation for this function.
-    TODO();
-#    endif
-    return __builtin_atan(value);
-#endif
-}
-
-template<FloatingPoint T>
 constexpr T asin(T x)
 {
     CONSTEXPR_STATE(asin, x);
@@ -793,6 +771,28 @@ constexpr T acos(T value)
 
     // FIXME: I am naive
     return static_cast<T>(0.5) * Pi<T> - asin<T>(value);
+}
+
+template<FloatingPoint T>
+constexpr T atan(T value)
+{
+    CONSTEXPR_STATE(atan, value);
+
+#if ARCH(X86_64)
+    T ret;
+    asm(
+        "fld1\n"
+        "fpatan\n"
+        : "=t"(ret)
+        : "0"(value));
+    return ret;
+#else
+#    if defined(AK_OS_SERENITY)
+    // TODO: Add implementation for this function.
+    TODO();
+#    endif
+    return __builtin_atan(value);
+#endif
 }
 
 template<FloatingPoint T>

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -798,8 +798,7 @@ constexpr T atan(T value)
     return ret;
 #else
 #    if defined(AK_OS_SERENITY)
-    // TODO: Add implementation for this function.
-    TODO();
+    return asin(value / sqrt(1 + value * value));
 #    endif
     return __builtin_atan(value);
 #endif


### PR DESCRIPTION
asin() now no longer relies on atan(), and atan() is now implemented in terms of asin().

With atan() implemented, Browser starts up, and paths can be stroked.

`/usr/Tests/LibC/TestMath` now passes 7 of 14 tests, compared to 2 of 14 before.

(While here, also implement tan() as sin() / cos().)