### PR TITLE
Meta: Use `rm -rf` instead of `rmdir` in QEMU image build script

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -159,10 +159,8 @@ cleanup() {
             else
                 umount mnt || ( sleep 1 && sync && umount mnt )
             fi
-            rmdir mnt
-        else
-            rm -rf mnt
         fi
+        rm -rf mnt
 
         if [ "$(uname -s)" = "OpenBSD" ]; then
             vnconfig -u "$VND"


### PR DESCRIPTION
If you run `serenity.sh run` with missing fuse2fs and/or fusermount3,
then install the needed packages, and then try to run the script
again, rmdir step will fail with "non-empty directory" error
causing QEMU to not start. The patch avoids this by recursively
removing disk mount directory instead of just unlinking it.