### PR TITLE
Ports: Add menu entry for Jakt

### DIFF
--- a/Ports/jakt/package.sh
+++ b/Ports/jakt/package.sh
@@ -10,6 +10,10 @@ archive_hash='d7b5e772074a44f428facd230ac9dafdcf2034c188e31715f592b6058162e4d7'
 files=(
     "https://github.com/SerenityOS/jakt/archive/${commit_hash}.tar.gz#${archive_hash}"
 )
+launcher_name='Jakt'
+launcher_category='D&evelopment'
+launcher_command='/usr/local/bin/jakt --repl'
+launcher_run_in_terminal='true'
 workdir="jakt-${commit_hash}"
 
 configure() {


### PR DESCRIPTION
No change in version, just added menu entry
![image](https://github.com/user-attachments/assets/b1083b1e-f29f-4eeb-b20d-fc0111ffc02a)

Note:
If after building the jakt port, it doesn't launch inside **Serenity**OS:
- switch to root account
- unlink / remove `/usr/local/bin/jakt`
- soft link `/usr/local/bin/jakt_stage1` as `/usr/local/bin/jakt`
- enjoy