### PR TITLE
SystemMonitor: Grow CPU and memory charts to window size

### DIFF
--- a/Userland/Applications/SystemMonitor/SystemMonitor.gml
+++ b/Userland/Applications/SystemMonitor/SystemMonitor.gml
@@ -43,12 +43,14 @@
                 @GUI::GroupBox {
                     title: "CPU usage"
                     name: "cpu_graph"
+                    preferred_height: "opportunistic_grow"
                     layout: @GUI::VerticalBoxLayout {}
                 }
 
                 @GUI::GroupBox {
                     title: "Memory usage"
-                    fixed_height: 120
+                    preferred_height: "opportunistic_grow"
+                    min_height: 120
                     layout: @GUI::VerticalBoxLayout {
                         margins: [6]
                     }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -597,15 +597,15 @@ ErrorOr<void> build_performance_tab(GUI::Widget& graphs_container)
 {
     auto& cpu_graph_group_box = *graphs_container.find_descendant_of_type_named<GUI::GroupBox>("cpu_graph");
 
-    size_t cpu_graphs_per_row = min(4, ProcessModel::the().cpus().size());
-    auto cpu_graph_rows = ceil_div(ProcessModel::the().cpus().size(), cpu_graphs_per_row);
-    cpu_graph_group_box.set_fixed_height(120u * cpu_graph_rows);
+    size_t cpus_count = ProcessModel::the().cpus().size();
+    size_t cpu_graphs_per_row = min(cpus_count, 4);
+    auto cpu_graph_rows = ceil_div(cpus_count, cpu_graphs_per_row);
 
     Vector<SystemMonitor::GraphWidget&> cpu_graphs;
     for (auto row = 0u; row < cpu_graph_rows; ++row) {
         auto& cpu_graph_row = cpu_graph_group_box.add<GUI::Widget>();
         cpu_graph_row.set_layout<GUI::HorizontalBoxLayout>(6);
-        cpu_graph_row.set_fixed_height(108);
+        cpu_graph_row.set_min_height(108);
         for (auto i = 0u; i < cpu_graphs_per_row; ++i) {
             auto& cpu_graph = cpu_graph_row.add<SystemMonitor::GraphWidget>();
             cpu_graph.set_max(100);


### PR DESCRIPTION
Small style fix

## Before
<img width="1136" alt="Screenshot 2024-12-29 at 11 40 42" src="https://github.com/user-attachments/assets/466c0a52-88cd-4bce-9755-df6d727342a3" />

## After
<img width="1136" alt="Screenshot 2024-12-29 at 11 39 40" src="https://github.com/user-attachments/assets/e4d709ad-e92f-4d76-81a6-07fb517aa904" />
