### PR TITLE
Meta: Add User-Agent string on request for download_file

### DIFF
--- a/Meta/download_file.py
+++ b/Meta/download_file.py
@@ -74,7 +74,10 @@ def main():
 
     os.makedirs(output_file.parent, exist_ok=True)
 
-    request = urllib.request.Request(args.url, headers={"Accept-Encoding": "gzip"})
+    request = urllib.request.Request(args.url, headers={
+                      "Accept-Encoding": "gzip",
+                      "User-Agent": "Serenity Meta/download_file.py",
+                  })
     with urllib.request.urlopen(request) as f:
         try:
             with tempfile.NamedTemporaryFile(delete=False, dir=output_file.parent) as out:


### PR DESCRIPTION
When downloading pnp_ids.csv from https://uefi.org/uefi-pnp-export it needs to have a User-Agent string set, or it will return an 403: Forbidden error.