### PR TITLE
Ports/boost: Fix download link, fix paths in patches

### DIFF
--- a/Ports/boost/package.sh
+++ b/Ports/boost/package.sh
@@ -2,7 +2,6 @@
 port='boost'
 version='1.83.0'
 useconfigure='true'
-workdir="boost_${version//./_}"
 depends=(
     'zlib'
     'bzip2'
@@ -11,7 +10,7 @@ depends=(
     'libicu'
 )
 files=(
-    "https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${version//./_}.tar.bz2#6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e"
+    "https://github.com/boostorg/boost/releases/download/boost-${version}/boost-${version}.tar.gz#0c6049764e80aa32754acd7d4f179fd5551d8172a83b71532ae093e7384e98da"
 )
 bjamopts=(
     '--user-config=user-config.jam'

--- a/Ports/boost/patches/0001-Add-platform-support-for-SerenityOS.patch
+++ b/Ports/boost/patches/0001-Add-platform-support-for-SerenityOS.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Add platform support for SerenityOS
 
 ---
  .../config/detail/select_platform_config.hpp  |  5 ++++
- boost/config/platform/serenity.hpp            | 26 +++++++++++++++++++
+ .../boost/config/platform/serenity.hpp        | 26 +++++++++++++++++++
  tools/build/src/tools/features/os-feature.jam |  4 +--
  tools/build/src/tools/gcc.jam                 |  4 ++-
  tools/build/src/tools/python.jam              |  1 +
  5 files changed, 37 insertions(+), 3 deletions(-)
- create mode 100644 boost/config/platform/serenity.hpp
+ create mode 100644 libs/config/include/boost/config/platform/serenity.hpp
 
-diff --git a/boost/config/detail/select_platform_config.hpp b/boost/config/detail/select_platform_config.hpp
-index dbff74aaf74ea59eaf204f463bf2b37df9c432a5..d280ed5c02ff90b5eb0dfef3948d17a2d4310109 100644
---- a/boost/config/detail/select_platform_config.hpp
-+++ b/boost/config/detail/select_platform_config.hpp
+diff --git a/libs/config/include/boost/config/detail/select_platform_config.hpp b/libs/config/include/boost/config/detail/select_platform_config.hpp
+index dbff74aaf74ea59eaf204f463bf2b37df9c432a5..3b664107303df336bab8010caad42ddaed24550e 100644
+--- a/libs/config/include/boost/config/detail/select_platform_config.hpp
++++ b/libs/config/include/boost/config/detail/select_platform_config.hpp
 @@ -93,6 +93,10 @@
  // Web assembly:
  #  define BOOST_PLATFORM_CONFIG "boost/config/platform/wasm.hpp"
@@ -35,11 +35,11 @@ index dbff74aaf74ea59eaf204f463bf2b37df9c432a5..d280ed5c02ff90b5eb0dfef3948d17a2
  #  include <boost/config/detail/posix_features.hpp>
  
  
-diff --git a/boost/config/platform/serenity.hpp b/boost/config/platform/serenity.hpp
+diff --git a/libs/config/include/boost/config/platform/serenity.hpp b/libs/config/include/boost/config/platform/serenity.hpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..ecde1fe0e4adf068aaf44aee75757a26df5e1af9
+index 0000000000000000000000000000000000000000..89d09ca6b01626691ed2c45184bd8d322973df49
 --- /dev/null
-+++ b/boost/config/platform/serenity.hpp
++++ b/libs/config/include/boost/config/platform/serenity.hpp
 @@ -0,0 +1,26 @@
 +//  (C) Copyright 2022 Gunnar Beutner
 +//  Use, modification and distribution are subject to the

--- a/Ports/boost/patches/0002-Fix-building-Boost.Interprocess.patch
+++ b/Ports/boost/patches/0002-Fix-building-Boost.Interprocess.patch
@@ -4,13 +4,13 @@ Date: Sun, 23 Oct 2022 10:27:07 +0200
 Subject: [PATCH] Fix building Boost.Interprocess
 
 ---
- boost/interprocess/detail/workaround.hpp | 2 +-
+ .../include/boost/interprocess/detail/workaround.hpp            | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/boost/interprocess/detail/workaround.hpp b/boost/interprocess/detail/workaround.hpp
-index 01b6c6eb05dddff8c8b6fbb0c5c279deb971b7c2..704456e290c9ad7b8c523769bdc68147d63e4536 100644
---- a/boost/interprocess/detail/workaround.hpp
-+++ b/boost/interprocess/detail/workaround.hpp
+diff --git a/libs/interprocess/include/boost/interprocess/detail/workaround.hpp b/libs/interprocess/include/boost/interprocess/detail/workaround.hpp
+index 01b6c6eb05dddff8c8b6fbb0c5c279deb971b7c2..6fc793b6009c24f2db4fc6b1aefb2d4d3eb4cfae 100644
+--- a/libs/interprocess/include/boost/interprocess/detail/workaround.hpp
++++ b/libs/interprocess/include/boost/interprocess/detail/workaround.hpp
 @@ -37,7 +37,7 @@
     //////////////////////////////////////////////////////
     //Check for XSI shared memory objects. They are available in nearly all UNIX platforms


### PR DESCRIPTION
Boostorg's artifactory instance is down, let's switch to github instead.