### PR TITLE
Kernel: Don't allow text relocations

### DIFF
--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -85,15 +85,12 @@ private:
 static UNMAP_AFTER_INIT FlatPtr calculate_physical_to_link_time_address_offset()
 {
     FlatPtr physical_address;
-    FlatPtr link_time_address;
 
     asm volatile(
-        "   adr %[physical_address], #0\n"
-        "1: ldr %[link_time_address], =1b\n"
-        : [physical_address] "=r"(physical_address),
-        [link_time_address] "=r"(link_time_address));
+        "adrp %[physical_address], start_of_kernel_image"
+        : [physical_address] "=r"(physical_address));
 
-    return link_time_address - physical_address - 4;
+    return KERNEL_MAPPING_BASE - physical_address;
 }
 
 // NOTE: To access global variables while the MMU is not yet enabled, we need

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -172,7 +172,8 @@ void ProcessorBase<T>::switch_context(Thread*& from_thread, Thread*& to_thread)
         "mov x0, sp \n"
         "str x0, %[from_sp] \n"
         "str fp, %[from_fp] \n"
-        "ldr x0, =1f \n"
+        "adrp x0, 1f \n"
+        "add x0, x0, :lo12:1f \n"
         "str x0, %[from_ip] \n"
 
         "ldr x0, %[to_sp] \n"
@@ -395,8 +396,9 @@ NAKED void do_assume_context(Thread*, u32)
         "mov x0, x19 \n" // to_thread
         "mov x1, x19 \n" // from_thread
         "sub sp, sp, 32 \n"
-        "stp x19, x19, [sp] \n"                  // to_thread, from_thread (for thread_context_first_enter)
-        "ldr lr, =thread_context_first_enter \n" // should be same as regs.elr_el1
+        "stp x19, x19, [sp] \n"                           // to_thread, from_thread (for thread_context_first_enter)
+        "adrp lr, thread_context_first_enter \n"          // should be same as regs.elr_el1
+        "add lr, lr, :lo12:thread_context_first_enter \n" // should be same as regs.elr_el1
         "b enter_thread_context \n");
     // clang-format on
 }

--- a/Kernel/Arch/aarch64/boot.S
+++ b/Kernel/Arch/aarch64/boot.S
@@ -13,32 +13,32 @@
 .global start
 .type start, @function
 start:
-  // Let only core 0 continue, put other cores to sleep.
-  mrs x13, MPIDR_EL1
-  and x13, x13, 0xff
-  cbnz x13, halt
+    // Let only core 0 continue, put other cores to sleep.
+    mrs x13, MPIDR_EL1
+    and x13, x13, 0xff
+    cbnz x13, halt
 
-  // Set the stack pointer register to the location defined in the linker script.
-  adrp x14, end_of_initial_stack
-  add x14, x14, :lo12:end_of_initial_stack
-  mov sp, x14
+    // Set the stack pointer register to the location defined in the linker script.
+    adrp x14, end_of_initial_stack
+    add x14, x14, :lo12:end_of_initial_stack
+    mov sp, x14
 
-  // Clear BSS.
-  adrp x14, start_of_bss
-  add x14, x14, :lo12:start_of_bss
-  adrp x15, end_of_bss
-  add x15, x15, :lo12:end_of_bss
-  cmp x14, x15
-  b.ge Lbss_clear_done
-Lbss_clear_loop:
-  str xzr, [x14], #8
-  cmp x14, x15
-  b.lt Lbss_clear_loop
-Lbss_clear_done:
+    // Clear BSS.
+    adrp x14, start_of_bss
+    add x14, x14, :lo12:start_of_bss
+    adrp x15, end_of_bss
+    add x15, x15, :lo12:end_of_bss
+    cmp x14, x15
+    b.ge .Lbss_clear_done
+.Lbss_clear_loop:
+    str xzr, [x14], #8
+    cmp x14, x15
+    b.lt .Lbss_clear_loop
+.Lbss_clear_done:
 
-  b pre_init
+    b pre_init
 
 halt:
-  msr daifset, #2
-  wfi
-  b halt
+    msr daifset, #2
+    wfi
+    b halt

--- a/Kernel/Arch/aarch64/boot.S
+++ b/Kernel/Arch/aarch64/boot.S
@@ -26,11 +26,15 @@ start:
   // Clear BSS.
   adrp x14, start_of_bss
   add x14, x14, :lo12:start_of_bss
-  ldr x15, =size_of_bss_divided_by_8
+  adrp x15, end_of_bss
+  add x15, x15, :lo12:end_of_bss
+  cmp x14, x15
+  b.ge Lbss_clear_done
 Lbss_clear_loop:
   str xzr, [x14], #8
-  subs x15, x15, #1
-  bne Lbss_clear_loop
+  cmp x14, x15
+  b.lt Lbss_clear_loop
+Lbss_clear_done:
 
   b pre_init
 

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -111,5 +111,3 @@ SECTIONS
 
     end_of_kernel_image = .;
 }
-
-size_of_bss_divided_by_8 = (end_of_bss - start_of_bss + 7) / 8;

--- a/Kernel/Arch/aarch64/pre_init.cpp
+++ b/Kernel/Arch/aarch64/pre_init.cpp
@@ -34,12 +34,14 @@ extern "C" [[noreturn]] void pre_init(PhysicalPtr flattened_devicetree_paddr)
     // from the physical memory address, so we have to jump to the kernel in high memory. We also need to
     // switch the stack pointer to high memory, such that we can unmap the identity mapping.
 
-    // Continue execution at high virtual address, by using an absolute jump.
+    // Continue execution at high virtual address.
     asm volatile(
-        "ldr x0, =1f \n"
+        "adrp x0, 1f \n"
+        "add x0, x0, :lo12:1f \n"
+        "add x0, x0, %[base] \n"
         "br x0 \n"
-        "1: \n" ::
-            : "x0");
+        "1: \n" ::[base] "r"(g_boot_info.physical_to_virtual_offset)
+        : "x0");
 
     // Add kernel_mapping_base to the stack pointer, such that it is also using the mapping
     // in high virtual memory.

--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -189,11 +189,11 @@ static UNMAP_AFTER_INIT void setup_kernel_page_directory(u64* root_table)
         "   csrw satp, %[satp] \n"
         "   sfence.vma \n"
 
-        // Continue execution at high virtual address, by using an absolute jump.
-        "   ld t0, 3f \n"
+        // Continue execution at high virtual address.
+        "   lla t0, 2f \n"
+        "   add t0, t0, %[offset] \n"
         "   jr t0 \n"
-        "3: .dword 4f \n"
-        "4: \n"
+        "2: \n"
 
         // Add kernel_mapping_base to the stack pointer, such that it is also using the mapping in high virtual memory.
         "   add sp, sp, %[offset] \n"

--- a/Kernel/Arch/riscv64/boot.S
+++ b/Kernel/Arch/riscv64/boot.S
@@ -12,89 +12,89 @@
 linux_header:
 .option push
 .option arch, -c
-  j start                                   // u32 code0
-  j start                                   // u32 code1
+    j start                                   // u32 code0
+    j start                                   // u32 code1
 .option pop
 
-  // This offset is needed, as otherwise U-Boot will try to load us at the same address where OpenSBI is loaded.
-  // The value is the same that Linux uses.
-  .dword 0x400000                           // u64 text_offset
+    // This offset is needed, as otherwise U-Boot will try to load us at the same address where OpenSBI is loaded.
+    // The value is the same that Linux uses.
+    .dword 0x400000                           // u64 text_offset
 
-  .dword end_of_kernel_image - linux_header // u64 image_size
-  .dword 0                                  // u64 flags
-  .word 2                                   // u32 version
-  .word 0                                   // u32 res1
-  .dword 0                                  // u64 res2
-  .ascii "RISCV\0\0\0"                      // u64 magic (deprecated)
-  .ascii "RSC\x5"                           // u32 magic2
-  .word 0                                   // u32 res3
+    .dword end_of_kernel_image - linux_header // u64 image_size
+    .dword 0                                  // u64 flags
+    .word 2                                   // u32 version
+    .word 0                                   // u32 res1
+    .dword 0                                  // u64 res2
+    .ascii "RISCV\0\0\0"                      // u64 magic (deprecated)
+    .ascii "RSC\x5"                           // u32 magic2
+    .word 0                                   // u32 res3
 
 .global start
 .type start, @function
 start:
-  // We expect that only one hart jumps here and that we are running in supervisor mode.
-  // We also expect that an implementation of the RISC-V Supervisor Binary Interface is available.
+    // We expect that only one hart jumps here and that we are running in supervisor mode.
+    // We also expect that an implementation of the RISC-V Supervisor Binary Interface is available.
 
-  // Don't touch a0/a1 as we expect those registers to contain the hart ID
-  // and a pointer to the Flattened Devicetree.
+    // Don't touch a0/a1 as we expect those registers to contain the hart ID
+    // and a pointer to the Flattened Devicetree.
 
-  // Clear sstatus.SIE, which disables all interrupts in supervisor mode.
-  csrci sstatus, 1 << 1
+    // Clear sstatus.SIE, which disables all interrupts in supervisor mode.
+    csrci sstatus, 1 << 1
 
-  // Also, disable all interrupts sources and mark them as non-pending.
-  csrw sie, zero
-  csrw sip, zero
+    // Also, disable all interrupts sources and mark them as non-pending.
+    csrw sie, zero
+    csrw sip, zero
 
-  // TODO: maybe load the gp register here?
+    // TODO: maybe load the gp register here?
 
-  // Clear the BSS.
-  lla t0, start_of_bss
-  lla t1, end_of_bss
-  bgeu t0, t1, Lclear_bss_done
-Lclear_bss_loop:
-  sd zero, (t0)
-  addi t0, t0, 8
-  bltu t0, t1, Lclear_bss_loop
-Lclear_bss_done:
+    // Clear the BSS.
+    lla t0, start_of_bss
+    lla t1, end_of_bss
+    bgeu t0, t1, .Lclear_bss_done
+.Lclear_bss_loop:
+    sd zero, (t0)
+    addi t0, t0, 8
+    bltu t0, t1, .Lclear_bss_loop
+.Lclear_bss_done:
 
-  // Set the stack pointer register to the location defined in the linker script.
-  lla sp, end_of_initial_stack
+    // Set the stack pointer register to the location defined in the linker script.
+    lla sp, end_of_initial_stack
 
-  // Zero all registers except sp, a0 and a1.
-  li ra, 0
-  // sp
-  li gp, 0
-  li tp, 0
-  li t0, 0
-  li t1, 0
-  li t2, 0
-  li fp, 0
-  li s1, 0
-  // a0
-  // a1
-  li a2, 0
-  li a3, 0
-  li a4, 0
-  li a5, 0
-  li a6, 0
-  li a7, 0
-  li s2, 0
-  li s3, 0
-  li s4, 0
-  li s5, 0
-  li s6, 0
-  li s7, 0
-  li s8, 0
-  li s9, 0
-  li s10, 0
-  li s11, 0
-  li t3, 0
-  li t4, 0
-  li t5, 0
-  li t6, 0
+    // Zero all registers except sp, a0 and a1.
+    li ra, 0
+    // sp
+    li gp, 0
+    li tp, 0
+    li t0, 0
+    li t1, 0
+    li t2, 0
+    li fp, 0
+    li s1, 0
+    // a0
+    // a1
+    li a2, 0
+    li a3, 0
+    li a4, 0
+    li a5, 0
+    li a6, 0
+    li a7, 0
+    li s2, 0
+    li s3, 0
+    li s4, 0
+    li s5, 0
+    li s6, 0
+    li s7, 0
+    li s8, 0
+    li s9, 0
+    li s10, 0
+    li s11, 0
+    li t3, 0
+    li t4, 0
+    li t5, 0
+    li t6, 0
 
-  // The trap handler expects sscratch to be zero if we are in supervisor mode.
-  // sscratch contains the kernel stack pointer if we are in user mode.
-  csrw sscratch, zero
+    // The trap handler expects sscratch to be zero if we are in supervisor mode.
+    // sscratch contains the kernel stack pointer if we are in user mode.
+    csrw sscratch, zero
 
-  tail pre_init
+    tail pre_init

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -811,7 +811,6 @@ set(SOURCES
 )
 
 add_compile_definitions(KERNEL)
-add_link_options(LINKER:-z,notext)
 
 add_library(kernel_heap STATIC ${KERNEL_HEAP_SOURCES})
 target_link_libraries(kernel_heap PUBLIC GenericClangPlugin)

--- a/Kernel/Prekernel/boot.S
+++ b/Kernel/Prekernel/boot.S
@@ -136,7 +136,7 @@ print_no_halt:
 
 
 
-/* 
+/*
     this function assumes that paging is disabled (or everything is mapped 1:1)
     param 1: pointer to string ended with null terminator (C string)
 */
@@ -222,15 +222,15 @@ print_and_halt:
 gdt_table_real_mode:
     .quad 0             /* Empty entry */
 
-	.short 0xffff
-	.short 0
+    .short 0xffff
+    .short 0
     .byte 0
     .byte 0b10011010
     .byte 0b00001111
     .byte 0x0
 
     .short 0xffff
-	.short 0
+    .short 0
     .byte 0
     .byte 0b10010010
     .byte 0b00001111
@@ -328,7 +328,7 @@ real_start:
     mov $end_of_prekernel_image, %esi
     cmp $MAX_KERNEL_SIZE, %esi
     jbe kernel_not_too_large
-    
+
     movl $kernel_image_too_big_string, %esi
     pushl %esi
     call print_and_halt

--- a/Userland/Libraries/LibC/arch/x86_64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/x86_64/setjmp.S
@@ -42,7 +42,7 @@ sigsetjmp:
     mov %rbp, (5 * 8)(%rdi)
     mov %rsp, (6 * 8)(%rdi)
     mov (%rsp), %rax        // Grab return address
-    mov %rax, (7 * 8)(%rdi)    
+    mov %rax, (7 * 8)(%rdi)
     xor %eax, %eax
     ret
 


### PR DESCRIPTION
Only aarch64 and riscv64 had a few simple to remove text relocations left.

(The riscv64 one actually will cause problems when trying to boot with the EFIPrekernel because the generated textrel is broken for some reason)