### PR TITLE
LibGfx: Only use draw_scaled_bitmap() fast path when not flipping image

### DIFF
--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -35,8 +35,14 @@ public:
         return m_values[0] == 1 && m_values[1] == 0 && m_values[2] == 0 && m_values[3] == 1;
     }
 
-    [[nodiscard]] bool is_identity_or_translation_or_scale() const
+    enum class AllowNegativeScaling {
+        No,
+        Yes,
+    };
+    [[nodiscard]] bool is_identity_or_translation_or_scale(AllowNegativeScaling allow_negative_scaling) const
     {
+        if (allow_negative_scaling == AllowNegativeScaling::No && (m_values[0] < 0 || m_values[3] < 0))
+            return false;
         return m_values[1] == 0 && m_values[2] == 0;
     }
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2443,7 +2443,7 @@ void Painter::draw_text_run(FloatPoint baseline_start, Utf8View const& string, F
 
 void Painter::draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Bitmap const& bitmap, FloatRect const& src_rect, AffineTransform const& transform, float opacity, ScalingMode scaling_mode)
 {
-    if (transform.is_identity_or_translation_or_scale()) {
+    if (transform.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::No)) {
         draw_scaled_bitmap(transform.map(dst_rect.to_type<float>()).to_rounded<int>(), bitmap, src_rect, opacity, scaling_mode);
     } else {
         // The painter has an affine transform, we have to draw through it!

--- a/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.cpp
@@ -138,7 +138,7 @@ CommandResult AffineDisplayListPlayerCPU::set_clip_rect(SetClipRect const& clip)
     auto clip_quad = current_stacking_context.transform.map_to_quad(clip.rect.to_type<float>());
     current_stacking_context.clip.bounds = enclosing_int_rect(clip_quad.bounding_rect());
     // FIXME: Flips and rotations by x*90° should also be marked as rectangular.
-    current_stacking_context.clip.is_rectangular = current_stacking_context.transform.is_identity_or_translation_or_scale();
+    current_stacking_context.clip.is_rectangular = current_stacking_context.transform.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::Yes);
     current_stacking_context.clip.quad = clip_quad;
     painter().add_clip_rect(current_stacking_context.clip.bounds);
     return CommandResult::Continue;


### PR DESCRIPTION
If we're drawing a transform with a negative scale, we have to go through the slow path since draw_scaled_bitmap() is unable to flip images.

Fixes a regression from the 2nd commit in #24465.