### PR TITLE
Kernel/aarch64: Make us boot to desktop on the Pi 4 (with USB 2 support)

### DIFF
--- a/Kernel/Arch/aarch64/RPi/Timer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Timer.cpp
@@ -189,9 +189,6 @@ DEVICETREE_DRIVER(BCM2835TimerDriver, compatibles_array);
 // https://www.kernel.org/doc/Documentation/devicetree/bindings/timer/brcm,bcm2835-system-timer.txt
 ErrorOr<void> BCM2835TimerDriver::probe(DeviceTree::Device const& device, StringView) const
 {
-    if (DeviceTree::get().is_compatible_with("raspberrypi,4-model-b"sv))
-        return ENOTSUP; // HACK: The Pi 4 system timer doesn't appear to work on QEMU; only the generic ARM timer does.
-
     auto const interrupts = TRY(device.node().interrupts(DeviceTree::get()));
     if (interrupts.size() != 4)
         return EINVAL; // The devicetree binding requires 4 interrupts.

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -362,9 +362,7 @@ void init_stage2(void*)
 
     auto boot_profiling = kernel_command_line().is_boot_profiling_enabled();
 
-    if (!PCI::Access::is_disabled()) {
-        USB::USBManagement::initialize();
-    }
+    USB::USBManagement::initialize();
     SysFSFirmwareDirectory::initialize();
 
     if (!PCI::Access::is_disabled()) {

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -13,7 +13,7 @@
 #include <Kernel/Bus/USB/EHCI/EHCIController.h>
 #include <Kernel/Bus/USB/UHCI/UHCIController.h>
 #include <Kernel/Bus/USB/USBManagement.h>
-#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+#include <Kernel/Bus/USB/xHCI/PCIxHCIController.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.h>
 #include <Kernel/Sections.h>
 
@@ -59,7 +59,7 @@ UNMAP_AFTER_INIT void USBManagement::enumerate_controllers()
             return;
         case xHCI: {
             dmesgln("USBManagement: xHCI controller found at {}", device_identifier.address());
-            auto xhci_controller_or_error = xHCIController::try_to_initialize(device_identifier);
+            auto xhci_controller_or_error = PCIxHCIController::try_to_initialize(device_identifier);
             if (xhci_controller_or_error.is_error())
                 dmesgln("USBManagement: Failed initializing xHCI controller - {}", xhci_controller_or_error.error());
             else

--- a/Kernel/Bus/USB/USBManagement.h
+++ b/Kernel/Bus/USB/USBManagement.h
@@ -25,6 +25,8 @@ public:
     static LockRefPtr<Driver> get_driver_by_name(StringView name);
     static void unregister_driver(NonnullLockRefPtr<Driver> driver);
 
+    static void add_recipe(DeviceTree::DeviceRecipe<NonnullLockRefPtr<USBController>>);
+
     static Vector<NonnullLockRefPtr<Driver>>& available_drivers();
 
 private:

--- a/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/USB/USBManagement.h>
+#include <Kernel/Bus/USB/xHCI/DeviceTreexHCIController.h>
+#include <Kernel/Bus/USB/xHCI/xHCIInterrupter.h>
+#include <Kernel/Firmware/DeviceTree/DeviceTree.h>
+#include <Kernel/Firmware/DeviceTree/Driver.h>
+#include <Kernel/Firmware/DeviceTree/Management.h>
+
+namespace Kernel::USB {
+
+ErrorOr<NonnullLockRefPtr<DeviceTreexHCIController>> DeviceTreexHCIController::try_to_initialize(DeviceTree::Device::Resource registers_resource, StringView node_name, size_t interrupt_number)
+{
+    auto registers_mapping = TRY(Memory::map_typed_writable<u8>(registers_resource.paddr));
+
+    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) DeviceTreexHCIController(move(registers_mapping), node_name, interrupt_number)));
+    TRY(controller->initialize());
+    return controller;
+}
+
+UNMAP_AFTER_INIT DeviceTreexHCIController::DeviceTreexHCIController(Memory::TypedMapping<u8> registers_mapping, StringView node_name, size_t interrupt_number)
+    : xHCIController(move(registers_mapping))
+    , m_node_name(node_name)
+    , m_interrupt_number(interrupt_number)
+{
+}
+
+ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> DeviceTreexHCIController::create_interrupter(u16 interrupter_id)
+{
+    return TRY(xHCIDeviceTreeInterrupter::create(*this, m_interrupt_number, interrupter_id));
+}
+
+static constinit Array const compatibles_array = {
+    "generic-xhci"sv,
+};
+
+DEVICETREE_DRIVER(DeviceTreexHCIControllerDriver, compatibles_array);
+
+// https://www.kernel.org/doc/Documentation/devicetree/bindings/usb/generic-xhci.yaml
+ErrorOr<void> DeviceTreexHCIControllerDriver::probe(DeviceTree::Device const& device, StringView) const
+{
+    auto registers_resource = TRY(device.get_resource(0));
+    auto interrupt = TRY(device.node().interrupts(DeviceTree::get()))[0];
+
+    // FIXME: Don't depend on a specific interrupt descriptor format and implement proper devicetree interrupt mapping/translation.
+    if (!interrupt.domain_root->is_compatible_with("arm,gic-400"sv) && !interrupt.domain_root->is_compatible_with("arm,cortex-a15-gic"sv))
+        return ENOTSUP;
+    if (interrupt.interrupt_identifier.size() != 3 * sizeof(BigEndian<u32>))
+        return ENOTSUP;
+
+    // The interrupt type is in the first cell. It should be 0 for SPIs.
+    if (reinterpret_cast<BigEndian<u32> const*>(interrupt.interrupt_identifier.data())[0] != 0)
+        return ENOTSUP;
+
+    // The interrupt number is in the second cell.
+    // GIC interrupts 32-1019 are for SPIs, so add 32 to get the GIC interrupt ID.
+    auto interrupt_number = (reinterpret_cast<BigEndian<u32> const*>(interrupt.interrupt_identifier.data())[1]) + 32;
+
+    DeviceTree::DeviceRecipe<NonnullLockRefPtr<USBController>> recipe {
+        name(),
+        device.node_name(),
+        [registers_resource, node_name = device.node_name(), interrupt_number] {
+            return DeviceTreexHCIController::try_to_initialize(registers_resource, node_name, interrupt_number);
+        },
+    };
+
+    USBManagement::add_recipe(move(recipe));
+
+    return {};
+}
+
+}

--- a/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.h
+++ b/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+#include <Kernel/Firmware/DeviceTree/Device.h>
+
+namespace Kernel::USB {
+
+class DeviceTreexHCIController final : public xHCIController {
+public:
+    static ErrorOr<NonnullLockRefPtr<DeviceTreexHCIController>> try_to_initialize(DeviceTree::Device::Resource, StringView node_name, size_t interrupt_number);
+
+private:
+    DeviceTreexHCIController(Memory::TypedMapping<u8> registers_mapping, StringView node_name, size_t interrupt_number);
+
+    // ^xHCIController
+    virtual bool using_message_signalled_interrupts() const override { return m_using_message_signalled_interrupts; }
+    virtual ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
+    virtual ErrorOr<void> write_dmesgln_prefix(StringBuilder& builder) const override
+    {
+        TRY(builder.try_appendff("xHCI: {}: "sv, m_node_name));
+        return {};
+    }
+
+    StringView m_node_name;
+    size_t m_interrupt_number { 0 };
+    bool m_using_message_signalled_interrupts { false };
+};
+
+}

--- a/Kernel/Bus/USB/xHCI/PCIxHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/PCIxHCIController.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/BarMapping.h>
+#include <Kernel/Bus/PCI/IDs.h>
+#include <Kernel/Bus/USB/xHCI/PCIxHCIController.h>
+#include <Kernel/Bus/USB/xHCI/xHCIInterrupter.h>
+
+namespace Kernel::USB {
+
+ErrorOr<NonnullLockRefPtr<PCIxHCIController>> PCIxHCIController::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier)
+{
+    auto registers_mapping = TRY(PCI::map_bar<u8>(pci_device_identifier, PCI::HeaderType0BaseRegister::BAR0));
+    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PCIxHCIController(pci_device_identifier, move(registers_mapping))));
+
+    PCI::enable_bus_mastering(pci_device_identifier);
+    PCI::enable_memory_space(pci_device_identifier);
+
+    auto interrupt_type = TRY(controller->reserve_irqs(1, true)); // TODO: Support more than one interrupter using MSI/MSI-X
+    controller->m_using_message_signalled_interrupts = interrupt_type != PCI::InterruptType::PIN;
+
+    TRY(controller->initialize());
+    return controller;
+}
+
+UNMAP_AFTER_INIT PCIxHCIController::PCIxHCIController(PCI::DeviceIdentifier const& pci_device_identifier, Memory::TypedMapping<u8> registers_mapping)
+    : xHCIController(move(registers_mapping))
+    , PCI::Device(pci_device_identifier)
+{
+    if (device_identifier().hardware_id().vendor_id == PCI::VendorID::Intel)
+        intel_quirk_enable_xhci_ports();
+}
+
+void PCIxHCIController::intel_quirk_enable_xhci_ports()
+{
+    // Intel chipsets that include both xHCI and EHCI USB controllers default to configuring their USB ports to be attached to the EHCI controller,
+    // Attach them to the xHCI controller instead.
+    bool ehci_controller_found = false;
+    MUST(PCI::enumerate([&ehci_controller_found](PCI::DeviceIdentifier const& device_identifier) {
+        if (device_identifier.hardware_id().vendor_id != PCI::VendorID::Intel
+            || device_identifier.class_code() != PCI::ClassID::SerialBus
+            || device_identifier.subclass_code() != PCI::SerialBus::SubclassID::USB
+            || device_identifier.prog_if() != PCI::SerialBus::USBProgIf::EHCI)
+            return;
+        ehci_controller_found = true;
+    }));
+    if (!ehci_controller_found)
+        return;
+    dmesgln_xhci("Switching Intel chipset USB ports to xHCI instead of EHCI");
+    SpinlockLocker const locker(device_identifier().operation_lock());
+    // Enable USB3 Ports
+    PCI::write32_locked(device_identifier(), intel_xhci_usb3_port_super_speed_enable_offset, PCI::read32_locked(device_identifier(), intel_xhci_usb3_port_routing_mask_offset));
+    // Enable USB2 Ports
+    PCI::write32_locked(device_identifier(), intel_xhci_usb2_port_routing_offset, PCI::read32_locked(device_identifier(), intel_xhci_usb2_port_routing_mask_offset));
+}
+
+ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> PCIxHCIController::create_interrupter(u16 interrupter_id)
+{
+    return TRY(xHCIPCIInterrupter::create(*this, interrupter_id));
+}
+
+}

--- a/Kernel/Bus/USB/xHCI/PCIxHCIController.h
+++ b/Kernel/Bus/USB/xHCI/PCIxHCIController.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+
+namespace Kernel::USB {
+
+class PCIxHCIController final
+    : public xHCIController
+    , public PCI::Device {
+
+public:
+    static ErrorOr<NonnullLockRefPtr<PCIxHCIController>> try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier);
+
+    // ^PCI::Device
+    virtual StringView device_name() const override { return "xHCI"sv; }
+
+private:
+    PCIxHCIController(PCI::DeviceIdentifier const&, Memory::TypedMapping<u8> registers_mapping);
+
+    // ^xHCIController
+    virtual bool using_message_signalled_interrupts() const override { return m_using_message_signalled_interrupts; }
+    virtual ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
+    virtual ErrorOr<void> write_dmesgln_prefix(StringBuilder& builder) const override
+    {
+        TRY(builder.try_appendff("{}: {}: "sv, device_name(), device_identifier().address()));
+        return {};
+    }
+
+    void intel_quirk_enable_xhci_ports();
+
+    static constexpr PCI::RegisterOffset intel_xhci_usb2_port_routing_offset = static_cast<PCI::RegisterOffset>(0xD0);
+    static constexpr PCI::RegisterOffset intel_xhci_usb2_port_routing_mask_offset = static_cast<PCI::RegisterOffset>(0xD4);
+    static constexpr PCI::RegisterOffset intel_xhci_usb3_port_super_speed_enable_offset = static_cast<PCI::RegisterOffset>(0xD8);
+    static constexpr PCI::RegisterOffset intel_xhci_usb3_port_routing_mask_offset = static_cast<PCI::RegisterOffset>(0xDC);
+
+    bool m_using_message_signalled_interrupts { false };
+};
+
+}

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -16,10 +16,12 @@
 namespace Kernel::USB {
 
 class xHCIPCIInterrupter;
+class xHCIDeviceTreeInterrupter;
 
 class xHCIController
     : public USBController {
     friend class xHCIPCIInterrupter;
+    friend class xHCIDeviceTreeInterrupter;
 
 public:
     virtual ~xHCIController() override;

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
@@ -28,4 +28,23 @@ bool xHCIPCIInterrupter::handle_irq()
     return true;
 }
 
+ErrorOr<NonnullOwnPtr<xHCIDeviceTreeInterrupter>> xHCIDeviceTreeInterrupter::create(DeviceTreexHCIController& controller, size_t irq, u16 interrupter_id)
+{
+    return TRY(adopt_nonnull_own_or_enomem(new (nothrow) xHCIDeviceTreeInterrupter(controller, interrupter_id, irq)));
+}
+
+xHCIDeviceTreeInterrupter::xHCIDeviceTreeInterrupter(DeviceTreexHCIController& controller, u16 interrupter_id, size_t irq)
+    : IRQHandler(irq)
+    , m_controller(controller)
+    , m_interrupter_id(interrupter_id)
+{
+    enable_irq();
+}
+
+bool xHCIDeviceTreeInterrupter::handle_irq()
+{
+    m_controller.handle_interrupt(m_interrupter_id);
+    return true;
+}
+
 }

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.cpp
@@ -8,13 +8,13 @@
 
 namespace Kernel::USB {
 
-ErrorOr<NonnullOwnPtr<xHCIInterrupter>> xHCIInterrupter::create(xHCIController& controller, u16 interrupter_id)
+ErrorOr<NonnullOwnPtr<xHCIPCIInterrupter>> xHCIPCIInterrupter::create(PCIxHCIController& controller, u16 interrupter_id)
 {
     auto irq = TRY(controller.allocate_irq(0));
-    return TRY(adopt_nonnull_own_or_enomem(new (nothrow) xHCIInterrupter(controller, interrupter_id, irq)));
+    return TRY(adopt_nonnull_own_or_enomem(new (nothrow) xHCIPCIInterrupter(controller, interrupter_id, irq)));
 }
 
-xHCIInterrupter::xHCIInterrupter(xHCIController& controller, u16 interrupter_id, u16 irq)
+xHCIPCIInterrupter::xHCIPCIInterrupter(PCIxHCIController& controller, u16 interrupter_id, u16 irq)
     : PCI::IRQHandler(controller, irq)
     , m_controller(controller)
     , m_interrupter_id(interrupter_id)
@@ -22,9 +22,9 @@ xHCIInterrupter::xHCIInterrupter(xHCIController& controller, u16 interrupter_id,
     enable_irq();
 }
 
-bool xHCIInterrupter::handle_irq()
+bool xHCIPCIInterrupter::handle_irq()
 {
-    m_controller.handle_interrupt({}, m_interrupter_id);
+    m_controller.handle_interrupt(m_interrupter_id);
     return true;
 }
 

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
@@ -8,23 +8,23 @@
 
 #include <AK/StdLibExtras.h>
 #include <Kernel/Bus/PCI/Device.h>
-#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+#include <Kernel/Bus/USB/xHCI/PCIxHCIController.h>
 #include <Kernel/Interrupts/PCIIRQHandler.h>
 
 namespace Kernel::USB {
 
-class xHCIInterrupter final : public PCI::IRQHandler {
+class xHCIPCIInterrupter final : public PCI::IRQHandler {
 public:
-    static ErrorOr<NonnullOwnPtr<xHCIInterrupter>> create(xHCIController&, u16 interrupter_id);
+    static ErrorOr<NonnullOwnPtr<xHCIPCIInterrupter>> create(PCIxHCIController&, u16 interrupter_id);
 
     virtual StringView purpose() const override { return "xHCI Interrupter"sv; }
 
 private:
-    xHCIInterrupter(xHCIController& controller, u16 interrupter_id, u16 irq);
+    xHCIPCIInterrupter(PCIxHCIController& controller, u16 interrupter_id, u16 irq);
 
     virtual bool handle_irq() override;
 
-    xHCIController& m_controller;
+    PCIxHCIController& m_controller;
     u16 m_interrupter_id { 0 };
 };
 

--- a/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
+++ b/Kernel/Bus/USB/xHCI/xHCIInterrupter.h
@@ -8,7 +8,9 @@
 
 #include <AK/StdLibExtras.h>
 #include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Bus/USB/xHCI/DeviceTreexHCIController.h>
 #include <Kernel/Bus/USB/xHCI/PCIxHCIController.h>
+#include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Interrupts/PCIIRQHandler.h>
 
 namespace Kernel::USB {
@@ -25,6 +27,21 @@ private:
     virtual bool handle_irq() override;
 
     PCIxHCIController& m_controller;
+    u16 m_interrupter_id { 0 };
+};
+
+class xHCIDeviceTreeInterrupter final : public IRQHandler {
+public:
+    static ErrorOr<NonnullOwnPtr<xHCIDeviceTreeInterrupter>> create(DeviceTreexHCIController&, size_t irq, u16 interrupter_id);
+
+    virtual StringView purpose() const override { return "xHCI Interrupter"sv; }
+
+private:
+    xHCIDeviceTreeInterrupter(DeviceTreexHCIController& controller, u16 interrupter_id, size_t irq);
+
+    virtual bool handle_irq() override;
+
+    DeviceTreexHCIController& m_controller;
     u16 m_interrupter_id { 0 };
 };
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -34,6 +34,7 @@ set(KERNEL_SOURCES
     Bus/USB/EHCI/EHCIController.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
+    Bus/USB/xHCI/DeviceTreexHCIController.cpp
     Bus/USB/xHCI/PCIxHCIController.cpp
     Bus/USB/xHCI/xHCIController.cpp
     Bus/USB/xHCI/xHCIInterrupter.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -34,6 +34,7 @@ set(KERNEL_SOURCES
     Bus/USB/EHCI/EHCIController.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
+    Bus/USB/xHCI/PCIxHCIController.cpp
     Bus/USB/xHCI/xHCIController.cpp
     Bus/USB/xHCI/xHCIInterrupter.cpp
     Bus/USB/xHCI/xHCIRootHub.cpp

--- a/Kernel/Devices/GPU/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/DisplayConnector.cpp
@@ -33,13 +33,16 @@ DisplayConnector::DisplayConnector(size_t framebuffer_resource_size, bool enable
 {
 }
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> DisplayConnector::vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool)
+ErrorOr<File::VMObjectAndMemoryType> DisplayConnector::vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool)
 {
     VERIFY(m_shared_framebuffer_vmobject);
     if (offset != 0)
         return Error::from_errno(ENOTSUP);
 
-    return *m_shared_framebuffer_vmobject;
+    return VMObjectAndMemoryType {
+        .vmobject = *m_shared_framebuffer_vmobject,
+        .memory_type = m_framebuffer_region->memory_type(),
+    };
 }
 
 ErrorOr<size_t> DisplayConnector::read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t)

--- a/Kernel/Devices/GPU/DisplayConnector.h
+++ b/Kernel/Devices/GPU/DisplayConnector.h
@@ -137,7 +137,7 @@ private:
     virtual bool can_write(OpenFileDescription const&, u64) const final override { return true; }
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override final;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override final;
-    virtual ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64&, bool) override final;
+    virtual ErrorOr<VMObjectAndMemoryType> vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64&, bool) override final;
     virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override final;
     virtual StringView class_name() const override final { return "DisplayConnector"sv; }
 

--- a/Kernel/Devices/Generic/MemoryDevice.cpp
+++ b/Kernel/Devices/Generic/MemoryDevice.cpp
@@ -38,7 +38,7 @@ ErrorOr<size_t> MemoryDevice::read(OpenFileDescription&, u64 offset, UserOrKerne
     return length;
 }
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> MemoryDevice::vmobject_for_mmap(Process&, Memory::VirtualRange const& range, u64& offset, bool)
+ErrorOr<File::VMObjectAndMemoryType> MemoryDevice::vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const& range, u64& offset, bool)
 {
     auto viewed_address = PhysicalAddress(offset);
 
@@ -58,7 +58,10 @@ ErrorOr<NonnullLockRefPtr<Memory::VMObject>> MemoryDevice::vmobject_for_mmap(Pro
     }
 
     offset = 0;
-    return TRY(Memory::AnonymousVMObject::try_create_for_physical_range(viewed_address, range.size()));
+    return VMObjectAndMemoryType {
+        .vmobject = TRY(Memory::AnonymousVMObject::try_create_for_physical_range(viewed_address, range.size())),
+        .memory_type = Memory::MemoryType::IO,
+    };
 }
 
 }

--- a/Kernel/Devices/Generic/MemoryDevice.h
+++ b/Kernel/Devices/Generic/MemoryDevice.h
@@ -19,7 +19,7 @@ public:
     static NonnullRefPtr<MemoryDevice> must_create();
     ~MemoryDevice();
 
-    virtual ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
+    virtual ErrorOr<VMObjectAndMemoryType> vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
 
 private:
     MemoryDevice();

--- a/Kernel/Devices/KCOVDevice.cpp
+++ b/Kernel/Devices/KCOVDevice.cpp
@@ -71,7 +71,7 @@ ErrorOr<void> KCOVDevice::ioctl(OpenFileDescription&, unsigned request, Userspac
     }
 }
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> KCOVDevice::vmobject_for_mmap(Process& process, Memory::VirtualRange const&, u64&, bool)
+ErrorOr<File::VMObjectAndMemoryType> KCOVDevice::vmobject_and_memory_type_for_mmap(Process& process, Memory::VirtualRange const&, u64&, bool)
 {
     auto* kcov_instance = process.kcov_instance();
     VERIFY(kcov_instance != nullptr); // Should have happened on fd open()
@@ -79,7 +79,10 @@ ErrorOr<NonnullLockRefPtr<Memory::VMObject>> KCOVDevice::vmobject_for_mmap(Proce
     if (!kcov_instance->vmobject())
         return ENOBUFS; // mmaped, before KCOV_SETBUFSIZE
 
-    return *kcov_instance->vmobject();
+    return VMObjectAndMemoryType {
+        .vmobject = *kcov_instance->vmobject(),
+        .memory_type = Memory::MemoryType::Normal,
+    };
 }
 
 }

--- a/Kernel/Devices/KCOVDevice.h
+++ b/Kernel/Devices/KCOVDevice.h
@@ -19,7 +19,7 @@ public:
     static void free_process();
 
     // ^File
-    ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
+    ErrorOr<VMObjectAndMemoryType> vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
     virtual ErrorOr<NonnullRefPtr<OpenFileDescription>> open(int options) override;
 
 protected:

--- a/Kernel/Devices/Storage/SD/SDHostController.cpp
+++ b/Kernel/Devices/Storage/SD/SDHostController.cpp
@@ -963,7 +963,8 @@ ErrorOr<u32> SDHostController::retrieve_sd_clock_frequency()
     if (m_registers->capabilities.base_clock_frequency == 0) {
         // Spec says:
         // If these bits are all 0, the Host System has to get information via another method
-        TODO();
+        dbgln("FIXME: The SD Host Controller does not provide the base clock frequency; get this frequency using another method");
+        return ENOTSUP;
     }
     i64 const one_mhz = 1'000'000;
     return { m_registers->capabilities.base_clock_frequency * one_mhz };

--- a/Kernel/FileSystem/AnonymousFile.cpp
+++ b/Kernel/FileSystem/AnonymousFile.cpp
@@ -17,12 +17,15 @@ AnonymousFile::AnonymousFile(NonnullLockRefPtr<Memory::AnonymousVMObject> vmobje
 
 AnonymousFile::~AnonymousFile() = default;
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> AnonymousFile::vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool)
+ErrorOr<File::VMObjectAndMemoryType> AnonymousFile::vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool)
 {
     if (offset != 0)
         return EINVAL;
 
-    return m_vmobject;
+    return VMObjectAndMemoryType {
+        .vmobject = m_vmobject,
+        .memory_type = Memory::MemoryType::Normal,
+    };
 }
 
 ErrorOr<NonnullOwnPtr<KString>> AnonymousFile::pseudo_path(OpenFileDescription const&) const

--- a/Kernel/FileSystem/AnonymousFile.h
+++ b/Kernel/FileSystem/AnonymousFile.h
@@ -20,7 +20,7 @@ public:
 
     virtual ~AnonymousFile() override;
 
-    virtual ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
+    virtual ErrorOr<VMObjectAndMemoryType> vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
 
 private:
     virtual StringView class_name() const override { return "AnonymousFile"sv; }

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -35,7 +35,7 @@ ErrorOr<void> File::ioctl(OpenFileDescription&, unsigned, Userspace<void*>)
     return ENOTTY;
 }
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> File::vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64&, bool)
+ErrorOr<File::VMObjectAndMemoryType> File::vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64&, bool)
 {
     return ENODEV;
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -64,7 +64,7 @@ public:
 //   - Can be overridden in subclasses to implement arbitrary functionality.
 //   - Subclasses should take care to validate incoming addresses before dereferencing.
 //
-// vmobject_for_mmap()
+// vmobject_and_memory_type_for_mmap()
 //
 //   - Optional. If unimplemented, mmap() on this File will fail with -ENODEV.
 //   - Called by mmap() when userspace wants to memory-map this File somewhere.
@@ -90,8 +90,13 @@ public:
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) = 0;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) = 0;
     virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg);
-    virtual ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared);
     virtual ErrorOr<struct stat> stat() const { return EBADF; }
+
+    struct VMObjectAndMemoryType {
+        NonnullLockRefPtr<Memory::VMObject> vmobject;
+        Memory::MemoryType memory_type;
+    };
+    virtual ErrorOr<VMObjectAndMemoryType> vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared);
 
     // Although this might be better described "name" or "description", these terms already have other meanings.
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_path(OpenFileDescription const&) const = 0;

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -81,11 +81,18 @@ ErrorOr<void> InodeFile::ioctl(OpenFileDescription& description, unsigned reques
     }
 }
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> InodeFile::vmobject_for_mmap(Process&, Memory::VirtualRange const& range, u64& offset, bool shared)
+ErrorOr<File::VMObjectAndMemoryType> InodeFile::vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const& range, u64& offset, bool shared)
 {
-    if (shared)
-        return TRY(Memory::SharedInodeVMObject::try_create_with_inode_and_range(inode(), offset, range.size()));
-    return TRY(Memory::PrivateInodeVMObject::try_create_with_inode_and_range(inode(), offset, range.size()));
+    if (shared) {
+        return VMObjectAndMemoryType {
+            .vmobject = TRY(Memory::SharedInodeVMObject::try_create_with_inode_and_range(inode(), offset, range.size())),
+            .memory_type = Memory::MemoryType::Normal,
+        };
+    }
+    return VMObjectAndMemoryType {
+        .vmobject = TRY(Memory::PrivateInodeVMObject::try_create_with_inode_and_range(inode(), offset, range.size())),
+        .memory_type = Memory::MemoryType::Normal,
+    };
 }
 
 ErrorOr<NonnullOwnPtr<KString>> InodeFile::pseudo_path(OpenFileDescription const&) const

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -33,7 +33,7 @@ public:
     virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;
     virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override;
-    virtual ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
+    virtual ErrorOr<VMObjectAndMemoryType> vmobject_and_memory_type_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared) override;
     virtual ErrorOr<struct stat> stat() const override { return inode().metadata().stat(); }
 
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_path(OpenFileDescription const&) const override;

--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -379,9 +379,9 @@ InodeMetadata OpenFileDescription::metadata() const
     return {};
 }
 
-ErrorOr<NonnullLockRefPtr<Memory::VMObject>> OpenFileDescription::vmobject_for_mmap(Process& process, Memory::VirtualRange const& range, u64& offset, bool shared)
+ErrorOr<File::VMObjectAndMemoryType> OpenFileDescription::vmobject_for_mmap(Process& process, Memory::VirtualRange const& range, u64& offset, bool shared)
 {
-    return m_file->vmobject_for_mmap(process, range, offset, shared);
+    return m_file->vmobject_and_memory_type_for_mmap(process, range, offset, shared);
 }
 
 ErrorOr<void> OpenFileDescription::truncate(u64 length)

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -95,7 +95,7 @@ public:
     RefPtr<Custody> custody();
     RefPtr<Custody const> custody() const;
 
-    ErrorOr<NonnullLockRefPtr<Memory::VMObject>> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared);
+    ErrorOr<File::VMObjectAndMemoryType> vmobject_for_mmap(Process&, Memory::VirtualRange const&, u64& offset, bool shared);
 
     bool is_blocking() const;
     void set_blocking(bool b);

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -172,12 +172,12 @@ ErrorOr<Region*> AddressSpace::allocate_region(RandomizeVirtualAddress randomize
     return region.leak_ptr();
 }
 
-ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(VirtualRange requested_range, NonnullLockRefPtr<VMObject> vmobject, size_t offset_in_vmobject, StringView name, int prot, bool shared)
+ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(VirtualRange requested_range, NonnullLockRefPtr<VMObject> vmobject, size_t offset_in_vmobject, StringView name, int prot, bool shared, MemoryType memory_type)
 {
-    return allocate_region_with_vmobject(RandomizeVirtualAddress::Yes, requested_range.base(), requested_range.size(), PAGE_SIZE, move(vmobject), offset_in_vmobject, name, prot, shared);
+    return allocate_region_with_vmobject(RandomizeVirtualAddress::Yes, requested_range.base(), requested_range.size(), PAGE_SIZE, move(vmobject), offset_in_vmobject, name, prot, shared, memory_type);
 }
 
-ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(RandomizeVirtualAddress randomize_virtual_address, VirtualAddress requested_address, size_t requested_size, size_t requested_alignment, NonnullLockRefPtr<VMObject> vmobject, size_t offset_in_vmobject, StringView name, int prot, bool shared)
+ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(RandomizeVirtualAddress randomize_virtual_address, VirtualAddress requested_address, size_t requested_size, size_t requested_alignment, NonnullLockRefPtr<VMObject> vmobject, size_t offset_in_vmobject, StringView name, int prot, bool shared, MemoryType memory_type)
 {
     if (!requested_address.is_page_aligned())
         return EINVAL;
@@ -201,7 +201,7 @@ ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(RandomizeVirtualAdd
     if (!name.is_null())
         region_name = TRY(KString::try_create(name));
 
-    auto region = TRY(Region::create_unplaced(move(vmobject), offset_in_vmobject, move(region_name), prot_to_region_access_flags(prot), MemoryType::Normal, shared));
+    auto region = TRY(Region::create_unplaced(move(vmobject), offset_in_vmobject, move(region_name), prot_to_region_access_flags(prot), memory_type, shared));
 
     if (requested_address.is_null())
         TRY(m_region_tree.place_anywhere(*region, randomize_virtual_address, size, alignment));

--- a/Kernel/Memory/AddressSpace.h
+++ b/Kernel/Memory/AddressSpace.h
@@ -35,8 +35,8 @@ public:
 
     ErrorOr<void> unmap_mmap_range(VirtualAddress, size_t);
 
-    ErrorOr<Region*> allocate_region_with_vmobject(VirtualRange requested_range, NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, StringView name, int prot, bool shared);
-    ErrorOr<Region*> allocate_region_with_vmobject(RandomizeVirtualAddress, VirtualAddress requested_address, size_t requested_size, size_t requested_alignment, NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, StringView name, int prot, bool shared);
+    ErrorOr<Region*> allocate_region_with_vmobject(VirtualRange requested_range, NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, StringView name, int prot, bool shared, MemoryType = MemoryType::Normal);
+    ErrorOr<Region*> allocate_region_with_vmobject(RandomizeVirtualAddress, VirtualAddress requested_address, size_t requested_size, size_t requested_alignment, NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, StringView name, int prot, bool shared, MemoryType = MemoryType::Normal);
     ErrorOr<Region*> allocate_region(RandomizeVirtualAddress, VirtualAddress requested_address, size_t requested_size, size_t requested_alignment, StringView name, int prot = PROT_READ | PROT_WRITE, AllocationStrategy strategy = AllocationStrategy::Reserve);
     void deallocate_region(Region& region);
     NonnullOwnPtr<Region> take_region(Region& region);

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -88,9 +88,9 @@ ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_with
     return adopt_nonnull_lock_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages), strategy, move(committed_pages)));
 }
 
-ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_physically_contiguous_with_size(size_t size)
+ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_physically_contiguous_with_size(size_t size, MemoryType memory_type_for_zero_fill)
 {
-    auto contiguous_physical_pages = TRY(MM.allocate_contiguous_physical_pages(size));
+    auto contiguous_physical_pages = TRY(MM.allocate_contiguous_physical_pages(size, memory_type_for_zero_fill));
 
     auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalRAMPage>>::create(contiguous_physical_pages.span()));
 

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -22,7 +22,7 @@ public:
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_for_physical_range(PhysicalAddress paddr, size_t size);
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalRAMPage>>);
     static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_purgeable_with_size(size_t, AllocationStrategy);
-    static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_physically_contiguous_with_size(size_t);
+    static ErrorOr<NonnullLockRefPtr<AnonymousVMObject>> try_create_physically_contiguous_with_size(size_t, MemoryType memory_type_for_zero_fill);
     virtual ErrorOr<NonnullLockRefPtr<VMObject>> try_clone() override;
 
     [[nodiscard]] NonnullRefPtr<PhysicalRAMPage> allocate_committed_page(Badge<Region>);

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -165,7 +165,7 @@ public:
 
     NonnullRefPtr<PhysicalRAMPage> allocate_committed_physical_page(Badge<CommittedPhysicalPageSet>, ShouldZeroFill = ShouldZeroFill::Yes);
     ErrorOr<NonnullRefPtr<PhysicalRAMPage>> allocate_physical_page(ShouldZeroFill = ShouldZeroFill::Yes, bool* did_purge = nullptr);
-    ErrorOr<Vector<NonnullRefPtr<PhysicalRAMPage>>> allocate_contiguous_physical_pages(size_t size);
+    ErrorOr<Vector<NonnullRefPtr<PhysicalRAMPage>>> allocate_contiguous_physical_pages(size_t size, MemoryType memory_type_for_zero_fill);
     void deallocate_physical_page(PhysicalAddress);
 
     ErrorOr<NonnullOwnPtr<Region>> allocate_contiguous_kernel_region(size_t, StringView name, Region::Access access, MemoryType = MemoryType::Normal);


### PR DESCRIPTION
This PR includes all changes necessary to make us boot to desktop on the Pi 4!

Our SDHCI driver doesn't seem to work on the Pi 4 yet. So this PR adds support for the USB 2-only xHCI host controller that is available on to the USB-C connector.
This xHCI controller can be enabled by setting [`otg_mode=1` in the config.txt](https://www.raspberrypi.com/documentation/computers/config_txt.html#otg_mode-raspberry-pi-4-only).

If you want to try this, you need to either have a USB-C dock that can supply power to the Pi or connect power directly to the GPIOs and use a USB-C to USB-A adapter (like I do).

Here are some instructions on how to get it running on a Pi 4:
- Create a FAT partition on a microSD card for the bootloader files (putting those files on a USB drive partition should work as well, but I haven't tried that yet)
- Copy all files from https://github.com/raspberrypi/firmware/tree/master/boot onto that FAT partition
- Create a cmdline.txt file containing `serial_debug root=block3:0`
- Create a config.txt file with the following content:
```
arm_64bit=1
uart_2ndstage=1
enable_uart=1
enable_gic=1
dtoverlay=disable-bt
otg_mode=1
```
- Copy Build/aarch64/kernel8.img to the FAT partition
- Write Build/aarch64/_disk_image to a USB drive