### PR TITLE
Kernel: Make UserOrKernelBuffer a lot more safe to use

### DIFF
--- a/Kernel/Devices/Serial/VirtIO/Console.cpp
+++ b/Kernel/Devices/Serial/VirtIO/Console.cpp
@@ -210,7 +210,7 @@ void Console::write_control_message(ControlMessage message)
     PhysicalAddress start_of_chunk;
     size_t length_of_chunk;
 
-    auto data = UserOrKernelBuffer::for_kernel_buffer((u8*)&message);
+    auto data = UserOrKernelBuffer::for_kernel_buffer((u8*)&message, sizeof(ControlMessage));
     while (!m_control_transmit_buffer->copy_data_in(data, 0, sizeof(message), start_of_chunk, length_of_chunk)) {
         ringbuffer_lock.unlock();
         m_control_wait_queue.wait_forever();

--- a/Kernel/Devices/Storage/SD/SDHostController.cpp
+++ b/Kernel/Devices/Storage/SD/SDHostController.cpp
@@ -953,7 +953,7 @@ ErrorOr<SD::SDConfigurationRegister> SDHostController::retrieve_sd_configuration
     TRY(transaction_control_with_data_transfer_using_the_dat_line_without_dma(
         SD::Commands::app_send_scr,
         0, 1, 8,
-        UserOrKernelBuffer::for_kernel_buffer(scr.raw), DataTransferType::Read));
+        UserOrKernelBuffer::for_kernel_buffer(scr.raw, sizeof(SD::SDConfigurationRegister)), DataTransferType::Read));
 
     return scr;
 }

--- a/Kernel/Devices/Storage/StorageDevice.cpp
+++ b/Kernel/Devices/Storage/StorageDevice.cpp
@@ -118,7 +118,7 @@ ErrorOr<size_t> StorageDevice::read(OpenFileDescription&, u64 offset, UserOrKern
 
     if (remaining > 0) {
         auto data = TRY(ByteBuffer::create_uninitialized(block_size()));
-        auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(data.data());
+        auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(data.data(), block_size());
         auto read_request = TRY(try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index + whole_blocks, 1, data_buffer, block_size()));
         auto result = read_request->wait();
         if (result.wait_result().was_interrupted())
@@ -191,7 +191,7 @@ ErrorOr<size_t> StorageDevice::write(OpenFileDescription&, u64 offset, UserOrKer
     // partial write, we have to read the block's content first, modify it,
     // then write the whole block back to the disk.
     if (remaining > 0) {
-        auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(partial_write_block->data());
+        auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(partial_write_block->data(), block_size());
         {
             auto read_request = TRY(try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index + whole_blocks, 1, data_buffer, block_size()));
             auto result = read_request->wait();

--- a/Kernel/Devices/TTY/SlavePTY.cpp
+++ b/Kernel/Devices/TTY/SlavePTY.cpp
@@ -60,7 +60,7 @@ ErrorOr<NonnullOwnPtr<KString>> SlavePTY::pseudo_name() const
 void SlavePTY::echo(u8 ch)
 {
     if (should_echo_input()) {
-        auto buffer = UserOrKernelBuffer::for_kernel_buffer(&ch);
+        auto buffer = UserOrKernelBuffer::for_kernel_buffer(&ch, sizeof(u8));
         [[maybe_unused]] auto result = m_master->on_slave_write(buffer, 1);
     }
 }

--- a/Kernel/Devices/TTY/TTY.cpp
+++ b/Kernel/Devices/TTY/TTY.cpp
@@ -94,7 +94,7 @@ ErrorOr<size_t> TTY::write(OpenFileDescription&, u64, UserOrKernelBuffer const& 
                 modified_data[modified_data_size++] = out_ch;
             });
         }
-        auto bytes_written_or_error = on_tty_write(UserOrKernelBuffer::for_kernel_buffer(modified_data), modified_data_size);
+        auto bytes_written_or_error = on_tty_write(UserOrKernelBuffer::for_kernel_buffer(modified_data, num_chars * 2), modified_data_size);
         if (bytes_written_or_error.is_error() || !(m_termios.c_oflag & OPOST) || !(m_termios.c_oflag & ONLCR))
             return bytes_written_or_error;
         auto bytes_written = bytes_written_or_error.value();

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -27,7 +27,7 @@ protected:
 
     virtual ErrorOr<void> initialize_while_locked() override;
 
-    ErrorOr<void> read_block(BlockIndex, UserOrKernelBuffer*, size_t count, u64 offset = 0, bool allow_cache = true) const;
+    ErrorOr<void> read_block(BlockIndex, Optional<UserOrKernelBuffer>, size_t count, u64 offset = 0, bool allow_cache = true) const;
     ErrorOr<void> read_blocks(BlockIndex, unsigned count, UserOrKernelBuffer&, bool allow_cache = true) const;
 
     ErrorOr<void> raw_read(BlockIndex, UserOrKernelBuffer&);

--- a/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
@@ -97,7 +97,7 @@ ErrorOr<void> ISO9660FS::parse_volume_set()
     VERIFY(!m_primary_volume);
 
     auto block = TRY(KBuffer::try_create_with_size("ISO9660FS: Temporary volume descriptor storage"sv, m_device_block_size, Memory::Region::Access::Read | Memory::Region::Access::Write));
-    auto block_buffer = UserOrKernelBuffer::for_kernel_buffer(block->data());
+    auto block_buffer = UserOrKernelBuffer::for_kernel_buffer(*block);
 
     auto current_block_index = first_data_area_block;
     while (true) {
@@ -253,7 +253,7 @@ ErrorOr<NonnullLockRefPtr<ISO9660FSDirectoryEntry>> ISO9660FS::directory_entry_f
     }
 
     auto blocks = TRY(KBuffer::try_create_with_size("ISO9660FS: Directory traversal buffer"sv, data_length, Memory::Region::Access::Read | Memory::Region::Access::Write));
-    auto blocks_buffer = UserOrKernelBuffer::for_kernel_buffer(blocks->data());
+    auto blocks_buffer = UserOrKernelBuffer::for_kernel_buffer(*blocks);
     TRY(raw_read_blocks(BlockBasedFileSystem::BlockIndex { extent_location }, data_length / device_block_size(), blocks_buffer));
     auto entry = TRY(ISO9660FSDirectoryEntry::try_create(extent_location, data_length, move(blocks)));
     m_directory_entry_cache.set(key, entry);

--- a/Kernel/FileSystem/ISO9660FS/Inode.cpp
+++ b/Kernel/FileSystem/ISO9660FS/Inode.cpp
@@ -21,7 +21,7 @@ ErrorOr<size_t> ISO9660Inode::read_bytes_locked(off_t offset, size_t size, UserO
         return 0;
 
     auto block = TRY(KBuffer::try_create_with_size("ISO9660FS: Inode read buffer"sv, fs().device_block_size()));
-    auto block_buffer = UserOrKernelBuffer::for_kernel_buffer(block->data());
+    auto block_buffer = UserOrKernelBuffer::for_kernel_buffer(*block);
 
     size_t total_bytes = min(size, data_length - offset);
     size_t nread = 0;

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -64,7 +64,7 @@ ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(VFSRootContext const& vfs
     VERIFY(size() <= MAXPATHLEN);
 
     Array<u8, MAXPATHLEN> contents;
-    auto read_bytes = TRY(read_until_filled_or_end(0, contents.size(), UserOrKernelBuffer::for_kernel_buffer(contents.data()), nullptr));
+    auto read_bytes = TRY(read_until_filled_or_end(0, contents.size(), UserOrKernelBuffer::for_kernel_buffer(contents.data(), MAXPATHLEN), nullptr));
     return VirtualFileSystem::resolve_path(vfs_root_context, credentials, StringView { contents.span().trim(read_bytes) }, base, out_parent, options, symlink_recursion_level);
 }
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -873,7 +873,7 @@ ErrorOr<void> VirtualFileSystem::symlink(VFSRootContext const& vfs_root_context,
 
     auto inode = TRY(parent_inode.create_child(basename, S_IFLNK | 0644, 0, credentials.euid(), credentials.egid()));
 
-    auto target_buffer = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>((u8 const*)target.characters_without_null_termination()));
+    auto target_buffer = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>((u8 const*)target.characters_without_null_termination()), target.length());
     TRY(inode->write_bytes(0, target.length(), target_buffer, nullptr));
     return {};
 }

--- a/Kernel/Library/DoubleBuffer.h
+++ b/Kernel/Library/DoubleBuffer.h
@@ -20,18 +20,18 @@ public:
     ErrorOr<size_t> write(UserOrKernelBuffer const&, size_t);
     ErrorOr<size_t> write(u8 const* data, size_t size)
     {
-        return write(UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data)), size);
+        return write(UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data), size), size);
     }
     ErrorOr<size_t> read(UserOrKernelBuffer&, size_t);
     ErrorOr<size_t> read(u8* data, size_t size)
     {
-        auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
+        auto buffer = UserOrKernelBuffer::for_kernel_buffer(data, size);
         return read(buffer, size);
     }
     ErrorOr<size_t> peek(UserOrKernelBuffer&, size_t);
     ErrorOr<size_t> peek(u8* data, size_t size)
     {
-        auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
+        auto buffer = UserOrKernelBuffer::for_kernel_buffer(data, size);
         return peek(buffer, size);
     }
 

--- a/Kernel/Library/KBuffer.h
+++ b/Kernel/Library/KBuffer.h
@@ -18,7 +18,6 @@
 #include <AK/Assertions.h>
 #include <AK/StringView.h>
 #include <Kernel/Library/StdLib.h> // For memcpy. FIXME: Make memcpy less expensive to access a declaration of in the Kernel.
-#include <Kernel/Library/UserOrKernelBuffer.h>
 #include <Kernel/Memory/MemoryManager.h>
 
 namespace Kernel {
@@ -38,8 +37,6 @@ public:
         memcpy(buffer->data(), bytes.data(), bytes.size());
         return buffer;
     }
-
-    UserOrKernelBuffer as_kernel_buffer() { return UserOrKernelBuffer::for_kernel_buffer(data()); }
 
     [[nodiscard]] u8* data() { return m_region->vaddr().as_ptr(); }
     [[nodiscard]] u8 const* data() const { return m_region->vaddr().as_ptr(); }

--- a/Kernel/Library/UserOrKernelBuffer.cpp
+++ b/Kernel/Library/UserOrKernelBuffer.cpp
@@ -12,6 +12,9 @@ namespace Kernel {
 
 bool UserOrKernelBuffer::is_kernel_buffer() const
 {
+    // NOTE: This is safe to do, because when we instantiate a UserOrKernelBuffer,
+    // we check for the entire range (i.e. use the given size), so now checking only
+    // the base pointer is considered safe.
     return !Memory::is_user_address(VirtualAddress(m_buffer));
 }
 

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -594,7 +594,7 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region, bool m
     u8 page_buffer[PAGE_SIZE];
     auto& inode = inode_vmobject.inode();
 
-    auto buffer = UserOrKernelBuffer::for_kernel_buffer(page_buffer);
+    auto buffer = UserOrKernelBuffer::for_kernel_buffer(page_buffer, PAGE_SIZE);
     auto result = inode.read_bytes(page_index_in_vmobject * PAGE_SIZE, PAGE_SIZE, buffer, nullptr);
 
     if (result.is_error()) {

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -91,7 +91,7 @@ ErrorOr<void> SharedInodeVMObject::sync_impl(off_t offset_in_pages, size_t pages
         u8 page_buffer[PAGE_SIZE];
 
         MM.copy_physical_page(*physical_page, page_buffer);
-        TRY(m_inode->write_bytes(page_index * PAGE_SIZE, PAGE_SIZE, UserOrKernelBuffer::for_kernel_buffer(page_buffer), nullptr));
+        TRY(m_inode->write_bytes(page_index * PAGE_SIZE, PAGE_SIZE, UserOrKernelBuffer::for_kernel_buffer(page_buffer, PAGE_SIZE), nullptr));
     }
 
     return {};

--- a/Kernel/Net/IP/Socket.cpp
+++ b/Kernel/Net/IP/Socket.cpp
@@ -436,7 +436,7 @@ bool IPv4Socket::did_receive(IPv4Address const& source_address, u16 source_port,
             VERIFY(m_can_read);
             return false;
         }
-        auto scratch_buffer = UserOrKernelBuffer::for_kernel_buffer(m_scratch_buffer->data());
+        auto scratch_buffer = UserOrKernelBuffer::for_kernel_buffer(*m_scratch_buffer);
         auto nreceived_or_error = protocol_receive(packet, scratch_buffer, m_scratch_buffer->size(), 0);
         if (nreceived_or_error.is_error())
             return false;

--- a/Kernel/Net/VirtIO/VirtIONetworkAdapter.cpp
+++ b/Kernel/Net/VirtIO/VirtIONetworkAdapter.cpp
@@ -236,7 +236,7 @@ void VirtIONetworkAdapter::handle_queue_update(u16 queue_index)
 
 static bool copy_data_to_chain(VirtIO::QueueChain& chain, Memory::RingBuffer& ring, u8 const* data, size_t length)
 {
-    UserOrKernelBuffer buf = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data));
+    UserOrKernelBuffer buf = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data), length);
 
     size_t offset = 0;
     while (offset < length) {

--- a/Kernel/Syscalls/readlink.cpp
+++ b/Kernel/Syscalls/readlink.cpp
@@ -27,7 +27,7 @@ ErrorOr<FlatPtr> Process::sys$readlink(Userspace<Syscall::SC_readlink_params con
     VERIFY(description->inode()->size() <= MAXPATHLEN);
 
     Array<u8, MAXPATHLEN> link_target;
-    auto read_bytes = TRY(description->inode()->read_until_filled_or_end(0, link_target.size(), UserOrKernelBuffer::for_kernel_buffer(link_target.data()), description));
+    auto read_bytes = TRY(description->inode()->read_until_filled_or_end(0, link_target.size(), UserOrKernelBuffer::for_kernel_buffer(link_target.span()), description));
     auto size_to_copy = min(read_bytes, params.buffer.size);
     TRY(copy_to_user(params.buffer.data, link_target.data(), size_to_copy));
     // Note: we return the whole size here, not the copied size.

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -833,7 +833,7 @@ ErrorOr<void> Process::dump_perfcore()
         dbgln("Failed to generate perfcore for pid {}: Could not allocate buffer.", pid().value());
         return ENOMEM;
     }
-    auto json_buffer = UserOrKernelBuffer::for_kernel_buffer(json->data());
+    auto json_buffer = UserOrKernelBuffer::for_kernel_buffer(*json);
     TRY(description->write(json_buffer, json->size()));
 
     dbgln("Wrote perfcore for pid {} to {}", pid().value(), perfcore_filename);

--- a/Userland/Libraries/LibPartition/PartitionableDevice.cpp
+++ b/Userland/Libraries/LibPartition/PartitionableDevice.cpp
@@ -83,7 +83,7 @@ size_t PartitionableDevice::block_size() const
 ErrorOr<void> PartitionableDevice::read_block(size_t block_index, Bytes block_buffer)
 {
     VERIFY(block_buffer.size() == block_size());
-    auto buffer = UserOrKernelBuffer::for_kernel_buffer(block_buffer.data());
+    auto buffer = UserOrKernelBuffer::for_kernel_buffer(block_buffer);
     bool read_successful = m_device.read_block(block_index, buffer);
     if (!read_successful)
         return Error::from_errno(EIO);


### PR DESCRIPTION
First, we should not allow passing a pointer to UserOrKernelBuffer in the BlockBasedFileSystem code, so instead require to use Optional.

To add memory safety to this component, we require instances to hold the size of the buffer, so offsetting outside of a buffer is no longer possible.

In addition to that, instantiating a new UserOrKernelBuffer is a lot more straightforward, as it can be generated from many AK containers which ensures memory safety by using the actual type or its properties to acquire the buffer size.

Fixes #25547.