### PR TITLE
LibGfx/ISOBMFF: Add JPEG2000PaletteBox

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -38,6 +38,22 @@ struct JPEG2000ColorSpecificationBox final : public Box {
     ByteBuffer icc_data;              // Only set if method == 2
 };
 
+// I.5.3.4 Palette box
+struct JPEG2000PaletteBox final : public Box {
+    BOX_SUBTYPE(JPEG2000PaletteBox);
+
+    struct BitDepth {
+        u8 depth;
+        bool is_signed;
+    };
+    Vector<BitDepth> bit_depths;
+
+    // BitDepth::depth is at most 38 per spec (Table I.13).
+    // i64 is more than enough. Palettes don't have a ton of entries, so memory use here isn't critical.
+    using Color = Vector<i64, 4>;
+    Vector<Color> palette_entries;
+};
+
 // I.5.3.6 Channel Definition box
 struct JPEG2000ChannelDefinitionBox final : public Box {
     BOX_SUBTYPE(JPEG2000ChannelDefinitionBox);

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -50,7 +50,7 @@ struct JPEG2000ChannelDefinitionBox final : public Box {
     Vector<Channel> channels;
 };
 
-// I.5.3.7 Resolution box
+// I.5.3.7 Resolution box (superbox)
 struct JPEG2000ResolutionBox final : public SuperBox {
     BOX_SUBTYPE(JPEG2000ResolutionBox);
 };


### PR DESCRIPTION
For the the jpeg2000 file in object 71 in 0000190.pdf from the PDF dataset (here: 
[out_71.zip](https://github.com/user-attachments/files/18462602/out_71.zip)), before:

```
% Build/lagom/bin/isobmff out_71.jpx  
('jP  ')
- signature = 0x0d0a870a
('ftyp')
- major_brand = 'jp2 '
- minor_version = 0
- compatible_brands = { 'jp2 ', 'jpxb', 'jpx ' }
Unknown Box ('rreq')
[ 22 bytes ]
('jp2h')
  ('ihdr')
  - height = 264
  - width = 14
  - num_components = 1
  - are_components_signed = false
  - bits_per_component = 8
  - compression_type = 7
  - is_colorspace_unknown = 1
  - contains_intellectual_property_rights = 0
  ('colr')
  - method = 1
  - precedence = 2
  - approximation = 1
  - enumerated_color_space = 12
  ('pclr')
  [ 627 bytes ]
  ('cmap')
  [ 16 bytes ]
('jp2c')
- codestream = 2448 bytes
```

After:

```
% Build/lagom/bin/isobmff out_71.jpx  
('jP  ')
- signature = 0x0d0a870a
('ftyp')
- major_brand = 'jp2 '
- minor_version = 0
- compatible_brands = { 'jp2 ', 'jpxb', 'jpx ' }
Unknown Box ('rreq')
[ 22 bytes ]
('jp2h')
  ('ihdr')
  - height = 264
  - width = 14
  - num_components = 1
  - are_components_signed = false
  - bits_per_component = 8
  - compression_type = 7
  - is_colorspace_unknown = 1
  - contains_intellectual_property_rights = 0
  ('colr')
  - method = 1
  - precedence = 2
  - approximation = 1
  - enumerated_color_space = 12
  ('pclr')
  - number_of_entries = 155
  - number_of_palette_columns = 4
  - bit_depths
    - 8, unsigned
    - 8, unsigned
    - 8, unsigned
    - 8, unsigned
  - palette_entries
    - 0x2e 0xa 0x33 0x0 
    - 0x2e 0xa 0x32 0x0 
    - 0x2e 0xa 0x31 0x0 
    - 0x2d 0x9 0x30 0x0 
    - 0x2c 0xa 0x2f 0x0 
    - 0x2c 0xa 0x2e 0x0 
    - 0x2b 0x9 0x2c 0x0 
    - 0x29 0x9 0x2a 0x0 
    - 0x28 0x9 0x28 0x0 
    - 0x26 0x9 0x26 0x0 
    - 0x24 0x8 0x23 0x0 
    - 0x21 0x7 0x20 0x0 
    - 0x2c 0x9 0x2e 0x0 
    - 0x2b 0x9 0x2d 0x0 
    - 0x2a 0x9 0x2b 0x0 
    - 0x28 0x9 0x29 0x0 
    - 0x27 0x9 0x27 0x0 
    - 0x25 0x8 0x25 0x0 
    - 0x23 0x8 0x22 0x0 
    - 0x20 0x7 0x20 0x0 
    - 0x24 0x8 0x24 0x0 
    - 0x22 0x7 0x21 0x0 
    - 0x1f 0x7 0x1e 0x0 
    - 0x2d 0x9 0x31 0x0 
    - 0x2c 0x9 0x2f 0x0 
    - 0x2a 0x9 0x2c 0x0 
    - 0x27 0x9 0x28 0x0 
    - 0x23 0x8 0x23 0x0 
    - 0x21 0x8 0x21 0x0 
    - 0x1e 0x7 0x1d 0x0 
    - 0x22 0x8 0x22 0x0 
    - 0x1d 0x6 0x1c 0x0 
    - 0x29 0x9 0x2b 0x0 
    - 0x26 0x9 0x27 0x0 
    - 0x1f 0x7 0x1f 0x0 
    - 0x1c 0x6 0x1b 0x0 
    - 0x23 0x8 0x24 0x0 
    - 0x21 0x7 0x21 0x0 
    - 0x1e 0x7 0x1e 0x0 
    - 0x1b 0x6 0x1b 0x0 
    - 0x27 0x9 0x29 0x0 
    - 0x25 0x8 0x26 0x0 
    - 0x20 0x8 0x20 0x0 
    - 0x1a 0x6 0x1a 0x0 
    - 0x2a 0x9 0x2d 0x0 
    - 0x22 0x8 0x23 0x0 
    - 0x1d 0x7 0x1d 0x0 
    - 0x1a 0x6 0x19 0x0 
    - 0x2d 0x9 0x2f 0x0 
    - 0x24 0x8 0x25 0x0 
    - 0x20 0x8 0x1f 0x0 
    - 0x1a 0x5 0x19 0x0 
    - 0x2d 0xa 0x31 0x0 
    - 0x2b 0x9 0x2e 0x0 
    - 0x21 0x8 0x22 0x0 
    - 0x19 0x5 0x18 0x0 
    - 0x28 0x9 0x2a 0x0 
    - 0x1c 0x6 0x1c 0x0 
    - 0x27 0x9 0x2a 0x0 
    - 0x21 0x7 0x22 0x0 
    - 0x18 0x5 0x18 0x0 
    - 0x29 0x9 0x2c 0x0 
    - 0x26 0x9 0x28 0x0 
    - 0x2d 0xa 0x32 0x0 
    - 0x2d 0x9 0x32 0x0 
    - 0x2c 0x9 0x31 0x0 
    - 0x2c 0x9 0x30 0x0 
    - 0x2b 0x9 0x2f 0x0 
    - 0x2a 0x9 0x2f 0x0 
    - 0x2a 0x9 0x2e 0x0 
    - 0x29 0x9 0x2e 0x0 
    - 0x29 0x9 0x2d 0x0 
    - 0x29 0x8 0x2d 0x0 
    - 0x28 0x8 0x2c 0x0 
    - 0x2a 0x8 0x2d 0x0 
    - 0x27 0x8 0x2b 0x0 
    - 0x29 0x8 0x2c 0x0 
    - 0x27 0x8 0x2a 0x0 
    - 0x2a 0x8 0x2c 0x0 
    - 0x29 0x8 0x2b 0x0 
    - 0x26 0x8 0x2a 0x0 
    - 0x28 0x8 0x2b 0x0 
    - 0x25 0x8 0x2a 0x0 
    - 0x25 0x7 0x2a 0x0 
    - 0x25 0x8 0x29 0x0 
    - 0x25 0x9 0x27 0x0 
    - 0x24 0x8 0x28 0x0 
    - 0x28 0x8 0x2a 0x0 
    - 0x24 0x8 0x27 0x0 
    - 0x26 0x8 0x29 0x0 
    - 0x28 0x9 0x2b 0x0 
    - 0x22 0x8 0x21 0x0 
    - 0x23 0x8 0x27 0x0 
    - 0x25 0x8 0x28 0x0 
    - 0x25 0x8 0x27 0x0 
    - 0x22 0x8 0x26 0x0 
    - 0x22 0x8 0x25 0x0 
    - 0x22 0x7 0x25 0x0 
    - 0x26 0x9 0x29 0x0 
    - 0x22 0x6 0x25 0x0 
    - 0x21 0x6 0x24 0x0 
    - 0x23 0x8 0x26 0x0 
    - 0x26 0x7 0x29 0x0 
    - 0x26 0x8 0x28 0x0 
    - 0x21 0x7 0x24 0x0 
    - 0x20 0x7 0x23 0x0 
    - 0x26 0x8 0x27 0x0 
    - 0x26 0x7 0x28 0x0 
    - 0x22 0x7 0x26 0x0 
    - 0x24 0x8 0x26 0x0 
    - 0x1f 0x7 0x22 0x0 
    - 0x20 0x7 0x22 0x0 
    - 0x23 0x7 0x25 0x0 
    - 0x25 0x7 0x27 0x0 
    - 0x25 0x7 0x28 0x0 
    - 0x23 0x8 0x25 0x0 
    - 0x1f 0x6 0x22 0x0 
    - 0x1f 0x6 0x21 0x0 
    - 0x1e 0x7 0x21 0x0 
    - 0x1e 0x6 0x21 0x0 
    - 0x21 0x7 0x23 0x0 
    - 0x1d 0x7 0x20 0x0 
    - 0x23 0x7 0x26 0x0 
    - 0x24 0x7 0x26 0x0 
    - 0x20 0x7 0x21 0x0 
    - 0x1c 0x6 0x1f 0x0 
    - 0x1d 0x6 0x20 0x0 
    - 0x1f 0x7 0x21 0x0 
    - 0x1c 0x6 0x1e 0x0 
    - 0x22 0x7 0x24 0x0 
    - 0x1d 0x7 0x1e 0x0 
    - 0x1b 0x5 0x1e 0x0 
    - 0x1e 0x7 0x20 0x0 
    - 0x1b 0x6 0x1e 0x0 
    - 0x1a 0x5 0x1c 0x0 
    - 0x1a 0x5 0x1d 0x0 
    - 0x1d 0x6 0x1f 0x0 
    - 0x21 0x6 0x23 0x0 
    - 0x21 0x7 0x25 0x0 
    - 0x22 0x8 0x24 0x0 
    - 0x1b 0x6 0x1a 0x0 
    - 0x18 0x5 0x17 0x0 
    - 0x19 0x5 0x1c 0x0 
    - 0x19 0x5 0x1b 0x0 
    - 0x18 0x5 0x1a 0x0 
    - 0x1b 0x5 0x1b 0x0 
    - 0x1b 0x5 0x1d 0x0 
    - 0x22 0x7 0x23 0x0 
    - 0x1f 0x7 0x20 0x0 
    - 0x17 0x5 0x1a 0x0 
    - 0x21 0x8 0x23 0x0 
    - 0x1e 0x6 0x1f 0x0 
    - 0x27 0x8 0x29 0x0 
    - 0x27 0x9 0x2b 0x0 
    - 0x25 0x9 0x26 0x0 
  ('cmap')
  [ 16 bytes ]
('jp2c')
- codestream = 2448 bytes
```

Prerequisite to one day loading this jpx file in JPEG2000Loader.