### PR TITLE
Taskbar: Fix applet/clock area background color

### DIFF
--- a/Userland/Services/Taskbar/TaskbarFrame.cpp
+++ b/Userland/Services/Taskbar/TaskbarFrame.cpp
@@ -11,6 +11,6 @@
 void TaskbarFrame::paint_event(GUI::PaintEvent& event)
 {
     GUI::Painter painter(*this);
-    painter.fill_rect(rect(), palette().window());
+    painter.fill_rect(rect(), palette().button());
     Frame::paint_event(event);
 }


### PR DESCRIPTION
To be consistent with WindowServer, the background color should be "button", not "window". This fixes the painting for themes like Nord.