### PR TITLE
LibGfx/ISOBMFF: Add support for jpeg2000 cmap and bpcc boxes

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -54,6 +54,26 @@ struct JPEG2000PaletteBox final : public Box {
     Vector<Color> palette_entries;
 };
 
+// I.5.3.5 Component Mapping box
+struct JPEG2000ComponentMappingBox final : public Box {
+    BOX_SUBTYPE(JPEG2000ComponentMappingBox);
+
+    struct Mapping {
+        u16 component_index;
+
+        // "0: Direct use. This channel is created directly from an actual component in the codestream. The index of the
+        //     component mapped to this channel is specified in the CMP^i field for this channel."
+        // "1: Palette mapping. This channel is created by applying the palette to an actual component in the codestream. The
+        //     index of the component mapped into the palette is specified in the CMP^i field for this channel. The column from
+        //     the palette to use is specified in the PCOL^i field for this channel."
+        // "2 to 255: Reserved for ITU-T | ISO use"
+        u8 mapping_type;
+
+        u8 palette_component_index;
+    };
+    Vector<Mapping> component_mappings;
+};
+
 // I.5.3.6 Channel Definition box
 struct JPEG2000ChannelDefinitionBox final : public Box {
     BOX_SUBTYPE(JPEG2000ChannelDefinitionBox);

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -155,8 +155,8 @@ struct JPEG2000URLBox final : public Box {
 
     ErrorOr<String> url_as_string() const;
 
-    u8 version_number;
-    u32 flag;
+    u8 version_number { 0 };
+    u32 flag { 0 };
     ByteBuffer url_bytes;
 };
 

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -27,6 +27,17 @@ struct JPEG2000ImageHeaderBox final : public Box {
     u8 contains_intellectual_property_rights { 0 };
 };
 
+// I.5.3.2 Bits Per Component box
+struct JPEG2000BitsPerComponentBox final : public Box {
+    BOX_SUBTYPE(JPEG2000BitsPerComponentBox);
+
+    struct BitsPerComponent {
+        u8 depth;
+        bool is_signed;
+    };
+    Vector<BitsPerComponent> bits_per_components;
+};
+
 // I.5.3.3 Colour Specification box
 struct JPEG2000ColorSpecificationBox final : public Box {
     BOX_SUBTYPE(JPEG2000ColorSpecificationBox);


### PR DESCRIPTION
This completes support for all jpeg2000 boxes in I.5.3.

cmap demo, for the file attached to #25656, before:

```
% Build/lagom/bin/isobmff out_71.jpx  
...
  ('cmap')
  [ 16 bytes ]
('jp2c')
- codestream = 2448 bytes
```

After:

```
% Build/lagom/bin/isobmff out_71.jpx  
...
  ('cmap')
  - component_index = 0
  - mapping_type = 1
  - palette_component_index = 0
  - component_index = 0
  - mapping_type = 1
  - palette_component_index = 1
  - component_index = 0
  - mapping_type = 1
  - palette_component_index = 2
  - component_index = 0
  - mapping_type = 1
  - palette_component_index = 3
('jp2c')
- codestream = 2448 bytes
```

I haven't seen the bpcc box in the wild yet, but it's the only missing box type in I.5.3 and it's similar to to a subset of palette box in I.5.3.4, so maybe the implementation is not completely wrong.