### PR TITLE
LibWeb: Unbreak (`help://`) links in the Help app

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -789,14 +789,10 @@ void BrowserWindow::initialize_tab(Tab* tab)
     };
 
     tab->view().on_link_click = [this](auto url, auto target, unsigned modifiers) {
+        (void)target;
         // TODO: maybe activate tabs according to some configuration, this is just normal current browser behavior
-        if (modifiers == Web::UIEvents::Mod_Ctrl) {
+        if (modifiers == Web::UIEvents::Mod_Ctrl)
             m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::No);
-        } else if (target == "_blank") {
-            m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::Yes);
-        } else {
-            m_current_tab->view().load(url);
-        }
     };
 
     tab->view().on_link_middle_click = [this](auto url, auto target, unsigned modifiers) {

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -818,12 +818,12 @@ void Tab::reload()
 
 void Tab::open_link(URL::URL const& url)
 {
-    view().on_link_click(url, "", 0);
+    view().load(url);
 }
 
 void Tab::open_link_in_new_tab(URL::URL const& url)
 {
-    view().on_link_click(url, "_blank", Web::UIEvents::Mod_Ctrl);
+    view().on_tab_open_request(url, Web::HTML::ActivateTab::Yes);
 }
 
 void Tab::copy_link_url(URL::URL const& url)

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -264,11 +264,9 @@ Tab::Tab(BrowserWindow& window)
     };
 
     view().on_link_click = [this](auto& url, auto& target, unsigned modifiers) {
-        if (target == "_blank" || modifiers == Mod_Ctrl) {
+        (void)target;
+        if (modifiers == Mod_Ctrl)
             on_tab_open_request(url);
-        } else {
-            load(url);
-        }
     };
 
     view().on_resource_status_change = [this](auto count_waiting) {
@@ -309,12 +307,12 @@ Tab::Tab(BrowserWindow& window)
 
     m_link_context_menu = GUI::Menu::construct();
     auto link_default_action = GUI::Action::create("&Open", g_icon_bag.go_to, [this](auto&) {
-        view().on_link_click(m_link_context_menu_url, "", 0);
+        load(m_link_context_menu_url);
     });
     m_link_context_menu->add_action(link_default_action);
     m_link_context_menu_default_action = link_default_action;
     m_link_context_menu->add_action(GUI::Action::create("Open in New &Tab", g_icon_bag.new_tab, [this](auto&) {
-        view().on_link_click(m_link_context_menu_url, "_blank", 0);
+        on_tab_open_request(m_link_context_menu_url);
     }));
     m_link_context_menu->add_separator();
     m_link_copy_action = GUI::Action::create("Copy &URL", g_icon_bag.copy, [this](auto&) {
@@ -349,10 +347,10 @@ Tab::Tab(BrowserWindow& window)
 
     m_image_context_menu = GUI::Menu::construct();
     m_image_context_menu->add_action(GUI::Action::create("&Open Image", g_icon_bag.filetype_image, [this](auto&) {
-        view().on_link_click(m_image_context_menu_url, "", 0);
+        load(m_image_context_menu_url);
     }));
     m_image_context_menu->add_action(GUI::Action::create("Open Image in New &Tab", g_icon_bag.new_tab, [this](auto&) {
-        view().on_link_click(m_image_context_menu_url, "_blank", 0);
+        on_tab_open_request(m_image_context_menu_url);
     }));
     m_image_context_menu->add_separator();
     m_image_context_menu->add_action(GUI::Action::create("&Copy Image", g_icon_bag.copy, [this](auto&) {
@@ -397,10 +395,10 @@ Tab::Tab(BrowserWindow& window)
     m_audio_context_menu->add_action(*m_media_context_menu_loop_action);
     m_audio_context_menu->add_separator();
     m_audio_context_menu->add_action(GUI::Action::create("&Open Audio", g_icon_bag.filetype_audio, [this](auto&) {
-        view().on_link_click(m_media_context_menu_url, "", 0);
+        load(m_media_context_menu_url);
     }));
     m_audio_context_menu->add_action(GUI::Action::create("Open Audio in New &Tab", g_icon_bag.new_tab, [this](auto&) {
-        view().on_link_click(m_media_context_menu_url, "_blank", 0);
+        on_tab_open_request(m_media_context_menu_url);
     }));
     m_audio_context_menu->add_separator();
     m_audio_context_menu->add_action(GUI::Action::create("Copy Audio &URL", g_icon_bag.copy, [this](auto&) {
@@ -420,10 +418,10 @@ Tab::Tab(BrowserWindow& window)
     m_video_context_menu->add_action(*m_media_context_menu_loop_action);
     m_video_context_menu->add_separator();
     m_video_context_menu->add_action(GUI::Action::create("&Open Video", g_icon_bag.filetype_video, [this](auto&) {
-        view().on_link_click(m_media_context_menu_url, "", 0);
+        load(m_media_context_menu_url);
     }));
     m_video_context_menu->add_action(GUI::Action::create("Open Video in New &Tab", g_icon_bag.new_tab, [this](auto&) {
-        view().on_link_click(m_media_context_menu_url, "_blank", 0);
+        on_tab_open_request(m_media_context_menu_url);
     }));
     m_video_context_menu->add_separator();
     m_video_context_menu->add_action(GUI::Action::create("Copy Video &URL", g_icon_bag.copy, [this](auto&) {
@@ -467,7 +465,7 @@ Tab::Tab(BrowserWindow& window)
     };
 
     view().on_link_middle_click = [this](auto& href, auto&, auto) {
-        view().on_link_click(href, "_blank", 0);
+        on_tab_open_request(href);
     };
 
     view().on_title_change = [this](auto const& title) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -487,6 +487,10 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     if (!url.is_valid())
         return;
 
+    // AD-HOC: LibWeb (and navigables) don't support help://. Once a "link click" event is sent to the chrome (i.e. the Help app) navigation is handled there.
+    if (url.scheme() == "help"sv)
+        return;
+
     auto url_string = MUST(url.to_string());
 
     // 10. If hyperlinkSuffix is non-null, then append it to urlString.

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -333,8 +333,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
                     JS::NonnullGCPtr<DOM::Document> document = *m_navigable->active_document();
                     auto href = link->href();
                     auto url = document->parse_url(href);
-
-                    if (button == UIEvents::MouseButton::Primary && (modifiers & UIEvents::Mod_PlatformCtrl) != 0) {
+                    if (button == UIEvents::MouseButton::Primary) {
                         m_navigable->page().client().page_did_click_link(url, link->target().to_byte_string(), modifiers);
                     } else if (button == UIEvents::MouseButton::Middle) {
                         m_navigable->page().client().page_did_middle_click_link(url, link->target().to_byte_string(), modifiers);


### PR DESCRIPTION
See commits for details. 

Fixes #25288 (note: this did not just affect "see also" links, but any `help://` link)