### PR TITLE
LibPDF: Check DecodeParms array element type before casting

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -452,8 +452,11 @@ PDFErrorOr<void> Parser::unfilter_stream(NonnullRefPtr<StreamObject> stream_obje
             for (size_t i = 0; i < decode_parms_array->size(); ++i) {
                 RefPtr<DictObject> decode_parms;
                 auto entry = decode_parms_array->at(i);
-                if (entry.has<NonnullRefPtr<Object>>())
-                    decode_parms = entry.get<NonnullRefPtr<Object>>()->cast<DictObject>();
+                if (entry.has<NonnullRefPtr<Object>>()) {
+                    auto entry_object = entry.get<NonnullRefPtr<Object>>();
+                    if (entry_object->is<DictObject>())
+                        decode_parms = entry_object->cast<DictObject>();
+                }
                 decode_parms_vector.append(decode_parms);
             }
         } else {


### PR DESCRIPTION
0000337.pdf contains:

    /DecodeParms[(null)<</K -1/Columns 2545>>]

where the array's first entry `(null)` is a string with the characters `"null"`. Casting the string to a dict used to crash.
Instead, treat non-dict array entries as if no decode parms were present for the filter at that array position.

This will fix a crash for 0000337.pdf once we can decode /JPXDecode filters.