### PR TITLE
Cherry-pick "Meta: Disable clang-tidy “implicit-bool-conversion” check"

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,6 +45,7 @@ Checks: >
   -readability-named-parameter,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,
+  -readability-implicit-bool-conversion,
 WarningsAsErrors: ''
 HeaderFilterRegex: 'AK|Userland|Kernel|Tests'
 FormatStyle: none
@@ -52,6 +53,4 @@ CheckOptions:
   - key: bugprone-dangling-handle.HandleClasses
     value: 'AK::StringView;AK::Span'
   - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value: true
-  - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: true


### PR DESCRIPTION
This change causes the “readability-implicit-bool-conversion” check to be completely skipped by clang-tidy.

(cherry picked from commit 94a8b635c95270f93d5f8904fe4c73d4df414116)

---

https://github.com/LadybirdBrowser/ladybird/pull/3351