### PR TITLE
LibGfx/JPEG2000: The rest of the owl

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -672,12 +672,17 @@ TEST_CASE(test_jpeg2000_spec_annex_j_10)
     // clang-format on
 
     auto plugin_decoder = TRY_OR_FAIL(Gfx::JPEG2000ImageDecoderPlugin::create(data));
-    EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(1, 9));
+    auto frame = TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 1, 9 }));
 
-    // FIXME: Do something with this.
-    // For now, this is useful for debugging:
-    // `Build/lagom/bin/TestImageDecoder test_jpeg2000_spec_annex_j_10` prints internal state with JPEG2000_DEBUG=1.
-    (void)plugin_decoder->frame(0);
+    // "After the inverse 5-3 reversible filter and level shifting, the component samples in decimal are:"
+    Array expected_values = { 101, 103, 104, 105, 96, 97, 96, 102, 109 };
+    for (int i = 0; i < 9; ++i) {
+        auto pixel = frame.image->get_pixel(0, i);
+        EXPECT_EQ(pixel.red(), expected_values[i]);
+        EXPECT_EQ(pixel.green(), expected_values[i]);
+        EXPECT_EQ(pixel.blue(), expected_values[i]);
+        EXPECT_EQ(pixel.alpha(), 0xff);
+    }
 }
 
 TEST_CASE(test_jpeg2000_simple)

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -302,6 +302,15 @@ static ErrorOr<ImageAndTileSize> read_image_and_tile_size(ReadonlyBytes data)
     siz.tile_y_offset = TRY(stream.read_value<BigEndian<u32>>());
     u16 component_count = TRY(stream.read_value<BigEndian<u16>>()); // "Csiz" in spec.
 
+    // Table A.9 – Image and tile size parameter values
+    // Xsiz, Ysiz, XTsiz, YTsiz: 1 to 2^32-1.
+    if (siz.width == 0 || siz.height == 0 || siz.tile_width == 0 || siz.tile_height == 0)
+        return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Invalid image or tile size");
+
+    // CSiz: 1 to 16384.
+    if (component_count < 1 || component_count > 16384)
+        return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Invalid number of components");
+
     for (size_t i = 0; i < component_count; ++i) {
         ImageAndTileSize::ComponentInformation component;
         component.depth_and_sign = TRY(stream.read_value<u8>());

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -310,6 +310,10 @@ static ErrorOr<ImageAndTileSize> read_image_and_tile_size(ReadonlyBytes data)
     if (siz.width == 0 || siz.height == 0 || siz.tile_width == 0 || siz.tile_height == 0)
         return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Invalid image or tile size");
 
+    // Ad-hoc: Limit image size to < 4 GiB.
+    if (static_cast<u64>(siz.width) * siz.height > INT32_MAX)
+        return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Image is suspiciously large, not decoding");
+
     // CSiz: 1 to 16384.
     if (component_count < 1 || component_count > 16384)
         return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Invalid number of components");

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -30,8 +30,8 @@
 // -------------------
 //
 // 1. An image is first divided into independent tiles
-// 2. Each tile is split into component tiles (one each for R, G, B, A)
-// 3. Each component tiles undergoes Discrete Wavelet Transform (DWT)
+// 2. Each tile is split into tile components (one each for R, G, B, A)
+// 3. Each tile component undergoes Discrete Wavelet Transform (DWT)
 //
 // Resolution Levels and Subbands
 // ------------------------------


### PR DESCRIPTION
This uses the previously landed TagTree, grid coordinate math, progression iterators, bitplane decoding, and IDWT code to implement a working jpeg2000 decoder :^)

We already had code to:

1. (Optional) Decoding an ISOBMFF box container structure.
   Used to store metadata such as icc profiles.

2. Decode the jpeg2000 codestream, which consists of several marker segments.

This now also adds these steps:

3. Compute coordinate for all tiles, precincts, resolution levels, components to determine how many code-blocks are in a packet.

4. Decode packet headers to find packet metadata and compressed data, using TagTrees of the right dimension.

5. Run the bitplane decompression algorithm to convert the compressed data into coefficients.

6. Run IDWT algorithm (and some postprocessing) to convert to samples.

7. Convert samples into a Bitmap.

With this, `image` can convert most jpeg2000 files I've seen to other formats, FileManager can show previews for jpeg2000 files, etc. (It's not yet hooked up in LibPDF, though.)

Many things work: Support for tiles, layers, multiple precincts, both reversible and irreversible wavelet filters, the optional multiple component transformation, progression orders 0 and 1.

Many other things don't work yet (they're rare in practice, but we should grow support for at least some of these over time anyhow): palettes (silently ignored atm; we return a grayscale image with the palette indexes), CMYK, SOP and EPH markers, 
progression orders 2-4, `code_block_style != 0` (selective arithmetic coding bypass, context probability resets, termination coding on each pass, vertically-casual contexts, predictable termination, segmentation symbols), ROI, HTJ2K.

The next step after this is adding test images (+ automated tests) for all the things that do work, and then iterate with that in place.