### PR TITLE
LibGfx+LibGUI: Small grabbag of jpeg2000-related tweaks

### DIFF
--- a/Userland/Libraries/LibGUI/FileTypeFilter.h
+++ b/Userland/Libraries/LibGUI/FileTypeFilter.h
@@ -30,7 +30,7 @@ struct FileTypeFilter {
 
     static FileTypeFilter image_files()
     {
-        return FileTypeFilter { "Image Files", Vector<ByteString> { "png", "gif", "bmp", "dip", "pam", "pbm", "pgm", "ppm", "ico", "iff", "jb2", "jbig2", "jp2", "jpeg", "jpg", "jpx", "jxl", "dds", "qoi", "tif", "tiff", "webp", "tvg" } };
+        return FileTypeFilter { "Image Files", Vector<ByteString> { "png", "gif", "bmp", "dip", "pam", "pbm", "pgm", "ppm", "ico", "iff", "jb2", "jbig2", "jp2", "jpeg", "jpf", "jpg", "jpx", "jxl", "dds", "qoi", "tif", "tiff", "webp", "tvg" } };
     }
 
     static FileTypeFilter video_files()

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -27,6 +27,7 @@
     __ENUMERATE_IMAGE_FORMAT(jpeg, ".jbig2")   \
     __ENUMERATE_IMAGE_FORMAT(jpeg2000, ".jp2") \
     __ENUMERATE_IMAGE_FORMAT(jpeg, ".jpeg")    \
+    __ENUMERATE_IMAGE_FORMAT(jpeg, ".jpf")     \
     __ENUMERATE_IMAGE_FORMAT(jpeg, ".jpg")     \
     __ENUMERATE_IMAGE_FORMAT(jpeg2000, ".jpx") \
     __ENUMERATE_IMAGE_FORMAT(jxl, ".jxl")      \

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.h
@@ -25,6 +25,43 @@ struct JPEG2000ImageHeaderBox final : public Box {
     u8 compression_type { 0 };
     u8 is_colorspace_unknown { 0 };
     u8 contains_intellectual_property_rights { 0 };
+
+    enum CompressionType {
+        // T.800, I.5.3.1 Image Header box
+
+        // "The value of this field shall be 7."
+        Default = 7,
+
+        // T.801, Table M.19 – Legal C values
+        Uncompressed = 0,
+
+        // "Rec. ITU-T T.4, the basic algorithm known as MH (Modified Huffman). This value is only permitted for bi-level images."
+        T_4_Modified_Huffman = 1,
+
+        // "Rec. ITU-T T.4, commonly known as MR (Modified READ). This value is only permitted for bi-level images."
+        T_4_Modified_Read = 2,
+
+        // "Rec. ITU-T T.6, commonly known as MMR (Modified Modified READ). This value is only permitted for bi-level images."
+        T_4_Modified_Modified_Read = 3,
+
+        // "Rec. ITU-T T.82 | ISO/IEC 11544. Commonly known as JBIG. This value is only permitted for bi-level images."
+        JBIG_BILEVEL = 4,
+
+        // "Rec. ITU-T T.81 | ISO/IEC 10918-1 or Rec. ITU-T T.84 | ISO/IEC 10918-3. Commonly known as JPEG. [...]
+        //  This value is only permitted for continuous tone, greyscale or colour images."
+        JPEG = 5,
+
+        JPEG_LS = 6,
+
+        JBIG2 = 8,
+
+        // "Rec. ITU-T T.82 | ISO/IEC 11544. Commonly known as JBIG. This value is permitted for any image permitted by the JBIG standard."
+        JBIG_ANY = 9,
+
+        RUN_LENGTH = 10,
+        JPEG_XR = 11,
+        JPEG_XS = 12,
+    };
 };
 
 // I.5.3.2 Bits Per Component box
@@ -47,6 +84,48 @@ struct JPEG2000ColorSpecificationBox final : public Box {
     u8 approximation { 0 };
     u32 enumerated_color_space { 0 }; // Only set if method == 1
     ByteBuffer icc_data;              // Only set if method == 2
+
+    enum EnumCS {
+        // T.800, Table I.10 – Legal EnumCS values
+
+        // "sRGB as defined by IEC 61966-2-1 with Lmini=0 and Lmaxi=255. This colourspace shall be used with channels carrying unsigned values only."
+        sRGB = 16,
+
+        // "A greyscale space where image luminance is related to code values using the sRGB non-linearity given in Equations (2) to (4) of IEC 61966-2-1 (sRGB) specification. [...]
+        //  This colourspace shall be used with channels carrying unsigned values only."
+        Greyscale = 17,
+
+        // "sYCC as defined by IEC 61966-2-1 Amd. 1with Lmini=0 and Lmaxi=255. This colourspace shall be used with channels carrying unsigned values only."
+        sYCC = 18,
+
+        // T.801, Table M.25 – Additional legal EnumCS values
+
+        // "This value shall be used to indicate bi-level images. Each image sample is one bit: 0 = white, 1 = black."
+        BiLevel = 0,
+
+        YCbCr1 = 1,
+        YCbCr2 = 3,
+        YCbCr3 = 4,
+        PhotoYCC = 9,
+        CMY = 11,
+        CMYK = 12,
+        YCCK = 13,
+        CIELab = 14,
+
+        // "This value shall be used to indicate bi-level images. Each image sample is one bit: 1 = white, 0 = black.""
+        BiLevel2 = 15,
+
+        // (T.801 also lists 18 for sYCC, but that's already in T.800 above.)
+
+        CIEJab = 19,
+        e_sRGB = 20,
+        ROMM_RGB = 21,
+        YPbPr_1125_60 = 22,
+        YPbPr_1150_50 = 23,
+        e_sYCC = 24,
+        scRGB = 25,
+        scRGB_Gray_Scale = 26, // [sic], inconsistent with the spelling of "greyscale" in T.800.
+    };
 };
 
 // I.5.3.4 Palette box

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -1081,6 +1081,12 @@ static ErrorOr<void> decode_jpeg2000_header(JPEG2000LoadingContext& context, Rea
     auto reader = TRY(Gfx::ISOBMFF::Reader::create(TRY(try_make<FixedMemoryStream>(data))));
     context.boxes = TRY(reader.read_entire_file());
 
+    dbgln_if(JPEG2000_DEBUG, "Embedded ISOBMFF boxes:");
+    if constexpr (JPEG2000_DEBUG) {
+        for (auto& box : context.boxes)
+            box->dump();
+    }
+
     // I.2.2 File organization
     // "A particular order of those boxes in the file is not generally implied. However, the JPEG 2000 Signature box
     //  shall be the first box in a JP2 file, the File Type box shall immediately follow the JPEG 2000 Signature box

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -1165,6 +1165,9 @@ static ErrorOr<void> decode_jpeg2000_header(JPEG2000LoadingContext& context, Rea
     auto const& image_header_box = static_cast<ISOBMFF::JPEG2000ImageHeaderBox const&>(*header_box.child_boxes()[image_header_box_index.value()]);
     context.size = { image_header_box.width, image_header_box.height };
 
+    if (image_header_box.compression_type != ISOBMFF::JPEG2000ImageHeaderBox::CompressionType::Default)
+        return Error::from_string_literal("JPEG2000ImageDecoderPlugin: Decoding of non-jpeg2000 data embedded in jpeg2000 files is not implemented");
+
     auto const& color_header_box = static_cast<ISOBMFF::JPEG2000ColorSpecificationBox const&>(*header_box.child_boxes()[color_header_box_index.value()]);
     if (color_header_box.method == 2 || color_header_box.method == 3)
         context.icc_data = color_header_box.icc_data.bytes();


### PR DESCRIPTION
[LibGfx+LibGUI: Add .jpf to known image extensions](https://github.com/SerenityOS/serenity/commit/50e871724bc3111f0e8a26dfef12bd52f4b9d81b) 

This should have been part of https://github.com/SerenityOS/serenity/commit/f2e381ae19255a7df298476951af2fce58894b5c in https://github.com/SerenityOS/serenity/pull/24016.

The Bitmap.h change has the effect that FileManager now shows a
preview of buggie-gray.jpf when opening
/usr/Tests/LibGfx/test-inputs/jpeg2000.

---

[LibGfx/JPEG2000: Dump ISOBMFF boxes in JPEG2000_DEBUG builds](https://github.com/SerenityOS/serenity/commit/945eb178578aae93024da50f8fba0117fe1fa579)

---

[LibGfx/ISOBMFF/JPEG2000: Add a few known values](https://github.com/SerenityOS/serenity/commit/23e113b192b0eab2793bdb5000050a1dcf6f9ab1) 

...for compression_type and enumerated_color_space values.

(Since these are open fields, the field type can't be an enum.)

---

[LibGfx/JPEG2000: Reject images that do not use JPEG2000 compression](https://github.com/SerenityOS/serenity/commit/846948297ee889a93610bbfa403f4b2c85b5f21d)