### PR TITLE
LibGfx/JPEG2000: LibGfx/JPEG2000: Move TagTree to its own file, and other minor cleanups

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
@@ -81,6 +81,7 @@ shared_library("LibGfx") {
     "ImageFormats/JBIG2Loader.cpp",
     "ImageFormats/JPEG2000Loader.cpp",
     "ImageFormats/JPEG2000ProgressionIterators.cpp",
+    "ImageFormats/JPEG2000TagTree.cpp",
     "ImageFormats/JPEGLoader.cpp",
     "ImageFormats/JPEGWriter.cpp",
     "ImageFormats/JPEGXLEntropyDecoder.cpp",

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -18,6 +18,7 @@
 #include <LibGfx/ImageFormats/JPEG2000InverseDiscreteWaveletTransform.h>
 #include <LibGfx/ImageFormats/JPEG2000Loader.h>
 #include <LibGfx/ImageFormats/JPEG2000ProgressionIterators.h>
+#include <LibGfx/ImageFormats/JPEG2000TagTree.h>
 #include <LibGfx/ImageFormats/JPEGLoader.h>
 #include <LibGfx/ImageFormats/JPEGXLLoader.h>
 #include <LibGfx/ImageFormats/PAMLoader.h>

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SOURCES
     ImageFormats/JBIG2Loader.cpp
     ImageFormats/JPEG2000Loader.cpp
     ImageFormats/JPEG2000ProgressionIterators.cpp
+    ImageFormats/JPEG2000TagTree.cpp
     ImageFormats/JPEGLoader.cpp
     ImageFormats/JPEGXLEntropyDecoder.cpp
     ImageFormats/JPEGXLICC.cpp

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -1413,18 +1413,6 @@ static ErrorOr<u32> read_one_packet_header(JPEG2000LoadingContext& context, Tile
         return bit;
     };
 
-    // Tag trees are used to store the code-block inclusion bits and the zero bit-plane information.
-    // B.10.2 Tag trees
-    // "At every node of this tree the minimum integer of the (up to four) nodes below it is recorded. [...]
-    //  Level 0 is the lowest level of the tag tree; it contains the top node. [...]
-    //  Each node has a [...] current value, [...] initialized to zero. A 0 bit in the tag tree means that the minimum
-    //  (or the value in the case of the highest level) is larger than the current value and a 1 bit means that the minimum
-    //  (or the value in the case of the highest level) is equal to the current value.
-    //  For each contiguous 0 bit in the tag tree the current value is incremented by one.
-    //  Nodes at higher levels cannot be coded until lower level node values are fixed (i.e, a 1 bit is coded). [...]
-    //  Only the information needed for the current code-block is stored at the current point in the packet header."
-    // The example in Figure B.13 / Table B.5 is useful to understand what exactly "only the information needed" means.
-
     // The most useful section to understand the overall flow is B.10.8 Order of information within packet header,
     // which has an example packet header bitstream, and the data layout:
     // "bit for zero or non-zero length packet

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -14,6 +14,7 @@
 #include <LibGfx/ImageFormats/JPEG2000InverseDiscreteWaveletTransform.h>
 #include <LibGfx/ImageFormats/JPEG2000Loader.h>
 #include <LibGfx/ImageFormats/JPEG2000ProgressionIterators.h>
+#include <LibGfx/ImageFormats/JPEG2000TagTree.h>
 #include <LibTextCodec/Decoder.h>
 
 // Core coding system spec (.jp2 format): T-REC-T.800-201511-S!!PDF-E.pdf available here:
@@ -1182,103 +1183,6 @@ static ErrorOr<void> decode_jpeg2000_header(JPEG2000LoadingContext& context, Rea
     }
 
     return {};
-}
-
-namespace JPEG2000 {
-
-// Tag trees are used to store the code-block inclusion bits and the zero bit-plane information.
-// B.10.2 Tag trees
-// "At every node of this tree the minimum integer of the (up to four) nodes below it is recorded. [...]
-//  Level 0 is the lowest level of the tag tree; it contains the top node. [...]
-//  Each node has a [...] current value, [...] initialized to zero. A 0 bit in the tag tree means that the minimum
-//  (or the value in the case of the highest level) is larger than the current value and a 1 bit means that the minimum
-//  (or the value in the case of the highest level) is equal to the current value.
-//  For each contiguous 0 bit in the tag tree the current value is incremented by one.
-//  Nodes at higher levels cannot be coded until lower level node values are fixed (i.e, a 1 bit is coded). [...]
-//  Only the information needed for the current code-block is stored at the current point in the packet header."
-// The example in Figure B.13 / Table B.5 is useful to understand what exactly "only the information needed" means.
-struct TagTreeNode {
-    u32 value { 0 };
-    enum State {
-        Pending,
-        Final,
-    };
-    State state { Pending };
-    Array<OwnPtr<TagTreeNode>, 4> children {};
-    u32 level { 0 }; // 0 for leaf nodes, 1 for the next level, etc.
-
-    bool is_leaf() const { return level == 0; }
-
-    ErrorOr<u32> read_value(u32 x, u32 y, Function<ErrorOr<bool>()> const& read_bit, u32 start_value, Optional<u32> stop_at = {})
-    {
-        value = max(value, start_value);
-        while (true) {
-            if (stop_at.has_value() && value == stop_at.value())
-                return value;
-
-            if (state == Final) {
-                if (is_leaf())
-                    return value;
-                u32 x_index = (x >> (level - 1)) & 1;
-                u32 y_index = (y >> (level - 1)) & 1;
-                return children[y_index * 2 + x_index]->read_value(x, y, read_bit, value, stop_at);
-            }
-
-            bool bit = TRY(read_bit());
-            if (!bit)
-                value++;
-            else
-                state = Final;
-        }
-    }
-
-    static ErrorOr<NonnullOwnPtr<TagTreeNode>> create(u32 x_count, u32 y_count, u32 level)
-    {
-        VERIFY(x_count > 0);
-        VERIFY(y_count > 0);
-
-        auto node = TRY(try_make<TagTreeNode>());
-        node->level = level;
-        if (node->is_leaf()) {
-            VERIFY(x_count == 1);
-            VERIFY(y_count == 1);
-            return node;
-        }
-
-        u32 top_left_x_child_count = min(x_count, 1u << (max(level, 1) - 1));
-        u32 top_left_y_child_count = min(y_count, 1u << (max(level, 1) - 1));
-        for (u32 y = 0; y < 2; ++y) {
-            for (u32 x = 0; x < 2; ++x) {
-                u32 child_x_count = x == 1 ? x_count - top_left_x_child_count : top_left_x_child_count;
-                u32 child_y_count = y == 1 ? y_count - top_left_y_child_count : top_left_y_child_count;
-                if (child_x_count == 0 || child_y_count == 0)
-                    continue;
-                node->children[y * 2 + x] = TRY(create(child_x_count, child_y_count, level - 1));
-            }
-        }
-        return node;
-    }
-};
-
-TagTree::TagTree(NonnullOwnPtr<TagTreeNode> root)
-    : m_root(move(root))
-{
-}
-
-TagTree::TagTree(TagTree&&) = default;
-TagTree::~TagTree() = default;
-
-ErrorOr<TagTree> TagTree::create(u32 x_count, u32 y_count)
-{
-    auto level = ceil(log2(max(x_count, y_count)));
-    return TagTree { TRY(TagTreeNode::create(x_count, y_count, level)) };
-}
-
-ErrorOr<u32> TagTree::read_value(u32 x, u32 y, Function<ErrorOr<bool>()> const& read_bit, Optional<u32> stop_at) const
-{
-    return m_root->read_value(x, y, read_bit, m_root->value, stop_at);
-}
-
 }
 
 static IntRect aligned_enclosing_rect(IntRect outer_rect, IntRect inner_rect, int width_increment, int height_increment)

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -1459,8 +1459,6 @@ static ErrorOr<u32> read_one_packet_header(JPEG2000LoadingContext& context, Tile
             continue;
 
         TRY(temporary_code_block_data[sub_band_index].try_resize(precinct.code_blocks.size()));
-        auto& code_block_inclusion_tree = precinct.code_block_inclusion_tree.value();
-        auto& p_tree = precinct.p_tree.value();
 
         for (auto const& [code_block_index, current_block] : enumerate(precinct.code_blocks)) {
             size_t code_block_x = code_block_index % precinct.num_code_blocks_wide;
@@ -1476,7 +1474,7 @@ static ErrorOr<u32> read_one_packet_header(JPEG2000LoadingContext& context, Tile
                 // "For code-blocks that have not been previously included in any packet, this information is signalled with a separate tag
                 //  tree code for each precinct as confined to a sub-band. The values in this tag tree are the number of the layer in which the
                 //  current code-block is first included."
-                is_included = TRY(code_block_inclusion_tree.read_value(code_block_x, code_block_y, read_bit, current_layer_index + 1)) <= current_layer_index;
+                is_included = TRY(precinct.code_block_inclusion_tree->read_value(code_block_x, code_block_y, read_bit, current_layer_index + 1)) <= current_layer_index;
             }
             dbgln_if(JPEG2000_DEBUG, "code-block inclusion: {}", is_included);
             current_block.is_included = is_included;
@@ -1494,7 +1492,7 @@ static ErrorOr<u32> read_one_packet_header(JPEG2000LoadingContext& context, Tile
             //  where the number of guard bits G and the exponent exp_b are specified in the QCD or QCC marker segments (see A.6.4 and A.6.5)."
             bool is_included_for_the_first_time = is_included && !current_block.has_been_included_in_previous_packet;
             if (is_included_for_the_first_time) {
-                u32 p = TRY(p_tree.read_value(code_block_x, code_block_y, read_bit));
+                u32 p = TRY(precinct.p_tree->read_value(code_block_x, code_block_y, read_bit));
                 dbgln_if(JPEG2000_DEBUG, "zero bit-plane information: {}", p);
                 current_block.p = p;
                 current_block.has_been_included_in_previous_packet = true;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.h
@@ -19,22 +19,6 @@ enum class SubBand {
     HorizontalHighpassVerticalHighpass, // "HH" in spec
 };
 
-struct TagTreeNode;
-class TagTree {
-public:
-    TagTree(TagTree&&);
-    ~TagTree();
-
-    static ErrorOr<TagTree> create(u32 x_count, u32 y_count);
-
-    ErrorOr<u32> read_value(u32 x, u32 y, Function<ErrorOr<bool>()> const& read_bit, Optional<u32> stop_at = {}) const;
-
-private:
-    TagTree(NonnullOwnPtr<TagTreeNode>);
-
-    NonnullOwnPtr<TagTreeNode> m_root;
-};
-
 }
 
 struct JPEG2000LoadingContext;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000TagTree.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000TagTree.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Function.h>
+#include <AK/Math.h>
+#include <AK/OwnPtr.h>
+#include <LibGfx/ImageFormats/JPEG2000TagTree.h>
+
+namespace Gfx::JPEG2000 {
+
+// Tag trees are used to store the code-block inclusion bits and the zero bit-plane information.
+// B.10.2 Tag trees
+// "At every node of this tree the minimum integer of the (up to four) nodes below it is recorded. [...]
+//  Level 0 is the lowest level of the tag tree; it contains the top node. [...]
+//  Each node has a [...] current value, [...] initialized to zero. A 0 bit in the tag tree means that the minimum
+//  (or the value in the case of the highest level) is larger than the current value and a 1 bit means that the minimum
+//  (or the value in the case of the highest level) is equal to the current value.
+//  For each contiguous 0 bit in the tag tree the current value is incremented by one.
+//  Nodes at higher levels cannot be coded until lower level node values are fixed (i.e, a 1 bit is coded). [...]
+//  Only the information needed for the current code-block is stored at the current point in the packet header."
+// The example in Figure B.13 / Table B.5 is useful to understand what exactly "only the information needed" means.
+struct TagTreeNode {
+    u32 value { 0 };
+    enum State {
+        Pending,
+        Final,
+    };
+    State state { Pending };
+    Array<OwnPtr<TagTreeNode>, 4> children {};
+    u32 level { 0 }; // 0 for leaf nodes, 1 for the next level, etc.
+
+    bool is_leaf() const { return level == 0; }
+
+    ErrorOr<u32> read_value(u32 x, u32 y, Function<ErrorOr<bool>()> const& read_bit, u32 start_value, Optional<u32> stop_at = {})
+    {
+        value = max(value, start_value);
+        while (true) {
+            if (stop_at.has_value() && value == stop_at.value())
+                return value;
+
+            if (state == Final) {
+                if (is_leaf())
+                    return value;
+                u32 x_index = (x >> (level - 1)) & 1;
+                u32 y_index = (y >> (level - 1)) & 1;
+                return children[y_index * 2 + x_index]->read_value(x, y, read_bit, value, stop_at);
+            }
+
+            bool bit = TRY(read_bit());
+            if (!bit)
+                value++;
+            else
+                state = Final;
+        }
+    }
+
+    static ErrorOr<NonnullOwnPtr<TagTreeNode>> create(u32 x_count, u32 y_count, u32 level)
+    {
+        VERIFY(x_count > 0);
+        VERIFY(y_count > 0);
+
+        auto node = TRY(try_make<TagTreeNode>());
+        node->level = level;
+        if (node->is_leaf()) {
+            VERIFY(x_count == 1);
+            VERIFY(y_count == 1);
+            return node;
+        }
+
+        u32 top_left_x_child_count = min(x_count, 1u << (max(level, 1) - 1));
+        u32 top_left_y_child_count = min(y_count, 1u << (max(level, 1) - 1));
+        for (u32 y = 0; y < 2; ++y) {
+            for (u32 x = 0; x < 2; ++x) {
+                u32 child_x_count = x == 1 ? x_count - top_left_x_child_count : top_left_x_child_count;
+                u32 child_y_count = y == 1 ? y_count - top_left_y_child_count : top_left_y_child_count;
+                if (child_x_count == 0 || child_y_count == 0)
+                    continue;
+                node->children[y * 2 + x] = TRY(create(child_x_count, child_y_count, level - 1));
+            }
+        }
+        return node;
+    }
+};
+
+TagTree::TagTree(NonnullOwnPtr<TagTreeNode> root)
+    : m_root(move(root))
+{
+}
+
+TagTree::TagTree(TagTree&&) = default;
+TagTree::~TagTree() = default;
+
+ErrorOr<TagTree> TagTree::create(u32 x_count, u32 y_count)
+{
+    auto level = ceil(log2(max(x_count, y_count)));
+    return TagTree { TRY(TagTreeNode::create(x_count, y_count, level)) };
+}
+
+ErrorOr<u32> TagTree::read_value(u32 x, u32 y, Function<ErrorOr<bool>()> const& read_bit, Optional<u32> stop_at) const
+{
+    return m_root->read_value(x, y, read_bit, m_root->value, stop_at);
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000TagTree.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000TagTree.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+
+namespace Gfx::JPEG2000 {
+
+struct TagTreeNode;
+class TagTree {
+public:
+    TagTree(TagTree&&);
+    ~TagTree();
+
+    static ErrorOr<TagTree> create(u32 x_count, u32 y_count);
+
+    ErrorOr<u32> read_value(u32 x, u32 y, Function<ErrorOr<bool>()> const& read_bit, Optional<u32> stop_at = {}) const;
+
+private:
+    TagTree(NonnullOwnPtr<TagTreeNode>);
+
+    NonnullOwnPtr<TagTreeNode> m_root;
+};
+
+}


### PR DESCRIPTION
No behavior change.