### PR TITLE
Kernel+Meta: Make the x86 framebuffer fast again

### DIFF
--- a/Kernel/Arch/x86_64/Hypervisor/BochsDisplayConnector.cpp
+++ b/Kernel/Arch/x86_64/Hypervisor/BochsDisplayConnector.cpp
@@ -65,7 +65,7 @@ ErrorOr<NonnullRefPtr<BochsDisplayConnector>> BochsDisplayConnector::create(Phys
 }
 
 BochsDisplayConnector::BochsDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::IO)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::NonCacheable)
 {
 }
 

--- a/Kernel/Arch/x86_64/Hypervisor/BochsDisplayConnector.cpp
+++ b/Kernel/Arch/x86_64/Hypervisor/BochsDisplayConnector.cpp
@@ -65,7 +65,7 @@ ErrorOr<NonnullRefPtr<BochsDisplayConnector>> BochsDisplayConnector::create(Phys
 }
 
 BochsDisplayConnector::BochsDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, false)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::IO)
 {
 }
 

--- a/Kernel/Arch/x86_64/Hypervisor/BochsDisplayConnector.h
+++ b/Kernel/Arch/x86_64/Hypervisor/BochsDisplayConnector.h
@@ -25,8 +25,6 @@ class BochsDisplayConnector
 public:
     AK_TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
 
-    static ErrorOr<NonnullRefPtr<BochsDisplayConnector>> try_create_for_vga_isa_connector();
-
     static ErrorOr<NonnullRefPtr<BochsDisplayConnector>> create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool virtual_box_hardware);
 
 private:

--- a/Kernel/Devices/GPU/3dfx/VoodooDisplayConnector.cpp
+++ b/Kernel/Devices/GPU/3dfx/VoodooDisplayConnector.cpp
@@ -33,7 +33,7 @@ ErrorOr<void> VoodooDisplayConnector::create_attached_framebuffer_console()
 }
 
 VoodooDisplayConnector::VoodooDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<RegisterMap volatile> registers_mapping, NonnullOwnPtr<IOWindow> io_window)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, true)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::NonCacheable)
     , m_registers(move(registers_mapping))
     , m_io_window(move(io_window))
 {

--- a/Kernel/Devices/GPU/Bochs/QEMUDisplayConnector.cpp
+++ b/Kernel/Devices/GPU/Bochs/QEMUDisplayConnector.cpp
@@ -77,7 +77,7 @@ ErrorOr<void> QEMUDisplayConnector::set_safe_mode_setting()
 }
 
 QEMUDisplayConnector::QEMUDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::IO)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::NonCacheable)
     , m_registers(move(registers_mapping))
 {
 }

--- a/Kernel/Devices/GPU/Bochs/QEMUDisplayConnector.cpp
+++ b/Kernel/Devices/GPU/Bochs/QEMUDisplayConnector.cpp
@@ -77,7 +77,7 @@ ErrorOr<void> QEMUDisplayConnector::set_safe_mode_setting()
 }
 
 QEMUDisplayConnector::QEMUDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, false)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::IO)
     , m_registers(move(registers_mapping))
 {
 }

--- a/Kernel/Devices/GPU/DisplayConnector.h
+++ b/Kernel/Devices/GPU/DisplayConnector.h
@@ -105,8 +105,8 @@ public:
 protected:
     void set_edid_bytes(Array<u8, 128> const& edid_bytes, bool might_be_invalid = false);
 
-    DisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, bool enable_write_combine_optimization);
-    DisplayConnector(size_t framebuffer_resource_size, bool enable_write_combine_optimization);
+    DisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::MemoryType);
+    DisplayConnector(size_t framebuffer_resource_size, Memory::MemoryType);
     virtual void enable_console() = 0;
     virtual void disable_console() = 0;
     virtual ErrorOr<void> flush_first_surface() = 0;
@@ -156,7 +156,7 @@ private:
     OwnPtr<Memory::Region> m_fake_writes_framebuffer_region;
     u8* m_framebuffer_data {};
 
-    bool const m_enable_write_combine_optimization { false };
+    Memory::MemoryType m_memory_type { Memory::MemoryType::NonCacheable };
     bool const m_framebuffer_at_arbitrary_physical_range { false };
 
 protected:

--- a/Kernel/Devices/GPU/Generic/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/Generic/DisplayConnector.cpp
@@ -20,7 +20,7 @@ ErrorOr<NonnullRefPtr<GenericDisplayConnector>> GenericDisplayConnector::create_
 }
 
 GenericDisplayConnector::GenericDisplayConnector(PhysicalAddress framebuffer_address, size_t width, size_t height, size_t pitch)
-    : DisplayConnector(framebuffer_address, height * pitch, true)
+    : DisplayConnector(framebuffer_address, height * pitch, Memory::MemoryType::NonCacheable)
 {
     m_current_mode_setting.horizontal_active = width;
     m_current_mode_setting.vertical_active = height;

--- a/Kernel/Devices/GPU/Intel/NativeDisplayConnector.cpp
+++ b/Kernel/Devices/GPU/Intel/NativeDisplayConnector.cpp
@@ -38,7 +38,7 @@ ErrorOr<void> IntelNativeDisplayConnector::create_attached_framebuffer_console(B
 }
 
 IntelNativeDisplayConnector::IntelNativeDisplayConnector(IntelDisplayConnectorGroup const& parent_connector_group, ConnectorIndex connector_index, Type type, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, true)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::NonCacheable)
     , m_type(type)
     , m_connector_index(connector_index)
     , m_parent_connector_group(parent_connector_group)

--- a/Kernel/Devices/GPU/VMWare/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/VMWare/DisplayConnector.cpp
@@ -27,7 +27,7 @@ ErrorOr<void> VMWareDisplayConnector::create_attached_framebuffer_console()
 }
 
 VMWareDisplayConnector::VMWareDisplayConnector(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::IO)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::NonCacheable)
     , m_parent_adapter(parent_adapter)
 {
 }

--- a/Kernel/Devices/GPU/VMWare/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/VMWare/DisplayConnector.cpp
@@ -27,7 +27,7 @@ ErrorOr<void> VMWareDisplayConnector::create_attached_framebuffer_console()
 }
 
 VMWareDisplayConnector::VMWareDisplayConnector(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size)
-    : DisplayConnector(framebuffer_address, framebuffer_resource_size, false)
+    : DisplayConnector(framebuffer_address, framebuffer_resource_size, Memory::MemoryType::IO)
     , m_parent_adapter(parent_adapter)
 {
 }

--- a/Kernel/Devices/GPU/VirtIO/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/VirtIO/DisplayConnector.cpp
@@ -23,7 +23,7 @@ ErrorOr<NonnullRefPtr<VirtIODisplayConnector>> VirtIODisplayConnector::create(Vi
 static_assert((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2) % PAGE_SIZE == 0);
 
 VirtIODisplayConnector::VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id)
-    : DisplayConnector((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2), false)
+    : DisplayConnector((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2), Memory::MemoryType::IO)
     , m_graphics_adapter(graphics_adapter)
     , m_scanout_id(scanout_id)
 {

--- a/Kernel/Devices/GPU/VirtIO/DisplayConnector.cpp
+++ b/Kernel/Devices/GPU/VirtIO/DisplayConnector.cpp
@@ -23,7 +23,7 @@ ErrorOr<NonnullRefPtr<VirtIODisplayConnector>> VirtIODisplayConnector::create(Vi
 static_assert((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2) % PAGE_SIZE == 0);
 
 VirtIODisplayConnector::VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id)
-    : DisplayConnector((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2), Memory::MemoryType::IO)
+    : DisplayConnector((MAX_VIRTIOGPU_RESOLUTION_WIDTH * MAX_VIRTIOGPU_RESOLUTION_HEIGHT * sizeof(u32) * 2), Memory::MemoryType::NonCacheable)
     , m_graphics_adapter(graphics_adapter)
     , m_scanout_id(scanout_id)
 {

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -182,7 +182,7 @@ class Configuration:
     # QEMU -display; if None, will omit the option and let QEMU figure out which backend to use on its own.
     display_backend: str | None = None
     # A QEMU -device for the graphics card.
-    display_device: str | None = "VGA,vgamem_mb=64"
+    display_device: str | None = "virtio-gpu-pci"
     # QEMU -netdev
     network_backend: str | None = None
     # A QEMU -device for networking.
@@ -640,10 +640,6 @@ def set_up_display_device(config: Configuration):
             raise RunError("SERENITY_GL and multi-monitor support cannot be set up simultaneously")
         config.display_device = "virtio-vga-gl"
 
-    elif config.screen_count == 1:
-        # FIXME: The default VGA device is broken when running in a hypervisor on arm.
-        if config.architecture == Arch.Aarch64 and not config.machine_type.is_raspberry_pi():
-            config.display_device = "virtio-gpu-pci"
     elif config.screen_count > 1:
         # QEMU appears to not support the virtio-vga VirtIO GPU variant on macOS.
         # To ensure we can still boot on macOS with VirtIO GPU, use the virtio-gpu-pci


### PR DESCRIPTION
This should fix the huge framebuffer performance regression caused by 0d11e70cfeb0a77fcc4cb351d5af5e81209ed1fd.