### PR TITLE
Cherry-pick most of "Qt: Fix -Werror=deprecated-declarations when using Qt > 6.7"

### DIFF
--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -62,7 +62,11 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     m_match_case = new QCheckBox(this);
     m_match_case->setText("Match &Case");
     m_match_case->setChecked(false);
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_match_case, &QCheckBox::checkStateChanged, this, [this] {
+#else
     connect(m_match_case, &QCheckBox::stateChanged, this, [this] {
+#endif
         find_text_changed();
     });
 

--- a/Ladybird/Qt/SettingsDialog.cpp
+++ b/Ladybird/Qt/SettingsDialog.cpp
@@ -61,7 +61,11 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
 
     m_enable_do_not_track = new QCheckBox(this);
     m_enable_do_not_track->setChecked(Settings::the()->enable_do_not_track());
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    QObject::connect(m_enable_do_not_track, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     QObject::connect(m_enable_do_not_track, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_do_not_track(state == Qt::Checked);
     });
 
@@ -116,12 +120,20 @@ void SettingsDialog::setup_search_engines()
     m_autocomplete_engine_dropdown->setMenu(autocomplete_engine_menu);
     m_autocomplete_engine_dropdown->setEnabled(Settings::the()->enable_autocomplete());
 
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_enable_search, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     connect(m_enable_search, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_search(state == Qt::Checked);
         m_search_engine_dropdown->setEnabled(state == Qt::Checked);
     });
 
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_enable_autocomplete, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     connect(m_enable_autocomplete, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_autocomplete(state == Qt::Checked);
         m_autocomplete_engine_dropdown->setEnabled(state == Qt::Checked);
     });


### PR DESCRIPTION
(cherry picked from commit 07400b515c3d8d03bf3d6e35c26ec8a3d7317560; amended to omit change to code added in LadybirdBrowser/ladybird#1497 since we don't have that yet)

---

https://github.com/LadybirdBrowser/ladybird/pull/1807