### PR TITLE
Kernel: Remove leftovers from x86 software interrupt-based syscalls

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -16,8 +16,6 @@
 #    include <Kernel/Arch/RegisterState.h>
 #endif
 
-constexpr int syscall_vector = 0x82;
-
 extern "C" {
 struct pollfd;
 struct timeval;

--- a/Kernel/Arch/x86_64/InterruptManagement.cpp
+++ b/Kernel/Arch/x86_64/InterruptManagement.cpp
@@ -86,8 +86,6 @@ u8 InterruptManagement::acquire_irq_number(u8 mapped_interrupt_vector)
 u8 InterruptManagement::get_mapped_interrupt_vector(u8 original_irq)
 {
     // FIXME: For SMP configuration (with IOAPICs) use a better routing scheme to make redirections more efficient.
-    // FIXME: Find a better way to handle conflict with Syscall interrupt gate.
-    VERIFY((original_irq + IRQ_VECTOR_BASE) != syscall_vector);
     return original_irq;
 }
 


### PR DESCRIPTION
This definition and the accompanying VERIFY is unnecessary since bfbb4bcd9bd removed support for `int 0x82` syscalls.