### PR TITLE
Kernel/aarch64: Don't make the vector table weak

### DIFF
--- a/Kernel/Arch/aarch64/vector_table.S
+++ b/Kernel/Arch/aarch64/vector_table.S
@@ -118,7 +118,6 @@
 .endm
 
 .global vector_table_el1
-.weak vector_table_el1 // Vector table is weak in case someone wants to hook us in C++ land :^)
 .type vector_table_el1, @object
 
 // Vector table is 2KiB aligned (2^11)


### PR DESCRIPTION
This gets rid of the following linker warning:
"warning: vector_table_el1 changed binding to STB_WEAK"

There is no reason for the vector table to be weak. We don't override it anywhere.