### PR TITLE
Kernel: Increase the ksyms section size to 8 MiB

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -21,7 +21,7 @@ FlatPtr g_highest_kernel_symbol_address = 0;
 SetOnce g_kernel_symbols_available;
 
 extern "C" {
-__attribute__((section(".kernel_symbols"))) char kernel_symbols[5 * MiB] {};
+__attribute__((section(".kernel_symbols"))) char kernel_symbols[8 * MiB] {};
 }
 
 static KernelSymbol* s_symbols;


### PR DESCRIPTION
The x86 kernel.map is 6.1 MiB big when building with GCC and ENABLE_EXTRA_KERNEL_DEBUG_SYMBOLS is enabled.

I had this patch applied locally for quite a long time now and didn't want to upstream it.
But solving this properly (instead of hardcoding the size) isn't very easy, since calculating the size needed for the symbol table is a chicken and egg problem.
We could maybe link the kernel multiple times: First with an empty symbol table, then with the symbol table from the first linked kernel and finally replace the section contents with the real symbol table.
But the linker could potentially move things around and cause the symbol table to grow too much.