### PR TITLE
MacPDF: Unbreak "Go to Page…" keyboard shortcut

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -136,6 +136,8 @@
 {
     if ([_pdfView validateMenuItem:item])
         return YES;
+    if (item.action == @selector(showGoToPageDialog:))
+        return _pdfDocument.pdf ? YES : NO;
     return [super validateMenuItem:item];
 }
 

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -138,7 +138,7 @@
         return YES;
     if (item.action == @selector(showGoToPageDialog:))
         return _pdfDocument.pdf ? YES : NO;
-    return [super validateMenuItem:item];
+    return NO;
 }
 
 - (IBAction)toggleShowClippingPaths:(id)sender


### PR DESCRIPTION
I broke this in a7fbb7fd0bb02e of #22791.

Almost all of MacPDFWindowController's IBActions are forwarded to `_pdfView`, but `showGoToPageDialog:` isn't and needs to be explicitly handled in `validateMenuItem:`.

---

This not working was bugging me quite a bit. I'm glad I finally figured it out; `git bisect` is the best.

Also a bonus commit that fixes the cause of the weird "keyboard shortcut does not work, but clicking the menu item does" state that "Go to Page…" was in before the first commit in this PR.