### PR TITLE
LibPDF: Tolerate indirect object in array DecodeParm

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -451,7 +451,7 @@ PDFErrorOr<void> Parser::unfilter_stream(NonnullRefPtr<StreamObject> stream_obje
             auto decode_parms_array = decode_parms_object->cast<ArrayObject>();
             for (size_t i = 0; i < decode_parms_array->size(); ++i) {
                 RefPtr<DictObject> decode_parms;
-                auto entry = decode_parms_array->at(i);
+                auto entry = TRY(m_document->resolve(decode_parms_array->at(i)));
                 if (entry.has<NonnullRefPtr<Object>>()) {
                     auto entry_object = entry.get<NonnullRefPtr<Object>>();
                     if (entry_object->is<DictObject>())


### PR DESCRIPTION
Fixes rendering of the non-JPEG2000 images mentioned in #25701.

---

Previously: #21909, #21584, #21524. It's as if our APIs here aren't quite ideal.

example.pdf, before:
![image](https://github.com/user-attachments/assets/6b3e99e3-80b7-4194-b989-158c24e45f79)

After:
![out](https://github.com/user-attachments/assets/ae322de7-94cd-4405-8767-5386489382ae)