### PR TITLE
EFI Prekernel (7/N): EFIPrekernel: Make it boot the RISC-V kernel

### DIFF
--- a/Kernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/Arch/riscv64/MMU.cpp
@@ -8,8 +8,8 @@
 
 #include <Kernel/Arch/riscv64/CPU.h>
 #include <Kernel/Arch/riscv64/MMU.h>
-#include <Kernel/Arch/riscv64/PageDirectory.h>
 #include <Kernel/Arch/riscv64/SBI.h>
+#include <Kernel/Arch/riscv64/VirtualMemoryDefinitions.h>
 #include <Kernel/Arch/riscv64/pre_init.h>
 #include <Kernel/Firmware/DeviceTree/DeviceTree.h>
 #include <Kernel/Memory/MemoryManager.h>

--- a/Kernel/Arch/riscv64/PageDirectory.h
+++ b/Kernel/Arch/riscv64/PageDirectory.h
@@ -10,6 +10,7 @@
 #include <AK/IntrusiveRedBlackTree.h>
 #include <AK/RefPtr.h>
 
+#include <Kernel/Arch/riscv64/VirtualMemoryDefinitions.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/MemoryType.h>
@@ -20,44 +21,6 @@
 VALIDATE_IS_RISCV64()
 
 namespace Kernel::Memory {
-
-// Documentation for RISC-V Virtual Memory:
-// The RISC-V Instruction Set Manual, Volume II: Privileged Architecture
-// https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
-
-// Currently, only the Sv39 (3 level paging) virtual memory system is implemented
-
-// Figure 4.19-4.21
-constexpr size_t PAGE_TABLE_SHIFT = 12;
-constexpr size_t PAGE_TABLE_SIZE = 1LU << PAGE_TABLE_SHIFT;
-
-constexpr size_t PADDR_PPN_OFFSET = PAGE_TABLE_SHIFT;
-constexpr size_t VADDR_VPN_OFFSET = PAGE_TABLE_SHIFT;
-constexpr size_t PTE_PPN_OFFSET = 10;
-
-constexpr size_t PPN_SIZE = 26 + 9 + 9;
-constexpr size_t VPN_SIZE = 9 + 9 + 9;
-
-constexpr size_t VPN_2_OFFSET = 30;
-constexpr size_t VPN_1_OFFSET = 21;
-constexpr size_t VPN_0_OFFSET = 12;
-
-constexpr size_t PPN_MASK = (1LU << PPN_SIZE) - 1;
-constexpr size_t PTE_PPN_MASK = PPN_MASK << PTE_PPN_OFFSET;
-
-constexpr size_t PAGE_TABLE_INDEX_MASK = 0x1ff;
-
-enum class PageTableEntryBits {
-    Valid = 1 << 0,
-    Readable = 1 << 1,
-    Writeable = 1 << 2,
-    Executable = 1 << 3,
-    UserAllowed = 1 << 4,
-    Global = 1 << 5,
-    Accessed = 1 << 6,
-    Dirty = 1 << 7,
-};
-AK_ENUM_BITWISE_OPERATORS(PageTableEntryBits);
 
 class PageDirectoryEntry {
 public:

--- a/Kernel/Arch/riscv64/VirtualMemoryDefinitions.h
+++ b/Kernel/Arch/riscv64/VirtualMemoryDefinitions.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+#include <AK/Types.h>
+
+namespace Kernel {
+
+// Documentation for RISC-V Virtual Memory:
+// The RISC-V Instruction Set Manual, Volume II: Privileged Architecture
+// https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
+
+// Currently, only the Sv39 (3 level paging) virtual memory system is implemented
+
+// Figure 4.19-4.21
+constexpr size_t PAGE_TABLE_SHIFT = 12;
+constexpr size_t PAGE_TABLE_SIZE = 1LU << PAGE_TABLE_SHIFT;
+
+constexpr size_t PADDR_PPN_OFFSET = PAGE_TABLE_SHIFT;
+constexpr size_t VADDR_VPN_OFFSET = PAGE_TABLE_SHIFT;
+constexpr size_t PTE_PPN_OFFSET = 10;
+
+constexpr size_t PPN_SIZE = 26 + 9 + 9;
+constexpr size_t VPN_SIZE = 9 + 9 + 9;
+
+constexpr size_t VPN_2_OFFSET = 30;
+constexpr size_t VPN_1_OFFSET = 21;
+constexpr size_t VPN_0_OFFSET = 12;
+
+constexpr size_t PPN_MASK = (1LU << PPN_SIZE) - 1;
+constexpr size_t PTE_PPN_MASK = PPN_MASK << PTE_PPN_OFFSET;
+
+constexpr size_t PAGE_TABLE_INDEX_MASK = 0x1ff;
+
+enum class PageTableEntryBits {
+    Valid = 1 << 0,
+    Readable = 1 << 1,
+    Writeable = 1 << 2,
+    Executable = 1 << 3,
+    UserAllowed = 1 << 4,
+    Global = 1 << 5,
+    Accessed = 1 << 6,
+    Dirty = 1 << 7,
+};
+AK_ENUM_BITWISE_OPERATORS(PageTableEntryBits);
+
+}

--- a/Kernel/Arch/riscv64/VirtualMemoryDefinitions.h
+++ b/Kernel/Arch/riscv64/VirtualMemoryDefinitions.h
@@ -35,7 +35,12 @@ constexpr size_t VPN_0_OFFSET = 12;
 constexpr size_t PPN_MASK = (1LU << PPN_SIZE) - 1;
 constexpr size_t PTE_PPN_MASK = PPN_MASK << PTE_PPN_OFFSET;
 
-constexpr size_t PAGE_TABLE_INDEX_MASK = 0x1ff;
+constexpr size_t PAGE_TABLE_INDEX_BITS = 9;
+constexpr size_t PAGE_TABLE_INDEX_MASK = (1 << PAGE_TABLE_INDEX_BITS) - 1;
+
+constexpr size_t PAGE_OFFSET_BITS = 12;
+
+constexpr size_t PAGE_TABLE_LEVEL_COUNT = 3;
 
 enum class PageTableEntryBits {
     Valid = 1 << 0,

--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -4,26 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-ENTRY(start)
+ENTRY(init)
 
 #define PF_X 0x1
 #define PF_W 0x2
 #define PF_R 0x4
 
-KERNEL_MAPPING_BASE = 0x2000000000;
-
 PHDRS
 {
     text PT_LOAD FLAGS(PF_R | PF_X);
     data PT_LOAD FLAGS(PF_R | PF_W);
-    ksyms PT_LOAD FLAGS(PF_R);
     bss PT_LOAD FLAGS(PF_R | PF_W);
+    dynamic_segment PT_LOAD FLAGS(PF_R | PF_W);
+    dynamic PT_DYNAMIC FLAGS(PF_R | PF_W);
+    ksyms PT_LOAD FLAGS(PF_R | PF_W);
 }
 
 SECTIONS
 {
-    . = KERNEL_MAPPING_BASE;
-
     start_of_kernel_image = .;
 
     .text ALIGN(4K) :
@@ -84,13 +82,6 @@ SECTIONS
         end_of_ro_after_init = .;
     } :data
 
-    .ksyms ALIGN(4K) :
-    {
-        start_of_kernel_ksyms = .;
-        *(.kernel_symbols)
-        end_of_kernel_ksyms = .;
-    } :ksyms
-
     /* The bss has to be in its own program header so the prekernel doesn't have to copy segments */
     .bss ALIGN(4K) (NOLOAD) :
     {
@@ -101,6 +92,18 @@ SECTIONS
         . = ALIGN(4K);
         *(.heap)
     } :bss
+
+    .dynamic ALIGN(4K) :
+    {
+        *(.dynamic)
+    } :dynamic_segment :dynamic
+
+    .ksyms ALIGN(4K) :
+    {
+        start_of_kernel_ksyms = .;
+        *(.kernel_symbols)
+        end_of_kernel_ksyms = .;
+    } :ksyms
 
     . = ALIGN(4K);
     start_of_initial_stack = .;

--- a/Kernel/Arch/riscv64/pre_init.cpp
+++ b/Kernel/Arch/riscv64/pre_init.cpp
@@ -11,6 +11,8 @@
 #include <Kernel/Arch/riscv64/SBI.h>
 #include <Kernel/Sections.h>
 
+#include <LibELF/Relocation.h>
+
 namespace Kernel {
 
 UNMAP_AFTER_INIT void dbgln_without_mmu(StringView message)
@@ -43,8 +45,37 @@ UNMAP_AFTER_INIT void dbgln_without_mmu(StringView message)
     panic_without_mmu("Unexpected trap"sv);
 }
 
+static UNMAP_AFTER_INIT PhysicalPtr physical_load_base()
+{
+    PhysicalPtr physical_load_base;
+
+    asm volatile(
+        "lla %[physical_load_base], start_of_kernel_image\n"
+        : [physical_load_base] "=r"(physical_load_base));
+
+    return physical_load_base;
+}
+
+static UNMAP_AFTER_INIT PhysicalPtr dynamic_section_addr()
+{
+    PhysicalPtr dynamic_section_addr;
+
+    // Use lla explicitly to prevent a GOT load.
+    asm volatile(
+        "lla %[dynamic_section_addr], _DYNAMIC\n"
+        : [dynamic_section_addr] "=r"(dynamic_section_addr));
+
+    return dynamic_section_addr;
+}
+
 extern "C" [[noreturn]] UNMAP_AFTER_INIT void pre_init(FlatPtr boot_hart_id, PhysicalPtr flattened_devicetree_paddr)
 {
+    // Apply relative relocations as if we were running at KERNEL_MAPPING_BASE.
+    // This means that all global variables must be accessed with adjust_by_mapping_base, since we are still running identity mapped.
+    // Otherwise, we would have to relocate twice: once while running identity mapped, and again when we enable the MMU.
+    if (!ELF::perform_relative_relocations(physical_load_base(), KERNEL_MAPPING_BASE, dynamic_section_addr()))
+        panic_without_mmu("Failed to perform relative relocations"sv);
+
     // Catch traps in pre_init
     RISCV64::CSR::write(RISCV64::CSR::Address::STVEC, bit_cast<FlatPtr>(&early_trap_handler));
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -616,6 +616,7 @@ set(EDID_SOURCES
 
 set(ELF_SOURCES
     ../Userland/Libraries/LibELF/Image.cpp
+    ../Userland/Libraries/LibELF/Relocation.cpp
     ../Userland/Libraries/LibELF/Validation.cpp
 )
 
@@ -837,7 +838,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
 
     # The final kernel binary for some reason includes temporary local symbols on riscv64 clang, which causes kernel.map to be too big to fit in its section in the kernel.
     # Explicitly pass -X to the linker to remove them.
-    target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib LINKER:--no-pie LINKER:-X)
+    target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib LINKER:-X)
 
     set_target_properties(Kernel PROPERTIES LINK_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/linker.ld")
 elseif ("${SERENITY_ARCH}" STREQUAL "x86_64")

--- a/Kernel/EFIPrekernel/Arch/Boot.h
+++ b/Kernel/EFIPrekernel/Arch/Boot.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Prekernel/Prekernel.h>
+
+#include <Kernel/EFIPrekernel/Error.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info);
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr);
+
+}

--- a/Kernel/EFIPrekernel/Arch/MMU.h
+++ b/Kernel/EFIPrekernel/Arch/MMU.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+#include <AK/Types.h>
+
+#include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+
+#include <Kernel/EFIPrekernel/Error.h>
+
+namespace Kernel {
+
+enum class Access {
+    None = 0,
+    Read = 1,
+    Write = 2,
+    Execute = 4,
+};
+AK_ENUM_BITWISE_OPERATORS(Access);
+
+EFIErrorOr<void*> allocate_empty_root_page_table();
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level = 0, bool has_to_be_new = false);
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access);
+
+}

--- a/Kernel/EFIPrekernel/Arch/aarch64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/aarch64/Boot.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
+{
+    (void)root_page_table;
+    (void)boot_info;
+    TODO();
+}
+
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
+{
+    (void)root_page_table;
+    (void)kernel_entry_vaddr;
+    (void)kernel_stack_pointer;
+    (void)boot_info_vaddr;
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/aarch64/MMU.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+static constexpr size_t PAGE_TABLE_SIZE = PAGE_SIZE;
+
+EFIErrorOr<void*> allocate_empty_root_page_table()
+{
+    EFI::PhysicalAddress root_page_table_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &root_page_table_paddr); status != EFI::Status::Success)
+        return status;
+
+    auto* root_page_table = bit_cast<void*>(root_page_table_paddr);
+    __builtin_memset(root_page_table, 0, PAGE_TABLE_SIZE);
+
+    return root_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)paddr;
+    (void)access;
+    TODO();
+}
+
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)level;
+    (void)has_to_be_new;
+    TODO();
+}
+
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)
+{
+    for (size_t i = 0; i < page_count; i++)
+        TRY(map_single_page(root_page_table, start_vaddr + i * PAGE_SIZE, start_paddr + i * PAGE_SIZE, access));
+
+    return {};
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
+{
+    (void)root_page_table;
+    (void)boot_info;
+    TODO();
+}
+
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
+{
+    (void)root_page_table;
+    (void)kernel_entry_vaddr;
+    (void)kernel_stack_pointer;
+    (void)boot_info_vaddr;
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
@@ -6,25 +6,130 @@
 
 #include <AK/Types.h>
 
+#include <Kernel/Arch/riscv64/CSR.h>
+#include <Kernel/Arch/riscv64/VirtualMemoryDefinitions.h>
+#include <Kernel/Firmware/EFI/Protocols/RISCVBootProtocol.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+#include <Kernel/Prekernel/Prekernel.h>
+#include <Kernel/Sections.h>
+
 #include <Kernel/EFIPrekernel/Arch/Boot.h>
-#include <Kernel/EFIPrekernel/Runtime.h>
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/EFIPrekernel.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/VirtualMemoryLayout.h>
 
 namespace Kernel {
 
+// This function has to fit into one page as it will be identity mapped.
+[[gnu::aligned(PAGE_SIZE)]] [[noreturn]] static void enter_kernel_helper(FlatPtr satp, FlatPtr kernel_entry, FlatPtr kernel_sp, FlatPtr boot_info_vaddr)
+{
+    // Switch the active root page table to argument 0.
+    // This will immediately take effect, but we won't crash as this function is identity mapped.
+    // Also set up a temporary trap handler to catch traps while switching page tables.
+    register FlatPtr a0 asm("a0") = boot_info_vaddr;
+    register FlatPtr sp asm("sp") = kernel_sp;
+    asm volatile(R"(
+        lla t0, 1f
+        csrw stvec, t0
+
+        csrw satp, %[satp]
+        sfence.vma
+
+        li ra, 0
+        li fp, 0
+        jr %[kernel_entry]
+
+    .p2align 2
+    1:
+        csrw sie, zero
+        wfi
+        j 1b
+    )"
+                 :
+                 : "r"(a0), "r"(sp), [satp] "r"(satp), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
+                 : "t0", "memory");
+
+    __builtin_unreachable();
+}
+
+static FlatPtr get_boot_hart_id()
+{
+    auto riscv_boot_protocol_guid = EFI::RISCVBootProtocol::guid;
+    EFI::RISCVBootProtocol* riscv_boot_protocol = nullptr;
+
+    if (auto status = g_efi_system_table->boot_services->locate_protocol(&riscv_boot_protocol_guid, nullptr, reinterpret_cast<void**>(&riscv_boot_protocol)); status != EFI::Status::Success)
+        PANIC("Failed to locate the RISC-V boot protocol: {}. RISC-V systems that don't support RISCV_EFI_BOOT_PROTOCOL are not supported.", status);
+
+    FlatPtr boot_hart_id { 0 };
+    if (auto status = riscv_boot_protocol->get_boot_hart_id(riscv_boot_protocol, &boot_hart_id); status != EFI::Status::Success)
+        PANIC("Failed to get the RISC-V boot hart ID: {}", status);
+
+    return boot_hart_id;
+}
+
+static void map_bootstrap_page(void* root_page_table, BootInfo& boot_info)
+{
+    // FIXME: This leaks < (page table levels) pages, since all active allocations after ExitBootServices are currently eternal.
+    //        We could theoretically reclaim them in the kernel.
+    // NOTE: If this map_pages ever fails, the kernel vaddr range is inside our (physical) prekernel range.
+    if (auto result = map_pages(root_page_table, bit_cast<FlatPtr>(&enter_kernel_helper), bit_cast<PhysicalPtr>(&enter_kernel_helper), 1, Access::Read | Access::Execute); result.is_error())
+        PANIC("Failed to identity map the enter_kernel_helper function: {}", result.release_error());
+
+    auto maybe_bootstrap_page_page_directory = get_or_insert_page_table(root_page_table, bit_cast<PhysicalPtr>(&enter_kernel_helper), 1);
+    if (maybe_bootstrap_page_page_directory.is_error())
+        PANIC("Could not find the bootstrap page page directory: {}", maybe_bootstrap_page_page_directory.release_error());
+
+    boot_info.boot_method_specific.efi.bootstrap_page_vaddr = VirtualAddress { bit_cast<FlatPtr>(&enter_kernel_helper) };
+    boot_info.boot_method_specific.efi.bootstrap_page_page_directory_paddr = PhysicalAddress { bit_cast<PhysicalPtr>(maybe_bootstrap_page_page_directory.value()) };
+}
+
+static void set_up_quickmap_page_table(void* root_page_table, BootInfo& boot_info)
+{
+    auto kernel_pt1024_base = boot_info.kernel_mapping_base + KERNEL_PT1024_OFFSET;
+
+    auto maybe_quickmap_page_table_paddr = get_or_insert_page_table(root_page_table, kernel_pt1024_base, 0, true);
+    if (maybe_quickmap_page_table_paddr.is_error())
+        PANIC("Failed to insert the quickmap page table: {}", maybe_quickmap_page_table_paddr.release_error());
+
+    boot_info.boot_pd_kernel_pt1023 = bit_cast<Memory::PageTableEntry*>(QUICKMAP_PAGE_TABLE_VADDR);
+
+    if (auto result = map_pages(root_page_table, bit_cast<FlatPtr>(boot_info.boot_pd_kernel_pt1023), bit_cast<PhysicalPtr>(maybe_quickmap_page_table_paddr.value()), 1, Access::Read | Access::Write); result.is_error())
+        PANIC("Failed to map the quickmap page table: {}", result.release_error());
+}
+
 void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
 {
-    (void)root_page_table;
-    (void)boot_info;
-    TODO();
+    if (boot_info.flattened_devicetree_paddr.is_null())
+        PANIC("No devicetree configuration table was found. RISC-V systems without a devicetree UEFI configuration table are not supported.");
+
+    boot_info.arch_specific.boot_hart_id = get_boot_hart_id();
+
+    map_bootstrap_page(root_page_table, boot_info);
+    set_up_quickmap_page_table(root_page_table, boot_info);
+
+    auto maybe_kernel_page_directory = get_or_insert_page_table(root_page_table, boot_info.kernel_mapping_base, 1);
+    if (maybe_kernel_page_directory.is_error())
+        PANIC("Could not find the kernel page directory: {}", maybe_kernel_page_directory.release_error());
+
+    // There is no level 4 table in Sv39.
+    boot_info.boot_pml4t = PhysicalAddress { 0 };
+
+    boot_info.boot_pdpt = PhysicalAddress { bit_cast<PhysicalPtr>(root_page_table) };
+    boot_info.boot_pd_kernel = PhysicalAddress { bit_cast<PhysicalPtr>(maybe_kernel_page_directory.value()) };
 }
 
 [[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
 {
-    (void)root_page_table;
-    (void)kernel_entry_vaddr;
-    (void)kernel_stack_pointer;
-    (void)boot_info_vaddr;
-    halt();
+    RISCV64::CSR::SATP satp = {
+        .PPN = bit_cast<u64>(root_page_table) >> PADDR_PPN_OFFSET,
+        .ASID = 0,
+        .MODE = RISCV64::CSR::SATP::Mode::Sv39,
+    };
+
+    enter_kernel_helper(bit_cast<FlatPtr>(satp), kernel_entry_vaddr, kernel_stack_pointer, boot_info_vaddr);
 }
 
 }

--- a/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
@@ -23,22 +23,68 @@ EFIErrorOr<void*> allocate_empty_root_page_table()
     return root_page_table;
 }
 
-static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+static u64* get_pte(u64* page_table, FlatPtr vaddr, size_t level)
 {
-    (void)root_page_table;
-    (void)vaddr;
-    (void)paddr;
-    (void)access;
-    TODO();
+    size_t pte_index_offset = (PAGE_TABLE_INDEX_BITS * level) + PAGE_OFFSET_BITS;
+    size_t pte_index = (vaddr >> pte_index_offset) & PAGE_TABLE_INDEX_MASK;
+
+    return &page_table[pte_index];
 }
 
 EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
 {
-    (void)root_page_table;
-    (void)vaddr;
-    (void)level;
-    (void)has_to_be_new;
-    TODO();
+    VERIFY(root_page_table != nullptr);
+
+    if (level >= PAGE_TABLE_LEVEL_COUNT - 1)
+        return EFI::Status::InvalidParameter;
+
+    u64* current_page_table = static_cast<u64*>(root_page_table);
+
+    for (size_t current_level = PAGE_TABLE_LEVEL_COUNT - 1; current_level > level; current_level--) {
+        u64* pte = get_pte(current_page_table, vaddr, current_level);
+
+        if ((*pte & to_underlying(PageTableEntryBits::Valid)) != 0) {
+            if (current_level - 1 == level && has_to_be_new)
+                return EFI::Status::InvalidParameter;
+
+            current_page_table = bit_cast<u64*>((*pte >> PTE_PPN_OFFSET) << PADDR_PPN_OFFSET);
+        } else {
+            EFI::PhysicalAddress new_page_table_paddr = 0;
+            if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &new_page_table_paddr); status != EFI::Status::Success)
+                return status;
+
+            __builtin_memset(bit_cast<void*>(new_page_table_paddr), 0, PAGE_TABLE_SIZE);
+
+            *pte = ((new_page_table_paddr >> PADDR_PPN_OFFSET) << PTE_PPN_OFFSET) | to_underlying(PageTableEntryBits::Valid);
+
+            current_page_table = bit_cast<u64*>(new_page_table_paddr);
+        }
+    }
+
+    return current_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    auto* page_table = TRY(get_or_insert_page_table(root_page_table, vaddr));
+    u64* pte = get_pte(bit_cast<u64*>(page_table), vaddr, 0);
+
+    if ((*pte & to_underlying(PageTableEntryBits::Valid)) != 0)
+        return EFI::Status::InvalidParameter; // already mapped
+
+    // Always set the A/D bits as we don't know if the hardware updates them automatically (i.e. if Svadu is supported).
+    // If the hardware doesn't update them automatically they act like additional permission bits.
+    PageTableEntryBits flags = PageTableEntryBits::Valid | PageTableEntryBits::Accessed | PageTableEntryBits::Dirty;
+    if (to_underlying(access & Access::Read) != 0)
+        flags |= PageTableEntryBits::Readable;
+    if (to_underlying(access & Access::Write) != 0)
+        flags |= PageTableEntryBits::Writeable;
+    if (to_underlying(access & Access::Execute) != 0)
+        flags |= PageTableEntryBits::Executable;
+
+    *pte = ((paddr >> PADDR_PPN_OFFSET) << PTE_PPN_OFFSET) | to_underlying(flags);
+
+    return {};
 }
 
 EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)

--- a/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/MMU.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/riscv64/VirtualMemoryDefinitions.h>
+
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+EFIErrorOr<void*> allocate_empty_root_page_table()
+{
+    EFI::PhysicalAddress root_page_table_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &root_page_table_paddr); status != EFI::Status::Success)
+        return status;
+
+    auto* root_page_table = bit_cast<void*>(root_page_table_paddr);
+    __builtin_memset(root_page_table, 0, PAGE_TABLE_SIZE);
+
+    return root_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)paddr;
+    (void)access;
+    TODO();
+}
+
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)level;
+    (void)has_to_be_new;
+    TODO();
+}
+
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)
+{
+    for (size_t i = 0; i < page_count; i++)
+        TRY(map_single_page(root_page_table, start_vaddr + i * PAGE_SIZE, start_paddr + i * PAGE_SIZE, access));
+
+    return {};
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/x86_64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/x86_64/Boot.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Runtime.h>
+
+namespace Kernel {
+
+void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
+{
+    (void)root_page_table;
+    (void)boot_info;
+    TODO();
+}
+
+[[noreturn]] void arch_enter_kernel(void* root_page_table, FlatPtr kernel_entry_vaddr, FlatPtr kernel_stack_pointer, FlatPtr boot_info_vaddr)
+{
+    (void)root_page_table;
+    (void)kernel_entry_vaddr;
+    (void)kernel_stack_pointer;
+    (void)boot_info_vaddr;
+    halt();
+}
+
+}

--- a/Kernel/EFIPrekernel/Arch/x86_64/MMU.cpp
+++ b/Kernel/EFIPrekernel/Arch/x86_64/MMU.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+static constexpr size_t PAGE_TABLE_SIZE = PAGE_SIZE;
+
+EFIErrorOr<void*> allocate_empty_root_page_table()
+{
+    EFI::PhysicalAddress root_page_table_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, 1, &root_page_table_paddr); status != EFI::Status::Success)
+        return status;
+
+    auto* root_page_table = bit_cast<void*>(root_page_table_paddr);
+    __builtin_memset(root_page_table, 0, PAGE_TABLE_SIZE);
+
+    return root_page_table;
+}
+
+static EFIErrorOr<void> map_single_page(void* root_page_table, FlatPtr vaddr, PhysicalPtr paddr, Access access)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)paddr;
+    (void)access;
+    TODO();
+}
+
+EFIErrorOr<void*> get_or_insert_page_table(void* root_page_table, FlatPtr vaddr, size_t level, bool has_to_be_new)
+{
+    (void)root_page_table;
+    (void)vaddr;
+    (void)level;
+    (void)has_to_be_new;
+    TODO();
+}
+
+EFIErrorOr<void> map_pages(void* root_page_table, FlatPtr start_vaddr, PhysicalPtr start_paddr, size_t page_count, Access access)
+{
+    for (size_t i = 0; i < page_count; i++)
+        TRY(map_single_page(root_page_table, start_vaddr + i * PAGE_SIZE, start_paddr + i * PAGE_SIZE, access));
+
+    return {};
+}
+
+}

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -4,6 +4,7 @@ configure_file(KernelImage.S.in KernelImage.S @ONLY)
 set(SOURCES
     init.cpp
 
+    ConfigurationTable.cpp
     DebugOutput.cpp
     Panic.cpp
     Relocation.cpp

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
 
     DebugOutput.cpp
     Panic.cpp
+    Relocation.cpp
     Runtime.cpp
     kmalloc.cpp
 
@@ -17,6 +18,9 @@ set(SOURCES
     ../Firmware/EFI/EFI.cpp
     ../Library/MiniStdLib.cpp
     ../Prekernel/UBSanitizer.cpp
+
+    ../../Userland/Libraries/LibELF/Image.cpp
+    ../../Userland/Libraries/LibELF/Validation.cpp
 
     ../../AK/Format.cpp
     ../../AK/StringBuilder.cpp

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
 
     KernelImage.S
 
+    Arch/${SERENITY_ARCH}/Boot.cpp
     Arch/${SERENITY_ARCH}/MMU.cpp
 
     ../Firmware/EFI/EFI.cpp

--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES
 
     KernelImage.S
 
+    Arch/${SERENITY_ARCH}/MMU.cpp
+
     ../Firmware/EFI/EFI.cpp
     ../Library/MiniStdLib.cpp
     ../Prekernel/UBSanitizer.cpp

--- a/Kernel/EFIPrekernel/ConfigurationTable.cpp
+++ b/Kernel/EFIPrekernel/ConfigurationTable.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/ConfigurationTable.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+#include <LibDeviceTree/FlattenedDeviceTree.h>
+
+namespace Kernel {
+
+static void* search_efi_configuration_table(EFI::GUID guid)
+{
+    for (FlatPtr i = 0; i < g_efi_system_table->number_of_table_entries; i++) {
+        if (g_efi_system_table->configuration_table[i].vendor_guid == guid)
+            return g_efi_system_table->configuration_table[i].vendor_table;
+    }
+
+    return nullptr;
+}
+
+void populate_devicetree_and_acpi_boot_info(BootInfo* boot_info)
+{
+    boot_info->flattened_devicetree_paddr = PhysicalAddress { bit_cast<PhysicalPtr>(search_efi_configuration_table(EFI::DTB_TABLE_GUID)) };
+    if (!boot_info->flattened_devicetree_paddr.is_null()) {
+        DeviceTree::FlattenedDeviceTreeHeader* fdt_header = reinterpret_cast<DeviceTree::FlattenedDeviceTreeHeader*>(boot_info->flattened_devicetree_paddr.as_ptr());
+        boot_info->flattened_devicetree_size = fdt_header->totalsize;
+    }
+
+    // Prefer ACPI 2.0.
+    boot_info->acpi_rsdp_paddr = PhysicalAddress { bit_cast<PhysicalPtr>(search_efi_configuration_table(EFI::ACPI_2_0_TABLE_GUID)) };
+    if (boot_info->acpi_rsdp_paddr.is_null())
+        boot_info->acpi_rsdp_paddr = PhysicalAddress { bit_cast<PhysicalPtr>(search_efi_configuration_table(EFI::ACPI_TABLE_GUID)) };
+}
+
+}

--- a/Kernel/EFIPrekernel/ConfigurationTable.h
+++ b/Kernel/EFIPrekernel/ConfigurationTable.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Prekernel/Prekernel.h>
+
+namespace Kernel {
+
+void populate_devicetree_and_acpi_boot_info(BootInfo* boot_info);
+
+}

--- a/Kernel/EFIPrekernel/Relocation.cpp
+++ b/Kernel/EFIPrekernel/Relocation.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Relocation.h>
+
+#include <LibELF/Arch/GenericDynamicRelocationType.h>
+#include <LibELF/ELFABI.h>
+#include <LibELF/Image.h>
+
+namespace Kernel {
+
+// This function only works on ELF addresses that are not in a zero-padded area of a program header.
+static ErrorOr<Bytes> get_data_at_kernel_elf_virtual_address(ELF::Image const& kernel_elf_image, Bytes kernel_elf_image_data, FlatPtr start_vaddr, size_t size)
+{
+    ErrorOr<Bytes> result = EINVAL;
+    static Optional<ELF::Image::ProgramHeader> cached_program_header;
+
+    static auto is_range_in_program_header = [](FlatPtr start_vaddr, size_t size, ELF::Image::ProgramHeader const& program_header) {
+        return start_vaddr >= program_header.vaddr().get() && start_vaddr + size <= program_header.vaddr().get() + program_header.size_in_memory();
+    };
+
+    if (cached_program_header.has_value() && is_range_in_program_header(start_vaddr, size, cached_program_header.value()))
+        return kernel_elf_image_data.slice(cached_program_header->offset() + start_vaddr - cached_program_header->vaddr().get(), size);
+
+    kernel_elf_image.for_each_program_header([&result, kernel_elf_image_data, start_vaddr, size](ELF::Image::ProgramHeader const& program_header) {
+        if (program_header.type() == PT_LOAD && is_range_in_program_header(start_vaddr, size, program_header)) {
+            result = kernel_elf_image_data.slice(program_header.offset() + start_vaddr - program_header.vaddr().get(), size);
+            cached_program_header = program_header;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    return result;
+}
+
+void perform_kernel_relocations(ELF::Image const& kernel_elf_image, Bytes kernel_elf_image_data, FlatPtr base_address)
+{
+    size_t dynamic_section_offset { 0 };
+    kernel_elf_image.for_each_program_header([&dynamic_section_offset](ELF::Image::ProgramHeader const& program_header) {
+        if (program_header.type() == PT_DYNAMIC) {
+            dynamic_section_offset = program_header.offset();
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    if (dynamic_section_offset == 0)
+        PANIC("Kernel image does not have a PT_DYNAMIC program header; can't perform relocations");
+
+    FlatPtr relocation_table_vaddr = 0;
+    size_t relocation_table_size = 0;
+    size_t relocation_entry_size = 0;
+    size_t number_of_relative_relocs = 0;
+
+    FlatPtr relr_relocation_table_vaddr = 0;
+    size_t relr_relocation_table_size = 0;
+
+    auto const* dynamic_section_entries = bit_cast<Elf_Dyn const*>(bit_cast<FlatPtr>(kernel_elf_image_data.data()) + dynamic_section_offset);
+    for (size_t i = 0;; i++) {
+        auto const& entry = dynamic_section_entries[i];
+
+        if (entry.d_tag == DT_NULL)
+            break;
+
+        switch (entry.d_tag) {
+        case DT_REL:
+        case DT_RELSZ:
+        case DT_RELENT:
+        case DT_RELCOUNT:
+            PANIC("DT_REL relocation tables are not supported");
+
+        case DT_RELA:
+            relocation_table_vaddr = entry.d_un.d_ptr;
+            break;
+        case DT_RELASZ:
+            relocation_table_size = entry.d_un.d_val;
+            break;
+        case DT_RELAENT:
+            relocation_entry_size = entry.d_un.d_val;
+            break;
+        case DT_RELACOUNT:
+            number_of_relative_relocs = entry.d_un.d_val;
+            break;
+
+        case DT_RELR:
+            relr_relocation_table_vaddr = entry.d_un.d_ptr;
+            break;
+        case DT_RELRSZ:
+            relr_relocation_table_size = entry.d_un.d_val;
+            break;
+        case DT_RELRENT:
+            VERIFY(entry.d_un.d_val == sizeof(FlatPtr));
+            break;
+        }
+    }
+
+    VERIFY((relocation_table_vaddr != 0 && relocation_table_size != 0 && relocation_entry_size != 0 && number_of_relative_relocs != 0)
+        || (relr_relocation_table_vaddr != 0 && relr_relocation_table_size != 0));
+
+    if (relocation_table_vaddr != 0) {
+        // We are still identity mapped, so translate the address of the relocation table.
+        auto relocation_table_data = MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, relocation_table_vaddr, relocation_table_size));
+
+        for (size_t i = 0; i < number_of_relative_relocs; i++) {
+            auto const& raw_relocation = *bit_cast<Elf_Rela const*>(bit_cast<FlatPtr>(relocation_table_data.data()) + (i * relocation_entry_size));
+            ELF::Image::Relocation relocation(kernel_elf_image, raw_relocation, true);
+
+            VERIFY(relocation.type() == to_underlying(ELF::GenericDynamicRelocationType::RELATIVE));
+
+            // Elf_Rela::r_offset is a virtual address for executables, so we need to translate it as well.
+            auto* patch_ptr = bit_cast<FlatPtr*>(MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, relocation.offset(), sizeof(FlatPtr))).data());
+
+            FlatPtr relocated_address = base_address + relocation.addend();
+            __builtin_memcpy(patch_ptr, &relocated_address, sizeof(FlatPtr));
+        }
+    }
+
+    if (relr_relocation_table_vaddr != 0) {
+        auto patch_relr = [&kernel_elf_image, kernel_elf_image_data, base_address](FlatPtr patch_vaddr) {
+            auto* patch_ptr = bit_cast<FlatPtr*>(MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, patch_vaddr, sizeof(FlatPtr))).data());
+
+            FlatPtr relocated_address;
+            __builtin_memcpy(&relocated_address, patch_ptr, sizeof(FlatPtr));
+            relocated_address += base_address;
+            __builtin_memcpy(patch_ptr, &relocated_address, sizeof(FlatPtr));
+        };
+
+        auto relr_relocation_table_data = MUST(get_data_at_kernel_elf_virtual_address(kernel_elf_image, kernel_elf_image_data, relr_relocation_table_vaddr, relr_relocation_table_size));
+        auto* entries = bit_cast<Elf_Relr*>(relr_relocation_table_data.data());
+        FlatPtr patch_vaddr = 0;
+
+        for (size_t i = 0; i < relr_relocation_table_size / sizeof(FlatPtr); i++) {
+            if ((entries[i] & 1) == 0) {
+                patch_vaddr = entries[i];
+                patch_relr(patch_vaddr);
+                patch_vaddr += sizeof(FlatPtr);
+            } else {
+                auto bitmap = entries[i];
+                for (size_t j = 0; (bitmap >>= 1) != 0; j++)
+                    if ((bitmap & 1) != 0)
+                        patch_relr(patch_vaddr + (j * sizeof(FlatPtr)));
+
+                patch_vaddr += (8 * sizeof(FlatPtr) - 1) * sizeof(FlatPtr);
+            }
+        }
+    }
+}
+
+}

--- a/Kernel/EFIPrekernel/Relocation.h
+++ b/Kernel/EFIPrekernel/Relocation.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibELF/Image.h>
+
+namespace Kernel {
+
+void perform_kernel_relocations(ELF::Image const& kernel_elf_image, Bytes kernel_elf_image_data, FlatPtr base_address);
+
+}

--- a/Kernel/EFIPrekernel/VirtualMemoryLayout.h
+++ b/Kernel/EFIPrekernel/VirtualMemoryLayout.h
@@ -13,9 +13,9 @@
 namespace Kernel {
 
 // Kernel virtual memory layout:
-// Kernel stack | BootInfo | Quickmap page table | EFI memory map | Kernel
+// Kernel stack | BootInfo | Quickmap page table | EFI memory map | Kernel cmdline | Kernel
 // ^ KERNEL_MAPPING_BASE
-// NOTE: If the memory map overflows into the kernel memory range, we catch that in the map_pages function (a page is not allowed to be remapped)
+// NOTE: If the kernel cmdline overflows into the kernel memory range, we catch that in the map_pages function (a page is not allowed to be remapped)
 
 static constexpr size_t KERNEL_STACK_SIZE = 64 * KiB;
 static_assert(KERNEL_STACK_SIZE % PAGE_SIZE == 0);
@@ -27,5 +27,9 @@ static constexpr FlatPtr QUICKMAP_PAGE_TABLE_VADDR = round_up_to_power_of_two(BO
 
 // This assumes PAGE_SIZE == PAGE_TABLE_SIZE
 static constexpr FlatPtr EFI_MEMORY_MAP_VADDR = QUICKMAP_PAGE_TABLE_VADDR + PAGE_SIZE;
+
+static constexpr size_t EFI_MEMORY_MAP_MAX_SIZE = 10uz * PAGE_SIZE;
+
+static constexpr FlatPtr KERNEL_CMDLINE_VADDR = EFI_MEMORY_MAP_VADDR + EFI_MEMORY_MAP_MAX_SIZE;
 
 }

--- a/Kernel/EFIPrekernel/init.cpp
+++ b/Kernel/EFIPrekernel/init.cpp
@@ -5,16 +5,42 @@
  */
 
 #include <Kernel/Firmware/EFI/EFI.h>
+#include <Kernel/Firmware/EFI/Protocols/LoadedImage.h>
 #include <Kernel/Firmware/EFI/SystemTable.h>
+#include <Kernel/Prekernel/Prekernel.h>
 
+#include <Kernel/EFIPrekernel/Arch/Boot.h>
+#include <Kernel/EFIPrekernel/Arch/MMU.h>
+#include <Kernel/EFIPrekernel/ConfigurationTable.h>
 #include <Kernel/EFIPrekernel/DebugOutput.h>
+#include <Kernel/EFIPrekernel/EFIPrekernel.h>
 #include <Kernel/EFIPrekernel/Panic.h>
+#include <Kernel/EFIPrekernel/Relocation.h>
 #include <Kernel/EFIPrekernel/Runtime.h>
+#include <Kernel/EFIPrekernel/VirtualMemoryLayout.h>
+
+#include <LibELF/ELFABI.h>
+#include <LibELF/Image.h>
 
 // FIXME: Initialize the __stack_chk_guard with a random value via the EFI_RNG_PROTOCOL or other arch-specific methods.
 uintptr_t __stack_chk_guard __attribute__((used));
 
+extern "C" u8 pe_image_base[];
+
+extern "C" u8 start_of_kernel_image[];
+extern "C" u8 end_of_kernel_image[];
+
 namespace Kernel {
+
+static_assert(EFI::EFI_PAGE_SIZE == PAGE_SIZE, "The EFIPrekernel assumes that EFI_PAGE_SIZE == PAGE_SIZE");
+
+EFI::Handle g_efi_image_handle = 0;
+EFI::SystemTable* g_efi_system_table = nullptr;
+
+static size_t pages_needed(size_t bytes)
+{
+    return ceil_div(bytes, static_cast<size_t>(PAGE_SIZE));
+}
 
 extern "C" [[noreturn]] void __stack_chk_fail();
 extern "C" [[noreturn]] void __stack_chk_fail()
@@ -22,10 +48,176 @@ extern "C" [[noreturn]] void __stack_chk_fail()
     PANIC("Stack protector failure, stack smashing detected!");
 }
 
-EFI::Handle g_efi_image_handle = 0;
-EFI::SystemTable* g_efi_system_table = nullptr;
+static void convert_and_map_cmdline(EFI::LoadedImageProtocol* loaded_image_protocol, void* root_page_table, BootInfo& boot_info)
+{
+    // Get the cmdline from loaded_image_protocol->load_options.
+    // FIXME: Support non-ASCII characters.
 
-static_assert(EFI::EFI_PAGE_SIZE == PAGE_SIZE, "The EFIPrekernel assumes that EFI_PAGE_SIZE == PAGE_SIZE");
+    if (loaded_image_protocol->load_options_size == 0 || loaded_image_protocol->load_options == nullptr)
+        return;
+
+    char16_t* load_options_ucs_2 = reinterpret_cast<char16_t*>(loaded_image_protocol->load_options);
+    size_t cmdline_length = loaded_image_protocol->load_options_size / sizeof(char16_t);
+
+    // Allocate pages for the cmdline buffer and map it to KERNEL_CMDLINE_VADDR.
+    // TODO: KASLR
+    EFI::PhysicalAddress cmdline_buffer_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, pages_needed(cmdline_length), &cmdline_buffer_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate pages for the cmdline buffer: {}", status);
+
+    if (auto result = map_pages(root_page_table, KERNEL_CMDLINE_VADDR, cmdline_buffer_paddr, pages_needed(cmdline_length), Access::Read); result.is_error())
+        PANIC("Failed to map the cmdline buffer: {}", result.release_error());
+
+    char* cmdline_buffer = bit_cast<char*>(cmdline_buffer_paddr);
+
+    size_t actual_length = 0;
+    for (size_t i = 0; i < cmdline_length && load_options_ucs_2[i] != u'\0'; i++) {
+        cmdline_buffer[i] = static_cast<char>(load_options_ucs_2[i]);
+        actual_length++;
+    }
+
+    boot_info.cmdline = StringView { bit_cast<char*>(KERNEL_CMDLINE_VADDR), actual_length };
+}
+
+static void map_kernel_image(void* root_page_table, ELF::Image const& kernel_elf_image, ReadonlyBytes kernel_elf_image_data, FlatPtr kernel_load_base)
+{
+    kernel_elf_image.for_each_program_header([root_page_table, kernel_elf_image_data, kernel_load_base](ELF::Image::ProgramHeader const& program_header) {
+        if (program_header.type() != PT_LOAD)
+            return IterationDecision::Continue;
+
+        auto page_count = pages_needed(program_header.size_in_memory());
+
+        auto start_vaddr = kernel_load_base + program_header.vaddr().get();
+        auto start_paddr = bit_cast<PhysicalPtr>(kernel_elf_image_data.data()) + program_header.offset();
+
+        if (program_header.size_in_memory() != program_header.size_in_image()) {
+            if (program_header.size_in_image() != 0)
+                PANIC("Program headers with p_memsz != p_filesz && p_filesz != 0 are not supported");
+
+            // Allocate a zeroed memory region for the program header.
+            EFI::PhysicalAddress segment_data_paddr = 0;
+            if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, page_count, &segment_data_paddr); status != EFI::Status::Success)
+                PANIC("Failed to allocate memory for program header {}: {}", program_header.index(), status);
+
+            __builtin_memset(bit_cast<void*>(segment_data_paddr), 0, page_count * PAGE_SIZE);
+
+            start_paddr = segment_data_paddr;
+        }
+
+        VERIFY(program_header.alignment() % PAGE_SIZE == 0);
+        VERIFY(start_vaddr % PAGE_SIZE == 0);
+        VERIFY(start_paddr % PAGE_SIZE == 0);
+
+        auto access = Access::None;
+        if (program_header.is_readable())
+            access |= Access::Read;
+        if (program_header.is_writable())
+            access |= Access::Write;
+        if (program_header.is_executable())
+            access |= Access::Execute;
+
+        if (auto result = map_pages(root_page_table, start_vaddr, start_paddr, page_count, access); result.is_error())
+            PANIC("Failed to map program header {}: {}", program_header.index(), result.release_error());
+
+        return IterationDecision::Continue;
+    });
+}
+
+static void get_memory_map_and_exit_boot_services(void* root_page_table, BootInfo& boot_info)
+{
+    auto* boot_services = g_efi_system_table->boot_services;
+    auto& memory_map = boot_info.boot_method_specific.efi.memory_map;
+
+    // Print this message before the first call to GetMemoryMap(), as calling OutputString() could change the memory map.
+    dbgln("Exiting EFI Boot Services...");
+
+    // Get the required size for the memory map.
+    if (auto status = boot_services->get_memory_map(&memory_map.descriptor_array_size, nullptr, &memory_map.map_key, &memory_map.descriptor_size, &memory_map.descriptor_version); status != EFI::Status::BufferTooSmall)
+        PANIC("Failed to acquire the required size for memory map: {}", status);
+
+    // Reserve space for 10 extra descriptors in the memory map, as the memory map could change between the first GetMemoryMap() and ExitBootServices().
+    // This also allows us to reuse the memory map even if the first call to ExitBootServices() fails.
+    // We probably shouldn't allocate memory if ExitBootServices() failed, as that might change the memory map again.
+    memory_map.descriptor_array_size = round_up_to_power_of_two(memory_map.descriptor_array_size + memory_map.descriptor_size * 10, PAGE_SIZE);
+
+    if (memory_map.descriptor_array_size > EFI_MEMORY_MAP_MAX_SIZE)
+        PANIC("EFI Memory map is too large: {} bytes (max: {} bytes)", memory_map.descriptor_array_size, EFI_MEMORY_MAP_MAX_SIZE);
+
+    // We have to save the size here, as GetMemoryMap() overrides the value pointed to by the MemoryMap argument.
+    memory_map.buffer_size = memory_map.descriptor_array_size;
+
+    if (auto status = boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, memory_map.buffer_size / PAGE_SIZE, &memory_map.descriptor_array_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate memory for the EFI memory map: {}", status);
+
+    __builtin_memset(bit_cast<void*>(memory_map.descriptor_array_paddr), 0, memory_map.buffer_size);
+
+    if (auto result = map_pages(root_page_table, EFI_MEMORY_MAP_VADDR, memory_map.descriptor_array_paddr, memory_map.buffer_size / PAGE_SIZE, Access::Read); result.is_error())
+        PANIC("Failed to map the EFI memory map: {}", result.release_error());
+
+    // Tell the kernel the location of the EFI memory map.
+    memory_map.descriptor_array = bit_cast<EFI::MemoryDescriptor*>(EFI_MEMORY_MAP_VADDR);
+
+    if (auto status = boot_services->get_memory_map(&memory_map.descriptor_array_size, bit_cast<EFI::MemoryDescriptor*>(memory_map.descriptor_array_paddr), &memory_map.map_key, &memory_map.descriptor_size, &memory_map.descriptor_version); status != EFI::Status::Success)
+        PANIC("Failed to get the EFI memory map: {}", status);
+
+    // A very crude memory leak detector
+    // We should check for leaks before calling ExitBootServices(), as we have no way of freeing them after that.
+    // Memory that should stay allocated has to directly be allocated via Allocate{Pages,Pool}().
+    kmalloc_stats stats;
+    get_kmalloc_stats(stats);
+
+    if (stats.kmalloc_call_count != stats.kfree_call_count)
+        PANIC("Memory leak(s) detected! kmalloc call count: {}, kfree call count: {}", stats.kmalloc_call_count, stats.kfree_call_count);
+
+    // From now on, we can't use any boot service or device-handle-based protocol anymore, even if ExitBootServices() failed.
+    if (auto status = boot_services->exit_boot_services(g_efi_image_handle, memory_map.map_key); status == EFI::Status::InvalidParameter) {
+        // We have to call GetMemoryMap() again, as the memory map changed between GetMemoryMap() and ExitBootServices().
+        // Memory allocation services are still allowed to be used if ExitBootServices() failed.
+        memory_map.descriptor_array_size = memory_map.buffer_size;
+        if (boot_services->get_memory_map(&memory_map.descriptor_array_size, bit_cast<EFI::MemoryDescriptor*>(memory_map.descriptor_array_paddr), &memory_map.map_key, &memory_map.descriptor_size, &memory_map.descriptor_version) != EFI::Status::Success)
+            halt();
+
+        if (boot_services->exit_boot_services(g_efi_image_handle, memory_map.map_key) != EFI::Status::Success)
+            halt();
+    } else if (status != EFI::Status::Success) {
+        halt();
+    }
+}
+
+static void set_up_kernel_stack(void* root_page_table)
+{
+    // Allocate pages for the kernel stack and map it to KERNEL_STACK_VADDR.
+    // TODO: KASLR
+    EFI::PhysicalAddress kernel_stack_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, KERNEL_STACK_SIZE / PAGE_SIZE, &kernel_stack_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate pages for the kernel stack: {}", status);
+
+    __builtin_memset(bit_cast<void*>(kernel_stack_paddr), 0, KERNEL_STACK_SIZE);
+
+    if (auto result = map_pages(root_page_table, KERNEL_STACK_VADDR, kernel_stack_paddr, KERNEL_STACK_SIZE / PAGE_SIZE, Access::Read | Access::Write); result.is_error())
+        PANIC("Failed to map the kernel stack: {}", result.release_error());
+}
+
+static BootInfo* set_up_boot_info(void* root_page_table)
+{
+    // Allocate pages for the boot info struct and map it to BOOT_INFO_VADDR.
+    // TODO: KASLR
+    EFI::PhysicalAddress boot_info_paddr = 0;
+    if (auto status = g_efi_system_table->boot_services->allocate_pages(EFI::AllocateType::AnyPages, EFI::MemoryType::LoaderData, pages_needed(sizeof(BootInfo)), &boot_info_paddr); status != EFI::Status::Success)
+        PANIC("Failed to allocate pages for the BootInfo struct: {}", status);
+
+    if (auto result = map_pages(root_page_table, BOOT_INFO_VADDR, boot_info_paddr, pages_needed(sizeof(BootInfo)), Access::Read); result.is_error())
+        PANIC("Failed to map the BootInfo struct: {}", result.release_error());
+
+    auto* boot_info = bit_cast<BootInfo*>(boot_info_paddr);
+    new (boot_info) BootInfo;
+
+    boot_info->boot_method = BootMethod::EFI;
+    boot_info->boot_method_specific.pre_init.~PreInitBootInfo();
+    new (&boot_info->boot_method_specific.efi) EFIBootInfo;
+
+    return boot_info;
+}
 
 extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table);
 extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* system_table)
@@ -38,6 +230,8 @@ extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* s
     g_efi_image_handle = image_handle;
     g_efi_system_table = system_table;
 
+    auto* boot_services = system_table->boot_services;
+
     system_table->con_out->set_attribute(system_table->con_out,
         EFI::TextAttribute {
             .foreground_color = EFI::TextAttribute::ForegroundColor::White,
@@ -49,7 +243,53 @@ extern "C" EFIAPI EFI::Status init(EFI::Handle image_handle, EFI::SystemTable* s
 
     ucs2_dbgln(u"SerenityOS EFI Prekernel");
 
-    TODO();
+    auto loaded_image_protocol_guid = EFI::LoadedImageProtocol::guid;
+    EFI::LoadedImageProtocol* loaded_image_protocol;
+    if (auto status = boot_services->handle_protocol(image_handle, &loaded_image_protocol_guid, reinterpret_cast<void**>(&loaded_image_protocol)); status != EFI::Status::Success)
+        PANIC("Failed to get the loaded image protocol: {}", status);
+
+    VERIFY(loaded_image_protocol->image_base == pe_image_base);
+    VERIFY(bit_cast<FlatPtr>(loaded_image_protocol->image_base) % PAGE_SIZE == 0);
+
+    auto maybe_root_page_table = allocate_empty_root_page_table();
+    if (maybe_root_page_table.is_error())
+        PANIC("Failed to allocate root page table: {}", maybe_root_page_table.release_error());
+
+    auto* root_page_table = maybe_root_page_table.value();
+
+    auto* boot_info = set_up_boot_info(root_page_table);
+
+    auto kernel_image_paddr = bit_cast<PhysicalPtr>(&start_of_kernel_image);
+    VERIFY(kernel_image_paddr % PAGE_SIZE == 0);
+    auto kernel_image_size = bit_cast<PhysicalPtr>(&end_of_kernel_image) - kernel_image_paddr;
+
+    Bytes kernel_elf_image_data { bit_cast<u8*>(kernel_image_paddr), kernel_image_size };
+    ELF::Image kernel_elf_image { kernel_elf_image_data };
+
+    // TODO: KASLR
+    FlatPtr default_kernel_load_base = KERNEL_MAPPING_BASE + 0x200000;
+
+    boot_info->kernel_mapping_base = KERNEL_MAPPING_BASE;
+    boot_info->kernel_load_base = default_kernel_load_base;
+    boot_info->physical_to_virtual_offset = boot_info->kernel_load_base - kernel_image_paddr;
+
+    dbgln("Mapping the kernel image...");
+    map_kernel_image(root_page_table, kernel_elf_image, kernel_elf_image_data, boot_info->kernel_load_base);
+
+    dbgln("Performing relative relocations of the kernel image...");
+    perform_kernel_relocations(kernel_elf_image, kernel_elf_image_data, boot_info->kernel_load_base);
+
+    set_up_kernel_stack(root_page_table);
+    convert_and_map_cmdline(loaded_image_protocol, root_page_table, *boot_info);
+    populate_devicetree_and_acpi_boot_info(boot_info);
+
+    arch_prepare_boot(root_page_table, *boot_info);
+
+    get_memory_map_and_exit_boot_services(root_page_table, *boot_info);
+
+    auto kernel_entry_vaddr = boot_info->kernel_load_base + kernel_elf_image.entry().get();
+
+    arch_enter_kernel(root_page_table, kernel_entry_vaddr, KERNEL_STACK_VADDR + KERNEL_STACK_SIZE, BOOT_INFO_VADDR);
 }
 
 }

--- a/Kernel/Firmware/EFI/SystemTable.h
+++ b/Kernel/Firmware/EFI/SystemTable.h
@@ -24,6 +24,10 @@ static_assert(AssertSize<ConfigurationTable, 24>());
 // EFI_DTB_TABLE_GUID: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#devicetree-tables
 static constexpr GUID DTB_TABLE_GUID = { 0xb1b621d5, 0xf19c, 0x41a5, { 0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0 } };
 
+// https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#industry-standard-configuration-tables
+static constexpr GUID ACPI_2_0_TABLE_GUID = { 0x8868e871, 0xe4f1, 0x11d3, { 0xbc, 0x22, 0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81 } };
+static constexpr GUID ACPI_TABLE_GUID = { 0xeb9d2d30, 0x2d88, 0x11d3, { 0x9a, 0x16, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d } };
+
 // EFI_SYSTEM_TABLE: https://uefi.org/specs/UEFI/2.10/04_EFI_System_Table.html#efi-system-table-1
 struct SystemTable {
     static constexpr u64 signature = 0x5453595320494249;

--- a/Userland/Libraries/LibELF/Relocation.cpp
+++ b/Userland/Libraries/LibELF/Relocation.cpp
@@ -10,19 +10,8 @@
 
 namespace ELF {
 
-[[gnu::no_stack_protector]] bool perform_relative_relocations(FlatPtr base_address)
+[[gnu::no_stack_protector]] bool perform_relative_relocations(FlatPtr base_address, FlatPtr runtime_base_address, FlatPtr dynamic_section_addr)
 {
-    Elf_Ehdr* header = (Elf_Ehdr*)(base_address);
-    Elf_Phdr* pheader = (Elf_Phdr*)(base_address + header->e_phoff);
-    FlatPtr dynamic_section_addr = 0;
-    for (size_t i = 0; i < (size_t)header->e_phnum; ++i, ++pheader) {
-        if (pheader->p_type != PT_DYNAMIC)
-            continue;
-        dynamic_section_addr = pheader->p_vaddr + base_address;
-    }
-    if (!dynamic_section_addr)
-        return false;
-
     FlatPtr relocation_section_addr = 0;
     size_t relocation_table_size = 0;
     size_t relocation_count = 0;
@@ -63,18 +52,18 @@ namespace ELF {
         auto* patch_address = (FlatPtr*)(base_address + relocation->r_offset);
         FlatPtr relocated_address;
         if (use_addend) {
-            relocated_address = base_address + relocation->r_addend;
+            relocated_address = runtime_base_address + relocation->r_addend;
         } else {
             __builtin_memcpy(&relocated_address, patch_address, sizeof(relocated_address));
-            relocated_address += base_address;
+            relocated_address += runtime_base_address;
         }
         __builtin_memcpy(patch_address, &relocated_address, sizeof(relocated_address));
     }
 
-    auto patch_relr = [base_address](FlatPtr* patch_ptr) {
+    auto patch_relr = [runtime_base_address](FlatPtr* patch_ptr) {
         FlatPtr relocated_address;
         __builtin_memcpy(&relocated_address, patch_ptr, sizeof(FlatPtr));
-        relocated_address += base_address;
+        relocated_address += runtime_base_address;
         __builtin_memcpy(patch_ptr, &relocated_address, sizeof(FlatPtr));
     };
 
@@ -97,4 +86,21 @@ namespace ELF {
     }
     return true;
 }
+
+[[gnu::no_stack_protector]] bool perform_relative_relocations(FlatPtr base_address)
+{
+    Elf_Ehdr* header = (Elf_Ehdr*)(base_address);
+    Elf_Phdr* pheader = (Elf_Phdr*)(base_address + header->e_phoff);
+    FlatPtr dynamic_section_addr = 0;
+    for (size_t i = 0; i < (size_t)header->e_phnum; ++i, ++pheader) {
+        if (pheader->p_type != PT_DYNAMIC)
+            continue;
+        dynamic_section_addr = pheader->p_vaddr + base_address;
+    }
+    if (!dynamic_section_addr)
+        return false;
+
+    return perform_relative_relocations(base_address, base_address, dynamic_section_addr);
+}
+
 }

--- a/Userland/Libraries/LibELF/Relocation.h
+++ b/Userland/Libraries/LibELF/Relocation.h
@@ -10,6 +10,7 @@
 
 namespace ELF {
 
+bool perform_relative_relocations(FlatPtr base_address, FlatPtr runtime_base_address, FlatPtr dynamic_section_addr);
 bool perform_relative_relocations(FlatPtr base_address);
 
 }


### PR DESCRIPTION
This adds all the remaining code necessary to actually boot the kernel.
This only works on riscv64 for now (as booting the RISC-V kernel is the easiest).
GOP, x86-64, and AArch64 support will be in a future PR.

I didn't add any build/run scripts (yet), so you have to run it manually like so:
- Build a RISC-V image like normal with `Meta/serenity.sh image riscv64`
- Build U-Boot (EDK2 doesn't provide a devicetree configuration table but we need one)
  - `git clone https://source.denx.de/u-boot/u-boot.git --depth 1 --branch v2025.01; cd u-boot`
  - `make CROSS_COMPILE=riscv64-linux-gnu- qemu-riscv64_smode_defconfig`
  - `make CROSS_COMPILE=riscv64-linux-gnu- -j$(nproc)`
- Run QEMU with U-Boot as the firmware:
  `qemu-system-riscv64 -M virt -kernel <u-boot file> -m 2G -drive file=Build/riscv64/_disk_image,format=raw,if=none,id=disk -device nvme,serial=deadbeef,drive=disk -device VGA -serial mon:stdio -device virtio-keyboard -device virtio-tablet`
- Boot the kernel:
  `env set bootargs 'hello serial_debug root=nvme0:1:0'; nvme scan; load nvme 0 $kernel_addr_r /boot/Kernel.efi; bootefi $kernel_addr_r`
  (you can also set CONFIG_BOOTCOMMAND to that command line so it boots automatically)