### PR TITLE
Cherry-pick some of "ImageDecoder+LibThreading: Fix ImageDecoder memory leaks"

### DIFF
--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -65,7 +65,7 @@ private:
             promise->on_resolution = [](NonnullRefPtr<Core::EventReceiver>& object) -> ErrorOr<void> {
                 auto self = static_ptr_cast<BackgroundAction<Result>>(object);
                 VERIFY(self->m_result.has_value());
-                if (auto maybe_error = self->m_on_complete(self->m_result.value()); maybe_error.is_error())
+                if (auto maybe_error = self->m_on_complete(self->m_result.release_value()); maybe_error.is_error())
                     self->m_on_error(maybe_error.release_error());
 
                 return {};


### PR DESCRIPTION
Commits 3 and 4 of https://github.com/LadybirdBrowser/ladybird/pull/3519

Commit 1 is nice too, but doesn't apply cleanly because we don't pass through color spaces yet, like upstream does.

(Commit 2 is upstream-specific.)