### PR TITLE
LibPDF+LibGfx/CCITT: Add support for byte aligned Group4 images

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -629,14 +629,14 @@ ErrorOr<ByteBuffer> decode_ccitt_group3(ReadonlyBytes bytes, u32 image_width, u3
             if (options.require_end_of_line == Group3Options::RequireEndOfLine::Yes)
                 TRY(read_eol(*bit_stream, options.use_fill_bits));
             TRY(decode_single_ccitt3_1d_line(*bit_stream, *decoded_bits, image_width));
-            if (options.encoded_byte_aligned == Group3Options::EncodedByteAligned::Yes)
+            if (options.encoded_byte_aligned == EncodedByteAligned::Yes)
                 bit_stream->align_to_byte_boundary();
         }
 
         return decoded_bytes;
     }
 
-    if (options.require_end_of_line == Group3Options::RequireEndOfLine::No || options.encoded_byte_aligned == Group3Options::EncodedByteAligned::Yes)
+    if (options.require_end_of_line == Group3Options::RequireEndOfLine::No || options.encoded_byte_aligned == EncodedByteAligned::Yes)
         return Error::from_string_literal("CCITTDecoder: Unsupported option for CCITT3 2D decoding");
 
     TRY(decode_single_ccitt3_2d_block(*bit_stream, *decoded_bits, image_width, image_height, options.use_fill_bits));

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -658,6 +658,9 @@ ErrorOr<ByteBuffer> decode_ccitt_group4(ReadonlyBytes bytes, u32 image_width, u3
 
     u32 i {};
     while (!status.has_reached_eol && (image_height == 0 || i < image_height)) {
+        if (options.encoded_byte_aligned == EncodedByteAligned::Yes)
+            bit_stream->align_to_byte_boundary();
+
         status = TRY(decode_single_ccitt_2d_line(*bit_stream, *decoded_bits, move(status.current_line), image_width, options));
         ++i;
     }

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
@@ -26,6 +26,11 @@ namespace Gfx::CCITT {
 // Section 10: Modified Huffman Compression
 ErrorOr<ByteBuffer> decode_ccitt_rle(ReadonlyBytes bytes, u32 image_width, u32 image_height);
 
+enum class EncodedByteAligned : u8 {
+    No = 0,
+    Yes = 1,
+};
+
 // While this is named for a CCITT context, this struct holds data like TIFF's T4Options tag
 struct Group3Options {
     enum class Mode : u8 {
@@ -45,11 +50,6 @@ struct Group3Options {
 
     // Addition from the PDF specification
     enum class RequireEndOfLine : u8 {
-        No = 0,
-        Yes = 1,
-    };
-
-    enum class EncodedByteAligned : u8 {
         No = 0,
         Yes = 1,
     };

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
@@ -72,6 +72,7 @@ struct Group4Options {
     };
 
     HasEndOfBlock has_end_of_block = HasEndOfBlock::No;
+    EncodedByteAligned encoded_byte_aligned = EncodedByteAligned::No;
 };
 
 ErrorOr<ByteBuffer> decode_ccitt_group4(ReadonlyBytes bytes, u32 image_width, u32 image_height, Group4Options const& = {});

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -326,7 +326,7 @@ PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes bytes, RefPtr<DictObje
     } else if (k == 0) {
         Gfx::CCITT::Group3Options options {
             .require_end_of_line = require_end_of_line ? Gfx::CCITT::Group3Options::RequireEndOfLine::Yes : Gfx::CCITT::Group3Options::RequireEndOfLine::No,
-            .encoded_byte_aligned = encoded_byte_align ? Gfx::CCITT::Group3Options::EncodedByteAligned::Yes : Gfx::CCITT::Group3Options::EncodedByteAligned::No,
+            .encoded_byte_aligned = encoded_byte_align ? Gfx::CCITT::EncodedByteAligned::Yes : Gfx::CCITT::EncodedByteAligned::No,
         };
 
         decoded = TRY(Gfx::CCITT::decode_ccitt_group3(bytes, columns, rows, options));

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -314,13 +314,14 @@ PDFErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes bytes, RefPtr<DictObje
             damaged_rows_before_error = decode_parms->get_value(CommonNames::DamagedRowsBeforeError).get<int>();
     }
 
-    if (require_end_of_line || (encoded_byte_align && k != 0) || damaged_rows_before_error > 0)
+    if (require_end_of_line || damaged_rows_before_error > 0)
         return Error::rendering_unsupported_error("Unimplemented option for the CCITTFaxDecode Filter");
 
     ByteBuffer decoded {};
     if (k < 0) {
         Gfx::CCITT::Group4Options options {
-            .has_end_of_block = end_of_block ? Gfx::CCITT::Group4Options::HasEndOfBlock::Yes : Gfx::CCITT::Group4Options::HasEndOfBlock::No
+            .has_end_of_block = end_of_block ? Gfx::CCITT::Group4Options::HasEndOfBlock::Yes : Gfx::CCITT::Group4Options::HasEndOfBlock::No,
+            .encoded_byte_aligned = encoded_byte_align ? Gfx::CCITT::EncodedByteAligned::Yes : Gfx::CCITT::EncodedByteAligned::No,
         };
         decoded = TRY(Gfx::CCITT::decode_ccitt_group4(bytes, columns, rows, options));
     } else if (k == 0) {


### PR DESCRIPTION
This allows us to render 000871.pdf correctly!

This means that we no longer have this error when running `test_pdf.py`:
```
Rendering of feature not supported: Unimplemented option for the CCITTFaxDecode Filter, in 1 files, on 11 pages, 11 times
  0000/0000871.pdf 1 2 3 4 5 6 7 8 9 10 11
```

And thus go from `829 files without issues (82.9%)` to `830 files without issues (83.0%)`.
