### PR TITLE
LibPDF: Add some scaffolding for the `sh` operator

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibPDF/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibPDF/BUILD.gn
@@ -26,6 +26,7 @@ shared_library("LibPDF") {
     "Parser.cpp",
     "Reader.cpp",
     "Renderer.cpp",
+    "Shading.cpp",
     "Value.cpp",
   ]
   deps = [

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
     Parser.cpp
     Reader.cpp
     Renderer.cpp
+    Shading.cpp
     Value.cpp
     )
 

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -170,6 +170,8 @@
     X(SMask)                      \
     X(SMaskInData)                \
     X(Separation)                 \
+    X(Shading)                    \
+    X(ShadingType)                \
     X(Size)                       \
     X(StmF)                       \
     X(StrF)                       \

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/CommonNames.h>
+#include <LibPDF/Document.h>
+#include <LibPDF/Shading.h>
+
+namespace PDF {
+
+PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRefPtr<Object> shading_dict_or_stream)
+{
+    // "Shading types 4 to 7 are defined by a stream containing descriptive data charac-
+    //  terizing the shading’s gradient fill. In these cases, the shading dictionary is also a
+    //  stream dictionary and can contain any of the standard entries common to all
+    //  streams"
+    auto shading_dict = TRY([&]() -> PDFErrorOr<NonnullRefPtr<DictObject>> {
+        if (shading_dict_or_stream->is<DictObject>())
+            return shading_dict_or_stream->cast<DictObject>();
+        if (shading_dict_or_stream->is<StreamObject>())
+            return shading_dict_or_stream->cast<StreamObject>()->dict();
+        return Error::malformed_error("Shading must be a dictionary or stream");
+    }());
+
+    // TABLE 4.28 Entries common to all shading dictionaries
+    int shading_type = TRY(document->resolve(shading_dict->get_value(CommonNames::ShadingType))).to_int();
+
+    switch (shading_type) {
+    case 1:
+        return Error::rendering_unsupported_error("Function-based shading not yet implemented");
+    case 2:
+        return Error::rendering_unsupported_error("Axial shading not yet implemented");
+    case 3:
+        return Error::rendering_unsupported_error("Radial shading not yet implemented");
+    case 4:
+        return Error::rendering_unsupported_error("Free-form Gouraud-shaded triangle mesh not yet implemented");
+    case 5:
+        return Error::rendering_unsupported_error("Lattice-form Gouraud-shaded triangle mesh not yet implemented");
+    case 6:
+        return Error::rendering_unsupported_error("Coons patch mesh not yet implemented");
+    case 7:
+        return Error::rendering_unsupported_error("Tensor-product patch mesh not yet implemented");
+    }
+    dbgln("Shading type {}", shading_type);
+    return Error::malformed_error("Invalid shading type");
+}
+
+}

--- a/Userland/Libraries/LibPDF/Shading.h
+++ b/Userland/Libraries/LibPDF/Shading.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <LibPDF/Value.h>
+
+namespace PDF {
+
+class Shading : public RefCounted<Shading> {
+public:
+    static PDFErrorOr<NonnullRefPtr<Shading>> create(Document*, NonnullRefPtr<Object>);
+
+    virtual ~Shading() = default;
+};
+
+}


### PR DESCRIPTION
Adds a `Shading` class, which is supposed to be implemented similarly to LibPDF's ColorSpace class: `Shading::create()` will return a Shading subclass for every shading type, and they'll all implement some future pure virtual method for drawing the shading.

Shadings are used with both the `sh` operator and as part of pattern color spaces. We don't implement the latter yet either, and `Shading` will assume that its used with the `sh` operator for now.

For now, `Shading::create()` returns a `rendering_unsupported_error` for every shading type, so this commit doesn't do a whole lot. It does produce different errors for different shading types though, making it possible to see which shading types are common.

It also removes the last use of `RENDERER_TODO`, so remove that :^)