### PR TITLE
LibPDF: Implement painting of axial shadings; stitching function improvements

### DIFF
--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -8,6 +8,7 @@
 
 namespace Gfx {
 
+class AffineTransform;
 class Bitmap;
 class CMYKBitmap;
 class ImmutableBitmap;

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -14,10 +14,13 @@
     X(ASCII85Decode)              \
     X(ASCIIHexDecode)             \
     X(Alternate)                  \
+    X(AntiAlias)                  \
     X(Author)                     \
+    X(BBox)                       \
     X(BG)                         \
     X(BG2)                        \
     X(BM)                         \
+    X(Background)                 \
     X(BaseEncoding)               \
     X(BaseFont)                   \
     X(BitsPerComponent)           \

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -47,6 +47,7 @@
     X(Colors)                     \
     X(Columns)                    \
     X(Contents)                   \
+    X(Coords)                     \
     X(Count)                      \
     X(CreationDate)               \
     X(Creator)                    \
@@ -78,6 +79,7 @@
     X(EndOfBlock)                 \
     X(EndOfLine)                  \
     X(ExtGState)                  \
+    X(Extend)                     \
     X(F)                          \
     X(FL)                         \
     X(Filter)                     \
@@ -100,6 +102,7 @@
     X(FontFile3)                  \
     X(FontMatrix)                 \
     X(FunctionType)               \
+    X(Function)                   \
     X(Functions)                  \
     X(Gamma)                      \
     X(H)                          \

--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -358,7 +358,7 @@ StitchingFunction::create(Document* document, Vector<Bound> domain, Optional<Vec
 
     Vector<NonnullRefPtr<Function>> functions;
     for (size_t i = 0; i < functions_array->size(); i++) {
-        auto function = TRY(Function::create(document, functions_array->get_object_at(i)));
+        auto function = TRY(Function::create(document, TRY(functions_array->get_object_at(document, i))));
         functions.append(move(function));
     }
 

--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -394,11 +394,8 @@ StitchingFunction::create(Document* document, Vector<Bound> domain, Optional<Vec
         return Error { Error::Type::MalformedPDF, "Function stitching /Encode size does not match /Functions size" };
 
     Vector<Bound> encode;
-    for (size_t i = 0; i < encode_array->size(); i += 2) {
+    for (size_t i = 0; i < encode_array->size(); i += 2)
         encode.append({ encode_array->at(i).to_float(), encode_array->at(i + 1).to_float() });
-        if (encode.last().lower > encode.last().upper)
-            return Error { Error::Type::MalformedPDF, "Function stitching /Encode lower bound > upper bound" };
-    }
 
     auto function = adopt_ref(*new StitchingFunction(move(functions)));
     function->m_domain = domain[0];

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -104,9 +104,9 @@ Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitm
     // insert a horizontal reflection about the vertical midpoint into our transformation
     // matrix
 
-    static Gfx::AffineTransform horizontal_reflection_matrix = { 1, 0, 0, -1, 0, 0 };
+    static Gfx::AffineTransform vertical_reflection_matrix = { 1, 0, 0, -1, 0, 0 };
 
-    userspace_matrix.multiply(horizontal_reflection_matrix);
+    userspace_matrix.multiply(vertical_reflection_matrix);
     userspace_matrix.translate(0.0f, -height);
 
     auto initial_clipping_path = rect_path(userspace_matrix.map(Gfx::FloatRect(0, 0, width, height)));

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -743,10 +743,7 @@ RENDERER_HANDLER(shade)
 
     auto shading_dict_or_stream = TRY(shading_resource_dict->get_object(m_document, shading_name));
     auto shading = TRY(Shading::create(m_document, shading_dict_or_stream, *this));
-
-    // FIXME: Draw something with `shading`.
-
-    return Error(Error::Type::RenderingUnsupported, "draw operation: shade");
+    return shading->draw();
 }
 
 RENDERER_HANDLER(inline_image_begin)

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -742,7 +742,7 @@ RENDERER_HANDLER(shade)
     }
 
     auto shading_dict_or_stream = TRY(shading_resource_dict->get_object(m_document, shading_name));
-    auto shading = TRY(Shading::create(m_document, shading_dict_or_stream));
+    auto shading = TRY(Shading::create(m_document, shading_dict_or_stream, *this));
 
     // FIXME: Draw something with `shading`.
 

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -78,6 +78,112 @@ PDFErrorOr<CommonEntries> read_common_entries(Document* document, DictObject con
     return common_entries;
 }
 
+class AxialShading final : public Shading {
+public:
+    static PDFErrorOr<NonnullRefPtr<AxialShading>> create(Document*, NonnullRefPtr<DictObject>, CommonEntries);
+
+    virtual PDFErrorOr<void> draw() override;
+
+private:
+    using FunctionsType = Variant<NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
+
+    AxialShading(CommonEntries common_entries, Gfx::FloatPoint start, Gfx::FloatPoint end, float t0, float t1, FunctionsType functions, bool extend_start, bool extend_end)
+        : m_common_entries(move(common_entries))
+        , m_start(start)
+        , m_end(end)
+        , m_t0(t0)
+        , m_t1(t1)
+        , m_functions(move(functions))
+        , m_extend_start(extend_start)
+        , m_extend_end(extend_end)
+    {
+    }
+
+    CommonEntries m_common_entries;
+    Gfx::FloatPoint m_start;
+    Gfx::FloatPoint m_end;
+    float m_t0 { 0.0f };
+    float m_t1 { 1.0f };
+    FunctionsType m_functions;
+    bool m_extend_start { false };
+    bool m_extend_end { false };
+};
+
+PDFErrorOr<NonnullRefPtr<AxialShading>> AxialShading::create(Document* document, NonnullRefPtr<DictObject> shading_dict, CommonEntries common_entries)
+{
+    // TABLE 4.30 Additional entries specific to a type 2 shading dictionary
+    // "(Required) An array of four numbers [ x0 y0 x1 y1 ] specifying the starting and
+    //  ending coordinates of the axis, expressed in the shading’s target coordinate
+    //  space."
+    auto coords = TRY(shading_dict->get_array(document, CommonNames::Coords));
+    if (coords->size() != 4)
+        return Error::malformed_error("Coords must have 4 elements");
+    Gfx::FloatPoint start { coords->at(0).to_float(), coords->at(1).to_float() };
+    Gfx::FloatPoint end { coords->at(2).to_float(), coords->at(3).to_float() };
+
+    // "(Optional) An array of two numbers [ t0 t1 ] specifying the limiting values of a
+    //  parametric variable t. The variable is considered to vary linearly between these
+    //  two values as the color gradient varies between the starting and ending points of
+    //  the axis. The variable t becomes the input argument to the color function(s). De-
+    //  fault value: [ 0.0 1.0 ]."
+    float t0 = 0.0f;
+    float t1 = 1.0f;
+    if (shading_dict->contains(CommonNames::Domain)) {
+        auto domain_array = TRY(shading_dict->get_array(document, CommonNames::Domain));
+        if (domain_array->size() != 2)
+            return Error::malformed_error("Domain must have 2 elements");
+        t0 = domain_array->at(0).to_float();
+        t1 = domain_array->at(1).to_float();
+    }
+
+    // "(Required) A 1-in, n-out function or an array of n 1-in, 1-out functions (where n
+    //  is the number of color components in the shading dictionary’s color space). The
+    //  function(s) are called with values of the parametric variable t in the domain de-
+    //  fined by the Domain entry. Each function’s domain must be a superset of that of
+    //  the shading dictionary. If the value returned by the function for a given color
+    //  component is out of range, it is adjusted to the nearest valid value."
+    FunctionsType functions = TRY([&]() -> PDFErrorOr<FunctionsType> {
+        auto function_object = TRY(shading_dict->get_object(document, CommonNames::Function));
+        if (function_object->is<ArrayObject>()) {
+            auto function_array = function_object->cast<ArrayObject>();
+            Vector<NonnullRefPtr<Function>> functions_vector;
+            if (function_array->size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+                return Error::malformed_error("Function array must have as many elements as color space has components");
+            for (size_t i = 0; i < function_array->size(); ++i) {
+                auto function = TRY(Function::create(document, TRY(document->resolve_to<Object>(function_array->at(i)))));
+                if (TRY(function->evaluate(to_array({ 0.0f }))).size() != 1)
+                    return Error::malformed_error("Function must have 1 output component");
+                TRY(functions_vector.try_append(move(function)));
+            }
+            return functions_vector;
+        }
+        auto function = TRY(Function::create(document, function_object));
+        if (TRY(function->evaluate(to_array({ 0.0f }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+            return Error::malformed_error("Function must have as many output components as color space");
+        return function;
+    }());
+
+    // "(Optional) An array of two boolean values specifying whether to extend the
+    //  shading beyond the starting and ending points of the axis, respectively. Default
+    //  value: [ false false ]."
+    bool extend_start = false;
+    bool extend_end = false;
+    if (shading_dict->contains(CommonNames::Extend)) {
+        auto extend_array = TRY(shading_dict->get_array(document, CommonNames::Extend));
+        if (extend_array->size() != 2)
+            return Error::malformed_error("Extend must have 2 elements");
+        extend_start = extend_array->at(0).get<bool>();
+        extend_end = extend_array->at(1).get<bool>();
+    }
+
+    return adopt_ref(*new AxialShading(move(common_entries), start, end, t0, t1, move(functions), extend_start, extend_end));
+}
+
+PDFErrorOr<void> AxialShading::draw()
+{
+    return Error::rendering_unsupported_error("Cannot draw axial shading yet");
+}
+
 }
 
 PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRefPtr<Object> shading_dict_or_stream, Renderer& renderer)
@@ -101,7 +207,9 @@ PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRe
     case 1:
         return Error::rendering_unsupported_error("Function-based shading not yet implemented");
     case 2:
-        return Error::rendering_unsupported_error("Axial shading not yet implemented");
+        if (!shading_dict_or_stream->is<DictObject>())
+            return Error::malformed_error("Axial shading dictionary has wrong type");
+        return AxialShading::create(document, shading_dict, move(common_entries));
     case 3:
         return Error::rendering_unsupported_error("Radial shading not yet implemented");
     case 4:

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -4,13 +4,83 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibPDF/ColorSpace.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
 #include <LibPDF/Shading.h>
 
 namespace PDF {
 
-PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRefPtr<Object> shading_dict_or_stream)
+namespace {
+
+// TABLE 4.28 Entries common to all shading dictionaries
+struct CommonEntries {
+    // "(Required) The color space in which color values are expressed. This may be
+    //  any device, CIE-based, or special color space except a Pattern space."
+    AK::NonnullRefPtr<ColorSpace> color_space;
+
+    // "(Optional) An array of color components appropriate to the color space,
+    //  specifying a single background color value. If present, this color is used, be-
+    //  fore any painting operation involving the shading, to fill those portions of the
+    //  area to be painted that lie outside the bounds of the shading object
+    //  Note: The background color is applied only when the shading is used as part of
+    //  a shading pattern, not when it is painted directly with the sh operator."
+    // We currently don't support shading patterns yet, so we don't use this yet.
+    Optional<Vector<float>> background {};
+
+    // "(Optional) An array of four numbers giving the left, bottom, right, and top
+    //  coordinates, respectively, of the shading’s bounding box. The coordinates are
+    //  interpreted in the shading’s target coordinate space. If present, this bounding
+    //  box is applied as a temporary clipping boundary when the shading is painted,
+    //  in addition to the current clipping path and any other clipping boundaries in
+    //  effect at that time."
+    Optional<Gfx::FloatRect> b_box {};
+
+    // "(Optional) A flag indicating whether to filter the shading function to prevent
+    //  aliasing artifacts. [...] Anti-aliasing
+    //  may not be implemented on some output devices, in which case this flag is
+    //  ignored. Default value: false."
+    // We currently ignore this.
+    bool anti_alias { false };
+};
+
+PDFErrorOr<CommonEntries> read_common_entries(Document* document, DictObject const& shading_dict, Renderer& renderer)
+{
+    auto color_space_object = TRY(shading_dict.get_object(document, CommonNames::ColorSpace));
+    auto color_space = TRY(ColorSpace::create(document, move(color_space_object), renderer));
+
+    CommonEntries common_entries { .color_space = color_space };
+
+    if (shading_dict.contains(CommonNames::Background)) {
+        auto background_array = TRY(shading_dict.get_array(document, CommonNames::Background));
+        Vector<float> background;
+        for (auto const& value : background_array->elements())
+            background.append(value.to_float());
+        common_entries.background = move(background);
+    }
+
+    if (shading_dict.contains(CommonNames::BBox)) {
+        auto bbox_array = TRY(shading_dict.get_array(document, CommonNames::BBox));
+        if (bbox_array->size() != 4)
+            return Error::malformed_error("BBox must have 4 elements");
+        Gfx::FloatRect bbox {
+            bbox_array->at(0).to_float(),
+            bbox_array->at(1).to_float(),
+            bbox_array->at(2).to_float(),
+            bbox_array->at(3).to_float(),
+        };
+        common_entries.b_box = bbox;
+    }
+
+    if (shading_dict.contains(CommonNames::AntiAlias))
+        common_entries.anti_alias = TRY(document->resolve(shading_dict.get_value(CommonNames::AntiAlias))).get<bool>();
+
+    return common_entries;
+}
+
+}
+
+PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRefPtr<Object> shading_dict_or_stream, Renderer& renderer)
 {
     // "Shading types 4 to 7 are defined by a stream containing descriptive data charac-
     //  terizing the shading’s gradient fill. In these cases, the shading dictionary is also a
@@ -24,8 +94,8 @@ PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRe
         return Error::malformed_error("Shading must be a dictionary or stream");
     }());
 
-    // TABLE 4.28 Entries common to all shading dictionaries
     int shading_type = TRY(document->resolve(shading_dict->get_value(CommonNames::ShadingType))).to_int();
+    auto common_entries = TRY(read_common_entries(document, *shading_dict, renderer));
 
     switch (shading_type) {
     case 1:

--- a/Userland/Libraries/LibPDF/Shading.h
+++ b/Userland/Libraries/LibPDF/Shading.h
@@ -11,9 +11,11 @@
 
 namespace PDF {
 
+class Renderer;
+
 class Shading : public RefCounted<Shading> {
 public:
-    static PDFErrorOr<NonnullRefPtr<Shading>> create(Document*, NonnullRefPtr<Object>);
+    static PDFErrorOr<NonnullRefPtr<Shading>> create(Document*, NonnullRefPtr<Object>, Renderer&);
 
     virtual ~Shading() = default;
 };

--- a/Userland/Libraries/LibPDF/Shading.h
+++ b/Userland/Libraries/LibPDF/Shading.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefCounted.h>
+#include <LibGfx/Forward.h>
 #include <LibPDF/Value.h>
 
 namespace PDF {
@@ -19,7 +20,7 @@ public:
 
     virtual ~Shading() = default;
 
-    virtual PDFErrorOr<void> draw() = 0;
+    virtual PDFErrorOr<void> draw(Gfx::Painter&, Gfx::AffineTransform const&) = 0;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Shading.h
+++ b/Userland/Libraries/LibPDF/Shading.h
@@ -18,6 +18,8 @@ public:
     static PDFErrorOr<NonnullRefPtr<Shading>> create(Document*, NonnullRefPtr<Object>, Renderer&);
 
     virtual ~Shading() = default;
+
+    virtual PDFErrorOr<void> draw() = 0;
 };
 
 }


### PR DESCRIPTION
Or, as they're called elsewhere, linear gradients.

Since this uses PDF function objects and PDF color spaces, it can't use
the existing gradient code in LibGfx.

The way shadings are drawn with the `sh` operator is that one sets a
clip path that's to be filled with the shading and the calls the `sh`
operator.

However, we only support clip rects at the moment, not yet arbitrary
clip paths. So this leads to rectangles with linear gradients
appearing, which sometimes can overlap other page elements. This will
improve once we implement support for arbitrary clip paths.

This is also still missing support for the optional additional /BBox
shading dict entry, which further constrains the clip rect.

Also improve `StitchingFunction` a bit, since that's heavily used with axial shadings to create color ramps.