### PR TITLE
Kernel: Remove `Processor::has_pat()`

### DIFF
--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -94,7 +94,6 @@ public:
     ALWAYS_INLINE static u32 current_id();
     ALWAYS_INLINE static bool is_bootstrap_processor();
     ALWAYS_INLINE bool has_nx() const;
-    ALWAYS_INLINE bool has_pat() const;
     ALWAYS_INLINE bool has_feature(CPUFeature::Type const& feature) const
     {
         return m_features.has_flag(feature);

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -172,12 +172,6 @@ ALWAYS_INLINE bool ProcessorBase<T>::has_nx() const
 }
 
 template<typename T>
-ALWAYS_INLINE bool ProcessorBase<T>::has_pat() const
-{
-    return false;
-}
-
-template<typename T>
 ALWAYS_INLINE FlatPtr ProcessorBase<T>::current_in_irq()
 {
     return current().m_in_irq;

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -169,12 +169,6 @@ ALWAYS_INLINE bool ProcessorBase<T>::has_nx() const
 }
 
 template<typename T>
-ALWAYS_INLINE bool ProcessorBase<T>::has_pat() const
-{
-    return false;
-}
-
-template<typename T>
 ALWAYS_INLINE FlatPtr ProcessorBase<T>::current_in_irq()
 {
     return current().m_in_irq;

--- a/Kernel/Arch/x86_64/PageDirectory.h
+++ b/Kernel/Arch/x86_64/PageDirectory.h
@@ -122,7 +122,7 @@ public:
         case MemoryType::Normal: // WB (write back) => PAT=0b000
             break;
         case MemoryType::NonCacheable: // WC (write combining) => PAT=0b100
-            if (Processor::current().has_pat()) {
+            if (Processor::current().has_feature(CPUFeature::PAT)) {
                 m_raw |= PAT;
                 break;
             }

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -264,12 +264,6 @@ ALWAYS_INLINE bool ProcessorBase<T>::has_nx() const
 }
 
 template<typename T>
-ALWAYS_INLINE bool ProcessorBase<T>::has_pat() const
-{
-    return has_feature(CPUFeature::PAT);
-}
-
-template<typename T>
 ALWAYS_INLINE Optional<u64> ProcessorBase<T>::read_cycle_count()
 {
     return read_tsc();


### PR DESCRIPTION
PAT is an x86-specific feature, so it doesn't make sense to have that function for all processor classes.

The only current user of this function can instead check for `CPUFeature::PAT` directly.