### PR TITLE
LibHID: Limit the maximum collection tree depth

### DIFF
--- a/Userland/Libraries/LibHID/ReportDescriptorParser.cpp
+++ b/Userland/Libraries/LibHID/ReportDescriptorParser.cpp
@@ -246,6 +246,12 @@ ErrorOr<ParsedReportDescriptor> ReportDescriptorParser::parse()
             }
 
             case MainItemTag::Collection: {
+                m_current_collection_tree_depth++;
+
+                // Prevent generating collection trees with a huge depth.
+                if (m_current_collection_tree_depth > 50)
+                    return Error::from_string_view_or_print_error_and_return_errno("Report descriptor defines more than 50 nested collections"sv, E2BIG);
+
                 auto collection_type = static_cast<CollectionType>(TRY(m_stream.read_item_data_unsigned(item_header)));
 
                 Collection new_collection {};
@@ -274,6 +280,8 @@ ErrorOr<ParsedReportDescriptor> ReportDescriptorParser::parse()
                     return Error::from_string_view_or_print_error_and_return_errno("End Collection item with a corresponding Collection item"sv, EINVAL);
 
                 m_current_collection = m_current_collection->parent;
+                m_current_collection_tree_depth--;
+
                 break;
 
             default:

--- a/Userland/Libraries/LibHID/ReportDescriptorParser.h
+++ b/Userland/Libraries/LibHID/ReportDescriptorParser.h
@@ -183,6 +183,7 @@ private:
     SetOnce m_input_output_or_feature_item_seen;
 
     size_t m_total_report_field_count { 0 };
+    size_t m_current_collection_tree_depth { 0 };
 };
 
 }


### PR DESCRIPTION
Calling the `Collection` destructor otherwise can end up causing a stack overflow, as each `Collection` destructor will recursively call the destructor of each child collection.

This fixes the following OSS-Fuzz issue:
https://issues.oss-fuzz.com/issues/397488020