### PR TITLE
Kernel/x86: Remove `gdt64ptr` and `code64_sel`

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -140,11 +140,6 @@ ALWAYS_INLINE static Processor& bsp_processor()
 
 Atomic<Graphics::Console*> g_boot_console;
 
-#if ARCH(X86_64)
-extern "C" u32 gdt64ptr;
-extern "C" u16 code64_sel;
-#endif
-
 READONLY_AFTER_INIT static StringView s_kernel_cmdline;
 
 READONLY_AFTER_INIT constinit BootInfo g_boot_info;
@@ -153,8 +148,6 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init(BootInfo
 {
 #if ARCH(X86_64)
     g_boot_info = boot_info;
-    gdt64ptr = boot_info.arch_specific.gdt64ptr;
-    code64_sel = boot_info.arch_specific.code64_sel;
     s_kernel_cmdline = boot_info.cmdline;
 #elif ARCH(AARCH64) || ARCH(RISCV64)
     if (boot_info.boot_method == BootMethod::EFI) {

--- a/Kernel/Arch/x86_64/Boot/ap_setup.S
+++ b/Kernel/Arch/x86_64/Boot/ap_setup.S
@@ -2,14 +2,6 @@
 
 .section .text
 
-.global gdt64ptr
-gdt64ptr:
-.quad 0
-
-.global code64_sel
-code64_sel:
-.short 0
-
 /*
   The apic_ap_start function will be loaded to P0x00008000 where the APIC
   will boot the AP from in real mode. This code also contains space for

--- a/Kernel/Prekernel/Arch/x86_64/ArchSpecificBootInfo.h
+++ b/Kernel/Prekernel/Arch/x86_64/ArchSpecificBootInfo.h
@@ -14,8 +14,6 @@ VALIDATE_IS_X86()
 namespace Kernel {
 
 struct ArchSpecificBootInfo {
-    u32 gdt64ptr;
-    u16 code64_sel;
 };
 
 }

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -28,8 +28,6 @@ extern "C" u8 end_of_prekernel_image[];
 extern "C" u8 _binary_Kernel_standalone_start[];
 extern "C" u8 end_of_prekernel_image_after_kernel_image[];
 
-extern "C" u8 gdt64ptr[];
-extern "C" u16 code64_sel;
 extern "C" u64 boot_pml4t[512];
 extern "C" u64 boot_pdpt[512];
 extern "C" u64 boot_pd0[512];
@@ -227,8 +225,6 @@ extern "C" [[noreturn]] void init()
     info.kernel_mapping_base = kernel_mapping_base;
     info.kernel_load_base = kernel_load_base;
 #if ARCH(X86_64)
-    info.arch_specific.gdt64ptr = (PhysicalPtr)gdt64ptr;
-    info.arch_specific.code64_sel = code64_sel;
     info.boot_pml4t = PhysicalAddress { bit_cast<PhysicalPtr>(+boot_pml4t) };
 #endif
     info.boot_pdpt = PhysicalAddress { bit_cast<PhysicalPtr>(+boot_pdpt) };


### PR DESCRIPTION
The AP setup code no longer uses the Prekernel GDT, so these variables and arch-specific boot info members are unnecessary.