### PR TITLE
LibGfx+PixelPaint: Unify `Rect::centered_at` and `Rect::centered_on`

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -72,7 +72,7 @@ void GradientTool::on_mousemove(Layer* layer, MouseEvent& event)
             auto handle_offset = m_editor->content_to_frame_position(layer->location());
             float scale = m_editor->scale();
             auto frame_postion = p.value().to_type<float>().scaled(scale, scale).translated(handle_offset).to_type<int>();
-            auto handle = Gfx::IntRect::centered_at(frame_postion, { 16, 16 });
+            auto handle = Gfx::IntRect::centered_on(frame_postion, { 16, 16 });
             if (flag != handle.contains(event.raw_event().position())) {
                 flag = !flag;
                 m_editor->update_tool_cursor();
@@ -369,7 +369,7 @@ void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, Gf
     auto gradient_rect_height = determine_required_side_length(t_gradient_center.y(), height);
     auto gradient_rect_width = determine_required_side_length(t_gradient_center.x(), width);
     auto gradient_max_side_length = AK::max(gradient_rect_height, gradient_rect_width);
-    auto gradient_rect = Gfx::IntRect::centered_at(t_gradient_center, { gradient_max_side_length, gradient_max_side_length });
+    auto gradient_rect = Gfx::IntRect::centered_on(t_gradient_center, { gradient_max_side_length, gradient_max_side_length });
     float overall_gradient_length_in_rect = Gfx::calculate_gradient_length(gradient_rect.size().to_type<float>(), rotation_degrees - 90);
 
     if (m_gradient_half_length == 0 || overall_gradient_length_in_rect == 0 || isnan(overall_gradient_length_in_rect))

--- a/Userland/Applications/PixelPaint/VectorscopeWidget.cpp
+++ b/Userland/Applications/PixelPaint/VectorscopeWidget.cpp
@@ -79,7 +79,7 @@ void VectorscopeWidget::rebuild_vectorscope_image()
             auto const brightness = m_vectorscope_data[u_index][v_index];
             if (brightness < 0.0001f)
                 continue;
-            auto const pseudo_rect = Gfx::FloatRect::centered_at(color_vector.to_vector(scope_size) * 2.0f, size_1x1);
+            auto const pseudo_rect = Gfx::FloatRect::centered_on(color_vector.to_vector(scope_size) * 2.0f, size_1x1);
             auto color = Color::from_yuv(0.6f, color_vector.u, color_vector.v);
             color = color.saturated_to(1.0f - min(brightness, 1.0f));
             color.set_alpha(static_cast<u8>(min(AK::sqrt(brightness), alpha_range) * NumericLimits<u8>::max() / alpha_range));
@@ -101,7 +101,7 @@ void VectorscopeWidget::paint_event(GUI::PaintEvent& event)
     auto const scope_size = min(height(), width());
     auto const graticule_size = scope_size / 6;
     auto const graticule_thickness = graticule_size / 12;
-    auto const entire_scope_rect = Gfx::FloatRect::centered_at({ 0, 0 }, { scope_size, scope_size });
+    auto const entire_scope_rect = Gfx::FloatRect::centered_on({ 0, 0 }, { scope_size, scope_size });
 
     painter.fill_ellipse(entire_scope_rect.to_rounded<int>().shrunken(graticule_thickness * 2, graticule_thickness * 2), Color::Black);
 
@@ -153,13 +153,13 @@ void VectorscopeWidget::paint_event(GUI::PaintEvent& event)
         base_painter.draw_line(Gfx::IntPoint(right_outer_vertex, center_rounded.y() + graticule_size / 2), Gfx::IntPoint(right_outer_vertex, bottom_inner_vertex), corner_color, graticule_thickness);
 
         // Add text label to vectorscope
-        auto text_rect = Gfx::FloatRect::centered_at(center, { graticule_size, graticule_size }).to_rounded<int>().translated(-(graticule_thickness + 1), -(graticule_thickness + 1));
+        auto text_rect = Gfx::FloatRect::centered_on(center, { graticule_size, graticule_size }).to_rounded<int>().translated(-(graticule_thickness + 1), -(graticule_thickness + 1));
         base_painter.draw_text(text_rect, StringView { &primary_color.symbol, 1 }, Gfx::TextAlignment::BottomRight, graticule_color);
     }
 
     if (m_color_at_mouseposition != Color::Transparent) {
         auto color_vector = ColorVector { m_color_at_mouseposition };
-        painter.draw_ellipse(Gfx::FloatRect::centered_at(color_vector.to_vector(scope_size) * 2.0, { graticule_size, graticule_size }).to_rounded<int>(), graticule_color, graticule_thickness);
+        painter.draw_ellipse(Gfx::FloatRect::centered_on(color_vector.to_vector(scope_size) * 2.0, { graticule_size, graticule_size }).to_rounded<int>(), graticule_color, graticule_thickness);
     }
 }
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -586,7 +586,7 @@ void AntiAliasingPainter::fill_rect_with_rounded_corners(IntRect const& a_rect, 
     auto fill_corner = [&](auto const& ellipse_center, auto const& corner_point, CornerRadius const& corner) {
         PainterStateSaver save { m_underlying_painter };
         m_underlying_painter.add_clip_rect(IntRect::from_two_points(ellipse_center, corner_point));
-        fill_ellipse(IntRect::centered_at(ellipse_center, { corner.horizontal_radius * 2, corner.vertical_radius * 2 }), color, blend_mode);
+        fill_ellipse(IntRect::centered_on(ellipse_center, { corner.horizontal_radius * 2, corner.vertical_radius * 2 }), color, blend_mode);
     };
 
     auto bounding_rect = a_rect.inflated(0, 1, 1, 0);

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -830,11 +830,6 @@ public:
         return false;
     }
 
-    [[nodiscard]] static Rect<T> centered_at(Point<T> const& point, Size<T> const& size)
-    {
-        return { { point.x() - size.width() / 2, point.y() - size.height() / 2 }, size };
-    }
-
     void unite_horizontally(Rect<T> const& other)
     {
         auto new_left = min(left(), other.left());


### PR DESCRIPTION
I have chosen `centered_on` to prevail for it is the older one.