### PR TITLE
DisplaySettings: Fix a division by zero exception

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -85,7 +85,7 @@ ErrorOr<void> MonitorSettingsWidget::generate_resolution_strings()
         i32 gcf = 0;
 
         if (a == 0 || b == 0)
-            continue; // Skip "0" resolutions to prevent a #DE.
+            continue;
         
         for (;;) {
             i32 r = a % b;

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -83,6 +83,10 @@ ErrorOr<void> MonitorSettingsWidget::generate_resolution_strings()
         i32 a = resolution.width();
         i32 b = resolution.height();
         i32 gcf = 0;
+
+        if (a == 0 || b == 0)
+            continue; // Skip "0" resolutions to prevent a #DE.
+        
         for (;;) {
             i32 r = a % b;
             if (r == 0) {


### PR DESCRIPTION
The resolutions list may contains resolutions that are zeroed, and these might cause a division by zero exception. Fix them by skipping any resolutions that have 0 as the width or the height.
