### PR TITLE
Meta: Use the raw archive.org copy for the download_file fallback

### DIFF
--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -295,7 +295,7 @@ function(download_file url path)
     cmake_parse_arguments(DOWNLOAD "" "SHA256;VERSION;VERSION_FILE;CACHE_PATH" "" ${ARGN})
 
     # If the timestamp doesn't match exactly, the Web Archive should redirect to the closest archived file automatically.
-    download_file_multisource("${url};https://web.archive.org/web/99991231235959/${url}" "${path}" SHA256 "${DOWNLOAD_SHA256}" VERSION "${DOWNLOAD_VERSION}" VERSION_FILE "${DOWNLOAD_VERSION_FILE}" CACHE_PATH "${DOWNLOAD_CACHE_PATH}")
+    download_file_multisource("${url};https://web.archive.org/web/99991231235959id_/${url}" "${path}" SHA256 "${DOWNLOAD_SHA256}" VERSION "${DOWNLOAD_VERSION}" VERSION_FILE "${DOWNLOAD_VERSION_FILE}" CACHE_PATH "${DOWNLOAD_CACHE_PATH}")
 endfunction()
 
 function(extract_path dest_dir zip_path source_path dest_path)


### PR DESCRIPTION
Appending "id_" to the datetime part gives you a raw copy without the navigational toolbar:
https://en.wikipedia.org/wiki/Help:Using_the_Wayback_Machine#Specific_archive_copy
Otherwise we get an HTML file.

This should prevent the PNP download from failing CI when uefi.org is down again.