### PR TITLE
LibC: Disallow environment variable names that are empty or contain '='

### DIFF
--- a/Tests/LibC/TestEnvironment.cpp
+++ b/Tests/LibC/TestEnvironment.cpp
@@ -41,3 +41,18 @@ TEST_CASE(putenv_overwrite_invalid_value)
     EXPECT_NE(environment_variable, nullptr);
     EXPECT_EQ(strcmp(environment_variable, "789"), 0);
 }
+
+TEST_CASE(setenv_invalid_name)
+{
+    // Empty name
+    auto result = setenv("", "test", 1);
+    EXPECT_EQ(result, -1);
+    auto* val = getenv("");
+    EXPECT_EQ(val, nullptr);
+
+    // Name which contains '='
+    result = setenv("TEST=", "test", 1);
+    EXPECT_EQ(result, -1);
+    val = getenv("TEST=");
+    EXPECT_EQ(val, nullptr);
+}

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -477,9 +477,16 @@ int clearenv()
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/setenv.html
 int setenv(char const* name, char const* value, int overwrite)
 {
+    auto new_var_len = strlen(name);
+    if (new_var_len == 0 || strchr(name, '=')) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (!overwrite && getenv(name))
         return 0;
-    auto const total_length = strlen(name) + strlen(value) + 2;
+
+    auto const total_length = new_var_len + strlen(value) + 2;
     auto* var = (char*)malloc(total_length);
     snprintf(var, total_length, "%s=%s", name, value);
     s_malloced_environment_variables.set((FlatPtr)var);


### PR DESCRIPTION
Hi, I tried SerenityOS with [my C project](https://github.com/matyalatte/c-env-utils) today.
A unit test found that `setenv` accepted an empty string as a variable name.
I think this is unexpected behavior since `unsetenv` rejects empty strings.