### PR TITLE
AK: Make Optional and ErrorOr constexpr

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -22,4 +22,8 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 #endif
 }
 
+// Properties that ErrorOr should have:
+static_assert(IsTriviallyMoveConstructible<ErrorOr<int>>);
+static_assert(IsTriviallyDestructible<ErrorOr<int>>);
+
 }

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -16,7 +16,10 @@ namespace AK {
 
 class JsonArray {
     template<typename Callback>
-    using CallbackErrorType = decltype(declval<Callback>()(declval<JsonValue const&>()).release_error());
+    using CallbackErrorType = decltype(declval<Callback>()(declval<JsonValue const&>()))::ErrorType;
+
+    static_assert(SameAs<CallbackErrorType<ErrorOr<void> (*)(JsonValue const&)>, Error>);
+    static_assert(SameAs<ErrorOr<void, CallbackErrorType<ErrorOr<void> (*)(JsonValue const&)>>, ErrorOr<void>>);
 
 public:
     JsonArray() = default;

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -20,7 +20,10 @@ namespace AK {
 
 class JsonObject {
     template<typename Callback>
-    using CallbackErrorType = decltype(declval<Callback>()(declval<ByteString const&>(), declval<JsonValue const&>()).release_error());
+    using CallbackErrorType = decltype(declval<Callback>()(declval<ByteString const&>(), declval<JsonValue const&>()))::ErrorType;
+
+    static_assert(SameAs<CallbackErrorType<ErrorOr<void> (*)(ByteString const&, JsonValue const&)>, Error>);
+    static_assert(SameAs<ErrorOr<void, CallbackErrorType<ErrorOr<void> (*)(ByteString const&, JsonValue const&)>>, ErrorOr<void>>);
 
 public:
     JsonObject();

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -16,6 +16,7 @@
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringBuilder.h>
+#include <AK/Variant.h>
 
 namespace AK {
 

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -119,15 +119,18 @@ public:
     requires(!IsMoveConstructible<T>)
     = delete;
     ALWAYS_INLINE constexpr Optional(Optional&& other)
+    requires(IsMoveConstructible<T> && !IsTriviallyMoveConstructible<T>)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
             construct_at<RemoveConst<T>>(&m_storage, other.release_value());
     }
+    // Note: Checking for Move-Constructible to allow for reference members in T
     Optional& operator=(Optional&& other)
     requires(!IsMoveConstructible<T> || !IsDestructible<T>)
     = delete;
     ALWAYS_INLINE constexpr Optional& operator=(Optional&& other)
+    requires(IsMoveConstructible<T> && !IsTriviallyMoveAssignable<T>)
     {
         if (this == &other)
             return *this;
@@ -139,6 +142,9 @@ public:
             construct_at<RemoveConst<T>>(&m_storage, other.release_value());
         return *this;
     }
+
+    ALWAYS_INLINE constexpr Optional(Optional&& other) = default;
+    ALWAYS_INLINE constexpr Optional& operator=(Optional&& other) = default;
 
     ~Optional()
     requires(!IsDestructible<T>)

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -425,7 +425,7 @@ using IdentityType = typename __IdentityType<T>::Type;
 template<typename T, typename = void>
 struct __AddReference {
     using LvalueType = T;
-    using TvalueType = T;
+    using RvalueType = T;
 };
 
 template<typename T>

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -53,6 +53,10 @@ struct _RawPtr {
 
 namespace AK {
 
+struct Empty {
+    constexpr bool operator==(Empty const&) const = default;
+};
+
 template<typename T, typename SizeType = decltype(sizeof(T)), SizeType N>
 constexpr SizeType array_size(T (&)[N])
 {
@@ -194,6 +198,7 @@ __DEFINE_GENERIC_ABS(long double, 0.0L, fabsl);
 using AK::array_size;
 using AK::ceil_div;
 using AK::clamp;
+using AK::Empty;
 using AK::exchange;
 using AK::floor_div;
 using AK::forward;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <AK/StdLibExtraDetails.h>
+#include <AK/StdShim.h>
 
 #include <AK/Assertions.h>
 
@@ -42,38 +43,6 @@ void compiletime_fail(Args...);
 #else
 #    define AK_REPLACED_STD_NAMESPACE std
 #endif
-
-namespace AK_REPLACED_STD_NAMESPACE { // NOLINT(cert-dcl58-cpp) Names in std to aid tools
-
-// NOTE: These are in the "std" namespace since some compilers and static analyzers rely on it.
-//       If USING_AK_GLOBALLY is false, we can't put them in ::std, so we put them in AK::replaced_std instead
-//       The user code should not notice anything unless it explicitly asks for std::stuff, so...don't.
-
-template<typename T>
-constexpr T&& forward(AK::Detail::RemoveReference<T>& param)
-{
-    return static_cast<T&&>(param);
-}
-
-template<typename T>
-constexpr T&& forward(AK::Detail::RemoveReference<T>&& param) noexcept
-{
-    static_assert(!AK::Detail::IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
-    return static_cast<T&&>(param);
-}
-
-template<typename T>
-constexpr T&& move(T& arg)
-{
-    return static_cast<T&&>(arg);
-}
-
-}
-
-namespace AK {
-using AK_REPLACED_STD_NAMESPACE::forward;
-using AK_REPLACED_STD_NAMESPACE::move;
-}
 
 namespace AK::Detail {
 template<typename T>

--- a/AK/StdShim.h
+++ b/AK/StdShim.h
@@ -6,13 +6,23 @@
 
 #pragma once
 
-// Note: std::forward and move are often special cased in compilers and static analyzers
-//       so we should always, if possible, use the std:: versions
-//       and not introduce a fake version in a look-alike namespace, aka AK::replaced_std
+// Note:
+// `construct_at` is required to come from the std namespace to be constexpr in C++20
+// so we cannot put it in an AK::replaced_std and still have it work in constexpr contexts.
+// `move` and `forward` are visible from the construct_at headers, so the similar applies to them.
+// They are also often special cased in compilers and static analyzers,
+// which makes it advantageous to use a `std::` sourced version
+// So for non-Kernel code we will use the STL versions of these functions
+// and for Kernel code we can provide our own versions.
+// FIXME:
+// Ideally we'd poison the std namespace after exporting what we need, but that would
+// break any subsequent includes of STL headers, including <new> which is required by kmalloc.h
 
 #ifdef KERNEL
 
+#    include <AK/Assertions.h>
 #    include <AK/StdLibExtraDetails.h>
+#    include <Kernel/Heap/kmalloc.h>
 
 namespace std { // NOLINT(cert-dcl58-cpp) We are the standard library
 
@@ -35,24 +45,38 @@ constexpr T&& move(T& arg)
     return static_cast<T&&>(arg);
 }
 
+// `new` will be constexpr in C++26, until then we need this
+template<typename T, typename... Args, class = decltype(::new(declval<void*>()) T(declval<Args>()...))>
+constexpr T* construct_at(T* location, Args&&... args) noexcept
+{
+    VERIFY(location);
+    return ::new (static_cast<void*>(location)) T(forward<Args>(args)...);
+}
+
 }
 
 #else
 // Note: Try to include as little STL as possible
-#    if __has_include(<bits/move.h>)
+#    if __has_include(<bits/move.h>) && __has_include(<bits/stl_construct.h>)
 //       GLIBC LIBSTDC++
 #        include <bits/move.h>
-#    elif __has_include(<__utility/forward.h>)
+#        include <bits/stl_construct.h>
+#    elif __has_include(<__utility/forward.h>) && __has_include(<__memory/construct_at.h>)
 //       LLVM LIBCXX
+#        include <__memory/construct_at.h>
 #        include <__utility/forward.h>
 #        include <__utility/move.h>
 #    else
 // FIXME: Find a smaller header to include in these cases
+#        warning "Using <utility> and <memory> for move, forward and construct_at"
+#        include <memory>
 #        include <utility>
 #    endif
-#endif
+
+#endif // KERNEL
 
 namespace AK {
+using std::construct_at;
 using std::forward;
 using std::move;
 }

--- a/AK/StdShim.h
+++ b/AK/StdShim.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Note: std::forward and move are often special cased in compilers and static analyzers
+//       so we should always, if possible, use the std:: versions
+//       and not introduce a fake version in a look-alike namespace, aka AK::replaced_std
+
+#ifdef KERNEL
+
+#    include <AK/StdLibExtraDetails.h>
+
+namespace std { // NOLINT(cert-dcl58-cpp) We are the standard library
+
+template<typename T>
+constexpr T&& forward(AK::Detail::RemoveReference<T>& param)
+{
+    return static_cast<T&&>(param);
+}
+
+template<typename T>
+constexpr T&& forward(AK::Detail::RemoveReference<T>&& param) noexcept
+{
+    static_assert(!AK::Detail::IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
+    return static_cast<T&&>(param);
+}
+
+template<typename T>
+constexpr T&& move(T& arg)
+{
+    return static_cast<T&&>(arg);
+}
+
+}
+
+#else
+// Note: Try to include as little STL as possible
+#    if __has_include(<bits/move.h>)
+//       GLIBC LIBSTDC++
+#        include <bits/move.h>
+#    elif __has_include(<__utility/forward.h>)
+//       LLVM LIBCXX
+#        include <__utility/forward.h>
+#        include <__utility/move.h>
+#    else
+// FIXME: Find a smaller header to include in these cases
+#        include <utility>
+#    endif
+#endif
+
+namespace AK {
+using std::forward;
+using std::move;
+}

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -216,10 +216,6 @@ using MergeAndDeduplicatePacks = InheritFromPacks<MakeIndexSequence<sizeof...(Ps
 
 namespace AK {
 
-struct Empty {
-    constexpr bool operator==(Empty const&) const = default;
-};
-
 template<typename T>
 concept NotLvalueReference = !IsLvalueReference<T>;
 
@@ -522,6 +518,5 @@ struct TypeList<Variant<Ts...>> : TypeList<Ts...> { };
 }
 
 #if USING_AK_GLOBALLY
-using AK::Empty;
 using AK::Variant;
 #endif

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -707,7 +707,6 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_multiboot(MemoryManager::G
         PhysicalAddress upper;
     };
 
-    Optional<ContiguousPhysicalVirtualRange> last_contiguous_physical_range;
     for (auto const* mmap = mmap_begin; mmap < mmap_end; mmap++) {
         // We have to copy these onto the stack, because we take a reference to these when printing them out,
         // and doing so on a packed struct field is UB.

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -374,7 +374,7 @@ TEST_CASE(fallible_json_object_for_each)
         return CustomError {};
     });
     EXPECT(result2.is_error());
-    EXPECT((IsSame<decltype(result2.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result2.release_error()), CustomError&&>));
 
     auto result3 = object.try_for_each_member([](auto const&, auto const&) -> CustomErrorOr<int> {
         return 42;
@@ -385,7 +385,7 @@ TEST_CASE(fallible_json_object_for_each)
         return CustomError {};
     });
     EXPECT(result4.is_error());
-    EXPECT((IsSame<decltype(result4.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result4.release_error()), CustomError&&>));
 }
 
 TEST_CASE(fallible_json_array_for_each)
@@ -414,7 +414,7 @@ TEST_CASE(fallible_json_array_for_each)
         return CustomError {};
     });
     EXPECT(result2.is_error());
-    EXPECT((IsSame<decltype(result2.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result2.release_error()), CustomError&&>));
 
     auto result3 = array.try_for_each([](auto const&) -> CustomErrorOr<int> {
         return 42;
@@ -425,7 +425,7 @@ TEST_CASE(fallible_json_array_for_each)
         return CustomError {};
     });
     EXPECT(result4.is_error());
-    EXPECT((IsSame<decltype(result4.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result4.release_error()), CustomError&&>));
 }
 
 TEST_CASE(json_array_is_empty)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -327,6 +327,9 @@ struct CustomError {
 template<typename T>
 class CustomErrorOr {
 public:
+    using ResultType = T;
+    using ErrorType = CustomError;
+
     CustomErrorOr(T)
         : m_is_error(false)
     {

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -32,7 +32,6 @@ TEST_CASE(move_optional)
     y = move(x);
     EXPECT_EQ(y.has_value(), true);
     EXPECT_EQ(y.value(), 3);
-    EXPECT_EQ(x.has_value(), false);
 }
 
 TEST_CASE(optional_rvalue_ref_qualified_getters)
@@ -54,6 +53,11 @@ TEST_CASE(optional_rvalue_ref_qualified_getters)
 
     EXPECT_EQ(make_an_optional().value().x, 13);
     EXPECT_EQ(make_an_optional().value_or(DontCopyMe {}).x, 13);
+
+    auto opt = make_an_optional();
+    EXPECT_EQ(opt->x, 13);
+    auto y = move(opt);
+    EXPECT_EQ(y->x, 13);
 }
 
 TEST_CASE(optional_leak_1)
@@ -123,12 +127,11 @@ TEST_CASE(comparison_with_numeric_types)
 TEST_CASE(test_copy_ctor_and_dtor_called)
 {
     static_assert(IsTriviallyDestructible<Optional<u8>>);
-    // static_assert(IsTriviallyCopyable<Optional<u8>>);
+    static_assert(IsTriviallyCopyable<Optional<u8>>);
     static_assert(IsTriviallyCopyConstructible<Optional<u8>>);
     static_assert(IsTriviallyCopyAssignable<Optional<u8>>);
-    // These can't be trivial as we have to clear the original object.
-    static_assert(!IsTriviallyMoveConstructible<Optional<u8>>);
-    static_assert(!IsTriviallyMoveAssignable<Optional<u8>>);
+    static_assert(IsTriviallyMoveConstructible<Optional<u8>>);
+    static_assert(IsTriviallyMoveAssignable<Optional<u8>>);
 
     static_assert(IsTriviallyCopyConstructible<Optional<int&>>);
     static_assert(IsTriviallyCopyAssignable<Optional<int&>>);

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -12,6 +12,7 @@
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
 #include <AK/Span.h>
+#include <AK/Variant.h>
 #include <LibCore/File.h>
 #include <LibCore/Socket.h>
 

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <AK/Variant.h>
 #include <LibCore/Proxy.h>
 #include <LibCore/Socket.h>
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -16,6 +16,7 @@
 #include <AK/Forward.h>
 #include <AK/Span.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <LibGfx/Font/OpenType/DataTypes.h>
 
 namespace OpenType {

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -12,6 +12,7 @@
 #include <AK/RefCounted.h>
 #include <AK/Span.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/ICC/DistinctFourCC.h>
 #include <LibGfx/ICC/Enums.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/OwnPtr.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>

--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -12,6 +12,7 @@
 #include <AK/Forward.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/FontCascadeList.h>

--- a/Userland/Libraries/LibHTTP/Http11Connection.h
+++ b/Userland/Libraries/LibHTTP/Http11Connection.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 
 namespace HTTP {

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -13,7 +13,7 @@ Client::Client(StringView host, u16 port, NonnullOwnPtr<Core::Socket> socket)
     : m_host(host)
     , m_port(port)
     , m_socket(move(socket))
-    , m_connect_pending(Promise<Empty>::construct())
+    , m_connect_pending(Promise<void>::construct())
 {
     setup_callbacks();
 }
@@ -84,7 +84,7 @@ ErrorOr<void> Client::on_ready_to_receive()
 
     // Once we get server hello we can start sending.
     if (m_connect_pending) {
-        m_connect_pending->resolve({});
+        m_connect_pending->resolve();
         m_connect_pending.clear();
         m_buffer.clear();
         return {};

--- a/Userland/Libraries/LibIMAP/Client.h
+++ b/Userland/Libraries/LibIMAP/Client.h
@@ -25,7 +25,7 @@ public:
 
     Client(Client&&);
 
-    RefPtr<Promise<Empty>> connection_promise()
+    RefPtr<Promise<void>> connection_promise()
     {
         return m_connect_pending;
     }
@@ -72,7 +72,7 @@ private:
     u16 m_port;
 
     NonnullOwnPtr<Core::Socket> m_socket;
-    RefPtr<Promise<Empty>> m_connect_pending {};
+    RefPtr<Promise<void>> m_connect_pending;
 
     int m_current_command = 1;
 

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -11,6 +11,7 @@
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibJS/Forward.h>

--- a/Userland/Libraries/LibMedia/Sample.h
+++ b/Userland/Libraries/LibMedia/Sample.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Time.h>
+#include <AK/Variant.h>
 
 #include "VideoSampleData.h"
 

--- a/Userland/Libraries/LibURL/Host.h
+++ b/Userland/Libraries/LibURL/Host.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <AK/Variant.h>
 
 namespace URL {
 

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Variant.h>
 
 namespace Web::CSS {
 
@@ -71,11 +72,17 @@ private:
     };
 
     GridTrackPlacement()
-        : m_value(Auto {}) {};
+        : m_value(Auto {})
+    {
+    }
     GridTrackPlacement(AreaOrLine value)
-        : m_value(value) {};
+        : m_value(value)
+    {
+    }
     GridTrackPlacement(Span value)
-        : m_value(value) {};
+        : m_value(value)
+    {
+    }
 
     Variant<Auto, AreaOrLine, Span> m_value;
 };

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -10,6 +10,7 @@
 #include <AK/FlyString.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/Keyword.h>
 #include <LibWeb/CSS/PseudoClass.h>

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -419,7 +419,6 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         CSSPixels initial_image_x = image_rect.x();
         CSSPixels image_y = image_rect.y();
-        Optional<DevicePixelRect> last_image_device_rect;
 
         image.resolve_for_size(layout_node, image_rect.size());
 

--- a/Userland/Libraries/LibWebView/Database.h
+++ b/Userland/Libraries/LibWebView/Database.h
@@ -36,18 +36,18 @@ public:
     template<typename... PlaceholderValues>
     void execute_statement(SQL::StatementID statement_id, OnResult on_result, OnComplete on_complete, OnError on_error, PlaceholderValues&&... placeholder_values)
     {
-        auto sync_promise = Core::Promise<Empty>::construct();
+        auto sync_promise = Core::Promise<void>::construct();
 
         PendingExecution pending_execution {
             .on_result = move(on_result),
             .on_complete = [sync_promise, on_complete = move(on_complete)] {
                 if (on_complete)
                     on_complete();
-                sync_promise->resolve({}); },
+                sync_promise->resolve(); },
             .on_error = [sync_promise, on_error = move(on_error)](auto message) {
                 if (on_error)
                     on_error(message);
-                sync_promise->resolve({}); },
+                sync_promise->resolve(); },
         };
 
         Vector<SQL::Value> values { SQL::Value(forward<PlaceholderValues>(placeholder_values))... };

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
@@ -46,7 +46,6 @@ RefPtr<MultiScaleBitmaps> MultiScaleBitmaps::create(StringView filename, StringV
 
 bool MultiScaleBitmaps::load(StringView filename, StringView default_filename)
 {
-    Optional<Gfx::BitmapFormat> bitmap_format;
     bool did_load_any = false;
 
     // If we're reloading the bitmaps get rid of the old ones.

--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Base64.h>
+#include <AK/Variant.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -411,10 +411,8 @@ static ErrorOr<TestResult> run_test(HeadlessWebContentView& view, StringView inp
 {
     // Clear the current document.
     // FIXME: Implement a debug-request to do this more thoroughly.
-    auto promise = Core::Promise<Empty>::construct();
-    view.on_load_finish = [&](auto) {
-        promise->resolve({});
-    };
+    auto promise = Core::Promise<void>::construct();
+    view.on_load_finish = [&](auto const&) { promise->resolve(); };
     view.on_text_test_finish = {};
 
     view.on_request_file_picker = [&](auto const& accepted_file_types, auto allow_multiple_files) {


### PR DESCRIPTION
This will allow the compiler to reason more about them (as hinted at by the drive-by changes).
Also decoupling `ErrorOr` from `Variant` lessens the strain on the compiler.
some data, in the hope I am holding `bloaty` correctly:
```
$ bloaty Kernel.newest -- Kernel.orig
    FILE SIZE        VM SIZE    
 --------------  -------------- 
   +14%  +815Ki   +14%  +815Ki    [LOAD #6 [RW]]
  +6.7% +27.1Ki  +6.7% +27.1Ki    .unmap_after_init
   +57% +1.25Ki   +57% +1.25Ki    [LOAD #2 [RW]]
  +8.6%    +888  [ = ]       0    [Unmapped]
  +3.7%      +8  +3.7%      +8    .got
   +20%      +4  [ = ]       0    .gnu_debuglink
 -41.7% -2.87Ki -41.7% -2.87Ki    [LOAD #1 [RX]]
 -34.0% -32.9Ki -34.0% -32.9Ki    .relr.dyn
 -19.4% -66.2Ki  [ = ]       0    .symtab
 -32.4%  -421Ki  [ = ]       0    .strtab
 -34.7%  -815Ki -34.7%  -815Ki    .ksyms
 -13.5%  -896Ki -13.5%  -896Ki    .text
 -34.0% -2.03Mi -34.0% -2.03Mi    .data
 -41.5% -2.33Mi -41.5% -2.33Mi    .rodata
 -20.3% -5.71Mi -11.7% -5.24Mi    TOTAL
```

CC: @alimpfard for some of the template weirdness I needed to add in `ErrorOr`
CC: @DanShaders  @ADKaster For the StdShim