### PR TITLE
Shell: Ensure the shell starts as the session leader

### DIFF
--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -207,8 +207,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (auto res = Core::System::setpgid(pid, sid); res.is_error())
                 dbgln("{}", res.release_error());
 
-            if (auto res = Core::System::setsid(); res.is_error())
+            if (auto res = Core::System::setsid(); res.is_error()) {
                 dbgln("{}", res.release_error());
+            } else {
+                TRY(Core::System::exec(arguments.strings.first(), arguments.strings, Core::System::SearchInPath::No));
+                VERIFY_NOT_REACHED();
+            }
         }
     }
 


### PR DESCRIPTION
...and if it doesn't, exec again assuming setsid() works. Fixes broken shells on terminals that don't make the shell they run a session leader.

Imagine my surprise when I install ghostty, run it, press the `l` in ls and...it crashes. well no more.