### PR TITLE
LibPDF: Skip whitespace before values in compressed stream

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -629,6 +629,7 @@ PDFErrorOr<Value> DocumentParser::parse_compressed_object_with_index(u32 index)
     }
 
     stream_parser.push_reference({ index, 0 });
+    stream_parser.consume_whitespace();
     auto value = TRY(stream_parser.parse_value());
     stream_parser.pop_reference();
 

--- a/Userland/Libraries/LibPDF/Parser.h
+++ b/Userland/Libraries/LibPDF/Parser.h
@@ -34,6 +34,7 @@ public:
     void set_document(WeakPtr<Document> const&);
 
     ByteString parse_comment();
+    void consume_whitespace() { m_reader.consume_whitespace(); }
 
     void move_by(size_t count) { m_reader.move_by(count); }
     void move_to(size_t offset) { m_reader.move_to(offset); }


### PR DESCRIPTION
`parse_value()` expects to start on the value.

It's a bit surprising that the object_offset in the compressed stream would point at whitespace instead of the value directly, but it seems to happen in at least one file: This allows us to open 0001215.pdf from the CC-MAIN-2021-31-PDF-UNTRUNCATED test corpus.