### PR TITLE
LibPDF: Remove incorrect page tree heuristic

### DIFF
--- a/Tests/LibPDF/colorspaces.pdf
+++ b/Tests/LibPDF/colorspaces.pdf
@@ -2,34 +2,38 @@
 %µ¶
 
 1 0 obj
-<</Type/Pages/Kids[3 0 R]/Count 1>>
+<</Type/Catalog/Pages 2 0 R>>
 endobj
 
 2 0 obj
-<</Type/Catalog/Pages 1 0 R>>
+<</Type/Pages/Kids[3 0 R]/Count 1>>
 endobj
 
 3 0 obj
-<</Type/Page/Parent 1 0 R/Resources 4 0 R/Contents 8 0 R/MediaBox[0 0 310 370]/Rotate 0>>
+<</Type/Pages/Kids[4 0 R]/Count 1>>
 endobj
 
 4 0 obj
-<</ColorSpace<</MyCalRGB 5 0 R/MyLab 6 0 R/MyCalGray 7 0 R>>>>
+<</Type/Page/Parent 3 0 R/Resources 5 0 R/Contents 9 0 R/MediaBox[0 0 310 370]/Rotate 0>>
 endobj
 
 5 0 obj
-[/CalRGB<</WhitePoint[.95045 1 1.08905]/Gamma[2.16942 2.16942 2.16942]/Matrix[.41241 .21265 .01933 .35762 .71513 .11922 .18051 .07219 .95076]>>]
+<</ColorSpace<</MyCalRGB 6 0 R/MyLab 7 0 R/MyCalGray 8 0 R>>>>
 endobj
 
 6 0 obj
-[/Lab<</WhitePoint[.9505 1 1.089]/Range[-128 127 -128 127]>>]
+[/CalRGB<</WhitePoint[.95045 1 1.08905]/Gamma[2.16942 2.16942 2.16942]/Matrix[.41241 .21265 .01933 .35762 .71513 .11922 .18051 .07219 .95076]>>]
 endobj
 
 7 0 obj
-[/CalGray<</WhitePoint[.9505 1 1.089]/Gamma 2.222>>]
+[/Lab<</WhitePoint[.9505 1 1.089]/Range[-128 127 -128 127]>>]
 endobj
 
 8 0 obj
+[/CalGray<</WhitePoint[.9505 1 1.089]/Gamma 2.222>>]
+endobj
+
+9 0 obj
 <</Length 986>>
 stream
 /DeviceGray cs
@@ -78,19 +82,20 @@ endstream
 endobj
 
 xref
-0 9
-0000000000 65536 f 
+0 10
+0000000000 00001 f 
 0000000016 00000 n 
-0000000068 00000 n 
+0000000062 00000 n 
 0000000114 00000 n 
-0000000220 00000 n 
-0000000299 00000 n 
-0000000460 00000 n 
-0000000538 00000 n 
-0000000607 00000 n 
+0000000166 00000 n 
+0000000272 00000 n 
+0000000351 00000 n 
+0000000512 00000 n 
+0000000590 00000 n 
+0000000659 00000 n 
 
 trailer
-<</Size 9/Root 2 0 R>>
+<</Size 10/Root 1 0 R>>
 startxref
-1643
+1695
 %%EOF


### PR DESCRIPTION
add_page_tree_node_to_page_tree() had a heuristic where it would decide that a page tree node where number of items in the /Kids array was equal of the number of total children stored in /Count in that same node must be the final non-leaf level of the page tree.

That seems sensible, but it is e.g. possible to have a page tree node that has one kid and one page tree node total below it. Such a node isn't useful, but it can exist, and it does exist e.g. in 0000037.pdf page 37:

```
505 0 obj
<<
  /Type /Pages
  /Count 37
  /Kids [ 503 0 R 504 0 R ]
>>
endobj

504 0 obj
<<
  /Type /Pages
  /Count 1
  /Parent 505 0 R
  /Kids [ 467 0 R ]
>>
endobj

467 0 obj
<<
  /Type /Pages
  /Count 1
  /Parent 504 0 R
  /Kids [ 464 0 R ]
>>
endobj
```

Object 504 is useless here and object 505 could just reference object 467 directly, but it doesn't.

Furthermore, conditionally_parse_page_tree_node() already handles all this correctly, so we can just remove this special case.

With this, we render page 37 of 0000037.pdf correctly (previously, we thought that the page didn't have any contents.)

Add such a silly internal page tree node to colorspaces.pdf, so that we have an automated test for this slightly subtle behavior.