### PR TITLE
Services/ImageDecoder: Return an error if no frame was decoded

### DIFF
--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -29,7 +29,9 @@ void ConnectionFromClient::die()
     Core::EventLoop::current().quit(0);
 }
 
-static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder const& decoder, Optional<Gfx::IntSize> ideal_size, Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>>& bitmaps, Vector<u32>& durations)
+namespace {
+
+void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder const& decoder, Optional<Gfx::IntSize> ideal_size, Vector<Optional<NonnullRefPtr<Gfx::Bitmap>>>& bitmaps, Vector<u32>& durations)
 {
     for (size_t i = 0; i < decoder.frame_count(); ++i) {
         auto frame_or_error = decoder.frame(i, ideal_size);
@@ -44,7 +46,7 @@ static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder
     }
 }
 
-static ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> const& known_mime_type)
+ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> const& known_mime_type)
 {
     auto decoder = TRY(Gfx::ImageDecoder::try_create_for_raw_bytes(ReadonlyBytes { encoded_buffer.data<u8>(), encoded_buffer.size() }, known_mime_type));
 
@@ -80,6 +82,8 @@ static ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core:
     result.bitmaps = Gfx::BitmapSequence { bitmaps };
 
     return result;
+}
+
 }
 
 NonnullRefPtr<ConnectionFromClient::Job> ConnectionFromClient::make_decode_image_job(i64 image_id, Core::AnonymousBuffer encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -83,7 +83,7 @@ ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core::Anonym
     if (bitmaps.is_empty() || no_frame_available)
         return Error::from_string_literal("Could not decode image");
 
-    result.bitmaps = Gfx::BitmapSequence { bitmaps };
+    result.bitmaps = { move(bitmaps) };
 
     return result;
 }

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -76,7 +76,11 @@ ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core::Anonym
 
     decode_image_to_bitmaps_and_durations_with_decoder(*decoder, move(ideal_size), bitmaps, result.durations);
 
-    if (bitmaps.is_empty())
+    auto no_frame_available = !any_of(bitmaps, [](Optional<NonnullRefPtr<Gfx::Bitmap>> bitmap) {
+        return bitmap.has_value();
+    });
+
+    if (bitmaps.is_empty() || no_frame_available)
         return Error::from_string_literal("Could not decode image");
 
     result.bitmaps = Gfx::BitmapSequence { bitmaps };


### PR DESCRIPTION
This fixes the crash in FileManager, when a thumbnail couldn't be generated.