### PR TITLE
Services/ImageDecoder: Move bitmaps instead of copying them

### DIFF
--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -97,7 +97,7 @@ NonnullRefPtr<ConnectionFromClient::Job> ConnectionFromClient::make_decode_image
             return TRY(decode_image_to_details(encoded_buffer, ideal_size, mime_type));
         },
         [strong_this = NonnullRefPtr(*this), image_id](DecodeResult result) -> ErrorOr<void> {
-            strong_this->async_did_decode_image(image_id, result.is_animated, result.loop_count, result.bitmaps, result.durations, result.scale);
+            strong_this->async_did_decode_image(image_id, result.is_animated, result.loop_count, move(result.bitmaps), move(result.durations), result.scale);
             strong_this->m_pending_jobs.remove(image_id);
             return {};
         },


### PR DESCRIPTION
Manual cherry-pick of the second change in aa521c8e@ladybird [1], the first part was already done independently in this repo in b499dc18.

[1] https://github.com/LadybirdBrowser/ladybird/pull/3519/commits/aa521c8ec5bd11d2b2ec67ed222b43024991f4d9