### PR TITLE
LibGfx/JPEGXL: VarDCT-related progress

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -714,6 +714,9 @@ static ErrorOr<FrameHeader> read_frame_header(LittleEndianInputBitStream& stream
             && (frame_header.height + frame_header.y0 == size_header.height);
         bool const full_frame = !frame_header.have_crop || cover_image_area;
 
+        // Set default value for is_last
+        frame_header.is_last = frame_header.frame_type == FrameHeader::FrameType::kRegularFrame;
+
         if (normal_frame) {
             frame_header.blending_info = TRY(read_blending_info(stream, metadata, full_frame));
 
@@ -727,7 +730,6 @@ static ErrorOr<FrameHeader> read_frame_header(LittleEndianInputBitStream& stream
             frame_header.is_last = TRY(stream.read_bit());
         }
 
-        // FIXME: Ensure that is_last has the correct default value
         VERIFY(normal_frame);
 
         auto const resets_canvas = full_frame && frame_header.blending_info.mode == BlendingInfo::BlendMode::kReplace;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -942,7 +942,19 @@ static ErrorOr<WPHeader> read_self_correcting_predictor(LittleEndianInputBitStre
     bool const default_wp = TRY(stream.read_bit());
 
     if (!default_wp) {
-        TODO();
+        self_correcting_predictor.wp_p1 = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_p2 = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_p3a = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_p3b = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_p3c = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_p3d = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_p3e = TRY(stream.read_bits(5));
+        self_correcting_predictor.wp_w = {
+            TRY(stream.read_bits<u8>(4)),
+            TRY(stream.read_bits<u8>(4)),
+            TRY(stream.read_bits<u8>(4)),
+            TRY(stream.read_bits<u8>(4)),
+        };
     }
 
     return self_correcting_predictor;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2031,13 +2031,16 @@ public:
     ErrorOr<void> decode_frame()
     {
         auto frame = TRY(read_frame(m_stream, m_header, m_metadata, m_entropy_decoder));
+        auto const& frame_header = frame.frame_header;
 
-        if (frame.frame_header.restoration_filter.gab || frame.frame_header.restoration_filter.epf_iters != 0)
+        if (frame_header.restoration_filter.gab || frame_header.restoration_filter.epf_iters != 0)
             TODO();
 
         TRY(apply_image_features(frame, m_metadata));
 
-        apply_colour_transformation(frame, m_metadata);
+        if (!frame_header.save_before_ct) {
+            apply_colour_transformation(frame, m_metadata);
+        }
 
         TRY(render_extra_channels(frame.image, m_metadata));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -730,15 +730,11 @@ static ErrorOr<FrameHeader> read_frame_header(LittleEndianInputBitStream& stream
             frame_header.is_last = TRY(stream.read_bit());
         }
 
-        VERIFY(normal_frame);
+        if (frame_header.frame_type != FrameHeader::FrameType::kLFFrame && !frame_header.is_last)
+            frame_header.save_as_reference = TRY(stream.read_bits(2));
 
         auto const resets_canvas = full_frame && frame_header.blending_info.mode == BlendingInfo::BlendMode::kReplace;
         auto const can_reference = !frame_header.is_last && (frame_header.duration == 0 || frame_header.save_as_reference != 0) && frame_header.frame_type != FrameHeader::FrameType::kLFFrame;
-
-        if (frame_header.frame_type != FrameHeader::FrameType::kLFFrame) {
-            if (!frame_header.is_last)
-                TODO();
-        }
 
         frame_header.save_before_ct = !normal_frame;
         if (frame_header.frame_type == FrameHeader::FrameType::kReferenceOnly || (resets_canvas && can_reference))


### PR DESCRIPTION
I realized that I didn't upstream my last work on modular images, so instead of making progress in this area, I decided to work on VarDCT. More specifically, I worked on [this](https://github.com/libjxl/conformance/blob/master/testcases/bike/input.jxl) conformance test.

The image is composed of two frames, one kReferenceOnly (modular) and one kNormalFrame (VarDCT). With these commits, we can decode everything until the VarDCT-specific data in the LfGlobal of the second frame.