### PR TITLE
Kernel: Remove some unnecessary VERIFYs from StorageManagement

### DIFF
--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -10,9 +10,6 @@
 #include <AK/Singleton.h>
 #include <AK/StringView.h>
 #include <AK/UUID.h>
-#if ARCH(AARCH64)
-#    include <Kernel/Arch/aarch64/RPi/SDHostController.h>
-#endif
 #include <Kernel/API/DeviceFileTypes.h>
 #include <Kernel/Boot/CommandLine.h>
 #include <Kernel/Bus/PCI/API.h>

--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -188,9 +188,9 @@ UNMAP_AFTER_INIT void StorageManagement::dump_storage_devices_and_partitions() c
     for (auto const& storage_device : m_storage_devices) {
         auto const& partitions = storage_device.partitions();
         if (partitions.is_empty()) {
-            critical_dmesgln("  Device: block{}:{} (no partitions)", storage_device.major(), storage_device.minor());
+            critical_dmesgln("  Device: block{}:{} ({}, no partitions)", storage_device.major(), storage_device.minor(), storage_device.command_set_to_string_view());
         } else {
-            critical_dmesgln("  Device: block{}:{} ({} partitions)", storage_device.major(), storage_device.minor(), partitions.size());
+            critical_dmesgln("  Device: block{}:{} ({}, {} partitions)", storage_device.major(), storage_device.minor(), storage_device.command_set_to_string_view(), partitions.size());
             unsigned partition_number = 1;
             for (auto const& partition : partitions) {
                 critical_dmesgln("    Partition: {}, block{}:{} (UUID {})", partition_number, partition->major(), partition->minor(), partition->metadata().unique_guid().to_string());

--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -103,8 +103,6 @@ void StorageManagement::add_recipe(DeviceTree::DeviceRecipe<NonnullRefPtr<Storag
 
 UNMAP_AFTER_INIT void StorageManagement::enumerate_pci_controllers(bool nvme_poll)
 {
-    VERIFY(m_controllers.is_empty());
-
     if (!kernel_command_line().disable_physical_storage()) {
         // NOTE: Search for VMD devices before actually searching for storage controllers
         // because the VMD device is only a bridge to such (NVMe) controllers.
@@ -177,7 +175,6 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_pci_controllers(bool nvme_pol
 
 UNMAP_AFTER_INIT void StorageManagement::enumerate_storage_devices()
 {
-    VERIFY(!m_controllers.is_empty());
     for (auto& controller : m_controllers) {
         for (size_t device_index = 0; device_index < controller->devices_count(); device_index++) {
             auto device = controller->device(device_index);
@@ -383,7 +380,6 @@ UNMAP_AFTER_INIT void StorageManagement::determine_boot_device_with_logical_unit
 
 UNMAP_AFTER_INIT bool StorageManagement::determine_boot_device(StringView boot_argument)
 {
-    VERIFY(!m_controllers.is_empty());
     m_boot_argument = boot_argument;
 
     if (m_boot_argument.starts_with(block_device_prefix)) {
@@ -420,7 +416,6 @@ UNMAP_AFTER_INIT bool StorageManagement::determine_boot_device(StringView boot_a
 
 UNMAP_AFTER_INIT void StorageManagement::determine_boot_device_with_partition_uuid()
 {
-    VERIFY(!m_storage_devices.is_empty());
     VERIFY(m_boot_argument.starts_with(partition_uuid_prefix));
 
     auto partition_uuid = UUID(m_boot_argument.substring_view(partition_uuid_prefix.length()), UUID::Endianness::Mixed);
@@ -493,7 +488,6 @@ ErrorOr<NonnullRefPtr<VFSRootContext>> StorageManagement::create_first_vfs_root_
 
 UNMAP_AFTER_INIT void StorageManagement::initialize(bool poll)
 {
-    VERIFY(s_storage_device_minor_number == 0);
     if (!PCI::Access::is_disabled()) {
         enumerate_pci_controllers(poll);
     }


### PR DESCRIPTION
m_storage_devices might be empty if USB devices weren't detected yet
(USB devices are probed asynchronously in a separate kernel process).
The code already handles cases were m_storage_devices is empty.
This also causes us to print a nicer panic message when no storage
devices were found.

Similarly, s_storage_device_minor_number might be non-zero if storage
devices were constructed before this VERIFY. The Atomic constructor
already ensures this variable is initially zero.

The !m_controllers.is_empty() VERIFYs fail if only USB drives are
attached, since we don't create StorageControllers for those.

The m_controllers.is_empty() assertion shouldn't cause any issues
currently, but it also shouldn't be necessary.

Removing these VERIFYs should make booting from USB more reliable.

I also included two small related StorageManagement commits.