### PR TITLE
LibGfx+Base: Try harder to add .jpf to known image extensions

### DIFF
--- a/Base/res/apps/ImageViewer.af
+++ b/Base/res/apps/ImageViewer.af
@@ -4,4 +4,4 @@ Executable=/bin/ImageViewer
 Category=Gra&phics
 
 [Launcher]
-FileTypes=bmp,dds,gif,ico,iff,jb2,jbig2,jp2,jpeg,jpg,jpx,jxl,lbm,pbm,pgm,png,ppm,qoi,tga,tiff,tif,tvg
+FileTypes=bmp,dds,gif,ico,iff,jb2,jbig2,jp2,jpeg,jpf,jpg,jpx,jxl,lbm,pbm,pgm,png,ppm,qoi,tga,tiff,tif,tvg

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -27,7 +27,7 @@
     __ENUMERATE_IMAGE_FORMAT(jpeg, ".jbig2")   \
     __ENUMERATE_IMAGE_FORMAT(jpeg2000, ".jp2") \
     __ENUMERATE_IMAGE_FORMAT(jpeg, ".jpeg")    \
-    __ENUMERATE_IMAGE_FORMAT(jpeg, ".jpf")     \
+    __ENUMERATE_IMAGE_FORMAT(jpeg2000, ".jpf") \
     __ENUMERATE_IMAGE_FORMAT(jpeg, ".jpg")     \
     __ENUMERATE_IMAGE_FORMAT(jpeg2000, ".jpx") \
     __ENUMERATE_IMAGE_FORMAT(jxl, ".jxl")      \


### PR DESCRIPTION
I first tried doing this in the second commit of #24016, but I only updated LibCore/MimeData.cpp there.

I then tried to update Bitmap.h in the first commit of #25671 but gave it type `jpeg` instead of `jpeg2000`. Fix that. (That commit did successfully update FileTypeFilter.h though!)

And I forgot to update ImageViewer.af, so do this too.

With this, double-clicking a jpf file in File Manager now opens the image in Image View instead of in Text Editor :^)