### PR TITLE
Utilities/ln: Add verbose option

### DIFF
--- a/Userland/Utilities/ln.cpp
+++ b/Userland/Utilities/ln.cpp
@@ -14,12 +14,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool force = false;
     bool symbolic = false;
+    bool verbose = false;
     StringView target;
     StringView path;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(force, "Force the creation", "force", 'f');
     args_parser.add_option(symbolic, "Create a symlink", "symbolic", 's');
+    args_parser.add_option(verbose, "Verbose", "verbose", 'v');
     args_parser.add_positional_argument(target, "Link target", "target");
     args_parser.add_positional_argument(path, "Link path", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -51,6 +53,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     } else {
         TRY(Core::System::link(target, path));
     }
+
+    if (verbose)
+        outln("'{}' -> '{}'", path, target);
 
     return 0;
 }


### PR DESCRIPTION
I noticed that the ncurses port used `ln -svf` but SerenityOS didn't support it.
https://github.com/SerenityOS/serenity/blob/175697ac207664be7886900bcd5796c11aae678c/Ports/ncurses/package.sh#L79
![ln_fail](https://github.com/user-attachments/assets/b0d0dc14-408e-4e0e-8539-9c3dcc2ecdd1)

You can use the `-v` flag now.
![ln_patch](https://github.com/user-attachments/assets/6ae4b2b4-257d-4f09-91b9-42bc334af11d)

(edit)
Sorry, I accidentally merged the master branch here. I’ve fixed it now.