### PR TITLE
Kernel: Fix file reference leak in loop device during remove_mount()

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -305,6 +305,10 @@ ErrorOr<void> VirtualFileSystem::remove_mount(Mount& mount, FileBackedFileSystem
             if (fs->is_file_backed()) {
                 dbgln("VirtualFileSystem: Unmounting file backed file system {} for the last time...", fs->fsid());
                 auto& file_backed_fs = static_cast<FileBackedFileSystem&>(*fs);
+                if (file_backed_fs.file().is_loop_device()) {
+                    auto& device = static_cast<LoopDevice&>(file_backed_fs.file());
+                    device.unref();
+                }
                 file_backed_fs_list.remove(file_backed_fs);
             }
         } else {


### PR DESCRIPTION
Temporarily fixes #25761. The code is suggested in the issue by @implicitfield. 

I'm going to keep looking into the original issue, so I don't suggest for the issue to be closed, but this seems like a fine temporary fix. 