### PR TITLE
Ports/ca-certificates: Create symlinks in /usr/local/ssl

### DIFF
--- a/Ports/ca-certificates/package.sh
+++ b/Ports/ca-certificates/package.sh
@@ -17,4 +17,10 @@ build() {
 install() {
     mkdir -p "${SERENITY_INSTALL_ROOT}/etc/ssl/certs"
     cp -vf "cacert-${version}.pem" "${SERENITY_INSTALL_ROOT}/etc/ssl/certs/ca-certificates.crt"
+
+    # Create symlinks in /usr/local/ssl since some ports don't read /etc/ssl
+    mkdir -p "${SERENITY_INSTALL_ROOT}/usr/local/ssl"
+    rm -rvf "${SERENITY_INSTALL_ROOT}/usr/local/ssl/certs"
+    ln -svf "/etc/ssl/certs" "${SERENITY_INSTALL_ROOT}/usr/local/ssl"
+    ln -svf "/etc/ssl/certs/ca-certificates.crt" "${SERENITY_INSTALL_ROOT}/usr/local/ssl/cert.pem"
 }


### PR DESCRIPTION
Some ports (e.g. wget and python3) do not read `/etc/ssl` with the default settings.

![without_symlinks](https://github.com/user-attachments/assets/cad492f3-3c29-4c32-99a4-21fe6d609029)

They work fine if there is a symlink to `ca-certificates.crt` in `/usr/local/ssl`.

![with_symlinks](https://github.com/user-attachments/assets/569babf3-be98-4063-90c9-5948a01bcf5b)

I confirmed that Ubuntu24.04 used the same workaround.

![ubuntu24_symlinks](https://github.com/user-attachments/assets/42d6a07d-4887-41dd-b837-382ce6b4e66e)

I also confirmed that SerenityOS can now build [my meson project](https://github.com/matyalatte/c-env-utils) which uses python's ssl module to download GoogleTest.