### PR TITLE
Base: Add ilbm, jbig2, jpeg2000, tiff to Pixel Paint file type list

### DIFF
--- a/Base/res/apps/PixelPaint.af
+++ b/Base/res/apps/PixelPaint.af
@@ -4,4 +4,4 @@ Executable=/bin/PixelPaint
 Category=Gra&phics
 
 [Launcher]
-FileTypes=pp,bmp,dds,gif,ico,jpeg,jpg,jxl,pbm,pgm,png,ppm,qoi,tga
+FileTypes=pp,bmp,dds,gif,ico,iff,jb2,jbig2,jp2,jpeg,jpf,jpg,jpx,jxl,lbm,pbm,pgm,png,ppm,qoi,tga,tiff,tif


### PR DESCRIPTION
Allows "Open With>Pixel Paint" in the context menu for these file extensions in File Explorer.