### PR TITLE
TextEditor: Add gmi to TextEditor file type list

### DIFF
--- a/Base/res/apps/TextEditor.af
+++ b/Base/res/apps/TextEditor.af
@@ -4,4 +4,4 @@ Executable=/bin/TextEditor
 Category=&Utilities
 
 [Launcher]
-FileTypes=txt,md,html,htm,js,json,ini
+FileTypes=txt,md,html,htm,js,json,ini,gmi


### PR DESCRIPTION
As suggested by nico in #25756.