### PR TITLE
Kernel: BlockBasedFilesystem cleanup

### DIFF
--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -121,14 +121,6 @@ BlockBasedFileSystem::BlockBasedFileSystem(OpenFileDescription& file_description
 
 BlockBasedFileSystem::~BlockBasedFileSystem() = default;
 
-void BlockBasedFileSystem::remove_disk_cache_before_last_unmount()
-{
-    VERIFY(m_lock.is_locked());
-    m_cache.with_exclusive([&](auto& cache) {
-        cache.clear();
-    });
-}
-
 ErrorOr<void> BlockBasedFileSystem::initialize_while_locked()
 {
     VERIFY(m_lock.is_locked());

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -41,8 +41,6 @@ protected:
 
     u64 m_device_block_size { 512 };
 
-    void remove_disk_cache_before_last_unmount();
-
 private:
     void flush_specific_block_if_needed(BlockIndex index);
 

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -674,7 +674,6 @@ ErrorOr<void> Ext2FS::prepare_to_clear_last_mount(Inode& mount_guest_inode)
     dmesgln("Ext2FS: Clean unmount, setting superblock to valid state");
     m_super_block.s_state = EXT2_VALID_FS;
     TRY(flush_super_block());
-    BlockBasedFileSystem::remove_disk_cache_before_last_unmount();
 
     return {};
 }

--- a/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
@@ -88,7 +88,6 @@ u8 ISO9660FS::internal_file_type_to_directory_entry_type(DirectoryEntryView cons
 ErrorOr<void> ISO9660FS::prepare_to_clear_last_mount(Inode&)
 {
     // FIXME: Do proper cleaning here.
-    BlockBasedFileSystem::remove_disk_cache_before_last_unmount();
     return {};
 }
 


### PR DESCRIPTION
This breaks the reference cycle between BlockBasedFileSystem and DiskCache, which means that filesystem drivers no longer need to call `remove_disk_cache_before_last_unmount` in order to get destroyed. I've confirmed that this is now the case with both loop device and block device-backed instances of FATFS.

Fixes #25761.

CC @spholz (also, thanks for debugging the reference cycle!)