### PR TITLE
AK+Everywhere: Remove a bunch of unused includes and run HeaderCheck :^)

### DIFF
--- a/AK/AllOf.h
+++ b/AK/AllOf.h
@@ -8,7 +8,6 @@
 
 #include <AK/Concepts.h>
 #include <AK/Find.h>
-#include <AK/Iterator.h>
 
 namespace AK {
 

--- a/AK/AnyOf.h
+++ b/AK/AnyOf.h
@@ -8,7 +8,6 @@
 
 #include <AK/Concepts.h>
 #include <AK/Find.h>
-#include <AK/Iterator.h>
 
 namespace AK {
 

--- a/AK/ArbitrarySizedEnum.h
+++ b/AK/ArbitrarySizedEnum.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/Concepts.h>
 #include <AK/DistinctNumeric.h>
 
 namespace AK {

--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -7,8 +7,6 @@
 #include <AK/Assertions.h>
 #include <AK/Format.h>
 #include <AK/Platform.h>
-#include <AK/StringBuilder.h>
-#include <AK/StringView.h>
 
 #if (defined(AK_OS_LINUX) && defined(AK_LIBC_GLIBC)) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU) || defined(AK_OS_GNU_HURD)
 #    define EXECINFO_BACKTRACE
@@ -17,6 +15,8 @@
 #define PRINT_ERROR(s) (void)fputs((s), stderr)
 
 #if defined(EXECINFO_BACKTRACE)
+#    include <AK/StringBuilder.h>
+#    include <AK/StringView.h>
 #    include <cxxabi.h>
 #    include <execinfo.h>
 #endif

--- a/AK/AsyncStream.h
+++ b/AK/AsyncStream.h
@@ -7,10 +7,8 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/ByteBuffer.h>
 #include <AK/Coroutine.h>
 #include <AK/Error.h>
-#include <AK/ScopeGuard.h>
 
 namespace AK {
 

--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -8,6 +8,7 @@
 
 #include <AK/Concepts.h>
 #include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -7,7 +7,6 @@
 #include <AK/Assertions.h>
 #include <AK/Base64.h>
 #include <AK/Error.h>
-#include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Array.h>
-#include <AK/ByteBuffer.h>
 #include <AK/Error.h>
 #include <AK/String.h>
 #include <AK/StringView.h>

--- a/AK/BigIntBase.h
+++ b/AK/BigIntBase.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/BuiltinWrappers.h>
+#include <AK/NumericLimits.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>

--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/StdLibExtras.h>
-#include <AK/Types.h>
 
 namespace AK {
 

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -6,11 +6,9 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/Concepts.h>
 #include <AK/MaybeOwned.h>
 #include <AK/NumericLimits.h>
-#include <AK/OwnPtr.h>
 #include <AK/Stream.h>
 
 namespace AK {

--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -9,10 +9,8 @@
 #include <AK/BitmapView.h>
 #include <AK/Error.h>
 #include <AK/Noncopyable.h>
-#include <AK/Optional.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Try.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/BuiltinWrappers.h>
+#include <AK/NumericLimits.h>
 #include <AK/Optional.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>

--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/CircularBuffer.h>
-#include <AK/OwnPtr.h>
 #include <AK/Stream.h>
 
 namespace AK {

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -6,7 +6,8 @@
 
 #pragma once
 
-#include "Concepts.h"
+#include <AK/Assertions.h>
+#include <AK/Concepts.h>
 
 namespace AK {
 

--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Atomic.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 #include <sys/mman.h>

--- a/AK/ByteString.cpp
+++ b/AK/ByteString.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/ByteString.h>
 #include <AK/DeprecatedFlyString.h>
 #include <AK/Format.h>

--- a/AK/CircularBuffer.h
+++ b/AK/CircularBuffer.h
@@ -10,7 +10,7 @@
 #include <AK/Error.h>
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
-#include <AK/Vector.h>
+#include <cstddef>
 
 namespace AK {
 
@@ -54,7 +54,7 @@ protected:
     [[nodiscard]] ReadonlyBytes next_read_span(size_t offset = 0) const;
     [[nodiscard]] ReadonlyBytes next_seekback_span(size_t distance) const;
 
-    ByteBuffer m_buffer {};
+    ByteBuffer m_buffer;
 
     size_t m_reading_head {};
     size_t m_used_space {};

--- a/AK/CircularDeque.h
+++ b/AK/CircularDeque.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/CircularQueue.h>
-#include <AK/Types.h>
 
 namespace AK {
 

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -7,7 +7,9 @@
 #pragma once
 
 #include <AK/Concepts.h>
+#include <AK/Format.h>
 #include <AK/Math.h>
+#include <AK/String.h>
 
 namespace AK {
 

--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -8,7 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/IterationDecision.h>
-#include <AK/StdLibExtras.h>
+#include <AK/StdShim.h>
 
 namespace AK::Concepts {
 

--- a/AK/Coroutine.h
+++ b/AK/Coroutine.h
@@ -8,6 +8,7 @@
 
 #include <AK/Concepts.h>
 #include <AK/Noncopyable.h>
+#include <AK/StdLibExtras.h>
 #include <coroutine>
 
 namespace AK {

--- a/AK/Coroutine.h
+++ b/AK/Coroutine.h
@@ -242,6 +242,12 @@ struct TryAwaiter {
         }
     }
 
+    void await_resume()
+    requires(IsSame<T, ErrorOr<void>>)
+    {
+        m_expression->release_value();
+    }
+
     decltype(auto) await_resume()
     {
         return m_expression->release_value();
@@ -263,7 +269,7 @@ auto declval_coro_result(T&&) -> T;
 
 // GCC cannot handle CO_TRY(...CO_TRY(...)...), this hack ensures that it always has the right type information available.
 // FIXME: Remove this once GCC can correctly infer the result type of `co_await TryAwaiter { ... }`.
-#        define CO_TRY(expression) static_cast<decltype(AK::Detail::declval_coro_result(expression).release_value())>(co_await ::AK::Detail::TryAwaiter { (expression) })
+#        define CO_TRY(expression) static_cast<AddRvalueReference<typename RemoveReference<decltype(expression)>::ResultType>>(co_await ::AK::Detail::TryAwaiter { (expression) })
 #    endif
 #elifndef AK_COROUTINE_STATEMENT_EXPRS_BROKEN
 #    define CO_TRY(expression)                               \

--- a/AK/DeprecatedFlyString.cpp
+++ b/AK/DeprecatedFlyString.cpp
@@ -7,7 +7,6 @@
 #include <AK/ByteString.h>
 #include <AK/DeprecatedFlyString.h>
 #include <AK/HashTable.h>
-#include <AK/Optional.h>
 #include <AK/Singleton.h>
 #include <AK/StringUtils.h>
 #include <AK/StringView.h>

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -11,7 +11,6 @@
 #include <AK/Forward.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Try.h>
 
 namespace AK {
 

--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -10,7 +10,6 @@
 
 #include <AK/Format.h>
 #include <AK/Traits.h>
-#include <AK/Types.h>
 
 namespace AK {
 

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -9,7 +9,7 @@
 #include <AK/Assertions.h>
 #include <AK/Error.h>
 #include <AK/Find.h>
-#include <AK/StdLibExtras.h>
+#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/Enumerate.h
+++ b/AK/Enumerate.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StdLibExtras.h>
+#include <AK/Types.h>
 
 namespace AK {
 

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Error.h>
+#include <AK/StdLibExtraDetails.h>
 
 #ifdef KERNEL
 #    include <AK/Format.h>

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -22,4 +22,8 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 #endif
 }
 
+// Properties that Error should have:
+static_assert(IsTriviallyMoveConstructible<ErrorOr<int>>);
+static_assert(IsTriviallyDestructible<ErrorOr<int>>);
+
 }

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -8,7 +8,6 @@
 
 #include <AK/StringView.h>
 #include <AK/Try.h>
-#include <AK/Variant.h>
 
 #if defined(AK_OS_SERENITY) && defined(KERNEL)
 #    include <errno_codes.h>
@@ -21,10 +20,10 @@ namespace AK {
 
 class [[nodiscard]] Error {
 public:
-    ALWAYS_INLINE Error(Error&&) = default;
-    ALWAYS_INLINE Error& operator=(Error&&) = default;
+    constexpr ALWAYS_INLINE Error(Error&&) = default;
+    constexpr ALWAYS_INLINE Error& operator=(Error&&) = default;
 
-    static Error from_errno(int code)
+    constexpr static Error from_errno(int code)
     {
         VERIFY(code != 0);
         return Error(code);
@@ -37,24 +36,20 @@ public:
     static Error from_string_view_or_print_error_and_return_errno(StringView string_literal, int code);
 
 #ifndef KERNEL
-    static Error from_syscall(StringView syscall_name, int rc)
+    constexpr static Error from_syscall(StringView syscall_name, int rc)
     {
         return Error(syscall_name, rc);
     }
-    static Error from_string_view(StringView string_literal) { return Error(string_literal); }
+    constexpr static Error from_string_view(StringView string_literal) { return Error(string_literal); }
 
+    // `Error::from_string_view(ByteString::formatted(...))` is a somewhat common mistake, which leads to a UAF situation.
+    // If your string outlives this error and _isn't_ a temporary being passed to this function, explicitly call .view() on it to resolve to the StringView overload.
     template<OneOf<ByteString, DeprecatedFlyString, String, FlyString> T>
-    static Error from_string_view(T)
-    {
-        // `Error::from_string_view(ByteString::formatted(...))` is a somewhat common mistake, which leads to a UAF situation.
-        // If your string outlives this error and _isn't_ a temporary being passed to this function, explicitly call .view() on it to resolve to the StringView overload.
-        static_assert(DependentFalse<T>, "Error::from_string_view(String) is almost always a use-after-free");
-        VERIFY_NOT_REACHED();
-    }
+    constexpr static Error from_string_view(T) = delete;
 
 #endif
 
-    static Error copy(Error const& error)
+    constexpr static Error copy(Error const& error)
     {
         return Error(error);
     }
@@ -67,20 +62,20 @@ public:
     // If you need to return a static string based on a dynamic condition (like
     // picking an error from an array), then prefer `from_string_view` instead.
     template<size_t N>
-    ALWAYS_INLINE static Error from_string_literal(char const (&string_literal)[N])
+    constexpr static Error from_string_literal(char const (&string_literal)[N])
     {
         return from_string_view(StringView { string_literal, N - 1 });
     }
 
     // Note: Don't call this from C++; it's here for Jakt interop (as the name suggests).
     template<SameAs<StringView> T>
-    ALWAYS_INLINE static Error __jakt_from_string_literal(T string)
+    constexpr ALWAYS_INLINE static Error __jakt_from_string_literal(T string)
     {
         return from_string_view(string);
     }
 #endif
 
-    bool operator==(Error const& other) const
+    constexpr bool operator==(Error const& other) const
     {
 #ifdef KERNEL
         return m_code == other.m_code;
@@ -89,36 +84,36 @@ public:
 #endif
     }
 
-    int code() const { return m_code; }
-    bool is_errno() const
+    constexpr int code() const { return m_code; }
+    constexpr bool is_errno() const
     {
         return m_code != 0;
     }
 #ifndef KERNEL
-    bool is_syscall() const
+    constexpr bool is_syscall() const
     {
         return m_syscall;
     }
-    StringView string_literal() const
+    constexpr StringView string_literal() const
     {
         return m_string_literal;
     }
 #endif
 
 protected:
-    Error(int code)
+    constexpr Error(int code)
         : m_code(code)
     {
     }
 
 private:
 #ifndef KERNEL
-    Error(StringView string_literal)
+    constexpr Error(StringView string_literal)
         : m_string_literal(string_literal)
     {
     }
 
-    Error(StringView syscall_name, int rc)
+    constexpr Error(StringView syscall_name, int rc)
         : m_string_literal(syscall_name)
         , m_code(-rc)
         , m_syscall(true)
@@ -126,8 +121,8 @@ private:
     }
 #endif
 
-    Error(Error const&) = default;
-    Error& operator=(Error const&) = default;
+    constexpr Error(Error const&) = default;
+    constexpr Error& operator=(Error const&) = default;
 
 #ifndef KERNEL
     StringView m_string_literal;
@@ -149,62 +144,136 @@ public:
     using ResultType = T;
     using ErrorType = E;
 
-    ErrorOr()
+    constexpr ALWAYS_INLINE ErrorOr()
     requires(IsSame<T, Empty>)
-        : m_value_or_error(Empty {})
+        : m_value {}
+        , m_is_error(false)
     {
     }
 
-    ALWAYS_INLINE ErrorOr(ErrorOr&&) = default;
-    ALWAYS_INLINE ErrorOr& operator=(ErrorOr&&) = default;
+    constexpr ALWAYS_INLINE ErrorOr(ErrorOr&& other)
+    requires(!Detail::IsTriviallyMoveConstructible<T> || !Detail::IsTriviallyMoveConstructible<E>)
+        : m_is_error(other.m_is_error)
+    {
+        if (other.is_error())
+            construct_at<E>(&m_error, other.release_error());
+        else
+            construct_at<T>(&m_value, other.release_value());
+    }
+    constexpr ALWAYS_INLINE ErrorOr(ErrorOr&& other) = default;
+
+    constexpr ALWAYS_INLINE ErrorOr& operator=(ErrorOr&& other)
+    requires(!Detail::IsTriviallyMoveConstructible<T> || !Detail::IsTriviallyMoveConstructible<E>)
+    {
+        if (this == &other)
+            return *this;
+
+        if (m_is_error)
+            m_error.~ErrorType();
+        else
+            m_value.~T();
+
+        if (other.is_error())
+            construct_at<E>(&m_error, other.release_error());
+        else
+            construct_at<T>(&m_value, other.release_value());
+
+        m_is_error = other.m_is_error;
+        return *this;
+    }
+    constexpr ALWAYS_INLINE ErrorOr& operator=(ErrorOr&& other) = default;
 
     ErrorOr(ErrorOr const&) = delete;
     ErrorOr& operator=(ErrorOr const&) = delete;
 
     template<typename U>
-    ALWAYS_INLINE ErrorOr(ErrorOr<U, ErrorType>&& value)
+    constexpr ALWAYS_INLINE ErrorOr(ErrorOr<U, ErrorType>&& value)
     requires(IsConvertible<U, T>)
-        : m_value_or_error(value.m_value_or_error.visit([](U& v) { return Variant<T, ErrorType>(move(v)); }, [](ErrorType& error) { return Variant<T, ErrorType>(move(error)); }))
+        : m_is_error(value.is_error())
     {
+        if (value.is_error())
+            construct_at<E>(&m_error, value.release_error());
+        else
+            construct_at<T>(&m_value, value.release_value());
     }
 
     template<typename U>
-    ALWAYS_INLINE ErrorOr(U&& value)
-    requires(
-        requires { T(declval<U>()); } || requires { ErrorType(declval<RemoveCVReference<U>>()); })
-        : m_value_or_error(forward<U>(value))
+    constexpr ALWAYS_INLINE ErrorOr(U&& value)
+    requires(requires { T(declval<U>()); } && !IsSame<U, ErrorType>)
+        : m_value(forward<U>(value))
+        , m_is_error(false)
+    {
+    }
+    template<typename U>
+    constexpr ALWAYS_INLINE ErrorOr(U&& error)
+    requires(requires { ErrorType(declval<RemoveCVReference<U>>()); } && !IsSame<U, T>)
+        : m_error(forward<U>(error))
+        , m_is_error(true)
     {
     }
 
 #ifdef AK_OS_SERENITY
-    ErrorOr(ErrnoCode code)
-        : m_value_or_error(Error::from_errno(code))
+    constexpr ALWAYS_INLINE ErrorOr(ErrnoCode code)
+        : m_error(Error::from_errno(code))
+        , m_is_error(true)
     {
     }
 #endif
 
-    T& value()
+    constexpr ALWAYS_INLINE T& value()
     {
-        return m_value_or_error.template get<T>();
+        VERIFY(!is_error());
+        return m_value;
     }
-    T const& value() const { return m_value_or_error.template get<T>(); }
+    constexpr ALWAYS_INLINE T const& value() const
+    {
+        VERIFY(!is_error());
+        return m_value;
+    }
 
-    ErrorType& error() { return m_value_or_error.template get<ErrorType>(); }
-    ErrorType const& error() const { return m_value_or_error.template get<ErrorType>(); }
+    constexpr ALWAYS_INLINE ErrorType& error()
+    {
+        VERIFY(is_error());
+        return m_error;
+    }
+    constexpr ALWAYS_INLINE ErrorType const& error() const
+    {
+        VERIFY(is_error());
+        return m_error;
+    }
 
-    bool is_error() const { return m_value_or_error.template has<ErrorType>(); }
+    constexpr ALWAYS_INLINE bool is_error() const { return m_is_error; }
 
-    T release_value() { return move(value()); }
-    ErrorType release_error() { return move(error()); }
+    constexpr ALWAYS_INLINE T&& release_value() { return move(value()); }
+    constexpr ALWAYS_INLINE ErrorType&& release_error() { return move(error()); }
 
-    T release_value_but_fixme_should_propagate_errors()
+    constexpr ALWAYS_INLINE T release_value_but_fixme_should_propagate_errors()
     {
         VERIFY(!is_error());
         return release_value();
     }
 
+    ~ErrorOr()
+    requires(!Detail::IsDestructible<T> || !Detail::IsDestructible<ErrorType>)
+    = delete;
+
+    constexpr ALWAYS_INLINE ~ErrorOr()
+    requires(IsTriviallyDestructible<T> && IsTriviallyDestructible<ErrorType>)
+    = default;
+    constexpr ALWAYS_INLINE ~ErrorOr()
+    {
+        if (m_is_error)
+            m_error.~ErrorType();
+        else
+            m_value.~T();
+    }
+
 private:
-    Variant<T, ErrorType> m_value_or_error;
+    union {
+        T m_value;
+        ErrorType m_error;
+    };
+    bool m_is_error;
 };
 
 template<typename ErrorType>

--- a/AK/Find.h
+++ b/AK/Find.h
@@ -8,7 +8,6 @@
 
 #include <AK/Concepts.h>
 #include <AK/Traits.h>
-#include <AK/Types.h>
 
 namespace AK {
 

--- a/AK/FixedStringBuffer.h
+++ b/AK/FixedStringBuffer.h
@@ -9,10 +9,9 @@
 #include <AK/Array.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
-#include <AK/TypedTransfer.h>
-#include <AK/Userspace.h>
 
 #if defined(KERNEL) && !defined(PREKERNEL)
+#    include <AK/Userspace.h>
 #    include <Kernel/Arch/SafeMem.h>
 #    include <Kernel/Arch/SmapDisabler.h>
 #    include <Kernel/Memory/MemorySections.h>

--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/BitCast.h>
-#include <AK/StdLibExtras.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/AK/FloatingPointStringConversions.cpp
+++ b/AK/FloatingPointStringConversions.cpp
@@ -7,11 +7,9 @@
 #include <AK/BigIntBase.h>
 #include <AK/CharacterTypes.h>
 #include <AK/FloatingPointStringConversions.h>
-#include <AK/Format.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringView.h>
 #include <AK/UFixedBigInt.h>
-#include <AK/UFixedBigIntDivision.h>
 
 namespace AK {
 
@@ -30,7 +28,7 @@ struct FloatingPointInfo {
     using SameSizeUnsigned = Conditional<sizeof(T) == sizeof(u64), u64, u32>;
 
     // Implementing just this gives all the other bit sizes and mask immediately.
-    static constexpr inline i32 mantissa_bits()
+    static constexpr i32 mantissa_bits()
     {
         if constexpr (sizeof(T) == sizeof(u64))
             return 52;
@@ -38,48 +36,48 @@ struct FloatingPointInfo {
         return 23;
     }
 
-    static constexpr inline i32 exponent_bits()
+    static constexpr i32 exponent_bits()
     {
         return sizeof(T) * 8u - 1u - mantissa_bits();
     }
 
-    static constexpr inline i32 exponent_bias()
+    static constexpr i32 exponent_bias()
     {
         return (1 << (exponent_bits() - 1)) - 1;
     }
 
-    static constexpr inline i32 minimum_exponent()
+    static constexpr i32 minimum_exponent()
     {
         return -exponent_bias();
     }
 
-    static constexpr inline i32 infinity_exponent()
+    static constexpr i32 infinity_exponent()
     {
         static_assert(exponent_bits() < 31);
         return (1 << exponent_bits()) - 1;
     }
 
-    static constexpr inline i32 sign_bit_index()
+    static constexpr i32 sign_bit_index()
     {
         return sizeof(T) * 8 - 1;
     }
 
-    static constexpr inline SameSizeUnsigned sign_mask()
+    static constexpr SameSizeUnsigned sign_mask()
     {
         return SameSizeUnsigned { 1 } << sign_bit_index();
     }
 
-    static constexpr inline SameSizeUnsigned mantissa_mask()
+    static constexpr SameSizeUnsigned mantissa_mask()
     {
         return (SameSizeUnsigned { 1 } << mantissa_bits()) - 1;
     }
 
-    static constexpr inline SameSizeUnsigned exponent_mask()
+    static constexpr SameSizeUnsigned exponent_mask()
     {
         return SameSizeUnsigned { infinity_exponent() } << mantissa_bits();
     }
 
-    static constexpr inline i32 max_exponent_round_to_even()
+    static constexpr i32 max_exponent_round_to_even()
     {
         if constexpr (sizeof(T) == sizeof(u64))
             return 23;
@@ -87,7 +85,7 @@ struct FloatingPointInfo {
         return 10;
     }
 
-    static constexpr inline i32 min_exponent_round_to_even()
+    static constexpr i32 min_exponent_round_to_even()
     {
         if constexpr (sizeof(T) == sizeof(u64))
             return -4;
@@ -95,7 +93,7 @@ struct FloatingPointInfo {
         return -17;
     }
 
-    static constexpr inline size_t max_possible_digits_needed_for_parsing()
+    static constexpr size_t max_possible_digits_needed_for_parsing()
     {
         if constexpr (sizeof(T) == sizeof(u64))
             return 769;
@@ -103,7 +101,7 @@ struct FloatingPointInfo {
         return 114;
     }
 
-    static constexpr inline i32 max_power_of_10()
+    static constexpr i32 max_power_of_10()
     {
         if constexpr (sizeof(T) == sizeof(u64))
             return 308;
@@ -111,7 +109,7 @@ struct FloatingPointInfo {
         return 38;
     }
 
-    static constexpr inline i32 min_power_of_10()
+    static constexpr i32 min_power_of_10()
     {
         // Closest double value to zero is xe-324 and since we have at most 19 digits
         // we know that -324 -19 = -343 so exponent below that must be zero (for double)
@@ -121,7 +119,7 @@ struct FloatingPointInfo {
         return -65;
     }
 
-    static constexpr inline i32 max_exact_power_of_10()
+    static constexpr i32 max_exact_power_of_10()
     {
         // These are the largest power of 10 representable in T
         // So all powers of 10*i less than or equal to this should be the exact
@@ -133,7 +131,7 @@ struct FloatingPointInfo {
         return 10;
     }
 
-    static constexpr inline T power_of_ten(i32 exponent)
+    static constexpr T power_of_ten(i32 exponent)
     {
         VERIFY(exponent <= max_exact_power_of_10());
         VERIFY(exponent >= 0);
@@ -141,7 +139,7 @@ struct FloatingPointInfo {
     }
 
     template<u32 MaxPower>
-    static constexpr inline Array<T, MaxPower + 1> compute_powers_of_ten()
+    static constexpr Array<T, MaxPower + 1> compute_powers_of_ten()
     {
         // All these values are guaranteed to be exact all powers of MaxPower is the
         Array<T, MaxPower + 1> values {};

--- a/AK/FloatingPointStringConversions.h
+++ b/AK/FloatingPointStringConversions.h
@@ -11,7 +11,8 @@
            and there is no guraantee does not do any floating point computations.
 #endif
 
-#include <AK/StringView.h>
+#include <AK/Concepts.h>
+#include <AK/Optional.h>
 
 namespace AK {
 

--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/DeprecatedFlyString.h>
 #include <AK/FlyString.h>
-#include <AK/HashMap.h>
+#include <AK/HashTable.h>
 #include <AK/Singleton.h>
 #include <AK/String.h>
 #include <AK/StringData.h>

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -9,7 +9,6 @@
 #include <AK/FormatParser.h>
 #include <AK/GenericLexer.h>
 #include <AK/IntegralMath.h>
-#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/kstdio.h>
 

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -8,8 +8,6 @@
 
 #include <AK/CheckedFormatString.h>
 
-#include <AK/AllOf.h>
-#include <AK/AnyOf.h>
 #include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -8,7 +8,7 @@
 
 #include <AK/DefaultDelete.h>
 #include <AK/SinglyLinkedListSizePolicy.h>
-#include <AK/StdLibExtras.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -7,8 +7,6 @@
 
 #include <AK/Hex.h>
 #include <AK/StringBuilder.h>
-#include <AK/Types.h>
-#include <AK/Vector.h>
 
 namespace AK {
 

--- a/AK/Hex.h
+++ b/AK/Hex.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/Error.h>
 #include <AK/StringView.h>
 

--- a/AK/IPv6Address.h
+++ b/AK/IPv6Address.h
@@ -6,11 +6,9 @@
 
 #pragma once
 
-#include <AK/Endian.h>
 #include <AK/Format.h>
 #include <AK/Optional.h>
 #include <AK/StringView.h>
-#include <AK/UFixedBigInt.h>
 #include <AK/Vector.h>
 
 #ifdef KERNEL

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -16,7 +16,10 @@ namespace AK {
 
 class JsonArray {
     template<typename Callback>
-    using CallbackErrorType = decltype(declval<Callback>()(declval<JsonValue const&>()).release_error());
+    using CallbackErrorType = decltype(declval<Callback>()(declval<JsonValue const&>()))::ErrorType;
+
+    static_assert(SameAs<CallbackErrorType<ErrorOr<void> (*)(JsonValue const&)>, Error>);
+    static_assert(SameAs<ErrorOr<void, CallbackErrorType<ErrorOr<void> (*)(JsonValue const&)>>, ErrorOr<void>>);
 
 public:
     JsonArray() = default;

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -20,7 +20,10 @@ namespace AK {
 
 class JsonObject {
     template<typename Callback>
-    using CallbackErrorType = decltype(declval<Callback>()(declval<ByteString const&>(), declval<JsonValue const&>()).release_error());
+    using CallbackErrorType = decltype(declval<Callback>()(declval<ByteString const&>(), declval<JsonValue const&>()))::ErrorType;
+
+    static_assert(SameAs<CallbackErrorType<ErrorOr<void> (*)(ByteString const&, JsonValue const&)>, Error>);
+    static_assert(SameAs<ErrorOr<void, CallbackErrorType<ErrorOr<void> (*)(ByteString const&, JsonValue const&)>>, ErrorOr<void>>);
 
 public:
     JsonObject();

--- a/AK/JsonPath.h
+++ b/AK/JsonPath.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/JsonValue.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -16,6 +16,7 @@
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringBuilder.h>
+#include <AK/Variant.h>
 
 namespace AK {
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -13,8 +13,8 @@
 
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
-#include <AK/OwnPtr.h>
 #include <AK/StringBuilder.h>
 #include <AK/Variant.h>
 

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/NumericLimits.h>
 #include <AK/Stream.h>
 #include <AK/Types.h>
 

--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -12,7 +12,7 @@
 
 namespace AK {
 
-char s_single_dot = '.';
+static char s_single_dot = '.';
 
 LexicalPath::LexicalPath(ByteString path)
     : m_string(canonicalized_path(move(path)))

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -6,13 +6,12 @@
 
 #pragma once
 
-#include <AK/BuiltinWrappers.h>
 #include <AK/Concepts.h>
 #include <AK/FloatingPoint.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtraDetails.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
-#include <math.h>
 
 #ifdef KERNEL
 #    error "Including AK/Math.h from the Kernel is never correct! Floating point is disabled."

--- a/AK/MaybeOwned.h
+++ b/AK/MaybeOwned.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Variant.h>
 

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/FixedArray.h>
 #include <AK/MemMem.h>
 #include <AK/MemoryStream.h>

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -9,7 +9,6 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Error.h>
-#include <AK/OwnPtr.h>
 #include <AK/Stream.h>
 #include <AK/Vector.h>
 

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/Forward.h>
 #include <AK/Noncopyable.h>
+#include <AK/Platform.h>
 
 #if defined(KERNEL)
 #    include <Kernel/Arch/Processor.h>

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -8,10 +8,10 @@
 
 #include <AK/Assertions.h>
 #include <AK/Format.h>
-#include <AK/RefCounted.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
+#include <AK/kmalloc.h>
 
 #define NONNULLOWNPTR_SCRUB_BYTE 0xf1
 

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -12,6 +12,7 @@
 #include <AK/Format.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
+#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/OptionParser.cpp
+++ b/AK/OptionParser.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/OptionParser.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
 
 namespace AK {
 

--- a/AK/OptionParser.h
+++ b/AK/OptionParser.h
@@ -9,7 +9,6 @@
 
 #include <AK/Format.h>
 #include <AK/StringView.h>
-#include <AK/Vector.h>
 
 namespace AK {
 

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -133,6 +133,7 @@ public:
     requires(!IsMoveConstructible<T>)
     = delete;
     constexpr ALWAYS_INLINE Optional(Optional&& other)
+    requires(IsMoveConstructible<T> && !IsTriviallyMoveConstructible<T>)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
@@ -140,10 +141,12 @@ public:
         else
             construct_null();
     }
+    // Note: Checking for Move-Constructible to allow for reference members in T
     Optional& operator=(Optional&& other)
     requires(!IsMoveConstructible<T> || !IsDestructible<T>)
     = delete;
     constexpr ALWAYS_INLINE Optional& operator=(Optional&& other)
+    requires(IsMoveConstructible<T> && !IsTriviallyMoveAssignable<T>)
     {
         if (this == &other)
             return *this;
@@ -155,6 +158,9 @@ public:
             construct_null();
         return *this;
     }
+
+    constexpr ALWAYS_INLINE Optional(Optional&& other) = default;
+    constexpr ALWAYS_INLINE Optional& operator=(Optional&& other) = default;
 
     ~Optional()
     requires(!IsDestructible<T>)

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -15,7 +15,6 @@
 #include <AK/StdLibExtras.h>
 #include <AK/Try.h>
 #include <AK/Types.h>
-#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -8,6 +8,10 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Concepts.h>
+#include <AK/Forward.h>
+#include <AK/Platform.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Try.h>
 #include <AK/Types.h>
@@ -45,7 +49,7 @@ template<typename>
 class Optional;
 
 struct OptionalNone {
-    explicit OptionalNone() = default;
+    explicit constexpr OptionalNone() = default;
 };
 
 template<typename T>
@@ -55,16 +59,37 @@ requires(!IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
 
     static_assert(!IsLvalueReference<T> && !IsRvalueReference<T>);
 
+    // FIXME: GCC seems to have an issue with uninitialized unions
+    //        which forces us to have an equally sized trivial null member in the union
+    //        to pseudo-initialize the union,
+    //        Note this could/should be an AK::Array, but it can't as that depends on Optional,
+    //        we use an anonymous struct with a dummy member instead
+    constexpr ALWAYS_INLINE void construct_null()
+    {
+#ifdef AK_COMPILER_GCC
+        m_null = {};
+#endif
+    }
+
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    // FIXME: Why do we need the IsConst here, probably fixed in c++26
+    constexpr ALWAYS_INLINE Optional()
+    requires(!IsTriviallyConstructible<T> || IsConst<T>)
+    {
+        construct_null();
+    }
+    constexpr ALWAYS_INLINE Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V)
+    {
+        construct_null();
+    }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
@@ -73,110 +98,118 @@ public:
     Optional(Optional const& other)
     requires(!IsCopyConstructible<T>)
     = delete;
-    Optional(Optional const& other) = default;
-
-    Optional(Optional&& other)
-    requires(!IsMoveConstructible<T>)
-    = delete;
-
     Optional& operator=(Optional const&)
     requires(!IsCopyConstructible<T> || !IsDestructible<T>)
     = delete;
-    Optional& operator=(Optional const&) = default;
 
-    Optional& operator=(Optional&& other)
-    requires(!IsMoveConstructible<T> || !IsDestructible<T>)
-    = delete;
-
-    ~Optional()
-    requires(!IsDestructible<T>)
-    = delete;
-    ~Optional() = default;
-
-    ALWAYS_INLINE Optional(Optional const& other)
+    constexpr ALWAYS_INLINE Optional(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T>)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.value());
+            construct_at<RemoveConst<T>>(&m_storage, other.value());
+        else
+            construct_null();
+    }
+    constexpr ALWAYS_INLINE Optional& operator=(Optional const& other)
+    requires(!IsTriviallyCopyAssignable<T> || !IsTriviallyDestructible<T>)
+    {
+        if (this == &other)
+            return *this;
+
+        clear();
+        m_has_value = other.m_has_value;
+        if (other.has_value())
+            construct_at<RemoveConst<T>>(&m_storage, other.value());
+        else
+            construct_null();
+        return *this;
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    constexpr Optional(Optional const& other) = default;
+    constexpr Optional& operator=(Optional const&) = default;
+
+    Optional(Optional&& other)
+    requires(!IsMoveConstructible<T>)
+    = delete;
+    constexpr ALWAYS_INLINE Optional(Optional&& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.release_value());
+            construct_at<RemoveConst<T>>(&m_storage, other.release_value());
+        else
+            construct_null();
+    }
+    Optional& operator=(Optional&& other)
+    requires(!IsMoveConstructible<T> || !IsDestructible<T>)
+    = delete;
+    constexpr ALWAYS_INLINE Optional& operator=(Optional&& other)
+    {
+        if (this == &other)
+            return *this;
+        clear();
+        m_has_value = other.m_has_value;
+        if (other.has_value())
+            construct_at<RemoveConst<T>>(&m_storage, other.release_value());
+        else
+            construct_null();
+        return *this;
+    }
+
+    ~Optional()
+    requires(!IsDestructible<T>)
+    = delete;
+    constexpr ALWAYS_INLINE ~Optional()
+    requires(IsDestructible<T> && !IsTriviallyDestructible<T>)
+    {
+        clear();
+    }
+    constexpr ~Optional() = default;
+
+    template<typename U>
+    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && !IsLvalueReference<U>)
+    constexpr explicit Optional(Optional<U> const& other)
+        : m_has_value(other.m_has_value)
+    {
+        if (other.has_value())
+            construct_at<RemoveConst<T>>(&m_storage, other.value());
+        else
+            construct_null();
     }
 
     template<typename U>
-    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && !IsLvalueReference<U>) ALWAYS_INLINE explicit Optional(Optional<U> const& other)
+    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && !IsLvalueReference<U>)
+    constexpr ALWAYS_INLINE explicit Optional(Optional<U>&& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.value());
-    }
-
-    template<typename U>
-    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && !IsLvalueReference<U>) ALWAYS_INLINE explicit Optional(Optional<U>&& other)
-        : m_has_value(other.m_has_value)
-    {
-        if (other.has_value())
-            new (&m_storage) T(other.release_value());
+            construct_at<RemoveConst<T>>(&m_storage, other.release_value());
+        else
+            construct_null();
     }
 
     template<typename U = T>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value)
+    constexpr ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<T>> && IsConstructible<T, U &&>)
         : m_has_value(true)
     {
-        new (&m_storage) T(forward<U>(value));
-    }
-
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
-    requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
-    {
-        if (this != &other) {
-            clear();
-            m_has_value = other.m_has_value;
-            if (other.has_value()) {
-                new (&m_storage) T(other.value());
-            }
-        }
-        return *this;
-    }
-
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
-    {
-        if (this != &other) {
-            clear();
-            m_has_value = other.m_has_value;
-            if (other.has_value()) {
-                new (&m_storage) T(other.release_value());
-            }
-        }
-        return *this;
+        construct_at<RemoveConst<T>>(&m_storage, forward<U>(value));
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    constexpr ALWAYS_INLINE bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    constexpr ALWAYS_INLINE bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    ALWAYS_INLINE ~Optional()
-    requires(!IsTriviallyDestructible<T>)
-    {
-        clear();
-    }
-
-    ALWAYS_INLINE void clear()
+    constexpr ALWAYS_INLINE void clear()
     {
         if (m_has_value) {
             value().~T();
@@ -185,41 +218,41 @@ public:
     }
 
     template<typename... Parameters>
-    ALWAYS_INLINE void emplace(Parameters&&... parameters)
+    constexpr ALWAYS_INLINE void emplace(Parameters&&... parameters)
     {
         clear();
         m_has_value = true;
-        new (&m_storage) T(forward<Parameters>(parameters)...);
+        construct_at<RemoveConst<T>>(&m_storage, forward<Parameters>(parameters)...);
     }
 
     template<typename Callable>
-    ALWAYS_INLINE void lazy_emplace(Callable callable)
+    constexpr ALWAYS_INLINE void lazy_emplace(Callable callable)
     {
         clear();
         m_has_value = true;
-        new (&m_storage) T { callable() };
+        construct_at<RemoveConst<T>>(&m_storage, callable());
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_has_value; }
+    [[nodiscard]] constexpr ALWAYS_INLINE bool has_value() const { return m_has_value; }
 
-    [[nodiscard]] ALWAYS_INLINE T& value() &
+    [[nodiscard]] constexpr ALWAYS_INLINE T& value() &
     {
         VERIFY(m_has_value);
-        return *__builtin_launder(reinterpret_cast<T*>(&m_storage));
+        return m_storage;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& value() const&
+    [[nodiscard]] constexpr ALWAYS_INLINE T const& value() const&
     {
         VERIFY(m_has_value);
-        return *__builtin_launder(reinterpret_cast<T const*>(&m_storage));
+        return m_storage;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value() &&
+    [[nodiscard]] constexpr ALWAYS_INLINE T value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] constexpr ALWAYS_INLINE T release_value()
     {
         VERIFY(m_has_value);
         T released_value = move(value());
@@ -228,14 +261,14 @@ public:
         return released_value;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T const& fallback) const&
+    [[nodiscard]] constexpr ALWAYS_INLINE T value_or(T const& fallback) const&
     {
         if (m_has_value)
             return value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T&& fallback) &&
+    [[nodiscard]] constexpr ALWAYS_INLINE T value_or(T&& fallback) &&
     {
         if (m_has_value)
             return move(value());
@@ -243,7 +276,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
     {
         if (m_has_value)
             return value();
@@ -251,7 +284,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_has_value)
             return value();
@@ -259,7 +292,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (m_has_value)
             return value();
@@ -267,21 +300,21 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_has_value)
             return value();
         return TRY(callback());
     }
 
-    ALWAYS_INLINE T const& operator*() const { return value(); }
-    ALWAYS_INLINE T& operator*() { return value(); }
+    constexpr ALWAYS_INLINE T const& operator*() const { return value(); }
+    constexpr ALWAYS_INLINE T& operator*() { return value(); }
 
-    ALWAYS_INLINE T const* operator->() const { return &value(); }
-    ALWAYS_INLINE T* operator->() { return &value(); }
+    constexpr ALWAYS_INLINE T const* operator->() const { return &value(); }
+    constexpr ALWAYS_INLINE T* operator->() { return &value(); }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    constexpr ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (m_has_value)
@@ -296,7 +329,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    constexpr ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (m_has_value)
@@ -311,7 +344,12 @@ public:
     }
 
 private:
-    alignas(T) u8 m_storage[sizeof(T)];
+    union {
+        struct {
+            u8 _[sizeof(T)];
+        } m_null; // GCC Compat, see above
+        RemoveConst<T> m_storage;
+    };
     bool m_has_value { false };
 };
 
@@ -326,63 +364,55 @@ requires(IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    constexpr ALWAYS_INLINE Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr ALWAYS_INLINE Optional(V) { }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr ALWAYS_INLINE Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
     template<typename U = T>
-    ALWAYS_INLINE Optional(U& value)
+    constexpr ALWAYS_INLINE Optional(U& value)
     requires(CanBePlacedInOptional<U&>)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(RemoveReference<T>& value)
+    constexpr ALWAYS_INLINE Optional(RemoveReference<T>& value)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(Optional const& other)
-        : m_pointer(other.m_pointer)
-    {
-    }
+    constexpr ALWAYS_INLINE Optional(Optional const& other) = default;
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    constexpr ALWAYS_INLINE Optional(Optional&& other)
         : m_pointer(other.m_pointer)
     {
         other.m_pointer = nullptr;
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U> const& other)
+    constexpr ALWAYS_INLINE Optional(Optional<U> const& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.m_pointer)
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U>&& other)
+    constexpr ALWAYS_INLINE Optional(Optional<U>&& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.m_pointer)
     {
         other.m_pointer = nullptr;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
-    {
-        m_pointer = other.m_pointer;
-        return *this;
-    }
-
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    constexpr ALWAYS_INLINE Optional& operator=(Optional const& other) = default;
+    constexpr ALWAYS_INLINE Optional& operator=(Optional&& other)
     {
         m_pointer = other.m_pointer;
         other.m_pointer = nullptr;
@@ -390,7 +420,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U> const& other)
+    constexpr ALWAYS_INLINE Optional& operator=(Optional<U> const& other)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = other.m_pointer;
@@ -398,7 +428,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U>&& other)
+    constexpr ALWAYS_INLINE Optional& operator=(Optional<U>&& other)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = other.m_pointer;
@@ -409,34 +439,35 @@ public:
     // Note: Disallows assignment from a temporary as this does not do any lifetime extension.
     template<typename U>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE Optional& operator=(U&& value)
+    constexpr ALWAYS_INLINE Optional& operator=(U&& value)
     requires(CanBePlacedInOptional<U> && IsLvalueReference<U>)
     {
         m_pointer = &value;
         return *this;
     }
 
-    ALWAYS_INLINE void clear()
+    constexpr ALWAYS_INLINE void clear()
     {
         m_pointer = nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_pointer != nullptr; }
+    [[nodiscard]] constexpr ALWAYS_INLINE bool has_value() const { return m_pointer != nullptr; }
 
-    [[nodiscard]] ALWAYS_INLINE T value()
+    [[nodiscard]] constexpr ALWAYS_INLINE T value()
     {
         VERIFY(m_pointer);
         return *m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE AddConstToReferencedType<T> value() const
+    [[nodiscard]] constexpr ALWAYS_INLINE AddConstToReferencedType<T> value() const
     {
         VERIFY(m_pointer);
         return *m_pointer;
     }
 
     template<typename U>
-    requires(IsBaseOf<RemoveCVReference<T>, U>) [[nodiscard]] ALWAYS_INLINE AddConstToReferencedType<T> value_or(U& fallback) const
+    requires(IsBaseOf<RemoveCVReference<T>, U>) [[nodiscard]]
+    constexpr ALWAYS_INLINE AddConstToReferencedType<T> value_or(U& fallback) const
     {
         if (m_pointer)
             return value();
@@ -444,50 +475,50 @@ public:
     }
 
     // Note that this ends up copying the value.
-    [[nodiscard]] ALWAYS_INLINE RemoveCVReference<T> value_or(RemoveCVReference<T> fallback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE RemoveCVReference<T> value_or(RemoveCVReference<T> fallback) const
     {
         if (m_pointer)
             return value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] constexpr ALWAYS_INLINE T release_value()
     {
         return *exchange(m_pointer, nullptr);
     }
 
     template<typename U>
-    ALWAYS_INLINE bool operator==(Optional<U> const& other) const
+    constexpr ALWAYS_INLINE bool operator==(Optional<U> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename U>
-    ALWAYS_INLINE bool operator==(U const& other) const
+    constexpr ALWAYS_INLINE bool operator==(U const& other) const
     {
         return has_value() && value() == other;
     }
 
-    ALWAYS_INLINE AddConstToReferencedType<T> operator*() const { return value(); }
-    ALWAYS_INLINE T operator*() { return value(); }
+    constexpr ALWAYS_INLINE AddConstToReferencedType<T> operator*() const { return value(); }
+    constexpr ALWAYS_INLINE T operator*() { return value(); }
 
-    ALWAYS_INLINE RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
-    ALWAYS_INLINE RawPtr<RemoveReference<T>> operator->() { return &value(); }
+    constexpr ALWAYS_INLINE RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
+    constexpr ALWAYS_INLINE RawPtr<RemoveReference<T>> operator->() { return &value(); }
 
     // Conversion operators from Optional<T&> -> Optional<T>
-    ALWAYS_INLINE explicit operator Optional<RemoveCVReference<T>>() const
+    constexpr ALWAYS_INLINE explicit operator Optional<RemoveCVReference<T>>() const
     {
         if (has_value())
             return Optional<RemoveCVReference<T>>(value());
         return {};
     }
-    ALWAYS_INLINE constexpr Optional<RemoveCVReference<T>> copy() const
+    constexpr ALWAYS_INLINE Optional<RemoveCVReference<T>> copy() const
     {
         return static_cast<Optional<RemoveCVReference<T>>>(*this);
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -495,7 +526,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -503,7 +534,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -511,7 +542,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] constexpr ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -519,7 +550,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    constexpr ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (m_pointer != nullptr)
@@ -534,7 +565,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    constexpr ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (m_pointer != nullptr)

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -9,7 +9,6 @@
 #include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtr.h>
-#include <AK/RefCounted.h>
 
 #define OWNPTR_SCRUB_BYTE 0xf0
 
@@ -171,7 +170,11 @@ protected:
         : m_ptr(ptr)
     {
         static_assert(
-            requires { requires typename T::AllowOwnPtr()(); } || !requires { requires !typename T::AllowOwnPtr()(); declval<T>().ref(); declval<T>().unref(); }, "Use RefPtr<> for RefCounted types");
+            requires { requires typename T::AllowOwnPtr()(); }
+                || !requires { 
+                    requires !typename T::AllowOwnPtr()();
+                    declval<T>().ref(); declval<T>().unref(); },
+            "Use RefPtr<> for RefCounted types");
     }
 
 private:

--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -7,8 +7,6 @@
 #pragma once
 
 #include <AK/IntrusiveList.h>
-#include <AK/OwnPtr.h>
-#include <AK/SinglyLinkedList.h>
 #include <AK/Vector.h>
 
 namespace AK {

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -12,7 +12,7 @@
 #include <AK/Types.h>
 #include <stdlib.h>
 
-#if defined(__unix__)
+#if defined(__unix__) && !(defined(AK_OS_SERENITY) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU) || AK_LIBC_GLIBC_PREREQ(2, 36) || defined(OSS_FUZZ))
 #    include <unistd.h>
 #endif
 

--- a/AK/RefCountForwarder.h
+++ b/AK/RefCountForwarder.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T>

--- a/AK/SIMD.h
+++ b/AK/SIMD.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 namespace AK::SIMD {

--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/BitCast.h>
-#include <AK/Concepts.h>
 #include <AK/SIMD.h>
 
 namespace AK::SIMD {

--- a/AK/ScopedValueRollback.h
+++ b/AK/ScopedValueRollback.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T>

--- a/AK/SegmentedVector.h
+++ b/AK/SegmentedVector.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/OwnPtr.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Vector.h>
 
 namespace AK {

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -9,9 +9,9 @@
 #include <AK/Assertions.h>
 #include <AK/Error.h>
 #include <AK/Find.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
+#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -425,7 +425,7 @@ using IdentityType = typename __IdentityType<T>::Type;
 template<typename T, typename = void>
 struct __AddReference {
     using LvalueType = T;
-    using TvalueType = T;
+    using RvalueType = T;
 };
 
 template<typename T>

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -53,6 +53,10 @@ struct _RawPtr {
 
 namespace AK {
 
+struct Empty {
+    constexpr bool operator==(Empty const&) const = default;
+};
+
 template<typename T, typename SizeType = decltype(sizeof(T)), SizeType N>
 constexpr SizeType array_size(T (&)[N])
 {
@@ -194,6 +198,7 @@ __DEFINE_GENERIC_ABS(long double, 0.0L, fabsl);
 using AK::array_size;
 using AK::ceil_div;
 using AK::clamp;
+using AK::Empty;
 using AK::exchange;
 using AK::floor_div;
 using AK::forward;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -15,6 +15,7 @@
 #include <AK/StdLibExtraDetails.h>
 
 #include <AK/Assertions.h>
+#include <AK/StdShim.h>
 
 namespace AK {
 
@@ -42,38 +43,6 @@ void compiletime_fail(Args...);
 #else
 #    define AK_REPLACED_STD_NAMESPACE std
 #endif
-
-namespace AK_REPLACED_STD_NAMESPACE { // NOLINT(cert-dcl58-cpp) Names in std to aid tools
-
-// NOTE: These are in the "std" namespace since some compilers and static analyzers rely on it.
-//       If USING_AK_GLOBALLY is false, we can't put them in ::std, so we put them in AK::replaced_std instead
-//       The user code should not notice anything unless it explicitly asks for std::stuff, so...don't.
-
-template<typename T>
-constexpr T&& forward(AK::Detail::RemoveReference<T>& param)
-{
-    return static_cast<T&&>(param);
-}
-
-template<typename T>
-constexpr T&& forward(AK::Detail::RemoveReference<T>&& param) noexcept
-{
-    static_assert(!AK::Detail::IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
-    return static_cast<T&&>(param);
-}
-
-template<typename T>
-constexpr T&& move(T& arg)
-{
-    return static_cast<T&&>(arg);
-}
-
-}
-
-namespace AK {
-using AK_REPLACED_STD_NAMESPACE::forward;
-using AK_REPLACED_STD_NAMESPACE::move;
-}
 
 namespace AK::Detail {
 template<typename T>

--- a/AK/StdShim.h
+++ b/AK/StdShim.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Note:
+// These functions we might need to implement to get some stuff working in constexpr contexts,
+// Or because they'd are visible in the standard library and we need to provide them,
+// So we need to include the official implementations and poison the rest of std in lagom builds
+// for serenity builds we are the standard lib so we can implement them ourselves
+// ALSO NOTE for move/forward: These have to be in the "std" namespace since some compilers and static analyzers rely on it.
+
+// Note: Named in a way that will sort this after other headers that might need to include stl headers
+
+#ifdef KERNEL
+#    include <AK/StdLibExtraDetails.h>
+#    include <Kernel/Heap/kmalloc.h>
+
+namespace std { // NOLINT(cert-dcl58-cpp) We are the standard library
+
+template<typename T>
+constexpr T&& forward(AK::Detail::RemoveReference<T>& param)
+{
+    return static_cast<T&&>(param);
+}
+
+template<typename T>
+constexpr T&& forward(AK::Detail::RemoveReference<T>&& param) noexcept
+{
+    static_assert(!AK::Detail::IsLvalueReference<T>, "Can't forward an rvalue as an lvalue.");
+    return static_cast<T&&>(param);
+}
+
+template<typename T>
+constexpr T&& move(T& arg)
+{
+    return static_cast<T&&>(arg);
+}
+
+// `new` will be constexpr in C++26, until then we need this
+template<typename T, typename... Args>
+constexpr T* construct_at(T* location, Args&&... args) noexcept
+{
+    return ::new ((void*)location) T(forward<Args>(args)...);
+}
+
+}
+
+#else
+// Note: Try to include as little STL as possible
+#    if __has_include(<bits/stl_construct.h>)
+//       GLIBC LIBSTDC++
+#        include <bits/stl_construct.h>
+#    elif __has_include(<__memory/construct_at.h>)
+//       LLVM LIBCXX
+#        include <__memory/construct_at.h>
+#    else
+// FIXME: Find a smaller header to include in these cases
+#        include <memory>
+#    endif
+
+#endif
+
+namespace AK {
+using std::construct_at;
+using std::forward;
+using std::move;
+}
+
+// FIXME: Poison STD
+//        kmalloc.h includes a few system headers as well, which would break when poisoning std here

--- a/AK/StdShim.h
+++ b/AK/StdShim.h
@@ -44,6 +44,7 @@ constexpr T&& move(T& arg)
 template<typename T, typename... Args>
 constexpr T* construct_at(T* location, Args&&... args) noexcept
 {
+    // FIXME: GCC may complain here about casting away const....
     return ::new ((void*)location) T(forward<Args>(args)...);
 }
 

--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/Format.h>
 #include <AK/Stream.h>
 #include <AK/StringBuilder.h>

--- a/AK/StreamBuffer.h
+++ b/AK/StreamBuffer.h
@@ -8,6 +8,8 @@
 
 #include <AK/Coroutine.h>
 #include <AK/Error.h>
+#include <AK/Span.h>
+#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -11,6 +11,7 @@
 #include <AK/MemMem.h>
 #include <AK/Stream.h>
 #include <AK/String.h>
+#include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <stdlib.h>
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -12,7 +12,6 @@
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
-#include <AK/RefCounted.h>
 #include <AK/Span.h>
 #include <AK/StringBase.h>
 #include <AK/StringBuilder.h>

--- a/AK/StringBase.cpp
+++ b/AK/StringBase.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
-#include <AK/FlyString.h>
 #include <AK/StringBase.h>
 #include <AK/StringData.h>
 

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -8,6 +8,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Checked.h>
 #include <AK/PrintfImplementation.h>
+#include <AK/StdShim.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/AK/StringData.h
+++ b/AK/StringData.h
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/StringBase.h>
 #include <AK/kmalloc.h>
 
 namespace AK::Detail {

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/AnyOf.h>
-#include <AK/ByteBuffer.h>
-#include <AK/Find.h>
 #include <AK/Function.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -9,13 +9,14 @@
 #include <AK/Assertions.h>
 #include <AK/Checked.h>
 #include <AK/Concepts.h>
-#include <AK/EnumBits.h>
 #include <AK/Forward.h>
+#include <AK/Iterator.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringHash.h>
 #include <AK/StringUtils.h>
+#include <AK/Traits.h>
 
 namespace AK {
 

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -8,12 +8,12 @@
 
 #include <AK/Array.h>
 #include <AK/Assertions.h>
-#include <AK/Badge.h>
 #include <AK/Checked.h>
 #include <AK/Platform.h>
 #include <AK/Types.h>
 
 #if defined(AK_OS_SERENITY) && defined(KERNEL)
+#    include <AK/Badge.h>
 #    include <Kernel/API/POSIX/sys/time.h>
 #    include <Kernel/API/POSIX/time.h>
 

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -10,6 +10,7 @@
 #include <AK/Concepts.h>
 #include <AK/Forward.h>
 #include <AK/HashFunctions.h>
+#include <AK/StdLibExtras.h>
 #include <AK/StringHash.h>
 
 namespace AK {

--- a/AK/Try.h
+++ b/AK/Try.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Diagnostics.h>
-#include <AK/StdLibExtras.h>
 
 // NOTE: This macro works with any result type that has the expected APIs.
 //       It's designed with AK::Result and AK::Error in mind.

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/StdLibExtras.h>
 #include <AK/TypeList.h>
 
 namespace AK::Detail {

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
 
 namespace AK {

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -9,14 +9,13 @@
 
 #include <AK/BigIntBase.h>
 #include <AK/BuiltinWrappers.h>
-#include <AK/Checked.h>
 #include <AK/Concepts.h>
 #include <AK/Endian.h>
 #include <AK/Format.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtraDetails.h>
 #include <AK/StdLibExtras.h>
-#include <AK/StringBuilder.h>
+#include <AK/UFixedBigIntDivision.h>
 
 namespace AK {
 

--- a/AK/UFixedBigIntDivision.h
+++ b/AK/UFixedBigIntDivision.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Diagnostics.h>
 #include <AK/UFixedBigInt.h>
 
 namespace AK::Detail {

--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Array.h>
-#include <AK/ByteBuffer.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Assertions.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 #ifdef KERNEL

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -216,10 +216,6 @@ using MergeAndDeduplicatePacks = InheritFromPacks<MakeIndexSequence<sizeof...(Ps
 
 namespace AK {
 
-struct Empty {
-    constexpr bool operator==(Empty const&) const = default;
-};
-
 template<typename T>
 concept NotLvalueReference = !IsLvalueReference<T>;
 
@@ -522,6 +518,5 @@ struct TypeList<Variant<Ts...>> : TypeList<Ts...> { };
 }
 
 #if USING_AK_GLOBALLY
-using AK::Empty;
 using AK::Variant;
 #endif

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Assertions.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/StdLibExtras.h>

--- a/Kernel/Devices/GPU/Bochs/Definitions.h
+++ b/Kernel/Devices/GPU/Bochs/Definitions.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 namespace Kernel {

--- a/Kernel/FileSystem/FUSE/FUSEConnection.h
+++ b/Kernel/FileSystem/FUSE/FUSEConnection.h
@@ -7,6 +7,9 @@
 #pragma once
 
 #include <AK/Atomic.h>
+#include <AK/RefCounted.h>
+#include <Kernel/Devices/Device.h>
+#include <Kernel/Devices/FUSEDevice.h>
 #include <Kernel/FileSystem/FUSE/Definitions.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Library/KBuffer.h>

--- a/Kernel/Library/KString.h
+++ b/Kernel/Library/KString.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Format.h>
+#include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
 
 namespace Kernel {

--- a/Kernel/Library/NonnullLockRefPtr.h
+++ b/Kernel/Library/NonnullLockRefPtr.h
@@ -9,6 +9,7 @@
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/Format.h>
+#include <AK/Forward.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -707,7 +707,6 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map_multiboot(MemoryManager::G
         PhysicalAddress upper;
     };
 
-    Optional<ContiguousPhysicalVirtualRange> last_contiguous_physical_range;
     for (auto const* mmap = mmap_begin; mmap < mmap_end; mmap++) {
         // We have to copy these onto the stack, because we take a reference to these when printing them out,
         // and doing so on a packed struct field is UB.

--- a/Meta/HeaderCheck/generate_all.py
+++ b/Meta/HeaderCheck/generate_all.py
@@ -3,46 +3,66 @@
 import os
 import sys
 import subprocess
+import re
 
-TEST_FILE_TEMPLATE = '''\
+TEST_FILE_TEMPLATE = """\
 #include <{filename}>
 // Check idempotency:
 #include <{filename}>
-'''
+"""
+
+# FIXME: This list is to get this working on all platforms.
+#        Ideally we'd have a smarter way to ignore headers
+header_ignore_list = [
+    re.compile(".*/LibAccelGfx/.*"),
+    re.compile(".*PulseAudio.*"),
+    re.compile(".*/LibC/.*"),
+    re.compile(".*/LibCore/MachPort.h*"),
+    re.compile(".*/LibCore/MachPort.h*"),
+    re.compile(".*/LibCore/Platform/ProcessStatisticsMach.h"),
+    re.compile(
+        ".*/(Kernel|LibELF)/Arch/(?!{}).*/.*".format(*(sys.argv[1:] or [r"\w"]))
+    ),
+]
 
 
 def get_headers_here():
     result = subprocess.run(
-        ['git', 'ls-files', 'AK/*.h', 'Userland/Libraries/*.h'],
-        check=True, capture_output=True, text=True)
-    assert result.stderr == ''
-    output = result.stdout.split('\n')
-    assert output[-1] == ''  # Trailing newline
-    assert len(output) > 500, 'There should be well over a thousand headers, not only {}?!'.format(len(output))
+        ["git", "ls-files", "AK/*.h", "Userland/Libraries/*.h"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stderr == ""
+    output = result.stdout.split("\n")
+    assert output[-1] == ""  # Trailing newline
+    assert (
+        len(output) > 500
+    ), "There should be well over a thousand headers, not only {}?!".format(len(output))
     return output[:-1]
 
 
 def as_filename(header_path):
-    return header_path.replace('/', '__') + '__test.cpp'
+    return header_path.replace("/", "__") + "__test.cpp"
 
 
 def verbosely_write(path, new_content):
     print(path)
     # FIXME: Ensure directory exists
     if os.path.exists(path):
-        with open(path, 'r') as fp:
+        with open(path, "r") as fp:
             old_data = fp.read()
         if old_data == new_content:
             # Fast path! Don't trigger ninja
             return
-    with open(path, 'w') as fp:
+    with open(path, "w") as fp:
         fp.write(new_content)
 
 
 def generate_part(header):
     content = TEST_FILE_TEMPLATE.format(filename=header)
-    if header.startswith('Kernel/'):
-        content += '#define KERNEL\n'
+    if header.startswith("Kernel/"):
+        content += "#define KERNEL\n"
     verbosely_write(as_filename(header), content)
 
 
@@ -50,21 +70,27 @@ def run(root_path, arch):
     os.chdir(root_path)
     headers_list = get_headers_here()
 
-    generated_files_path = os.path.join(root_path, 'Build', arch, 'Meta', 'HeaderCheck')
+    generated_files_path = os.path.join(root_path, "Build", arch, "Meta", "HeaderCheck")
     if not os.path.exists(generated_files_path):
         os.mkdir(generated_files_path)
     os.chdir(generated_files_path)
     for header in headers_list:
+        if any(ignore.match(header) for ignore in header_ignore_list):
+            continue
         generate_part(header)
 
 
-if __name__ == '__main__':
-    if 'SERENITY_SOURCE_DIR' not in os.environ:
-        print('Must set SERENITY_SOURCE_DIR first!', file=sys.stderr)
+if __name__ == "__main__":
+    if "SERENITY_SOURCE_DIR" not in os.environ:
+        print("Must set SERENITY_SOURCE_DIR first!", file=sys.stderr)
         exit(1)
     if len(sys.argv) == 2:
-        run(os.environ['SERENITY_SOURCE_DIR'], sys.argv[1])
+        run(os.environ["SERENITY_SOURCE_DIR"], sys.argv[1])
     else:
-        print('Usage: SERENITY_SOURCE_DIR=/path/to/serenity {} SERENITY_BUILD_ARCH'
-              .format(sys.argv[0]), file=sys.stderr)
+        print(
+            "Usage: SERENITY_SOURCE_DIR=/path/to/serenity {} SERENITY_BUILD_ARCH".format(
+                sys.argv[0]
+            ),
+            file=sys.stderr,
+        )
         exit(1)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -374,7 +374,7 @@ TEST_CASE(fallible_json_object_for_each)
         return CustomError {};
     });
     EXPECT(result2.is_error());
-    EXPECT((IsSame<decltype(result2.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result2.release_error()), CustomError&&>));
 
     auto result3 = object.try_for_each_member([](auto const&, auto const&) -> CustomErrorOr<int> {
         return 42;
@@ -385,7 +385,7 @@ TEST_CASE(fallible_json_object_for_each)
         return CustomError {};
     });
     EXPECT(result4.is_error());
-    EXPECT((IsSame<decltype(result4.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result4.release_error()), CustomError&&>));
 }
 
 TEST_CASE(fallible_json_array_for_each)
@@ -414,7 +414,7 @@ TEST_CASE(fallible_json_array_for_each)
         return CustomError {};
     });
     EXPECT(result2.is_error());
-    EXPECT((IsSame<decltype(result2.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result2.release_error()), CustomError&&>));
 
     auto result3 = array.try_for_each([](auto const&) -> CustomErrorOr<int> {
         return 42;
@@ -425,7 +425,7 @@ TEST_CASE(fallible_json_array_for_each)
         return CustomError {};
     });
     EXPECT(result4.is_error());
-    EXPECT((IsSame<decltype(result4.release_error()), CustomError>));
+    static_assert((IsSame<decltype(result4.release_error()), CustomError&&>));
 }
 
 TEST_CASE(json_array_is_empty)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -327,6 +327,9 @@ struct CustomError {
 template<typename T>
 class CustomErrorOr {
 public:
+    using ResultType = T;
+    using ErrorType = CustomError;
+
     CustomErrorOr(T)
         : m_is_error(false)
     {

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/BufferedStream.h>
 #include <AK/MemoryStream.h>
-#include <AK/String.h>
+#include <AK/NonnullOwnPtr.h>
 #include <LibTest/TestCase.h>
 
 TEST_CASE(allocating_memory_stream_empty)

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -32,7 +32,6 @@ TEST_CASE(move_optional)
     y = move(x);
     EXPECT_EQ(y.has_value(), true);
     EXPECT_EQ(y.value(), 3);
-    EXPECT_EQ(x.has_value(), false);
 }
 
 TEST_CASE(optional_rvalue_ref_qualified_getters)
@@ -54,6 +53,11 @@ TEST_CASE(optional_rvalue_ref_qualified_getters)
 
     EXPECT_EQ(make_an_optional().value().x, 13);
     EXPECT_EQ(make_an_optional().value_or(DontCopyMe {}).x, 13);
+
+    auto opt = make_an_optional();
+    EXPECT_EQ(opt->x, 13);
+    auto y = move(opt);
+    EXPECT_EQ(y->x, 13);
 }
 
 TEST_CASE(optional_leak_1)
@@ -123,13 +127,11 @@ TEST_CASE(comparison_with_numeric_types)
 TEST_CASE(test_copy_ctor_and_dtor_called)
 {
     static_assert(IsTriviallyDestructible<Optional<u8>>);
-    // FIXME: Figure out what is missing for this one:
-    // static_assert(IsTriviallyCopyable<Optional<u8>>);
+    static_assert(IsTriviallyCopyable<Optional<u8>>);
     static_assert(IsTriviallyCopyConstructible<Optional<u8>>);
     static_assert(IsTriviallyCopyAssignable<Optional<u8>>);
-    // These can't be trivial as we have to clear the original object.
-    static_assert(!IsTriviallyMoveConstructible<Optional<u8>>);
-    static_assert(!IsTriviallyMoveAssignable<Optional<u8>>);
+    static_assert(IsTriviallyMoveConstructible<Optional<u8>>);
+    static_assert(IsTriviallyMoveAssignable<Optional<u8>>);
 
     static_assert(IsTriviallyCopyConstructible<Optional<int&>>);
     static_assert(IsTriviallyCopyAssignable<Optional<int&>>);

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -122,15 +122,18 @@ TEST_CASE(comparison_with_numeric_types)
 
 TEST_CASE(test_copy_ctor_and_dtor_called)
 {
-#ifdef AK_HAVE_CONDITIONALLY_TRIVIAL
     static_assert(IsTriviallyDestructible<Optional<u8>>);
-    static_assert(IsTriviallyCopyable<Optional<u8>>);
+    // FIXME: Figure out what is missing for this one:
+    // static_assert(IsTriviallyCopyable<Optional<u8>>);
     static_assert(IsTriviallyCopyConstructible<Optional<u8>>);
     static_assert(IsTriviallyCopyAssignable<Optional<u8>>);
     // These can't be trivial as we have to clear the original object.
     static_assert(!IsTriviallyMoveConstructible<Optional<u8>>);
     static_assert(!IsTriviallyMoveAssignable<Optional<u8>>);
-#endif
+
+    static_assert(IsTriviallyCopyConstructible<Optional<int&>>);
+    static_assert(IsTriviallyCopyAssignable<Optional<int&>>);
+    static_assert(IsTriviallyDestructible<Optional<int&>>);
 
     struct DestructionChecker {
         explicit DestructionChecker(bool& was_destroyed)
@@ -204,12 +207,10 @@ TEST_CASE(test_copy_ctor_and_dtor_called)
     Optional<MoveChecker> move2 = move(move1);
     EXPECT(was_moved);
 
-#ifdef AK_HAVE_CONDITIONALLY_TRIVIAL
     struct NonDestructible {
         ~NonDestructible() = delete;
     };
     static_assert(!IsDestructible<Optional<NonDestructible>>);
-#endif
 }
 
 TEST_CASE(basic_optional_reference)
@@ -300,3 +301,32 @@ TEST_CASE(comparison_reference)
     EXPECT_EQ(opt1, opt2);
     EXPECT_NE(opt1, opt3);
 }
+
+consteval bool test_constexpr()
+{
+    Optional<int> none;
+    if (none.has_value())
+        return false;
+
+    Optional<int> x;
+    x = 3;
+    if (!x.has_value())
+        return false;
+
+    if (x.value() != 3)
+        return false;
+
+    Optional<int> y;
+    y = x.release_value();
+    if (!y.has_value())
+        return false;
+
+    if (y.value() != 3)
+        return false;
+
+    if (x.has_value())
+        return false;
+
+    return true;
+}
+static_assert(test_constexpr());

--- a/Tests/Kernel/setpgid-across-sessions-without-leader.cpp
+++ b/Tests/Kernel/setpgid-across-sessions-without-leader.cpp
@@ -7,9 +7,9 @@
 #include <AK/Assertions.h>
 #include <AK/Format.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <serenity.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 /*

--- a/Tests/LibTest/TestAsyncTestStreams.cpp
+++ b/Tests/LibTest/TestAsyncTestStreams.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/AsyncTestCase.h>
 #include <LibTest/AsyncTestStreams.h>
+#include <unistd.h>
 
 ASYNC_TEST_CASE(input_basic)
 {

--- a/Userland/Libraries/LibAccelGfx/Context.h
+++ b/Userland/Libraries/LibAccelGfx/Context.h
@@ -9,7 +9,7 @@
 #include <AK/Assertions.h>
 #include <AK/OwnPtr.h>
 
-#ifndef AK_OS_MACOS
+#if not defined(AK_OS_MACOS) and not defined(AK_OS_SERENITY)
 // Make sure egl.h doesn't give us definitions from X11 headers
 #    define EGL_NO_X11
 #    include <EGL/egl.h>

--- a/Userland/Libraries/LibC/search.cpp
+++ b/Userland/Libraries/LibC/search.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Format.h>
+#include <AK/kmalloc.h>
 #include <bits/search.h>
 #include <search.h>
 

--- a/Userland/Libraries/LibCMake/CMakeCache/Token.h
+++ b/Userland/Libraries/LibCMake/CMakeCache/Token.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibCMake/Position.h>
 
 namespace CMake::Cache {

--- a/Userland/Libraries/LibCompress/Brotli.h
+++ b/Userland/Libraries/LibCompress/Brotli.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/BitStream.h>
+#include <AK/ByteBuffer.h>
 #include <AK/CircularQueue.h>
 #include <AK/FixedArray.h>
 #include <AK/Vector.h>
@@ -20,7 +21,9 @@ public:
     CanonicalCode() = default;
     CanonicalCode(Vector<size_t> codes, Vector<size_t> values)
         : m_symbol_codes(move(codes))
-        , m_symbol_values(move(values)) {};
+        , m_symbol_values(move(values))
+    {
+    }
 
     static ErrorOr<CanonicalCode> read_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size);
     static ErrorOr<CanonicalCode> read_simple_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size);

--- a/Userland/Libraries/LibCompress/PackBitsDecoder.cpp
+++ b/Userland/Libraries/LibCompress/PackBitsDecoder.cpp
@@ -6,6 +6,7 @@
 
 #include "PackBitsDecoder.h"
 #include <AK/MemoryStream.h>
+#include <AK/NonnullOwnPtr.h>
 
 namespace Compress::PackBits {
 

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -12,6 +12,7 @@
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
 #include <AK/Span.h>
+#include <AK/Variant.h>
 #include <LibCore/File.h>
 #include <LibCore/Socket.h>
 

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <AK/Variant.h>
 #include <LibCore/Proxy.h>
 #include <LibCore/Socket.h>
 

--- a/Userland/Libraries/LibCore/ThreadEventQueue.h
+++ b/Userland/Libraries/LibCore/ThreadEventQueue.h
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <AK/NonnullOwnPtr.h>
+#include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
+#include <LibCore/EventReceiver.h>
 
 namespace Core {
 

--- a/Userland/Libraries/LibCrypto/Checksum/cksum.h
+++ b/Userland/Libraries/LibCrypto/Checksum/cksum.h
@@ -9,6 +9,7 @@
 #include <AK/Span.h>
 #include <AK/Types.h>
 #include <LibCrypto/Checksum/ChecksumFunction.h>
+#include <sys/types.h>
 
 namespace Crypto::Checksum {
 

--- a/Userland/Libraries/LibEDID/Definitions.h
+++ b/Userland/Libraries/LibEDID/Definitions.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
 namespace EDID::Definitions {

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGUI/Dialog.h>
 
 namespace GUI {

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -10,6 +10,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Concepts.h>
+#include <AK/Variant.h>
 #include <LibGUI/Icon.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Font.h>

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -7,12 +7,15 @@
 #pragma once
 
 #include <AK/Array.h>
+#include <AK/BuiltinWrappers.h>
 #include <AK/GenericShorthands.h>
+#include <AK/IntegralMath.h>
 #include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -16,6 +16,7 @@
 #include <AK/Forward.h>
 #include <AK/Span.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <LibGfx/Font/OpenType/DataTypes.h>
 
 namespace OpenType {

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -12,6 +12,7 @@
 #include <AK/RefCounted.h>
 #include <AK/Span.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/ICC/DistinctFourCC.h>
 #include <LibGfx/ICC/Enums.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000TagTree.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000TagTree.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <AK/Function.h>
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/ImageFormats/JPEG2000TagTree.h>
 
@@ -95,7 +95,7 @@ TagTree::~TagTree() = default;
 
 ErrorOr<TagTree> TagTree::create(u32 x_count, u32 y_count)
 {
-    auto level = ceil(log2(max(x_count, y_count)));
+    auto level = AK::ceil_log2(max(x_count, y_count));
     return TagTree { TRY(TagTreeNode::create(x_count, y_count, level)) };
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGShared.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGShared.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 // These names are defined in B.1.1.3 - Marker assignments
 
 #define JPEG_APPN0 0XFFE0

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -8,12 +8,10 @@
 #pragma once
 
 #include <AK/Debug.h>
-#include <AK/Endian.h>
-#include <AK/ScopeGuard.h>
+#include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
-#include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/OwnPtr.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossyTables.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossyTables.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 // Contains fixed data tables from the VP8 spec.
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -7,6 +7,7 @@
 // Lossless format: https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification
 
 #include <AK/BitStream.h>
+#include <AK/BuiltinWrappers.h>
 #include <AK/Debug.h>
 #include <AK/Endian.h>
 #include <AK/Enumerate.h>

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <initializer_list>
 

--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -12,6 +12,7 @@
 #include <AK/Forward.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/FontCascadeList.h>

--- a/Userland/Libraries/LibHTTP/Http11Connection.h
+++ b/Userland/Libraries/LibHTTP/Http11Connection.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 
 namespace HTTP {

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -13,7 +13,7 @@ Client::Client(StringView host, u16 port, NonnullOwnPtr<Core::Socket> socket)
     : m_host(host)
     , m_port(port)
     , m_socket(move(socket))
-    , m_connect_pending(Promise<Empty>::construct())
+    , m_connect_pending(Promise<void>::construct())
 {
     setup_callbacks();
 }
@@ -84,7 +84,7 @@ ErrorOr<void> Client::on_ready_to_receive()
 
     // Once we get server hello we can start sending.
     if (m_connect_pending) {
-        m_connect_pending->resolve({});
+        m_connect_pending->resolve();
         m_connect_pending.clear();
         m_buffer.clear();
         return {};

--- a/Userland/Libraries/LibIMAP/Client.h
+++ b/Userland/Libraries/LibIMAP/Client.h
@@ -25,7 +25,7 @@ public:
 
     Client(Client&&);
 
-    RefPtr<Promise<Empty>> connection_promise()
+    RefPtr<Promise<void>> connection_promise()
     {
         return m_connect_pending;
     }
@@ -72,7 +72,7 @@ private:
     u16 m_port;
 
     NonnullOwnPtr<Core::Socket> m_socket;
-    RefPtr<Promise<Empty>> m_connect_pending {};
+    RefPtr<Promise<void>> m_connect_pending;
 
     int m_current_command = 1;
 

--- a/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
+++ b/Userland/Libraries/LibJS/Bytecode/ScopedOperand.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <LibJS/Bytecode/Operand.h>
 

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -11,6 +11,7 @@
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibJS/Forward.h>

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
 

--- a/Userland/Libraries/LibJS/Heap/Internals.h
+++ b/Userland/Libraries/LibJS/Heap/Internals.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <AK/BitCast.h>
+#include <AK/Noncopyable.h>
 #include <AK/Types.h>
 #include <LibJS/Forward.h>
 

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -8,6 +8,7 @@
 
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -9,6 +9,7 @@
 
 #include <AK/String.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneMethods.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneMethods.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 

--- a/Userland/Libraries/LibManual/PageNode.h
+++ b/Userland/Libraries/LibManual/PageNode.h
@@ -8,10 +8,9 @@
 
 #include <AK/NonnullRefPtr.h>
 #include <LibManual/Node.h>
+#include <LibManual/SectionNode.h>
 
 namespace Manual {
-
-class SectionNode;
 
 class PageNode : public Node {
 public:

--- a/Userland/Libraries/LibMedia/Sample.h
+++ b/Userland/Libraries/LibMedia/Sample.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Time.h>
+#include <AK/Variant.h>
 
 #include "VideoSampleData.h"
 

--- a/Userland/Libraries/LibMedia/Video/VP9/LookupTables.h
+++ b/Userland/Libraries/LibMedia/Video/VP9/LookupTables.h
@@ -10,6 +10,7 @@
 #include "Enums.h"
 #include "MotionVector.h"
 #include "Symbols.h"
+#include <AK/StdLibExtras.h>
 
 namespace Media::Video::VP9 {
 

--- a/Userland/Libraries/LibPDF/Page.h
+++ b/Userland/Libraries/LibPDF/Page.h
@@ -8,6 +8,8 @@
 
 #include <AK/RefPtr.h>
 #include <LibPDF/Forward.h>
+#include <LibPDF/Object.h>
+#include <LibPDF/ObjectDerivatives.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibPDF/XRefTable.h
+++ b/Userland/Libraries/LibPDF/XRefTable.h
@@ -11,6 +11,7 @@
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
 #include <LibPDF/Error.h>
+#include <LibPDF/ObjectDerivatives.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibSQL/Index.h
+++ b/Userland/Libraries/LibSQL/Index.h
@@ -8,8 +8,8 @@
 
 #include <AK/RefCounted.h>
 #include <LibSQL/Forward.h>
-#include <LibSQL/Meta.h>
 #include <LibSQL/Serializer.h>
+#include <LibSQL/TupleDescriptor.h>
 
 namespace SQL {
 

--- a/Userland/Libraries/LibSanitizer/UBSanitizer.cpp
+++ b/Userland/Libraries/LibSanitizer/UBSanitizer.cpp
@@ -6,6 +6,11 @@
 
 #include <AK/Format.h>
 #include <AK/UBSanitizer.h>
+#ifdef KERNEL
+#    include <Kernel/Library/Assertions.h>
+#else
+#    include <stdlib.h> // For abort
+#endif
 
 using namespace AK::UBSanitizer;
 

--- a/Userland/Libraries/LibShell/Builtin.cpp
+++ b/Userland/Libraries/LibShell/Builtin.cpp
@@ -18,6 +18,7 @@
 #include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibShell/Execution.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>

--- a/Userland/Libraries/LibShell/Forward.h
+++ b/Userland/Libraries/LibShell/Forward.h
@@ -66,5 +66,6 @@ class WriteRedirection;
 namespace Shell {
 
 class Shell;
+class Job;
 
 }

--- a/Userland/Libraries/LibShell/Job.cpp
+++ b/Userland/Libraries/LibShell/Job.cpp
@@ -102,4 +102,15 @@ void Job::unblock()
         on_exit(*this);
 }
 
+Job::~Job()
+{
+    if constexpr (SHELL_JOB_DEBUG) {
+        if (m_active) {
+            auto elapsed = m_command_timer.elapsed();
+            // Don't mistake this for the command!
+            dbgln("Job entry '{}' deleted in {} ms", m_cmd, elapsed);
+        }
+    }
+}
+
 }

--- a/Userland/Libraries/LibShell/Job.h
+++ b/Userland/Libraries/LibShell/Job.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "Execution.h"
 #include "Forward.h"
 #include <AK/ByteString.h>
 #include <AK/Debug.h>
@@ -25,16 +24,7 @@ class Job : public RefCounted<Job> {
 public:
     static NonnullRefPtr<Job> create(pid_t pid, pid_t pgid, ByteString cmd, u64 job_id, AST::Command&& command) { return adopt_ref(*new Job(pid, pgid, move(cmd), job_id, move(command))); }
 
-    ~Job()
-    {
-        if constexpr (SHELL_JOB_DEBUG) {
-            if (m_active) {
-                auto elapsed = m_command_timer.elapsed();
-                // Don't mistake this for the command!
-                dbgln("Job entry '{}' deleted in {} ms", m_cmd, elapsed);
-            }
-        }
-    }
+    ~Job();
 
     Function<void(RefPtr<Job>)> on_exit;
 

--- a/Userland/Libraries/LibShell/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibShell/SyntaxHighlighter.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
 #include <AK/QuickSort.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/TemporaryChange.h>

--- a/Userland/Libraries/LibSoftGPU/ShaderProcessor.h
+++ b/Userland/Libraries/LibSoftGPU/ShaderProcessor.h
@@ -8,8 +8,8 @@
 
 #include <AK/Array.h>
 #include <AK/SIMD.h>
-#include <AK/Vector.h>
 #include <LibGPU/Config.h>
+#include <LibSoftGPU/ISA.h>
 #include <LibSoftGPU/PixelQuad.h>
 #include <LibSoftGPU/Sampler.h>
 

--- a/Userland/Libraries/LibSyntax/Document.h
+++ b/Userland/Libraries/LibSyntax/Document.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/RefCounted.h>
 #include <AK/Utf32View.h>
 #include <LibGfx/TextAttributes.h>
 #include <LibSyntax/Forward.h>

--- a/Userland/Libraries/LibTLS/Extensions.h
+++ b/Userland/Libraries/LibTLS/Extensions.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
 
 namespace TLS {

--- a/Userland/Libraries/LibThreading/RWLock.h
+++ b/Userland/Libraries/LibThreading/RWLock.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Error.h>
 #include <AK/Noncopyable.h>
 #include <AK/Types.h>
 #include <pthread.h>

--- a/Userland/Libraries/LibURL/Host.h
+++ b/Userland/Libraries/LibURL/Host.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <AK/Variant.h>
 
 namespace URL {
 

--- a/Userland/Libraries/LibVT/Color.h
+++ b/Userland/Libraries/LibVT/Color.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Types.h>
 
 namespace VT {

--- a/Userland/Libraries/LibVT/Position.h
+++ b/Userland/Libraries/LibVT/Position.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace VT {

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Queue.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Vector.h>
 #include <Kernel/API/KeyCode.h>
 #include <LibVT/CharacterSet.h>

--- a/Userland/Libraries/LibVirtGPU/CommandBufferBuilder.h
+++ b/Userland/Libraries/LibVirtGPU/CommandBufferBuilder.h
@@ -10,10 +10,10 @@
 
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <Kernel/API/VirGL.h>
 #include <LibGfx/Size.h>
 #include <LibVirtGPU/Commands.h>
 #include <LibVirtGPU/VirGLProtocol.h>
-#include <sys/ioctl.h>
 
 namespace VirtGPU {
 

--- a/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Weakable.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <AK/Concepts.h>
 #include <AK/GenericShorthands.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>

--- a/Userland/Libraries/LibWeb/CSS/ColumnCount.h
+++ b/Userland/Libraries/LibWeb/CSS/ColumnCount.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+
 namespace Web::CSS {
 
 class ColumnCount {
@@ -34,7 +36,7 @@ private:
         , m_value(value)
     {
     }
-    ColumnCount() {};
+    ColumnCount() { }
 
     Type m_type { Type::Auto };
     Optional<int> m_value;

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Variant.h>
 
 namespace Web::CSS {
 
@@ -71,11 +72,17 @@ private:
     };
 
     GridTrackPlacement()
-        : m_value(Auto {}) {};
+        : m_value(Auto {})
+    {
+    }
     GridTrackPlacement(AreaOrLine value)
-        : m_value(value) {};
+        : m_value(value)
+    {
+    }
     GridTrackPlacement(Span value)
-        : m_value(value) {};
+        : m_value(value)
+    {
+    }
 
     Variant<Auto, AreaOrLine, Span> m_value;
 };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Types.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Types.h
@@ -10,6 +10,7 @@
 #include <AK/Function.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/Parser/Token.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/CSS/PropertyName.h
+++ b/Userland/Libraries/LibWeb/CSS/PropertyName.h
@@ -12,7 +12,7 @@
 namespace Web::CSS {
 
 // https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string
-static bool is_a_custom_property_name_string(StringView string)
+inline bool is_a_custom_property_name_string(StringView string)
 {
     // A string is a custom property name string if it starts with two dashes (U+002D HYPHEN-MINUS), like --foo.
     return string.starts_with("--"sv);

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -10,6 +10,7 @@
 #include <AK/FlyString.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/Keyword.h>
 #include <LibWeb/CSS/PseudoClass.h>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <LibWeb/CSS/CSSStyleValue.h>
+#include <LibWeb/CSS/StyleValues/StyleValueList.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
@@ -8,6 +8,7 @@
 
 #include <AK/FlyString.h>
 #include <LibWeb/CSS/CSSStyleValue.h>
+#include <LibWeb/CSS/Serialize.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/Supports.h
+++ b/Userland/Libraries/LibWeb/CSS/Supports.h
@@ -8,10 +8,12 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/GeneralEnclosed.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/Crypto/CryptoBindings.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoBindings.h
@@ -10,7 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+#include <LibJS/Runtime/Object.h>
 
 // FIXME: Generate these from IDL
 namespace Web::Bindings {

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/ConnectionTimingInfo.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/ConnectionTimingInfo.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/HighResolutionTime/DOMHighResTimeStamp.h>
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -52,6 +52,7 @@ enum class StateAndProperties;
 namespace Web::Bindings {
 class Intrinsics;
 class OptionConstructor;
+class PlatformObject;
 
 enum class AudioContextLatencyCategory;
 enum class CanPlayTypeResult;

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/ImmutableBitmap.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
@@ -10,6 +10,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/WeakPtr.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.h
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 #define ENUMERATE_GLOBAL_EVENT_HANDLERS(E)                                    \

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/TextTrack.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Forward.h>

--- a/Userland/Libraries/LibWeb/HTML/ImageRequest.h
+++ b/Userland/Libraries/LibWeb/HTML/ImageRequest.h
@@ -6,10 +6,8 @@
 
 #pragma once
 
-#include <AK/Error.h>
-#include <AK/OwnPtr.h>
 #include <LibGfx/Size.h>
-#include <LibJS/Heap/Handle.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/HTML/LazyLoadingElement.h
+++ b/Userland/Libraries/LibWeb/HTML/LazyLoadingElement.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/HeapFunction.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/AttributeNames.h>
 

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibWeb/Fetch/BodyInit.h>
-#include <LibWeb/HTML/Navigator.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/MimeSniff/MimeType.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/SandboxingFlagSet.h
+++ b/Userland/Libraries/LibWeb/HTML/SandboxingFlagSet.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/EnumBits.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/SourceSnapshotParams.h
+++ b/Userland/Libraries/LibWeb/HTML/SourceSnapshotParams.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/WindowEventHandlers.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowEventHandlers.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 #define ENUMERATE_WINDOW_EVENT_HANDLERS(E)                        \

--- a/Userland/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageProvider.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/Size.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
 

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -419,7 +419,6 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         CSSPixels initial_image_x = image_rect.x();
         CSSPixels image_y = image_rect.y();
-        Optional<DevicePixelRect> last_image_device_rect;
 
         image.resolve_for_size(layout_node, image_rect.size());
 

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <LibGfx/Forward.h>
-#include <LibWeb/CSS/Filter.h>
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Painting {

--- a/Userland/Libraries/LibWeb/Painting/InputColors.h
+++ b/Userland/Libraries/LibWeb/Painting/InputColors.h
@@ -31,7 +31,7 @@ struct InputColors {
     }
 };
 
-static InputColors compute_input_colors(Palette const& palette, Optional<Color> accent_color)
+inline InputColors compute_input_colors(Palette const& palette, Optional<Color> accent_color)
 {
     // These shades have been picked to work well for all themes and have enough variation to paint
     // all input states (disabled, enabled, checked, etc).

--- a/Userland/Libraries/LibWeb/Painting/PaintBoxShadowParams.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintBoxShadowParams.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/Painting/BordersData.h>
+#include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/Painting/ShadowData.h>
 
 namespace Web::Painting {

--- a/Userland/Libraries/LibWeb/Painting/SVGMaskable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGMaskable.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/PixelUnits.h>
 

--- a/Userland/Libraries/LibWeb/Painting/ShadowData.h
+++ b/Userland/Libraries/LibWeb/Painting/ShadowData.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <LibGfx/Color.h>
-#include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <AK/Vector.h>
-#include <LibGfx/Matrix4x4.h>
 #include <LibWeb/Painting/InlinePaintable.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Painting {
 

--- a/Userland/Libraries/LibWeb/PermissionsPolicy/AutoplayAllowlist.h
+++ b/Userland/Libraries/LibWeb/PermissionsPolicy/AutoplayAllowlist.h
@@ -9,6 +9,7 @@
 #include <AK/Forward.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibURL/Origin.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PermissionsPolicy/Decision.h>
 

--- a/Userland/Libraries/LibWeb/Platform/FontPlugin.cpp
+++ b/Userland/Libraries/LibWeb/Platform/FontPlugin.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <LibWeb/Platform/FontPlugin.h>
 
 namespace Web::Platform {

--- a/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleRequest.h
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleRequest.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Forward.h>
+#include <AK/Optional.h>
 #include <AK/Types.h>
 
 namespace Web::RequestIdleCallback {

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/DecodedImageData.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::SVG {
 

--- a/Userland/Libraries/LibWeb/SVG/SVGURIReference.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGURIReference.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGAnimatedString.h>
+#include <LibWeb/SVG/SVGElement.h>
 
 namespace Web::SVG {
 

--- a/Userland/Libraries/LibWeb/SVG/SVGViewport.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGViewport.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Math.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/ViewBox.h>
 

--- a/Userland/Libraries/LibWeb/Streams/UnderlyingSink.h
+++ b/Userland/Libraries/LibWeb/Streams/UnderlyingSink.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/Forward.h>
-#include <LibJS/Forward.h>
-#include <LibWeb/Forward.h>
+#include <LibJS/Heap/Handle.h>
+#include <LibWeb/WebIDL/CallbackType.h>
 
 namespace Web::Streams {
 

--- a/Userland/Libraries/LibWebView/Database.h
+++ b/Userland/Libraries/LibWebView/Database.h
@@ -36,18 +36,18 @@ public:
     template<typename... PlaceholderValues>
     void execute_statement(SQL::StatementID statement_id, OnResult on_result, OnComplete on_complete, OnError on_error, PlaceholderValues&&... placeholder_values)
     {
-        auto sync_promise = Core::Promise<Empty>::construct();
+        auto sync_promise = Core::Promise<void>::construct();
 
         PendingExecution pending_execution {
             .on_result = move(on_result),
             .on_complete = [sync_promise, on_complete = move(on_complete)] {
                 if (on_complete)
                     on_complete();
-                sync_promise->resolve({}); },
+                sync_promise->resolve(); },
             .on_error = [sync_promise, on_error = move(on_error)](auto message) {
                 if (on_error)
                     on_error(message);
-                sync_promise->resolve({}); },
+                sync_promise->resolve(); },
         };
 
         Vector<SQL::Value> values { SQL::Value(forward<PlaceholderValues>(placeholder_values))... };

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -17,6 +17,7 @@
 #include <LibCore/File.h>
 #include <LibCore/Timer.h>
 #include <stdio.h>
+#include <unistd.h>
 
 static u8 mac_part(Vector<ByteString> const& parts, size_t index)
 {

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
@@ -46,7 +46,6 @@ RefPtr<MultiScaleBitmaps> MultiScaleBitmaps::create(StringView filename, StringV
 
 bool MultiScaleBitmaps::load(StringView filename, StringView default_filename)
 {
-    Optional<Gfx::BitmapFormat> bitmap_format;
     bool did_load_any = false;
 
     // If we're reloading the bitmaps get rid of the old ones.

--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Base64.h>
+#include <AK/Variant.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -411,10 +411,8 @@ static ErrorOr<TestResult> run_test(HeadlessWebContentView& view, StringView inp
 {
     // Clear the current document.
     // FIXME: Implement a debug-request to do this more thoroughly.
-    auto promise = Core::Promise<Empty>::construct();
-    view.on_load_finish = [&](auto) {
-        promise->resolve({});
-    };
+    auto promise = Core::Promise<void>::construct();
+    view.on_load_finish = [&](auto const&) { promise->resolve(); };
     view.on_text_test_finish = {};
 
     view.on_request_file_picker = [&](auto const& accepted_file_types, auto allow_multiple_files) {


### PR DESCRIPTION
Based on #25740, as that affects some here

Procedure:
Enable the clangd hints for includes, sprinkle in some IWYU comments (removed as linter did not like them?), go crazy as clangd does not handle forwarding headers very well (at all), go through AK, and then try to compile x86_64 with HeaderCheck enabled

PSA: HeaderCheck does not support clang builds and is annoying to get to regenerate