### PR TITLE
Meta: Add a script for building Raspberry Pi 3 and 4 images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,12 @@ if("${SERENITY_ARCH}" STREQUAL "x86_64")
         BYPRODUCTS "${CMAKE_BINARY_DIR}/extlinux_disk_image"
         USES_TERMINAL
     )
+elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
+    add_custom_target(raspberry-pi-image
+        COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-raspberry-pi.sh"
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/raspberry_pi_image
+        USES_TERMINAL
+    )
 endif()
 
 add_custom_target(install-native-partition

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -44,6 +44,7 @@ directory to `Build/<architecture>` and then running `ninja <target>`:
 -   `ninja grub-image`: Builds an x86-64 disk image (`grub_disk_image`) with GRUB for legacy BIOS systems
 -   `ninja grub-uefi-image`: Builds an x86-64 disk image (`grub_uefi_disk_image`) with GRUB for UEFI systems
 -   `ninja extlinux-image`: Builds an x86-64 disk image (`extlinux_disk_image`) with extlinux
+-   `ninja raspberry-pi-image`: Builds an AArch64 disk image (`raspberry_pi_disk_image`) for Raspberry Pis
 -   `ninja check-style`: Runs the same linters the CI does to verify project style on changed files
 -   `ninja install-ports`: Copies the entire ports tree into the installed rootfs for building ports in Serenity
 -   `ninja lint-shell-scripts`: Checks style of shell scripts in the source tree with shellcheck

--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -30,50 +30,32 @@ You can also run it under gdb with:
 Meta/serenity.sh gdb aarch64
 ```
 
-## Running on real hardware using an SD Card
+## Running on real hardware using an SD card
 
-### Step 0: Download and run Raspberry Pi OS from an SD Card
+### Step 0: Build a SerenityOS SD card image
 
-This step is needed because the original firmware files need to be present on the SD Card when booting Serenity. It will also help with the UART setup.
+You can build an SD card image for the Raspberry Pi 3 and 4 with:
+
+```console
+ninja -C Build/aarch64 raspberry-pi-image
+```
+
+The generated disk image will be written to `Build/aarch64/raspberry_pi_disk_image`.
+Write this image to the SD card you want to use to boot Serenity using a command such as:
+
+```console
+sudo cp Build/aarch64/raspberry_pi_disk_image /dev/sdx && sync
+```
+
+(Replace `/dev/sdx` with your sd card device file)
 
 ### Step 1: Connect your Raspberry Pi to your PC using a UART cable
 
 Please follow one of the existing guides (for example [here](https://scribles.net/setting-up-serial-communication-between-raspberry-pi-and-pc)) and make sure UART is working on Raspberry Pi OS before proceeding.
 
-If you're using a Raspberry Pi 4B and want to test if the UART is working correctly, you need to do a few extra steps.
-UART0 (the one that SerenityOS uses) is used for bluetooth on these models, so for the OS to use it instead, ensure that you disable Bluetooth inside the `config.txt`:
+### Step 2: Put the SD Card in the Raspberry Pi and power on
 
-```
-dtoverlay=disable-bt
-```
-
-### Step 2: Mount SD Card
-
-If you use a Raspberry Pi 4, and your serenity kernel is called `kernel8.img`
-(the default), and you don't have any other `kernel*.img` files on your SD
-card, make sure `config.txt` is empty.
-
-If you want to use filename that isn't `kernel8.img` or if you want to keep
-other `kernel*.img` files on your SD card, put this in config.txt:
-
-```
-arm_64bit=1
-kernel=myfilename.img
-```
-
-If you use a Raspberry Pi 3, put this in config.txt:
-
-```
-enable_uart=1
-```
-
-### Step 3: Copy Serenity kernel to SD Card
-
-`kernel8.img` can be found in `Build/aarch64/Kernel/`. Copy it to the main directory on the `Boot/` partition, next to `config.txt`. You can either replace the original file or use another name (see above).
-
-### Step 4: Put the SD Card in the Raspberry Pi and power on
-
-You should start seeing some messages in your UART terminal window.
+You should start seeing some messages in your UART terminal window. The default configuration is 115200-8-N-1 (115200 baud, one start bit, 8 data bits, no parity).
 
 ## Running on real hardware using network (Raspberry Pi 3)
 

--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -4,8 +4,6 @@
 
 This is for development purposes only - Serenity doesn't currently boot on Raspberry Pi! Use this guide if you want to set up a development environment.
 
-Currently only UART output is supported, no display.
-
 64-bit only, so you need a Raspberry Pi 3 or newer.
 
 ## Running in QEMU

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -898,13 +898,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.debug" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kernel.map" DESTINATION res)
 
-if ("${SERENITY_ARCH}" STREQUAL "aarch64")
-    add_custom_command(
-        TARGET Kernel POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -O binary Kernel kernel8.img
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel8.img
-    )
-elseif ("${SERENITY_ARCH}" STREQUAL "riscv64")
+if (("${SERENITY_ARCH}" STREQUAL "aarch64") OR ("${SERENITY_ARCH}" STREQUAL "riscv64"))
     add_custom_command(
         TARGET Kernel POST_BUILD
         COMMAND ${CMAKE_OBJCOPY} -O binary Kernel Kernel.bin

--- a/Meta/build-image-raspberry-pi.sh
+++ b/Meta/build-image-raspberry-pi.sh
@@ -110,7 +110,7 @@ uart_2ndstage=1
 enable_uart=1
 enable_gic=1
 
-kernel=kernel8.img
+kernel=Kernel.bin
 
 [pi4]
 # We use UART0 as the console.
@@ -120,4 +120,4 @@ EOF
 echo "serial_debug root=block100:1" >boot/cmdline.txt
 
 # FIXME: Mount the boot partition on /boot (both here and in serenity), so we don't need to move the kernel image to the boot filesystem.
-mv mnt/boot/kernel8.img boot/
+mv mnt/boot/Kernel.bin boot/

--- a/Meta/build-image-raspberry-pi.sh
+++ b/Meta/build-image-raspberry-pi.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+. "${script_path}/shell_include.sh"
+
+DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 512 + 300))
+
+if [ "$1" != "in-sudo" ]; then # Avoid making the repo root-owned when recursively running this script with sudo.
+    if [ ! -d "raspberry-pi-firmware" ]; then
+        echo "raspberry-pi-firmware directory not found, cloning the boot/ directory from https://github.com/raspberrypi/firmware"
+
+        # Do a sparse checkout of only the boot/ directory, since the repo is pretty large.
+        git clone --depth 1 --filter tree:0 --branch stable --no-checkout https://github.com/raspberrypi/firmware raspberry-pi-firmware
+        pushd raspberry-pi-firmware >/dev/null
+        git sparse-checkout set boot/
+        git checkout
+        popd >/dev/null
+    else
+        pushd raspberry-pi-firmware >/dev/null
+        git pull --ff-only
+        popd >/dev/null
+    fi
+fi
+
+# Remove unnecessary linux kernel images.
+rm -f raspberry-pi-firmware/boot/kernel*.img
+
+if [ "$(id -u)" != 0 ]; then
+    set +e
+    ${SUDO} -- "${SHELL}" -c "\"$0\" in-sudo || exit 42"
+    case $? in
+        1)
+            die "this script needs to run as root"
+            ;;
+        42)
+            exit 1
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
+else
+    : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
+fi
+
+printf "setting up disk image... "
+dd if=/dev/zero of=raspberry_pi_disk_image bs=1M count="${DISK_SIZE}" status=none || die "couldn't create disk image"
+chown "$SUDO_UID":"$SUDO_GID" raspberry_pi_disk_image || die "couldn't adjust permissions on disk image"
+echo "done"
+
+printf "creating loopback device... "
+dev=$(losetup --find --partscan --show raspberry_pi_disk_image)
+if [ -z "$dev" ]; then
+    die "couldn't mount loopback device"
+fi
+echo "loopback device is at ${dev}"
+
+cleanup() {
+    if [ -d boot ]; then
+        printf "unmounting boot filesystem... "
+        umount boot || ( sleep 1 && sync && umount boot )
+        rmdir boot
+        echo "done"
+    fi
+
+    if [ -d mnt ]; then
+        printf "unmounting root filesystem... "
+        umount mnt || ( sleep 1 && sync && umount mnt )
+        rmdir mnt
+        echo "done"
+    fi
+
+    if [ -e "${dev}" ]; then
+        printf "cleaning up loopback device... "
+        losetup -d "${dev}"
+        echo "done"
+    fi
+}
+trap cleanup EXIT
+
+printf "creating partition table... "
+parted -s "${dev}" mklabel msdos mkpart primary fat32 0% 512MB mkpart primary ext2 512MB 100% || die "couldn't partition disk"
+echo "done"
+
+printf "creating new filesystems... "
+mkfs.vfat -F 32 -n BOOT "${dev}p1" >/dev/null || die "couldn't create boot filesystem"
+mke2fs -q -L SerenityOS "${dev}p2" || die "couldn't create root filesystem"
+echo "done"
+
+printf "mounting filesystems... "
+mkdir -p mnt
+mount "${dev}p2" mnt || die "couldn't mount root filesystem"
+mkdir -p boot
+mount "${dev}p1" boot || die "couldn't mount boot filesystem"
+echo "done"
+
+"$script_path/build-root-filesystem.sh"
+
+cp -r raspberry-pi-firmware/boot/* boot/
+
+cat <<EOF >boot/config.txt
+# We only support AArch64.
+arm_64bit=1
+
+# Enable the bootloader debug log.
+uart_2ndstage=1
+enable_uart=1
+enable_gic=1
+
+kernel=kernel8.img
+
+[pi4]
+# We use UART0 as the console.
+dtoverlay=disable-bt
+EOF
+
+echo "serial_debug root=block100:1" >boot/cmdline.txt
+
+# FIXME: Mount the boot partition on /boot (both here and in serenity), so we don't need to move the kernel image to the boot filesystem.
+mv mnt/boot/kernel8.img boot/

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -735,9 +735,7 @@ hostfwd=tcp:{config.host_ip}:2222-10.0.2.15:22"
 
 
 def set_up_kernel(config: Configuration):
-    if config.architecture == Arch.Aarch64:
-        config.kernel_and_initrd_arguments = ["-kernel", "Kernel/kernel8.img"]
-    elif config.architecture == Arch.RISCV64:
+    if config.architecture in [Arch.Aarch64, Arch.RISCV64]:
         config.kernel_and_initrd_arguments = ["-kernel", "Kernel/Kernel.bin"]
     elif config.architecture == Arch.x86_64:
         config.kernel_and_initrd_arguments = ["-kernel", "Kernel/Kernel"]


### PR DESCRIPTION
This should make running serenity on Raspberry Pis easier.

Note that at least on my Raspberry Pi 3 and 4, we currently fail to initialize the SD card:
```
FIXME: The SD Host Controller does not provide the base clock frequency; get this frequency using another method
```