### PR TITLE
LibC: Add missing dependency on LibUBSanitizer

### DIFF
--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -274,7 +274,7 @@ else()
 endif()
 
 serenity_libc(LibC c)
-add_dependencies(LibC crt0)
+add_dependencies(LibC crt0 LibUBSanitizer)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_dependencies(LibC crti crt0_shared crtn)
 endif()


### PR DESCRIPTION
This prevents flaky "cannot find -lubsan: No such file or directory" error.