### PR TITLE
LibGemini+LibWeb: Load gemtext documents in Browser and related fixes for gemtext documents

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzGemini.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGemini.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     auto gemini = StringView(static_cast<unsigned char const*>(data), size);
-    (void)Gemini::Document::parse(gemini, {});
+    (void)Gemini::Document::parse(gemini);
     return 0;
 }

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -942,7 +942,7 @@ void MainWidget::update_html_preview()
 
 void MainWidget::update_gemtext_preview()
 {
-    auto document = Gemini::Document::parse(m_editor->text(), {});
+    auto document = Gemini::Document::parse(m_editor->text());
     auto html = document->render_to_html();
     m_page_view->load_html(html);
 }

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -144,6 +144,7 @@ static Array const s_registered_mime_type = {
     MimeType { .name = "text/markdown"sv, .common_extensions = { ".md"sv }, .description = "Markdown document"sv },
     MimeType { .name = "text/plain"sv, .common_extensions = Vector(s_plaintext_suffixes.span()), .description = "plain text"sv },
     MimeType { .name = "text/x-shellscript"sv, .common_extensions = { ".sh"sv }, .description = "POSIX shell script text executable"sv, .magic_bytes = Vector<u8> { '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n' } },
+    MimeType { .name = "text/gemini"sv, .common_extensions = { ".gmi"sv }, .description = "Gemtext document"sv },
 
     MimeType { .name = "video/matroska"sv, .common_extensions = { ".mkv"sv }, .description = "Matroska container"sv, .magic_bytes = Vector<u8> { 0x1A, 0x45, 0xDF, 0xA3 } },
     MimeType { .name = "video/webm"sv, .common_extensions = { ".webm"sv }, .description = "WebM video"sv },

--- a/Userland/Libraries/LibGemini/Document.cpp
+++ b/Userland/Libraries/LibGemini/Document.cpp
@@ -17,9 +17,6 @@ ByteString Document::render_to_html() const
 {
     StringBuilder html_builder;
     html_builder.append("<!DOCTYPE html>\n<html>\n"sv);
-    html_builder.append("<head>\n<title>"sv);
-    html_builder.append(m_url.serialize_path());
-    html_builder.append("</title>\n</head>\n"sv);
     html_builder.append("<body>\n"sv);
     for (auto& line : m_lines) {
         html_builder.append(line->render_to_html());
@@ -29,9 +26,9 @@ ByteString Document::render_to_html() const
     return html_builder.to_byte_string();
 }
 
-NonnullRefPtr<Document> Document::parse(StringView lines, const URL::URL& url)
+NonnullRefPtr<Document> Document::parse(StringView lines)
 {
-    auto document = adopt_ref(*new Document(url));
+    auto document = adopt_ref(*new Document());
     document->read_lines(lines);
     return document;
 }

--- a/Userland/Libraries/LibGemini/Document.cpp
+++ b/Userland/Libraries/LibGemini/Document.cpp
@@ -74,7 +74,7 @@ void Document::read_lines(StringView source)
         close_list_if_needed();
 
         if (line.starts_with("=>"sv)) {
-            m_lines.append(make<Link>(move(line), *this));
+            m_lines.append(make<Link>(move(line)));
             continue;
         }
 

--- a/Userland/Libraries/LibGemini/Document.h
+++ b/Userland/Libraries/LibGemini/Document.h
@@ -62,12 +62,12 @@ public:
 
 class Link : public Line {
 public:
-    Link(ByteString line, Document const&);
+    Link(ByteString line);
     virtual ~Link() override = default;
     virtual ByteString render_to_html() const override;
 
 private:
-    URL::URL m_url;
+    ByteString m_url;
     ByteString m_name;
 };
 

--- a/Userland/Libraries/LibGemini/Document.h
+++ b/Userland/Libraries/LibGemini/Document.h
@@ -32,20 +32,16 @@ class Document : public RefCounted<Document> {
 public:
     ByteString render_to_html() const;
 
-    static NonnullRefPtr<Document> parse(StringView source, const URL::URL&);
-
-    const URL::URL& url() const { return m_url; }
+    static NonnullRefPtr<Document> parse(StringView source);
 
 private:
-    explicit Document(const URL::URL& url)
-        : m_url(url)
+    explicit Document()
     {
     }
 
     void read_lines(StringView);
 
     Vector<NonnullOwnPtr<Line>> m_lines;
-    URL::URL m_url;
     bool m_inside_preformatted_block { false };
     bool m_inside_unordered_list { false };
 };

--- a/Userland/Libraries/LibGemini/Line.cpp
+++ b/Userland/Libraries/LibGemini/Line.cpp
@@ -52,7 +52,7 @@ ByteString Control::render_to_html() const
     }
 }
 
-Link::Link(ByteString text, Document const& document)
+Link::Link(ByteString text)
     : Line(move(text))
 {
     size_t index = 2;
@@ -68,16 +68,16 @@ Link::Link(ByteString text, Document const& document)
             ++offset;
         m_name = url_string.substring_view(offset, url_string.length() - offset);
     }
-    m_url = document.url().complete_url(url);
+    m_url = url.trim_whitespace();
     if (m_name.is_empty())
-        m_name = m_url.to_byte_string();
+        m_name = m_url;
 }
 
 ByteString Link::render_to_html() const
 {
     StringBuilder builder;
     builder.append("<a href=\""sv);
-    builder.append(escape_html_entities(m_url.to_byte_string()));
+    builder.append(escape_html_entities(m_url));
     builder.append("\">"sv);
     builder.append(escape_html_entities(m_name));
     builder.append("</a><br>\n"sv);

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -111,7 +111,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_gemtext_documen
     return create_document_for_inline_content(navigation_params.navigable.ptr(), navigation_params.id, [&](DOM::Document& document) {
         auto& realm = document.realm();
         auto process_body = JS::create_heap_function(realm.heap(), [&document, url = navigation_params.response->url().value()](ByteBuffer data) {
-            auto gemtext_document = Gemini::Document::parse(data, {});
+            auto gemtext_document = Gemini::Document::parse(data);
 
             auto parser = HTML::HTMLParser::create(document, gemtext_document->render_to_html(), "utf-8"sv);
             parser->run(url);


### PR DESCRIPTION
These commit make it possible to browse gemini pages, as long as they are served through http(s) or local files...

Now let's work on fixing gemini protocol support :^)