### PR TITLE
Kernel/riscv64: Don't use __builtin___clear_cache on RISC-V

### DIFF
--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -69,6 +69,8 @@ public:
     static void flush_tlb_local(VirtualAddress vaddr, size_t page_count);
     static void flush_tlb(Memory::PageDirectory const*, VirtualAddress, size_t);
 
+    static void flush_instruction_cache(VirtualAddress vaddr, size_t byte_count);
+
     void early_initialize(u32 cpu);
     void initialize(u32 cpu);
     ALWAYS_INLINE static bool is_initialized();

--- a/Kernel/Arch/ProcessorFunctions.include
+++ b/Kernel/Arch/ProcessorFunctions.include
@@ -17,6 +17,7 @@ template void ProcessorBase<Processor>::smp_enable();
 template void ProcessorBase<Processor>::flush_tlb_local(VirtualAddress vaddr, size_t page_count);
 template void ProcessorBase<Processor>::flush_entire_tlb_local();
 template void ProcessorBase<Processor>::flush_tlb(Memory::PageDirectory const*, VirtualAddress, size_t);
+template void ProcessorBase<Processor>::flush_instruction_cache(VirtualAddress vaddr, size_t byte_count);
 template void ProcessorBase<Processor>::early_initialize(u32 cpu);
 template void ProcessorBase<Processor>::initialize(u32 cpu);
 template void ProcessorBase<Processor>::halt();

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -97,6 +97,12 @@ void ProcessorBase<T>::flush_tlb(Memory::PageDirectory const*, VirtualAddress va
 }
 
 template<typename T>
+void ProcessorBase<T>::flush_instruction_cache(VirtualAddress vaddr, size_t byte_count)
+{
+    __builtin___clear_cache(reinterpret_cast<char*>(vaddr.as_ptr()), reinterpret_cast<char*>(vaddr.offset(byte_count).as_ptr()));
+}
+
+template<typename T>
 u32 ProcessorBase<T>::clear_critical()
 {
     InterruptDisabler disabler;

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -168,6 +168,13 @@ void ProcessorBase<T>::flush_tlb(Memory::PageDirectory const*, VirtualAddress va
 }
 
 template<typename T>
+void ProcessorBase<T>::flush_instruction_cache(VirtualAddress, size_t)
+{
+    // FIXME: Use the SBI RFENCE extension to flush the instruction cache of other harts when we support SMP on riscv64.
+    asm volatile("fence.i" ::: "memory");
+}
+
+template<typename T>
 u32 ProcessorBase<T>::clear_critical()
 {
     InterruptDisabler disabler;

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -853,6 +853,12 @@ void ProcessorBase<T>::flush_tlb(Memory::PageDirectory const* page_directory, Vi
         flush_tlb_local(vaddr, page_count);
 }
 
+template<typename T>
+void ProcessorBase<T>::flush_instruction_cache(VirtualAddress, size_t)
+{
+    // The instruction and data cache are coherent on x86, so we don't need to do anything here.
+}
+
 void Processor::smp_return_to_pool(ProcessorMessage& msg)
 {
     ProcessorMessage* next = nullptr;

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -629,9 +629,7 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region, bool m
             // This is required even if no instructions were previously fetched from that (physical) memory location,
             // because some systems have an I-cache that is not coherent with the D-cache,
             // resulting in the I-cache being filled with old values if the contents of the D-cache aren't written back yet.
-
-            // __builtin___clear_cache is a no-op on architectures where this isn't needed, like on x86.
-            __builtin___clear_cache(reinterpret_cast<char*>(dest_ptr), reinterpret_cast<char*>(dest_ptr + PAGE_SIZE));
+            Processor::flush_instruction_cache(VirtualAddress { dest_ptr }, PAGE_SIZE);
         }
 
         MM.unquickmap_page();


### PR DESCRIPTION
Clang compiles that builtin to an abort for freestanding environments because RISC-V does not have an instruction to the flush the instruction cache for all harts.

We don't support SMP on RISC-V currently, so simply use a `fence.i` for now.