### PR TITLE
Kernel/riscv64: Correctly calculate symbol addresses again

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -86,10 +86,13 @@ UNMAP_AFTER_INIT static void load_kernel_symbols_from_data(Bytes buffer)
         }
         auto& ksym = s_symbols[current_symbol_index];
 
-        if (g_boot_info.boot_method == BootMethod::PreInit)
-            ksym.address = address;
-        else
-            ksym.address = g_boot_info.kernel_load_base + address;
+#if ARCH(AARCH64)
+        // Currently, the AArch64 kernel is linked at a high virtual memory address, instead
+        // of zero, so the address of a symbol does not need to be offset by the g_boot_info.kernel_load_base.
+        ksym.address = address;
+#else
+        ksym.address = g_boot_info.kernel_load_base + address;
+#endif
 
         ksym.name = start_of_name;
 


### PR DESCRIPTION
c0d70a6e24 made the kernel linked at address zero, but forgot to change the symbol address calculation accordingly.