### PR TITLE
Kernel/riscv64: Clean up the CSR interface a bit + drive-by stuff

### DIFF
--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -68,7 +68,7 @@ ALWAYS_INLINE void clear_bits(Address address, FlatPtr bit_mask)
 }
 
 // 4.1.11 Supervisor Address Translation and Protection (satp) Register
-struct [[gnu::packed]] alignas(u64) SATP {
+struct SATP {
     enum class Mode : u64 {
         Bare = 0,
         Sv39 = 8,
@@ -95,15 +95,12 @@ struct [[gnu::packed]] alignas(u64) SATP {
         return bit_cast<SATP>(CSR::read(CSR::Address::SATP));
     }
 
-    bool operator==(SATP const& other) const
-    {
-        return bit_cast<u64>(*this) == bit_cast<u64>(other);
-    }
+    bool operator==(SATP const& other) const = default;
 };
 static_assert(AssertSize<SATP, 8>());
 
 // 4.1.1 Supervisor Status Register (sstatus)
-struct [[gnu::packed]] alignas(u64) SSTATUS {
+struct SSTATUS {
     // Useful for CSR::{set,clear}_bits
     enum class Offset {
         SIE = 1,

--- a/Kernel/Arch/riscv64/Delay.cpp
+++ b/Kernel/Arch/riscv64/Delay.cpp
@@ -18,10 +18,10 @@ void microseconds_delay(u32 microseconds)
 {
     VERIFY(s_timebase_frequency != 0);
 
-    u64 const start = RISCV64::CSR::read(RISCV64::CSR::Address::TIME);
+    u64 const start = RISCV64::CSR::read<RISCV64::CSR::Address::TIME>();
     u64 const delta = (static_cast<u64>(microseconds) * s_timebase_frequency) / 1'000'000ull;
 
-    while ((RISCV64::CSR::read(RISCV64::CSR::Address::TIME) - start) < delta)
+    while ((RISCV64::CSR::read<RISCV64::CSR::Address::TIME>() - start) < delta)
         Processor::pause();
 }
 

--- a/Kernel/Arch/riscv64/Interrupts/PLIC.cpp
+++ b/Kernel/Arch/riscv64/Interrupts/PLIC.cpp
@@ -35,7 +35,7 @@ UNMAP_AFTER_INIT void PLIC::initialize()
     // Initialize priority-threshold to 0 (accept any interrupt of priority 1 or above)
     m_registers->contexts[m_boot_hart_supervisor_mode_context_id].priority_threshold = 0;
     // Enable external interrupts in the current hart
-    RISCV64::CSR::set_bits(RISCV64::CSR::Address::SIE, 1 << (to_underlying(RISCV64::CSR::SCAUSE::SupervisorExternalInterrupt) & ~RISCV64::CSR::SCAUSE_INTERRUPT_MASK));
+    RISCV64::CSR::set_bits<RISCV64::CSR::Address::SIE>(RISCV64::CSR::SIE::SupervisorExternalInterrupt);
 }
 
 void PLIC::enable(GenericInterruptHandler const& handler)

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -125,7 +125,7 @@ void ProcessorBase<T>::initialize(u32)
 
     store_fpu_state(&s_clean_fpu_state);
 
-    RISCV64::CSR::write(RISCV64::CSR::Address::STVEC, bit_cast<FlatPtr>(+asm_trap_handler));
+    RISCV64::CSR::write<RISCV64::CSR::Address::STVEC>(bit_cast<FlatPtr>(+asm_trap_handler));
 
     initialize_interrupts();
 }
@@ -135,7 +135,7 @@ template<typename T>
 {
     // WFI ignores the value of sstatus.SIE, so we can't use disable_interrupts().
     // Instead, disable all interrupts sources by setting sie to zero.
-    RISCV64::CSR::write(RISCV64::CSR::Address::SIE, 0);
+    RISCV64::CSR::write<RISCV64::CSR::Address::SIE>(0);
     for (;;)
         asm volatile("wfi");
 }

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -12,6 +12,7 @@
 
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Arch/DeferredCallPool.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/ProcessorSpecificDataID.h>
 #include <Kernel/Arch/riscv64/CSR.h>
 #include <Kernel/Memory/VirtualAddress.h>

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -142,13 +142,13 @@ ALWAYS_INLINE bool ProcessorBase<T>::are_interrupts_enabled()
 template<typename T>
 ALWAYS_INLINE void ProcessorBase<T>::enable_interrupts()
 {
-    RISCV64::CSR::set_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SIE));
+    RISCV64::CSR::set_bits<RISCV64::CSR::Address::SSTATUS>(RISCV64::CSR::SSTATUS::Bit::SIE);
 }
 
 template<typename T>
 ALWAYS_INLINE void ProcessorBase<T>::disable_interrupts()
 {
-    RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SIE));
+    RISCV64::CSR::clear_bits<RISCV64::CSR::Address::SSTATUS>(RISCV64::CSR::SSTATUS::Bit::SIE);
 }
 
 template<typename T>
@@ -204,7 +204,7 @@ ALWAYS_INLINE void ProcessorBase<T>::wait_check()
 template<typename T>
 ALWAYS_INLINE Optional<u64> ProcessorBase<T>::read_cycle_count()
 {
-    return RISCV64::CSR::read(RISCV64::CSR::Address::CYCLE);
+    return RISCV64::CSR::read<RISCV64::CSR::Address::CYCLE>();
 }
 
 }

--- a/Kernel/Arch/riscv64/SmapDisabler.cpp
+++ b/Kernel/Arch/riscv64/SmapDisabler.cpp
@@ -10,14 +10,14 @@
 namespace Kernel {
 
 SmapDisabler::SmapDisabler()
-    : m_flags(RISCV64::CSR::read_and_set_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM)))
+    : m_flags(RISCV64::CSR::read_and_set_bits<RISCV64::CSR::Address::SSTATUS>(to_underlying(RISCV64::CSR::SSTATUS::Bit::SUM)))
 {
 }
 
 SmapDisabler::~SmapDisabler()
 {
-    if ((m_flags & (1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM))) == 0)
-        RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM));
+    if ((m_flags & to_underlying(RISCV64::CSR::SSTATUS::Bit::SUM)) == 0)
+        RISCV64::CSR::clear_bits<RISCV64::CSR::Address::SSTATUS>(RISCV64::CSR::SSTATUS::Bit::SUM);
 }
 
 }

--- a/Kernel/Arch/riscv64/Timer.cpp
+++ b/Kernel/Arch/riscv64/Timer.cpp
@@ -20,7 +20,7 @@ Timer::Timer()
     m_interrupt_interval = m_frequency / OPTIMAL_TICKS_PER_SECOND_RATE;
 
     set_compare(current_ticks() + m_interrupt_interval);
-    RISCV64::CSR::set_bits(RISCV64::CSR::Address::SIE, 1 << (to_underlying(CSR::SCAUSE::SupervisorTimerInterrupt) & ~CSR::SCAUSE_INTERRUPT_MASK));
+    RISCV64::CSR::set_bits<RISCV64::CSR::Address::SIE>(CSR::SIE::SupervisorTimerInterrupt);
 }
 
 NonnullLockRefPtr<Timer> Timer::initialize()
@@ -39,7 +39,7 @@ Timer& Timer::the()
 
 u64 Timer::current_ticks()
 {
-    return RISCV64::CSR::read(RISCV64::CSR::Address::TIME);
+    return RISCV64::CSR::read<RISCV64::CSR::Address::TIME>();
 }
 
 void Timer::handle_interrupt()
@@ -51,7 +51,7 @@ void Timer::handle_interrupt()
 
 void Timer::disable()
 {
-    RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SIE, 1 << (to_underlying(CSR::SCAUSE::SupervisorTimerInterrupt) & ~CSR::SCAUSE_INTERRUPT_MASK));
+    RISCV64::CSR::clear_bits<RISCV64::CSR::Address::SIE>(CSR::SIE::SupervisorTimerInterrupt);
 }
 
 u64 Timer::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only)

--- a/Kernel/Arch/riscv64/pre_init.cpp
+++ b/Kernel/Arch/riscv64/pre_init.cpp
@@ -35,7 +35,7 @@ UNMAP_AFTER_INIT void dbgln_without_mmu(StringView message)
     dbgln_without_mmu(message);
 
     // We can't use Processor::halt() here, as that would result in an absolute jump.
-    RISCV64::CSR::write(RISCV64::CSR::Address::SIE, 0);
+    RISCV64::CSR::write<RISCV64::CSR::Address::SIE>(0);
     for (;;)
         asm volatile("wfi");
 }
@@ -77,7 +77,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void pre_init(FlatPtr boot_hart_id, Phy
         panic_without_mmu("Failed to perform relative relocations"sv);
 
     // Catch traps in pre_init
-    RISCV64::CSR::write(RISCV64::CSR::Address::STVEC, bit_cast<FlatPtr>(&early_trap_handler));
+    RISCV64::CSR::write<RISCV64::CSR::Address::STVEC>(bit_cast<FlatPtr>(&early_trap_handler));
 
     Memory::init_page_tables_and_jump_to_init(boot_hart_id, flattened_devicetree_paddr);
 }

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -31,7 +31,7 @@ ErrorOr<FlatPtr> page_round_up(FlatPtr x);
 
 constexpr FlatPtr page_round_down(FlatPtr x)
 {
-    return ((FlatPtr)(x)) & ~(PAGE_SIZE - 1);
+    return x & ~(PAGE_SIZE - 1);
 }
 
 inline FlatPtr virtual_to_low_physical(FlatPtr virtual_)

--- a/Kernel/Memory/PhysicalRAMPage.h
+++ b/Kernel/Memory/PhysicalRAMPage.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Atomic.h>
+#include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
 #include <Kernel/Memory/PhysicalAddress.h>
 

--- a/Kernel/Syscalls/SyscallHandler.cpp
+++ b/Kernel/Syscalls/SyscallHandler.cpp
@@ -109,7 +109,7 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
 #elif ARCH(AARCH64)
     // FIXME: Implement the security mechanism for aarch64
 #elif ARCH(RISCV64)
-    RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM));
+    RISCV64::CSR::clear_bits<RISCV64::CSR::Address::SSTATUS>(RISCV64::CSR::SSTATUS::Bit::SUM);
 #else
 #    error Unknown architecture
 #endif


### PR DESCRIPTION
### Kernel: Add 2 missing includes


### Kernel/riscv64: Simplify CSR struct decalarations a bit

The `[[gnu::packed]] alignas(u64)` where a no-op, and the SATP
comparator is just the default one

### Kernel/riscv64: Make the CSR helpers a bit safer/saner and add some more

* The CSR address is now mandated to be a compile time constant as a
template argument, so we don't rely on inlining to make it a constant,
which caused compilation failures in the past.
* `CSR::[set|clear]_bits` now acts on enums which makes them a bit
  easier to use.
* SSTATUS now provides a pre-shifted Bit enum instead of an Offset one
  making that safer/easier to use.
* SIE reading/writing in now decoupled from the SCAUSE enum, removing
  some bit-fiddling in some places
* Added the remaining SCAUSE/SIE values

### Kernel: Remove redundant cast in `page_round_down`

It already takes a `FlatPtr` so no need to c-cast it to one...

