### PR TITLE
Ports: Add fribidi

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -88,6 +88,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 | [`freeciv`](freeciv/)                         | Freeciv                                                       | 3.1.1                    | http://freeciv.org/                                                  |
 | [`freedink`](freedink/)                       | FreeDink                                                      | 109.6                    | https://www.gnu.org/software/freedink/                               |
 | [`freetype`](freetype/)                       | FreeType                                                      | 2.13.2                   | https://www.freetype.org/                                            |
+| [`fribidi`](fribidi/)                         | GNU FriBidi                                                   | 1.0.16                   | https://github.com/fribidi/fribidi                                   |
 | [`frotz`](frotz/)                             | Frotz                                                         | 2.54                     | https://gitlab.com/DavidGriffith/frotz                               |
 | [`gawk`](gawk/)                               | GNU awk                                                       | 5.3.1                    | https://www.gnu.org/software/gawk/                                   |
 | [`gcc`](gcc/)                                 | GNU Compiler Collection                                       | 13.2.0                   | https://gcc.gnu.org/                                                 |

--- a/Ports/fribidi/package.sh
+++ b/Ports/fribidi/package.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='fribidi'
+version='1.0.16'
+useconfigure='true'
+configopts=(
+    "--buildtype=release"
+    "--cross-file=${SERENITY_BUILD_DIR}/meson-cross-file.txt"
+    "-Ddocs=false"
+    "-Dtests=false"
+    # disable -ansi option
+    "-Dc_args=-std=c99"
+)
+archive_hash='1b1cde5b235d40479e91be2f0e88a309e3214c8ab470ec8a2744d82a5a9ea05c'
+depends=(
+    'gettext'
+)
+files=(
+    "https://github.com/fribidi/fribidi/releases/download/v${version}/fribidi-${version}.tar.xz#$archive_hash"
+)
+
+configure() {
+    run meson setup build "${configopts[@]}"
+}
+
+build() {
+    run ninja -C build
+}
+
+install() {
+    export DESTDIR="${SERENITY_INSTALL_ROOT}"
+    run meson install -C build
+}


### PR DESCRIPTION
This is a reworked version of #22963.
It has the following changes from the first PR.

- Upgraded the version number from 1.0.13 to 1.0.16.
- No patches. (I noticed that `-Dc_args=-std=c99` was able to overwrite the `-ansi` flag.)
- Enabled release build.
- Disabled tests and docs.

I confirmed that I was able to build cairo and pango (which used fribidi) without subproject fallbacks.

(edit)
Sorry, I forgot to change the permission of package.sh. I've fixed it now.