### PR TITLE
Utilities/keymap: Write active keymap to config file

### DIFF
--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2021-2025, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -27,7 +27,11 @@ ErrorOr<int> serenity_main(Main::Arguments)
     if (keymaps_vector.size() == 0)
         exit(1);
 
-    TRY(Core::Process::spawn("/bin/keymap"sv, Array { "-m", keymaps_vector.first().characters() }, {}, Core::Process::KeepAsChild::Yes));
+    auto active_keymap = mapper_config->read_entry("Mapping", "ActiveKeymap", "");
+    if (active_keymap.is_empty())
+        active_keymap = keymaps_vector.first();
+
+    TRY(Core::Process::spawn("/bin/keymap"sv, Array { "-m", active_keymap.characters() }, {}, Core::Process::KeepAsChild::Yes));
 
     bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
     auto keyboard_device = TRY(Core::File::open("/dev/input/keyboard/0"sv, Core::File::OpenMode::Read));

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2025, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/ByteString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
@@ -89,8 +91,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         if (!keymaps_vector.find(mapping).is_end()) {
             int rc = set_keymap(mapping);
-            if (rc == 0)
+            if (rc == 0) {
+                mapper_config->write_entry("Mapping", "ActiveKeymap", mapping);
                 return rc;
+            }
         } else {
             warnln("Keymap '{}' is not in list of configured keymaps ({})", mapping, keymaps);
         }


### PR DESCRIPTION
... and read it on system startup.

Previously, the active keymap was set as the first of the defined keymaps, which was annoying for users of multiple keymaps.