### PR TITLE
LibDisassembly: RISC-V disassembly 4-1/4-5: Disassemble base ISA

### DIFF
--- a/AK/IntegralMath.h
+++ b/AK/IntegralMath.h
@@ -85,4 +85,12 @@ constexpr T reinterpret_as_octal(T decimal)
     return result;
 }
 
+template<Unsigned T>
+constexpr MakeSigned<T> sign_extend(T value, u8 bits)
+{
+    // C++ considers the shift by sizeof(T) * 8 UB, and it doesn’t make logical sense to sign-extend 0 bits anyways.
+    VERIFY(bits > 0);
+    return static_cast<MakeSigned<T>>((static_cast<i64>(value << (sizeof(T) * 8 - bits))) >> (sizeof(T) * 8 - bits));
+}
+
 }

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -16,8 +16,6 @@
 namespace Audio {
 
 ALWAYS_INLINE u8 frame_channel_type_to_channel_count(FlacFrameChannelType channel_type);
-// Sign-extend an arbitrary-size signed number to 64 bit signed
-ALWAYS_INLINE i64 sign_extend(u32 n, u8 size);
 // Decodes the sign representation method used in Rice coding.
 // Numbers alternate between positive and negative: 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, ...
 ALWAYS_INLINE i32 rice_to_signed(u32 x);

--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     riscv64/Encoding.cpp
     riscv64/Formatting.cpp
     riscv64/Instruction.cpp
+    riscv64/IM.cpp
 )
 
 serenity_lib(LibDisassembly disassembly)

--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     x86/Instruction.cpp
+    riscv64/Encoding.cpp
 )
 
 serenity_lib(LibDisassembly disassembly)

--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     x86/Instruction.cpp
     riscv64/Encoding.cpp
     riscv64/Formatting.cpp
+    riscv64/Instruction.cpp
 )
 
 serenity_lib(LibDisassembly disassembly)

--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     x86/Instruction.cpp
     riscv64/Encoding.cpp
+    riscv64/Formatting.cpp
 )
 
 serenity_lib(LibDisassembly disassembly)

--- a/Userland/Libraries/LibDisassembly/Disassembler.h
+++ b/Userland/Libraries/LibDisassembly/Disassembler.h
@@ -11,6 +11,7 @@
 #include <LibDisassembly/Architecture.h>
 #include <LibDisassembly/Instruction.h>
 #include <LibDisassembly/InstructionStream.h>
+#include <LibDisassembly/riscv64/Instruction.h>
 #include <LibDisassembly/x86/Instruction.h>
 
 namespace Disassembly {
@@ -28,6 +29,13 @@ public:
         if (!m_stream.can_read())
             return {};
         switch (m_arch) {
+        case Architecture::RISCV64:
+            return RISCV64::Instruction::from_stream(m_stream,
+                {
+                    .register_names = RISCV64::DisplayStyle::RegisterNames::ABIWithFramePointer,
+                    .use_pseudoinstructions = RISCV64::DisplayStyle::UsePseudoinstructions::Yes,
+                    .relative_address_style = RISCV64::DisplayStyle::RelativeAddressStyle::Symbol,
+                });
         case Architecture::X86:
             return make<X86::Instruction>(X86::Instruction::from_stream(m_stream, X86::ProcessorMode::Long));
         default:

--- a/Userland/Libraries/LibDisassembly/riscv64/Encoding.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Encoding.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Encoding.h"
+#include <AK/Assertions.h>
+#include <AK/BitCast.h>
+#include <AK/IntegralMath.h>
+
+namespace Disassembly::RISCV64 {
+
+// rd is always in bit positions [11:7].
+static Register extract_rd(u32 instruction)
+{
+    auto register_bits = (instruction >> 7) & 0b11111;
+    return static_cast<Register>(register_bits);
+}
+
+// rs1 is always in bit positions [19:15].
+static Register extract_rs1(u32 instruction)
+{
+    auto register_bits = (instruction >> 15) & 0b11111;
+    return static_cast<Register>(register_bits);
+}
+
+// rs2 is always in bit positions [24:20].
+static Register extract_rs2(u32 instruction)
+{
+    auto register_bits = (instruction >> 20) & 0b11111;
+    return static_cast<Register>(register_bits);
+}
+
+static u8 extract_funct3(u32 instruction)
+{
+    return static_cast<u8>((instruction >> 12) & 0b111);
+}
+
+static u8 extract_funct7(u32 instruction)
+{
+    return static_cast<u8>((instruction >> 25) & 0b1111111);
+}
+
+RawUType RawUType::parse(u32 instruction)
+{
+    auto destination_register = extract_rd(instruction);
+    i32 immediate = bit_cast<i32>(instruction & 0xfffff000);
+    u8 opcode = instruction & 0b1111111;
+    return RawUType {
+        .imm = immediate,
+        .rd = destination_register,
+        .opcode = opcode,
+    };
+}
+
+RawJType RawJType::parse(u32 instruction)
+{
+    auto destination_register = extract_rd(instruction);
+
+    // Figure 2.3; J-Type has a highly scrambled immediate that's hardware-friendly but not software-friendly.
+    u32 sign_bit = instruction >> 31;
+    u32 imm_10_1 = (instruction >> 21) & 0b11'1111'1111;
+    u32 imm_11 = (instruction >> 20) & 1;
+    u32 imm_19_12 = (instruction >> 12) & 0b1111'1111;
+    u32 raw_immediate = (imm_10_1 << 1) | (imm_11 << 11) | (imm_19_12 << 12) | (sign_bit << 20);
+    i32 immediate = AK::sign_extend(raw_immediate, 20);
+
+    u8 opcode = instruction & 0b1111111;
+    return RawJType {
+        .imm = immediate,
+        .rd = destination_register,
+        .opcode = opcode,
+    };
+}
+
+RawIType RawIType::parse(u32 instruction)
+{
+    auto destination_register = extract_rd(instruction);
+    auto source_register = extract_rs1(instruction);
+    auto funct3 = extract_funct3(instruction);
+    // Figure 2.4
+    u32 raw_immediate = (instruction >> 20) & 0xfff;
+    i32 immediate = AK::sign_extend(raw_immediate, 12);
+
+    u8 opcode = instruction & 0b1111111;
+    return RawIType {
+        .imm = immediate,
+        .rs1 = source_register,
+        .funct3 = funct3,
+        .rd = destination_register,
+        .opcode = opcode,
+    };
+}
+
+RawSType RawSType::parse(u32 instruction)
+{
+    auto source_register_1 = extract_rs1(instruction);
+    auto source_register_2 = extract_rs2(instruction);
+    auto funct3 = extract_funct3(instruction);
+    // Figure 2.3
+    u32 imm_11_5 = (instruction >> 25) & 0b1111111;
+    u32 imm_4_0 = (instruction >> 7) & 0b11111;
+    u32 raw_immediate = imm_4_0 | (imm_11_5 << 5);
+    i32 immediate = AK::sign_extend(raw_immediate, 12);
+
+    u8 opcode = instruction & 0b1111111;
+    return RawSType {
+        .imm = immediate,
+        .rs2 = source_register_2,
+        .rs1 = source_register_1,
+        .funct3 = funct3,
+        .opcode = opcode,
+    };
+}
+
+RawBType RawBType::parse(u32 instruction)
+{
+    auto source_register_1 = extract_rs1(instruction);
+    auto source_register_2 = extract_rs2(instruction);
+    auto funct3 = extract_funct3(instruction);
+    // Figure 2.3
+    u32 sign_bit = instruction >> 31;
+    u32 imm_10_5 = (instruction >> 25) & 0b111111;
+    u32 imm_4_1 = (instruction >> 8) & 0b1111;
+    u32 imm_11 = (instruction >> 7) & 1;
+    u32 raw_immediate = (imm_4_1 << 1) | (imm_10_5 << 5) | (imm_11 << 11) | (sign_bit << 12);
+    i32 immediate = AK::sign_extend(raw_immediate, 13);
+
+    u8 opcode = instruction & 0b1111111;
+    return RawBType {
+        .imm = immediate,
+        .rs2 = source_register_2,
+        .rs1 = source_register_1,
+        .funct3 = funct3,
+        .opcode = opcode,
+    };
+}
+
+RawRType RawRType::parse(u32 instruction)
+{
+    auto destination_register = extract_rd(instruction);
+    auto source_register_1 = extract_rs1(instruction);
+    auto source_register_2 = extract_rs2(instruction);
+    auto funct3 = extract_funct3(instruction);
+    auto funct7 = extract_funct7(instruction);
+
+    u8 opcode = instruction & 0b1111111;
+    return RawRType {
+        .funct7 = funct7,
+        .rs2 = source_register_2,
+        .rs1 = source_register_1,
+        .funct3 = funct3,
+        .rd = destination_register,
+        .opcode = opcode,
+    };
+}
+
+RawR4Type RawR4Type::parse(u32 instruction)
+{
+    auto destination_register = extract_rd(instruction);
+    auto source_register_1 = extract_rs1(instruction);
+    auto source_register_2 = extract_rs2(instruction);
+    auto funct3 = extract_funct3(instruction);
+    auto fmt = static_cast<u8>(extract_funct7(instruction) & 0b11);
+    auto source_register_3 = static_cast<Register>(extract_funct7(instruction) >> 2);
+
+    u8 opcode = instruction & 0b1111111;
+    return RawR4Type {
+        .rs3 = source_register_3,
+        .fmt = fmt,
+        .rs2 = source_register_2,
+        .rs1 = source_register_1,
+        .funct3 = funct3,
+        .rd = destination_register,
+        .opcode = opcode,
+    };
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Encoding.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Encoding.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibDisassembly/riscv64/Registers.h>
+
+namespace Disassembly::RISCV64 {
+
+struct RawRType {
+    u8 funct7;
+    Register rs2;
+    Register rs1;
+    u8 funct3;
+    Register rd;
+    u8 opcode;
+
+    static RawRType parse(u32 instruction);
+};
+struct RawIType {
+    i32 imm;
+    Register rs1;
+    u8 funct3;
+    Register rd;
+    u8 opcode;
+
+    static RawIType parse(u32 instruction);
+};
+struct RawSType {
+    i32 imm;
+    Register rs2;
+    Register rs1;
+    u8 funct3;
+    u8 opcode;
+
+    static RawSType parse(u32 instruction);
+};
+struct RawBType {
+    i32 imm;
+    Register rs2;
+    Register rs1;
+    u8 funct3;
+    u8 opcode;
+
+    static RawBType parse(u32 instruction);
+};
+struct RawUType {
+    i32 imm;
+    Register rd;
+    u8 opcode;
+
+    static RawUType parse(u32 instruction);
+};
+struct RawJType {
+    i32 imm;
+    Register rd;
+    u8 opcode;
+
+    static RawJType parse(u32 instruction);
+};
+struct RawR4Type {
+    Register rs3;
+    u8 fmt;
+    Register rs2;
+    Register rs1;
+    u8 funct3;
+    Register rd;
+    u8 opcode;
+
+    static RawR4Type parse(u32 instruction);
+};
+
+// Table 24.1
+enum class MajorOpcode : u8 {
+    LOAD = 0b00000'11,
+    STORE = 0b01000'11,
+    MADD = 0b10000'11,
+    BRANCH = 0b11000'11,
+    LOAD_FP = 0b00001'11,
+    STORE_FP = 0b01001'11,
+    MSUB = 0b10001'11,
+    JALR = 0b11001'11,
+    custom_0 = 0b00010'11,
+    custom_1 = 0b01010'11,
+    NMSUB = 0b10010'11,
+    reserved_0 = 0b11010'11,
+    MISC_MEM = 0b00011'11,
+    AMO = 0b01011'11,
+    NMADD = 0b10011'11,
+    JAL = 0b11011'11,
+    OP_IMM = 0b00100'11,
+    OP = 0b01100'11,
+    OP_FP = 0b10100'11,
+    SYSTEM = 0b11100'11,
+    AUIPC = 0b00101'11,
+    LUI = 0b01101'11,
+    reserved_1 = 0b10101'11,
+    reserved_2 = 0b11101'11,
+    OP_IMM_32 = 0b00110'11,
+    OP_32 = 0b01110'11,
+    custom_2_rv128 = 0b10110'11,
+    custom_3_rv128 = 0b11110'11,
+};
+
+// Table 16.4
+// Stored in the funct3 field and lowest 2 bits of compressed instructions.
+// Note that we always decode the RV64C version, but the names are as per specification and refer to all three variants.
+enum class CompressedOpcode : u8 {
+    ADDI4SPN = 0b000'00,
+    ADDI = 0b000'01,
+    SLLI = 0b000'10,
+    FLD_LQ = 0b001'00,
+    JAL_ADDIW = 0b001'01,
+    FLDSP_LQSP = 0b001'10,
+    LW = 0b010'00,
+    LI = 0b010'01,
+    LWSP = 0b010'10,
+    FLW_LD = 0b011'00,
+    LUI_ADDI16SP = 0b011'01,
+    FLWSP_LDSP = 0b011'10,
+    reserved = 0b100'00,
+    MISC_ALU = 0b100'01,
+    JALR_MV_ADD = 0b100'10,
+    FSD_SQ = 0b101'00,
+    J = 0b101'01,
+    FSDSP_SQSP = 0b101'10,
+    SW = 0b110'00,
+    BEQZ = 0b110'01,
+    SWSP = 0b110'10,
+    FSW_SD = 0b111'00,
+    BNEZ = 0b111'01,
+    FSWSP_SDSP = 0b111'10,
+};
+
+// Table 11.1
+enum class RoundingMode : u8 {
+    RNE = 0b000,
+    RTZ = 0b001,
+    RDN = 0b010,
+    RUP = 0b011,
+    RMM = 0b100,
+    Invalid1 = 0b101,
+    Invalid2 = 0b110,
+    DYN = 0b111,
+};
+
+constexpr CompressedOpcode extract_compressed_opcode(u16 instruction)
+{
+    u8 raw_opcode = (instruction & 0b11) | ((instruction >> 11) & 0b11100);
+    return static_cast<CompressedOpcode>(raw_opcode);
+}
+
+// 1.5 Base Instruction-Length Encoding, Figure 1.1
+constexpr bool is_compressed_instruction(u16 halfword)
+{
+    return (halfword & 0b11) != 0b11;
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Formatting.h"
+#include "Instruction.h"
 
 namespace Disassembly::RISCV64 {
 
@@ -43,6 +44,11 @@ static String format_relative_address(DisplayStyle display_style, Optional<Symbo
         formatted_target = MUST(String::formatted("{:+#06x}", offset));
     }
     return formatted_target;
+}
+
+String InstructionWithoutArguments::to_string(DisplayStyle, u32, Optional<SymbolProvider const&>) const
+{
+    return mnemonic();
 }
 
 }

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
@@ -51,4 +51,141 @@ String InstructionWithoutArguments::to_string(DisplayStyle, u32, Optional<Symbol
     return mnemonic();
 }
 
+String UnknownInstruction::to_string(DisplayStyle, u32, Optional<SymbolProvider const&>) const
+{
+    // FIXME: Print the full instruction’s bytes in some useful format.
+    return mnemonic();
+}
+
+String UnknownInstruction::mnemonic() const
+{
+    return ".insn"_string;
+}
+
+String LoadUpperImmediate::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {:d}", mnemonic(), format_register(destination_register(), display_style), immediate()));
+}
+
+String LoadUpperImmediate::mnemonic() const
+{
+    return "lui"_string;
+}
+
+String JumpAndLink::to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const
+{
+    auto formatted_target = format_relative_address(display_style, symbol_provider, origin, immediate());
+
+    if (display_style.use_pseudoinstructions == DisplayStyle::UsePseudoinstructions::Yes && destination_register() == RegisterABINames::zero)
+        return MUST(String::formatted("j          {}", formatted_target));
+
+    return MUST(String::formatted("{:10} {}, {}", mnemonic(), format_register(destination_register(), display_style), formatted_target));
+}
+
+String JumpAndLink::mnemonic() const
+{
+    return "jal"_string;
+}
+
+String JumpAndLinkRegister::to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const
+{
+    return MUST(String::formatted("{:10} {}, {}, {}", mnemonic(), format_register(destination_register(), display_style), format_register(source_register(), display_style), format_relative_address(display_style, symbol_provider, origin, immediate())));
+}
+
+String JumpAndLinkRegister::mnemonic() const
+{
+    return "jalr"_string;
+}
+
+String Branch::to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const
+{
+    return MUST(String::formatted("{:10} {}, {}, {}", m_condition, format_register(source_register_1(), display_style), format_register(source_register_2(), display_style), format_relative_address(display_style, symbol_provider, origin, immediate())));
+}
+
+String Branch::mnemonic() const
+{
+    return MUST(String::formatted("{}", m_condition));
+}
+
+String AddUpperImmediateToProgramCounter::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {}", mnemonic(), format_register(destination_register(), display_style), immediate()));
+}
+
+String AddUpperImmediateToProgramCounter::mnemonic() const
+{
+    return "auipc"_string;
+}
+
+String ArithmeticInstruction::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {}, {}", m_operation, format_register(destination_register(), display_style), format_register(source_register_1(), display_style), format_register(source_register_2(), display_style)));
+}
+
+String ArithmeticInstruction::mnemonic() const
+{
+    return MUST(String::formatted("{}", m_operation));
+}
+
+String ArithmeticImmediateInstruction::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {}, {:d}", m_operation, format_register(destination_register(), display_style), format_register(source_register(), display_style), immediate()));
+}
+
+String ArithmeticImmediateInstruction::mnemonic() const
+{
+    return MUST(String::formatted("{}", m_operation));
+}
+
+String MemoryLoad::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("l{:9} {}, {:#03x}({})", m_width, format_register(destination_register(), display_style), immediate(), format_register(source_register(), display_style)));
+}
+
+String MemoryLoad::mnemonic() const
+{
+    return MUST(String::formatted("l{}", m_width));
+}
+
+String MemoryStore::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("s{:9} {}, {:#03x}({})", m_width, format_register(source_register_2(), display_style), immediate(), format_register(source_register_1(), display_style)));
+}
+
+String MemoryStore::mnemonic() const
+{
+    return MUST(String::formatted("s{}", m_width));
+}
+
+String EnvironmentBreak::mnemonic() const
+{
+    return "ebreak"_string;
+}
+
+String EnvironmentCall::mnemonic() const
+{
+    return "ecall"_string;
+}
+
+String InstructionFetchFence::mnemonic() const
+{
+    return "fence.i"_string;
+}
+
+String Fence::to_string(DisplayStyle, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {}", mnemonic(), m_predecessor, m_successor));
+}
+
+String Fence::mnemonic() const
+{
+    switch (m_mode) {
+    case Fence::Mode::Normal:
+        return "fence"_string;
+    case Fence::Mode::NoStoreToLoadOrdering:
+        return "fence.tso"_string;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Formatting.h"
+
+namespace Disassembly::RISCV64 {
+
+template<typename RegisterType>
+static String format_register(RegisterType reg, DisplayStyle display_style)
+{
+    switch (display_style.register_names) {
+    case DisplayStyle::RegisterNames::Hardware:
+        return MUST(String::formatted("{}", reg));
+    case DisplayStyle::RegisterNames::ABI:
+        return MUST(String::formatted("{}", static_cast<RegisterNameTraits<RegisterType>::ABIType>(reg.value())));
+    case DisplayStyle::RegisterNames::ABIWithFramePointer:
+        return MUST(String::formatted("{}", static_cast<RegisterNameTraits<RegisterType>::ABIWithFPType>(reg.value())));
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static String format_relative_address(DisplayStyle display_style, Optional<SymbolProvider const&> symbol_provider, u32 origin, i32 offset)
+{
+    String formatted_target;
+    if (display_style.relative_address_style == DisplayStyle::RelativeAddressStyle::Symbol) {
+        auto target_address = origin + offset;
+        if (symbol_provider.has_value()) {
+            u32 offset;
+            auto symbol = symbol_provider->symbolicate(target_address, &offset);
+            if (symbol.is_empty())
+                formatted_target = MUST(String::formatted("{:#x}", target_address));
+            else if (offset == 0)
+                formatted_target = MUST(String::formatted("{:#x} <{}>", target_address, symbol));
+            else
+                formatted_target = MUST(String::formatted("{:#x} <{}{:+#x}>", target_address, symbol, offset));
+        } else {
+            formatted_target = MUST(String::formatted("{:#x}", target_address));
+        }
+    } else {
+        formatted_target = MUST(String::formatted("{:+#06x}", offset));
+    }
+    return formatted_target;
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <AK/String.h>
+#include <LibDisassembly/riscv64/Encoding.h>
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::Register> : AK::Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::Register reg)
+    {
+        return AK::Formatter<FormatString>::format(builder, "x{}"sv, static_cast<u8>(reg));
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::FloatRegister> : AK::Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::FloatRegister reg)
+    {
+        return AK::Formatter<FormatString>::format(builder, "f{}"sv, static_cast<u8>(reg));
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::RegisterABINames> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::RegisterABINames reg)
+    {
+        auto formatted = ""sv;
+        switch (reg) {
+        case Disassembly::RISCV64::RegisterABINames::zero:
+            formatted = "zero"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::ra:
+            formatted = "ra"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::sp:
+            formatted = "sp"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::gp:
+            formatted = "gp"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::tp:
+            formatted = "tp"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t0:
+            formatted = "t0"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t1:
+            formatted = "t1"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t2:
+            formatted = "t2"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s0:
+            formatted = "s0"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s1:
+            formatted = "s1"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a0:
+            formatted = "a0"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a1:
+            formatted = "a1"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a2:
+            formatted = "a2"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a3:
+            formatted = "a3"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a4:
+            formatted = "a4"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a5:
+            formatted = "a5"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a6:
+            formatted = "a6"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::a7:
+            formatted = "a7"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s2:
+            formatted = "s2"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s3:
+            formatted = "s3"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s4:
+            formatted = "s4"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s5:
+            formatted = "s5"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s6:
+            formatted = "s6"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s7:
+            formatted = "s7"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s8:
+            formatted = "s8"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s9:
+            formatted = "s9"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s10:
+            formatted = "s10"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::s11:
+            formatted = "s11"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t3:
+            formatted = "t3"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t4:
+            formatted = "t4"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t5:
+            formatted = "t5"sv;
+            break;
+        case Disassembly::RISCV64::RegisterABINames::t6:
+            formatted = "t6"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, formatted);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::RegisterABINamesWithFP> : AK::Formatter<Disassembly::RISCV64::RegisterABINames> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::RegisterABINamesWithFP reg)
+    {
+        if (reg == Disassembly::RISCV64::RegisterABINamesWithFP::fp)
+            return AK::Formatter<StringView>::format(builder, "fp"sv);
+        return AK::Formatter<Disassembly::RISCV64::RegisterABINames>::format(builder, static_cast<Disassembly::RISCV64::RegisterABINames>(reg));
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::FloatRegisterABINames> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::FloatRegisterABINames reg)
+    {
+        auto formatted = ""sv;
+        switch (reg) {
+        case Disassembly::RISCV64::FloatRegisterABINames::ft0:
+            formatted = "ft0"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft1:
+            formatted = "ft1"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft2:
+            formatted = "ft2"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft3:
+            formatted = "ft3"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft4:
+            formatted = "ft4"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft5:
+            formatted = "ft5"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft6:
+            formatted = "ft6"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft7:
+            formatted = "ft7"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs0:
+            formatted = "fs0"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs1:
+            formatted = "fs1"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa0:
+            formatted = "fa0"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa1:
+            formatted = "fa1"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa2:
+            formatted = "fa2"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa3:
+            formatted = "fa3"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa4:
+            formatted = "fa4"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa5:
+            formatted = "fa5"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa6:
+            formatted = "fa6"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fa7:
+            formatted = "fa7"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs2:
+            formatted = "fs2"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs3:
+            formatted = "fs3"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs4:
+            formatted = "fs4"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs5:
+            formatted = "fs5"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs6:
+            formatted = "fs6"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs7:
+            formatted = "fs7"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs8:
+            formatted = "fs8"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs9:
+            formatted = "fs9"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs10:
+            formatted = "fs10"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::fs11:
+            formatted = "fs11"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft8:
+            formatted = "ft8"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft9:
+            formatted = "ft9"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft10:
+            formatted = "ft10"sv;
+            break;
+        case Disassembly::RISCV64::FloatRegisterABINames::ft11:
+            formatted = "ft11"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, formatted);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::RoundingMode> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::RoundingMode reg)
+    {
+        auto formatted = ""sv;
+        switch (reg) {
+        case Disassembly::RISCV64::RoundingMode::RNE:
+            formatted = "rne"sv;
+            break;
+        case Disassembly::RISCV64::RoundingMode::RTZ:
+            formatted = "rtz"sv;
+            break;
+        case Disassembly::RISCV64::RoundingMode::RDN:
+            formatted = "rdn"sv;
+            break;
+        case Disassembly::RISCV64::RoundingMode::RUP:
+            formatted = "rup"sv;
+            break;
+        case Disassembly::RISCV64::RoundingMode::RMM:
+            formatted = "rmm"sv;
+            break;
+        case Disassembly::RISCV64::RoundingMode::Invalid1:
+        case Disassembly::RISCV64::RoundingMode::Invalid2:
+            formatted = "invalid"sv;
+            break;
+        case Disassembly::RISCV64::RoundingMode::DYN:
+            formatted = "dyn"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, formatted);
+    }
+};

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
@@ -9,6 +9,8 @@
 #include <AK/Format.h>
 #include <AK/String.h>
 #include <LibDisassembly/riscv64/Encoding.h>
+#include <LibDisassembly/riscv64/IM.h>
+#include <LibDisassembly/riscv64/Instruction.h>
 
 template<>
 struct AK::Formatter<Disassembly::RISCV64::Register> : AK::Formatter<FormatString> {
@@ -247,6 +249,228 @@ struct AK::Formatter<Disassembly::RISCV64::FloatRegisterABINames> : AK::Formatte
             break;
         }
         return AK::Formatter<StringView>::format(builder, formatted);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::ArithmeticInstruction::Operation> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::ArithmeticInstruction::Operation op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Add:
+            op_name = "add"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Subtract:
+            op_name = "sub"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::SetLessThan:
+            op_name = "slt"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::SetLessThanUnsigned:
+            op_name = "sltu"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Xor:
+            op_name = "xor"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Or:
+            op_name = "or"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::And:
+            op_name = "and"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::ShiftLeftLogical:
+            op_name = "sll"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::ShiftRightLogical:
+            op_name = "srl"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::ShiftRightArithmetic:
+            op_name = "sra"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::AddWord:
+            op_name = "addw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::SubtractWord:
+            op_name = "subw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::ShiftLeftLogicalWord:
+            op_name = "sllw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::ShiftRightLogicalWord:
+            op_name = "srlw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::ShiftRightArithmeticWord:
+            op_name = "sraw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Multiply:
+            op_name = "mul"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::MultiplyHigh:
+            op_name = "mulh"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::MultiplyHighSignedUnsigned:
+            op_name = "mulhsu"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::MultiplyHighUnsigned:
+            op_name = "mulhu"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Divide:
+            op_name = "div"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::DivideUnsigned:
+            op_name = "divu"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::Remainder:
+            op_name = "rem"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::RemainderUnsigned:
+            op_name = "remu"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::MultiplyWord:
+            op_name = "mulw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::DivideWord:
+            op_name = "divw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::DivideUnsignedWord:
+            op_name = "divuw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::RemainderWord:
+            op_name = "remw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticInstruction::Operation::RemainderUnsignedWord:
+            op_name = "remuw"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::Add:
+            op_name = "addi"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::SetLessThan:
+            op_name = "slti"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::SetLessThanUnsigned:
+            op_name = "sltiu"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::Xor:
+            op_name = "xori"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::Or:
+            op_name = "ori"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::And:
+            op_name = "andi"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftLeftLogical:
+            op_name = "slli"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightLogical:
+            op_name = "srli"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightArithmetic:
+            op_name = "srai"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::AddWord:
+            op_name = "addiw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftLeftLogicalWord:
+            op_name = "slliw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightLogicalWord:
+            op_name = "srliw"sv;
+            break;
+        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightArithmeticWord:
+            op_name = "sraiw"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::Branch::Condition> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::Branch::Condition op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+        case Disassembly::RISCV64::Branch::Condition::Equals:
+            op_name = "beq"sv;
+            break;
+        case Disassembly::RISCV64::Branch::Condition::NotEquals:
+            op_name = "bne"sv;
+            break;
+        case Disassembly::RISCV64::Branch::Condition::LessThan:
+            op_name = "blt"sv;
+            break;
+        case Disassembly::RISCV64::Branch::Condition::GreaterEquals:
+            op_name = "bge"sv;
+            break;
+        case Disassembly::RISCV64::Branch::Condition::LessThanUnsigned:
+            op_name = "bltu"sv;
+            break;
+        case Disassembly::RISCV64::Branch::Condition::GreaterEqualsUnsigned:
+            op_name = "bgeu"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::Fence::AccessType> : AK::Formatter<String> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::Fence::AccessType op)
+    {
+        StringBuilder op_name;
+        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Input))
+            op_name.append_code_point('i');
+        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Output))
+            op_name.append_code_point('o');
+        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Read))
+            op_name.append_code_point('r');
+        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Write))
+            op_name.append_code_point('w');
+
+        return AK::Formatter<String>::format(builder, MUST(op_name.to_string()));
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::MemoryAccessMode> : AK::Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::MemoryAccessMode mode)
+    {
+        auto width_str = ""sv;
+        switch (mode.width) {
+        case Disassembly::RISCV64::DataWidth::Byte:
+            width_str = "b"sv;
+            break;
+        case Disassembly::RISCV64::DataWidth::Halfword:
+            width_str = "h"sv;
+            break;
+        case Disassembly::RISCV64::DataWidth::Word:
+            width_str = "w"sv;
+            break;
+        case Disassembly::RISCV64::DataWidth::DoubleWord:
+            width_str = "d"sv;
+            break;
+        case Disassembly::RISCV64::DataWidth::QuadWord:
+            width_str = "q"sv;
+            break;
+        }
+        auto signedness_str = ""sv;
+        if (mode.signedness == Disassembly::RISCV64::Signedness::Unsigned)
+            signedness_str = "u"sv;
+
+        return AK::Formatter<FormatString>::format(builder, "{}{}"sv, width_str, signedness_str);
     }
 };
 

--- a/Userland/Libraries/LibDisassembly/riscv64/IM.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/IM.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "IM.h"
+#include <AK/NonnullOwnPtr.h>
+#include <LibDisassembly/riscv64/Instruction.h>
+
+namespace Disassembly::RISCV64 {
+
+NonnullOwnPtr<LoadUpperImmediate> parse_lui(u32 instruction)
+{
+    auto raw_parts = RawUType::parse(instruction);
+    return adopt_own(*new (nothrow) LoadUpperImmediate(raw_parts.imm, raw_parts.rd));
+}
+
+NonnullOwnPtr<JumpAndLink> parse_jal(u32 instruction)
+{
+    auto raw_parts = RawJType::parse(instruction);
+    return adopt_own(*new (nothrow) JumpAndLink(raw_parts.imm, raw_parts.rd));
+}
+
+NonnullOwnPtr<JumpAndLinkRegister> parse_jalr(u32 instruction)
+{
+    auto raw_parts = RawIType::parse(instruction);
+    return adopt_own(*new (nothrow) JumpAndLinkRegister(raw_parts.imm, raw_parts.rs1, raw_parts.rd));
+}
+
+NonnullOwnPtr<AddUpperImmediateToProgramCounter> parse_auipc(u32 instruction)
+{
+    auto raw_parts = RawUType::parse(instruction);
+    return adopt_own(*new (nothrow) AddUpperImmediateToProgramCounter(raw_parts.imm, raw_parts.rd));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_op_imm(u32 instruction)
+{
+    auto raw_parts = RawIType::parse(instruction);
+
+    auto operation = ArithmeticImmediateInstruction::Operation::Add;
+    switch (raw_parts.funct3) {
+    case 0b000:
+        operation = ArithmeticImmediateInstruction::Operation::Add;
+        break;
+    case 0b010:
+        operation = ArithmeticImmediateInstruction::Operation::SetLessThan;
+        break;
+    case 0b011:
+        operation = ArithmeticImmediateInstruction::Operation::SetLessThanUnsigned;
+        break;
+    case 0b100:
+        operation = ArithmeticImmediateInstruction::Operation::Xor;
+        break;
+    case 0b110:
+        operation = ArithmeticImmediateInstruction::Operation::Or;
+        break;
+    case 0b111:
+        operation = ArithmeticImmediateInstruction::Operation::And;
+        break;
+    case 0b001:
+        operation = ArithmeticImmediateInstruction::Operation::ShiftLeftLogical;
+        break;
+    case 0b101:
+        if ((instruction & (1 << 30)) == 0)
+            operation = ArithmeticImmediateInstruction::Operation::ShiftRightLogical;
+        else
+            operation = ArithmeticImmediateInstruction::Operation::ShiftRightArithmetic;
+        // Delete the possibly set 10th bit that distinguishes SRLI and SRAI.
+        raw_parts.imm &= ~(1 << 10);
+        break;
+    default:
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    }
+    return adopt_own(*new (nothrow) ArithmeticImmediateInstruction(operation, raw_parts.imm, raw_parts.rs1, raw_parts.rd));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_op_imm_32(u32 instruction)
+{
+    auto raw_parts = RawIType::parse(instruction);
+
+    auto operation = ArithmeticImmediateInstruction::Operation::Add;
+    switch (raw_parts.funct3) {
+    case 0b000:
+        operation = ArithmeticImmediateInstruction::Operation::AddWord;
+        break;
+    case 0b001:
+        operation = ArithmeticImmediateInstruction::Operation::ShiftLeftLogicalWord;
+        break;
+    case 0b101:
+        if ((instruction & (1 << 30)) == 0)
+            operation = ArithmeticImmediateInstruction::Operation::ShiftRightLogicalWord;
+        else
+            operation = ArithmeticImmediateInstruction::Operation::ShiftRightArithmeticWord;
+        // Delete the possibly set 10th bit that distinguishes SRLIW and SRAIW.
+        raw_parts.imm &= ~(1 << 10);
+        break;
+    default:
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    }
+    return adopt_own(*new (nothrow) ArithmeticImmediateInstruction(operation, raw_parts.imm, raw_parts.rs1, raw_parts.rd));
+}
+
+NonnullOwnPtr<ArithmeticInstruction> parse_op(u32 instruction)
+{
+    auto raw_parts = RawRType::parse(instruction);
+    // Distinguishes a few closely related operations, like add/sub.
+    auto mode_switch = (raw_parts.funct7 & 0b0100000) > 0;
+    auto is_m_extension = (raw_parts.funct7 & 1) == 1;
+
+    auto operation = ArithmeticInstruction::Operation::Add;
+    if (!is_m_extension) {
+        switch (raw_parts.funct3) {
+        case 0b000:
+            if (mode_switch)
+                operation = ArithmeticInstruction::Operation::Subtract;
+            else
+                operation = ArithmeticInstruction::Operation::Add;
+            break;
+        case 0b001:
+            operation = ArithmeticInstruction::Operation::ShiftLeftLogical;
+            break;
+        case 0b010:
+            operation = ArithmeticInstruction::Operation::SetLessThan;
+            break;
+        case 0b011:
+            operation = ArithmeticInstruction::Operation::SetLessThanUnsigned;
+            break;
+        case 0b100:
+            operation = ArithmeticInstruction::Operation::Xor;
+            break;
+        case 0b101:
+            if (mode_switch)
+                operation = ArithmeticInstruction::Operation::ShiftRightArithmetic;
+            else
+                operation = ArithmeticInstruction::Operation::ShiftRightLogical;
+            break;
+        case 0b110:
+            operation = ArithmeticInstruction::Operation::Or;
+            break;
+        case 0b111:
+            operation = ArithmeticInstruction::Operation::And;
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    } else {
+        switch (raw_parts.funct3) {
+        case 0b000:
+            operation = ArithmeticInstruction::Operation::Multiply;
+            break;
+        case 0b001:
+            operation = ArithmeticInstruction::Operation::MultiplyHigh;
+            break;
+        case 0b010:
+            operation = ArithmeticInstruction::Operation::MultiplyHighSignedUnsigned;
+            break;
+        case 0b011:
+            operation = ArithmeticInstruction::Operation::MultiplyHighUnsigned;
+            break;
+        case 0b100:
+            operation = ArithmeticInstruction::Operation::Divide;
+            break;
+        case 0b101:
+            operation = ArithmeticInstruction::Operation::DivideUnsigned;
+            break;
+        case 0b110:
+            operation = ArithmeticInstruction::Operation::Remainder;
+            break;
+        case 0b111:
+            operation = ArithmeticInstruction::Operation::RemainderUnsigned;
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+    return adopt_own(*new ArithmeticInstruction(operation, raw_parts.rs1, raw_parts.rs2, raw_parts.rd));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_op_32(u32 instruction)
+{
+    auto raw_parts = RawRType::parse(instruction);
+    auto is_m_extension = (raw_parts.funct7 & 1) == 1;
+
+    auto operation = ArithmeticInstruction::Operation::Add;
+    if (!is_m_extension) {
+        switch (raw_parts.funct3) {
+        case 0b000:
+            if ((raw_parts.funct7 & 0b0100000) == 0)
+                operation = ArithmeticInstruction::Operation::AddWord;
+            else
+                operation = ArithmeticInstruction::Operation::SubtractWord;
+            break;
+        case 0b001:
+            operation = ArithmeticInstruction::Operation::ShiftLeftLogicalWord;
+            break;
+        case 0b101:
+            if ((raw_parts.funct7 & 0b0100000) == 0)
+                operation = ArithmeticInstruction::Operation::ShiftRightLogicalWord;
+            else
+                operation = ArithmeticInstruction::Operation::ShiftRightArithmeticWord;
+            break;
+        default:
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        }
+    } else {
+        switch (raw_parts.funct3) {
+        case 0b000:
+            operation = ArithmeticInstruction::Operation::MultiplyWord;
+            break;
+        case 0b100:
+            operation = ArithmeticInstruction::Operation::DivideWord;
+            break;
+        case 0b101:
+            operation = ArithmeticInstruction::Operation::DivideUnsignedWord;
+            break;
+        case 0b110:
+            operation = ArithmeticInstruction::Operation::RemainderWord;
+            break;
+        case 0b111:
+            operation = ArithmeticInstruction::Operation::RemainderUnsignedWord;
+            break;
+        default:
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        }
+    }
+    return adopt_own(*new ArithmeticInstruction(operation, raw_parts.rs1, raw_parts.rs2, raw_parts.rd));
+}
+
+NonnullOwnPtr<MemoryLoad> parse_load(u32 instruction)
+{
+    auto raw_parts = RawIType::parse(instruction);
+    auto width = MemoryAccessMode::from_funct3(raw_parts.funct3);
+    return adopt_own(*new (nothrow) MemoryLoad(raw_parts.imm, raw_parts.rs1, width, raw_parts.rd));
+}
+
+NonnullOwnPtr<MemoryStore> parse_store(u32 instruction)
+{
+    auto raw_parts = RawSType::parse(instruction);
+    auto width = MemoryAccessMode::from_funct3(raw_parts.funct3);
+    return adopt_own(*new (nothrow) MemoryStore(raw_parts.imm, raw_parts.rs2, raw_parts.rs1, width));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_branch(u32 instruction)
+{
+    auto raw_parts = RawBType::parse(instruction);
+    if (raw_parts.funct3 == 0b010 || raw_parts.funct3 == 0b011)
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    auto condition = static_cast<Branch::Condition>(raw_parts.funct3);
+    return adopt_own(*new (nothrow) Branch(condition, raw_parts.imm, raw_parts.rs1, raw_parts.rs2));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_misc_mem(u32 instruction)
+{
+    auto raw_parts = RawIType::parse(instruction);
+
+    switch (raw_parts.funct3) {
+    case 0b000: {
+        auto successor = static_cast<Fence::AccessType>(raw_parts.imm & 0b1111);
+        auto predecessor = static_cast<Fence::AccessType>((raw_parts.imm >> 4) & 0b1111);
+        auto mode = static_cast<Fence::Mode>((raw_parts.imm >> 8) & 0b1111);
+        return adopt_own(*new (nothrow) Fence(predecessor, successor, mode));
+    }
+    case 0b001: {
+        return adopt_own(*new (nothrow) InstructionFetchFence);
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/IM.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/IM.h
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Instruction.h"
+
+// I, M, and Zifencei extensions.
+namespace Disassembly::RISCV64 {
+
+// LUI
+class LoadUpperImmediate : public UJTypeInstruction {
+public:
+    virtual ~LoadUpperImmediate() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(LoadUpperImmediate const&) const = default;
+
+    LoadUpperImmediate(i32 immediate, Register rd)
+        : UJTypeInstruction(immediate, rd)
+    {
+    }
+};
+
+// JAL
+class JumpAndLink : public UJTypeInstruction {
+public:
+    virtual ~JumpAndLink() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(JumpAndLink const&) const = default;
+
+    JumpAndLink(i32 immediate, Register rd)
+        : UJTypeInstruction(immediate, rd)
+    {
+    }
+};
+
+// JALR
+class JumpAndLinkRegister : public ITypeInstruction {
+public:
+    virtual ~JumpAndLinkRegister() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(JumpAndLinkRegister const&) const = default;
+
+    JumpAndLinkRegister(i32 offset, Register base, Register rd)
+        : ITypeInstruction(offset, base, rd)
+    {
+    }
+};
+
+// AUIPC
+class AddUpperImmediateToProgramCounter : public UJTypeInstruction {
+public:
+    virtual ~AddUpperImmediateToProgramCounter() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(AddUpperImmediateToProgramCounter const&) const = default;
+
+    AddUpperImmediateToProgramCounter(i32 immediate, Register rd)
+        : UJTypeInstruction(immediate, rd)
+    {
+    }
+};
+
+class ArithmeticImmediateInstruction : public ITypeInstruction {
+public:
+    enum class Operation {
+        Add,
+        SetLessThan,
+        SetLessThanUnsigned,
+        Xor,
+        Or,
+        And,
+        ShiftLeftLogical,
+        ShiftRightLogical,
+        ShiftRightArithmetic,
+        AddWord,
+        ShiftLeftLogicalWord,
+        ShiftRightLogicalWord,
+        ShiftRightArithmeticWord,
+    };
+
+    virtual ~ArithmeticImmediateInstruction() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(ArithmeticImmediateInstruction const&) const = default;
+
+    ArithmeticImmediateInstruction(Operation operation, i32 immediate, Register rs1, Register rd)
+        : ITypeInstruction(immediate, rs1, rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    Operation m_operation;
+};
+
+class ArithmeticInstruction : public RTypeInstruction {
+public:
+    enum class Operation {
+        // RV32I
+        Add,
+        Subtract,
+        SetLessThan,
+        SetLessThanUnsigned,
+        Xor,
+        Or,
+        And,
+        ShiftLeftLogical,
+        ShiftRightLogical,
+        ShiftRightArithmetic,
+        // RV64I
+        AddWord,
+        SubtractWord,
+        ShiftLeftLogicalWord,
+        ShiftRightLogicalWord,
+        ShiftRightArithmeticWord,
+        // RV32M
+        Multiply,
+        MultiplyHigh,
+        MultiplyHighSignedUnsigned,
+        MultiplyHighUnsigned,
+        Divide,
+        DivideUnsigned,
+        Remainder,
+        RemainderUnsigned,
+        // RV64M
+        MultiplyWord,
+        DivideWord,
+        DivideUnsignedWord,
+        RemainderWord,
+        RemainderUnsignedWord,
+    };
+
+    virtual ~ArithmeticInstruction() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(ArithmeticInstruction const&) const = default;
+
+    ArithmeticInstruction(Operation operation, Register rs1, Register rs2, Register rd)
+        : RTypeInstruction(rs1, rs2, rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    Operation m_operation;
+};
+
+class MemoryLoad : public ITypeInstruction {
+public:
+    virtual ~MemoryLoad() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(MemoryLoad const&) const = default;
+
+    MemoryLoad(i32 offset, Register base, MemoryAccessMode width, Register rd)
+        : ITypeInstruction(offset, base, rd)
+        , m_width(width)
+    {
+    }
+
+private:
+    MemoryAccessMode m_width;
+};
+
+class MemoryStore : public BSTypeInstruction {
+public:
+    virtual ~MemoryStore() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(MemoryStore const&) const = default;
+
+    MemoryStore(i32 offset, Register source, Register base, MemoryAccessMode width)
+        : BSTypeInstruction(offset, base, source)
+        , m_width(width)
+    {
+    }
+
+private:
+    MemoryAccessMode m_width;
+};
+
+class Branch : public BSTypeInstruction {
+public:
+    enum class Condition : u8 {
+        Equals = 0b000,
+        NotEquals = 0b001,
+        LessThan = 0b100,
+        GreaterEquals = 0b101,
+        LessThanUnsigned = 0b110,
+        GreaterEqualsUnsigned = 0b111,
+    };
+
+    virtual ~Branch() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(Branch const&) const = default;
+
+    Branch(Condition condition, i32 offset, Register rs1, Register rs2)
+        : BSTypeInstruction(offset, rs1, rs2)
+        , m_condition(condition)
+    {
+    }
+
+private:
+    Condition m_condition;
+};
+
+class Fence : public InstructionImpl {
+public:
+    enum class AccessType : u8 {
+        Input = 1 << 3,
+        Output = 1 << 2,
+        Read = 1 << 1,
+        Write = 1 << 0,
+    };
+
+    enum class Mode : u8 {
+        Normal = 0,
+        // Used by fence.tso for implementing Total Store Ordering (x86's memory consistency model)
+        // Chapter 2.7: "This leaves non-AMO store operations in the FENCE.TSO’s predecessor set unordered with non-AMO loads in its successor set."
+        NoStoreToLoadOrdering = 0b1000,
+    };
+
+    virtual ~Fence() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual i32 immediate() const override { return 0; }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(Fence const&) const = default;
+
+    Fence(AccessType predecessor, AccessType successor, Mode mode)
+        : m_predecessor(predecessor)
+        , m_successor(successor)
+        , m_mode(mode)
+    {
+    }
+
+private:
+    AccessType m_predecessor;
+    AccessType m_successor;
+    Mode m_mode;
+};
+AK_ENUM_BITWISE_OPERATORS(Fence::AccessType);
+
+class EnvironmentCall : public InstructionWithoutArguments {
+public:
+    virtual ~EnvironmentCall() = default;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(EnvironmentCall const&) const = default;
+
+    EnvironmentCall() = default;
+};
+
+class EnvironmentBreak : public InstructionWithoutArguments {
+public:
+    virtual ~EnvironmentBreak() = default;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(EnvironmentBreak const&) const = default;
+
+    EnvironmentBreak() = default;
+};
+
+class InstructionFetchFence : public InstructionWithoutArguments {
+public:
+    virtual ~InstructionFetchFence() = default;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(InstructionFetchFence const&) const = default;
+
+    InstructionFetchFence() = default;
+};
+
+NonnullOwnPtr<LoadUpperImmediate> parse_lui(u32 instruction);
+NonnullOwnPtr<JumpAndLink> parse_jal(u32 instruction);
+NonnullOwnPtr<JumpAndLinkRegister> parse_jalr(u32 instruction);
+NonnullOwnPtr<AddUpperImmediateToProgramCounter> parse_auipc(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_op_imm(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_op_imm_32(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_op_32(u32 instruction);
+NonnullOwnPtr<ArithmeticInstruction> parse_op(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_branch(u32 instruction);
+NonnullOwnPtr<MemoryLoad> parse_load(u32 instruction);
+NonnullOwnPtr<MemoryStore> parse_store(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_misc_mem(u32 instruction);
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Instruction.h"
+#include "Encoding.h"
+#include <AK/Assertions.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StdLibExtras.h>
+#include <AK/String.h>
+#include <AK/StringUtils.h>
+#include <AK/TypeCasts.h>
+#include <LibDisassembly/InstructionStream.h>
+
+namespace Disassembly::RISCV64 {
+
+MemoryAccessMode MemoryAccessMode::from_funct3(u8 funct3)
+{
+    auto width = static_cast<DataWidth>(funct3 & 0b11);
+    bool is_signed = (funct3 & 0b100) == 0;
+    return { width, is_signed ? Signedness::Signed : Signedness::Unsigned };
+}
+
+static NonnullOwnPtr<InstructionImpl> parse_full_impl(MajorOpcode opcode, u32 instruction)
+{
+    (void)opcode;
+    (void)instruction;
+    TODO();
+}
+
+static NonnullOwnPtr<InstructionImpl> parse_compressed_impl(CompressedOpcode opcode, u16 instruction)
+{
+    (void)opcode;
+    (void)instruction;
+    TODO();
+}
+
+NonnullOwnPtr<Instruction> Instruction::parse_full(u32 instruction)
+{
+    auto opcode = static_cast<MajorOpcode>(instruction & 0b11111'11);
+    auto instruction_data = parse_full_impl(opcode, instruction);
+    return adopt_own(*new (nothrow) Instruction(move(instruction_data), instruction));
+}
+
+NonnullOwnPtr<Instruction> Instruction::parse_compressed(u16 instruction)
+{
+    auto opcode = extract_compressed_opcode(instruction);
+    auto instruction_data = parse_compressed_impl(opcode, instruction);
+    return adopt_own(*new (nothrow) Instruction(move(instruction_data), instruction, CompressedTag {}));
+}
+
+NonnullOwnPtr<Instruction> Instruction::from_stream(InstructionStream& stream)
+{
+    u16 first_halfword = AK::convert_between_host_and_little_endian(stream.read16());
+    if (is_compressed_instruction(first_halfword))
+        return Instruction::parse_compressed(first_halfword);
+
+    u16 second_halfword = AK::convert_between_host_and_little_endian(stream.read16());
+    return Instruction::parse_full(first_halfword | (second_halfword << 16));
+}
+
+ByteString Instruction::to_byte_string(u32 origin, Optional<SymbolProvider const&> symbol_provider) const
+{
+    return m_data->to_string(m_display_style, origin, symbol_provider).to_byte_string();
+}
+
+ByteString Instruction::mnemonic() const
+{
+    return m_data->mnemonic().to_byte_string();
+}
+
+template<typename InstructionType>
+bool simple_instruction_equals(InstructionType const& self, InstructionImpl const& instruction)
+{
+    if (is<InstructionType>(instruction))
+        return self == static_cast<InstructionType const&>(instruction);
+    return false;
+}
+
+#define MAKE_INSTRUCTION_EQUALS(InstructionType) \
+    bool InstructionType::instruction_equals(InstructionImpl const& instruction) const { return simple_instruction_equals<InstructionType>(*this, instruction); }
+
+#define ENUMERATE_INSTRUCTION_IMPLS(M)
+
+ENUMERATE_INSTRUCTION_IMPLS(MAKE_INSTRUCTION_EQUALS)
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
@@ -6,6 +6,7 @@
 
 #include "Instruction.h"
 #include "Encoding.h"
+#include "IM.h"
 #include <AK/Assertions.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StdLibExtras.h>
@@ -82,7 +83,21 @@ bool simple_instruction_equals(InstructionType const& self, InstructionImpl cons
 #define MAKE_INSTRUCTION_EQUALS(InstructionType) \
     bool InstructionType::instruction_equals(InstructionImpl const& instruction) const { return simple_instruction_equals<InstructionType>(*this, instruction); }
 
-#define ENUMERATE_INSTRUCTION_IMPLS(M)
+#define ENUMERATE_INSTRUCTION_IMPLS(M)   \
+    M(UnknownInstruction)                \
+    M(JumpAndLink)                       \
+    M(JumpAndLinkRegister)               \
+    M(LoadUpperImmediate)                \
+    M(AddUpperImmediateToProgramCounter) \
+    M(ArithmeticImmediateInstruction)    \
+    M(ArithmeticInstruction)             \
+    M(MemoryLoad)                        \
+    M(MemoryStore)                       \
+    M(Branch)                            \
+    M(EnvironmentCall)                   \
+    M(EnvironmentBreak)                  \
+    M(Fence)                             \
+    M(InstructionFetchFence)
 
 ENUMERATE_INSTRUCTION_IMPLS(MAKE_INSTRUCTION_EQUALS)
 

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BitCast.h>
+#include <AK/ByteString.h>
+#include <AK/Endian.h>
+#include <AK/EnumBits.h>
+#include <AK/Forward.h>
+#include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
+#include <LibDisassembly/Instruction.h>
+#include <LibDisassembly/InstructionStream.h>
+#include <LibDisassembly/riscv64/Encoding.h>
+#include <LibDisassembly/riscv64/Registers.h>
+
+// All section numbers from the RISC-V Unprivileged ISA specification V20191213
+namespace Disassembly::RISCV64 {
+
+// Various parameters to control how RISC-V instructions are displayed.
+struct DisplayStyle {
+    enum class RegisterNames : u8 {
+        // Uses hardware names; x0 - x31, f0 - f31
+        Hardware,
+        // Uses standard ABI names; ra, zero, a0, s1, ft2, ...
+        ABI,
+        // Uses ABI names with fp instead of s0.
+        ABIWithFramePointer,
+    } register_names { RegisterNames::ABIWithFramePointer };
+
+    // Use various convenience aliases that most assemblers support, such as j <offset> instead of jal x0, <offset>.
+    enum class UsePseudoinstructions : bool {
+        No,
+        Yes,
+    } use_pseudoinstructions { UsePseudoinstructions::Yes };
+
+    // For instructions who encode a relative offset, show either the raw offset (as encoded in the instruction immediate)
+    // or the target address in addition to an associated symbol, if available.
+    enum class RelativeAddressStyle : u8 {
+        Offset,
+        Symbol,
+    } relative_address_style { RelativeAddressStyle::Symbol };
+};
+
+class InstructionImpl {
+public:
+    virtual ~InstructionImpl() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const = 0;
+    virtual i32 immediate() const = 0;
+    virtual String mnemonic() const = 0;
+    // Making the equality operator virtual would prevent us from defaulting (i.e. auto-generating) all normal equality operators,
+    // since C++ selects the virtual equality operator for "the parent's equality check", which in fact will just call the same virtual equality operator again.
+    virtual bool instruction_equals(InstructionImpl const&) const = 0;
+    // Do not call this if you wish to compare two instructions.
+    bool operator==(InstructionImpl const&) const { return true; }
+};
+
+class Instruction : public Disassembly::Instruction {
+    AK_MAKE_DEFAULT_MOVABLE(Instruction);
+    AK_MAKE_NONCOPYABLE(Instruction);
+
+private:
+    struct CompressedTag { };
+
+public:
+    virtual ~Instruction() = default;
+
+    template<typename InstructionStreamType>
+    static NonnullOwnPtr<Instruction> from_stream(InstructionStreamType&, DisplayStyle);
+    static NonnullOwnPtr<Instruction> from_stream(InstructionStream&);
+
+    virtual ByteString to_byte_string(u32, Optional<SymbolProvider const&>) const override;
+    virtual size_t length() const override
+    {
+        return m_was_compressed ? 2 : 4;
+    }
+    virtual ByteString mnemonic() const override;
+
+    static NonnullOwnPtr<Instruction> parse_compressed(u16 compressed_instruction);
+    static NonnullOwnPtr<Instruction> parse_full(u32 instruction);
+
+    Instruction(NonnullOwnPtr<InstructionImpl> data, u16 raw_instruction, CompressedTag)
+        : m_data(move(data))
+        , m_was_compressed(true)
+        , m_raw_instruction(raw_instruction)
+    {
+    }
+
+    Instruction(NonnullOwnPtr<InstructionImpl> data, u32 raw_instruction)
+        : m_data(move(data))
+        , m_was_compressed(false)
+        , m_raw_instruction(raw_instruction)
+    {
+    }
+
+    void set_display_style(DisplayStyle display_style) { m_display_style = display_style; }
+
+    InstructionImpl const& instruction_data() const { return *m_data; }
+    u32 raw_instruction() const { return m_raw_instruction; }
+
+private:
+    // FIXME: Figure out a nice way of storing this data inline (while being able to pass the InstructionImpl as a NonnullOwnPtr and not invoking tons of UB).
+    NonnullOwnPtr<InstructionImpl> m_data;
+    bool m_was_compressed;
+    // May only contain a halfword if it was a compressed instruction.
+    u32 m_raw_instruction;
+    DisplayStyle m_display_style;
+};
+
+class InstructionWithDestinationRegister {
+public:
+    InstructionWithDestinationRegister(Register rd)
+        : m_destination_register(rd)
+    {
+    }
+    bool operator==(InstructionWithDestinationRegister const&) const = default;
+
+    Register destination_register() const { return m_destination_register; }
+
+private:
+    Register m_destination_register;
+};
+
+class InstructionWithSourceRegister {
+public:
+    InstructionWithSourceRegister(Register rs1)
+        : m_source_register(rs1)
+    {
+    }
+    bool operator==(InstructionWithSourceRegister const&) const = default;
+
+    Register source_register() const { return m_source_register; }
+
+private:
+    Register m_source_register;
+};
+
+class InstructionWithTwoSourceRegisters {
+public:
+    InstructionWithTwoSourceRegisters(Register rs1, Register rs2)
+        : m_source_register_1(rs1)
+        , m_source_register_2(rs2)
+    {
+    }
+    bool operator==(InstructionWithTwoSourceRegisters const&) const = default;
+
+    Register source_register_1() const { return m_source_register_1; }
+    Register source_register_2() const { return m_source_register_2; }
+
+private:
+    Register m_source_register_1;
+    Register m_source_register_2;
+};
+
+// In terms of fields, U and J-type are identical, they just use differently scrambled immediate bits.
+class UJTypeInstruction : public InstructionWithDestinationRegister
+    , public InstructionImpl {
+public:
+    virtual ~UJTypeInstruction() = default;
+    virtual i32 immediate() const override { return m_immediate; }
+    bool operator==(UJTypeInstruction const&) const = default;
+
+    UJTypeInstruction(i32 immediate, Register rd)
+        : InstructionWithDestinationRegister(rd)
+        , m_immediate(immediate)
+    {
+    }
+
+private:
+    i32 m_immediate;
+};
+
+class ITypeInstruction : public InstructionWithDestinationRegister
+    , public InstructionWithSourceRegister
+    , public InstructionImpl {
+public:
+    virtual ~ITypeInstruction() = default;
+    virtual i32 immediate() const override { return m_immediate; }
+    bool operator==(ITypeInstruction const&) const = default;
+
+    ITypeInstruction(i32 immediate, Register rs1, Register rd)
+        : InstructionWithDestinationRegister(rd)
+        , InstructionWithSourceRegister(rs1)
+        , m_immediate(immediate)
+    {
+    }
+
+private:
+    i32 m_immediate;
+};
+
+// In terms of fields, S and B-type are identical, they just use differently scrambled immediate bits.
+class BSTypeInstruction : public InstructionImpl
+    , public InstructionWithTwoSourceRegisters {
+public:
+    virtual ~BSTypeInstruction() = default;
+    virtual i32 immediate() const override { return m_immediate; }
+    bool operator==(BSTypeInstruction const&) const = default;
+
+    BSTypeInstruction(i32 immediate, Register rs1, Register rs2)
+        : InstructionWithTwoSourceRegisters(rs1, rs2)
+        , m_immediate(immediate)
+    {
+    }
+
+private:
+    i32 m_immediate;
+};
+
+class RTypeInstruction : public InstructionImpl
+    , public InstructionWithDestinationRegister
+    , public InstructionWithTwoSourceRegisters {
+public:
+    virtual ~RTypeInstruction() = default;
+    virtual i32 immediate() const override { return 0; }
+    bool operator==(RTypeInstruction const&) const = default;
+
+    RTypeInstruction(Register rs1, Register rs2, Register rd)
+        : InstructionWithDestinationRegister(rd)
+        , InstructionWithTwoSourceRegisters(rs1, rs2)
+    {
+    }
+};
+
+class InstructionWithoutArguments : public InstructionImpl {
+public:
+    virtual ~InstructionWithoutArguments() = default;
+
+    virtual i32 immediate() const override { return 0; }
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+};
+
+enum class Signedness : bool {
+    Signed,
+    Unsigned,
+};
+
+// Widths are represented by their corresponding powers of two byte sizes.
+enum class DataWidth : u8 {
+    Byte = 0,
+    Halfword = 1,
+    Word = 2,
+    DoubleWord = 3,
+    QuadWord = 4,
+};
+
+struct MemoryAccessMode {
+    static MemoryAccessMode from_funct3(u8 funct3);
+
+    bool operator==(MemoryAccessMode const&) const = default;
+
+    DataWidth width;
+    Signedness signedness;
+};
+
+template<typename InstructionStreamType>
+NonnullOwnPtr<Instruction> Instruction::from_stream(InstructionStreamType& stream, DisplayStyle display_style)
+{
+    auto instruction = Instruction::from_stream(stream);
+    instruction->set_display_style(display_style);
+    return instruction;
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.h
@@ -111,6 +111,14 @@ private:
     DisplayStyle m_display_style;
 };
 
+class UnknownInstruction : public InstructionImpl {
+public:
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual i32 immediate() const override { return 0; }
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+};
+
 class InstructionWithDestinationRegister {
 public:
     InstructionWithDestinationRegister(Register rd)

--- a/Userland/Libraries/LibDisassembly/riscv64/Registers.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Registers.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DistinctNumeric.h>
+
+namespace Disassembly::RISCV64 {
+
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u8, Register, CastToUnderlying);
+
+// RISC-V ABIs Specification Version 1.0
+// 1.1 Integer Register Convention, Table 1
+enum class RegisterABINames : u8 {
+    zero = 0,
+    ra = 1,
+    sp = 2,
+    gp = 3,
+    tp = 4,
+    t0 = 5,
+    t1 = 6,
+    t2 = 7,
+    s0 = 8,
+    s1 = 9,
+    a0 = 10,
+    a1 = 11,
+    a2 = 12,
+    a3 = 13,
+    a4 = 14,
+    a5 = 15,
+    a6 = 16,
+    a7 = 17,
+    s2 = 18,
+    s3 = 19,
+    s4 = 20,
+    s5 = 21,
+    s6 = 22,
+    s7 = 23,
+    s8 = 24,
+    s9 = 25,
+    s10 = 26,
+    s11 = 27,
+    t3 = 28,
+    t4 = 29,
+    t5 = 30,
+    t6 = 31,
+};
+
+// As per 1.1 Integer Register Convention:
+// "The presence of a frame pointer is optional.
+//  If a frame pointer exists, it must reside in x8 (s0); the register remains callee-saved."
+// On default compile settings, SerenityOS uses a frame pointer, but with different compiler flags on the same ABI,
+// the frame pointer may be omitted or not on a function-by-function basis.
+// Disassembly frontends can therfore decide whether to print this register as s0 or fp.
+enum class RegisterABINamesWithFP : u8 {
+    zero = 0,
+    ra = 1,
+    sp = 2,
+    gp = 3,
+    tp = 4,
+    t0 = 5,
+    t1 = 6,
+    t2 = 7,
+    fp = 8,
+    s1 = 9,
+    a0 = 10,
+    a1 = 11,
+    a2 = 12,
+    a3 = 13,
+    a4 = 14,
+    a5 = 15,
+    a6 = 16,
+    a7 = 17,
+    s2 = 18,
+    s3 = 19,
+    s4 = 20,
+    s5 = 21,
+    s6 = 22,
+    s7 = 23,
+    s8 = 24,
+    s9 = 25,
+    s10 = 26,
+    s11 = 27,
+    t3 = 28,
+    t4 = 29,
+    t5 = 30,
+    t6 = 31,
+};
+
+AK_MAKE_DISTINCT_NUMERIC_COMPARABLE_TO_ENUM(Register, RegisterABINames);
+AK_MAKE_DISTINCT_NUMERIC_COMPARABLE_TO_ENUM(Register, RegisterABINamesWithFP);
+
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u8, FloatRegister, CastToUnderlying);
+
+// 1.2 Floating-point Register Convention, Table 2
+enum class FloatRegisterABINames : u8 {
+    ft0 = 0,
+    ft1 = 1,
+    ft2 = 2,
+    ft3 = 3,
+    ft4 = 4,
+    ft5 = 5,
+    ft6 = 6,
+    ft7 = 7,
+    fs0 = 8,
+    fs1 = 9,
+    fa0 = 10,
+    fa1 = 11,
+    fa2 = 12,
+    fa3 = 13,
+    fa4 = 14,
+    fa5 = 15,
+    fa6 = 16,
+    fa7 = 17,
+    fs2 = 18,
+    fs3 = 19,
+    fs4 = 20,
+    fs5 = 21,
+    fs6 = 22,
+    fs7 = 23,
+    fs8 = 24,
+    fs9 = 25,
+    fs10 = 26,
+    fs11 = 27,
+    ft8 = 28,
+    ft9 = 29,
+    ft10 = 30,
+    ft11 = 31,
+};
+
+AK_MAKE_DISTINCT_NUMERIC_COMPARABLE_TO_ENUM(FloatRegister, FloatRegisterABINames);
+
+// Specializations define two associated types:
+// ABIType: The type to use for printing ABI names
+// ABIWithFPType: The type to use for printing ABI names, with fp instead of s0.
+template<typename BaseRegisterType>
+struct RegisterNameTraits { };
+
+template<>
+struct RegisterNameTraits<Register> {
+    using ABIType = RegisterABINames;
+    using ABIWithFPType = RegisterABINamesWithFP;
+};
+
+template<>
+struct RegisterNameTraits<FloatRegister> {
+    using ABIType = FloatRegisterABINames;
+    using ABIWithFPType = FloatRegisterABINames;
+};
+
+// This API is intended for decoding / encoding purposes only, be careful when using it.
+constexpr FloatRegister as_float_register(Register reg)
+{
+    return static_cast<FloatRegister>(reg.value());
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEG2000Boxes.cpp
@@ -6,6 +6,7 @@
 
 #include "JPEG2000Boxes.h"
 #include <AK/Function.h>
+#include <AK/IntegralMath.h>
 
 // Core coding system spec (.jp2 format): T-REC-T.800-201511-S!!PDF-E.pdf available here:
 // https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-T.800-201511-S!!PDF-E&type=items
@@ -166,8 +167,8 @@ ErrorOr<void> JPEG2000PaletteBox::read_from_stream(BoxStream& stream)
             }
 
             // Sign extend if needed.
-            if (bit_depth.is_signed && (value >> (bit_depth.depth - 1)))
-                value |= ~((1LL << bit_depth.depth) - 1);
+            if (bit_depth.is_signed)
+                value = AK::sign_extend(static_cast<u64>(value), bit_depth.depth);
 
             color.append(value);
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/IntegralMath.h>
 #include <AK/Utf16View.h>
 #include <LibGfx/ImageFormats/CCITTDecoder.h>
 #include <LibGfx/ImageFormats/JBIG2Loader.h>
@@ -2044,10 +2045,7 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     u8 delta_s_offset_value = (text_region_segment_flags >> 10) & 0x1f; // "SBDSOFFSET" in spec.
     i8 delta_s_offset = delta_s_offset_value;
     if (delta_s_offset_value & 0x10) {
-        // This is converting a 5-bit two's complement number ot i8.
-        // FIXME: There's probably a simpler way to do this? Probably just sign-extend by or-ing in the top 3 bits?
-        delta_s_offset_value = (~delta_s_offset_value + 1) & 0x1f;
-        delta_s_offset = -delta_s_offset_value;
+        delta_s_offset = AK::sign_extend(delta_s_offset_value, 5);
     }
 
     u8 refinement_template = (text_region_segment_flags >> 15) != 0; // "SBRTEMPLATE" in spec.

--- a/Userland/Libraries/LibHID/ReportParser.cpp
+++ b/Userland/Libraries/LibHID/ReportParser.cpp
@@ -7,6 +7,7 @@
 #include <AK/ByteReader.h>
 #include <AK/Endian.h>
 #include <AK/Function.h>
+#include <AK/IntegralMath.h>
 #include <AK/MemoryStream.h>
 #include <LibHID/ReportDescriptorParser.h>
 #include <LibHID/ReportParser.h>
@@ -51,7 +52,7 @@ ErrorOr<void> parse_input_report(ParsedReportDescriptor const& report_descriptor
         // 5.8 Format of Multibyte Numeric Values: If Logical Minimum and Logical Maximum are both positive values
         // then a sign bit is unnecessary in the report field and the contents of a field can be assumed to be an unsigned value.
         if (field.logical_minimum < 0)
-            field_value = (static_cast<i32>(field_value << (32 - field_size_in_bits))) >> (32 - field_size_in_bits);
+            field_value = AK::sign_extend(static_cast<u64>(field_value), field_size_in_bits);
 
         if (TRY(callback(field, field_value)) == IterationDecision::Break)
             return {};

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -14,6 +14,7 @@
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Function.h>
+#include <AK/IntegralMath.h>
 #include <AK/Result.h>
 #include <AK/String.h>
 #include <AK/Types.h>
@@ -435,8 +436,7 @@ public:
         return static_cast<FlatPtr>(encoded & 0xffff'ffff);
 #elif ARCH(X86_64) || ARCH(RISCV64)
         // For x86_64 and riscv64 the top 16 bits should be sign extending the "real" top bit (47th).
-        // So first shift the top 16 bits away then using the right shift it sign extends the top 16 bits.
-        return static_cast<FlatPtr>((static_cast<i64>(encoded << 16)) >> 16);
+        return AK::sign_extend(encoded, 48);
 #elif ARCH(AARCH64)
         // For AArch64 the top 16 bits of the pointer should be zero.
         return static_cast<FlatPtr>(encoded & 0xffff'ffff'ffffULL);


### PR DESCRIPTION
As per popular request, #21540 is being split up to be easier to review. This is probably the smallest I can make the initial work without leaving a ton of dead code.

Actually, this is RV64IMZifencei and RV32IMZifencei:
- As per RISC-V, RV64I of course includes RV32I
- The M extension is not separable in a good way since it just adds more arithmetic instructions that are represented in a common class with other I instructions.
- Zifencei is just one instruction (FENCE.I) that doesn't need its own file.