### PR TITLE
LibGfx/JPEG2000: Add support for remaining progression orders

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -708,6 +708,7 @@ TEST_CASE(test_jpeg2000_decode)
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog1-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog2-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog3-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
+        TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog4-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/jasper-rgba-u8-cbstyle-01-bypass.jp2"sv),
         TEST_INPUT("jpeg2000/jasper-rgba-u8-cbstyle-01-bypass-layers.jp2"sv),
         TEST_INPUT("jpeg2000/jasper-rgba-u8-cbstyle-01-bypass-finer-layers.jp2"sv),
@@ -947,7 +948,6 @@ TEST_CASE(test_jpeg2000_decode_unsupported)
         TEST_INPUT("jpeg2000/openjpeg-lossless-RGN.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-bgra-u8.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog0-tile-part-index-overflow.jp2"sv),
-        TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog4-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
 
         // FIXME: See FIXME in JPEG2000ColorSpecificationBox::read_from_stream() for lab.
         // TEST_INPUT("jpeg2000/kakadu-lossless-lab-u8-prog1-layers1-res6.jp2"sv),
@@ -1107,6 +1107,39 @@ TEST_CASE(test_jpeg2000_progression_iterators)
 
         for (int precinct = 0; precinct < precinct_count_number; ++precinct)
             for (int component = 0; component < component_count; ++component)
+                for (int resolution_level = 0; resolution_level <= max_number_of_decomposition_levels; ++resolution_level)
+                    for (int layer = 0; layer < layer_count; ++layer) {
+                        EXPECT(iterator.has_next());
+                        EXPECT_EQ(iterator.next(), (Gfx::JPEG2000::ProgressionData { .layer = layer, .resolution_level = resolution_level, .component = component, .precinct = precinct }));
+                    }
+        EXPECT(!iterator.has_next());
+    }
+
+    {
+        int const layer_count = 2;
+        int const max_number_of_decomposition_levels = 2;
+        int const component_count = 4;
+        int const precinct_count_number = 5;
+        auto precinct_count = [](int, int) { return precinct_count_number; };
+
+        Gfx::IntRect tile_rect { 0, 0, 5 * 32, 32 };
+        auto XRsiz = [&](size_t) { return 1; };
+        auto YRsiz = [&](size_t) { return 1; };
+
+        auto PPx = [&](int r, int) { return 5 - (max_number_of_decomposition_levels - r); };
+        auto PPy = [&](int r, int) { return 5 - (max_number_of_decomposition_levels - r); };
+        auto N_L = [&](int) { return max_number_of_decomposition_levels; };
+        auto num_precincts_wide = [&](int, int) { return precinct_count_number; };
+        auto ll_rect = [&](int r, int) {
+            return tile_rect / (1 << (max_number_of_decomposition_levels - r));
+        };
+        Gfx::JPEG2000::ComponentPositionResolutionLevelLayerProgressionIterator iterator {
+            layer_count, component_count, move(precinct_count),
+            move(XRsiz), move(YRsiz), move(PPx), move(PPy), move(N_L), move(num_precincts_wide), tile_rect, move(ll_rect)
+        };
+
+        for (int component = 0; component < component_count; ++component)
+            for (int precinct = 0; precinct < precinct_count_number; ++precinct)
                 for (int resolution_level = 0; resolution_level <= max_number_of_decomposition_levels; ++resolution_level)
                     for (int layer = 0; layer < layer_count; ++layer) {
                         EXPECT(iterator.has_next());

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -706,6 +706,7 @@ TEST_CASE(test_jpeg2000_decode)
         TEST_INPUT("jpeg2000/kakadu-lossless-rgba-u8-prog1-layers1-res6-mct.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog0-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog1-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
+        TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog2-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/jasper-rgba-u8-cbstyle-01-bypass.jp2"sv),
         TEST_INPUT("jpeg2000/jasper-rgba-u8-cbstyle-01-bypass-layers.jp2"sv),
         TEST_INPUT("jpeg2000/jasper-rgba-u8-cbstyle-01-bypass-finer-layers.jp2"sv),
@@ -945,7 +946,6 @@ TEST_CASE(test_jpeg2000_decode_unsupported)
         TEST_INPUT("jpeg2000/openjpeg-lossless-RGN.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-bgra-u8.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog0-tile-part-index-overflow.jp2"sv),
-        TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog2-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog3-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
         TEST_INPUT("jpeg2000/openjpeg-lossless-rgba-u8-prog4-tile4x2-cblk4x16-tp3-layers3-res2.jp2"sv),
 
@@ -1043,6 +1043,39 @@ TEST_CASE(test_jpeg2000_progression_iterators)
             for (int layer = 0; layer < layer_count; ++layer)
                 for (int component = 0; component < component_count; ++component)
                     for (int precinct = 0; precinct < precinct_count(resolution_level, component); ++precinct) {
+                        EXPECT(iterator.has_next());
+                        EXPECT_EQ(iterator.next(), (Gfx::JPEG2000::ProgressionData { .layer = layer, .resolution_level = resolution_level, .component = component, .precinct = precinct }));
+                    }
+        EXPECT(!iterator.has_next());
+    }
+
+    {
+        int const layer_count = 2;
+        int const max_number_of_decomposition_levels = 2;
+        int const component_count = 4;
+        int const precinct_count_number = 5;
+        auto precinct_count = [](int, int) { return precinct_count_number; };
+
+        Gfx::IntRect tile_rect { 0, 0, 5 * 32, 32 };
+        auto XRsiz = [&](size_t) { return 1; };
+        auto YRsiz = [&](size_t) { return 1; };
+
+        auto PPx = [&](int r, int) { return 5 - (max_number_of_decomposition_levels - r); };
+        auto PPy = [&](int r, int) { return 5 - (max_number_of_decomposition_levels - r); };
+        auto N_L = [&](int) { return max_number_of_decomposition_levels; };
+        auto num_precincts_wide = [&](int, int) { return precinct_count_number; };
+        auto ll_rect = [&](int r, int) {
+            return tile_rect / (1 << (max_number_of_decomposition_levels - r));
+        };
+        Gfx::JPEG2000::ResolutionLevelPositionComponentLayerProgressionIterator iterator {
+            layer_count, max_number_of_decomposition_levels, component_count, move(precinct_count),
+            move(XRsiz), move(YRsiz), move(PPx), move(PPy), move(N_L), move(num_precincts_wide), tile_rect, move(ll_rect)
+        };
+
+        for (int resolution_level = 0; resolution_level <= max_number_of_decomposition_levels; ++resolution_level)
+            for (int precinct = 0; precinct < precinct_count_number; ++precinct)
+                for (int component = 0; component < component_count; ++component)
+                    for (int layer = 0; layer < layer_count; ++layer) {
                         EXPECT(iterator.has_next());
                         EXPECT_EQ(iterator.next(), (Gfx::JPEG2000::ProgressionData { .layer = layer, .resolution_level = resolution_level, .component = component, .precinct = precinct }));
                     }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000Loader.cpp
@@ -1625,7 +1625,8 @@ static ErrorOr<void> compute_decoding_metadata(JPEG2000LoadingContext& context)
         case CodingStyleDefault::ResolutionLayerComponentPosition:
             return make<JPEG2000::ResolutionLevelLayerComponentPositionProgressionIterator>(number_of_layers, max_number_of_decomposition_levels, context.siz.components.size(), move(number_of_precincts_from_resolution_level_and_component));
         case CodingStyleDefault::ResolutionPositionComponentLayer:
-        case CodingStyleDefault::PositionComponentResolutionLayer: {
+        case CodingStyleDefault::PositionComponentResolutionLayer:
+        case CodingStyleDefault::ComponentPositionResolutionLayer: {
             auto XRsiz = [&](size_t i) { return context.siz.components[i].horizontal_separation; };
             auto YRsiz = [&](size_t i) { return context.siz.components[i].vertical_separation; };
 
@@ -1658,12 +1659,14 @@ static ErrorOr<void> compute_decoding_metadata(JPEG2000LoadingContext& context)
                 return make<JPEG2000::ResolutionLevelPositionComponentLayerProgressionIterator>(
                     number_of_layers, max_number_of_decomposition_levels, context.siz.components.size(), move(number_of_precincts_from_resolution_level_and_component),
                     move(XRsiz), move(YRsiz), move(PPx), move(PPy), move(N_L), move(num_precincts_wide), tile.rect, move(ll_rect));
-            return make<JPEG2000::PositionComponentResolutionLevelLayerProgressionIterator>(
+            if (tile.cod.value_or(context.cod).progression_order == CodingStyleDefault::PositionComponentResolutionLayer)
+                return make<JPEG2000::PositionComponentResolutionLevelLayerProgressionIterator>(
+                    number_of_layers, context.siz.components.size(), move(number_of_precincts_from_resolution_level_and_component),
+                    move(XRsiz), move(YRsiz), move(PPx), move(PPy), move(N_L), move(num_precincts_wide), tile.rect, move(ll_rect));
+            return make<JPEG2000::ComponentPositionResolutionLevelLayerProgressionIterator>(
                 number_of_layers, context.siz.components.size(), move(number_of_precincts_from_resolution_level_and_component),
                 move(XRsiz), move(YRsiz), move(PPx), move(PPy), move(N_L), move(num_precincts_wide), tile.rect, move(ll_rect));
         }
-        case CodingStyleDefault::ComponentPositionResolutionLayer:
-            return Error::from_string_literal("JPEG2000Loader: ComponentPositionResolutionLayer progression order not yet supported");
         }
         VERIFY_NOT_REACHED();
     };

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.cpp
@@ -261,4 +261,89 @@ SyncGenerator<ProgressionData> PositionComponentResolutionLevelLayerProgressionI
     }
 }
 
+ComponentPositionResolutionLevelLayerProgressionIterator::ComponentPositionResolutionLevelLayerProgressionIterator(
+    int layer_count, int component_count, Function<int(int resolution_level, int component)> precinct_count,
+    Function<int(int component)> XRsiz, Function<int(int component)> YRsiz,
+    Function<int(int resolution_level, int component)> PPx, Function<int(int resolution_level, int component)> PPy,
+    Function<int(int component)> N_L,
+    Function<int(int resolution_level, int component)> num_precincts_wide,
+    Gfx::IntRect tile_rect,
+    Function<IntRect(int resolution_level, int component)> ll_rect)
+    : m_layer_count(layer_count)
+    , m_component_count(component_count)
+    , m_precinct_count(move(precinct_count))
+    , m_XRsiz(move(XRsiz))
+    , m_YRsiz(move(YRsiz))
+    , m_PPx(move(PPx))
+    , m_PPy(move(PPy))
+    , m_N_L(move(N_L))
+    , m_num_precincts_wide(move(num_precincts_wide))
+    , m_tile_rect(tile_rect)
+    , m_ll_rect(move(ll_rect))
+    , m_generator(generator())
+{
+    m_next = m_generator.next();
+}
+
+bool ComponentPositionResolutionLevelLayerProgressionIterator::has_next() const
+{
+    return m_next.has_value();
+}
+
+ProgressionData ComponentPositionResolutionLevelLayerProgressionIterator::next()
+{
+    auto result = m_next;
+    m_next = m_generator.next();
+    return result.value();
+}
+
+SyncGenerator<ProgressionData> ComponentPositionResolutionLevelLayerProgressionIterator::generator()
+{
+    auto compute_precinct = [&](int x, int y, int r, int i) {
+        // (B-20)
+        auto const trx0 = m_ll_rect(r, i).left();
+        auto const try0 = m_ll_rect(r, i).top();
+        auto const x_offset = floor_div(ceil_div(x, m_XRsiz(i) * (1 << (m_N_L(i) - r))), 1 << m_PPx(r, i)) - floor_div(trx0, 1 << m_PPx(r, i));
+        auto const y_offset = floor_div(ceil_div(y, m_YRsiz(i) * (1 << (m_N_L(i) - r))), 1 << m_PPy(r, i)) - floor_div(try0, 1 << m_PPy(r, i));
+        return x_offset + m_num_precincts_wide(r, i) * y_offset;
+    };
+    // B.12.1.5 Component-position-resolution level-layer progression
+    // "for each i = 0,..., Csiz – 1
+    //      for each y = ty0,..., ty1 – 1,
+    //          for each x = tx0,..., tx1 – 1,
+    //              for each r = 0,..., NL where NL is the number of decomposition levels for component i,
+    //                  if ((y divisible by YRsiz(i) * 2 ** (PPy(r, i) + N_L(i) - r) OR
+    //                      ((y == ty0) AND (try0 * 2 ** (N_L(i) - r) NOT divisible by 2 ** (PPy(r, i) + N_L(i) - r))))
+    //                      if ((x divisible by XRsiz(i) * 2 ** (PPx(r, i) + N_L(i) - r) OR
+    //                          ((x == tx0) AND (trx0 * 2 ** (N_L(i) - r) NOT divisible by 2 ** (PPx(r, i) + N_L(i) - r))))
+    //                              for the next precinct, k, if one exists, in the sequence shown in Figure B.8
+    //                                  for each l = 0,..., L – 1
+    //                                      packet for component i, resolution level r, layer l, and precinct k."
+    // The motivation for this loop is to walk corresponding precincts in different resolution levels at the same time,
+    // even if the resolution levels have different precinct counts.
+    auto const tx0 = m_tile_rect.left();
+    auto const ty0 = m_tile_rect.top();
+    for (int i = 0; i < m_component_count; ++i) {
+        for (int y = ty0; y < m_tile_rect.bottom(); ++y) {
+            for (int x = tx0; x < m_tile_rect.right(); ++x) {
+                for (int r = 0; r <= m_N_L(i); ++r) {
+                    auto const trx0 = m_ll_rect(r, i).left();
+                    auto const try0 = m_ll_rect(r, i).top();
+                    if ((y % (m_YRsiz(i) * (1 << (m_PPy(r, i) + m_N_L(i) - r))) == 0)
+                        || ((y == ty0) && (try0 * (1 << (m_N_L(i) - r)) % (1 << (m_PPy(r, i) + m_N_L(i) - r)) != 0))) {
+                        if ((x % (m_XRsiz(i) * (1 << (m_PPx(r, i) + m_N_L(i) - r))) == 0)
+                            || ((x == tx0) && (trx0 * (1 << (m_N_L(i) - r)) % (1 << (m_PPx(r, i) + m_N_L(i) - r)) != 0))) {
+                            if (int k = compute_precinct(x, y, r, i); k < m_precinct_count(r, i)) {
+                                for (int l = 0; l < m_layer_count; ++l) {
+                                    co_yield ProgressionData { l, r, i, k };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.cpp
@@ -176,4 +176,89 @@ SyncGenerator<ProgressionData> ResolutionLevelPositionComponentLayerProgressionI
     }
 }
 
+PositionComponentResolutionLevelLayerProgressionIterator::PositionComponentResolutionLevelLayerProgressionIterator(
+    int layer_count, int component_count, Function<int(int resolution_level, int component)> precinct_count,
+    Function<int(int component)> XRsiz, Function<int(int component)> YRsiz,
+    Function<int(int resolution_level, int component)> PPx, Function<int(int resolution_level, int component)> PPy,
+    Function<int(int component)> N_L,
+    Function<int(int resolution_level, int component)> num_precincts_wide,
+    Gfx::IntRect tile_rect,
+    Function<IntRect(int resolution_level, int component)> ll_rect)
+    : m_layer_count(layer_count)
+    , m_component_count(component_count)
+    , m_precinct_count(move(precinct_count))
+    , m_XRsiz(move(XRsiz))
+    , m_YRsiz(move(YRsiz))
+    , m_PPx(move(PPx))
+    , m_PPy(move(PPy))
+    , m_N_L(move(N_L))
+    , m_num_precincts_wide(move(num_precincts_wide))
+    , m_tile_rect(tile_rect)
+    , m_ll_rect(move(ll_rect))
+    , m_generator(generator())
+{
+    m_next = m_generator.next();
+}
+
+bool PositionComponentResolutionLevelLayerProgressionIterator::has_next() const
+{
+    return m_next.has_value();
+}
+
+ProgressionData PositionComponentResolutionLevelLayerProgressionIterator::next()
+{
+    auto result = m_next;
+    m_next = m_generator.next();
+    return result.value();
+}
+
+SyncGenerator<ProgressionData> PositionComponentResolutionLevelLayerProgressionIterator::generator()
+{
+    auto compute_precinct = [&](int x, int y, int r, int i) {
+        // (B-20)
+        auto const trx0 = m_ll_rect(r, i).left();
+        auto const try0 = m_ll_rect(r, i).top();
+        auto const x_offset = floor_div(ceil_div(x, m_XRsiz(i) * (1 << (m_N_L(i) - r))), 1 << m_PPx(r, i)) - floor_div(trx0, 1 << m_PPx(r, i));
+        auto const y_offset = floor_div(ceil_div(y, m_YRsiz(i) * (1 << (m_N_L(i) - r))), 1 << m_PPy(r, i)) - floor_div(try0, 1 << m_PPy(r, i));
+        return x_offset + m_num_precincts_wide(r, i) * y_offset;
+    };
+    // B.12.1.4 Position-component-resolution level-layer progression
+    // "for each y = ty0,..., ty1 – 1,
+    //      for each x = tx0,..., tx1 – 1,
+    //          for each i = 0,..., Csiz – 1
+    //              for each r = 0,..., NL where NL is the number of decomposition levels for component i,
+    //                  if ((y divisible by YRsiz(i) * 2 ** (PPy(r, i) + N_L(i) - r) OR
+    //                      ((y == ty0) AND (try0 * 2 ** (N_L(i) - r) NOT divisible by 2 ** (PPy(r, i) + N_L(i) - r))))
+    //                      if ((x divisible by XRsiz(i) * 2 ** (PPx(r, i) + N_L(i) - r) OR
+    //                          ((x == tx0) AND (trx0 * 2 ** (N_L(i) - r) NOT divisible by 2 ** (PPx(r, i) + N_L(i) - r))))
+    //                              for the next precinct, k, if one exists, in the sequence shown in Figure B.8
+    //                                  for each l = 0,..., L – 1
+    //                                      packet for component i, resolution level r, layer l, and precinct k."
+    // The motivation for this loop is to walk corresponding precincts in different components and resolution levels at the same time,
+    // even if the components or resolution levels have different precinct counts.
+    auto const tx0 = m_tile_rect.left();
+    auto const ty0 = m_tile_rect.top();
+    for (int y = ty0; y < m_tile_rect.bottom(); ++y) {
+        for (int x = tx0; x < m_tile_rect.right(); ++x) {
+            for (int i = 0; i < m_component_count; ++i) {
+                for (int r = 0; r <= m_N_L(i); ++r) {
+                    auto const trx0 = m_ll_rect(r, i).left();
+                    auto const try0 = m_ll_rect(r, i).top();
+                    if ((y % (m_YRsiz(i) * (1 << (m_PPy(r, i) + m_N_L(i) - r))) == 0)
+                        || ((y == ty0) && (try0 * (1 << (m_N_L(i) - r)) % (1 << (m_PPy(r, i) + m_N_L(i) - r)) != 0))) {
+                        if ((x % (m_XRsiz(i) * (1 << (m_PPx(r, i) + m_N_L(i) - r))) == 0)
+                            || ((x == tx0) && (trx0 * (1 << (m_N_L(i) - r)) % (1 << (m_PPx(r, i) + m_N_L(i) - r)) != 0))) {
+                            if (int k = compute_precinct(x, y, r, i); k < m_precinct_count(r, i)) {
+                                for (int l = 0; l < m_layer_count; ++l) {
+                                    co_yield ProgressionData { l, r, i, k };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.cpp
@@ -90,4 +90,90 @@ SyncGenerator<ProgressionData> ResolutionLevelLayerComponentPositionProgressionI
                     co_yield ProgressionData { l, r, i, k };
 }
 
+ResolutionLevelPositionComponentLayerProgressionIterator::ResolutionLevelPositionComponentLayerProgressionIterator(
+    int layer_count, int max_number_of_decomposition_levels, int component_count, Function<int(int resolution_level, int component)> precinct_count,
+    Function<int(int component)> XRsiz, Function<int(int component)> YRsiz,
+    Function<int(int resolution_level, int component)> PPx, Function<int(int resolution_level, int component)> PPy,
+    Function<int(int component)> N_L,
+    Function<int(int resolution_level, int component)> num_precincts_wide,
+    Gfx::IntRect tile_rect,
+    Function<IntRect(int resolution_level, int component)> ll_rect)
+    : m_layer_count(layer_count)
+    , m_max_number_of_decomposition_levels(max_number_of_decomposition_levels)
+    , m_component_count(component_count)
+    , m_precinct_count(move(precinct_count))
+    , m_XRsiz(move(XRsiz))
+    , m_YRsiz(move(YRsiz))
+    , m_PPx(move(PPx))
+    , m_PPy(move(PPy))
+    , m_N_L(move(N_L))
+    , m_num_precincts_wide(move(num_precincts_wide))
+    , m_tile_rect(tile_rect)
+    , m_ll_rect(move(ll_rect))
+    , m_generator(generator())
+{
+    m_next = m_generator.next();
+}
+
+bool ResolutionLevelPositionComponentLayerProgressionIterator::has_next() const
+{
+    return m_next.has_value();
+}
+
+ProgressionData ResolutionLevelPositionComponentLayerProgressionIterator::next()
+{
+    auto result = m_next;
+    m_next = m_generator.next();
+    return result.value();
+}
+
+SyncGenerator<ProgressionData> ResolutionLevelPositionComponentLayerProgressionIterator::generator()
+{
+    auto compute_precinct = [&](int x, int y, int r, int i) {
+        // (B-20)
+        auto const trx0 = m_ll_rect(r, i).left();
+        auto const try0 = m_ll_rect(r, i).top();
+        auto const x_offset = floor_div(ceil_div(x, m_XRsiz(i) * (1 << (m_N_L(i) - r))), 1 << m_PPx(r, i)) - floor_div(trx0, 1 << m_PPx(r, i));
+        auto const y_offset = floor_div(ceil_div(y, m_YRsiz(i) * (1 << (m_N_L(i) - r))), 1 << m_PPy(r, i)) - floor_div(try0, 1 << m_PPy(r, i));
+        return x_offset + m_num_precincts_wide(r, i) * y_offset;
+    };
+    // B.12.1.3 Resolution level-position-component-layer progression
+    // "for each r = 0,..., Nmax
+    //      for each y = ty0,..., ty1 – 1,
+    //          for each x = tx0,..., tx1 – 1,
+    //              for each i = 0,..., Csiz – 1
+    //                  if ((y divisible by YRsiz(i) * 2 ** (PPy(r, i) + N_L(i) - r) OR
+    //                      ((y == ty0) AND (try0 * 2 ** (N_L(i) - r) NOT divisible by 2 ** (PPy(r, i) + N_L(i) - r))))
+    //                  if ((x divisible by XRsiz(i) * 2 ** (PPx(r, i) + N_L(i) - r) OR
+    //                      ((x == tx0) AND (trx0 * 2 ** (N_L(i) - r) NOT divisible by 2 ** (PPx(r, i) + N_L(i) - r))))
+    //          for the next precinct, k, if one exists,
+    //              for each l = 0,..., L – 1
+    //                  packet for component i, resolution level r, layer l, and precinct k."
+    // The motivation for this loop is to walk corresponding precincts in different components at the same time,
+    // even if the components have different precinct counts.
+    for (int r = 0; r <= m_max_number_of_decomposition_levels; ++r) {
+        auto const tx0 = m_tile_rect.left();
+        auto const ty0 = m_tile_rect.top();
+        for (int y = ty0; y < m_tile_rect.bottom(); ++y) {
+            for (int x = tx0; x < m_tile_rect.right(); ++x) {
+                for (int i = 0; i < m_component_count; ++i) {
+                    auto const trx0 = m_ll_rect(r, i).left();
+                    auto const try0 = m_ll_rect(r, i).top();
+                    if ((y % (m_YRsiz(i) * (1 << (m_PPy(r, i) + m_N_L(i) - r))) == 0)
+                        || ((y == ty0) && (try0 * (1 << (m_N_L(i) - r)) % (1 << (m_PPy(r, i) + m_N_L(i) - r)) != 0))) {
+                        if ((x % (m_XRsiz(i) * (1 << (m_PPx(r, i) + m_N_L(i) - r))) == 0)
+                            || ((x == tx0) && (trx0 * (1 << (m_N_L(i) - r)) % (1 << (m_PPx(r, i) + m_N_L(i) - r)) != 0))) {
+                            if (int k = compute_precinct(x, y, r, i); k < m_precinct_count(r, i)) {
+                                for (int l = 0; l < m_layer_count; ++l) {
+                                    co_yield ProgressionData { l, r, i, k };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/SyncGenerator.h>
+#include <LibGfx/Rect.h>
 
 namespace Gfx::JPEG2000 {
 
@@ -65,6 +66,39 @@ private:
     int m_max_number_of_decomposition_levels { 0 };
     int m_component_count { 0 };
     Function<int(int resolution_level, int component)> m_precinct_count;
+    SyncGenerator<ProgressionData> m_generator;
+};
+
+// B.12.1.3 Resolution level-position-component-layer progression
+class ResolutionLevelPositionComponentLayerProgressionIterator : public ProgressionIterator {
+public:
+    // FIXME: Supporting POC packets will probably require changes to this.
+    ResolutionLevelPositionComponentLayerProgressionIterator(int layer_count, int max_number_of_decomposition_levels, int component_count, Function<int(int resolution_level, int component)> precinct_count,
+        Function<int(int component)> XRsiz, Function<int(int component)> YRsiz,
+        Function<int(int resolution_level, int component)> PPx, Function<int(int resolution_level, int component)> PPy,
+        Function<int(int component)> N_L,
+        Function<int(int resolution_level, int component)> num_precincts_wide,
+        Gfx::IntRect tile_rect,
+        Function<IntRect(int resolution_level, int component)> ll_rect);
+    virtual bool has_next() const override;
+    virtual ProgressionData next() override;
+
+private:
+    SyncGenerator<ProgressionData> generator();
+
+    Optional<ProgressionData> m_next;
+    int m_layer_count { 0 };
+    int m_max_number_of_decomposition_levels { 0 };
+    int m_component_count { 0 };
+    Function<int(int resolution_level, int component)> m_precinct_count;
+    Function<int(int component)> m_XRsiz;
+    Function<int(int component)> m_YRsiz;
+    Function<int(int resolution_level, int component)> m_PPx;
+    Function<int(int resolution_level, int component)> m_PPy;
+    Function<int(int component)> m_N_L;
+    Function<int(int resolution_level, int component)> m_num_precincts_wide;
+    Gfx::IntRect m_tile_rect;
+    Function<IntRect(int resolution_level, int component)> m_ll_rect;
     SyncGenerator<ProgressionData> m_generator;
 };
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/SyncGenerator.h>
 
@@ -65,6 +66,18 @@ private:
     int m_component_count { 0 };
     Function<int(int resolution_level, int component)> m_precinct_count;
     SyncGenerator<ProgressionData> m_generator;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Formatter<Gfx::JPEG2000::ProgressionData> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Gfx::JPEG2000::ProgressionData const& value)
+    {
+        return Formatter<FormatString>::format(builder, "layer={}, resolution_level={}, component={}, precinct={}"sv, value.layer, value.resolution_level, value.component, value.precinct);
+    }
 };
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
@@ -57,9 +57,14 @@ public:
     virtual ProgressionData next() override;
 
 private:
+    SyncGenerator<ProgressionData> generator();
+
+    Optional<ProgressionData> m_next;
+    int m_layer_count { 0 };
+    int m_max_number_of_decomposition_levels { 0 };
+    int m_component_count { 0 };
     Function<int(int resolution_level, int component)> m_precinct_count;
-    ProgressionData m_next {};
-    ProgressionData m_end {};
+    SyncGenerator<ProgressionData> m_generator;
 };
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
@@ -102,6 +102,38 @@ private:
     SyncGenerator<ProgressionData> m_generator;
 };
 
+// B.12.1.4 Position-component-resolution level-layer progression
+class PositionComponentResolutionLevelLayerProgressionIterator : public ProgressionIterator {
+public:
+    // FIXME: Supporting POC packets will probably require changes to this.
+    PositionComponentResolutionLevelLayerProgressionIterator(int layer_count, int component_count, Function<int(int resolution_level, int component)> precinct_count,
+        Function<int(int component)> XRsiz, Function<int(int component)> YRsiz,
+        Function<int(int resolution_level, int component)> PPx, Function<int(int resolution_level, int component)> PPy,
+        Function<int(int component)> N_L,
+        Function<int(int resolution_level, int component)> num_precincts_wide,
+        Gfx::IntRect tile_rect,
+        Function<IntRect(int resolution_level, int component)> ll_rect);
+    virtual bool has_next() const override;
+    virtual ProgressionData next() override;
+
+private:
+    SyncGenerator<ProgressionData> generator();
+
+    Optional<ProgressionData> m_next;
+    int m_layer_count { 0 };
+    int m_component_count { 0 };
+    Function<int(int resolution_level, int component)> m_precinct_count;
+    Function<int(int component)> m_XRsiz;
+    Function<int(int component)> m_YRsiz;
+    Function<int(int resolution_level, int component)> m_PPx;
+    Function<int(int resolution_level, int component)> m_PPy;
+    Function<int(int component)> m_N_L;
+    Function<int(int resolution_level, int component)> m_num_precincts_wide;
+    Gfx::IntRect m_tile_rect;
+    Function<IntRect(int resolution_level, int component)> m_ll_rect;
+    SyncGenerator<ProgressionData> m_generator;
+};
+
 }
 
 namespace AK {

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000ProgressionIterators.h
@@ -134,6 +134,38 @@ private:
     SyncGenerator<ProgressionData> m_generator;
 };
 
+// B.12.1.5 Component-position-resolution level-layer progression
+class ComponentPositionResolutionLevelLayerProgressionIterator : public ProgressionIterator {
+public:
+    // FIXME: Supporting POC packets will probably require changes to this.
+    ComponentPositionResolutionLevelLayerProgressionIterator(int layer_count, int component_count, Function<int(int resolution_level, int component)> precinct_count,
+        Function<int(int component)> XRsiz, Function<int(int component)> YRsiz,
+        Function<int(int resolution_level, int component)> PPx, Function<int(int resolution_level, int component)> PPy,
+        Function<int(int component)> N_L,
+        Function<int(int resolution_level, int component)> num_precincts_wide,
+        Gfx::IntRect tile_rect,
+        Function<IntRect(int resolution_level, int component)> ll_rect);
+    virtual bool has_next() const override;
+    virtual ProgressionData next() override;
+
+private:
+    SyncGenerator<ProgressionData> generator();
+
+    Optional<ProgressionData> m_next;
+    int m_layer_count { 0 };
+    int m_component_count { 0 };
+    Function<int(int resolution_level, int component)> m_precinct_count;
+    Function<int(int component)> m_XRsiz;
+    Function<int(int component)> m_YRsiz;
+    Function<int(int resolution_level, int component)> m_PPx;
+    Function<int(int resolution_level, int component)> m_PPy;
+    Function<int(int component)> m_N_L;
+    Function<int(int resolution_level, int component)> m_num_precincts_wide;
+    Gfx::IntRect m_tile_rect;
+    Function<IntRect(int resolution_level, int component)> m_ll_rect;
+    SyncGenerator<ProgressionData> m_generator;
+};
+
 }
 
 namespace AK {

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -479,6 +479,15 @@ public:
         return *this;
     }
 
+    [[nodiscard]] Rect<T> operator/(T factor) const { return { m_location / factor, m_size / factor }; }
+
+    Rect<T>& operator/=(T factor)
+    {
+        m_location /= factor;
+        m_size /= factor;
+        return *this;
+    }
+
     void intersect(Rect<T> const& other)
     {
         T l = max(left(), other.left());

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -146,6 +146,15 @@ public:
         return *this;
     }
 
+    [[nodiscard]] Size<T> operator/(T factor) const { return { m_width / factor, m_height / factor }; }
+
+    Size<T>& operator/=(T factor)
+    {
+        m_width /= factor;
+        m_height /= factor;
+        return *this;
+    }
+
     [[nodiscard]] constexpr T primary_size_for_orientation(Orientation orientation) const
     {
         return orientation == Orientation::Vertical ? height() : width();


### PR DESCRIPTION
This adds support for progression orders 2-4 (and moves the progression order 1 implementation to SyncGenerator, like #25797 already did for progression order 0). Thanks to SyncGenerator, this looks very close to the spec now :^)

Progression orders 2-4 are very rare in practice. In my 2000-file test PDF set, there's a single PDF that uses progression order 2 (and 0 for 3 and 4).