### PR TITLE
Kernel/riscv64: Support systems where the boot hart ID isn't 0 

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -175,11 +175,6 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT NO_SANITIZE_COVERAGE void init(BootInfo
     new (&bsp_processor()) Processor();
     bsp_processor().early_initialize(0);
 
-#if ARCH(RISCV64)
-    // We implicitly assume the boot hart is hart 0 above and below
-    VERIFY(boot_info.arch_specific.boot_hart_id == 0);
-#endif
-
     // Invoke the constructors needed for the kernel heap
     for (ctor_func_t* ctor = start_heap_ctors; ctor < end_heap_ctors; ctor++)
         (*ctor)();

--- a/Kernel/Arch/riscv64/InterruptManagement.h
+++ b/Kernel/Arch/riscv64/InterruptManagement.h
@@ -8,6 +8,7 @@
 
 #include <AK/Vector.h>
 #include <Kernel/Arch/riscv64/IRQController.h>
+#include <Kernel/Firmware/DeviceTree/DeviceRecipe.h>
 
 #include <AK/Platform.h>
 VALIDATE_IS_RISCV64()
@@ -19,6 +20,8 @@ public:
     static InterruptManagement& the();
     static void initialize();
     static bool initialized();
+
+    static void add_recipe(DeviceTree::DeviceRecipe<NonnullLockRefPtr<IRQController>>);
 
     static u8 acquire_mapped_interrupt_number(u8 original_irq);
 

--- a/Kernel/Arch/riscv64/Interrupts/PLIC.cpp
+++ b/Kernel/Arch/riscv64/Interrupts/PLIC.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Enumerate.h>
 #include <Kernel/Arch/riscv64/InterruptManagement.h>
 #include <Kernel/Arch/riscv64/Interrupts/PLIC.h>
 #include <Kernel/Firmware/DeviceTree/DeviceTree.h>
@@ -12,9 +13,10 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT PLIC::PLIC(Memory::TypedMapping<RegisterMap volatile> registers, u32 interrupt_count)
+UNMAP_AFTER_INIT PLIC::PLIC(Memory::TypedMapping<RegisterMap volatile> registers, u32 interrupt_count, size_t boot_hart_supervisor_mode_context_id)
     : m_registers(move(registers))
     , m_interrupt_count(interrupt_count)
+    , m_boot_hart_supervisor_mode_context_id(boot_hart_supervisor_mode_context_id)
 {
     VERIFY(m_interrupt_count < 256); // TODO: Serenity currently only supports up to 256 unique interrupts, but the PLIC supports up to 1024
     initialize();
@@ -28,10 +30,10 @@ UNMAP_AFTER_INIT void PLIC::initialize()
     }
     for (auto i = 0u; i <= ((m_interrupt_count - 1) >> 5); ++i) {
         // Initialize all interrupt sources to disabled
-        m_registers->interrupt_enable_bitmap[interrupt_context][i] = 0;
+        m_registers->interrupt_enable_bitmap[m_boot_hart_supervisor_mode_context_id][i] = 0;
     }
     // Initialize priority-threshold to 0 (accept any interrupt of priority 1 or above)
-    m_registers->contexts[interrupt_context].priority_threshold = 0;
+    m_registers->contexts[m_boot_hart_supervisor_mode_context_id].priority_threshold = 0;
     // Enable external interrupts in the current hart
     RISCV64::CSR::set_bits(RISCV64::CSR::Address::SIE, 1 << (to_underlying(RISCV64::CSR::SCAUSE::SupervisorExternalInterrupt) & ~RISCV64::CSR::SCAUSE_INTERRUPT_MASK));
 }
@@ -40,27 +42,28 @@ void PLIC::enable(GenericInterruptHandler const& handler)
 {
     auto interrupt_number = handler.interrupt_number();
     VERIFY(interrupt_number > 0); // Interrupt number 0 is reserved to mean no-interrupt
-    m_registers->interrupt_enable_bitmap[interrupt_context][interrupt_number >> 5] |= 1u << (interrupt_number & 0x1F);
+    m_registers->interrupt_enable_bitmap[m_boot_hart_supervisor_mode_context_id][interrupt_number >> 5] |= 1u << (interrupt_number & 0x1F);
 }
 
 void PLIC::disable(GenericInterruptHandler const& handler)
 {
     auto interrupt_number = handler.interrupt_number();
     VERIFY(interrupt_number > 0); // Interrupt number 0 is reserved to mean no-interrupt
-    m_registers->interrupt_enable_bitmap[interrupt_context][interrupt_number >> 5] &= ~(1u << (interrupt_number & 0x1F));
+    m_registers->interrupt_enable_bitmap[m_boot_hart_supervisor_mode_context_id][interrupt_number >> 5] &= ~(1u << (interrupt_number & 0x1F));
 }
 
 void PLIC::eoi(GenericInterruptHandler const& handler)
 {
-    m_registers->contexts[interrupt_context].claim_complete = handler.interrupt_number();
+    m_registers->contexts[m_boot_hart_supervisor_mode_context_id].claim_complete = handler.interrupt_number();
 }
 
 u8 PLIC::pending_interrupt() const
 {
-    return m_registers->contexts[interrupt_context].claim_complete;
+    return m_registers->contexts[m_boot_hart_supervisor_mode_context_id].claim_complete;
 }
 
 static constinit Array const compatibles_array = {
+    "riscv,plic0"sv,
     "sifive,plic-1.0.0"sv,
 };
 
@@ -76,12 +79,47 @@ ErrorOr<void> PLICDriver::probe(DeviceTree::Device const& device, StringView) co
         return EINVAL;
     auto max_interrupt_id = maybe_max_interrupt_id->as<u32>();
 
+    size_t boot_hart_supervisor_mode_context_id = 0;
+
+    // Get the context ID for the supervisor mode context of the boot hart.
+    // FIXME: Support multiple contexts when we support SMP on riscv64.
+    for (auto [context_id, interrupt] : enumerate(TRY(device.node().interrupts(DeviceTree::get())))) {
+        // interrupts-extended: "Each node pointed to should be a riscv,cpu-intc node, which has a riscv node as parent."
+        auto const& cpu_intc = *interrupt.domain_root;
+
+        if (!cpu_intc.is_compatible_with("riscv,cpu-intc"sv))
+            return EINVAL;
+
+        auto const* cpu = cpu_intc.parent();
+        if (cpu == nullptr)
+            return EINVAL;
+
+        if (!cpu->is_compatible_with("riscv"sv))
+            return EINVAL;
+
+        u64 interrupt_specifier = 0;
+        if (interrupt.interrupt_identifier.size() == sizeof(u32))
+            interrupt_specifier = *reinterpret_cast<BigEndian<u32> const*>(interrupt.interrupt_identifier.data());
+        else if (interrupt.interrupt_identifier.size() == sizeof(u64))
+            interrupt_specifier = *reinterpret_cast<BigEndian<u64> const*>(interrupt.interrupt_identifier.data());
+        else
+            return EINVAL;
+
+        // https://www.kernel.org/doc/Documentation/devicetree/bindings/riscv/cpus.yaml
+        // reg: "The hart ID of this CPU node."
+        auto hart_id = TRY(TRY(TRY(cpu->reg()).entry(0)).bus_address().as_flatptr());
+        if (hart_id == g_boot_info.arch_specific.boot_hart_id && interrupt_specifier == (to_underlying(RISCV64::CSR::SCAUSE::SupervisorExternalInterrupt) & ~RISCV64::CSR::SCAUSE_INTERRUPT_MASK)) {
+            boot_hart_supervisor_mode_context_id = context_id;
+            break;
+        }
+    }
+
     DeviceTree::DeviceRecipe<NonnullLockRefPtr<IRQController>> recipe {
         name(),
         device.node_name(),
-        [physical_address, max_interrupt_id]() -> ErrorOr<NonnullLockRefPtr<IRQController>> {
+        [physical_address, max_interrupt_id, boot_hart_supervisor_mode_context_id]() -> ErrorOr<NonnullLockRefPtr<IRQController>> {
             auto registers_mapping = TRY(Memory::map_typed_writable<PLIC::RegisterMap volatile>(physical_address));
-            return adopt_nonnull_lock_ref_or_enomem(new (nothrow) PLIC(move(registers_mapping), max_interrupt_id + 1));
+            return adopt_nonnull_lock_ref_or_enomem(new (nothrow) PLIC(move(registers_mapping), max_interrupt_id + 1, boot_hart_supervisor_mode_context_id));
         },
     };
 

--- a/Kernel/Arch/riscv64/Interrupts/PLIC.h
+++ b/Kernel/Arch/riscv64/Interrupts/PLIC.h
@@ -27,7 +27,7 @@ public:
     };
     static_assert(AssertSize<RegisterMap, 0x4000000>());
 
-    PLIC(Memory::TypedMapping<RegisterMap volatile>, u32 interrupt_count);
+    PLIC(Memory::TypedMapping<RegisterMap volatile>, u32 interrupt_count, size_t boot_hart_supervisor_mode_context_id);
 
     virtual void enable(GenericInterruptHandler const&) override;
     virtual void disable(GenericInterruptHandler const&) override;
@@ -39,17 +39,13 @@ public:
     virtual StringView model() const override { return "PLIC"sv; }
 
 private:
-    enum {
-        M_MODE_CONTEXT = 0,
-        S_MODE_CONTEXT,
-        CONTEXTS_PER_HART,
-    };
-    static constexpr size_t interrupt_context = (0 * CONTEXTS_PER_HART) + S_MODE_CONTEXT; // We assume we only have hart 0, change this once we support SMP
-
     void initialize();
 
     Memory::TypedMapping<RegisterMap volatile> m_registers;
     u32 m_interrupt_count { 0 };
+
+    // FIXME: Support more contexts once we support SMP on riscv64.
+    size_t m_boot_hart_supervisor_mode_context_id;
 };
 
 }

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -313,7 +313,7 @@ public:
 
     // Handles both the "interrupts" and "interrupts-extended" properties.
     // The returned Interrupt::domain_root is always non-null.
-    ErrorOr<FixedArray<Interrupt>> interrupts(DeviceTree const& device_tree) const;
+    ErrorOr<Vector<Interrupt>> interrupts(DeviceTree const& device_tree) const;
 
     // FIXME: Stringify?
     // FIXME: Flatten?


### PR DESCRIPTION
The JH7110/U74-MC (used in the VisionFive 2) uses hart ID 0 for the S7 monitor core, which can't run a general purpose OS, so the boot hart ID is 1 on that system. 