### PR TITLE
AK+LibLocale: Improve performance when looking for the next boundary

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -65,8 +65,39 @@ constexpr auto binary_search(
     return nullptr;
 }
 
+// Unlike their std equivalents, these two function require the entire Container to be sorted!
+// std::[lower,upper]_bound only require the array to be sorted after and before, respectively, the needle.
+
+template<typename Container, typename Needle, typename Comparator = DefaultComparator, typename Return = decltype(&Container {}[0])>
+constexpr auto lower_bound(
+    Container&& haystack,
+    Needle&& needle,
+    Comparator comparator = Comparator {}) -> size_t
+{
+    size_t index {};
+    binary_search(haystack, needle, &index, comparator);
+    if (index > 0 && haystack[index] >= needle)
+        index -= 1;
+    return index;
+}
+
+template<typename Container, typename Needle, typename Comparator = DefaultComparator, typename Return = decltype(&Container {}[0])>
+constexpr auto upper_bound(
+    Container&& haystack,
+    Needle&& needle,
+    Comparator comparator = Comparator {}) -> size_t
+{
+    size_t index {};
+    binary_search(haystack, needle, &index, comparator);
+    if (index < haystack.size() - 1 && haystack[index] <= needle)
+        index += 1;
+    return index;
+}
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::binary_search;
+using AK::lower_bound;
+using AK::upper_bound;
 #endif

--- a/Tests/AK/TestBinarySearch.cpp
+++ b/Tests/AK/TestBinarySearch.cpp
@@ -143,3 +143,25 @@ RANDOMIZED_TEST_CASE(doesnt_find_number_that_is_not_present)
 
     EXPECT_EQ(binary_search(vec, not_present), nullptr);
 }
+
+TEST_CASE(lower_bound)
+{
+    Array<u32, 5> const input { 0, 1, 2, 4, 5 };
+
+    EXPECT_EQ(lower_bound(input, 0u), 0u);
+    EXPECT_EQ(lower_bound(input, 2u), 1u);
+    EXPECT_EQ(lower_bound(input, 3u), 2u);
+    EXPECT_EQ(lower_bound(input, 4u), 2u);
+    EXPECT_EQ(lower_bound(input, 6u), 4u);
+}
+
+TEST_CASE(upper_bound)
+{
+    Array<u32, 4> const input { 1, 2, 4, 5 };
+
+    EXPECT_EQ(upper_bound(input, 0u), 0u);
+    EXPECT_EQ(upper_bound(input, 1u), 1u);
+    EXPECT_EQ(upper_bound(input, 2u), 2u);
+    EXPECT_EQ(upper_bound(input, 3u), 2u);
+    EXPECT_EQ(upper_bound(input, 5u), 3u);
+}

--- a/Userland/Libraries/LibLocale/Segmenter.cpp
+++ b/Userland/Libraries/LibLocale/Segmenter.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BinarySearch.h>
 #include <AK/Utf16View.h>
 #include <AK/Utf32View.h>
 #include <LibLocale/Locale.h>
@@ -78,19 +79,11 @@ public:
         if (inclusive == Inclusive::Yes)
             ++boundary;
 
-        // FIXME: Add AK::lower_bound, use
-        Optional<size_t> new_boundary;
-        for (auto segment_boundary : m_boundaries) {
-            if (segment_boundary < boundary) {
-                new_boundary = segment_boundary;
-                continue;
-            }
-            break;
-        }
+        auto lower_bound_index = lower_bound(m_boundaries.span(), boundary);
 
-        if (new_boundary.has_value())
-            m_current_boundary = new_boundary.value();
-        return new_boundary;
+        if (lower_bound_index == 0 && m_boundaries.first() >= boundary)
+            return OptionalNone {};
+        return m_boundaries[lower_bound_index];
     }
 
     virtual Optional<size_t> next_boundary(size_t boundary, Inclusive inclusive) override
@@ -100,18 +93,11 @@ public:
         if (inclusive == Inclusive::Yes)
             --boundary;
 
-        // FIXME: Add AK::upper_bound, use
-        Optional<size_t> new_boundary;
-        for (auto segment_boundary : m_boundaries) {
-            if (segment_boundary > boundary) {
-                new_boundary = segment_boundary;
-                break;
-            }
-        }
+        auto upper_bound_index = upper_bound(m_boundaries.span(), boundary);
 
-        if (new_boundary.has_value())
-            m_current_boundary = new_boundary.value();
-        return new_boundary;
+        if (upper_bound_index == m_boundaries.size() - 1 && m_boundaries.last() <= boundary)
+            return OptionalNone {};
+        return m_boundaries[upper_bound_index];
     }
 
     virtual void for_each_boundary(String text, SegmentationCallback callback) override


### PR DESCRIPTION
This should hopefully reduce the CI flakes on `Tests/LibWeb/Text/input/HTML/ImageData-create-with-size.html`.
Related to #25490 and #25494