### PR TITLE
LibGfx/JPEGXL: Enough work on the decoder to reach the point where it sees there is no work to do in the GlobalModular section

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1505,7 +1505,6 @@ static Neighborhood retrieve_neighborhood(Channel const& channel, u32 x, u32 y)
 
 static ErrorOr<ModularData> read_modular_bitstream(LittleEndianInputBitStream& stream,
     Span<IntSize> channels_info,
-    ImageMetadata const& metadata,
     Optional<EntropyDecoder>& decoder,
     MATree const& global_tree)
 {
@@ -1534,12 +1533,12 @@ static ErrorOr<ModularData> read_modular_bitstream(LittleEndianInputBitStream& s
     if (!modular_data.use_global_tree)
         TODO();
 
-    // where dist_multiplier is set to the largest channel width amongst all channels
-    // that are to be decoded, excluding the meta-channels.
+    // where the dist_multiplier from C.3.3 is set to the largest channel width amongst all channels
+    // that are to be decoded.
     auto const dist_multiplier = [&]() {
         u32 dist_multiplier {};
-        // FIXME: This should start at nb_meta_channels not 0
-        for (u16 i = 0; i < metadata.number_of_channels(); ++i) {
+        // FIXME: Only consider the channels that are to be decoded.
+        for (u32 i = 0; i < modular_data.channels.size(); ++i) {
             if (modular_data.channels[i].width() > dist_multiplier)
                 dist_multiplier = modular_data.channels[i].width();
         }
@@ -1625,7 +1624,7 @@ static ErrorOr<GlobalModular> read_global_modular(LittleEndianInputBitStream& st
     auto channels = TRY(FixedArray<IntSize>::create(num_channels));
     channels.fill_with(frame_size);
 
-    global_modular.modular_data = TRY(read_modular_bitstream(stream, channels, metadata, entropy_decoder, global_modular.ma_tree));
+    global_modular.modular_data = TRY(read_modular_bitstream(stream, channels, entropy_decoder, global_modular.ma_tree));
 
     return global_modular;
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1525,6 +1525,12 @@ static ErrorOr<ModularData> read_modular_bitstream(LittleEndianInputBitStream& s
             modular_data.use_global_tree ? "global"sv : "local"sv,
             nb_transforms);
 
+        for (auto const& tr : modular_data.transform) {
+            if (tr.tr == TransformInfo::TransformId::kPalette) {
+                dbgln("* Palette: begin_c={} - num_c={} - nb_colours={} - nb_deltas={} - d_pred={}",
+                    tr.begin_c, tr.num_c, tr.nb_colours, tr.nb_deltas, tr.d_pred);
+            }
+        }
         for (auto const& [i, channel] : enumerate(modular_data.channels))
             dbgln("- Channel {}: {}x{}", i, channel.width(), channel.height());
     }


### PR DESCRIPTION
Before these patches, we would raise an error when trying to decode the channels in the GlobalModular section, we now realize that there is no work to do there and crash on a TODO a little bit further.

In terms of log, before:
```cpp
Decoding a JPEG XL image with size 555x751 and 3 channels.
Frame: 555x751 Modular - type(0) - flags(0) - is_last
Decoding modular sub-stream (global tree, 1 transforms):
- Channel 0: 555x751
- Channel 1: 555x751
- Channel 2: 555x751
JPEGXLLoader: ANS decoder left in invalid state
Runtime error: Reached end-of-stream without collecting the required number of bits
```

After:
```cpp
Decoding a JPEG XL image with size 555x751 and 3 channels.
Frame: 555x751 Modular - type(0) - flags(0) - is_last
Decoding modular sub-stream (global tree, 1 transforms):
* Palette: begin_c=0 - num_c=3 - nb_colours=0 - nb_deltas=0 - d_pred=13
- Channel 0: 0x3 - skipped
- Channel 1: 555x751 - skipped
VERIFICATION FAILED: TODO at /home/lucas/repos/serenity/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp:1888
```