### PR TITLE
Kernel/riscv64: Make TimePrecision::Precise work (+resolve some TODO_RISCV64s in Timer.h)

### DIFF
--- a/Kernel/Arch/riscv64/Timer.cpp
+++ b/Kernel/Arch/riscv64/Timer.cpp
@@ -49,6 +49,11 @@ void Timer::handle_interrupt()
     set_compare(current_ticks() + m_interrupt_interval);
 }
 
+void Timer::disable()
+{
+    RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SIE, 1 << (to_underlying(CSR::SCAUSE::SupervisorTimerInterrupt) & ~CSR::SCAUSE_INTERRUPT_MASK));
+}
+
 u64 Timer::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only)
 {
     // Should only be called by the time keeper interrupt handler!

--- a/Kernel/Arch/riscv64/Timer.h
+++ b/Kernel/Arch/riscv64/Timer.h
@@ -22,16 +22,16 @@ public:
     virtual StringView model() const override { return "RISC-V Timer"sv; }
     virtual size_t ticks_per_second() const override { return m_frequency; }
 
-    virtual bool is_periodic() const override { TODO_RISCV64(); }
-    virtual bool is_periodic_capable() const override { TODO_RISCV64(); }
-    virtual void set_periodic() override { TODO_RISCV64(); }
-    virtual void set_non_periodic() override { TODO_RISCV64(); }
-    virtual void disable() override { TODO_RISCV64(); }
+    virtual bool is_periodic() const override { return false; }
+    virtual bool is_periodic_capable() const override { return false; }
+    virtual void set_periodic() override { }
+    virtual void set_non_periodic() override { }
+    virtual void disable() override;
 
-    virtual void reset_to_default_ticks_per_second() override { TODO_RISCV64(); }
-    virtual bool try_to_set_frequency(size_t) override { TODO_RISCV64(); }
-    virtual bool is_capable_of_frequency(size_t) const override { TODO_RISCV64(); }
-    virtual size_t calculate_nearest_possible_frequency(size_t) const override { TODO_RISCV64(); }
+    virtual void reset_to_default_ticks_per_second() override { }
+    virtual bool try_to_set_frequency(size_t frequency) override { return frequency == m_frequency; }
+    virtual bool is_capable_of_frequency(size_t frequency) const override { return frequency == m_frequency; }
+    virtual size_t calculate_nearest_possible_frequency(size_t) const override { return m_frequency; }
 
     virtual void will_be_destroyed() override { }
     virtual Function<void()> set_callback(Function<void()> callback) override

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -156,7 +156,11 @@ MonotonicTime TimeManagement::monotonic_time(TimePrecision precision) const
             else
                 VERIFY_NOT_REACHED();
 #elif ARCH(RISCV64)
-            TODO_RISCV64();
+            // FIXME: Get rid of these horrible casts
+            if (m_system_timer->timer_type() == HardwareTimerType::RISCVTimer)
+                const_cast<RISCV64::Timer*>(static_cast<RISCV64::Timer const*>(m_system_timer.ptr()))->update_time(seconds, ticks, true);
+            else
+                VERIFY_NOT_REACHED();
 #else
 #    error Unknown architecture
 #endif
@@ -550,6 +554,7 @@ UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_riscv64_hardware_timers()
         system_timer_tick();
     });
 
+    m_can_query_precise_time.set();
     m_time_keeper_timer = m_system_timer;
 
     return true;


### PR DESCRIPTION
This causes SystemMonitor to no longer claim that all CPU time is spent in the kernel.