### PR TITLE
Kernel/aarch64: Add support for the PL031

### DIFF
--- a/Kernel/Arch/aarch64/Time/PL031.cpp
+++ b/Kernel/Arch/aarch64/Time/PL031.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/NeverDestroyed.h>
+#include <AK/Optional.h>
+#include <Kernel/Arch/aarch64/Time/PL031.h>
+#include <Kernel/Firmware/DeviceTree/Driver.h>
+#include <Kernel/Firmware/DeviceTree/Management.h>
+
+namespace Kernel {
+
+static NeverDestroyed<Optional<PL031>> s_rtc;
+
+PL031::PL031(Memory::TypedMapping<RTCRegisters volatile> rtc_registers)
+    : m_rtc_registers(move(rtc_registers))
+{
+    m_boot_time = m_rtc_registers->data;
+}
+
+RawPtr<PL031> PL031::the()
+{
+    if (!s_rtc->has_value())
+        return nullptr;
+
+    return &s_rtc->value();
+}
+
+static constinit Array const compatibles_array = {
+    "arm,pl031"sv,
+};
+
+DEVICETREE_DRIVER(PL031Driver, compatibles_array);
+
+ErrorOr<void> PL031Driver::probe(DeviceTree::Device const& device, StringView) const
+{
+    if (s_rtc->has_value())
+        return {};
+
+    auto rtc_registers_resource = TRY(device.get_resource(0));
+    if (rtc_registers_resource.size < sizeof(PL031::RTCRegisters))
+        return EINVAL;
+    auto rtc_registers = TRY(Memory::map_typed_writable<PL031::RTCRegisters volatile>(rtc_registers_resource.paddr));
+    *s_rtc = PL031(move(rtc_registers));
+    return {};
+}
+
+}

--- a/Kernel/Arch/aarch64/Time/PL031.h
+++ b/Kernel/Arch/aarch64/Time/PL031.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+#include <AK/Time.h>
+#include <Kernel/Memory/TypedMapping.h>
+
+// https://developer.arm.com/documentation/ddi0224/c/?lang=en
+
+namespace Kernel {
+
+class PL031 {
+public:
+    struct RTCRegisters {
+        u32 data;                        // RTCDR
+        u32 match;                       // RTCMR
+        u32 load;                        // RTCLR
+        u32 control;                     // RTCCR
+        u32 interrupt_mask_set_or_clear; // RTCIMSC
+        u32 raw_interrupt_status;        // RTCRIS
+        u32 masked_interrupt_status;     // RTCMIS
+        u32 interrupt_clear_register;    // RTCICR
+        u32 reserved[1008];
+        u32 peripheral_id_bits_7_0;   // RTCPeriphID0
+        u32 peripheral_id_bits_15_8;  // RTCPeriphID1
+        u32 peripheral_id_bits_23_16; // RTCPeriphID2
+        u32 peripheral_id_bits_31_24; // RTCPeriphID3
+        u32 primecell_id_bits_7_0;    // RTCPCellID0
+        u32 primecell_id_bits_15_8;   // RTCPCellID1
+        u32 primecell_id_bits_23_16;  // RTCPCellID2
+        u32 primecell_id_bits_31_24;  // RTCPCellID3
+    };
+    static_assert(AssertSize<RTCRegisters, 0x1000>());
+
+    PL031(Memory::TypedMapping<RTCRegisters volatile>);
+
+    static RawPtr<PL031> the();
+
+    UnixDateTime boot_time() { return UnixDateTime::from_seconds_since_epoch(m_boot_time); }
+
+private:
+    Memory::TypedMapping<RTCRegisters volatile> m_rtc_registers;
+    time_t m_boot_time;
+};
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -515,6 +515,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/SafeMem.cpp
         Arch/aarch64/SmapDisabler.cpp
         Arch/aarch64/Time/ARMv8Timer.cpp
+        Arch/aarch64/Time/PL031.cpp
         Arch/aarch64/vector_table.S
 
         Arch/aarch64/PlatformInit/RaspberryPi.cpp


### PR DESCRIPTION
With this, it's now possible to properly set the system time on boot when using the QEMU virt machine.