### PR TITLE
Kernel/aarch64: Make TimePrecision::Precise work (+resolve some TODO_AARCH64s in the timer drivers)

### DIFF
--- a/Kernel/Arch/aarch64/RPi/Timer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Timer.cpp
@@ -67,6 +67,11 @@ bool Timer::handle_irq()
     return result;
 }
 
+void Timer::disable()
+{
+    disable_irq();
+}
+
 u64 Timer::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only)
 {
     // Should only be called by the time keeper interrupt handler!

--- a/Kernel/Arch/aarch64/RPi/Timer.h
+++ b/Kernel/Arch/aarch64/RPi/Timer.h
@@ -25,16 +25,16 @@ public:
     virtual HardwareTimerType timer_type() const override { return HardwareTimerType::RPiTimer; }
     virtual StringView model() const override { return "RPi Timer"sv; }
 
-    virtual bool is_periodic() const override { TODO_AARCH64(); }
-    virtual bool is_periodic_capable() const override { TODO_AARCH64(); }
-    virtual void set_periodic() override { TODO_AARCH64(); }
-    virtual void set_non_periodic() override { TODO_AARCH64(); }
-    virtual void disable() override { TODO_AARCH64(); }
+    virtual bool is_periodic() const override { return false; }
+    virtual bool is_periodic_capable() const override { return false; }
+    virtual void set_periodic() override { }
+    virtual void set_non_periodic() override { }
+    virtual void disable() override;
 
-    virtual void reset_to_default_ticks_per_second() override { TODO_AARCH64(); }
-    virtual bool try_to_set_frequency(size_t) override { TODO_AARCH64(); }
-    virtual bool is_capable_of_frequency(size_t) const override { TODO_AARCH64(); }
-    virtual size_t calculate_nearest_possible_frequency(size_t) const override { TODO_AARCH64(); }
+    virtual void reset_to_default_ticks_per_second() override { }
+    virtual bool try_to_set_frequency(size_t frequency) override { return frequency == m_frequency; }
+    virtual bool is_capable_of_frequency(size_t frequency) const override { return frequency == m_frequency; }
+    virtual size_t calculate_nearest_possible_frequency(size_t) const override { return m_frequency; }
 
     // FIXME: Share code with HPET::update_time
     u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);

--- a/Kernel/Arch/aarch64/Time/ARMv8Timer.cpp
+++ b/Kernel/Arch/aarch64/Time/ARMv8Timer.cpp
@@ -57,6 +57,11 @@ bool ARMv8Timer::handle_irq()
     return true;
 }
 
+void ARMv8Timer::disable()
+{
+    disable_irq();
+}
+
 u64 ARMv8Timer::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only)
 {
     // Should only be called by the time keeper interrupt handler!

--- a/Kernel/Arch/aarch64/Time/ARMv8Timer.h
+++ b/Kernel/Arch/aarch64/Time/ARMv8Timer.h
@@ -23,16 +23,16 @@ public:
     virtual StringView model() const override { return "ARMv8 Timer"sv; }
     virtual size_t ticks_per_second() const override { return m_frequency; }
 
-    virtual bool is_periodic() const override { TODO_AARCH64(); }
-    virtual bool is_periodic_capable() const override { TODO_AARCH64(); }
-    virtual void set_periodic() override { TODO_AARCH64(); }
-    virtual void set_non_periodic() override { TODO_AARCH64(); }
-    virtual void disable() override { TODO_AARCH64(); }
+    virtual bool is_periodic() const override { return false; }
+    virtual bool is_periodic_capable() const override { return false; }
+    virtual void set_periodic() override { }
+    virtual void set_non_periodic() override { }
+    virtual void disable() override;
 
-    virtual void reset_to_default_ticks_per_second() override { TODO_AARCH64(); }
-    virtual bool try_to_set_frequency(size_t) override { TODO_AARCH64(); }
-    virtual bool is_capable_of_frequency(size_t) const override { TODO_AARCH64(); }
-    virtual size_t calculate_nearest_possible_frequency(size_t) const override { TODO_AARCH64(); }
+    virtual void reset_to_default_ticks_per_second() override { }
+    virtual bool try_to_set_frequency(size_t frequency) override { return frequency == m_frequency; }
+    virtual bool is_capable_of_frequency(size_t frequency) const override { return frequency == m_frequency; }
+    virtual size_t calculate_nearest_possible_frequency(size_t) const override { return m_frequency; }
 
     // FIXME: Share code with HPET::update_time
     u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -530,6 +530,7 @@ UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_aarch64_hardware_timers()
         system_timer_tick();
     });
 
+    m_can_query_precise_time.set();
     m_time_keeper_timer = m_system_timer;
 
     return true;


### PR DESCRIPTION
AArch64 already implements `monotonic_time(TimePrecision::Precise)`, but
didn't advertise support for it by setting `m_can_query_precise_time`.

This causes SystemMonitor to no longer claim that all CPU time is spent
in the kernel.

This PR basically is basically #25821 ported to AArch64.