### PR TITLE
Kernel/aarch64: Correct the RPi Mini UART register map

### DIFF
--- a/Kernel/Arch/aarch64/RPi/MiniUART.cpp
+++ b/Kernel/Arch/aarch64/RPi/MiniUART.cpp
@@ -22,10 +22,12 @@ struct MiniUARTRegisters {
     u32 modem_control;
     u32 line_status;
     u32 modem_status;
+    u32 scratch;
     u32 extra_control;
     u32 extra_status;
     u32 baud_rate;
 };
+static_assert(AssertSize<MiniUARTRegisters, 0x6c - 0x40>());
 
 // "Table 8. AUX_MU_LCR_REG Register"
 enum LineControl {


### PR DESCRIPTION
This gets rid of the "bcm2835_aux_write: Bad offset 64" QEMU warning while we attempt to set the baud rate.