### PR TITLE
LibDisassembly: RISC-V disassembly 4-2/4-5: Disassemble extensions FD (floating-point), A (atomic) and Zicsr (CSRs)

### DIFF
--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     x86/Instruction.cpp
+    riscv64/A.cpp
     riscv64/Encoding.cpp
     riscv64/FD.cpp
     riscv64/Formatting.cpp

--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     x86/Instruction.cpp
     riscv64/Encoding.cpp
+    riscv64/FD.cpp
     riscv64/Formatting.cpp
     riscv64/Instruction.cpp
     riscv64/IM.cpp

--- a/Userland/Libraries/LibDisassembly/CMakeLists.txt
+++ b/Userland/Libraries/LibDisassembly/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     riscv64/Formatting.cpp
     riscv64/Instruction.cpp
     riscv64/IM.cpp
+    riscv64/Zicsr.cpp
 )
 
 serenity_lib(LibDisassembly disassembly)

--- a/Userland/Libraries/LibDisassembly/riscv64/A.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/A.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "A.h"
+
+namespace Disassembly::RISCV64 {
+
+NonnullOwnPtr<InstructionImpl> parse_amo(u32 instruction)
+{
+    auto raw_parts = RawRType::parse(instruction);
+    auto is_acquire = (raw_parts.funct7 & 0b10) > 0;
+    auto is_release = (raw_parts.funct7 & 1) > 0;
+    auto width = MemoryAccessMode::from_funct3(raw_parts.funct3).width;
+
+    auto numeric_operation = raw_parts.funct7 >> 2;
+    auto operation = static_cast<AtomicMemoryOperation::Operation>(numeric_operation);
+    switch (numeric_operation) {
+    case 0b00010:
+    case 0b00011: {
+        auto is_sc = (raw_parts.funct7 & 0b100) > 0;
+        return adopt_own(*new (nothrow) LoadReservedStoreConditional(is_sc ? LoadReservedStoreConditional::Operation::StoreConditional : LoadReservedStoreConditional::Operation::LoadReserved, is_acquire, is_release, width, raw_parts.rs1, raw_parts.rs2, raw_parts.rd));
+    }
+    case 0b00001:
+    case 0b00000:
+    case 0b00100:
+    case 0b01000:
+    case 0b01100:
+    case 0b10000:
+    case 0b10100:
+    case 0b11000:
+    case 0b11100:
+        return adopt_own(*new (nothrow) AtomicMemoryOperation(operation, is_acquire, is_release, width, raw_parts.rs1, raw_parts.rs2, raw_parts.rd));
+    default:
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    }
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/A.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/A.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibDisassembly/riscv64/Instruction.h>
+
+// A extension.
+namespace Disassembly::RISCV64 {
+
+class AtomicOperation : public RTypeInstruction {
+public:
+    virtual ~AtomicOperation() = default;
+    bool operator==(AtomicOperation const&) const = default;
+
+    AtomicOperation(DataWidth width, bool is_acquire, bool is_release, Register rs1, Register rs2, Register rd)
+        : RTypeInstruction(rs1, rs2, rd)
+        , m_width(width)
+        , m_is_acquire(is_acquire)
+        , m_is_release(is_release)
+    {
+    }
+
+    DataWidth width() const { return m_width; }
+    bool is_acquire() const { return m_is_acquire; }
+    bool is_release() const { return m_is_release; }
+    bool is_acquire_release() const { return m_is_acquire && m_is_release; }
+
+private:
+    DataWidth m_width;
+    bool m_is_acquire;
+    bool m_is_release;
+};
+
+class LoadReservedStoreConditional : public AtomicOperation {
+public:
+    enum class Operation : bool {
+        LoadReserved,
+        StoreConditional,
+    };
+
+    virtual ~LoadReservedStoreConditional() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(LoadReservedStoreConditional const&) const = default;
+
+    LoadReservedStoreConditional(Operation operation, bool is_acquire, bool is_release, DataWidth width, Register rs1, Register rs2, Register rd)
+        : AtomicOperation(width, is_acquire, is_release, rs1, rs2, rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    Operation m_operation;
+};
+
+class AtomicMemoryOperation : public AtomicOperation {
+public:
+    enum class Operation : u8 {
+        Swap = 0b00001,
+        Add = 0b00000,
+        Xor = 0b00100,
+        And = 0b01100,
+        Or = 0b01000,
+        Min = 0b10000,
+        Max = 0b10100,
+        MinUnsigned = 0b11000,
+        MaxUnsigned = 0b11100,
+    };
+
+    virtual ~AtomicMemoryOperation() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(AtomicMemoryOperation const&) const = default;
+
+    AtomicMemoryOperation(Operation operation, bool is_acquire, bool is_release, DataWidth width, Register rs1, Register rs2, Register rd)
+        : AtomicOperation(width, is_acquire, is_release, rs1, rs2, rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    Operation m_operation;
+};
+
+NonnullOwnPtr<InstructionImpl> parse_amo(u32 instruction);
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/FD.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/FD.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FD.h"
+#include <AK/Assertions.h>
+#include <LibDisassembly/riscv64/Instruction.h>
+
+namespace Disassembly::RISCV64 {
+
+NonnullOwnPtr<InstructionImpl> parse_op_fp(u32 instruction)
+{
+    auto raw_parts = RawRType::parse(instruction);
+    auto width = static_cast<FloatWidth>(raw_parts.funct7 & 0b11);
+    auto rounding_mode = static_cast<RoundingMode>(raw_parts.funct3);
+
+    auto operation = FloatArithmeticInstruction::Operation::Add;
+    switch (raw_parts.funct7 & ~0b11) {
+    case 0b0000000:
+        operation = FloatArithmeticInstruction::Operation::Add;
+        break;
+    case 0b0000100:
+        operation = FloatArithmeticInstruction::Operation::Subtract;
+        break;
+    case 0b0001000:
+        operation = FloatArithmeticInstruction::Operation::Multiply;
+        break;
+    case 0b0001100:
+        operation = FloatArithmeticInstruction::Operation::Divide;
+        break;
+    case 0b0010000:
+        switch (raw_parts.funct3) {
+        case 0b000:
+            operation = FloatArithmeticInstruction::Operation::SignInject;
+            break;
+        case 0b001:
+            operation = FloatArithmeticInstruction::Operation::SignInjectNegate;
+            break;
+        case 0b010:
+            operation = FloatArithmeticInstruction::Operation::SignInjectXor;
+            break;
+        default:
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        }
+        rounding_mode = RoundingMode::DYN;
+        break;
+    case 0b0010100:
+        switch (raw_parts.funct3) {
+        case 0b000:
+            operation = FloatArithmeticInstruction::Operation::Min;
+            break;
+        case 0b001:
+            operation = FloatArithmeticInstruction::Operation::Max;
+            break;
+        default:
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        }
+        rounding_mode = RoundingMode::DYN;
+        break;
+    case 0b0101100:
+        if (raw_parts.rs2 != 0)
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        return adopt_own(*new FloatSquareRoot(rounding_mode, width, as_float_register(raw_parts.rs1), as_float_register(raw_parts.rd)));
+    case 0b1010000: {
+        auto compare_operation = FloatCompare::Operation::Equals;
+        switch (raw_parts.funct3) {
+        case 0b010:
+            compare_operation = FloatCompare::Operation::Equals;
+            break;
+        case 0b001:
+            compare_operation = FloatCompare::Operation::LessThan;
+            break;
+        case 0b000:
+            compare_operation = FloatCompare::Operation::LessThanEquals;
+            break;
+        default:
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        }
+        return adopt_own(*new FloatCompare(compare_operation, width, as_float_register(raw_parts.rs1), as_float_register(raw_parts.rs2), raw_parts.rd));
+    }
+    case 0b0100000: {
+        if (raw_parts.funct7 == 0b0100000 && raw_parts.rs2 == 1)
+            return adopt_own(*new ConvertFloat(ConvertFloat::Operation::SingleToDouble, rounding_mode, as_float_register(raw_parts.rs1), as_float_register(raw_parts.rd)));
+        if (raw_parts.funct7 == 0b0100001 && raw_parts.rs2 == 0)
+            return adopt_own(*new ConvertFloat(ConvertFloat::Operation::DoubleToSingle, rounding_mode, as_float_register(raw_parts.rs1), as_float_register(raw_parts.rd)));
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    }
+    case 0b1110000: {
+        if (raw_parts.rs2 != 0 || raw_parts.funct3 > 0b001)
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        if (raw_parts.funct3 == 0b001)
+            return adopt_own(*new FloatClassify(width, as_float_register(raw_parts.rs1), raw_parts.rd));
+        if (raw_parts.funct3 == 0b000)
+            return adopt_own(*new MoveFloatToInteger(width, as_float_register(raw_parts.rs1), raw_parts.rd));
+        VERIFY_NOT_REACHED(); // Logically impossible
+    }
+    case 0b1100000:
+    case 0b1101000: {
+        if (raw_parts.rs2.value() > 0b11)
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        // Not mentioned in the spec, but bit 3 of funct7 distinguishes between float-to-integer (0) and integer-to-float (1) conversions.
+        auto is_int_to_float = (raw_parts.funct7 & (1 << 3)) > 0;
+        // Not mentioned in the spec either, but all "normal" float-integer conversion functions can be distinguished by 4 specific bits:
+        // - Bit 0 of "rs2" distinguishes between signed (0) and unsigned (1) integer conversions
+        auto signedness = (raw_parts.rs2.value() & 1) > 0 ? Signedness::Unsigned : Signedness::Signed;
+        // - Bit 1 of "rs2" distinguishes between word (0) and doubleword (1) integer conversions
+        auto integer_word_width = (raw_parts.rs2.value() & 0b10) > 0 ? DataWidth::DoubleWord : DataWidth::Word;
+        MemoryAccessMode integer_width { .width = integer_word_width, .signedness = signedness };
+        if (is_int_to_float)
+            return adopt_own(*new ConvertIntegerToFloat(rounding_mode, integer_width, width, raw_parts.rs1, as_float_register(raw_parts.rd)));
+        return adopt_own(*new ConvertFloatToInteger(rounding_mode, integer_width, width, as_float_register(raw_parts.rs1), raw_parts.rd));
+    }
+    case 0b1111000:
+        if (raw_parts.rs2 != 0)
+            return adopt_own(*new (nothrow) UnknownInstruction);
+        return adopt_own(*new MoveIntegerToFloat(width, raw_parts.rs1, as_float_register(raw_parts.rd)));
+    default:
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    }
+    return adopt_own(*new FloatArithmeticInstruction(operation, rounding_mode, width, as_float_register(raw_parts.rs1), as_float_register(raw_parts.rs2), as_float_register(raw_parts.rd)));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_fma(u32 instruction)
+{
+    auto raw_parts = RawR4Type::parse(instruction);
+    auto width = static_cast<FloatWidth>(raw_parts.fmt);
+    auto rounding_mode = static_cast<RoundingMode>(raw_parts.funct3);
+
+    auto operation = FloatFusedMultiplyAdd::Operation::MultiplyAdd;
+    switch (static_cast<MajorOpcode>(raw_parts.opcode)) {
+    case MajorOpcode::MADD:
+        operation = FloatFusedMultiplyAdd::Operation::MultiplyAdd;
+        break;
+    case MajorOpcode::MSUB:
+        operation = FloatFusedMultiplyAdd::Operation::MultiplySubtract;
+        break;
+    case MajorOpcode::NMADD:
+        operation = FloatFusedMultiplyAdd::Operation::NegatedMultiplyAdd;
+        break;
+    case MajorOpcode::NMSUB:
+        operation = FloatFusedMultiplyAdd::Operation::NegatedMultiplySubtract;
+        break;
+    default:
+        return adopt_own(*new (nothrow) UnknownInstruction);
+    }
+    return adopt_own(*new FloatFusedMultiplyAdd(operation, rounding_mode, width, as_float_register(raw_parts.rs1), as_float_register(raw_parts.rs2), as_float_register(raw_parts.rs3), as_float_register(raw_parts.rd)));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_load_fp(u32 instruction)
+{
+    auto raw_parts = RawIType::parse(instruction);
+    if (raw_parts.funct3 > 0b11)
+        return adopt_own(*new (nothrow) UnknownInstruction);
+
+    auto width = data_width_to_float_width(static_cast<DataWidth>(raw_parts.funct3 & 0b11));
+    return adopt_own(*new (nothrow) FloatMemoryLoad(raw_parts.imm, raw_parts.rs1, width, as_float_register(raw_parts.rd)));
+}
+
+NonnullOwnPtr<InstructionImpl> parse_store_fp(u32 instruction)
+{
+    auto raw_parts = RawSType::parse(instruction);
+    if (raw_parts.funct3 > 0b11)
+        return adopt_own(*new (nothrow) UnknownInstruction);
+
+    auto width = data_width_to_float_width(static_cast<DataWidth>(raw_parts.funct3 & 0b11));
+    return adopt_own(*new (nothrow) FloatMemoryStore(raw_parts.imm, as_float_register(raw_parts.rs2), raw_parts.rs1, width));
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/FD.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/FD.h
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibDisassembly/riscv64/Instruction.h>
+
+// F and D extensions.
+namespace Disassembly::RISCV64 {
+
+// Table 11.3; IEEE 754 floating-point "format" or width field.
+enum class FloatWidth : u8 {
+    // binary32
+    Single = 0,
+    // binary64
+    Double = 1,
+    // binary16
+    Half = 2,
+    // binary128
+    Quad = 3,
+};
+
+constexpr DataWidth float_width_to_data_width(FloatWidth width)
+{
+    switch (width) {
+    case FloatWidth::Single:
+        return DataWidth::Word;
+    case FloatWidth::Double:
+        return DataWidth::DoubleWord;
+    case FloatWidth::Half:
+        return DataWidth::Halfword;
+    case FloatWidth::Quad:
+        return DataWidth::QuadWord;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+constexpr FloatWidth data_width_to_float_width(DataWidth width)
+{
+    switch (width) {
+    case DataWidth::Word:
+        return FloatWidth::Single;
+    case DataWidth::DoubleWord:
+        return FloatWidth::Double;
+    case DataWidth::Halfword:
+        return FloatWidth::Half;
+    case DataWidth::QuadWord:
+        return FloatWidth::Quad;
+    case DataWidth::Byte:
+        VERIFY_NOT_REACHED();
+    }
+    VERIFY_NOT_REACHED();
+}
+
+class FloatInstruction : public InstructionImpl {
+public:
+    virtual ~FloatInstruction() = default;
+    bool operator==(FloatInstruction const&) const = default;
+
+    // When used in loads and stores, we can coerce a float width to its equivalent memory access type.
+    MemoryAccessMode memory_width() const
+    {
+        return { .width = float_width_to_data_width(m_width), .signedness = Signedness::Signed };
+    }
+    FloatWidth width() const { return m_width; }
+
+    FloatInstruction(FloatWidth width)
+        : m_width(width)
+    {
+    }
+
+private:
+    FloatWidth m_width;
+};
+
+class FloatComputationInstruction : public FloatInstruction {
+public:
+    virtual ~FloatComputationInstruction() = default;
+    virtual i32 immediate() const override { return 0; }
+    bool operator==(FloatComputationInstruction const&) const = default;
+    RoundingMode rounding_mode() const { return m_rounding_mode; }
+    String format_rounding_mode(DisplayStyle display_style) const;
+
+    FloatComputationInstruction(RoundingMode rounding_mode, FloatWidth width)
+        : FloatInstruction(width)
+        , m_rounding_mode(rounding_mode)
+    {
+    }
+
+private:
+    RoundingMode m_rounding_mode;
+};
+
+class FloatTwoArgumentInstruction : public FloatComputationInstruction {
+public:
+    bool operator==(FloatTwoArgumentInstruction const&) const = default;
+    FloatRegister source_register_1() const { return m_rs1; }
+    FloatRegister source_register_2() const { return m_rs2; }
+
+    FloatTwoArgumentInstruction(RoundingMode rounding_mode, FloatWidth width, FloatRegister rs1, FloatRegister rs2)
+        : FloatComputationInstruction(rounding_mode, width)
+        , m_rs1(rs1)
+        , m_rs2(rs2)
+    {
+    }
+
+private:
+    FloatRegister m_rs1;
+    FloatRegister m_rs2;
+};
+
+class FloatRTypeInstruction : public FloatTwoArgumentInstruction {
+public:
+    bool operator==(FloatRTypeInstruction const&) const = default;
+    FloatRegister destination_register() const { return m_rd; }
+
+    FloatRTypeInstruction(RoundingMode rounding_mode, FloatWidth width, FloatRegister rs1, FloatRegister rs2, FloatRegister rd)
+        : FloatTwoArgumentInstruction(rounding_mode, width, rs1, rs2)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    FloatRegister m_rd;
+};
+
+class FloatArithmeticInstruction : public FloatRTypeInstruction {
+public:
+    enum class Operation : u8 {
+        Add,
+        Subtract,
+        Multiply,
+        Divide,
+        Min,
+        Max,
+        // Always use rs1's value except the sign:
+        // Copy sign from rs2.
+        SignInject,
+        // Copy inverted sign from rs2.
+        SignInjectNegate,
+        // Xor both signs.
+        SignInjectXor,
+    };
+
+    virtual ~FloatArithmeticInstruction() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatArithmeticInstruction const&) const = default;
+    Operation operation() const { return m_operation; }
+
+    FloatArithmeticInstruction(Operation operation, RoundingMode rounding_mode, FloatWidth width, FloatRegister rs1, FloatRegister rs2, FloatRegister rd)
+        : FloatRTypeInstruction(rounding_mode, width, rs1, rs2, rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    Operation m_operation;
+};
+
+class FloatSquareRoot : public FloatComputationInstruction {
+public:
+    virtual ~FloatSquareRoot() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatSquareRoot const&) const = default;
+
+    FloatSquareRoot(RoundingMode rounding_mode, FloatWidth width, FloatRegister rs, FloatRegister rd)
+        : FloatComputationInstruction(rounding_mode, width)
+        , m_rs(rs)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    FloatRegister m_rs;
+    FloatRegister m_rd;
+};
+
+class FloatCompare : public FloatTwoArgumentInstruction {
+public:
+    enum class Operation : u8 {
+        Equals,
+        LessThan,
+        LessThanEquals,
+    };
+
+    virtual ~FloatCompare() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatCompare const&) const = default;
+
+    FloatCompare(Operation operation, FloatWidth width, FloatRegister rs1, FloatRegister rs2, Register rd)
+        : FloatTwoArgumentInstruction(RoundingMode::DYN, width, rs1, rs2)
+        , m_rd(rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    Register m_rd;
+    Operation m_operation;
+};
+
+class ConvertFloatAndInteger : public FloatComputationInstruction {
+public:
+    virtual ~ConvertFloatAndInteger() = default;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(ConvertFloatAndInteger const&) const = default;
+    MemoryAccessMode integer_width() const { return m_integer_width; }
+    String integer_width_suffix() const;
+
+    ConvertFloatAndInteger(RoundingMode rounding_mode, MemoryAccessMode integer_width, FloatWidth float_width)
+        : FloatComputationInstruction(rounding_mode, float_width)
+        , m_integer_width(integer_width)
+    {
+    }
+
+private:
+    MemoryAccessMode m_integer_width;
+};
+
+class ConvertFloatToInteger : public ConvertFloatAndInteger {
+public:
+    virtual ~ConvertFloatToInteger() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(ConvertFloatToInteger const&) const = default;
+
+    ConvertFloatToInteger(RoundingMode rounding_mode, MemoryAccessMode integer_width, FloatWidth float_width, FloatRegister rs, Register rd)
+        : ConvertFloatAndInteger(rounding_mode, integer_width, float_width)
+        , m_rs(rs)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    FloatRegister m_rs;
+    Register m_rd;
+};
+
+class ConvertIntegerToFloat : public ConvertFloatAndInteger {
+public:
+    virtual ~ConvertIntegerToFloat() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(ConvertIntegerToFloat const&) const = default;
+
+    ConvertIntegerToFloat(RoundingMode rounding_mode, MemoryAccessMode integer_width, FloatWidth float_width, Register rs, FloatRegister rd)
+        : ConvertFloatAndInteger(rounding_mode, integer_width, float_width)
+        , m_rs(rs)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    Register m_rs;
+    FloatRegister m_rd;
+};
+
+class ConvertFloat : public FloatComputationInstruction {
+public:
+    enum class Operation {
+        SingleToDouble,
+        DoubleToSingle,
+    };
+
+    virtual ~ConvertFloat() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(ConvertFloat const&) const = default;
+
+    ConvertFloat(Operation operation, RoundingMode rounding_mode, FloatRegister rs, FloatRegister rd)
+        : FloatComputationInstruction(rounding_mode, FloatWidth::Double)
+        , m_rs(rs)
+        , m_rd(rd)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    FloatRegister m_rs;
+    FloatRegister m_rd;
+    Operation m_operation;
+};
+
+class FloatClassify : public FloatInstruction {
+public:
+    virtual ~FloatClassify() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual i32 immediate() const override { return 0; }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatClassify const&) const = default;
+
+    FloatClassify(FloatWidth width, FloatRegister rs, Register rd)
+        : FloatInstruction(width)
+        , m_rs(rs)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    FloatRegister m_rs;
+    Register m_rd;
+};
+
+class MoveFloatToInteger : public FloatInstruction {
+public:
+    virtual ~MoveFloatToInteger() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual i32 immediate() const override { return 0; }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(MoveFloatToInteger const&) const = default;
+
+    MoveFloatToInteger(FloatWidth width, FloatRegister rs, Register rd)
+        : FloatInstruction(width)
+        , m_rs(rs)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    FloatRegister m_rs;
+    Register m_rd;
+};
+
+class MoveIntegerToFloat : public FloatInstruction {
+public:
+    virtual ~MoveIntegerToFloat() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual i32 immediate() const override { return 0; }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(MoveIntegerToFloat const&) const = default;
+
+    MoveIntegerToFloat(FloatWidth width, Register rs, FloatRegister rd)
+        : FloatInstruction(width)
+        , m_rs(rs)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    Register m_rs;
+    FloatRegister m_rd;
+};
+
+class FloatFusedMultiplyAdd : public FloatRTypeInstruction {
+public:
+    enum class Operation : u8 {
+        // (rs1 · rs2) + rs3
+        MultiplyAdd,
+        // (rs1 · rs2) - rs3
+        MultiplySubtract,
+        // - (rs1 · rs2) + rs3
+        NegatedMultiplyAdd,
+        // - (rs1 · rs2) - rs3
+        NegatedMultiplySubtract,
+    };
+
+    virtual ~FloatFusedMultiplyAdd() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatFusedMultiplyAdd const&) const = default;
+    FloatRegister source_register_3() const { return m_rs3; }
+
+    FloatFusedMultiplyAdd(Operation operation, RoundingMode rounding_mode, FloatWidth width, FloatRegister rs1, FloatRegister rs2, FloatRegister rs3, FloatRegister rd)
+        : FloatRTypeInstruction(rounding_mode, width, rs1, rs2, rd)
+        , m_operation(operation)
+        , m_rs3(rs3)
+    {
+    }
+
+private:
+    Operation m_operation;
+    FloatRegister m_rs3;
+};
+
+class FloatMemoryInstruction : public FloatInstruction {
+public:
+    virtual ~FloatMemoryInstruction() = default;
+    virtual i32 immediate() const override { return m_offset; }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatMemoryInstruction const&) const = default;
+    Register base() const { return m_base; }
+
+    FloatMemoryInstruction(i32 offset, Register base, FloatWidth width)
+        : FloatInstruction(width)
+        , m_base(base)
+        , m_offset(offset)
+    {
+    }
+
+private:
+    Register m_base;
+    i32 m_offset;
+};
+
+class FloatMemoryLoad : public FloatMemoryInstruction {
+public:
+    virtual ~FloatMemoryLoad() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatMemoryLoad const&) const = default;
+    FloatRegister destination_register() const { return m_rd; }
+
+    FloatMemoryLoad(i32 offset, Register base, FloatWidth width, FloatRegister rd)
+        : FloatMemoryInstruction(offset, base, width)
+        , m_rd(rd)
+    {
+    }
+
+private:
+    FloatRegister m_rd;
+};
+
+class FloatMemoryStore : public FloatMemoryInstruction {
+public:
+    virtual ~FloatMemoryStore() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(FloatMemoryStore const&) const = default;
+    FloatRegister source_register() const { return m_source; }
+
+    FloatMemoryStore(i32 offset, FloatRegister source, Register base, FloatWidth width)
+        : FloatMemoryInstruction(offset, base, width)
+        , m_source(source)
+    {
+    }
+
+private:
+    FloatRegister m_source;
+};
+
+NonnullOwnPtr<InstructionImpl> parse_op_fp(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_fma(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_load_fp(u32 instruction);
+NonnullOwnPtr<InstructionImpl> parse_store_fp(u32 instruction);
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
@@ -172,6 +172,26 @@ String InstructionFetchFence::mnemonic() const
     return "fence.i"_string;
 }
 
+String CSRImmediateInstruction::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {:#x}, {}", mnemonic(), format_register(destination_register(), display_style), csr(), immediate()));
+}
+
+String CSRImmediateInstruction::mnemonic() const
+{
+    return MUST(String::formatted("{}i", operation()));
+}
+
+String CSRRegisterInstruction::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {:#x}, {}", mnemonic(), format_register(destination_register(), display_style), csr(), format_register(source_register(), display_style)));
+}
+
+String CSRRegisterInstruction::mnemonic() const
+{
+    return MUST(String::formatted("{}", operation()));
+}
+
 String Fence::to_string(DisplayStyle, u32, Optional<SymbolProvider const&>) const
 {
     return MUST(String::formatted("{:10} {}, {}", mnemonic(), m_predecessor, m_successor));

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.cpp
@@ -352,4 +352,36 @@ String Fence::mnemonic() const
     VERIFY_NOT_REACHED();
 }
 
+String AtomicMemoryOperation::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    return MUST(String::formatted("{:10} {}, {}, ({})", mnemonic(), format_register(destination_register(), display_style), format_register(source_register_2(), display_style), format_register(source_register_1(), display_style)));
+}
+
+String AtomicMemoryOperation::mnemonic() const
+{
+    return MUST(String::formatted("amo{}.{}{}", m_operation, MemoryAccessMode { width(), Signedness::Signed },
+        is_acquire_release() ? ".aqrl"sv
+            : is_acquire()   ? ".aq"sv
+            : is_release()   ? ".rl"sv
+                             : ""sv));
+}
+
+String LoadReservedStoreConditional::to_string(DisplayStyle display_style, u32, Optional<SymbolProvider const&>) const
+{
+    if (m_operation == Operation::LoadReserved)
+        return MUST(String::formatted("{:10} {}, ({})", mnemonic(), format_register(destination_register(), display_style), format_register(source_register_1(), display_style)));
+    // Operation::StoreConditional
+    return MUST(String::formatted("{:10} {}, {}, ({})", mnemonic(), format_register(destination_register(), display_style), format_register(source_register_2(), display_style), format_register(source_register_1(), display_style)));
+}
+
+String LoadReservedStoreConditional::mnemonic() const
+{
+    auto operation = m_operation == Operation::LoadReserved ? "lr"sv : "sc"sv;
+    return MUST(String::formatted("{}.{}{}", operation, MemoryAccessMode { width(), Signedness::Signed },
+        is_acquire_release() ? ".aqrl"sv
+            : is_acquire()   ? ".aq"sv
+            : is_release()   ? ".rl"sv
+                             : ""sv));
+}
+
 }

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
@@ -8,6 +8,7 @@
 
 #include <AK/Format.h>
 #include <AK/String.h>
+#include <LibDisassembly/riscv64/A.h>
 #include <LibDisassembly/riscv64/Encoding.h>
 #include <LibDisassembly/riscv64/FD.h>
 #include <LibDisassembly/riscv64/IM.h>
@@ -585,6 +586,45 @@ struct AK::Formatter<Disassembly::RISCV64::MemoryAccessMode> : AK::Formatter<For
             signedness_str = "u"sv;
 
         return AK::Formatter<FormatString>::format(builder, "{}{}"sv, width_str, signedness_str);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::AtomicMemoryOperation::Operation> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::AtomicMemoryOperation::Operation op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+            using enum Disassembly::RISCV64::AtomicMemoryOperation::Operation;
+        case Swap:
+            op_name = "swap"sv;
+            break;
+        case Add:
+            op_name = "add"sv;
+            break;
+        case Xor:
+            op_name = "xor"sv;
+            break;
+        case And:
+            op_name = "and"sv;
+            break;
+        case Or:
+            op_name = "or"sv;
+            break;
+        case Min:
+            op_name = "min"sv;
+            break;
+        case Max:
+            op_name = "max"sv;
+            break;
+        case MinUnsigned:
+            op_name = "minu"sv;
+            break;
+        case MaxUnsigned:
+            op_name = "maxu"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
     }
 };
 

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
@@ -11,6 +11,7 @@
 #include <LibDisassembly/riscv64/Encoding.h>
 #include <LibDisassembly/riscv64/IM.h>
 #include <LibDisassembly/riscv64/Instruction.h>
+#include <LibDisassembly/riscv64/Zicsr.h>
 
 template<>
 struct AK::Formatter<Disassembly::RISCV64::Register> : AK::Formatter<FormatString> {
@@ -420,6 +421,27 @@ struct AK::Formatter<Disassembly::RISCV64::Branch::Condition> : AK::Formatter<St
             break;
         case Disassembly::RISCV64::Branch::Condition::GreaterEqualsUnsigned:
             op_name = "bgeu"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::CSRInstruction::Operation> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::CSRInstruction::Operation op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+            using enum Disassembly::RISCV64::CSRInstruction::Operation;
+        case ReadWrite:
+            op_name = "csrrw"sv;
+            break;
+        case ReadClear:
+            op_name = "csrrc"sv;
+            break;
+        case ReadSet:
+            op_name = "csrrs"sv;
             break;
         }
         return AK::Formatter<StringView>::format(builder, op_name);

--- a/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Formatting.h
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/String.h>
 #include <LibDisassembly/riscv64/Encoding.h>
+#include <LibDisassembly/riscv64/FD.h>
 #include <LibDisassembly/riscv64/IM.h>
 #include <LibDisassembly/riscv64/Instruction.h>
 #include <LibDisassembly/riscv64/Zicsr.h>
@@ -349,48 +350,112 @@ struct AK::Formatter<Disassembly::RISCV64::ArithmeticInstruction::Operation> : A
 };
 
 template<>
+struct AK::Formatter<Disassembly::RISCV64::FloatArithmeticInstruction::Operation> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::FloatArithmeticInstruction::Operation op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+            using enum Disassembly::RISCV64::FloatArithmeticInstruction::Operation;
+        case Add:
+            op_name = "fadd"sv;
+            break;
+        case Subtract:
+            op_name = "fsub"sv;
+            break;
+        case Multiply:
+            op_name = "fmul"sv;
+            break;
+        case Divide:
+            op_name = "fdiv"sv;
+            break;
+        case Min:
+            op_name = "fmin"sv;
+            break;
+        case Max:
+            op_name = "fmax"sv;
+            break;
+        case SignInject:
+            op_name = "fsgnj"sv;
+            break;
+        case SignInjectNegate:
+            op_name = "fsgnjn"sv;
+            break;
+        case SignInjectXor:
+            op_name = "fsgnjx"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::FloatFusedMultiplyAdd::Operation> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::FloatFusedMultiplyAdd::Operation op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+            using enum Disassembly::RISCV64::FloatFusedMultiplyAdd::Operation;
+        case MultiplyAdd:
+            op_name = "fmadd"sv;
+            break;
+        case MultiplySubtract:
+            op_name = "fmsub"sv;
+            break;
+        case NegatedMultiplyAdd:
+            op_name = "fnmadd"sv;
+            break;
+        case NegatedMultiplySubtract:
+            op_name = "fnmsub"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
+    }
+};
+
+template<>
 struct AK::Formatter<Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation> : AK::Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation op)
     {
         auto op_name = ""sv;
         switch (op) {
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::Add:
+            using enum Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation;
+        case Add:
             op_name = "addi"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::SetLessThan:
+        case SetLessThan:
             op_name = "slti"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::SetLessThanUnsigned:
+        case SetLessThanUnsigned:
             op_name = "sltiu"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::Xor:
+        case Xor:
             op_name = "xori"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::Or:
+        case Or:
             op_name = "ori"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::And:
+        case And:
             op_name = "andi"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftLeftLogical:
+        case ShiftLeftLogical:
             op_name = "slli"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightLogical:
+        case ShiftRightLogical:
             op_name = "srli"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightArithmetic:
+        case ShiftRightArithmetic:
             op_name = "srai"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::AddWord:
+        case AddWord:
             op_name = "addiw"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftLeftLogicalWord:
+        case ShiftLeftLogicalWord:
             op_name = "slliw"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightLogicalWord:
+        case ShiftRightLogicalWord:
             op_name = "srliw"sv;
             break;
-        case Disassembly::RISCV64::ArithmeticImmediateInstruction::Operation::ShiftRightArithmeticWord:
+        case ShiftRightArithmeticWord:
             op_name = "sraiw"sv;
             break;
         }
@@ -404,22 +469,23 @@ struct AK::Formatter<Disassembly::RISCV64::Branch::Condition> : AK::Formatter<St
     {
         auto op_name = ""sv;
         switch (op) {
-        case Disassembly::RISCV64::Branch::Condition::Equals:
+            using enum Disassembly::RISCV64::Branch::Condition;
+        case Equals:
             op_name = "beq"sv;
             break;
-        case Disassembly::RISCV64::Branch::Condition::NotEquals:
+        case NotEquals:
             op_name = "bne"sv;
             break;
-        case Disassembly::RISCV64::Branch::Condition::LessThan:
+        case LessThan:
             op_name = "blt"sv;
             break;
-        case Disassembly::RISCV64::Branch::Condition::GreaterEquals:
+        case GreaterEquals:
             op_name = "bge"sv;
             break;
-        case Disassembly::RISCV64::Branch::Condition::LessThanUnsigned:
+        case LessThanUnsigned:
             op_name = "bltu"sv;
             break;
-        case Disassembly::RISCV64::Branch::Condition::GreaterEqualsUnsigned:
+        case GreaterEqualsUnsigned:
             op_name = "bgeu"sv;
             break;
         }
@@ -452,17 +518,42 @@ template<>
 struct AK::Formatter<Disassembly::RISCV64::Fence::AccessType> : AK::Formatter<String> {
     ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::Fence::AccessType op)
     {
+        using namespace Disassembly::RISCV64;
         StringBuilder op_name;
-        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Input))
+        if (has_flag(op, Fence::AccessType::Input))
             op_name.append_code_point('i');
-        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Output))
+        if (has_flag(op, Fence::AccessType::Output))
             op_name.append_code_point('o');
-        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Read))
+        if (has_flag(op, Fence::AccessType::Read))
             op_name.append_code_point('r');
-        if (Disassembly::RISCV64::has_flag(op, Disassembly::RISCV64::Fence::AccessType::Write))
+        if (has_flag(op, Fence::AccessType::Write))
             op_name.append_code_point('w');
 
         return AK::Formatter<String>::format(builder, MUST(op_name.to_string()));
+    }
+};
+
+template<>
+struct AK::Formatter<Disassembly::RISCV64::FloatWidth> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Disassembly::RISCV64::FloatWidth op)
+    {
+        auto op_name = ""sv;
+        switch (op) {
+            using enum Disassembly::RISCV64::FloatWidth;
+        case Single:
+            op_name = "s"sv;
+            break;
+        case Double:
+            op_name = "d"sv;
+            break;
+        case Half:
+            op_name = "h"sv;
+            break;
+        case Quad:
+            op_name = "q"sv;
+            break;
+        }
+        return AK::Formatter<StringView>::format(builder, op_name);
     }
 };
 
@@ -472,19 +563,20 @@ struct AK::Formatter<Disassembly::RISCV64::MemoryAccessMode> : AK::Formatter<For
     {
         auto width_str = ""sv;
         switch (mode.width) {
-        case Disassembly::RISCV64::DataWidth::Byte:
+            using enum Disassembly::RISCV64::DataWidth;
+        case Byte:
             width_str = "b"sv;
             break;
-        case Disassembly::RISCV64::DataWidth::Halfword:
+        case Halfword:
             width_str = "h"sv;
             break;
-        case Disassembly::RISCV64::DataWidth::Word:
+        case Word:
             width_str = "w"sv;
             break;
-        case Disassembly::RISCV64::DataWidth::DoubleWord:
+        case DoubleWord:
             width_str = "d"sv;
             break;
-        case Disassembly::RISCV64::DataWidth::QuadWord:
+        case QuadWord:
             width_str = "q"sv;
             break;
         }
@@ -502,26 +594,27 @@ struct AK::Formatter<Disassembly::RISCV64::RoundingMode> : AK::Formatter<StringV
     {
         auto formatted = ""sv;
         switch (reg) {
-        case Disassembly::RISCV64::RoundingMode::RNE:
+            using enum Disassembly::RISCV64::RoundingMode;
+        case RNE:
             formatted = "rne"sv;
             break;
-        case Disassembly::RISCV64::RoundingMode::RTZ:
+        case RTZ:
             formatted = "rtz"sv;
             break;
-        case Disassembly::RISCV64::RoundingMode::RDN:
+        case RDN:
             formatted = "rdn"sv;
             break;
-        case Disassembly::RISCV64::RoundingMode::RUP:
+        case RUP:
             formatted = "rup"sv;
             break;
-        case Disassembly::RISCV64::RoundingMode::RMM:
+        case RMM:
             formatted = "rmm"sv;
             break;
-        case Disassembly::RISCV64::RoundingMode::Invalid1:
-        case Disassembly::RISCV64::RoundingMode::Invalid2:
+        case Invalid1:
+        case Invalid2:
             formatted = "invalid"sv;
             break;
-        case Disassembly::RISCV64::RoundingMode::DYN:
+        case DYN:
             formatted = "dyn"sv;
             break;
         }

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Instruction.h"
+#include "A.h"
 #include "Encoding.h"
 #include "FD.h"
 #include "IM.h"
@@ -116,7 +117,9 @@ bool simple_instruction_equals(InstructionType const& self, InstructionImpl cons
     M(CSRRegisterInstruction)            \
     M(CSRImmediateInstruction)           \
     M(Fence)                             \
-    M(InstructionFetchFence)
+    M(InstructionFetchFence)             \
+    M(AtomicMemoryOperation)             \
+    M(LoadReservedStoreConditional)
 
 ENUMERATE_INSTRUCTION_IMPLS(MAKE_INSTRUCTION_EQUALS)
 

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
@@ -7,6 +7,7 @@
 #include "Instruction.h"
 #include "Encoding.h"
 #include "IM.h"
+#include "Zicsr.h"
 #include <AK/Assertions.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StdLibExtras.h>
@@ -96,6 +97,9 @@ bool simple_instruction_equals(InstructionType const& self, InstructionImpl cons
     M(Branch)                            \
     M(EnvironmentCall)                   \
     M(EnvironmentBreak)                  \
+    M(CSRInstruction)                    \
+    M(CSRRegisterInstruction)            \
+    M(CSRImmediateInstruction)           \
     M(Fence)                             \
     M(InstructionFetchFence)
 

--- a/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Instruction.cpp
@@ -6,6 +6,7 @@
 
 #include "Instruction.h"
 #include "Encoding.h"
+#include "FD.h"
 #include "IM.h"
 #include "Zicsr.h"
 #include <AK/Assertions.h>
@@ -95,6 +96,20 @@ bool simple_instruction_equals(InstructionType const& self, InstructionImpl cons
     M(MemoryLoad)                        \
     M(MemoryStore)                       \
     M(Branch)                            \
+    M(FloatArithmeticInstruction)        \
+    M(FloatSquareRoot)                   \
+    M(FloatFusedMultiplyAdd)             \
+    M(ConvertFloatAndInteger)            \
+    M(ConvertFloatToInteger)             \
+    M(ConvertIntegerToFloat)             \
+    M(ConvertFloat)                      \
+    M(MoveFloatToInteger)                \
+    M(MoveIntegerToFloat)                \
+    M(FloatCompare)                      \
+    M(FloatClassify)                     \
+    M(FloatMemoryInstruction)            \
+    M(FloatMemoryLoad)                   \
+    M(FloatMemoryStore)                  \
     M(EnvironmentCall)                   \
     M(EnvironmentBreak)                  \
     M(CSRInstruction)                    \

--- a/Userland/Libraries/LibDisassembly/riscv64/Zicsr.cpp
+++ b/Userland/Libraries/LibDisassembly/riscv64/Zicsr.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Zicsr.h"
+
+namespace Disassembly::RISCV64 {
+
+NonnullOwnPtr<CSRInstruction> parse_csr(RawIType raw_parts)
+{
+    auto is_immediate = (raw_parts.funct3 & 0b100) > 0;
+    auto operation = CSRInstruction::Operation::ReadWrite;
+
+    switch (raw_parts.funct3 & 0b11) {
+    case 0b01:
+        operation = CSRInstruction::Operation::ReadWrite;
+        break;
+    case 0b10:
+        operation = CSRInstruction::Operation::ReadSet;
+        break;
+    case 0b11:
+        operation = CSRInstruction::Operation::ReadClear;
+        break;
+    case 0b00:
+        VERIFY_NOT_REACHED();
+    }
+
+    if (is_immediate)
+        return adopt_own(*new (nothrow) CSRImmediateInstruction(operation, static_cast<u16>(raw_parts.imm & 0xfff), raw_parts.rs1.value(), raw_parts.rd));
+    else
+        return adopt_own(*new (nothrow) CSRRegisterInstruction(operation, static_cast<u16>(raw_parts.imm & 0xfff), raw_parts.rs1, raw_parts.rd));
+}
+
+}

--- a/Userland/Libraries/LibDisassembly/riscv64/Zicsr.h
+++ b/Userland/Libraries/LibDisassembly/riscv64/Zicsr.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibDisassembly/riscv64/Instruction.h>
+
+// Zicsr extension.
+namespace Disassembly::RISCV64 {
+
+class CSRInstruction : public InstructionWithDestinationRegister
+    , public InstructionImpl {
+public:
+    enum class Operation {
+        ReadWrite,
+        ReadSet,
+        ReadClear,
+    };
+
+    virtual ~CSRInstruction() = default;
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(CSRInstruction const&) const = default;
+    u16 csr() const { return m_csr; }
+    Operation operation() const { return m_operation; }
+
+    CSRInstruction(Operation operation, u16 csr, Register rd)
+        : InstructionWithDestinationRegister(rd)
+        , m_csr(csr)
+        , m_operation(operation)
+    {
+    }
+
+private:
+    u16 m_csr;
+    Operation m_operation;
+};
+
+class CSRRegisterInstruction : public InstructionWithSourceRegister
+    , public CSRInstruction {
+public:
+    virtual ~CSRRegisterInstruction() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual i32 immediate() const override { return 0; }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(CSRRegisterInstruction const&) const = default;
+
+    CSRRegisterInstruction(Operation operation, u16 csr, Register rs, Register rd)
+        : InstructionWithSourceRegister(rs)
+        , CSRInstruction(operation, csr, rd)
+    {
+    }
+};
+
+class CSRImmediateInstruction : public CSRInstruction {
+public:
+    virtual ~CSRImmediateInstruction() = default;
+    virtual String to_string(DisplayStyle display_style, u32 origin, Optional<SymbolProvider const&> symbol_provider) const override;
+    virtual String mnemonic() const override;
+    virtual i32 immediate() const override { return static_cast<i32>(m_immediate); }
+    virtual bool instruction_equals(InstructionImpl const&) const override;
+    bool operator==(CSRImmediateInstruction const&) const = default;
+
+    CSRImmediateInstruction(Operation operation, u16 csr, u8 immediate, Register rd)
+        : CSRInstruction(operation, csr, rd)
+        , m_immediate(immediate)
+    {
+    }
+
+private:
+    u8 m_immediate;
+};
+
+NonnullOwnPtr<CSRInstruction> parse_csr(RawIType raw_parts);
+
+}


### PR DESCRIPTION
This second PR in the collection deals with all the remaining non-priviledged extensions we need right now. I encourage anyone with three years of free time to tackle V :3

### LibDisassembly: Add RISC-V Zicsr extension decoding

Note that CSR pretty-printing is not yet implemented, since we aim to establish shared CSR utilities in AK in the near future.

### LibDisassembly: Add RISC-V FD extension decoding

Again, no point in splitting these two since the orthagonal instruction set makes supporting both in common abstractions convenient.

### LibDisassembly: Add RISC-V A extension decoding