### PR TITLE
LibGfx/JPEGXL: Read pass groups and two other bug fixes

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLChannel.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLChannel.h
@@ -65,6 +65,23 @@ public:
         m_decoded = decoded;
     }
 
+    void copy_from(IntRect destination, Channel const& other)
+    {
+        VERIFY(destination.left() >= 0);
+        VERIFY(destination.top() >= 0);
+        VERIFY(static_cast<u32>(destination.right()) <= m_width);
+        VERIFY(static_cast<u32>(destination.bottom()) <= m_height);
+
+        VERIFY(static_cast<u32>(destination.width()) == other.width());
+        VERIFY(static_cast<u32>(destination.height()) == other.height());
+
+        for (i32 y = 0; y < destination.height(); ++y) {
+            for (i32 x = 0; x < destination.width(); ++x) {
+                set(x + destination.left(), y + destination.top(), other.get(x, y));
+            }
+        }
+    }
+
 private:
     u32 m_width {};
     u32 m_height {};

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLEntropyDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLEntropyDecoder.cpp
@@ -483,6 +483,8 @@ ErrorOr<void> EntropyDecoder::read_pre_clustered_distributions(LittleEndianInput
 
         if (use_mtf)
             TODO();
+
+        TRY(decoder.ensure_end_state());
     }
     TRY(m_configs.try_resize(num_clusters));
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLEntropyDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLEntropyDecoder.h
@@ -55,11 +55,7 @@ class EntropyDecoder {
 
 public:
     EntropyDecoder() = default;
-    ~EntropyDecoder()
-    {
-        if (m_state.has_value() && *m_state != 0x130000)
-            dbgln("JPEGXLLoader: ANS decoder left in invalid state");
-    }
+    ~EntropyDecoder() = default;
 
     static ErrorOr<EntropyDecoder> create(LittleEndianInputBitStream& stream, u32 initial_num_distrib);
 
@@ -68,6 +64,14 @@ public:
     void set_dist_multiplier(u32 dist_multiplier)
     {
         m_dist_multiplier = dist_multiplier;
+    }
+
+    ErrorOr<void> ensure_end_state()
+    {
+        if (m_state.has_value() && *m_state != 0x130000)
+            return Error::from_string_literal("JPEGXLLoader: ANS decoder left in invalid state");
+        m_state.clear();
+        return {};
     }
 
 private:

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLICC.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLICC.cpp
@@ -73,6 +73,7 @@ ErrorOr<ByteBuffer> read_encoded_icc_stream(LittleEndianInputBitStream& stream)
         uncompressed_icc_stream[index] = TRY(decoder.decode_hybrid_uint(stream, context));
     }
 
+    TRY(decoder.ensure_end_state());
     return uncompressed_icc_stream;
 }
 ///

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -933,6 +933,7 @@ public:
                 tree.m_tree.empend(leaf_node);
             }
         }
+        TRY(decoder->ensure_end_state());
 
         // Finally, the decoder reads (tree.size() + 1) / 2 pre-clustered distributions D as specified in C.1.
 
@@ -1626,6 +1627,7 @@ static ErrorOr<ModularData> read_modular_bitstream(LittleEndianInputBitStream& s
 
         channel.set_decoded(true);
     }
+    TRY(decoder->ensure_end_state());
 
     return modular_data;
 }
@@ -1738,6 +1740,7 @@ static ErrorOr<FixedArray<Patch>> read_patches(LittleEndianInputBitStream& strea
     for (auto& patch : patches)
         patch = TRY(read_patch(stream, decoder, num_extra_channels));
 
+    TRY(decoder.ensure_end_state());
     return patches;
 }
 


### PR DESCRIPTION
This allows us to progress a lot on the same test image as #25819, we are now able to reach the end of the bitstream without an error! We now crash on a TODO in `apply_transformation()` because we don't still don't know how to apply the inverse palette transform.

New log:
```cpp
Decoding a JPEG XL image with size 555x751 and 3 channels.
Frame: 555x751 Modular - type(0) - flags(0) - is_last
TOC: index |  size | offset
         0 |  3359 |      0
         1 |     0 |   3359
         2 |     0 |   3359
         3 | 14052 |   3359
         4 | 17154 |  17411
         5 |  1952 |  34565
         6 | 19462 |  36517
         7 | 20323 |  55979
         8 |  2859 |  76302
         9 | 12377 |  79161
        10 | 13920 |  91538
        11 |  2404 | 105458
Decoding modular sub-stream (global tree, 1 transforms, stream_index=0):
* Palette: begin_c=0 - num_c=3 - nb_colours=0 - nb_deltas=0 - d_pred=13
- Channel 0: 0x3 - skipped
- Channel 1: 555x751 - skipped
Discarding 4 remaining bytes
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [0,0 256x256]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=21):
- Channel 0: 256x256
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [256,0 256x256]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=22):
- Channel 0: 256x256
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [512,0 43x256]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=23):
- Channel 0: 43x256
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [0,256 256x256]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=24):
- Channel 0: 256x256
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [256,256 256x256]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=25):
- Channel 0: 256x256
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [512,256 43x256]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=26):
- Channel 0: 43x256
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [0,512 256x239]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=27):
- Channel 0: 256x239
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [256,512 256x239]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=28):
- Channel 0: 256x239
Discarding 0 remaining bytes
Decoding pass 0 for rectangle [512,512 43x239]
Decoding modular sub-stream (global tree, 0 transforms, stream_index=29):
- Channel 0: 43x239
Discarding 0 remaining bytes
VERIFICATION FAILED: TODO at /home/lucas/repos/serenity/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp:1874
```

This is the result of the decoded palette channel (`i32` cast to `u8`):
![palette_1](https://github.com/user-attachments/assets/f08573dd-1e50-4e92-82b1-b3f8112b2c3a)

A PNG version of the original being:
![ref](https://github.com/user-attachments/assets/0671a82f-2ee0-444b-9764-9d57f92e52fa)
