### PR TITLE
LibPDF: Read lattice-form gouraud-shaded triangle mesh shading entries

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -200,6 +200,7 @@
     X(UseBlackPTComp)             \
     X(UserUnit)                   \
     X(V)                          \
+    X(VerticesPerRow)             \
     X(W)                          \
     X(W2)                         \
     X(WhitePoint)                 \

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -788,6 +788,159 @@ PDFErrorOr<void> FreeFormGouraudShading::draw(Gfx::Painter&, Gfx::AffineTransfor
     return Error::rendering_unsupported_error("Cannot draw free-form gouraud-shaded triangle meshes yet");
 }
 
+class LatticeFormGouraudShading final : public Shading {
+public:
+    static PDFErrorOr<NonnullRefPtr<LatticeFormGouraudShading>> create(Document*, NonnullRefPtr<StreamObject>, CommonEntries);
+
+    virtual PDFErrorOr<void> draw(Gfx::Painter&, Gfx::AffineTransform const&) override;
+
+private:
+    using FunctionsType = Variant<Empty, NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
+
+    // Indexes into m_vertex_data.
+    struct Triangle {
+        u32 a;
+        u32 b;
+        u32 c;
+    };
+
+    LatticeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, Vector<Triangle> triangles, FunctionsType functions)
+        : m_common_entries(move(common_entries))
+        , m_vertex_data(move(vertex_data))
+        , m_triangles(move(triangles))
+        , m_functions(move(functions))
+    {
+    }
+
+    CommonEntries m_common_entries;
+
+    // Interleaved x, y, c0, c1, c2, ...
+    Vector<float> m_vertex_data;
+    Vector<Triangle> m_triangles;
+    FunctionsType m_functions;
+};
+
+PDFErrorOr<NonnullRefPtr<LatticeFormGouraudShading>> LatticeFormGouraudShading::create(Document* document, NonnullRefPtr<StreamObject> shading_stream, CommonEntries common_entries)
+{
+    auto shading_dict = shading_stream->dict();
+
+    // TABLE 4.33 Additional entries specific to a type 5 shading dictionary
+    // "(Required) The number of bits used to represent each vertex coordinate.
+    //  Valid values are 1, 2, 4, 8, 12, 16, 24, and 32."
+    int bits_per_coordinate = TRY(document->resolve(shading_dict->get_value(CommonNames::BitsPerCoordinate))).to_int();
+    if (!first_is_one_of(bits_per_coordinate, 1, 2, 4, 8, 12, 16, 24, 32))
+        return Error::malformed_error("BitsPerCoordinate invalid");
+
+    // "(Required) The number of bits used to represent each color component.
+    //  Valid values are 1, 2, 4, 8, 12, and 16."
+    int bits_per_component = TRY(document->resolve(shading_dict->get_value(CommonNames::BitsPerComponent))).to_int();
+    if (!first_is_one_of(bits_per_component, 1, 2, 4, 8, 12, 16))
+        return Error::malformed_error("BitsPerComponent invalid");
+
+    // "(Required) The number of vertices in each row of the lattice; the value
+    //  must be greater than or equal to 2. The number of rows need not be
+    //  specified."
+    int vertices_per_row = TRY(document->resolve(shading_dict->get_value(CommonNames::VerticesPerRow))).to_int();
+    if (vertices_per_row < 2)
+        return Error::malformed_error("VerticesPerRow invalid");
+
+    // "(Required) An array of numbers specifying how to map vertex coordinates
+    //  and color components into the appropriate ranges of values. The decoding
+    //  method is similar to that used in image dictionaries (see “Decode Arrays”
+    //  on page 344). The ranges are specified as follows:
+    //
+    //      [ xmin xmax ymin ymax c1,min c1,max … cn,min cn,max ]
+    //
+    //  Note that only one pair of c values should be specified if a Function entry
+    //  is present."
+    auto decode_array = TRY(shading_dict->get_array(document, CommonNames::Decode));
+    size_t number_of_components = static_cast<size_t>(shading_dict->contains(CommonNames::Function) ? 1 : common_entries.color_space->number_of_components());
+    if (decode_array->size() != 4 + 2 * number_of_components)
+        return Error::malformed_error("Decode array must have 4 + 2 * number of components elements");
+    Vector<float> decode;
+    decode.resize(decode_array->size());
+    for (size_t i = 0; i < decode_array->size(); ++i)
+        decode[i] = decode_array->at(i).to_float();
+
+    // "(Optional) A 1-in, n-out function or an array of n 1-in, 1-out functions
+    //  (where n is the number of color components in the shading dictionary’s
+    //  color space). If this entry is present, the color data for each vertex must be
+    //  specified by a single parametric variable rather than by n separate color
+    //  components. The designated function(s) are called with each interpolated
+    //  value of the parametric variable to determine the actual color at each
+    //  point. Each input value is forced into the range interval specified for the
+    //  corresponding color component in the shading dictionary’s Decode array.
+    //  Each function’s domain must be a superset of that interval. If the value re-
+    //  turned by the function for a given color component is out of range, it is
+    //  adjusted to the nearest valid value.
+    //  This entry may not be used with an Indexed color space."
+    FunctionsType functions;
+    if (shading_dict->contains(CommonNames::Function)) {
+        if (common_entries.color_space->family() == ColorSpaceFamily::Indexed)
+            return Error::malformed_error("Function cannot be used with Indexed color space");
+
+        functions = TRY([&]() -> PDFErrorOr<FunctionsType> {
+            auto function_object = TRY(shading_dict->get_object(document, CommonNames::Function));
+            if (function_object->is<ArrayObject>()) {
+                auto function_array = function_object->cast<ArrayObject>();
+                Vector<NonnullRefPtr<Function>> functions_vector;
+                if (function_array->size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+                    return Error::malformed_error("Function array must have as many elements as color space has components");
+                for (size_t i = 0; i < function_array->size(); ++i) {
+                    auto function = TRY(Function::create(document, TRY(document->resolve_to<Object>(function_array->at(i)))));
+                    if (TRY(function->evaluate(to_array({ decode[4] }))).size() != 1)
+                        return Error::malformed_error("Function must have 1 output component");
+                    TRY(functions_vector.try_append(move(function)));
+                }
+                return functions_vector;
+            }
+            auto function = TRY(Function::create(document, function_object));
+            if (TRY(function->evaluate(to_array({ decode[0] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+                return Error::malformed_error("Function must have as many output components as color space");
+            return function;
+        }());
+    }
+
+    // See "Type 5 Shadings (Lattice-Form Gouraud-Shaded Triangle Meshes)" in the PDF 1.7 spec for a description of the stream contents.
+    auto stream = FixedMemoryStream { shading_stream->bytes() };
+    BigEndianInputBitStream bitstream { MaybeOwned { stream } };
+
+    Vector<float> vertex_data;
+    while (!bitstream.is_eof()) {
+        u32 x = TRY(bitstream.read_bits<u32>(bits_per_coordinate));
+        u32 y = TRY(bitstream.read_bits<u32>(bits_per_coordinate));
+        TRY(vertex_data.try_append(mix(decode[0], decode[1], x / (powf(2.0f, bits_per_coordinate) - 1))));
+        TRY(vertex_data.try_append(mix(decode[2], decode[3], y / (powf(2.0f, bits_per_coordinate) - 1))));
+        for (size_t i = 0; i < number_of_components; ++i) {
+            u16 color = TRY(bitstream.read_bits<u16>(bits_per_component));
+            TRY(vertex_data.try_append(mix(decode[4 + 2 * i], decode[4 + 2 * i + 1], color / (powf(2.0f, bits_per_component) - 1))));
+        }
+        bitstream.align_to_byte_boundary();
+    }
+
+    size_t number_of_vertices = vertex_data.size() / (2 + number_of_components);
+    if (number_of_vertices % vertices_per_row != 0)
+        return Error::malformed_error("Number of vertices must be a multiple of vertices per row");
+    size_t number_of_rows = number_of_vertices / vertices_per_row;
+    if (number_of_rows < 2)
+        return Error::malformed_error("Number of rows must be at least 2");
+
+    Vector<Triangle> triangles;
+    for (u32 i = 0; i <= number_of_rows - 2; ++i) {
+        for (u32 j = 0; j <= static_cast<u32>(vertices_per_row - 2); ++j) {
+            triangles.append({ i * vertices_per_row + j, i * vertices_per_row + j + 1, (i + 1) * vertices_per_row + j });
+            triangles.append({ i * vertices_per_row + j + 1, (i + 1) * vertices_per_row + j, (i + 1) * vertices_per_row + j + 1 });
+        }
+    }
+
+    return adopt_ref(*new LatticeFormGouraudShading(move(common_entries), move(vertex_data), move(triangles), move(functions)));
+}
+
+PDFErrorOr<void> LatticeFormGouraudShading::draw(Gfx::Painter&, Gfx::AffineTransform const&)
+{
+    return Error::rendering_unsupported_error("Cannot draw lattice-form gouraud-shaded triangle meshes yet");
+}
+
 }
 
 PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRefPtr<Object> shading_dict_or_stream, Renderer& renderer)
@@ -825,7 +978,9 @@ PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRe
             return Error::malformed_error("Free-form Gouraud-shaded triangle mesh stream has wrong type");
         return FreeFormGouraudShading::create(document, shading_dict_or_stream->cast<StreamObject>(), move(common_entries));
     case 5:
-        return Error::rendering_unsupported_error("Lattice-form Gouraud-shaded triangle mesh not yet implemented");
+        if (!shading_dict_or_stream->is<StreamObject>())
+            return Error::malformed_error("Lattice-form Gouraud-shaded triangle mesh stream has wrong type");
+        return LatticeFormGouraudShading::create(document, shading_dict_or_stream->cast<StreamObject>(), move(common_entries));
     case 6:
         return Error::rendering_unsupported_error("Coons patch mesh not yet implemented");
     case 7:


### PR DESCRIPTION
We now create an LatticeFormGouraudShading object and read all required parameters and build objects for them, but we don't use them for any rendering yet.