### PR TITLE
Tests/LibGfx: A JPEG XL palette test sooner than expected

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -2072,9 +2072,7 @@ TEST_CASE(test_jxl_icc)
     EXPECT(TRY_OR_FAIL(plugin_decoder->icc_data()).has_value());
     EXPECT_EQ(TRY_OR_FAIL(plugin_decoder->icc_data()).value().size(), 2644u);
 
-    // FIXME: Also make sure we can decode the image. I unfortunately was unable to create an image
-    //        with both an ICC profile and only features that we support.
-    // TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 32, 32 }));
+    verify_checkerboard(*plugin_decoder);
 }
 
 TEST_CASE(test_dds)

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -2039,15 +2039,11 @@ TEST_CASE(test_jxl_modular_simple_tree_upsample2_10bits)
     EXPECT_EQ(frame.image->get_pixel(42, 57), Gfx::Color::from_string("#4c0072"sv));
 }
 
-TEST_CASE(test_jxl_modular_property_8)
+static void verify_checkerboard(Gfx::ImageDecoderPlugin& decoder)
 {
-    auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("jxl/modular_property_8.jxl"sv)));
-    EXPECT(Gfx::JPEGXLImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = TRY_OR_FAIL(Gfx::JPEGXLImageDecoderPlugin::create(file->bytes()));
+    TRY_OR_FAIL(expect_single_frame_of_size(decoder, { 32, 32 }));
 
-    TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 32, 32 }));
-
-    auto frame = TRY_OR_FAIL(plugin_decoder->frame(0));
+    auto frame = TRY_OR_FAIL(decoder.frame(0));
     for (u8 i = 0; i < 32; ++i) {
         for (u8 j = 0; j < 32; ++j) {
             auto const color = frame.image->get_pixel(i, j);
@@ -2057,6 +2053,15 @@ TEST_CASE(test_jxl_modular_property_8)
                 EXPECT_EQ(color, Gfx::Color::Yellow);
         }
     }
+}
+
+TEST_CASE(test_jxl_modular_property_8)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("jxl/modular_property_8.jxl"sv)));
+    EXPECT(Gfx::JPEGXLImageDecoderPlugin::sniff(file->bytes()));
+    auto plugin_decoder = TRY_OR_FAIL(Gfx::JPEGXLImageDecoderPlugin::create(file->bytes()));
+
+    verify_checkerboard(*plugin_decoder);
 }
 
 TEST_CASE(test_jxl_icc)


### PR DESCRIPTION
Here is the log when decoding `icc.jxl`:
```
Decoding a JPEG XL image with size 32x32 and 3 channels.
Frame: 32x32 Modular - type(0) - flags(0) - is_last
TOC: index |  size | offset
         0 |    33 |      0
Decoding modular sub-stream (global tree, 1 transforms, stream_index=0):
* Palette: begin_c=0 - num_c=3 - nb_colours=2 - nb_deltas=0 - d_pred=0
- Channel 0: 2x3
- Channel 1: 32x32
Discarding 0 remaining bytes
```