### PR TITLE
Kernel/Input: Correct the HID keyboard driver usage ID range check

### DIFF
--- a/Kernel/Devices/Input/HID/KeyboardDriver.cpp
+++ b/Kernel/Devices/Input/HID/KeyboardDriver.cpp
@@ -150,7 +150,7 @@ ErrorOr<void> KeyboardDriver::on_report(ReadonlyBytes report_data)
 
         u16 usage_id = usage & 0xffff;
 
-        if (usage_id >= new_key_state.size()) {
+        if (usage_id >= key_state_bitmap_size_in_bits) {
             dbgln_if(HID_DEBUG, "HID: Unknown Keyboard/Keypad Page Usage ID: {:#x}", usage_id);
             return IterationDecision::Continue;
         }


### PR DESCRIPTION
Since 7a7e77cc4b, the bitmap array is only 4 elements big, meaning that we only accepted keys with a usage ID below 4.

This should make the HID keyboard driver work again.

(apparently I totally forgot to test this, oops) 