### PR TITLE
Kernel/aarch64: Add basic Raspberry Pi 5 support

### DIFF
--- a/Kernel/Arch/aarch64/PlatformInit.h
+++ b/Kernel/Arch/aarch64/PlatformInit.h
@@ -10,7 +10,8 @@
 
 namespace Kernel {
 
-void raspberry_pi_platform_init(StringView compatible_string);
+void raspberry_pi_3_4_platform_init(StringView compatible_string);
+void raspberry_pi_5_platform_init(StringView compatible_string);
 void virt_platform_init(StringView compatible_string);
 
 }

--- a/Kernel/Arch/aarch64/PlatformInit/RaspberryPi.cpp
+++ b/Kernel/Arch/aarch64/PlatformInit/RaspberryPi.cpp
@@ -35,7 +35,7 @@ void raspberry_pi_3_4_platform_init(StringView compatible_string)
     else
         VERIFY_NOT_REACHED();
 
-    RPi::Mailbox::initialize();
+    MUST(RPi::Mailbox::initialize(peripheral_base_address.offset(0xb880)));
     RPi::GPIO::initialize();
     s_debug_console_uart = MUST(PL011::initialize(peripheral_base_address.offset(0x20'1000))).leak_ptr();
 
@@ -92,6 +92,9 @@ void raspberry_pi_5_platform_init(StringView)
     set_debug_console(&s_debug_console);
 
     // FIXME: Don't rely on the firmware configuring the baud rate.
+
+    MUST(RPi::Mailbox::initialize(PhysicalAddress { 0x10'7c01'3880 }));
+    RPi::Framebuffer::initialize();
 }
 
 }

--- a/Kernel/Arch/aarch64/RPi/Mailbox.h
+++ b/Kernel/Arch/aarch64/RPi/Mailbox.h
@@ -18,8 +18,6 @@ struct MailboxRegisters;
 // https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 class Mailbox {
 public:
-    Mailbox();
-
     // Base class for Mailbox messages. Implemented in subsystems that use Mailbox.
     class Message {
     protected:
@@ -51,7 +49,7 @@ public:
         u32 m_empty_tag = 0;
     };
 
-    static void initialize();
+    static ErrorOr<void> initialize(PhysicalAddress);
     static bool is_initialized();
     static Mailbox& the();
 
@@ -63,6 +61,7 @@ public:
     Memory::TypedMapping<MailboxRegisters volatile> m_registers;
 
 private:
+    Mailbox(Memory::TypedMapping<MailboxRegisters volatile> registers);
     void wait_until_we_can_write() const;
     void wait_for_reply() const;
 };

--- a/Kernel/Firmware/DeviceTree/PlatformInit.cpp
+++ b/Kernel/Firmware/DeviceTree/PlatformInit.cpp
@@ -23,9 +23,10 @@ struct PlatformInitTableEntry {
 
 static constinit auto const s_platform_init_table = to_array<PlatformInitTableEntry>({
 #if ARCH(AARCH64)
-    { "raspberrypi,3-model-b"sv, raspberry_pi_platform_init },
-    { "raspberrypi,4-model-b"sv, raspberry_pi_platform_init },
     { "linux,dummy-virt"sv, virt_platform_init },
+    { "raspberrypi,3-model-b"sv, raspberry_pi_3_4_platform_init },
+    { "raspberrypi,4-model-b"sv, raspberry_pi_3_4_platform_init },
+    { "raspberrypi,5-model-b"sv, raspberry_pi_5_platform_init },
 #endif
 });
 


### PR DESCRIPTION
These changes are enough to make us reach the "Couldn't find a suitable device to boot from" panic on the Pi 5.