### PR TITLE
Kernel: Remove reference to RegisterState from UnhandledInterruptHandler

### DIFF
--- a/Kernel/Interrupts/UnhandledInterruptHandler.cpp
+++ b/Kernel/Interrupts/UnhandledInterruptHandler.cpp
@@ -15,7 +15,7 @@ UnhandledInterruptHandler::UnhandledInterruptHandler(u8 interrupt_vector)
 
 bool UnhandledInterruptHandler::handle_interrupt()
 {
-    PANIC("Interrupt: Unhandled vector {} was invoked for handle_interrupt(RegisterState&).", interrupt_number());
+    PANIC("Interrupt: Unhandled vector {} was invoked for handle_interrupt().", interrupt_number());
 }
 
 [[noreturn]] bool UnhandledInterruptHandler::eoi()


### PR DESCRIPTION
Interrupt handlers don't take a `RegisterState` anymore since 0482f4e1170.