### PR TITLE
Tests/LibPDF: Add a shading type 6 and 7 test file each

### DIFF
--- a/Tests/LibPDF/shade-coons.pdf
+++ b/Tests/LibPDF/shade-coons.pdf
@@ -1,0 +1,94 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 520]/Contents 4 0 R/Resources<</Shading<</Sh1 5 0 R/Sh2 9 0 R>>>>>>
+endobj
+
+4 0 obj
+<</Length 38>>
+stream
+q
+1 0 0 1 0 240 cm
+/Sh1 sh
+Q
+
+/Sh2 sh
+
+endstream
+endobj
+
+5 0 obj
+<</ShadingType 6/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Decode[50 250 40 240 0 1 0 1 0 1]/Length 179/Filter/ASCIIHexDecode>>
+stream
+00
+           0ccd 0ccd  0219 8058
+1500 80ff  2800 d72a  a000 f0a7
+90f3 e20c  cdf2 f300  ff09 58d5
+c7ff 90ff  ffa7 2a58  2f00 4332
+f332 0dfe
+00 a7 2a
+ff ff 00
+ff 00 58
+d5 ff ff
+>
+
+endstream
+endobj
+
+6 0 obj
+<</FunctionType 2/Domain[0 1]/Range[0 1 0 1 0 1]/C0[1 0 0]/C1[0 1 0]/N 3>>
+endobj
+
+7 0 obj
+<</FunctionType 2/Domain[0 1]/Range[0 1 0 1 0 1]/C0[0 1 0]/C1[0 0 1]/N 3>>
+endobj
+
+8 0 obj
+<</FunctionType 3/Domain[0 1]/Functions[6 0 R 7 0 R]/Bounds[.5]/Encode[0 1 0 1]>>
+endobj
+
+9 0 obj
+<</ShadingType 6/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Function 8 0 R/Decode[50 250 40 240 0 1]/Length 155/Filter/ASCIIHexDecode>>
+stream
+00
+           0ccd 0ccd  0219 8058
+1500 80ff  2800 d72a  a000 f0a7
+90f3 e20c  cdf2 f300  ff09 58d5
+c7ff 90ff  ffa7 2a58  2f00 4332
+f332 0dfe
+00
+ff
+ff
+00
+>
+
+endstream
+endobj
+
+xref
+0 10
+0000000000 65536 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000241 00000 n 
+0000000328 00000 n 
+0000000702 00000 n 
+0000000793 00000 n 
+0000000884 00000 n 
+0000000982 00000 n 
+
+trailer
+<</Size 10/Root 1 0 R>>
+startxref
+1339
+%%EOF

--- a/Tests/LibPDF/shade-tensor.pdf
+++ b/Tests/LibPDF/shade-tensor.pdf
@@ -1,0 +1,97 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 520]/Contents 4 0 R/Resources<</Shading<</Sh1 5 0 R/Sh2 9 0 R>>>>>>
+endobj
+
+4 0 obj
+<</Length 38>>
+stream
+q
+1 0 0 1 0 240 cm
+/Sh1 sh
+Q
+
+/Sh2 sh
+
+endstream
+endobj
+
+5 0 obj
+<</ShadingType 7/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Decode[50 250 40 240 0 1 0 1 0 1]/Length 222/Filter/ASCIIHexDecode>>
+stream
+00
+           0ccd 0ccd  0219 8058
+1500 80ff  2800 d72a  a000 f0a7
+90f3 e20c  cdf2 f300  ff09 58d5
+c7ff 90ff  ffa7 2a58  2f00 4332
+f332 0dfe
+0eff 2f55  55aa bf00  a000 eaaa  d5aa 4072
+00 a7 2a
+ff ff 00
+ff 00 58
+d5 ff ff
+>
+
+endstream
+endobj
+
+6 0 obj
+<</FunctionType 2/Domain[0 1]/Range[0 1 0 1 0 1]/C0[1 0 0]/C1[0 1 0]/N 3>>
+endobj
+
+7 0 obj
+<</FunctionType 2/Domain[0 1]/Range[0 1 0 1 0 1]/C0[0 1 0]/C1[0 0 1]/N 3>>
+endobj
+
+8 0 obj
+<</FunctionType 3/Domain[0 1]/Functions[6 0 R 7 0 R]/Bounds[.5]/Encode[0 1 0 1]>>
+endobj
+
+9 0 obj
+<</ShadingType 7/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Function 8 0 R/Decode[50 250 40 240 0 1]/Length 199/Filter/ASCIIHexDecode>>
+stream
+00
+           0ccd 0ccd  0219 8058
+1500 80ff  2800 d72a  a000 f0a7
+90f3 e20c  cdf2 f300  ff09 58d5
+c7ff 90ff  ffa7 2a58  2f00 4332
+f332 0dfe
+0eff 2f55  55aa bf00  a000 eaaa  d5aa 4072
+00
+ff
+ff
+00
+>
+
+
+endstream
+endobj
+
+xref
+0 10
+0000000000 65536 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000241 00000 n 
+0000000328 00000 n 
+0000000745 00000 n 
+0000000836 00000 n 
+0000000927 00000 n 
+0000001025 00000 n 
+
+trailer
+<</Size 10/Root 1 0 R>>
+startxref
+1426
+%%EOF


### PR DESCRIPTION
We can neither parse nor draw these yet.

Also, they're very basic, they're both just a single patch.

Both contain a patch with a direct color, and a patch with a (nonlinear) function object for the color.