### PR TITLE
LibGfx/JPEGXL: Add a custom formatter for FrameHeader::FrameType

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2145,11 +2145,11 @@ static ErrorOr<Frame> read_frame(LittleEndianInputBitStream& stream,
         frame.height = ceil(static_cast<double>(frame.height) / frame.frame_header.upsampling);
     }
 
-    dbgln_if(JPEGXL_DEBUG, "Frame{}: {}x{} {} - type({}) - flags({}){}"sv,
+    dbgln_if(JPEGXL_DEBUG, "Frame{}: {}x{} {} - {} - flags({}){}"sv,
         frame.frame_header.name.is_empty() ? ""sv : MUST(String::formatted(" \"{}\"", frame.frame_header.name)),
         frame.width, frame.height,
         frame.frame_header.encoding,
-        to_underlying(frame.frame_header.frame_type),
+        frame.frame_header.frame_type,
         to_underlying(frame.frame_header.flags),
         frame.frame_header.is_last ? " - is_last"sv : ""sv);
 
@@ -2603,6 +2603,24 @@ struct Formatter<Gfx::Encoding> : Formatter<StringView> {
         }
 
         return Formatter<StringView>::format(builder, string);
+    }
+};
+
+template<>
+struct Formatter<Gfx::FrameHeader::FrameType> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Gfx::FrameHeader::FrameType const& header)
+    {
+        switch (header) {
+        case Gfx::FrameHeader::FrameType::kRegularFrame:
+            return Formatter<StringView>::format(builder, "RegularFrame"sv);
+        case Gfx::FrameHeader::FrameType::kLFFrame:
+            return Formatter<StringView>::format(builder, "LFFrame"sv);
+        case Gfx::FrameHeader::FrameType::kReferenceOnly:
+            return Formatter<StringView>::format(builder, "ReferenceOnly"sv);
+        case Gfx::FrameHeader::FrameType::kSkipProgressive:
+            return Formatter<StringView>::format(builder, "SkipProgressive"sv);
+        }
+        VERIFY_NOT_REACHED();
     }
 };
 


### PR DESCRIPTION
It makes it a bit easier to work on images with multiple frames:
```cpp
Decoding a JPEG XL image with size 1600x1096 and 4 channels.
Frame: 198x198 Modular - ReferenceOnly - flags(0)
TOC: index |  size | offset
         0 | 14407 |      0
Decoding modular sub-stream (global tree, 4 transforms, stream_index=0):
* Palette: begin_c=0 - num_c=1 - nb_colours=181 - nb_deltas=0 - d_pred=0
* Palette: begin_c=2 - num_c=1 - nb_colours=186 - nb_deltas=0 - d_pred=0
* Palette: begin_c=4 - num_c=1 - nb_colours=184 - nb_deltas=0 - d_pred=0
* Palette: begin_c=3 - num_c=4 - nb_colours=326 - nb_deltas=0 - d_pred=0
- Channel 0: 326x4
- Channel 1: 184x1
- Channel 2: 186x1
- Channel 3: 181x1
- Channel 4: 198x198
Discarding 0 remaining bytes
Frame: 1600x1096 Modular - RegularFrame - flags(2) - is_last
[...]
```