### PR TITLE
LibWeb: Unbreak `help://` and launch links in the Help app (v2)

### DIFF
--- a/Base/usr/share/man/man1/Applications/3DFileViewer.md
+++ b/Base/usr/share/man/man1/Applications/3DFileViewer.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-3d-file-viewer.png) 3D File Viewer
 
-[Open](file:///bin/3DFileViewer)
+[Open](launch:///bin/3DFileViewer)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/About.md
+++ b/Base/usr/share/man/man1/Applications/About.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/ladyball.png) About - About SerenityOS
 
-[Open](file:///bin/About)
+[Open](launch:///bin/About)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/AnalogClock.md
+++ b/Base/usr/share/man/man1/Applications/AnalogClock.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-analog-clock.png) Analog Clock
 
-[Open](file:///bin/AnalogClock)
+[Open](launch:///bin/AnalogClock)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Assistant.md
+++ b/Base/usr/share/man/man1/Applications/Assistant.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-assistant.png) Assistant - Serenity Assistant
 
-[Open](file:///bin/Assistant)
+[Open](launch:///bin/Assistant)
 
 ## Synopsis
 
@@ -18,5 +18,5 @@ $ Assistant
 
 -   Enter a URL to open it in [Browser](help://man/1/Applications/Browser), e.g. `serenityos.org`.
 -   Perform quick calculations by typing the equal sign (=) followed by a mathematical expression, e.g. `=22*101`. Press `Return` to copy the result.
--   Run commands in [Terminal](help://man/1/Applications/Terminal) by prefixing them with a dollar sign ($), e.g. `$ uname -a`.
+-   Run commands in [Terminal](help://man/1/Applications/Terminal) by prefixing them with a dollar sign (\$), e.g. `$ uname -a`.
 -   Launch applications with arguments, e.g. launch [Pixel Paint](help://man/1/Applications/PixelPaint) with a file: `pp image.png`.

--- a/Base/usr/share/man/man1/Applications/Browser.md
+++ b/Base/usr/share/man/man1/Applications/Browser.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-browser.png) Browser - Serenity WWW Browser
 
-[Open](file:///bin/Browser)
+[Open](launch:///bin/Browser)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Calculator.md
+++ b/Base/usr/share/man/man1/Applications/Calculator.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-calculator.png) Calculator - Serenity calculator
 
-[Open](file:///bin/Calculator)
+[Open](launch:///bin/Calculator)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Calendar.md
+++ b/Base/usr/share/man/man1/Applications/Calendar.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-calendar.png) Calendar - Serenity calendar
 
-[Open](file:///bin/Calendar)
+[Open](launch:///bin/Calendar)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/CatDog.md
+++ b/Base/usr/share/man/man1/Applications/CatDog.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-catdog.png) CatDog - A helpful companion
 
-[Open](file:///bin/CatDog)
+[Open](launch:///bin/CatDog)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/CertificateSettings.md
+++ b/Base/usr/share/man/man1/Applications/CertificateSettings.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/certificate.png) Certificate Settings
 
-[Open](file:///bin/CertificateSettings)
+[Open](launch:///bin/CertificateSettings)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/CharacterMap.md
+++ b/Base/usr/share/man/man1/Applications/CharacterMap.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-character-map.png) Character Map - Unicode character viewer
 
-[Open](file:///bin/CharacterMap)
+[Open](launch:///bin/CharacterMap)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/CrashReporter.md
+++ b/Base/usr/share/man/man1/Applications/CrashReporter.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-crash-reporter.png) CrashReporter - information about crashed programs
 
-[Open](file:///bin/CrashReporter)
+[Open](launch:///bin/CrashReporter)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Eyes.md
+++ b/Base/usr/share/man/man1/Applications/Eyes.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-eyes.png) Eyes - follow the mouse LibGUI demo
 
-[Open](file:///bin/Eyes)
+[Open](launch:///bin/Eyes)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/FontEditor.md
+++ b/Base/usr/share/man/man1/Applications/FontEditor.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-font-editor.png) FontEditor - Serenity font editor
 
-[Open](file:///bin/FontEditor)
+[Open](launch:///bin/FontEditor)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/GMLPlayground.md
+++ b/Base/usr/share/man/man1/Applications/GMLPlayground.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-gml-playground.png) GML Playground - GUI Markup Language (GML) editor
 
-[Open](file:///bin/GMLPlayground)
+[Open](launch:///bin/GMLPlayground)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Help.md
+++ b/Base/usr/share/man/man1/Applications/Help.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-help.png) Help - digital manual
 
-[Open](file:///bin/Help)
+[Open](launch:///bin/Help)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/HexEditor.md
+++ b/Base/usr/share/man/man1/Applications/HexEditor.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/hex.png) Hex Editor - Binary file editor
 
-[Open](file:///bin/HexEditor)
+[Open](launch:///bin/HexEditor)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/ImageViewer.md
+++ b/Base/usr/share/man/man1/Applications/ImageViewer.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-image-viewer.png) Image Viewer - SerenityOS image viewer
 
-[Open](file:///bin/ImageViewer)
+[Open](launch:///bin/ImageViewer)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Magnifier.md
+++ b/Base/usr/share/man/man1/Applications/Magnifier.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-magnifier.png) Magnifier - Magnifier application
 
-[Open](file:///bin/Magnifier)
+[Open](launch:///bin/Magnifier)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Mail.md
+++ b/Base/usr/share/man/man1/Applications/Mail.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-mail.png) Mail - Serenity e-mail client
 
-[Open](file:///bin/Mail)
+[Open](launch:///bin/Mail)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Maps.md
+++ b/Base/usr/share/man/man1/Applications/Maps.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-maps.png) Maps
 
-[Open](file:///bin/Maps)
+[Open](launch:///bin/Maps)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/MouseSettings.md
+++ b/Base/usr/share/man/man1/Applications/MouseSettings.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-mouse.png) Mouse Settings - Mouse settings application
 
-[Open](file:///bin/MouseSettings)
+[Open](launch:///bin/MouseSettings)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/PixelPaint.md
+++ b/Base/usr/share/man/man1/Applications/PixelPaint.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-pixel-paint.png) Pixel Paint - Image Editor
 
-[Open](file:///bin/PixelPaint)
+[Open](launch:///bin/PixelPaint)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Presenter.md
+++ b/Base/usr/share/man/man1/Applications/Presenter.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-presenter.png) Presenter - Present slides to an audience
 
-[Open](file:///bin/Presenter)
+[Open](launch:///bin/Presenter)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Profiler.md
+++ b/Base/usr/share/man/man1/Applications/Profiler.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-profiler.png) Profiler - Serenity process profiler
 
-[Open](file:///bin/Profiler)
+[Open](launch:///bin/Profiler)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/SQLStudio.md
+++ b/Base/usr/share/man/man1/Applications/SQLStudio.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-sql-studio.png) SQL Studio - SerenityOS SQL Manager
 
-[Open](file:///bin/SQLStudio)
+[Open](launch:///bin/SQLStudio)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Screenshot.md
+++ b/Base/usr/share/man/man1/Applications/Screenshot.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-screenshot.png) Screenshot
 
-[Open](file:///bin/Screenshot)
+[Open](launch:///bin/Screenshot)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/Terminal.md
+++ b/Base/usr/share/man/man1/Applications/Terminal.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-terminal.png) Terminal - Serenity terminal emulator
 
-[Open](file:///bin/Terminal)
+[Open](launch:///bin/Terminal)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Applications/TextEditor.md
+++ b/Base/usr/share/man/man1/Applications/TextEditor.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-text-editor.png) TextEditor - SerenityOS text editor
 
-[Open](file:///bin/TextEditor)
+[Open](launch:///bin/TextEditor)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/2048.md
+++ b/Base/usr/share/man/man6/2048.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-2048.png) 2048
 
-[Open](file:///bin/2048)
+[Open](launch:///bin/2048)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/BrickGame.md
+++ b/Base/usr/share/man/man6/BrickGame.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-brickgame.png) BrickGame
 
-[Open](file:///bin/BrickGame)
+[Open](launch:///bin/BrickGame)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Chess.md
+++ b/Base/usr/share/man/man6/Chess.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-chess.png) Chess
 
-[Open](file:///bin/Chess)
+[Open](launch:///bin/Chess)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/ColorLines.md
+++ b/Base/usr/share/man/man6/ColorLines.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-colorlines.png) Color Lines
 
-[Open](file:///bin/ColorLines)
+[Open](launch:///bin/ColorLines)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-flappybug.png) Flappy Bug
 
-[Open](file:///bin/FlappyBug)
+[Open](launch:///bin/FlappyBug)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Flood.md
+++ b/Base/usr/share/man/man6/Flood.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-flood.png) Flood
 
-[Open](file:///bin/Flood)
+[Open](launch:///bin/Flood)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/GameOfLife.md
+++ b/Base/usr/share/man/man6/GameOfLife.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-gameoflife.png) GameOfLife
 
-[Open](file:///bin/GameOfLife)
+[Open](launch:///bin/GameOfLife)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Hearts.md
+++ b/Base/usr/share/man/man6/Hearts.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-hearts.png) Hearts - The Hearts card game
 
-[Open](file:///bin/Hearts)
+[Open](launch:///bin/Hearts)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/MasterWord.md
+++ b/Base/usr/share/man/man6/MasterWord.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-masterword.png) MasterWord
 
-[Open](file:///bin/MasterWord)
+[Open](launch:///bin/MasterWord)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Minesweeper.md
+++ b/Base/usr/share/man/man6/Minesweeper.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-minesweeper.png) Minesweeper
 
-[Open](file:///bin/Minesweeper)
+[Open](launch:///bin/Minesweeper)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Snake.md
+++ b/Base/usr/share/man/man6/Snake.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-snake.png) Snake
 
-[Open](file:///bin/Snake)
+[Open](launch:///bin/Snake)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Solitaire.md
+++ b/Base/usr/share/man/man6/Solitaire.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-solitaire.png) Solitaire - The Solitaire card game
 
-[Open](file:///bin/Solitaire)
+[Open](launch:///bin/Solitaire)
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Spider.md
+++ b/Base/usr/share/man/man6/Spider.md
@@ -2,7 +2,7 @@
 
 ![Icon](/res/icons/16x16/app-spider.png) Spider - The Spider card game
 
-[Open](file:///bin/Spider)
+[Open](launch:///bin/Spider)
 
 ## Synopsis
 

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -118,8 +118,11 @@ ErrorOr<void> MainWidget::initialize(GUI::Window& window)
 
     m_web_view = find_descendant_of_type_named<WebView::OutOfProcessWebView>("web_view");
     m_web_view->use_native_user_style_sheet();
-    m_web_view->handle_custom_scheme = [this](auto& url) {
-        if (url.scheme() == "file") {
+    m_web_view->handle_custom_scheme = [this](auto& custom_url) {
+        auto url = custom_url;
+        if (url.scheme() == "launch") {
+            // Treat "launch://" URLs as "file://" for use with Desktop::Launcher.
+            url.set_scheme("file"_string);
             auto path = LexicalPath { URL::percent_decode(url.serialize_path()) };
             if (!path.is_child_of(Manual::manual_base_path)) {
                 open_external(url);

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1143,13 +1143,12 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
             // 2. Set saveExtraDocumentState to false.
             saveExtraDocumentState = false;
         }
-
         // 4. Otherwise, if any of the following are true:
         //  - navigationParams is null;
         //  - FIXME: the result of should navigation response to navigation request of type in target be blocked by Content Security Policy? given navigationParams's request, navigationParams's response, navigationParams's policy container's CSP list, cspNavigationType, and navigable is "Blocked";
         //  - FIXME: navigationParams's reserved environment is non-null and the result of checking a navigation response's adherence to its embedder policy given navigationParams's response, navigable, and navigationParams's policy container's embedder policy is false; or
         //  - FIXME: the result of checking a navigation response's adherence to `X-Frame-Options` given navigationParams's response, navigable, navigationParams's policy container's CSP list, and navigationParams's origin is false,
-        if (navigation_params.has<Empty>() || navigation_params.has<NullWithError>()) {
+        else if (navigation_params.has<Empty>() || navigation_params.has<NullWithError>()) {
             // 1. Set entry's document state's document to the result of creating a document for inline content that doesn't have a DOM, given navigable, null, and navTimingType. The inline content should indicate to the user the sort of error that occurred.
             auto error_message = navigation_params.has<NullWithError>() ? navigation_params.get<NullWithError>() : "Unknown error"sv;
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -394,6 +394,8 @@ public:
     virtual void schedule_repaint() = 0;
     virtual bool is_ready_to_paint() const = 0;
 
+    virtual bool handle_non_fetch_scheme(const URL::URL&) { return false; }
+
     virtual DisplayListPlayerType display_list_player_type() const = 0;
 
 protected:

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -225,6 +225,7 @@ public:
     Function<void(String const&)> on_inspector_executed_console_script;
     Function<void(String const&)> on_inspector_exported_inspector_html;
     Function<IPC::File()> on_request_worker_agent;
+    Function<bool(URL::URL const&)> handle_custom_scheme;
 
     virtual Web::DevicePixelSize viewport_size() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -724,4 +724,13 @@ Optional<ViewImplementation&> WebContentClient::view_for_page_id(u64 page_id, So
     return {};
 }
 
+Messages::WebContentClient::HandleNonFetchSchemeResponse WebContentClient::handle_non_fetch_scheme(u64 page_id, const URL::URL& url)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->handle_custom_scheme)
+            return view->handle_custom_scheme(url);
+    }
+    return false;
+}
+
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -119,6 +119,7 @@ private:
     virtual void inspector_did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> const& stylesheets) override;
     virtual void inspector_did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier) override;
     virtual void did_get_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier, URL::URL const&, String const& source) override;
+    virtual Messages::WebContentClient::HandleNonFetchSchemeResponse handle_non_fetch_scheme(u64 page_id, const URL::URL&) override;
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -861,6 +861,11 @@ Vector<Web::CSS::StyleSheetIdentifier> PageClient::list_style_sheets() const
     return results;
 }
 
+bool PageClient::handle_non_fetch_scheme(const URL::URL& url)
+{
+    return client().handle_non_fetch_scheme(m_id, url);
+}
+
 Web::DisplayListPlayerType PageClient::display_list_player_type() const
 {
     if (s_use_gpu_painter)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -171,6 +171,7 @@ private:
     virtual void inspector_did_request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& stylesheet_source) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
     virtual void inspector_did_export_inspector_html(String const& script) override;
+    virtual bool handle_non_fetch_scheme(const URL::URL&) override;
 
     Web::Layout::Viewport* layout_root();
     void setup_palette();

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -50,6 +50,8 @@ endpoint WebContentClient
     did_request_dismiss_dialog(u64 page_id) =|
     did_get_source(u64 page_id, URL::URL url, URL::URL base_url, String source) =|
 
+    handle_non_fetch_scheme(u64 page_id, URL::URL url) => (bool did_handle)
+
     did_inspect_dom_tree(u64 page_id, ByteString dom_tree) =|
     did_inspect_dom_node(u64 page_id, bool has_style, ByteString computed_style,  ByteString resolved_style,  ByteString custom_properties, ByteString node_box_sizing, ByteString aria_properties_state, ByteString fonts) =|
     did_inspect_accessibility_tree(u64 page_id, ByteString accessibility_tree) =|

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -209,7 +209,7 @@ RecursionDecision MarkdownLinkage::visit(Markdown::Text::LinkNode const& link_no
             m_file_links.append({ file, ByteString(), StringCollector::from(*link_node.text) });
             return RecursionDecision::Recurse;
         }
-        if (url.scheme() == "file") {
+        if (url.scheme() == "file" || url.scheme() == "launch") {
             auto file_path = URL::percent_decode(url.serialize_path());
             if (file_path.contains("man"sv) && file_path.ends_with(".md"sv)) {
                 warnln("Inter-manpage link without the help:// scheme: {}\nPlease use help URLs of the form 'help://man/<section>/<subsection...>/<page>'", href);


### PR DESCRIPTION
 See commits for details. 

This is an alternative solution to #25288 (rather than #25662). This instead fleshes out the "attempt to create a non-fetch scheme document" steps a little, and adds a new hook to allow web view clients to handle custom URL schemes. 

Using this we can fix `help://` URLs (and launch links) in the Help app, along with `spreadsheet://` URLs (in Spreadsheet).

Note: URL schemes that LibWeb knows about are a bit wonky (e.g. normal `http://` or `file://`) as it attempts to handle them itself without informing the client. So in help man pages, `file://` URLs have been replaced with `launch://`, which is a custom scheme the Help app can handle.   

Fixes #25288 
Closes #25662