### PR TITLE
Meta: Remove unnecessary nonlocal from serenity_gdb.py

### DIFF
--- a/Meta/serenity_gdb.py
+++ b/Meta/serenity_gdb.py
@@ -393,7 +393,6 @@ class AKHashMapPrettyPrinter:
         elements = []
 
         def cb(key, value):
-            nonlocal elements
             elements.append((f"[{key}]", value))
 
         AKHashMapPrettyPrinter._iter_hashmap(self.val, cb)


### PR DESCRIPTION
The variable `elements` is never reassigned in this scope.

flake8 started warning about unused global/nonlocal statements since https://github.com/PyCQA/pyflakes/commit/cadcd60a70c118c1d8b6dc8c09e53dc8f32b1666.

This should fix CI, since we apparently don't pin our flake8 version and fail the lint even if the affected files weren't touched.