### PR TITLE
Ports: Add cairo

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -31,6 +31,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 | [`c-ares`](c-ares/)                           | c-ares                                                        | 1.19.0                   | https://c-ares.org                                                   |
 | [`c-ray`](c-ray/)                             | C-Ray                                                         | 8f30eb9                  | https://github.com/vkoskiv/c-ray                                     |
 | [`ca-certificates`](ca-certificates/)         | Mozilla CA certificate store                                  | 2025-02-25               | https://curl.se/docs/caextract.html                                  |
+| [`cairo`](cairo/)                             | Cairo                                                         | 1.18.2                   | https://www.cairographics.org/                                       |
 | [`carl`](carl/)                               | Crypto Ancienne Resource Loader                               | 1.5                      | https://github.com/classilla/cryanc                                  |
 | [`cavestory`](cavestory/)                     | Cave Story                                                    | 2.6.5-1                  | https://github.com/nxengine/nxengine-evo                             |
 | [`cbonsai`](cbonsai/)                         | cbonsai                                                       | 1.3.1                    | https://gitlab.com/jallbrit/cbonsai                                  |

--- a/Ports/cairo/package.sh
+++ b/Ports/cairo/package.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='cairo'
+version='1.18.2'
+archive_hash='a62b9bb42425e844cc3d6ddde043ff39dbabedd1542eba57a2eb79f85889d45a'
+files=(
+    "https://cairographics.org/releases/cairo-${version}.tar.xz#${archive_hash}"
+)
+useconfigure='true'
+configopts=(
+    "--cross-file=${SERENITY_BUILD_DIR}/meson-cross-file.txt"
+    "--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+    '-Dbuildtype=release'
+    '-Dtests=disabled'
+    # Use patched ports instead of subprojects.
+    '--wrap-mode=nofallback'
+    '-Dfontconfig=enabled'
+    '-Dfreetype=enabled'
+    '-Dglib=enabled'
+    '-Dpng=enabled'
+    '-Dzlib=enabled'
+)
+depends=(
+    'expat'
+    'fontconfig'
+    'freetype'
+    'glib'
+    'libpng'
+    'pixman'
+    'zlib'
+)
+
+configure() {
+    run meson setup --reconfigure "${configopts[@]}" build
+}
+
+build() {
+    run ninja -C build
+}
+
+install() {
+    run ninja -C build install
+}


### PR DESCRIPTION
We can build Cairo without patches. (However, #25795 should be merged first since Cairo uses `scanf` to parse strings.)

I confirmed that an example code worked fine.

![cairo](https://github.com/user-attachments/assets/ff7ab0a4-b504-4572-b347-ac9553fc27c0)

```c
#include <cairo/cairo.h>

int main() {
    int width = 400, height = 300;
    
    // Create a Cairo surface and context
    cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
    cairo_t *cr = cairo_create(surface);
    
    // Set background color to white
    cairo_set_source_rgb(cr, 1, 1, 1);
    cairo_paint(cr);
    
    // Draw a rectangle with a blue fill
    cairo_set_source_rgb(cr, 0, 0, 1);
    cairo_rectangle(cr, 50, 50, 200, 100);
    cairo_fill(cr);
    
    // Draw a red circle
    cairo_set_source_rgb(cr, 1, 0, 0);
    cairo_arc(cr, 200, 150, 50, 0, 2 * 3.1416);
    cairo_fill(cr);
    
    // Draw a black line
    cairo_set_source_rgb(cr, 0, 0, 0);
    cairo_set_line_width(cr, 5);
    cairo_move_to(cr, 50, 250);
    cairo_line_to(cr, 350, 250);
    cairo_stroke(cr);
    
    // Save the drawing to a PNG file
    cairo_surface_write_to_png(surface, "output.png");
    
    // Cleanup
    cairo_destroy(cr);
    cairo_surface_destroy(surface);
    
    return 0;
}
```
