### PR TITLE
image+LibGfx/PNG: Add a --force-alpha flag

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.cpp
@@ -362,7 +362,7 @@ static bool bitmap_has_transparency(Bitmap const& bitmap)
 
 ErrorOr<void> PNGWriter::encode(Stream& stream, Bitmap const& bitmap, Options const& options)
 {
-    bool has_transparency = bitmap_has_transparency(bitmap);
+    bool has_transparency = options.force_alpha || bitmap_has_transparency(bitmap);
 
     PNGWriter writer { stream };
     TRY(writer.add_png_header());

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -23,6 +23,8 @@ class PNGChunk;
 struct PNGWriterOptions {
     Compress::ZlibCompressionLevel compression_level { Compress::ZlibCompressionLevel::Default };
 
+    bool force_alpha { false };
+
     // Data for the iCCP chunk.
     // FIXME: Allow writing cICP, sRGB, or gAMA instead too.
     Optional<ReadonlyBytes> icc_data;


### PR DESCRIPTION
The flag can be used to force the presence of an alpha channel in the encoded image. This is only supported by the PNG encoder for the moment.