### PR TITLE
AK: Silence false positive -Wstringop-overflow GCC warning in ByteBuffer

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -286,7 +286,15 @@ public:
     {
         // make sure we're not told to write past the end
         VERIFY(offset + data_size <= size());
+#ifdef AK_COMPILER_GCC
+#    pragma GCC diagnostic push
+//   GCC incorrectly claims that the size of the ByteBuffer is too small in some cases on AArch64/RISC-V when UBSan is disabled.
+#    pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         __builtin_memmove(this->data() + offset, data, data_size);
+#ifdef AK_COMPILER_GCC
+#    pragma GCC diagnostic pop
+#endif
     }
 
     void zero_fill()


### PR DESCRIPTION
This fixes the following warning caused by the call to `ByteBuffer::overwrite` in https://github.com/SerenityOS/serenity/blob/93ca4bc9d1a4fb9db21c3d26fb93e238476016f6/Userland/Libraries/LibCrypto/Hash/PBKDF2.h#L57 "error: writing 64 bytes into a region of size 48"

It seems like GCC incorrectly thinks that the ByteBuffer is using the inline storage in that case.

This error doesn't appear in CI since it enables UBSan.