### PR TITLE
AK: Make IPv6Address parsing constexpr

### DIFF
--- a/AK/IPv6Address.h
+++ b/AK/IPv6Address.h
@@ -24,6 +24,42 @@
 
 namespace AK {
 
+namespace Details {
+
+// constexpr version of StringUtils::convert_to_uint_from_hex which cannot be constexpr
+// thanks to trimming functionality and a circular dependency on StringView.
+constexpr Optional<u16> convert_to_u16_from_hex(StringView string)
+{
+    if (string.is_empty())
+        return {};
+
+    u16 value = 0;
+    auto const count = string.length();
+    u16 const upper_bound = NumericLimits<u16>::max();
+
+    for (size_t i = 0; i < count; i++) {
+        char digit = string[i];
+        u8 digit_val;
+        if (value > (upper_bound >> 4))
+            return {};
+
+        if (digit >= '0' && digit <= '9') {
+            digit_val = digit - '0';
+        } else if (digit >= 'a' && digit <= 'f') {
+            digit_val = 10 + (digit - 'a');
+        } else if (digit >= 'A' && digit <= 'F') {
+            digit_val = 10 + (digit - 'A');
+        } else {
+            return {};
+        }
+
+        value = (value << 4) + digit_val;
+    }
+    return value;
+}
+
+}
+
 class [[gnu::packed]] IPv6Address {
 public:
     using in6_addr_t = u8[16];
@@ -50,9 +86,9 @@ public:
     constexpr u16 operator[](int i) const { return group(i); }
 
 #ifdef KERNEL
-    ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const
+    constexpr ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const
 #else
-    ErrorOr<String> to_string() const
+    constexpr ErrorOr<String> to_string() const
 #endif
     {
         if (is_zero()) {
@@ -120,12 +156,31 @@ public:
 #endif
     }
 
-    static Optional<IPv6Address> from_string(StringView string)
+    static constexpr Optional<IPv6Address> from_string(StringView string)
     {
         if (string.is_null())
             return {};
 
-        auto const parts = string.split_view(':', SplitBehavior::KeepEmpty);
+        // Manual split_at(':', KeepEmpty) implementation, since the StringView one is not constexpr.
+        Array<StringView, 9> parts_creator;
+        size_t current_part = 0;
+        size_t current_part_start = 0;
+        for (size_t index = 0; index < string.length(); ++index) {
+            auto const character = string[index];
+            if (character == ':') {
+                // terminate current part
+                parts_creator[current_part] = string.substring_view(current_part_start, index - current_part_start);
+                ++current_part;
+                current_part_start = index + 1;
+            }
+        }
+        if (current_part_start != string.length())
+            parts_creator[current_part] = string.substring_view(current_part_start, string.length() - current_part_start);
+
+        auto const parts = parts_creator.span().trim(current_part + 1);
+
+        // dbgln("{}", parts);
+
         if (parts.is_empty())
             return {};
         if (parts.size() > 9) {
@@ -136,21 +191,21 @@ public:
             // when expanding the compression.
             return {};
         }
-        if (parts.size() >= 4 && parts[parts.size() - 1].contains('.')) {
+        if (parts.size() >= 4 && parts.last().contains('.')) {
             // Check if this may be an ipv4 mapped address
             auto is_ipv4_prefix = [&]() {
-                auto separator_part = parts[parts.size() - 2].trim_whitespace();
+                auto separator_part = parts[parts.size() - 2];
                 if (separator_part.is_empty())
                     return false;
-                auto separator_value = StringUtils::convert_to_uint_from_hex(separator_part);
+                auto separator_value = Details::convert_to_u16_from_hex(separator_part);
                 if (!separator_value.has_value() || separator_value.value() != 0xffff)
                     return false;
                 // TODO: this allows multiple compression tags "::" in the prefix, which is technically not legal
                 for (size_t i = 0; i < parts.size() - 2; i++) {
-                    auto part = parts[i].trim_whitespace();
+                    auto part = parts[i];
                     if (part.is_empty())
                         continue;
-                    auto value = StringUtils::convert_to_uint_from_hex(part);
+                    auto value = Details::convert_to_u16_from_hex(part);
                     if (!value.has_value() || value.value() != 0)
                         return false;
                 }
@@ -170,7 +225,7 @@ public:
         int have_groups = 0;
         bool found_compressed = false;
         for (size_t i = 0; i < parts.size();) {
-            auto trimmed_part = parts[i].trim_whitespace();
+            auto trimmed_part = parts[i];
             if (trimmed_part.is_empty()) {
                 if (found_compressed)
                     return {};
@@ -178,7 +233,7 @@ public:
                 bool is_leading = (i == 0);
                 bool is_trailing = false;
                 for (size_t j = i + 1; j < parts.size(); j++) {
-                    if (!parts[j].trim_whitespace().is_empty())
+                    if (!parts[j].is_empty())
                         break;
                     empty_parts++;
                     if (j == parts.size() - 1)
@@ -205,8 +260,8 @@ public:
             } else {
                 i++;
             }
-            auto part = StringUtils::convert_to_uint_from_hex(trimmed_part);
-            if (!part.has_value() || part.value() > 0xffff)
+            auto part = Details::convert_to_u16_from_hex(trimmed_part);
+            if (!part.has_value())
                 return {};
 
             if (++have_groups > 8)
@@ -244,7 +299,7 @@ public:
         return true;
     }
 
-    Optional<IPv4Address> ipv4_mapped_address() const
+    constexpr Optional<IPv4Address> ipv4_mapped_address() const
     {
         if (is_ipv4_mapped())
             return IPv4Address(m_data[12], m_data[13], m_data[14], m_data[15]);
@@ -252,7 +307,7 @@ public:
     }
 
     // https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.3
-    [[nodiscard]] static IPv6Address loopback()
+    [[nodiscard]] constexpr static IPv6Address loopback()
     {
         return IPv6Address({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 });
     }

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -172,15 +172,6 @@ bool StringView::matches(StringView mask, CaseSensitivity case_sensitivity) cons
     return StringUtils::matches(*this, mask, case_sensitivity);
 }
 
-bool StringView::contains(char needle) const
-{
-    for (char current : *this) {
-        if (current == needle)
-            return true;
-    }
-    return false;
-}
-
 bool StringView::contains(u32 needle) const
 {
     // A code point should be at most four UTF-8 bytes, which easily fits into StringBuilder's inline-buffer.

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -102,7 +102,14 @@ public:
     [[nodiscard]] bool ends_with(char) const;
     [[nodiscard]] bool matches(StringView mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
     [[nodiscard]] bool matches(StringView mask, Vector<MaskSpan>&, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
-    [[nodiscard]] bool contains(char) const;
+    [[nodiscard]] constexpr bool contains(char needle) const
+    {
+        for (char current : *this) {
+            if (current == needle)
+                return true;
+        }
+        return false;
+    }
     [[nodiscard]] bool contains(u32) const;
     [[nodiscard]] bool contains(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     [[nodiscard]] bool equals_ignoring_ascii_case(StringView) const;

--- a/Tests/AK/TestIPv6Address.cpp
+++ b/Tests/AK/TestIPv6Address.cpp
@@ -13,9 +13,7 @@ TEST_CASE(should_default_contructor_with_0s)
 {
     constexpr IPv6Address addr {};
 
-    static_assert(addr.is_zero());
-
-    EXPECT(addr.is_zero());
+    EXPECT_AND_STATIC_ASSERT(addr.is_zero());
 }
 
 TEST_CASE(should_construct_from_c_array)
@@ -25,32 +23,21 @@ TEST_CASE(should_construct_from_c_array)
         return IPv6Address(a);
     }();
 
-    static_assert(!addr.is_zero());
-
-    EXPECT(!addr.is_zero());
+    EXPECT_AND_STATIC_ASSERT(!addr.is_zero());
 }
 
 TEST_CASE(should_get_groups_by_index)
 {
     constexpr IPv6Address addr({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
 
-    static_assert(0x102 == addr[0]);
-    static_assert(0x304 == addr[1]);
-    static_assert(0x506 == addr[2]);
-    static_assert(0x708 == addr[3]);
-    static_assert(0x90a == addr[4]);
-    static_assert(0xb0c == addr[5]);
-    static_assert(0xd0e == addr[6]);
-    static_assert(0xf10 == addr[7]);
-
-    EXPECT_EQ(0x102, addr[0]);
-    EXPECT_EQ(0x304, addr[1]);
-    EXPECT_EQ(0x506, addr[2]);
-    EXPECT_EQ(0x708, addr[3]);
-    EXPECT_EQ(0x90a, addr[4]);
-    EXPECT_EQ(0xb0c, addr[5]);
-    EXPECT_EQ(0xd0e, addr[6]);
-    EXPECT_EQ(0xf10, addr[7]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0x102, addr[0]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0x304, addr[1]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0x506, addr[2]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0x708, addr[3]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0x90a, addr[4]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0xb0c, addr[5]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0xd0e, addr[6]);
+    EXPECT_EQ_AND_STATIC_ASSERT(0xf10, addr[7]);
 }
 
 TEST_CASE(should_convert_to_string)
@@ -71,17 +58,17 @@ TEST_CASE(should_convert_to_string)
 
 TEST_CASE(should_make_ipv6_address_from_string)
 {
-    EXPECT(!IPv6Address::from_string(":::"sv).has_value());
-    EXPECT(!IPv6Address::from_string(":::1"sv).has_value());
-    EXPECT(!IPv6Address::from_string("1:::"sv).has_value());
-    EXPECT_EQ(IPv6Address::from_string("102:304:506:708:90a:b0c:d0e:f10"sv).value(), IPv6Address({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
-    EXPECT_EQ(IPv6Address::from_string("::"sv).value(), IPv6Address());
-    EXPECT_EQ(IPv6Address::from_string("::1"sv).value(), IPv6Address({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
-    EXPECT_EQ(IPv6Address::from_string("1::"sv).value(), IPv6Address({ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
-    EXPECT_EQ(IPv6Address::from_string("102:0:506:708:900::10"sv).value(), IPv6Address({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 16 }));
-    EXPECT_EQ(IPv6Address::from_string("102:0:506:708:900::"sv).value(), IPv6Address({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0 }));
-    EXPECT_EQ(IPv6Address::from_string("::304:506:708:90a:b0c:d0e:f10"sv).value(), IPv6Address({ 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
-    EXPECT_EQ(IPv6Address::from_string("102:304::708:90a:b0c:d0e:f10"sv).value(), IPv6Address({ 1, 2, 3, 4, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
+    EXPECT_AND_STATIC_ASSERT(!IPv6Address::from_string(":::"sv).has_value());
+    EXPECT_AND_STATIC_ASSERT(!IPv6Address::from_string(":::1"sv).has_value());
+    EXPECT_AND_STATIC_ASSERT(!IPv6Address::from_string("1:::"sv).has_value());
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("102:304:506:708:90a:b0c:d0e:f10"sv).value(), IPv6Address({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("::"sv).value(), IPv6Address());
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("::1"sv).value(), IPv6Address({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("1::"sv).value(), IPv6Address({ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("102:0:506:708:900::10"sv).value(), IPv6Address({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 16 }));
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("102:0:506:708:900::"sv).value(), IPv6Address({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0 }));
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("::304:506:708:90a:b0c:d0e:f10"sv).value(), IPv6Address({ 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
+    EXPECT_EQ_AND_STATIC_ASSERT(IPv6Address::from_string("102:304::708:90a:b0c:d0e:f10"sv).value(), IPv6Address({ 1, 2, 3, 4, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
 }
 
 TEST_CASE(ipv4_mapped_ipv6)
@@ -97,16 +84,16 @@ TEST_CASE(ipv4_mapped_ipv6)
 
 TEST_CASE(should_make_empty_optional_from_bad_string)
 {
-    auto const addr = IPv6Address::from_string("bad string"sv);
+    constexpr auto addr = IPv6Address::from_string("bad string"sv);
 
-    EXPECT(!addr.has_value());
+    EXPECT_AND_STATIC_ASSERT(!addr.has_value());
 }
 
 TEST_CASE(should_make_empty_optional_from_out_of_range_values)
 {
-    auto const addr = IPv6Address::from_string("::10000"sv);
+    constexpr auto addr = IPv6Address::from_string("::10000"sv);
 
-    EXPECT(!addr.has_value());
+    EXPECT_AND_STATIC_ASSERT(!addr.has_value());
 }
 
 TEST_CASE(should_only_compare_bytes_from_address)
@@ -115,13 +102,9 @@ TEST_CASE(should_only_compare_bytes_from_address)
     constexpr IPv6Address addr_b({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 });
     constexpr IPv6Address addr_c({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 });
 
-    static_assert(addr_a != addr_b);
-    static_assert(addr_a == addr_a);
-    static_assert(addr_b == addr_c);
-
-    EXPECT(addr_a != addr_b);
-    EXPECT(addr_a == addr_a);
-    EXPECT(addr_b == addr_c);
+    EXPECT_AND_STATIC_ASSERT(addr_a != addr_b);
+    EXPECT_AND_STATIC_ASSERT(addr_a == addr_a);
+    EXPECT_AND_STATIC_ASSERT(addr_b == addr_c);
 }
 
 TEST_CASE(subnets)
@@ -133,37 +116,37 @@ TEST_CASE(subnets)
     constexpr IPv6Address broadcast({ 0xff, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 });
     constexpr IPv6Address all_routers({ 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2 });
 
-    EXPECT(loopback.is_loopback());
-    EXPECT(!all_routers.is_loopback());
+    EXPECT_AND_STATIC_ASSERT(loopback.is_loopback());
+    EXPECT_AND_STATIC_ASSERT(!all_routers.is_loopback());
 
-    EXPECT(lla.is_link_local());
-    EXPECT(ula.is_unique_local());
-    EXPECT(!lla.is_unique_local());
-    EXPECT(!ula.is_link_local());
-    EXPECT(!documentation.is_unique_local());
-    EXPECT(!documentation.is_link_local());
-    EXPECT(!broadcast.is_unique_local());
-    EXPECT(!broadcast.is_link_local());
-    EXPECT(!all_routers.is_unique_local());
-    EXPECT(!all_routers.is_link_local());
+    EXPECT_AND_STATIC_ASSERT(lla.is_link_local());
+    EXPECT_AND_STATIC_ASSERT(ula.is_unique_local());
+    EXPECT_AND_STATIC_ASSERT(!lla.is_unique_local());
+    EXPECT_AND_STATIC_ASSERT(!ula.is_link_local());
+    EXPECT_AND_STATIC_ASSERT(!documentation.is_unique_local());
+    EXPECT_AND_STATIC_ASSERT(!documentation.is_link_local());
+    EXPECT_AND_STATIC_ASSERT(!broadcast.is_unique_local());
+    EXPECT_AND_STATIC_ASSERT(!broadcast.is_link_local());
+    EXPECT_AND_STATIC_ASSERT(!all_routers.is_unique_local());
+    EXPECT_AND_STATIC_ASSERT(!all_routers.is_link_local());
 
-    EXPECT(lla.is_unicast());
-    EXPECT(ula.is_unicast());
-    EXPECT(loopback.is_unicast());
-    EXPECT(documentation.is_unicast());
-    EXPECT(broadcast.is_multicast());
-    EXPECT(all_routers.is_multicast());
+    EXPECT_AND_STATIC_ASSERT(lla.is_unicast());
+    EXPECT_AND_STATIC_ASSERT(ula.is_unicast());
+    EXPECT_AND_STATIC_ASSERT(loopback.is_unicast());
+    EXPECT_AND_STATIC_ASSERT(documentation.is_unicast());
+    EXPECT_AND_STATIC_ASSERT(broadcast.is_multicast());
+    EXPECT_AND_STATIC_ASSERT(all_routers.is_multicast());
 
-    EXPECT(!loopback.is_in_subnet(lla, 64));
-    EXPECT(lla.is_in_subnet(lla.network(64), 64));
-    EXPECT(ula.is_in_subnet(ula.network(128), 128));
-    EXPECT(loopback.is_in_subnet(loopback, 128));
-    EXPECT(documentation.is_in_subnet(documentation, 128));
-    EXPECT(broadcast.is_in_subnet(broadcast, 128));
-    EXPECT(all_routers.is_in_subnet(all_routers, 128));
-    EXPECT(!ula.is_in_subnet(lla, 64));
+    EXPECT_AND_STATIC_ASSERT(!loopback.is_in_subnet(lla, 64));
+    EXPECT_AND_STATIC_ASSERT(lla.is_in_subnet(lla.network(64), 64));
+    EXPECT_AND_STATIC_ASSERT(ula.is_in_subnet(ula.network(128), 128));
+    EXPECT_AND_STATIC_ASSERT(loopback.is_in_subnet(loopback, 128));
+    EXPECT_AND_STATIC_ASSERT(documentation.is_in_subnet(documentation, 128));
+    EXPECT_AND_STATIC_ASSERT(broadcast.is_in_subnet(broadcast, 128));
+    EXPECT_AND_STATIC_ASSERT(all_routers.is_in_subnet(all_routers, 128));
+    EXPECT_AND_STATIC_ASSERT(!ula.is_in_subnet(lla, 64));
     // Not sensible networks per IETF!
-    EXPECT(lla.is_in_subnet(ula.network(4), 4));
-    EXPECT(broadcast.is_in_subnet(all_routers.network(12), 12));
-    EXPECT(!documentation.is_in_subnet(lla, 4));
+    EXPECT_AND_STATIC_ASSERT(lla.is_in_subnet(ula.network(4), 4));
+    EXPECT_AND_STATIC_ASSERT(broadcast.is_in_subnet(all_routers.network(12), 12));
+    EXPECT_AND_STATIC_ASSERT(!documentation.is_in_subnet(lla, 4));
 }

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -46,6 +46,14 @@ u64 randomized_runs();
         }                                                                                                     \
     } while (false)
 
+// Performs both run-time EXPECT_EQ and compile-time static_assert.
+// This also ensures that both a and b are constant expressions (e.g. usable in constexpr/consteval contexts).
+#define EXPECT_EQ_AND_STATIC_ASSERT(a, b) \
+    do {                                  \
+        static_assert(a == b);            \
+        EXPECT_EQ(a, b);                  \
+    } while (false)
+
 #define EXPECT_EQ_TRUTH(a, b)                                                                                                 \
     do {                                                                                                                      \
         auto lhs = (a);                                                                                                       \
@@ -93,6 +101,12 @@ u64 randomized_runs();
                 ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT({}) failed", __FILE__, __LINE__, #x); \
             ::Test::set_current_test_result(::Test::TestResult::Failed);                                 \
         }                                                                                                \
+    } while (false)
+
+#define EXPECT_AND_STATIC_ASSERT(x) \
+    do {                            \
+        static_assert(x);           \
+        EXPECT(x);                  \
     } while (false)
 
 #define EXPECT_APPROXIMATE_WITH_ERROR(a, b, err)                                                                \


### PR DESCRIPTION
### LibTest: Add combined EXPECT+static_assert macros

This simplifies tests that are both compile-time and run-time, as well
as also ensuring that the expressions remain constexpr.

### AK: Make StringView::contains constexpr


### AK: Make almost all methods of IPv6Address constexpr

Especially the parser, with the exception of the IPv4 part.

### Tests: Perform compile-time tests on IPv6Address