### PR TITLE
Ports/harfbuzz: Enable optimized shared build

### DIFF
--- a/Ports/harfbuzz/package.sh
+++ b/Ports/harfbuzz/package.sh
@@ -8,14 +8,15 @@ useconfigure='true'
 depends=("freetype" "libicu")
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
+    '-DCMAKE_BUILD_TYPE=Release'
+    '-DBUILD_SHARED_LIBS=ON'
     '-DHB_HAVE_FREETYPE=ON'
     '-DHB_HAVE_ICU=ON'
-    '-DCMAKE_C_FLAGS=-lfreetype'
 )
 
 configure() {
     run mkdir -p build
-    run sh -c "cd build && cmake .. ${configopts[@]}"
+    run cmake -S . -B build "${configopts[@]}"
 }
 
 build() {


### PR DESCRIPTION
I added `BUILD_SHARED_LIBS=ON` to cmake options since I got the "recompile with -fPIC" errors while building pango.
```
.../libharfbuzz.a(harfbuzz.cc.o): relocation R_X86_64_PC32 against symbol `_ZN11hb_buffer_t19_cluster_group_funcERK15hb_glyph_info_tS2_' can not be used when making a shared object; recompile with -fPIC
```

I also fixed `configure()` since `sh -c "cd build && cmake .. ${configopts[@]}"` ignored cmake options except for `CMAKE_TOOLCHAIN_FILE`.

I confirmed that the `SuperTuxKart` port and pango worked fine with this PR.