### PR TITLE
 Ports/qt6-qtbase and Ports/qt6-qtsvg: Change the URLs from official_releases to archive

### DIFF
--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -4,7 +4,7 @@ version='6.4.0'
 workdir="qtbase-everywhere-src-${version}"
 useconfigure='true'
 files=(
-    "https://download.qt.io/official_releases/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qtbase-everywhere-src-${version}.tar.xz#cb6475a0bd8567c49f7ffbb072a05516ee6671171bed55db75b22b94ead9b37d"
+    "https://download.qt.io/archive/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qtbase-everywhere-src-${version}.tar.xz#cb6475a0bd8567c49f7ffbb072a05516ee6671171bed55db75b22b94ead9b37d"
 )
 configopts=(
     '-GNinja'

--- a/Ports/qt6-qtsvg/package.sh
+++ b/Ports/qt6-qtsvg/package.sh
@@ -4,7 +4,7 @@ version='6.4.0'
 workdir="qtsvg-everywhere-src-${version}"
 useconfigure='true'
 files=(
-    "https://download.qt.io/official_releases/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qtsvg-everywhere-src-${version}.tar.xz#03fdae9437d074dcfa387dc1f2c6e7e14fea0f989bf7e1aa265fd35ffc2c5b25"
+    "https://download.qt.io/archive/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qtsvg-everywhere-src-${version}.tar.xz#03fdae9437d074dcfa387dc1f2c6e7e14fea0f989bf7e1aa265fd35ffc2c5b25"
 )
 configopts=(
     '-GNinja'


### PR DESCRIPTION
from https://download.qt.io/official_releases/qt
to https://download.qt.io/archive/qt
#25774 
