### PR TITLE
LibPDF: Be more permissive in accepting box coordinates

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -245,11 +245,15 @@ PDFErrorOr<Page> Document::get_page(u32 index)
 
     auto to_rectangle = [](NonnullRefPtr<Object> const& object) -> Rectangle {
         auto array = object->cast<ArrayObject>();
+        float x0 = array->at(0).to_float();
+        float y0 = array->at(1).to_float();
+        float x1 = array->at(2).to_float();
+        float y1 = array->at(3).to_float();
         return Rectangle {
-            array->at(0).to_float(),
-            array->at(1).to_float(),
-            array->at(2).to_float(),
-            array->at(3).to_float(),
+            min(x0, x1),
+            min(y0, y1),
+            max(x0, x1),
+            max(y0, y1),
         };
     };
 


### PR DESCRIPTION
Almost all PDFs specify boxes as bottom left point, followed by
upper right point, like so:

    /MediaBox [ 0 0 612 792 ]

Some exceptions use upper left point, followed by lower left point
instead, like so:

    /MediaBox [ 0 792 612 0 ]

This makes us tolerate the latter.

------

Lets us load the "no xfa-support" fallback content in https://www.static.tu.berlin/fileadmin/www/10000070/Studium_und_Lehre/Formulare/Ueberpruefung_bisheriger_Leistungen_TeilB.pdf

(Also attached here: [Ueberpruefung_bisheriger_Leistungen_TeilB.pdf](https://github.com/user-attachments/files/19727556/Ueberpruefung_bisheriger_Leistungen_TeilB.pdf))

(We obviously don't support XFA yet, though.)

