### PR TITLE
LibGfx/JPEGXL: Progress on libjxl/conformance

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1965,10 +1965,7 @@ static ErrorOr<void> read_lf_group(LittleEndianInputBitStream&,
         if (channel.hshift() < 3 || channel.vshift() < 3)
             continue;
 
-        // This code actually only detect that we need to read a null image
-        // so a no-op. It should be fully rewritten when we add proper support
-        // for LfGroup.
-        TODO();
+        dbgln("Fixme: Decode ModularLFGroup for channel: {}x{}(h:{}, v:{})", channel.width(), channel.height(), channel.hshift(), channel.vshift());
     }
 
     // HF metadata

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -585,7 +585,12 @@ static ErrorOr<RestorationFilter> read_restoration_filter(LittleEndianInputBitSt
         if (restoration_filter.gab) {
             restoration_filter.gab_custom = TRY(stream.read_bit());
             if (restoration_filter.gab_custom) {
-                return Error::from_string_literal("JPEGXLLoader: Implement custom restoration filters");
+                restoration_filter.gab_x_weight1 = TRY(F16(stream));
+                restoration_filter.gab_x_weight2 = TRY(F16(stream));
+                restoration_filter.gab_y_weight1 = TRY(F16(stream));
+                restoration_filter.gab_y_weight2 = TRY(F16(stream));
+                restoration_filter.gab_b_weight1 = TRY(F16(stream));
+                restoration_filter.gab_b_weight2 = TRY(F16(stream));
             }
         }
 
@@ -605,7 +610,7 @@ static ErrorOr<RestorationFilter> read_restoration_filter(LittleEndianInputBitSt
                 return Error::from_string_literal("JPEGXLLoader: Implement custom restoration filters");
 
             if (encoding == Encoding::kModular)
-                return Error::from_string_literal("JPEGXLLoader: Implement custom restoration filters");
+                restoration_filter.epf_sigma_for_modular = TRY(F16(stream));
         }
 
         restoration_filter.extensions = TRY(read_extensions(stream));

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2299,7 +2299,13 @@ static ErrorOr<void> read_modular_group_data(LittleEndianInputBitStream& stream,
         if (channel_min_shift < min_shift || channel_min_shift >= max_shift)
             continue;
 
-        TRY(channels_info.try_append(ChannelInfo::from_size(rect_for_group(channel, frame_header.group_dim(), group_index).size())));
+        auto rect_size = rect_for_group(channel, frame_header.group_dim(), group_index).size();
+        TRY(channels_info.try_append({
+            .width = static_cast<u32>(rect_size.width()),
+            .height = static_cast<u32>(rect_size.height()),
+            .hshift = channel.hshift(),
+            .vshift = channel.vshift(),
+        }));
         TRY(original_channels.try_append(channel));
     }
     if (channels_info.is_empty())

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1191,6 +1191,11 @@ public:
                 };
 
                 auto const color = [&]() -> Color {
+                    if (metadata.number_of_color_channels() == 1) {
+                        auto gray = to_u8(m_channels[0].get(x, y));
+                        return { gray, gray, gray };
+                    }
+
                     if (!alpha_channel.has_value()) {
                         return { to_u8(m_channels[0].get(x, y)),
                             to_u8(m_channels[1].get(x, y)),

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2234,20 +2234,23 @@ static ErrorOr<void> apply_transformation(
 /// G.3.2 - PassGroup
 static IntRect rect_for_group(Channel const& channel, u32 group_dim, u32 group_index)
 {
-    IntRect rect(0, 0, group_dim, group_dim);
+    u32 horizontal_group_dim = group_dim >> channel.hshift();
+    u32 vertical_group_dim = group_dim >> channel.vshift();
 
-    auto nb_groups_per_row = (channel.width() + group_dim - 1) / group_dim;
+    IntRect rect(0, 0, horizontal_group_dim, vertical_group_dim);
+
+    auto nb_groups_per_row = (channel.width() + horizontal_group_dim - 1) / horizontal_group_dim;
     auto group_x = group_index % nb_groups_per_row;
-    rect.set_x(group_x * group_dim);
-    if (group_x == nb_groups_per_row - 1) {
-        rect.set_width(channel.width() % group_dim);
+    rect.set_x(group_x * horizontal_group_dim);
+    if (group_x == nb_groups_per_row - 1 && channel.width() % horizontal_group_dim != 0) {
+        rect.set_width(channel.width() % horizontal_group_dim);
     }
 
-    auto nb_groups_per_column = (channel.height() + group_dim - 1) / group_dim;
+    auto nb_groups_per_column = (channel.height() + vertical_group_dim - 1) / vertical_group_dim;
     auto group_y = group_index / nb_groups_per_row;
-    rect.set_y(group_y * group_dim);
-    if (group_y == nb_groups_per_column - 1) {
-        rect.set_height(channel.height() % group_dim);
+    rect.set_y(group_y * vertical_group_dim);
+    if (group_y == nb_groups_per_column - 1 && channel.height() % vertical_group_dim != 0) {
+        rect.set_height(channel.height() % vertical_group_dim);
     }
 
     return rect;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2518,6 +2518,17 @@ static u32 mirror_1d(i32 coord, u32 size)
 }
 ///
 
+/// J - Restoration filters
+// J.1  General
+static ErrorOr<void> apply_restoration_filters(Frame& frame)
+{
+    auto const& frame_header = frame.frame_header;
+    if (frame_header.restoration_filter.gab || frame_header.restoration_filter.epf_iters != 0)
+        dbgln("JPEGXLLoader: FIXME: Apply restoration filters");
+    return {};
+}
+///
+
 /// K - Image features
 static ErrorOr<void> apply_upsampling(Frame& frame, ImageMetadata const& metadata)
 {
@@ -2690,8 +2701,7 @@ public:
         auto frame = TRY(read_frame(m_stream, m_header, m_metadata));
         auto const& frame_header = frame.frame_header;
 
-        if (frame_header.restoration_filter.gab || frame_header.restoration_filter.epf_iters != 0)
-            TODO();
+        TRY(apply_restoration_filters(frame));
 
         TRY(apply_image_features(frame, m_metadata));
 


### PR DESCRIPTION
These patches allow us to decode `grayscale_public_univeristy` from the `libjxl/conformance` repo.

Note that it is not perfect yet, as we don't decode `ModularLFGroup`s and we don't apply restorations filters. The image has two `ModularLFGroup`s that compose one residual channel from the squeeze transform (a Haar-like transform). I just left the channel zero-initialized.

Still, this is what we get now:
![test](https://github.com/user-attachments/assets/0d1c7a7c-b083-4e18-8da7-ee43605f50dd)


And this is the original:
![ref](https://github.com/user-attachments/assets/fead2370-cc07-4f01-b5ed-c17fc6732874)
