### PR TITLE
LibPDF: Read coons patch mesh shading dict entries

### DIFF
--- a/Tests/LibPDF/shade-coons.pdf
+++ b/Tests/LibPDF/shade-coons.pdf
@@ -27,18 +27,42 @@ endstream
 endobj
 
 5 0 obj
-<</ShadingType 6/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Decode[50 250 40 240 0 1 0 1 0 1]/Length 179/Filter/ASCIIHexDecode>>
+<</ShadingType 6/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Decode[50 250 40 240 0 1 0 1 0 1]/Length 563/Filter/ASCIIHexDecode>>
 stream
 00
-           0ccd 0ccd  0219 8058
-1500 80ff  2800 d72a  a000 f0a7
-90f3 e20c  cdf2 f300  ff09 58d5
-c7ff 90ff  ffa7 2a58  2f00 4332
-f332 0dfe
+           0666 0666  010c 402c
+0a80 407f  1400 6b95  5000 7853
+4879 7106  66f9 7980  7f84 2c6a
+63ff 487f  7fd3 152c  1780 2199
+7999 06ff
 00 a7 2a
 ff ff 00
 ff 00 58
 d5 ff ff
+
+02
+                      910c 002c
+a000 0853  e400 0b95  da80 807f
+ef84 0c6a  f0f9 8980  6879 8106
+e3ff 887f
+00 a7 2a
+d5 ff ff
+
+03
+                      510c e02c
+6879 8106  60f9 e980  8f84 ec6a
+ba80 d07f  e409 eb95  d000 a853
+e3ff 987f
+ff a7 2a
+d5 0f ff
+
+01
+                      510c e02c
+3879 d106  10f9 e980  0f84 ec6a
+1a80 d07f  0400 6b95  2000 9853
+23ff 687f
+ff f0 f0
+05 8f 8f
 >
 
 endstream
@@ -82,13 +106,13 @@ xref
 0000000114 00000 n 
 0000000241 00000 n 
 0000000328 00000 n 
-0000000702 00000 n 
-0000000793 00000 n 
-0000000884 00000 n 
-0000000982 00000 n 
+0000001086 00000 n 
+0000001177 00000 n 
+0000001268 00000 n 
+0000001366 00000 n 
 
 trailer
 <</Size 10/Root 1 0 R>>
 startxref
-1339
+1723
 %%EOF


### PR DESCRIPTION
We now create an CoonsPatchShading object and read all required
parameters and build objects for them, but we don't use them for any
rendering yet.