### PR TITLE
Ports/pixman: Import the libtool patch

### DIFF
--- a/Ports/pixman/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/pixman/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 1d6b3591b0..2d84dccda2 100755
+--- a/configure
++++ b/configure
+@@ -6514,6 +6514,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9692,6 +9696,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -11224,6 +11232,10 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -12309,6 +12321,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;

--- a/Ports/pixman/patches/ReadMe.md
+++ b/Ports/pixman/patches/ReadMe.md
@@ -1,0 +1,15 @@
+# Patches for pixman on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.


### PR DESCRIPTION
Related to https://github.com/SerenityOS/serenity/pull/14178.
I noticed that `configure` disabled the shared build for pixman, so I made the libtool patch the same way as in other ports.

I confirmed that shared build was enabled in `config.log`.

```
configure:13089: checking if libtool supports shared libraries
configure:13091: result: yes
configure:13094: checking whether to build shared libraries
configure:13119: result: yes
```