### PR TITLE
LibPDF: Read tensor-product patch mesh shading dict entries

### DIFF
--- a/Tests/LibPDF/shade-tensor.pdf
+++ b/Tests/LibPDF/shade-tensor.pdf
@@ -27,19 +27,46 @@ endstream
 endobj
 
 5 0 obj
-<</ShadingType 7/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Decode[50 250 40 240 0 1 0 1 0 1]/Length 222/Filter/ASCIIHexDecode>>
+<</ShadingType 7/ColorSpace/DeviceRGB/BitsPerCoordinate 16/BitsPerComponent 8/BitsPerFlag 8/Decode[50 250 40 240 0 1 0 1 0 1]/Length 735/Filter/ASCIIHexDecode>>
 stream
 00
-           0ccd 0ccd  0219 8058
-1500 80ff  2800 d72a  a000 f0a7
-90f3 e20c  cdf2 f300  ff09 58d5
-c7ff 90ff  ffa7 2a58  2f00 4332
-f332 0dfe
-0eff 2f55  55aa bf00  a000 eaaa  d5aa 4072
+           1000 1000  0800 3000
+1800 5000  1000 7000  2000 7800
+5000 6800  7000 7000  7800 5000
+6800 3000  7000 1000  5000 0800
+3000 1800
+3000 3000  3000 5000  5000 5000  5000 3000
 00 a7 2a
 ff ff 00
 ff 00 58
 d5 ff ff
+
+02
+                      9000 1800
+b000 0800  d000 1000  c800 3000
+d800 5000  d000 7000  b000 6800
+9000 7800
+9000 5000  9000 3000  b000 3000  b000 5000
+00 a7 2a
+d5 ff ff
+
+03
+                      7000 9000
+7000 b000  7000 d000  9000 d000
+b000 c800  d000 d000  d800 b000
+c800 9000
+b000 9000  9000 9000  9000 b000  b000 b000
+ff a7 2a
+d5 0f ff
+
+01
+                      5000 d000
+3000 d000  1000 e000  1000 b000
+1000 9000  1000 8000  3000 7800
+5000 7000
+5000 9000  5000 b000  3000 b000  3000 9000
+ff f0 f0
+05 8f 8f
 >
 
 endstream
@@ -85,13 +112,13 @@ xref
 0000000114 00000 n 
 0000000241 00000 n 
 0000000328 00000 n 
-0000000745 00000 n 
-0000000836 00000 n 
-0000000927 00000 n 
-0000001025 00000 n 
+0000001258 00000 n 
+0000001349 00000 n 
+0000001440 00000 n 
+0000001538 00000 n 
 
 trailer
 <</Size 10/Root 1 0 R>>
 startxref
-1426
+1939
 %%EOF

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -1200,6 +1200,316 @@ PDFErrorOr<void> CoonsPatchShading::draw(Gfx::Painter&, Gfx::AffineTransform con
     return Error::rendering_unsupported_error("Cannot draw coons path mesh shadings yet");
 }
 
+class TensorProductPatchShading final : public Shading {
+public:
+    static PDFErrorOr<NonnullRefPtr<TensorProductPatchShading>> create(Document*, NonnullRefPtr<StreamObject>, CommonEntries);
+
+    virtual PDFErrorOr<void> draw(Gfx::Painter&, Gfx::AffineTransform const&) override;
+
+private:
+    using FunctionsType = Variant<Empty, NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
+
+    // Indexes into m_patch_data.
+    struct TensorProductPatch {
+        // Pij (col i, row j) is at index:
+        // p03 p13 p23 p33       12 13 14 15
+        // p02 p12 p22 p32  <=>   8  9 10 11
+        // p01 p11 p21 p31        4  5  6  7
+        // p00 p10 p20 p30        0  1  2  3
+        u32 control_points[16];
+
+        // cij (col i, row j) is at index:
+        // c03 c33       2 3
+        // c00 c30  <=>  0 1
+        u32 colors[4];
+    };
+
+    TensorProductPatchShading(CommonEntries common_entries, Vector<float> patch_data, Vector<TensorProductPatch> patches, FunctionsType functions)
+        : m_common_entries(move(common_entries))
+        , m_patch_data(move(patch_data))
+        , m_patches(move(patches))
+        , m_functions(move(functions))
+    {
+    }
+
+    CommonEntries m_common_entries;
+
+    // Interleaved x0, y0, x1, y1, ..., x15, y15, c0, c1, c2, c3, ...
+    // (For flags 1-3, only 12 coordinates and 2 colors.)
+    Vector<float> m_patch_data;
+    Vector<TensorProductPatch> m_patches;
+    FunctionsType m_functions;
+};
+
+PDFErrorOr<NonnullRefPtr<TensorProductPatchShading>> TensorProductPatchShading::create(Document* document, NonnullRefPtr<StreamObject> shading_stream, CommonEntries common_entries)
+{
+    auto shading_dict = shading_stream->dict();
+
+    // "Type 7 shadings (tensor-product patch meshes) are identical to type 6, except that
+    //  they are based on a bicubic tensor-product patch defined by 16 control points in-
+    //  stead of the 12 control points that define a Coons patch. The shading dictionaries
+    //  representing the two patch types differ only in the value of the ShadingType entry
+    //  and in the number of control points specified for each patch in the data stream."
+
+    // FIXME: Extract some common code once we have implemented painting and can make sure
+    //        that refactoring doesn't break things.
+
+    // TABLE 4.34 Additional entries specific to a type 6 shading dictionary
+    // "(Required) The number of bits used to represent each geometric coordi-
+    //  nate. Valid values are 1, 2, 4, 8, 12, 16, 24, and 32."
+    int bits_per_coordinate = TRY(document->resolve(shading_dict->get_value(CommonNames::BitsPerCoordinate))).to_int();
+    if (!first_is_one_of(bits_per_coordinate, 1, 2, 4, 8, 12, 16, 24, 32))
+        return Error::malformed_error("BitsPerCoordinate invalid");
+
+    // "(Required) The number of bits used to represent each color component.
+    //  Valid values are 1, 2, 4, 8, 12, and 16."
+    int bits_per_component = TRY(document->resolve(shading_dict->get_value(CommonNames::BitsPerComponent))).to_int();
+    if (!first_is_one_of(bits_per_component, 1, 2, 4, 8, 12, 16))
+        return Error::malformed_error("BitsPerComponent invalid");
+
+    // "(Required) The number of bits used to represent the edge flag for each
+    //  patch (see below). Valid values of BitsPerFlag are 2, 4, and 8, but only the
+    //  least significant 2 bits in each flag value are used. Valid values for the edge
+    //  flag are 0, 1, 2, and 3."
+    int bits_per_flag = TRY(document->resolve(shading_dict->get_value(CommonNames::BitsPerFlag))).to_int();
+    if (!first_is_one_of(bits_per_flag, 2, 4, 8))
+        return Error::malformed_error("BitsPerFlag invalid");
+
+    // "(Required) An array of numbers specifying how to map vertex coordinates
+    //  and color components into the appropriate ranges of values. The decoding
+    //  method is similar to that used in image dictionaries (see “Decode Arrays”
+    //  on page 344). The ranges are specified as follows:
+    //
+    //      [ xmin xmax ymin ymax c1,min c1,max … cn,min cn,max ]
+    //
+    //  Note that only one pair of c values should be specified if a Function entry
+    //  is present."
+    auto decode_array = TRY(shading_dict->get_array(document, CommonNames::Decode));
+    size_t number_of_components = static_cast<size_t>(shading_dict->contains(CommonNames::Function) ? 1 : common_entries.color_space->number_of_components());
+    if (decode_array->size() != 4 + 2 * number_of_components)
+        return Error::malformed_error("Decode array must have 4 + 2 * number of components elements");
+    Vector<float> decode;
+    decode.resize(decode_array->size());
+    for (size_t i = 0; i < decode_array->size(); ++i)
+        decode[i] = decode_array->at(i).to_float();
+
+    // "(Optional) A 1-in, n-out function or an array of n 1-in, 1-out functions
+    //  (where n is the number of color components in the shading dictionary’s
+    //  color space). If this entry is present, the color data for each vertex must be
+    //  specified by a single parametric variable rather than by n separate color
+    //  components. The designated function(s) are called with each interpolated
+    //  value of the parametric variable to determine the actual color at each
+    //  point. Each input value is forced into the range interval specified for the
+    //  corresponding color component in the shading dictionary’s Decode array.
+    //  Each function’s domain must be a superset of that interval. If the value re-
+    //  turned by the function for a given color component is out of range, it is
+    //  adjusted to the nearest valid value.
+    //  This entry may not be used with an Indexed color space."
+    FunctionsType functions;
+    if (shading_dict->contains(CommonNames::Function)) {
+        if (common_entries.color_space->family() == ColorSpaceFamily::Indexed)
+            return Error::malformed_error("Function cannot be used with Indexed color space");
+
+        functions = TRY([&]() -> PDFErrorOr<FunctionsType> {
+            auto function_object = TRY(shading_dict->get_object(document, CommonNames::Function));
+            if (function_object->is<ArrayObject>()) {
+                auto function_array = function_object->cast<ArrayObject>();
+                Vector<NonnullRefPtr<Function>> functions_vector;
+                if (function_array->size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+                    return Error::malformed_error("Function array must have as many elements as color space has components");
+                for (size_t i = 0; i < function_array->size(); ++i) {
+                    auto function = TRY(Function::create(document, TRY(document->resolve_to<Object>(function_array->at(i)))));
+                    if (TRY(function->evaluate(to_array({ decode[4] }))).size() != 1)
+                        return Error::malformed_error("Function must have 1 output component");
+                    TRY(functions_vector.try_append(move(function)));
+                }
+                return functions_vector;
+            }
+            auto function = TRY(Function::create(document, function_object));
+            if (TRY(function->evaluate(to_array({ decode[0] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+                return Error::malformed_error("Function must have as many output components as color space");
+            return function;
+        }());
+    }
+
+    // See "Type 6 Shadings (Coons Patch Meshes)" in the PDF 1.7 spec for a description of the stream contents.
+    auto stream = FixedMemoryStream { shading_stream->bytes() };
+    BigEndianInputBitStream bitstream { MaybeOwned { stream } };
+
+    Vector<float> patch_data;
+    Vector<TensorProductPatch> patches;
+
+    auto read_point = [&]() -> ErrorOr<void> {
+        u32 x = TRY(bitstream.read_bits<u32>(bits_per_coordinate));
+        u32 y = TRY(bitstream.read_bits<u32>(bits_per_coordinate));
+        TRY(patch_data.try_append(mix(decode[0], decode[1], x / (powf(2.0f, bits_per_coordinate) - 1))));
+        TRY(patch_data.try_append(mix(decode[2], decode[3], y / (powf(2.0f, bits_per_coordinate) - 1))));
+        return {};
+    };
+
+    auto read_points = [&](u32 n) -> ErrorOr<void> {
+        for (u32 i = 0; i < n; ++i)
+            TRY(read_point());
+        return {};
+    };
+
+    auto read_color = [&]() -> ErrorOr<void> {
+        for (size_t i = 0; i < number_of_components; ++i) {
+            u16 color = TRY(bitstream.read_bits<u16>(bits_per_component));
+            TRY(patch_data.try_append(mix(decode[4 + 2 * i], decode[4 + 2 * i + 1], color / (powf(2.0f, bits_per_component) - 1))));
+        }
+        return {};
+    };
+
+    auto read_colors = [&](u32 n) -> ErrorOr<void> {
+        for (u32 i = 0; i < n; ++i)
+            TRY(read_color());
+        return {};
+    };
+
+    // "The coordinates of the control points in a tensor-product patch are actually spec-
+    //  ified in the shading’s data stream in the following order:
+    //  4 5 6 7
+    //  3 14 15 8
+    //  2 13 16 9
+    //  1 12 11 10"
+    // We need to invert this to map data stream index to control point index.
+    u32 const patch_index[] = {
+        // clang-format off
+        0, 4, 8, 12,
+        13, 14, 15,
+        11, 7, 3,
+        2, 1,
+        5, 9, 10, 6,
+        // clang-format on
+    };
+    u32 const color_index[] = { 0, 2, 3, 1 };
+
+    // "The 16 control points can be arranged in a
+    //  4-by-4 array indexed by row and column, as follows (see Figure 4.24):
+    //  p03 p13 p23 p33
+    //  p02 p12 p22 p32
+    //  p01 p11 p21 p31
+    //  p00 p10 p20 p30"
+
+    while (!bitstream.is_eof()) {
+        u8 flag = TRY(bitstream.read_bits<u8>(bits_per_flag));
+
+        int n = patch_data.size();
+        TensorProductPatch patch;
+
+        // "TABLE 4.36 Data values in a tensor-product patch mesh"
+        switch (flag) {
+        case 0:
+            // "x00 y00 x01 y01 x02 y02 x03 y03 x13 y13 x23 y23 x33 y33 x32 y32
+            //  x31 y31 x30 y30 x20 y20 x10 y10 x11 y11 x12 y12 x22 y22 x21 y21
+            //  c00 c03 c33 c30
+            //  New patch; no implicit values"
+            TRY(patch_data.try_ensure_capacity(patch_data.size() + 16 * 2 + 4 + number_of_components));
+            TRY(read_points(16));
+            TRY(read_colors(4));
+            for (int i = 0; i < 16; ++i)
+                patch.control_points[patch_index[i]] = n + 2 * i;
+            for (int i = 0; i < 4; ++i)
+                patch.colors[color_index[i]] = n + 32 + number_of_components * i;
+            break;
+        case 1:
+            if (patches.is_empty())
+                return Error::malformed_error("Edge flag 1 without preceding patch");
+            // "x13 y13 x23 y23 x33 y33 x32 y32 x31 y31 x30 y30
+            //  x20 y20 x10 y10 x11 y11 x12 y12 x22 y22 x21 y21
+            //  c33 c30
+            //  Implicit values:
+            //  (x00, y00) = (x03, y03) previous
+            //  (x01, y01) = (x13, y13) previous
+            //  (x02, y02) = (x23, y23) previous
+            //  (x03, y03) = (x33, y33) previous
+            //  c00 = c03 previous
+            //  c03 = c33 previous"
+            TRY(patch_data.try_ensure_capacity(patch_data.size() + 12 * 2 + 2 + number_of_components));
+            TRY(read_points(12));
+            TRY(read_colors(2));
+            patch.control_points[patch_index[0]] = patches.last().control_points[12];
+            patch.control_points[patch_index[1]] = patches.last().control_points[13];
+            patch.control_points[patch_index[2]] = patches.last().control_points[14];
+            patch.control_points[patch_index[3]] = patches.last().control_points[15];
+            for (int i = 0; i < 12; ++i)
+                patch.control_points[patch_index[i + 4]] = n + 2 * i;
+            patch.colors[color_index[0]] = patches.last().colors[2];
+            patch.colors[color_index[1]] = patches.last().colors[3];
+            for (int i = 0; i < 2; ++i)
+                patch.colors[color_index[i + 2]] = n + 24 + number_of_components * i;
+            break;
+        case 2:
+            if (patches.is_empty())
+                return Error::malformed_error("Edge flag 2 without preceding patch");
+            // "x13 y13 x23 y23 x33 y33 x32 y32 x31 y31 x30 y30
+            //  x20 y20 x10 y10 x11 y11 x12 y12 x22 y22 x21 y21
+            //  c33 c30
+            //  Implicit values:
+            //  (x00, y00) = (x33, y33) previous
+            //  (x01, y01) = (x32, y32) previous
+            //  (x02, y02) = (x31, y31) previous
+            //  (x03, y03) = (x30, y30) previous
+            //  c00 = c33 previous
+            //  c03 = c30 previous"
+            TRY(patch_data.try_ensure_capacity(patch_data.size() + 12 * 2 + 2 + number_of_components));
+            TRY(read_points(12));
+            TRY(read_colors(2));
+            patch.control_points[patch_index[0]] = patches.last().control_points[15];
+            patch.control_points[patch_index[1]] = patches.last().control_points[11];
+            patch.control_points[patch_index[2]] = patches.last().control_points[7];
+            patch.control_points[patch_index[3]] = patches.last().control_points[3];
+            for (int i = 0; i < 12; ++i)
+                patch.control_points[patch_index[i + 4]] = n + 2 * i;
+            patch.colors[color_index[0]] = patches.last().colors[3];
+            patch.colors[color_index[1]] = patches.last().colors[1];
+            for (int i = 0; i < 2; ++i)
+                patch.colors[color_index[i + 2]] = n + 24 + number_of_components * i;
+            break;
+        case 3:
+            if (patches.is_empty())
+                return Error::malformed_error("Edge flag 3 without preceding patch");
+            // "x13 y13 x23 y23 x33 y33 x32 y32 x31 y31 x30 y30
+            //  x20 y20 x10 y10 x11 y11 x12 y12 x22 y22 x21 y21
+            //  c33 c30
+            //  Implicit values:
+            //  (x00, y00) = (x30, y30) previous
+            //  (x01, y01) = (x20, y20) previous
+            //  (x02, y02) = (x10, y10) previous
+            //  (x03, y03) = (x00, y00) previous
+            //  c00 = c30 previous
+            //  c03 = c00 previous"
+            TRY(patch_data.try_ensure_capacity(patch_data.size() + 12 * 2 + 2 + number_of_components));
+            TRY(read_points(12));
+            TRY(read_colors(2));
+            patch.control_points[patch_index[0]] = patches.last().control_points[3];
+            patch.control_points[patch_index[1]] = patches.last().control_points[2];
+            patch.control_points[patch_index[2]] = patches.last().control_points[1];
+            patch.control_points[patch_index[3]] = patches.last().control_points[0];
+            for (int i = 0; i < 12; ++i)
+                patch.control_points[patch_index[i + 4]] = n + 2 * i;
+            patch.colors[color_index[0]] = patches.last().colors[1];
+            patch.colors[color_index[1]] = patches.last().colors[0];
+            for (int i = 0; i < 2; ++i)
+                patch.colors[color_index[i + 2]] = n + 24 + number_of_components * i;
+            break;
+        default:
+            return Error::malformed_error("Invalid edge flag");
+        }
+
+        TRY(patches.try_append(patch));
+        bitstream.align_to_byte_boundary();
+    }
+
+    return adopt_ref(*new TensorProductPatchShading(move(common_entries), move(patch_data), move(patches), move(functions)));
+}
+
+PDFErrorOr<void> TensorProductPatchShading::draw(Gfx::Painter&, Gfx::AffineTransform const&)
+{
+    return Error::rendering_unsupported_error("Cannot draw tensor-product path mesh shadings yet");
+}
+
 }
 
 PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRefPtr<Object> shading_dict_or_stream, Renderer& renderer)
@@ -1245,7 +1555,9 @@ PDFErrorOr<NonnullRefPtr<Shading>> Shading::create(Document* document, NonnullRe
             return Error::malformed_error("Coons patch mesh stream has wrong type");
         return CoonsPatchShading::create(document, shading_dict_or_stream->cast<StreamObject>(), move(common_entries));
     case 7:
-        return Error::rendering_unsupported_error("Tensor-product patch mesh not yet implemented");
+        if (!shading_dict_or_stream->is<StreamObject>())
+            return Error::malformed_error("Tensor-product patch mesh stream has wrong type");
+        return TensorProductPatchShading::create(document, shading_dict_or_stream->cast<StreamObject>(), move(common_entries));
     }
     dbgln("Shading type {}", shading_type);
     return Error::malformed_error("Invalid shading type");


### PR DESCRIPTION
We now create an TensorProductPatchShading object and read all required
parameters and build objects for them, but we don't use them for any
rendering yet.

---

We can now parse all shading types :^)

(We still can't paint shading types 4-7 though.)

This file has some duplication. Once we can paint everything and check we don't regress things, I'll factor out some of the common bits.