### PR TITLE
LibGfx/PNG: Write grayscale images when sufficient

### DIFF
--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -79,6 +79,17 @@ static ErrorOr<void> test_roundtrip(Gfx::Bitmap const& bitmap)
     return {};
 }
 
+static void add_alpha_channel(Gfx::Bitmap& bitmap)
+{
+    for (int y = 0; y < bitmap.height(); ++y) {
+        for (int x = 0; x < bitmap.width(); ++x) {
+            Color pixel = bitmap.get_pixel(x, y);
+            pixel.set_alpha(255 - x);
+            bitmap.set_pixel(x, y, pixel);
+        }
+    }
+}
+
 static ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> create_test_rgb_bitmap()
 {
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 47, 33 }));
@@ -93,15 +104,7 @@ static ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> create_test_rgb_bitmap()
 static ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> create_test_rgba_bitmap()
 {
     auto bitmap = TRY(create_test_rgb_bitmap());
-
-    for (int y = 0; y < bitmap->height(); ++y) {
-        for (int x = 0; x < bitmap->width(); ++x) {
-            Color pixel = bitmap->get_pixel(x, y);
-            pixel.set_alpha(255 - x);
-            bitmap->set_pixel(x, y, pixel);
-        }
-    }
-
+    add_alpha_channel(*bitmap);
     return bitmap;
 }
 

--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -90,6 +90,27 @@ static void add_alpha_channel(Gfx::Bitmap& bitmap)
     }
 }
 
+static ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> create_test_grayscale_bitmap()
+{
+    auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 47, 33 }));
+
+    for (int y = 0; y < bitmap->height(); ++y) {
+        for (int x = 0; x < bitmap->width(); ++x) {
+            auto gray = (x + y) * 255 / (bitmap->width() + bitmap->height());
+            bitmap->set_pixel(x, y, Gfx::Color(gray, gray, gray));
+        }
+    }
+
+    return bitmap;
+}
+
+static ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> create_test_grayscale_alpha_bitmap()
+{
+    auto bitmap = TRY(create_test_grayscale_bitmap());
+    add_alpha_channel(*bitmap);
+    return bitmap;
+}
+
 static ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> create_test_rgb_bitmap()
 {
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 47, 33 }));
@@ -174,6 +195,8 @@ TEST_CASE(test_jpeg)
 
 TEST_CASE(test_png)
 {
+    TRY_OR_FAIL((test_roundtrip<Gfx::PNGWriter, Gfx::PNGImageDecoderPlugin>(TRY_OR_FAIL(create_test_grayscale_bitmap()))));
+    TRY_OR_FAIL((test_roundtrip<Gfx::PNGWriter, Gfx::PNGImageDecoderPlugin>(TRY_OR_FAIL(create_test_grayscale_alpha_bitmap()))));
     TRY_OR_FAIL((test_roundtrip<Gfx::PNGWriter, Gfx::PNGImageDecoderPlugin>(TRY_OR_FAIL(create_test_rgb_bitmap()))));
     TRY_OR_FAIL((test_roundtrip<Gfx::PNGWriter, Gfx::PNGImageDecoderPlugin>(TRY_OR_FAIL(create_test_rgba_bitmap()))));
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGWriter.h
@@ -51,12 +51,10 @@ private:
     ErrorOr<void> add_png_header();
     ErrorOr<void> add_acTL_chunk(u32 num_frames, u32 loop_count);
     ErrorOr<void> add_fcTL_chunk(fcTLData const& data);
-    template<bool include_alpha>
-    ErrorOr<void> add_fdAT_chunk(Gfx::Bitmap const&, u32 sequence_number, Compress::ZlibCompressionLevel);
+    ErrorOr<void> add_fdAT_chunk(Gfx::Bitmap const&, PNG::ColorType, u32 sequence_number, Compress::ZlibCompressionLevel);
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
     ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data, Compress::ZlibCompressionLevel);
-    template<bool include_alpha>
-    ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&, Compress::ZlibCompressionLevel);
+    ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&, PNG::ColorType, Compress::ZlibCompressionLevel);
     ErrorOr<void> add_IEND_chunk();
 };
 


### PR DESCRIPTION
Using [this](https://github.com/libjxl/conformance/blob/master/testcases/grayscale_public_university/ref.png) test image, it reduces its size from 2.3 MB to 1.5 MB, a nice 33% improvement :^)