### PR TITLE
Kernel/PCI: Modernize the devicetree PCI host controller initialization code

### DIFF
--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -181,7 +181,6 @@ ErrorOr<void> Access::fast_enumerate(Function<void(DeviceIdentifier const&)>& ca
     Vector<NonnullRefPtr<DeviceIdentifier>> device_identifiers;
     {
         SpinlockLocker locker(m_access_lock);
-        VERIFY(!m_device_identifiers.is_empty());
         TRY(device_identifiers.try_extend(m_device_identifiers));
     }
     for (auto const& device_identifier : device_identifiers) {

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -154,12 +154,11 @@ UNMAP_AFTER_INIT Access::Access()
     s_access = this;
 }
 
-UNMAP_AFTER_INIT void Access::configure_pci_space(PCIConfiguration& config)
+UNMAP_AFTER_INIT void Access::configure_pci_space(HostController& host_controller, PCIConfiguration& config)
 {
     SpinlockLocker locker(m_access_lock);
     SpinlockLocker scan_locker(m_scan_lock);
-    for (auto& [_, host_controller] : m_host_controllers)
-        host_controller->configure_attached_devices(config);
+    host_controller.configure_attached_devices(config);
 }
 
 UNMAP_AFTER_INIT void Access::rescan_hardware()

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -32,6 +32,8 @@ public:
     void configure_pci_space(HostController&, PCIConfiguration&);
     void rescan_hardware();
 
+    void add_host_controller(NonnullOwnPtr<HostController>);
+
     static Access& the();
     static bool is_initialized();
     static bool is_disabled();
@@ -54,12 +56,9 @@ public:
     ErrorOr<void> add_host_controller_and_scan_for_devices(NonnullOwnPtr<HostController>);
 
 private:
-    friend void PCI::initialize();
-
     u8 read8_field(DeviceIdentifier const&, RegisterOffset field);
     u16 read16_field(DeviceIdentifier const&, RegisterOffset field);
 
-    void add_host_controller(NonnullOwnPtr<HostController>);
     bool find_and_register_pci_host_bridges_from_acpi_mcfg_table(PhysicalAddress mcfg);
 
     mutable RecursiveSpinlock<LockRank::None> m_access_lock {};

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -27,7 +27,7 @@ public:
 #endif
 
     ErrorOr<void> fast_enumerate(Function<void(DeviceIdentifier const&)>&) const;
-    void configure_pci_space(PCIConfiguration&);
+    void configure_pci_space(HostController&, PCIConfiguration&);
     void rescan_hardware();
 
     static Access& the();

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -20,6 +20,8 @@ namespace Kernel::PCI {
 
 class Access {
 public:
+    Access();
+
     static bool initialize_for_multiple_pci_domains(PhysicalAddress mcfg_table);
 
 #if ARCH(X86_64)
@@ -59,7 +61,6 @@ private:
 
     void add_host_controller(NonnullOwnPtr<HostController>);
     bool find_and_register_pci_host_bridges_from_acpi_mcfg_table(PhysicalAddress mcfg);
-    Access();
 
     mutable RecursiveSpinlock<LockRank::None> m_access_lock {};
     mutable Spinlock<LockRank::None> m_scan_lock {};

--- a/Kernel/Bus/PCI/Controller/GenericECAMHostController.cpp
+++ b/Kernel/Bus/PCI/Controller/GenericECAMHostController.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023-2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Boot/CommandLine.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.h>
+#include <Kernel/Bus/PCI/DeviceTreeHelpers.h>
+#include <Kernel/Firmware/DeviceTree/DeviceTree.h>
+#include <Kernel/Firmware/DeviceTree/Driver.h>
+#include <Kernel/Firmware/DeviceTree/Management.h>
+
+namespace Kernel::PCI {
+
+class GenericDeviceTreeECAMHostController final : public MemoryBackedHostBridge {
+public:
+    static ErrorOr<NonnullOwnPtr<GenericDeviceTreeECAMHostController>> create(DeviceTree::Device const& device)
+    {
+        auto domain = TRY(determine_pci_domain_for_devicetree_node(device.node(), device.node_name()));
+        auto configuration_space = TRY(device.get_resource(0));
+
+        if (configuration_space.size < memory_range_per_bus * (domain.end_bus() - domain.start_bus() + 1))
+            return ERANGE;
+
+        return adopt_nonnull_own_or_enomem(new (nothrow) GenericDeviceTreeECAMHostController(domain, configuration_space.paddr));
+    }
+
+protected:
+    GenericDeviceTreeECAMHostController(Domain const& domain, PhysicalAddress physical_address)
+        : MemoryBackedHostBridge(domain, physical_address)
+    {
+    }
+};
+
+static constinit Array const compatibles_array = {
+    "pci-host-ecam-generic"sv,
+};
+
+DEVICETREE_DRIVER(GenericECAMPCIHostControllerDriver, compatibles_array);
+
+// https://www.kernel.org/doc/Documentation/devicetree/bindings/pci/host-generic-pci.yaml
+ErrorOr<void> GenericECAMPCIHostControllerDriver::probe(DeviceTree::Device const& device, StringView) const
+{
+    if (kernel_command_line().is_pci_disabled())
+        return {};
+
+    auto host_controller = TRY(GenericDeviceTreeECAMHostController::create(device));
+
+    TRY(configure_devicetree_host_controller(*host_controller, device.node(), device.node_name()));
+    Access::the().add_host_controller(move(host_controller));
+
+    return {};
+}
+
+}

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -119,7 +119,7 @@ union OpenFirmwareAddress {
         u32 : 3;                  // 0
         u32 aliased : 1;          // t
         u32 prefetchable : 1;     // p
-        u32 relocatable : 1;      // n
+        u32 non_relocatable : 1;  // n
     };
     u32 raw;
 };

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -18,8 +18,13 @@ ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node cons
     Array<u8, 2> bus_range { 0, 255 };
     auto maybe_bus_range = node.get_property("bus-range"sv);
     if (maybe_bus_range.has_value()) {
-        auto provided_bus_range = maybe_bus_range.value().as<Array<BigEndian<u32>, 2>>();
-        // FIXME: Range check these
+        if (maybe_bus_range->size() != sizeof(u32) * 2)
+            return EINVAL;
+
+        auto provided_bus_range = maybe_bus_range->as<Array<BigEndian<u32>, 2>>();
+        if (provided_bus_range[0] > 255 || provided_bus_range[1] > 255 || provided_bus_range[1] < provided_bus_range[0])
+            return EINVAL;
+
         bus_range[0] = provided_bus_range[0];
         bus_range[1] = provided_bus_range[1];
     }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -73,7 +73,7 @@ ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node cons
     };
 }
 
-ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const& node, StringView node_name)
+ErrorOr<void> configure_devicetree_host_controller(HostController& host_controller, ::DeviceTree::Node const& node, StringView node_name)
 {
     FlatPtr pci_32bit_mmio_base = 0;
     u32 pci_32bit_mmio_size = 0;
@@ -252,7 +252,7 @@ ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const& nod
             move(masked_interrupt_mapping),
             interrupt_mask,
         };
-        Access::the().configure_pci_space(config);
+        Access::the().configure_pci_space(host_controller, config);
     } else {
         dmesgln("PCI: No MMIO ranges found - assuming pre-configured by bootloader");
     }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -19,7 +19,7 @@ namespace Kernel::PCI {
 static TriState s_linux_pci_domain_property_used = TriState::Unknown;
 static u32 s_next_pci_domain_number { 0 };
 
-ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const& node)
+ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const& node, StringView node_name)
 {
     // PCI Bus Binding to IEEE Std 1275-1994, 3.1.2. Bus-specific Properties for Bus Nodes:
     // ""bus-range" [...] denotes range of bus numbers controlled by this PCI bus."
@@ -63,6 +63,8 @@ ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node cons
     }
 
     s_linux_pci_domain_property_used = static_cast<TriState>(maybe_domain_number.has_value());
+
+    dbgln("PCI: Assigned domain number {} for {}", domain_number, node_name);
 
     return Domain {
         domain_number,

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023-2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/Controller/HostController.h>
+#include <Kernel/Bus/PCI/DeviceTreeHelpers.h>
+#include <LibDeviceTree/DeviceTree.h>
+
+namespace Kernel::PCI {
+
+ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const& node)
+{
+    FlatPtr pci_32bit_mmio_base = 0;
+    u32 pci_32bit_mmio_size = 0;
+    FlatPtr pci_64bit_mmio_base = 0;
+    u64 pci_64bit_mmio_size = 0;
+    HashMap<PCIInterruptSpecifier, u64> masked_interrupt_mapping;
+    PCIInterruptSpecifier interrupt_mask;
+
+    auto const& device_tree = DeviceTree::get();
+
+    if (node.parent() == nullptr)
+        return EINVAL;
+
+    auto parent_address_cells = node.parent()->address_cells();
+
+    auto maybe_ranges = node.get_property("ranges"sv);
+    if (maybe_ranges.has_value()) {
+        auto address_cells = node.get_property("#address-cells"sv).value().as<u32>();
+        VERIFY(address_cells == 3); // Additional cell for OpenFirmware PCI address metadata
+        auto size_cells = node.get_property("#size-cells"sv).value().as<u32>();
+
+        auto stream = maybe_ranges.value().as_stream();
+        while (!stream.is_eof()) {
+            auto pci_address_metadata = bit_cast<OpenFirmwareAddress>(MUST(stream.read_cell()));
+            FlatPtr pci_address = MUST(stream.read_cells(2));
+
+            FlatPtr mmio_address = MUST(stream.read_cells(parent_address_cells));
+            u64 mmio_size = MUST(stream.read_cells(size_cells));
+
+            if (pci_address_metadata.space_type != OpenFirmwareAddress::SpaceType::Memory32BitSpace
+                && pci_address_metadata.space_type != OpenFirmwareAddress::SpaceType::Memory64BitSpace)
+                continue; // We currently only support memory-mapped PCI on RISC-V and AArch64
+
+            // TODO: Support mapped PCI addresses
+            VERIFY(pci_address == mmio_address);
+            if (pci_address_metadata.space_type == OpenFirmwareAddress::SpaceType::Memory32BitSpace) {
+                if (pci_address_metadata.prefetchable)
+                    continue; // We currently only use non-prefetchable 32-bit regions, since 64-bit regions are always prefetchable - TODO: Use 32-bit prefetchable regions if only they are available
+                if (pci_32bit_mmio_size >= mmio_size)
+                    continue; // We currently only use the single largest region - TODO: Use all available regions if needed
+
+                pci_32bit_mmio_base = mmio_address;
+                pci_32bit_mmio_size = mmio_size;
+            } else {
+                if (pci_64bit_mmio_size >= mmio_size)
+                    continue; // We currently only use the single largest region - TODO: Use all available regions if needed
+
+                pci_64bit_mmio_base = mmio_address;
+                pci_64bit_mmio_size = mmio_size;
+            }
+        }
+    }
+
+    // 2.4.3 Interrupt Nexus Properties
+    // #interrupt-cells: [2] `1` for pci busses
+    // interrupt-map:
+    //  [{
+    //     child-unit-address(bus-node/#address-cells|3),
+    //     child-interrupt-specifier(#interrupt-cells|1),
+    //     interrupt-parent(phandle),
+    //     parent-unit-address(interrupt-parent/#address-cells),
+    //     parent-interrupt-specifier(interrupt-parent/#interrupt-cells)
+    //  }]
+    //   Note: The bus-node may be any other bus the child is connected to
+    //   FIXME?: Let's just hope this is always this/a PCI bus
+    // interrupt-map-mask:
+    // > This property specifies a  mask that is ANDed with the incoming
+    // > unit interrupt specifier being looked up in the table specified in the
+    // > interrupt-map property.
+    // Hence this should be of size:
+    // pci/#address-cells(3) + #interrupt-cells(1) = 4
+    auto maybe_interrupt_map = node.get_property("interrupt-map"sv);
+    auto maybe_interrupt_map_mask = node.get_property("interrupt-map-mask"sv);
+    if (maybe_interrupt_map.has_value() && maybe_interrupt_map_mask.has_value()) {
+        VERIFY(node.get_property("#interrupt-cells"sv)->as<u32>() == 1);
+        VERIFY(maybe_interrupt_map_mask.value().size() == 4 * sizeof(u32));
+
+        auto mask_stream = maybe_interrupt_map_mask.value().as_stream();
+        auto metadata_mask = bit_cast<OpenFirmwareAddress>(MUST(mask_stream.read_cell()));
+        u64 phyical_address_mask = MUST(mask_stream.read_cells(2));
+        // [2]: phys.mid and phys.lo mask should be 0 -> physical-address-mask = 0
+        //      0 < metadata_mask < 0xff00
+        VERIFY(phyical_address_mask == 0);
+        VERIFY(metadata_mask.raw <= 0xff00);
+        // Additionally it would be ludicrous/impossible to differentiate interrupts on registers
+        VERIFY(metadata_mask.register_ == 0);
+
+        u32 pin_mask = MUST(mask_stream.read_cell());
+        // [2]: The interrupt specifier mask should be between 0 and 7
+        VERIFY(pin_mask <= 7);
+
+        interrupt_mask = PCIInterruptSpecifier {
+            .interrupt_pin = static_cast<u8>(pin_mask),
+            .function = metadata_mask.function,
+            .device = metadata_mask.device,
+            .bus = metadata_mask.bus,
+        };
+        auto map_stream = maybe_interrupt_map.value().as_stream();
+        while (!map_stream.is_eof()) {
+            auto pci_address_metadata = bit_cast<OpenFirmwareAddress>(MUST(map_stream.read_cell()));
+            MUST(map_stream.discard(sizeof(u32) * 2)); // Physical Address, the mask for those is guaranteed to be 0
+            u32 pin = MUST(map_stream.read_cell());
+
+            u32 interrupt_controller_phandle = MUST(map_stream.read_cell());
+            auto const* interrupt_controller = device_tree.phandle(interrupt_controller_phandle);
+            VERIFY(interrupt_controller);
+
+            if (!interrupt_controller->has_property("interrupt-controller"sv)) {
+                dmesgln("PCI: Implement support for nested interrupt nexuses");
+                TODO();
+            }
+
+            MUST(map_stream.discard(sizeof(u32) * interrupt_controller->address_cells()));
+
+            auto interrupt_cells = interrupt_controller->get_property("#interrupt-cells"sv)->as<u32>();
+#if ARCH(RISCV64)
+            VERIFY(interrupt_cells == 1 || interrupt_cells == 2);
+            u64 interrupt = MUST(map_stream.read_cells(interrupt_cells));
+#elif ARCH(AARCH64)
+            // FIXME: Don't depend on a specific interrupt descriptor format.
+            auto const& domain_root = *MUST(interrupt_controller->interrupt_domain_root(device_tree));
+            if (!domain_root.is_compatible_with("arm,gic-400"sv) && !domain_root.is_compatible_with("arm,cortex-a15-gic"sv))
+                TODO();
+
+            VERIFY(interrupt_cells == 3);
+            MUST(map_stream.discard(sizeof(u32))); // This is the IRQ type.
+            u64 interrupt = MUST(map_stream.read_cell()) + 32;
+            MUST(map_stream.discard(sizeof(u32))); // This is the trigger type.
+#else
+#    error Unknown architecture
+#endif
+
+            pin &= pin_mask;
+            pci_address_metadata.raw &= metadata_mask.raw;
+            masked_interrupt_mapping.set(
+                PCIInterruptSpecifier {
+                    .interrupt_pin = static_cast<u8>(pin),
+                    .function = pci_address_metadata.function,
+                    .device = pci_address_metadata.device,
+                    .bus = pci_address_metadata.bus,
+                },
+                interrupt);
+        }
+    }
+
+    if (pci_32bit_mmio_size != 0 || pci_64bit_mmio_size != 0) {
+        PCIConfiguration config {
+            pci_32bit_mmio_base,
+            pci_32bit_mmio_base + pci_32bit_mmio_size,
+            pci_64bit_mmio_base,
+            pci_64bit_mmio_base + pci_64bit_mmio_size,
+            move(masked_interrupt_mapping),
+            interrupt_mask,
+        };
+        Access::the().configure_pci_space(config);
+    } else {
+        dmesgln("PCI: No MMIO ranges found - assuming pre-configured by bootloader");
+    }
+
+    return {};
+}
+
+}

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.h
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.h
@@ -7,12 +7,13 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <Kernel/Bus/PCI/Controller/HostController.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Firmware/DeviceTree/DeviceTree.h>
 
 namespace Kernel::PCI {
 
 ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&, StringView node_name);
-ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const&, StringView node_name);
+ErrorOr<void> configure_devicetree_host_controller(HostController&, ::DeviceTree::Node const&, StringView node_name);
 
 }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.h
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.h
@@ -12,7 +12,7 @@
 
 namespace Kernel::PCI {
 
-ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&, StringView node_name);
+ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&);
 ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const&);
 
 }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.h
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.h
@@ -12,7 +12,7 @@
 
 namespace Kernel::PCI {
 
-ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&);
+ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&, StringView node_name);
 ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const&, StringView node_name);
 
 }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.h
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.h
@@ -13,6 +13,6 @@
 namespace Kernel::PCI {
 
 ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&);
-ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const&);
+ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const&, StringView node_name);
 
 }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.h
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.h
@@ -7,10 +7,12 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Firmware/DeviceTree/DeviceTree.h>
 
 namespace Kernel::PCI {
 
-ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const& node);
+ErrorOr<Domain> determine_pci_domain_for_devicetree_node(::DeviceTree::Node const&, StringView node_name);
+ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const&);
 
 }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.h
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023-2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <Kernel/Firmware/DeviceTree/DeviceTree.h>
+
+namespace Kernel::PCI {
+
+ErrorOr<void> configure_devicetree_host_controller(::DeviceTree::Node const& node);
+
+}

--- a/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
@@ -8,12 +8,8 @@
 #include <Kernel/Boot/CommandLine.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.h>
-#include <Kernel/Bus/PCI/DeviceTreeHelpers.h>
 #include <Kernel/Bus/PCI/Initializer.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h>
-#include <Kernel/Firmware/DeviceTree/DeviceTree.h>
-#include <Userland/Libraries/LibDeviceTree/DeviceTree.h>
 
 namespace Kernel::PCI {
 
@@ -27,101 +23,7 @@ void initialize()
         return;
     }
 
-    // [1]: https://github.com/devicetree-org/devicetree-specification/releases/download/v0.4/devicetree-specification-v0.4.pdf
-    // [2]: https://github.com/devicetree-org/dt-schema/blob/main/dtschema/schemas/pci/pci-bus-common.yaml
-    // [3]: https://github.com/devicetree-org/dt-schema/blob/main/dtschema/schemas/pci/pci-host-bridge.yaml
-
-    // The pci controllers are usually in /soc/pcie?@XXXXXXXX on RISC-V, and in /pcie?@XXXXXXXX on AArch64
-    // FIXME: They can also appear in any simple-bus other than soc
-    auto const& device_tree = DeviceTree::get();
-
-    auto maybe_soc = device_tree.get_child("soc"sv);
-
-    auto const& pci_host_controller_node_parent = maybe_soc.has_value() ? maybe_soc.value() : device_tree;
-
-    enum class ControllerCompatible {
-        Unknown,
-        ECAM,
-    };
-
-    // These properties must be present
-    auto soc_address_cells = pci_host_controller_node_parent.get_property("#address-cells"sv).value().as<u32>();
-    [[maybe_unused]] auto soc_size_cells = pci_host_controller_node_parent.get_property("#size-cells"sv).value().as<u32>();
-
-    bool found_compatible_pci_controller = false;
-    for (auto const& [name, node] : pci_host_controller_node_parent.children()) {
-        if (!name.starts_with("pci"sv))
-            continue;
-
-        if (auto device_type = node.get_property("device_type"sv); !device_type.has_value() || device_type.value().as_string() != "pci"sv) {
-            // Technically, the device_type property is deprecated, but if it is present,
-            // no harm's done in checking it anyway
-            dmesgln("PCI: PCI named devicetree entry {} not a PCI type device, got device type '{}' instead", name, device_type.has_value() ? device_type.value().as_string() : "<None>"sv);
-            continue;
-        }
-
-        auto maybe_compatible = node.get_property("compatible"sv);
-        if (!maybe_compatible.has_value()) {
-            dmesgln("PCI: Devicetree node for {} does not have a 'compatible' string, rejecting", name);
-            continue;
-        }
-        auto compatible = maybe_compatible.value();
-        auto controller_compatibility = ControllerCompatible::Unknown;
-        // Compatible strings are a list of strings;
-        // They should be sorted from most specific to least specific,
-        // so it's best to take the first one we recognize
-        compatible.for_each_string([&controller_compatibility](StringView compatible_string) -> IterationDecision {
-            if (compatible_string == "pci-host-ecam-generic"sv) {
-                controller_compatibility = ControllerCompatible::ECAM;
-                return IterationDecision::Break;
-            }
-            // FIXME: Implement CAM (pci-host-cam-generic), but maybe it's to old to be relevant
-
-            return IterationDecision::Continue;
-        });
-        if (controller_compatibility == ControllerCompatible::Unknown) {
-            dmesgln("PCI: Devicetree node for {} does not have a known 'compatible' string, rejecting", name);
-            dmesgln("PCI: Compatible strings provided: {}", compatible.as_strings());
-            continue;
-        }
-
-        auto maybe_reg = node.get_property("reg"sv);
-        if (!maybe_reg.has_value()) {
-            dmesgln("PCI: Devicetree node for {} does not have a physical address assigned to it, rejecting", name);
-            continue;
-        }
-        auto reg = maybe_reg.value();
-
-        auto domain = determine_pci_domain_for_devicetree_node(node, name).release_value_but_fixme_should_propagate_errors();
-
-        OwnPtr<HostController> host_controller = nullptr;
-
-        switch (controller_compatibility) {
-        case ControllerCompatible::ECAM: {
-            // FIXME: Make this use a nice helper function
-            // FIXME: Use the provided size field
-            auto stream = reg.as_stream();
-            FlatPtr paddr = MUST(stream.read_cells(soc_address_cells));
-
-            host_controller = MemoryBackedHostBridge::must_create(domain, PhysicalAddress { paddr });
-            break;
-        }
-        case ControllerCompatible::Unknown:
-            VERIFY_NOT_REACHED(); // This should have been rejected earlier
-        }
-
-        found_compatible_pci_controller = true;
-
-        configure_devicetree_host_controller(*host_controller, node, name).release_value_but_fixme_should_propagate_errors();
-
-        Access::the().add_host_controller(host_controller.release_nonnull());
-    }
-
-    if (!found_compatible_pci_controller) {
-        dmesgln("PCI: No compatible controller found");
-        g_pci_access_io_probe_failed.set();
-        return;
-    }
+    // Host controllers defined in the devicetree are added before PCI::initialize() is called.
 
     Access::the().rescan_hardware();
 

--- a/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
@@ -27,8 +27,6 @@ void initialize()
         return;
     }
 
-    new Access();
-
     // [1]: https://github.com/devicetree-org/devicetree-specification/releases/download/v0.4/devicetree-specification-v0.4.pdf
     // [2]: https://github.com/devicetree-org/dt-schema/blob/main/dtschema/schemas/pci/pci-bus-common.yaml
     // [3]: https://github.com/devicetree-org/dt-schema/blob/main/dtschema/schemas/pci/pci-host-bridge.yaml

--- a/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
@@ -94,7 +94,7 @@ void initialize()
         }
         auto reg = maybe_reg.value();
 
-        auto domain = determine_pci_domain_for_devicetree_node(node).release_value_but_fixme_should_propagate_errors();
+        auto domain = determine_pci_domain_for_devicetree_node(node, name).release_value_but_fixme_should_propagate_errors();
 
         switch (controller_compatibility) {
         case ControllerCompatible::ECAM: {

--- a/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
@@ -112,7 +112,7 @@ void initialize()
 
         found_compatible_pci_controller = true;
 
-        configure_devicetree_host_controller(node).release_value_but_fixme_should_propagate_errors();
+        configure_devicetree_host_controller(node, name).release_value_but_fixme_should_propagate_errors();
     }
 
     if (!found_compatible_pci_controller) {

--- a/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.h>
+#include <Kernel/Bus/PCI/DeviceTreeHelpers.h>
 #include <Kernel/Bus/PCI/Initializer.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.h>
 #include <Kernel/Firmware/DeviceTree/DeviceTree.h>
@@ -50,12 +51,6 @@ void initialize()
     [[maybe_unused]] auto soc_size_cells = pci_host_controller_node_parent.get_property("#size-cells"sv).value().as<u32>();
 
     Optional<u32> domain_counter;
-    FlatPtr pci_32bit_mmio_base = 0;
-    u32 pci_32bit_mmio_size = 0;
-    FlatPtr pci_64bit_mmio_base = 0;
-    u64 pci_64bit_mmio_size = 0;
-    HashMap<PCIInterruptSpecifier, u64> masked_interrupt_mapping;
-    PCIInterruptSpecifier interrupt_mask;
     bool found_compatible_pci_controller = false;
     for (auto const& [name, node] : pci_host_controller_node_parent.children()) {
         if (!name.starts_with("pci"sv))
@@ -150,135 +145,7 @@ void initialize()
 
         found_compatible_pci_controller = true;
 
-        auto maybe_ranges = node.get_property("ranges"sv);
-        if (maybe_ranges.has_value()) {
-            auto address_cells = node.get_property("#address-cells"sv).value().as<u32>();
-            VERIFY(address_cells == 3); // Additional cell for OpenFirmware PCI address metadata
-            auto size_cells = node.get_property("#size-cells"sv).value().as<u32>();
-
-            auto stream = maybe_ranges.value().as_stream();
-            while (!stream.is_eof()) {
-                auto pci_address_metadata = bit_cast<OpenFirmwareAddress>(MUST(stream.read_cell()));
-                FlatPtr pci_address = MUST(stream.read_cells(2));
-
-                FlatPtr mmio_address = MUST(stream.read_cells(soc_address_cells));
-                u64 mmio_size = MUST(stream.read_cells(size_cells));
-
-                if (pci_address_metadata.space_type != OpenFirmwareAddress::SpaceType::Memory32BitSpace
-                    && pci_address_metadata.space_type != OpenFirmwareAddress::SpaceType::Memory64BitSpace)
-                    continue; // We currently only support memory-mapped PCI on RISC-V and AArch64
-
-                // TODO: Support mapped PCI addresses
-                VERIFY(pci_address == mmio_address);
-                if (pci_address_metadata.space_type == OpenFirmwareAddress::SpaceType::Memory32BitSpace) {
-                    if (pci_address_metadata.prefetchable)
-                        continue; // We currently only use non-prefetchable 32-bit regions, since 64-bit regions are always prefetchable - TODO: Use 32-bit prefetchable regions if only they are available
-                    if (pci_32bit_mmio_size >= mmio_size)
-                        continue; // We currently only use the single largest region - TODO: Use all available regions if needed
-
-                    pci_32bit_mmio_base = mmio_address;
-                    pci_32bit_mmio_size = mmio_size;
-                } else {
-                    if (pci_64bit_mmio_size >= mmio_size)
-                        continue; // We currently only use the single largest region - TODO: Use all available regions if needed
-
-                    pci_64bit_mmio_base = mmio_address;
-                    pci_64bit_mmio_size = mmio_size;
-                }
-            }
-        }
-
-        // 2.4.3 Interrupt Nexus Properties
-        // #interrupt-cells: [2] `1` for pci busses
-        // interrupt-map:
-        //  [{
-        //     child-unit-address(bus-node/#address-cells|3),
-        //     child-interrupt-specifier(#interrupt-cells|1),
-        //     interrupt-parent(phandle),
-        //     parent-unit-address(interrupt-parent/#address-cells),
-        //     parent-interrupt-specifier(interrupt-parent/#interrupt-cells)
-        //  }]
-        //   Note: The bus-node may be any other bus the child is connected to
-        //   FIXME?: Let's just hope this is always this/a PCI bus
-        // interrupt-map-mask:
-        // > This property specifies a  mask that is ANDed with the incoming
-        // > unit interrupt specifier being looked up in the table specified in the
-        // > interrupt-map property.
-        // Hence this should be of size:
-        // pci/#address-cells(3) + #interrupt-cells(1) = 4
-        auto maybe_interrupt_map = node.get_property("interrupt-map"sv);
-        auto maybe_interrupt_map_mask = node.get_property("interrupt-map-mask"sv);
-        if (maybe_interrupt_map.has_value() && maybe_interrupt_map_mask.has_value()) {
-            VERIFY(node.get_property("#interrupt-cells"sv)->as<u32>() == 1);
-            VERIFY(maybe_interrupt_map_mask.value().size() == 4 * sizeof(u32));
-
-            auto mask_stream = maybe_interrupt_map_mask.value().as_stream();
-            auto metadata_mask = bit_cast<OpenFirmwareAddress>(MUST(mask_stream.read_cell()));
-            u64 phyical_address_mask = MUST(mask_stream.read_cells(2));
-            // [2]: phys.mid and phys.lo mask should be 0 -> physical-address-mask = 0
-            //      0 < metadata_mask < 0xff00
-            VERIFY(phyical_address_mask == 0);
-            VERIFY(metadata_mask.raw <= 0xff00);
-            // Additionally it would be ludicrous/impossible to differentiate interrupts on registers
-            VERIFY(metadata_mask.register_ == 0);
-
-            u32 pin_mask = MUST(mask_stream.read_cell());
-            // [2]: The interrupt specifier mask should be between 0 and 7
-            VERIFY(pin_mask <= 7);
-
-            interrupt_mask = PCIInterruptSpecifier {
-                .interrupt_pin = static_cast<u8>(pin_mask),
-                .function = metadata_mask.function,
-                .device = metadata_mask.device,
-                .bus = metadata_mask.bus,
-            };
-            auto map_stream = maybe_interrupt_map.value().as_stream();
-            while (!map_stream.is_eof()) {
-                auto pci_address_metadata = bit_cast<OpenFirmwareAddress>(MUST(map_stream.read_cell()));
-                MUST(map_stream.discard(sizeof(u32) * 2)); // Physical Address, the mask for those is guaranteed to be 0
-                u32 pin = MUST(map_stream.read_cell());
-
-                u32 interrupt_controller_phandle = MUST(map_stream.read_cell());
-                auto const* interrupt_controller = device_tree.phandle(interrupt_controller_phandle);
-                VERIFY(interrupt_controller);
-
-                if (!interrupt_controller->has_property("interrupt-controller"sv)) {
-                    dmesgln("PCI: Implement support for nested interrupt nexuses");
-                    TODO();
-                }
-
-                MUST(map_stream.discard(sizeof(u32) * interrupt_controller->address_cells()));
-
-                auto interrupt_cells = interrupt_controller->get_property("#interrupt-cells"sv)->as<u32>();
-#if ARCH(RISCV64)
-                VERIFY(interrupt_cells == 1 || interrupt_cells == 2);
-                u64 interrupt = MUST(map_stream.read_cells(interrupt_cells));
-#elif ARCH(AARCH64)
-                // FIXME: Don't depend on a specific interrupt descriptor format.
-                auto const& domain_root = *MUST(interrupt_controller->interrupt_domain_root(device_tree));
-                if (!domain_root.is_compatible_with("arm,gic-400"sv) && !domain_root.is_compatible_with("arm,cortex-a15-gic"sv))
-                    TODO();
-
-                VERIFY(interrupt_cells == 3);
-                MUST(map_stream.discard(sizeof(u32))); // This is the IRQ type.
-                u64 interrupt = MUST(map_stream.read_cell()) + 32;
-                MUST(map_stream.discard(sizeof(u32))); // This is the trigger type.
-#else
-#    error Unknown architecture
-#endif
-
-                pin &= pin_mask;
-                pci_address_metadata.raw &= metadata_mask.raw;
-                masked_interrupt_mapping.set(
-                    PCIInterruptSpecifier {
-                        .interrupt_pin = static_cast<u8>(pin),
-                        .function = pci_address_metadata.function,
-                        .device = pci_address_metadata.device,
-                        .bus = pci_address_metadata.bus,
-                    },
-                    interrupt);
-            }
-        }
+        configure_devicetree_host_controller(node).release_value_but_fixme_should_propagate_errors();
     }
 
     if (!found_compatible_pci_controller) {
@@ -287,19 +154,6 @@ void initialize()
         return;
     }
 
-    if (pci_32bit_mmio_size != 0 || pci_64bit_mmio_size != 0) {
-        PCIConfiguration config {
-            pci_32bit_mmio_base,
-            pci_32bit_mmio_base + pci_32bit_mmio_size,
-            pci_64bit_mmio_base,
-            pci_64bit_mmio_base + pci_64bit_mmio_size,
-            move(masked_interrupt_mapping),
-            interrupt_mask,
-        };
-        Access::the().configure_pci_space(config);
-    } else {
-        dmesgln("PCI: No MMIO ranges found - assuming pre-configured by bootloader");
-    }
     Access::the().rescan_hardware();
 
     PCIBusSysFSDirectory::initialize();

--- a/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeInitializer.cpp
@@ -94,7 +94,7 @@ void initialize()
         }
         auto reg = maybe_reg.value();
 
-        auto domain = determine_pci_domain_for_devicetree_node(node, name).release_value_but_fixme_should_propagate_errors();
+        auto domain = determine_pci_domain_for_devicetree_node(node).release_value_but_fixme_should_propagate_errors();
 
         switch (controller_compatibility) {
         case ControllerCompatible::ECAM: {

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -525,6 +525,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
 
         Arch/aarch64/Serial/PL011.cpp
 
+        Bus/PCI/DeviceTreeHelpers.cpp
         Bus/PCI/DeviceTreeInitializer.cpp
     )
 
@@ -570,6 +571,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/Timer.cpp
         Arch/riscv64/trap_handler.S
 
+        Bus/PCI/DeviceTreeHelpers.cpp
         Bus/PCI/DeviceTreeInitializer.cpp
     )
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -525,6 +525,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
 
         Arch/aarch64/Serial/PL011.cpp
 
+        Bus/PCI/Controller/GenericECAMHostController.cpp
         Bus/PCI/DeviceTreeHelpers.cpp
         Bus/PCI/DeviceTreeInitializer.cpp
     )
@@ -571,6 +572,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/Timer.cpp
         Arch/riscv64/trap_handler.S
 
+        Bus/PCI/Controller/GenericECAMHostController.cpp
         Bus/PCI/DeviceTreeHelpers.cpp
         Bus/PCI/DeviceTreeInitializer.cpp
     )


### PR DESCRIPTION
This should be the last devicetree driver that wasn't a `DeviceTree::Driver`.

This PR also adds support for systems with multiple host controllers (we will need this for the VisionFive 2 and Raspberry Pi 5) and makes us no longer panic on invalid PCI host controller nodes.