### PR TITLE
Kernel+AK: Another pack of FATFS improvements

### DIFF
--- a/AK/DOSPackedTime.cpp
+++ b/AK/DOSPackedTime.cpp
@@ -5,8 +5,11 @@
  */
 
 #include <AK/DOSPackedTime.h>
+#include <AK/Error.h>
 
 namespace AK {
+
+constexpr auto seconds_per_day = 86'400;
 
 UnixDateTime time_from_packed_dos(DOSPackedDate date, DOSPackedTime time)
 {
@@ -34,6 +37,54 @@ DOSPackedTime to_packed_dos_time(unsigned hour, unsigned minute, unsigned second
     time.second = second / 2;
 
     return time;
+}
+
+// FIXME: Improve these naive algorithms.
+ErrorOr<DOSPackedDate> to_packed_dos_date(UnixDateTime const& unix_date_time)
+{
+    auto truncated_seconds_since_epoch = unix_date_time.truncated_seconds_since_epoch();
+    if (truncated_seconds_since_epoch < first_dos_representable_unix_timestamp || truncated_seconds_since_epoch > static_cast<i64>(last_dos_representable_unix_timestamp))
+        return EINVAL;
+
+    auto years_since_epoch = 0;
+    auto leftover_seconds = truncated_seconds_since_epoch;
+    while (leftover_seconds >= days_in_year(years_since_epoch + 1970) * seconds_per_day) {
+        leftover_seconds -= days_in_year(years_since_epoch + 1970) * seconds_per_day;
+        ++years_since_epoch;
+    }
+
+    auto month_of_year = 1;
+    for (; month_of_year <= 12; ++month_of_year) {
+        auto seconds_in_current_month = days_in_month(years_since_epoch + 1970, month_of_year) * seconds_per_day;
+        if (leftover_seconds < seconds_in_current_month)
+            break;
+        leftover_seconds -= seconds_in_current_month;
+    }
+
+    VERIFY(month_of_year <= 12);
+
+    auto day = leftover_seconds / seconds_per_day + 1;
+
+    return to_packed_dos_date(years_since_epoch + 1970, month_of_year, day);
+}
+
+ErrorOr<DOSPackedTime> to_packed_dos_time(UnixDateTime const& unix_date_time)
+{
+    constexpr auto seconds_per_hour = 3'600;
+    constexpr auto seconds_per_minute = 60;
+
+    auto date = TRY(to_packed_dos_date(unix_date_time));
+
+    auto truncated_seconds_since_epoch = unix_date_time.truncated_seconds_since_epoch();
+    auto leftover_seconds = truncated_seconds_since_epoch - days_since_epoch(date.year + first_dos_year, date.month, date.day) * seconds_per_day;
+
+    auto hours = leftover_seconds / seconds_per_hour;
+    leftover_seconds -= hours * seconds_per_hour;
+
+    auto minutes = leftover_seconds / seconds_per_minute;
+    leftover_seconds -= minutes * seconds_per_minute;
+
+    return to_packed_dos_time(hours, minutes, leftover_seconds);
 }
 
 }

--- a/AK/DOSPackedTime.h
+++ b/AK/DOSPackedTime.h
@@ -32,10 +32,14 @@ union DOSPackedDate {
 static_assert(sizeof(DOSPackedDate) == 2);
 
 inline constexpr u16 first_dos_year = 1980;
+inline constexpr u32 first_dos_representable_unix_timestamp = UnixDateTime::from_unix_time_parts(1980, 1, 1, 0, 0, 0, 0).seconds_since_epoch();
+inline constexpr u64 last_dos_representable_unix_timestamp = UnixDateTime::from_unix_time_parts(2107, 12, 31, 23, 59, 59, 0).seconds_since_epoch();
 
 UnixDateTime time_from_packed_dos(DOSPackedDate, DOSPackedTime);
 DOSPackedDate to_packed_dos_date(unsigned year, unsigned month, unsigned day);
 DOSPackedTime to_packed_dos_time(unsigned hour, unsigned minute, unsigned second);
+ErrorOr<DOSPackedDate> to_packed_dos_date(UnixDateTime const&);
+ErrorOr<DOSPackedTime> to_packed_dos_time(UnixDateTime const&);
 
 }
 

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -110,66 +110,6 @@ i64 Duration::to_truncated_microseconds() const
     return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
 }
 
-i64 Duration::to_seconds() const
-{
-    VERIFY(m_nanoseconds < 1'000'000'000);
-    if (m_seconds >= 0 && m_nanoseconds) {
-        Checked<i64> seconds(m_seconds);
-        seconds++;
-        return seconds.has_overflow() ? 0x7fff'ffff'ffff'ffffLL : seconds.value();
-    }
-    return m_seconds;
-}
-
-i64 Duration::to_milliseconds() const
-{
-    VERIFY(m_nanoseconds < 1'000'000'000);
-    Checked<i64> milliseconds((m_seconds < 0) ? m_seconds + 1 : m_seconds);
-    milliseconds *= 1'000;
-    milliseconds += m_nanoseconds / 1'000'000;
-    if (m_seconds >= 0 && m_nanoseconds % 1'000'000 != 0)
-        milliseconds++;
-    if (m_seconds < 0) {
-        // We dropped one second previously, put it back in now that we have handled the rounding.
-        milliseconds -= 1'000;
-    }
-    if (!milliseconds.has_overflow())
-        return milliseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
-}
-
-i64 Duration::to_microseconds() const
-{
-    VERIFY(m_nanoseconds < 1'000'000'000);
-    Checked<i64> microseconds((m_seconds < 0) ? m_seconds + 1 : m_seconds);
-    microseconds *= 1'000'000;
-    microseconds += m_nanoseconds / 1'000;
-    if (m_seconds >= 0 && m_nanoseconds % 1'000 != 0)
-        microseconds++;
-    if (m_seconds < 0) {
-        // We dropped one second previously, put it back in now that we have handled the rounding.
-        microseconds -= 1'000'000;
-    }
-    if (!microseconds.has_overflow())
-        return microseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
-}
-
-i64 Duration::to_nanoseconds() const
-{
-    VERIFY(m_nanoseconds < 1'000'000'000);
-    Checked<i64> nanoseconds((m_seconds < 0) ? m_seconds + 1 : m_seconds);
-    nanoseconds *= 1'000'000'000;
-    nanoseconds += m_nanoseconds;
-    if (m_seconds < 0) {
-        // We dropped one second previously, put it back in now that we have handled the rounding.
-        nanoseconds -= 1'000'000'000;
-    }
-    if (!nanoseconds.has_overflow())
-        return nanoseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
-}
-
 timespec Duration::to_timespec() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -492,6 +492,7 @@ public:
     [[nodiscard]] constexpr i64 nanoseconds_since_epoch() const { return m_offset.to_nanoseconds(); }
     // Never returns a point after this UnixDateTime, since fractional seconds are cut off.
     [[nodiscard]] i64 truncated_seconds_since_epoch() const { return m_offset.to_truncated_seconds(); }
+    [[nodiscard]] i64 truncated_milliseconds_since_epoch() const { return m_offset.to_truncated_milliseconds(); }
 
     // Offsetting a UNIX time by a duration yields another UNIX time.
     constexpr UnixDateTime operator+(Duration const& other) const { return UnixDateTime { m_offset + other }; }

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -648,13 +648,15 @@ ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView name, mode_t mod
     MutexLocker locker(m_inode_lock);
 
     auto entries = TRY(allocate_entries(lfn_entries.size() + 1));
-    u32 allocated_cluster = TRY(fs().allocate_cluster());
-    if (fs().m_fat_version == FATVersion::FAT32)
-        entry.first_cluster_high = allocated_cluster >> 16;
-
-    entry.first_cluster_low = allocated_cluster & 0xFFFF;
 
     if (mode & S_IFDIR) {
+        u32 allocated_cluster = TRY(fs().allocate_cluster());
+        if (fs().m_fat_version == FATVersion::FAT32)
+            entry.first_cluster_high = allocated_cluster >> 16;
+
+        entry.first_cluster_low = allocated_cluster & 0xFFFF;
+
+        // This is used for generating a directory's "." and ".." entries.
         auto create_directory_entry = [&](StringView entry_name) {
             VERIFY(entry_name.length() <= 8);
             FATEntry directory_entry {};

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -623,6 +623,9 @@ ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView name, mode_t mod
 
     dbgln_if(FAT_DEBUG, "FATInode[{}]::create_child(): creating inode \"{}\"", identifier(), name);
 
+    if (!Kernel::is_directory(mode) && !Kernel::is_regular_file(mode))
+        return ENOTSUP;
+
     FATEntry entry {};
 
     bool valid_sfn = SFNUtils::is_valid_sfn(name);

--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -710,50 +710,9 @@ ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView name, mode_t mod
     return TRY(FATInode::create(fs(), entry, entries[lfn_entries.size()], lfn_entries));
 }
 
-ErrorOr<void> FATInode::add_child(Inode& inode, StringView name, mode_t mode)
+ErrorOr<void> FATInode::add_child(Inode&, StringView, mode_t)
 {
-    VERIFY(has_flag(m_entry.attributes, FATAttributes::Directory));
-    VERIFY(inode.fsid() == fsid());
-
-    // FIXME: There's a lot of similar code between this function and create_child, we should try to factor out some of the common code.
-
-    dbgln_if(FAT_DEBUG, "FATInode[{}]::add_child(): appending inode {} as \"{}\"", identifier(), inode.identifier(), name);
-
-    auto entry = bit_cast<FATInode*>(&inode)->m_entry;
-
-    bool valid_sfn = SFNUtils::is_valid_sfn(name);
-
-    if (valid_sfn) {
-        TRY(encode_known_good_sfn_for(entry, name));
-    } else {
-        auto sfn = TRY(SFNUtils::create_sfn_from_lfn(name));
-        Vector<ByteBuffer> existing_sfns = TRY(collect_sfns());
-        TRY(create_unique_sfn_for(entry, move(sfn), move(existing_sfns)));
-    }
-
-    // TODO: We should set the hidden attribute if the file starts with a dot or read only (the same way Linux does this).
-    if (mode & S_IFDIR)
-        entry.attributes |= FATAttributes::Directory;
-
-    // FIXME: Set the dates
-
-    Vector<FATLongFileNameEntry> lfn_entries = {};
-    if (!valid_sfn)
-        lfn_entries = TRY(create_lfn_entries(name, lfn_entry_checksum(entry)));
-
-    MutexLocker locker(m_inode_lock);
-
-    auto entries = TRY(allocate_entries(lfn_entries.size() + 1));
-
-    // FIXME: If we fail here we should clean up the entries we wrote
-    TRY(fs().write_block(entries[lfn_entries.size()].block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&entry)), sizeof(FATEntry), entries[lfn_entries.size()].entry * sizeof(FATEntry)));
-
-    for (u32 i = 0; i < lfn_entries.size(); i++) {
-        auto location = entries[lfn_entries.size() - i - 1];
-        TRY(fs().write_block(location.block, UserOrKernelBuffer::for_kernel_buffer(bit_cast<u8*>(&lfn_entries[i])), sizeof(FATLongFileNameEntry), location.entry * sizeof(FATLongFileNameEntry)));
-    }
-
-    return {};
+    return ENOTSUP;
 }
 
 ErrorOr<void> FATInode::remove_child_impl(StringView name, FreeClusters free_clusters)

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -61,6 +61,7 @@ private:
     static ErrorOr<void> create_unique_sfn_for(FATEntry& entry, NonnullRefPtr<SFNUtils::SFN> sfn, Vector<ByteBuffer> existing_sfns);
     static ErrorOr<void> encode_known_good_sfn_for(FATEntry& entry, StringView name);
     static ErrorOr<Vector<FATLongFileNameEntry>> create_lfn_entries(StringView name, u8 checksum);
+    static ErrorOr<void> fill_in_creation_time(FATEntry&, UnixDateTime const&);
 
     ErrorOr<RawPtr<Vector<u32>>> get_cluster_list();
     ErrorOr<Vector<u32>> compute_cluster_list(FATFS&, u32 first_cluster);

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -68,10 +68,6 @@ private:
     ErrorOr<NonnullOwnPtr<KBuffer>> read_block_list();
     ErrorOr<RefPtr<FATInode>> traverse(Function<ErrorOr<bool>(RefPtr<FATInode>)> callback);
     u32 first_cluster() const;
-    // This overload of `first_cluster` does not rely on the base Inode
-    // already being created to determine the FAT version. It is used
-    // during FATInode creation (create()).
-    static u32 first_cluster(FATVersion const version, u16 first_cluster_low, u16 first_cluster_high);
     ErrorOr<void> allocate_and_add_cluster_to_chain();
     ErrorOr<void> remove_last_cluster_from_chain();
     ErrorOr<Vector<FATEntryLocation>> allocate_entries(u32 count);

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -23,6 +23,7 @@ set(AK_TEST_SOURCES
     TestComplex.cpp
     TestConstrainedStream.cpp
     TestCoroutine.cpp
+    TestDOSPackedTime.cpp
     TestDisjointChunks.cpp
     TestDistinctNumeric.cpp
     TestDoublyLinkedList.cpp

--- a/Tests/AK/TestDOSPackedTime.cpp
+++ b/Tests/AK/TestDOSPackedTime.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/DOSPackedTime.h>
+#include <AK/Time.h>
+
+TEST_CASE(test_date_serialization)
+{
+    auto matches = [](i32 year, u8 month, u8 day) -> bool {
+        DOSPackedDate date = {};
+        date.year = year - 1980;
+        date.month = month;
+        date.day = day;
+
+        return MUST(to_packed_dos_date(UnixDateTime::from_unix_time_parts(year, month, day, 0, 0, 0, 0))).value == date.value;
+    };
+
+    EXPECT(matches(1980, 1, 1));
+    EXPECT(matches(2000, 1, 1));
+    EXPECT(matches(2016, 2, 29));
+    EXPECT(matches(2016, 3, 1));
+    EXPECT(matches(2017, 2, 28));
+    EXPECT(matches(2017, 3, 1));
+    EXPECT(matches(2018, 10, 10));
+    EXPECT(matches(2025, 4, 26));
+}
+
+TEST_CASE(test_time_serialization)
+{
+    auto matches = [](u8 hour, u8 minute, u8 second) -> bool {
+        DOSPackedTime time = {};
+        time.hour = hour;
+        time.minute = minute;
+        // This can only handle 2-second intervals, since it's stored in only 5 bits.
+        time.second = second / 2;
+
+        return MUST(to_packed_dos_time(UnixDateTime::from_unix_time_parts(2025, 1, 1, hour, minute, second, 0))).value == time.value;
+    };
+
+    auto test_hour = [&matches](u8 hour) -> bool {
+        for (size_t minute = 0; minute < 60; ++minute) {
+            for (size_t second = 0; second < 60; ++second) {
+                if (!matches(hour, minute, second))
+                    return false;
+            }
+        }
+        return true;
+    };
+
+    EXPECT(test_hour(0));
+    EXPECT(test_hour(23));
+}


### PR DESCRIPTION
The most interesting thing here is probably the improved timestamp support (which is now better than what macOS has, since macOS apparently doesn't bother reading the record that we call `creation_time_seconds` at all), but as usual, I've also thrown in some other miscellaneous changes.