### PR TITLE
init: Define ENABLE_KERNEL_COVERAGE_COLLECTION if KCOV enabled

### DIFF
--- a/Userland/Services/SystemServer/CMakeLists.txt
+++ b/Userland/Services/SystemServer/CMakeLists.txt
@@ -11,8 +11,3 @@ set(SOURCES
 
 serenity_bin(SystemServer)
 target_link_libraries(SystemServer PRIVATE LibCore LibFileSystem LibMain)
-
-# Required for conditionally creating hardcoded /dev/kcov entry
-if (ENABLE_KERNEL_COVERAGE_COLLECTION)
-    add_compile_definitions(ENABLE_KERNEL_COVERAGE_COLLECTION)
-endif()

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -398,6 +398,11 @@ target_link_libraries(zip PRIVATE LibArchive LibFileSystem)
 # FIXME: Link this file into headless-browser without compiling it again.
 target_sources(headless-browser PRIVATE "${SerenityOS_SOURCE_DIR}/Userland/Services/WebContent/WebDriverConnection.cpp")
 
+# Required for conditionally creating hardcoded /dev/kcov entry
+if (ENABLE_KERNEL_COVERAGE_COLLECTION)
+    target_compile_definitions(init PRIVATE ENABLE_KERNEL_COVERAGE_COLLECTION)
+endif()
+
 include("${SerenityOS_SOURCE_DIR}/Meta/Lagom/Fuzzers/fuzzers.cmake")
 
 foreach(name IN LISTS FUZZER_TARGETS)


### PR DESCRIPTION
Moving this definition from SystemServer to init was missed in 1e73a584a7b.