### PR TITLE
uptime: Add the number of users

### DIFF
--- a/Userland/Utilities/uptime.cpp
+++ b/Userland/Utilities/uptime.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/JsonObject.h>
 #include <AK/NumberFormat.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
@@ -25,9 +26,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(output_since, "Show when the system is up since, in yyyy-mm-dd HH:MM:SS format", "since", 's');
     args_parser.parse(arguments);
 
-    auto file = TRY(Core::File::open("/sys/kernel/uptime"sv, Core::File::OpenMode::Read));
+    TRY(Core::System::unveil("/sys/kernel/uptime"sv, "r"sv));
+    TRY(Core::System::unveil("/var/run/utmp"sv, "r"sv));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
-    TRY(Core::System::pledge("stdio"));
+    auto file = TRY(Core::File::open("/sys/kernel/uptime"sv, Core::File::OpenMode::Read));
 
     Array<u8, BUFSIZ> buffer;
     auto read_buffer = TRY(file->read_some(buffer));
@@ -44,9 +47,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         outln("Up {}", human_readable_time(seconds));
     } else {
         auto current_time = TRY(Core::DateTime::now().to_string());
-        // FIXME: To match Linux and the BSDs, we should also include the number of current users,
-        //        and some load averages, but these don't seem to be available yet.
-        outln("{} up {}", current_time, human_readable_digital_time(seconds));
+        // FIXME: To match Linux and the BSDs, we should also include
+        // some load averages, but these don't seem to be available yet.
+
+        auto utmp_file = TRY(Core::File::open("/var/run/utmp"sv, Core::File::OpenMode::Read));
+        auto utmp_contents = TRY(utmp_file->read_until_eof());
+        auto json = TRY(AK::JsonValue::from_string(utmp_contents));
+        auto object = json.as_object();
+        auto user_count = object.size();
+
+        if (user_count == 1) {
+            outln("{} up {}, {} user", current_time, human_readable_digital_time(seconds), user_count);
+        } else {
+            outln("{} up {}, {} users", current_time, human_readable_digital_time(seconds), user_count);
+        }
     }
 
     return 0;


### PR DESCRIPTION
Add the number of users (active terminal sessions) to `uptime`.

The number of users is fetched from `/var/run/utmp`:

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/6546fcfa-1b93-4d8c-a230-c406cf838e96" />
