### PR TITLE
Kernel/aarch64: Add USB support for the Raspberry Pi 5

### DIFF
--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -58,6 +58,13 @@
         return lhs;                                                        \
     }                                                                      \
                                                                            \
+    Prefix inline void operator|=(Enum volatile& lhs, Enum rhs)            \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        lhs = static_cast<Enum>(                                           \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));              \
+    }                                                                      \
+                                                                           \
     Prefix constexpr Enum& operator&=(Enum& lhs, Enum rhs)                 \
     {                                                                      \
         using Type = UnderlyingType<Enum>;                                 \
@@ -66,12 +73,26 @@
         return lhs;                                                        \
     }                                                                      \
                                                                            \
+    Prefix inline void operator&=(Enum volatile& lhs, Enum rhs)            \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        lhs = static_cast<Enum>(                                           \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));              \
+    }                                                                      \
+                                                                           \
     Prefix constexpr Enum& operator^=(Enum& lhs, Enum rhs)                 \
     {                                                                      \
         using Type = UnderlyingType<Enum>;                                 \
         lhs = static_cast<Enum>(                                           \
             static_cast<Type>(lhs) ^ static_cast<Type>(rhs));              \
         return lhs;                                                        \
+    }                                                                      \
+                                                                           \
+    Prefix inline void operator^=(Enum volatile& lhs, Enum rhs)            \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        lhs = static_cast<Enum>(                                           \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));              \
     }                                                                      \
                                                                            \
     Prefix constexpr bool has_flag(Enum value, Enum mask)                  \

--- a/Kernel/Arch/aarch64/PCI/Controller/BCM2712HostController.cpp
+++ b/Kernel/Arch/aarch64/PCI/Controller/BCM2712HostController.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2024-2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Delay.h>
+#include <Kernel/Boot/CommandLine.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/DeviceTreeHelpers.h>
+#include <Kernel/Firmware/DeviceTree/DeviceTree.h>
+#include <Kernel/Firmware/DeviceTree/Driver.h>
+#include <Kernel/Firmware/DeviceTree/Management.h>
+#include <Kernel/Memory/TypedMapping.h>
+
+namespace Kernel::PCI {
+
+// This driver requires the host controller to be already initialized by the firmware.
+
+// This host controller is not ECAM-compliant.
+// The config space is accessible through a single 4K window that can be mapped to any bus/device/function.
+// The b/d/f can be configured by writing an ECAM offset to Registers::config_space_window_address.
+
+struct Registers {
+    u8 unknown1[0x400c];
+
+    // Bus base [31:0] @ [31:0]
+    u32 bus_window_base_low; // 0x400c
+
+    // Bus base [63:32] @ [31:0]
+    u32 bus_window_base_high; // 0x4010
+
+    u8 unknown2[0x4064 - (0x4010 + 4)];
+
+    enum class Control : u32 {
+        PERST_N = 1 << 2,
+    };
+    Control control; // 0x4064
+
+    enum class State : u32 {
+        LinkUp = 0b11 << 4,
+    };
+    State state; // 0x4068
+
+    u8 unknown3[0x4070 - (0x4068 + 4)];
+
+    // The host controller doesn't seem to support 16-bit accesses, so the base and limit are grouped into one field.
+    // CPU limit [31:20] @ [31:20]
+    // CPU base [31:20] @ [15:4]
+    u32 cpu_window_base_low_and_cpu_window_limit_low; // 0x4070
+
+    u8 unknown4[0x4080 - (0x4070 + 4)];
+
+    // CPU base [39:32] @ [7:0]
+    u32 cpu_window_base_high; // 0x4080
+
+    // CPU limit [39:32] @ [7:0]
+    u32 cpu_window_limit_high; // 0x4084
+
+    u8 unknown5[0x8000 - (0x4084 + 4)];
+
+    u8 config_space_window[0x1000];  // 0x8000
+    u32 config_space_window_address; // 0x9000
+
+    u8 unknown6[0x9310 - (0x9000 + 4)]; // 0x9000
+};
+static_assert(AssertSize<Registers, 0x9310>());
+
+AK_ENUM_BITWISE_OPERATORS(Registers::Control)
+AK_ENUM_BITWISE_OPERATORS(Registers::State)
+
+class BCM2712HostController : public HostController {
+public:
+    static ErrorOr<NonnullOwnPtr<BCM2712HostController>> create(DeviceTree::Device const& device);
+
+private:
+    ErrorOr<VirtualAddress> map_config_space_for(BusNumber, DeviceNumber, FunctionNumber);
+
+    virtual void write8_field_locked(BusNumber, DeviceNumber, FunctionNumber, u32 field, u8 value) override;
+    virtual void write16_field_locked(BusNumber, DeviceNumber, FunctionNumber, u32 field, u16 value) override;
+    virtual void write32_field_locked(BusNumber, DeviceNumber, FunctionNumber, u32 field, u32 value) override;
+
+    virtual u8 read8_field_locked(BusNumber, DeviceNumber, FunctionNumber, u32 field) override;
+    virtual u16 read16_field_locked(BusNumber, DeviceNumber, FunctionNumber, u32 field) override;
+    virtual u32 read32_field_locked(BusNumber, DeviceNumber, FunctionNumber, u32 field) override;
+
+    explicit BCM2712HostController(PCI::Domain const&, Memory::TypedMapping<Registers volatile>);
+
+    Memory::TypedMapping<Registers volatile> m_registers;
+};
+
+ErrorOr<NonnullOwnPtr<BCM2712HostController>> BCM2712HostController::create(DeviceTree::Device const& device)
+{
+    auto domain = TRY(determine_pci_domain_for_devicetree_node(device.node(), device.node_name()));
+    auto registers_resource = TRY(device.get_resource(0));
+
+    if (registers_resource.size < sizeof(Registers))
+        return ERANGE;
+
+    auto const* parent_node = device.node().parent();
+    if (parent_node == nullptr)
+        return EINVAL;
+
+    auto registers = TRY(Memory::map_typed_writable<Registers volatile>(registers_resource.paddr));
+
+    for (auto range : TRY(device.node().ranges())) {
+        auto pci_address = TRY(range.child_bus_address().as<OpenFirmwareAddress>());
+        auto cpu_base = TRY(TRY(parent_node->translate_child_bus_address_to_root_address(range.parent_bus_address())).as_flatptr());
+        auto range_size = TRY(range.length().as_size_t());
+
+        // FIXME: Configure the 64-bit window.
+        if (pci_address.space_type != OpenFirmwareAddress::SpaceType::Memory32BitSpace)
+            continue;
+
+        auto bus_base = pci_address.io_or_memory_space_address;
+        auto cpu_limit = cpu_base + range_size;
+
+        // Configure the CPU -> PCIe window. This determines how CPU addresses are mapped to PCIe addresses.
+
+        registers->bus_window_base_low = bus_base & 0xffff'ffff;
+        registers->bus_window_base_high = bus_base >> 32;
+
+        registers->cpu_window_base_low_and_cpu_window_limit_low = (cpu_limit & 0xfff0'0000) | ((cpu_base & 0xfff0'0000) >> 16);
+        registers->cpu_window_base_high = cpu_base >> 32;
+        registers->cpu_window_limit_high = cpu_limit >> 32;
+
+        // FIXME: Are we guaranteed to only have one 32-bit window?
+        break;
+    }
+
+    // Deassert PERST# to initialize the link.
+    registers->control |= Registers::Control::PERST_N;
+
+    microseconds_delay(100'000);
+
+    // Check the link state.
+    if ((registers->state & Registers::State::LinkUp) != Registers::State::LinkUp) {
+        dbgln("{}: Link down", device.node_name());
+
+        // We failed to initialize the link; assert PERST# again.
+        registers->control &= ~Registers::Control::PERST_N;
+        return EIO;
+    }
+
+    dbgln("{}: Link up", device.node_name());
+
+    return TRY(adopt_nonnull_own_or_enomem(new (nothrow) BCM2712HostController(domain, move(registers))));
+}
+
+BCM2712HostController::BCM2712HostController(PCI::Domain const& domain, Memory::TypedMapping<Registers volatile> registers)
+    : HostController(domain)
+    , m_registers(move(registers))
+{
+}
+
+ErrorOr<VirtualAddress> BCM2712HostController::map_config_space_for(BusNumber bus, DeviceNumber device, FunctionNumber function)
+{
+    if (bus == 0) {
+        if (device != 0 || function != 0)
+            return EINVAL;
+
+        return m_registers.base_address();
+    }
+
+    u32 const address = (bus.value() << 20) | (device.value() << 15) | (function.value() << 12);
+    m_registers->config_space_window_address = address;
+
+    return VirtualAddress { bit_cast<FlatPtr>(&m_registers->config_space_window) };
+}
+
+void BCM2712HostController::write8_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u8 value)
+{
+    VERIFY(m_access_lock.is_locked());
+
+    auto vaddr_or_error = map_config_space_for(bus, device, function);
+    if (vaddr_or_error.is_error())
+        return;
+
+    *reinterpret_cast<u8 volatile*>(vaddr_or_error.release_value().offset(field).as_ptr()) = value;
+}
+
+void BCM2712HostController::write16_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u16 value)
+{
+    VERIFY(m_access_lock.is_locked());
+    VERIFY(field % sizeof(u16) == 0);
+
+    auto vaddr_or_error = map_config_space_for(bus, device, function);
+    if (vaddr_or_error.is_error())
+        return;
+
+    *reinterpret_cast<u16 volatile*>(vaddr_or_error.release_value().offset(field).as_ptr()) = value;
+}
+
+void BCM2712HostController::write32_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u32 value)
+{
+    VERIFY(m_access_lock.is_locked());
+    VERIFY(field % sizeof(u32) == 0);
+
+    auto vaddr_or_error = map_config_space_for(bus, device, function);
+    if (vaddr_or_error.is_error())
+        return;
+
+    *reinterpret_cast<u32 volatile*>(vaddr_or_error.release_value().offset(field).as_ptr()) = value;
+}
+
+u8 BCM2712HostController::read8_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
+{
+    VERIFY(m_access_lock.is_locked());
+
+    auto vaddr_or_error = map_config_space_for(bus, device, function);
+    if (vaddr_or_error.is_error())
+        return 0xff;
+
+    return *reinterpret_cast<u8 volatile*>(vaddr_or_error.release_value().offset(field).as_ptr());
+}
+
+u16 BCM2712HostController::read16_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
+{
+    VERIFY(m_access_lock.is_locked());
+    VERIFY(field % sizeof(u16) == 0);
+
+    auto vaddr_or_error = map_config_space_for(bus, device, function);
+    if (vaddr_or_error.is_error())
+        return 0xffff;
+
+    return *reinterpret_cast<u16 volatile*>(vaddr_or_error.release_value().offset(field).as_ptr());
+}
+
+u32 BCM2712HostController::read32_field_locked(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
+{
+    VERIFY(m_access_lock.is_locked());
+    VERIFY(field % sizeof(u32) == 0);
+
+    auto vaddr_or_error = map_config_space_for(bus, device, function);
+    if (vaddr_or_error.is_error())
+        return 0xffff'ffff;
+
+    return *reinterpret_cast<u32 volatile*>(vaddr_or_error.release_value().offset(field).as_ptr());
+}
+
+static constinit Array const compatibles_array = {
+    "brcm,bcm2712-pcie"sv,
+};
+
+DEVICETREE_DRIVER(BCM2712PCIeHostControllerDriver, compatibles_array);
+
+// https://www.kernel.org/doc/Documentation/devicetree/bindings/pci/brcm%2Cstb-pcie.yaml
+ErrorOr<void> BCM2712PCIeHostControllerDriver::probe(DeviceTree::Device const& device, StringView) const
+{
+    if (kernel_command_line().is_pci_disabled())
+        return {};
+
+    auto host_controller = TRY(BCM2712HostController::create(device));
+
+    TRY(configure_devicetree_host_controller(*host_controller, device.node(), device.node_name()));
+    Access::the().add_host_controller(move(host_controller));
+
+    return {};
+}
+
+}

--- a/Kernel/Arch/aarch64/RPi/RP1.cpp
+++ b/Kernel/Arch/aarch64/RPi/RP1.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/aarch64/RPi/RP1.h>
+#include <Kernel/Bus/PCI/BarMapping.h>
+#include <Kernel/Bus/USB/USBManagement.h>
+#include <Kernel/Bus/USB/xHCI/xHCIController.h>
+#include <Kernel/Interrupts/IRQHandler.h>
+
+namespace Kernel::RPi {
+
+class RP1xHCIController final : public USB::xHCIController {
+public:
+    static ErrorOr<NonnullLockRefPtr<RP1xHCIController>> try_to_initialize(PhysicalAddress, size_t index, size_t interrupt_number);
+
+private:
+    RP1xHCIController(Memory::TypedMapping<u8> registers_mapping, size_t index, size_t interrupt_number);
+
+    // ^xHCIController
+    virtual bool using_message_signalled_interrupts() const override { return m_using_message_signalled_interrupts; }
+    virtual ErrorOr<OwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
+    virtual ErrorOr<void> write_dmesgln_prefix(StringBuilder& builder) const override
+    {
+        TRY(builder.try_appendff("xHCI: RP1 USBHOST{}: "sv, m_index));
+        return {};
+    }
+
+    size_t m_index { 0 };
+    size_t m_interrupt_number { 0 };
+    bool m_using_message_signalled_interrupts { false };
+};
+
+ErrorOr<NonnullLockRefPtr<RP1xHCIController>> RP1xHCIController::try_to_initialize(PhysicalAddress paddr, size_t index, size_t interrupt_number)
+{
+    auto registers_mapping = TRY(Memory::map_typed_writable<u8>(paddr));
+
+    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) RP1xHCIController(move(registers_mapping), index, interrupt_number)));
+    TRY(controller->initialize());
+    return controller;
+}
+
+UNMAP_AFTER_INIT RP1xHCIController::RP1xHCIController(Memory::TypedMapping<u8> registers_mapping, size_t index, size_t interrupt_number)
+    : xHCIController(move(registers_mapping))
+    , m_index(index)
+    , m_interrupt_number(interrupt_number)
+{
+}
+
+ErrorOr<OwnPtr<GenericInterruptHandler>> RP1xHCIController::create_interrupter(u16)
+{
+    // FIXME: Add interrupt support. This requires adding support for the BCM2712 MSI-X interrupt controller.
+    return nullptr;
+}
+
+ErrorOr<void> RP1::try_to_initialize_xhci_controllers(PCI::DeviceIdentifier const& pci_identifier)
+{
+    PCI::enable_memory_space(pci_identifier);
+    PCI::enable_bus_mastering(pci_identifier);
+
+    auto bar1_address = TRY(get_bar_address(pci_identifier, PCI::HeaderType0BaseRegister::BAR1));
+
+    // Chapter 5. USB, https://datasheets.raspberrypi.com/rp1/rp1-peripherals.pdf
+    // The interrupt numbers are taken from the devicetree.
+    auto usbhost0 = TRY(RP1xHCIController::try_to_initialize(bar1_address.offset(0x20'0000), 0, 31));
+    auto usbhost1 = TRY(RP1xHCIController::try_to_initialize(bar1_address.offset(0x30'0000), 1, 36));
+
+    USB::USBManagement::the().add_controller(usbhost0);
+    USB::USBManagement::the().add_controller(usbhost1);
+
+    return {};
+}
+
+}

--- a/Kernel/Arch/aarch64/RPi/RP1.h
+++ b/Kernel/Arch/aarch64/RPi/RP1.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <Kernel/Bus/PCI/Definitions.h>
+
+namespace Kernel::RPi {
+
+class RP1 {
+public:
+    static ErrorOr<void> try_to_initialize_xhci_controllers(PCI::DeviceIdentifier const&);
+};
+
+}

--- a/Kernel/Bus/PCI/API.cpp
+++ b/Kernel/Bus/PCI/API.cpp
@@ -311,4 +311,9 @@ DeviceIdentifier const& get_device_identifier(Address address)
     return Access::the().get_device_identifier(address);
 }
 
+ErrorOr<PhysicalAddress> translate_bus_address_to_host_address(DeviceIdentifier const& identifier, BARSpaceType address_space_type, u64 bus_address)
+{
+    return Access::the().translate_bus_address_to_host_address(identifier, address_space_type, bus_address);
+}
+
 }

--- a/Kernel/Bus/PCI/API.h
+++ b/Kernel/Bus/PCI/API.h
@@ -47,4 +47,7 @@ void disable_memory_space(DeviceIdentifier const&);
 // FIXME: Remove this once we can use PCI::Capability with inline buffer
 // so we don't need this method
 DeviceIdentifier const& get_device_identifier(Address address);
+
+ErrorOr<PhysicalAddress> translate_bus_address_to_host_address(DeviceIdentifier const&, BARSpaceType, u64);
+
 }

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -264,4 +264,11 @@ u32 Access::read32_field(DeviceIdentifier const& identifier, u32 field)
     return controller.read32_field(identifier.address().bus(), identifier.address().device(), identifier.address().function(), field);
 }
 
+ErrorOr<PhysicalAddress> Access::translate_bus_address_to_host_address(DeviceIdentifier const& identifier, BARSpaceType address_space_type, u64 bus_address)
+{
+    VERIFY(m_host_controllers.contains(identifier.address().domain()));
+    auto& controller = *m_host_controllers.get(identifier.address().domain()).value();
+    return controller.translate_bus_address_to_host_address(address_space_type, bus_address);
+}
+
 }

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -13,6 +13,7 @@
 #include <AK/Vector.h>
 #include <Kernel/Bus/PCI/Controller/HostController.h>
 #include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Bus/PCI/Initializer.h>
 #include <Kernel/Locking/Spinlock.h>
 
@@ -45,6 +46,8 @@ public:
     u8 read8_field(DeviceIdentifier const&, u32 field);
     u16 read16_field(DeviceIdentifier const&, u32 field);
     u32 read32_field(DeviceIdentifier const&, u32 field);
+
+    ErrorOr<PhysicalAddress> translate_bus_address_to_host_address(DeviceIdentifier const&, BARSpaceType, u64);
 
     // FIXME: Remove this once we can use PCI::Capability with inline buffer
     // so we don't need this method

--- a/Kernel/Bus/PCI/Controller/HostController.h
+++ b/Kernel/Bus/PCI/Controller/HostController.h
@@ -86,6 +86,16 @@ public:
     void enumerate_attached_devices(Function<void(EnumerableDeviceIdentifier const&)> callback, Function<void(EnumerableDeviceIdentifier const&)> post_bridge_callback = nullptr);
     void configure_attached_devices(PCIConfiguration&);
 
+    ErrorOr<PhysicalAddress> translate_bus_address_to_host_address(BARSpaceType, u64) const;
+
+    struct Window {
+        PhysicalAddress host_address;
+        u64 bus_address;
+        size_t size;
+    };
+
+    ErrorOr<void> add_memory_space_window(Window const&);
+
 private:
     void enumerate_bus(Function<void(EnumerableDeviceIdentifier const&)> const& callback, Function<void(EnumerableDeviceIdentifier const&)>& post_bridge_callback, BusNumber, bool recursive_search_into_bridges);
     void enumerate_functions(Function<void(EnumerableDeviceIdentifier const&)> const& callback, Function<void(EnumerableDeviceIdentifier const&)>& post_bridge_callback, BusNumber, DeviceNumber, FunctionNumber, bool recursive_search_into_bridges);
@@ -118,6 +128,8 @@ protected:
 
 private:
     Bitmap m_enumerated_buses;
+
+    Vector<Window> m_memory_space_windows;
 };
 
 }

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -91,12 +91,9 @@ ErrorOr<void> configure_devicetree_host_controller(HostController& host_controll
 
     auto maybe_ranges = node.ranges();
     if (!maybe_ranges.is_error()) {
-        auto ranges = maybe_ranges.release_value();
-
         dbgln("PCI: Address mapping for {}:", node_name);
-        for (size_t i = 0; i < ranges.entry_count(); i++) {
-            auto range = MUST(ranges.entry(i));
 
+        for (auto range : maybe_ranges.release_value()) {
             auto pci_address = TRY(range.child_bus_address().as<OpenFirmwareAddress>());
             auto cpu_physical_address = TRY(TRY(parent->translate_child_bus_address_to_root_address(range.parent_bus_address())).as_flatptr());
             auto range_size = TRY(range.length().as_size_t());

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -118,10 +118,11 @@ ErrorOr<void> configure_devicetree_host_controller(HostController& host_controll
                 && pci_address.space_type != OpenFirmwareAddress::SpaceType::Memory64BitSpace)
                 continue; // We currently only support memory-mapped PCI on RISC-V and AArch64
 
-            if (pci_address.io_or_memory_space_address != cpu_physical_address) {
-                dbgln("PCI: FIXME: Support non-identity-mapped PCI ranges");
-                return ENOTSUP;
-            }
+            TRY(host_controller.add_memory_space_window(HostController::Window {
+                .host_address = PhysicalAddress { cpu_physical_address },
+                .bus_address = pci_address.io_or_memory_space_address,
+                .size = range_size,
+            }));
 
             if (pci_address.space_type == OpenFirmwareAddress::SpaceType::Memory32BitSpace) {
                 if (pci_address.prefetchable)

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -97,15 +97,9 @@ ErrorOr<void> configure_devicetree_host_controller(HostController& host_controll
         for (size_t i = 0; i < ranges.entry_count(); i++) {
             auto range = MUST(ranges.entry(i));
 
-            auto raw_pci_address = range.child_bus_address();
+            auto pci_address = TRY(range.child_bus_address().as<OpenFirmwareAddress>());
             auto cpu_physical_address = TRY(TRY(parent->translate_child_bus_address_to_root_address(range.parent_bus_address())).as_flatptr());
             auto range_size = TRY(range.length().as_size_t());
-
-            if (raw_pci_address.raw().size() != sizeof(OpenFirmwareAddress))
-                return EINVAL;
-
-            OpenFirmwareAddress pci_address {};
-            memcpy(&pci_address, raw_pci_address.raw().data(), sizeof(OpenFirmwareAddress));
 
             static constexpr auto space_type_names = Array {
                 "Configuration Space"sv,

--- a/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
+++ b/Kernel/Bus/PCI/DeviceTreeHelpers.cpp
@@ -129,13 +129,13 @@ ErrorOr<void> configure_devicetree_host_controller(HostController& host_controll
                 if (pci_32bit_mmio_size >= range_size)
                     continue; // We currently only use the single largest region - TODO: Use all available regions if needed
 
-                pci_32bit_mmio_base = cpu_physical_address;
+                pci_32bit_mmio_base = pci_address.io_or_memory_space_address;
                 pci_32bit_mmio_size = range_size;
             } else {
                 if (pci_64bit_mmio_size >= range_size)
                     continue; // We currently only use the single largest region - TODO: Use all available regions if needed
 
-                pci_64bit_mmio_base = cpu_physical_address;
+                pci_64bit_mmio_base = pci_address.io_or_memory_space_address;
                 pci_64bit_mmio_size = range_size;
             }
         }

--- a/Kernel/Bus/PCI/IDs.h
+++ b/Kernel/Bus/PCI/IDs.h
@@ -18,6 +18,7 @@ enum VendorID {
     VirtualBox = 0x80ee,
     VMWare = 0x15ad,
     Tdfx = 0x121a,
+    RaspberryPi = 0x1de4,
 };
 
 enum DeviceID {
@@ -27,6 +28,8 @@ enum DeviceID {
     VirtIOEntropy = 0x1005,
     VirtIOGPU = 0x1050,
     VirtIOInput = 0x1052,
+
+    RaspberryPiRP1 = 0x0001,
 };
 
 }

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -27,10 +27,7 @@ static NeverDestroyed<Vector<DeviceTree::DeviceRecipe<NonnullLockRefPtr<USBContr
 
 READONLY_AFTER_INIT bool s_initialized_sys_fs_directory = false;
 
-UNMAP_AFTER_INIT USBManagement::USBManagement()
-{
-    enumerate_controllers();
-}
+UNMAP_AFTER_INIT USBManagement::USBManagement() = default;
 
 UNMAP_AFTER_INIT void USBManagement::enumerate_controllers()
 {
@@ -106,6 +103,7 @@ UNMAP_AFTER_INIT void USBManagement::initialize()
     }
 
     s_the.ensure_instance();
+    s_the->enumerate_controllers();
 }
 
 void USBManagement::register_driver(NonnullLockRefPtr<Driver> driver)

--- a/Kernel/Bus/USB/USBManagement.h
+++ b/Kernel/Bus/USB/USBManagement.h
@@ -25,6 +25,8 @@ public:
     static LockRefPtr<Driver> get_driver_by_name(StringView name);
     static void unregister_driver(NonnullLockRefPtr<Driver> driver);
 
+    void add_controller(NonnullLockRefPtr<USBController>);
+
     static void add_recipe(DeviceTree::DeviceRecipe<NonnullLockRefPtr<USBController>>);
 
     static Vector<NonnullLockRefPtr<Driver>>& available_drivers();

--- a/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.cpp
@@ -29,7 +29,7 @@ UNMAP_AFTER_INIT DeviceTreexHCIController::DeviceTreexHCIController(Memory::Type
 {
 }
 
-ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> DeviceTreexHCIController::create_interrupter(u16 interrupter_id)
+ErrorOr<OwnPtr<GenericInterruptHandler>> DeviceTreexHCIController::create_interrupter(u16 interrupter_id)
 {
     return TRY(xHCIDeviceTreeInterrupter::create(*this, m_interrupt_number, interrupter_id));
 }

--- a/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.h
+++ b/Kernel/Bus/USB/xHCI/DeviceTreexHCIController.h
@@ -20,7 +20,7 @@ private:
 
     // ^xHCIController
     virtual bool using_message_signalled_interrupts() const override { return m_using_message_signalled_interrupts; }
-    virtual ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
+    virtual ErrorOr<OwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
     virtual ErrorOr<void> write_dmesgln_prefix(StringBuilder& builder) const override
     {
         TRY(builder.try_appendff("xHCI: {}: "sv, m_node_name));

--- a/Kernel/Bus/USB/xHCI/PCIxHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/PCIxHCIController.cpp
@@ -59,7 +59,7 @@ void PCIxHCIController::intel_quirk_enable_xhci_ports()
     PCI::write32_locked(device_identifier(), intel_xhci_usb2_port_routing_offset, PCI::read32_locked(device_identifier(), intel_xhci_usb2_port_routing_mask_offset));
 }
 
-ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> PCIxHCIController::create_interrupter(u16 interrupter_id)
+ErrorOr<OwnPtr<GenericInterruptHandler>> PCIxHCIController::create_interrupter(u16 interrupter_id)
 {
     return TRY(xHCIPCIInterrupter::create(*this, interrupter_id));
 }

--- a/Kernel/Bus/USB/xHCI/PCIxHCIController.h
+++ b/Kernel/Bus/USB/xHCI/PCIxHCIController.h
@@ -28,7 +28,7 @@ private:
 
     // ^xHCIController
     virtual bool using_message_signalled_interrupts() const override { return m_using_message_signalled_interrupts; }
-    virtual ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
+    virtual ErrorOr<OwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) override;
     virtual ErrorOr<void> write_dmesgln_prefix(StringBuilder& builder) const override
     {
         TRY(builder.try_appendff("{}: {}: "sv, device_name(), device_identifier().address()));

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -52,7 +52,7 @@ protected:
     xHCIController(Memory::TypedMapping<u8> registers_mapping);
 
     virtual bool using_message_signalled_interrupts() const = 0;
-    virtual ErrorOr<NonnullOwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) = 0;
+    virtual ErrorOr<OwnPtr<GenericInterruptHandler>> create_interrupter(u16 interrupter_id) = 0;
     virtual ErrorOr<void> write_dmesgln_prefix(StringBuilder&) const = 0;
 
 private:
@@ -63,6 +63,7 @@ private:
 
     void event_handling_thread();
     void hot_plug_thread();
+    void poll_thread();
 
     // Arbitrarily chosen to decrease allocation sizes, can be increased up to 256 if we reach this limit
     static constexpr size_t max_devices = 64;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -525,6 +525,8 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
 
         Arch/aarch64/Serial/PL011.cpp
 
+        Arch/aarch64/PCI/Controller/BCM2712HostController.cpp
+
         Bus/PCI/Controller/GenericECAMHostController.cpp
         Bus/PCI/DeviceTreeHelpers.cpp
         Bus/PCI/DeviceTreeInitializer.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -482,6 +482,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/RPi/InterruptController.cpp
         Arch/aarch64/RPi/Mailbox.cpp
         Arch/aarch64/RPi/MiniUART.cpp
+        Arch/aarch64/RPi/RP1.cpp
         Arch/aarch64/RPi/SDHostController.cpp
         Arch/aarch64/RPi/Timer.cpp
         Arch/aarch64/RPi/Watchdog.cpp

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -34,6 +34,18 @@ public:
 
     ReadonlyBytes raw() const { return m_raw; }
 
+    template<typename T>
+    ErrorOr<T> as() const
+    {
+        if (m_raw.size() != sizeof(T))
+            return ERANGE;
+
+        T value;
+        __builtin_memcpy(&value, m_raw.data(), sizeof(T));
+
+        return value;
+    }
+
     static Address from_flatptr(FlatPtr flatptr)
     {
         BigEndian<FlatPtr> big_endian_flatptr { flatptr };

--- a/Userland/Libraries/LibDeviceTree/DeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/DeviceTree.h
@@ -263,6 +263,31 @@ public:
 
     ErrorOr<Address> translate_child_bus_address_to_parent_bus_address(Address const&) const;
 
+    struct Iterator {
+        Iterator(Ranges const& ranges, size_t index)
+            : m_ranges(ranges)
+            , m_index(index)
+        {
+        }
+
+        RangesEntry operator*() const { return MUST(m_ranges.entry(m_index)); }
+
+        Iterator& operator++()
+        {
+            ++m_index;
+            return *this;
+        }
+
+        bool operator==(Iterator const& other) const { return m_index == other.m_index; }
+
+    private:
+        Ranges const& m_ranges;
+        size_t m_index;
+    };
+
+    Iterator begin() const { return Iterator(*this, 0); }
+    Iterator end() const { return Iterator(*this, entry_count()); }
+
 private:
     ReadonlyBytes m_raw;
     Node const& m_node;


### PR DESCRIPTION
This PR adds support for the Pi 5 PCIe host controller and the xHCI USB host controllers inside the RP1 I/O controller.