### PR TITLE
Ports: Add pango

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -257,6 +257,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 | [`opusfile`](opusfile/)                       | opusfile                                                      | 0.12                     | https://opus-codec.org/                                              |
 | [`p7zip`](p7zip/)                             | p7zip                                                         | 17.04                    | https://github.com/jinfeihan57/p7zip                                 |
 | [`pacman`](pacman/)                           | Pacman                                                        | b6241a3                  | https://github.com/ebuc99/pacman                                     |
+| [`pango`](pango/)                             | Pango                                                         | 1.54.0                   | https://gitlab.gnome.org/GNOME/pango                                 |
 | [`patch`](patch/)                             | patch (GNU)                                                   | 2.7.6                    | https://savannah.gnu.org/projects/patch/                             |
 | [`patchelf`](patchelf/)                       | Utility for modifying existing ELF executables and libraries  | 0.18.0                   | https://github.com/NixOS/patchelf/                                   |
 | [`pcre`](pcre/)                               | Perl-compatible Regular Expressions (PCRE)                    | 8.45                     | https://www.pcre.org/                                                |

--- a/Ports/pango/package.sh
+++ b/Ports/pango/package.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='pango'
+# pango 1.55 requires fontconfig 2.15 but SerenityOS uses fontconfig 2.14
+version='1.54.0'
+archive_hash='8a9eed75021ee734d7fc0fdf3a65c3bba51dfefe4ae51a9b414a60c70b2d1ed8'
+files=(
+    "https://download.gnome.org/sources/pango/${version%.*}/pango-${version}.tar.xz#${archive_hash}"
+)
+useconfigure='true'
+configopts=(
+    "--cross-file=${SERENITY_BUILD_DIR}/meson-cross-file.txt"
+    "--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+    '-Dbuildtype=release'
+    '-Dbuild-testsuite=false'
+    '-Dbuild-examples=false'
+    # Use patched ports instead of subprojects.
+    '--wrap-mode=nofallback'
+    '-Dcairo=enabled'
+    '-Dfontconfig=enabled'
+    '-Dfreetype=enabled'
+)
+depends=(
+    'cairo'
+    'expat'
+    'fontconfig'
+    'freetype'
+    'fribidi'
+    'glib'
+    'harfbuzz'
+)
+
+configure() {
+    run meson setup build "${configopts[@]}"
+}
+
+build() {
+    run ninja -C build
+}
+
+install() {
+    run ninja -C build install
+}


### PR DESCRIPTION
You can now build pango without patches.
I confirmed that examples worked fine with `-Dbuild-examples=true` and [msttcorefonts](https://github.com/SerenityOS/serenity/pull/25905).

![pango](https://github.com/user-attachments/assets/814176bc-f366-43ae-ad47-a8c46bd9c610)
