### PR TITLE
LibPDF: Prep work for {Free,Lattice}FormGouraudShading::draw()

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -734,13 +734,8 @@ IndexedColorSpace::IndexedColorSpace(NonnullRefPtr<ColorSpace> base)
 PDFErrorOr<ColorOrStyle> IndexedColorSpace::style(ReadonlySpan<float> arguments) const
 {
     VERIFY(arguments.size() == 1);
-
     auto index = static_cast<int>(arguments[0]);
-    if (index < 0 || index > m_hival)
-        return Error { Error::Type::MalformedPDF, "Indexed color space index out of range" };
-
-    size_t const n = m_base->number_of_components();
-    return m_base->style(m_lookup.span().slice(index * n, n));
+    return m_base->style(TRY(base_components(index)));
 }
 
 Vector<float> IndexedColorSpace::default_decode() const

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -237,6 +237,16 @@ public:
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Indexed; }
 
+    NonnullRefPtr<ColorSpace> base_color_space() const { return m_base; }
+
+    PDFErrorOr<ReadonlySpan<float>> base_components(int index) const
+    {
+        if (index < 0 || index > m_hival)
+            return Error { Error::Type::MalformedPDF, "Indexed color space index out of range" };
+        size_t const n = m_base->number_of_components();
+        return m_lookup.span().slice(index * n, n);
+    }
+
 private:
     IndexedColorSpace(NonnullRefPtr<ColorSpace>);
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -733,10 +733,6 @@ RENDERER_HANDLER(set_painting_color_and_space_to_cmyk)
 
 RENDERER_HANDLER(shade)
 {
-    auto inverse_ctm = state().ctm.inverse();
-    if (!inverse_ctm.has_value())
-        return {};
-
     VERIFY(args.size() == 1);
     auto shading_name = MUST(m_document->resolve_to<NameObject>(args[0]))->name();
     auto resources = extra_resources.value_or(m_page.resources);
@@ -750,7 +746,7 @@ RENDERER_HANDLER(shade)
     auto shading = TRY(Shading::create(m_document, shading_dict_or_stream, *this));
 
     ClipRAII clip_raii { *this };
-    return shading->draw(m_painter, inverse_ctm.value());
+    return shading->draw(m_painter, state().ctm);
 }
 
 RENDERER_HANDLER(inline_image_begin)

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -640,6 +640,12 @@ PDFErrorOr<void> RadialShading::draw(Gfx::Painter& painter, Gfx::AffineTransform
     return {};
 }
 
+struct Triangle {
+    u32 a;
+    u32 b;
+    u32 c;
+};
+
 class FreeFormGouraudShading final : public Shading {
 public:
     static PDFErrorOr<NonnullRefPtr<FreeFormGouraudShading>> create(Document*, NonnullRefPtr<StreamObject>, CommonEntries);
@@ -648,13 +654,6 @@ public:
 
 private:
     using FunctionsType = Variant<Empty, NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
-
-    // Indexes into m_vertex_data.
-    struct Triangle {
-        u32 a;
-        u32 b;
-        u32 c;
-    };
 
     FreeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, size_t number_of_components, Vector<Triangle> triangles, FunctionsType functions)
         : m_common_entries(move(common_entries))
@@ -813,13 +812,6 @@ public:
 
 private:
     using FunctionsType = Variant<Empty, NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
-
-    // Indexes into m_vertex_data.
-    struct Triangle {
-        u32 a;
-        u32 b;
-        u32 c;
-    };
 
     LatticeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, size_t number_of_components, Vector<Triangle> triangles, FunctionsType functions)
         : m_common_entries(move(common_entries))

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -174,8 +174,13 @@ PDFErrorOr<NonnullRefPtr<FunctionBasedShading>> FunctionBasedShading::create(Doc
     return adopt_ref(*new FunctionBasedShading(move(common_entries), domain, matrix, move(functions)));
 }
 
-PDFErrorOr<void> FunctionBasedShading::draw(Gfx::Painter& painter, Gfx::AffineTransform const& inverse_ctm)
+PDFErrorOr<void> FunctionBasedShading::draw(Gfx::Painter& painter, Gfx::AffineTransform const& ctm)
 {
+    auto maybe_inverse_ctm = ctm.inverse();
+    if (!maybe_inverse_ctm.has_value())
+        return {};
+    auto inverse_ctm = maybe_inverse_ctm.value();
+
     auto& bitmap = painter.target();
 
     auto scale = painter.scale();
@@ -321,8 +326,13 @@ PDFErrorOr<NonnullRefPtr<AxialShading>> AxialShading::create(Document* document,
     return adopt_ref(*new AxialShading(move(common_entries), start, end, t0, t1, move(functions), extend_start, extend_end));
 }
 
-PDFErrorOr<void> AxialShading::draw(Gfx::Painter& painter, Gfx::AffineTransform const& inverse_ctm)
+PDFErrorOr<void> AxialShading::draw(Gfx::Painter& painter, Gfx::AffineTransform const& ctm)
 {
+    auto maybe_inverse_ctm = ctm.inverse();
+    if (!maybe_inverse_ctm.has_value())
+        return {};
+    auto inverse_ctm = maybe_inverse_ctm.value();
+
     auto& bitmap = painter.target();
 
     auto scale = painter.scale();
@@ -487,8 +497,13 @@ PDFErrorOr<NonnullRefPtr<RadialShading>> RadialShading::create(Document* documen
     return adopt_ref(*new RadialShading(move(common_entries), start, start_radius, end, end_radius, t0, t1, move(functions), extend_start, extend_end));
 }
 
-PDFErrorOr<void> RadialShading::draw(Gfx::Painter& painter, Gfx::AffineTransform const& inverse_ctm)
+PDFErrorOr<void> RadialShading::draw(Gfx::Painter& painter, Gfx::AffineTransform const& ctm)
 {
+    auto maybe_inverse_ctm = ctm.inverse();
+    if (!maybe_inverse_ctm.has_value())
+        return {};
+    auto inverse_ctm = maybe_inverse_ctm.value();
+
     auto& bitmap = painter.target();
 
     auto scale = painter.scale();

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -656,9 +656,10 @@ private:
         u32 c;
     };
 
-    FreeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, Vector<Triangle> triangles, FunctionsType functions)
+    FreeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, size_t number_of_components, Vector<Triangle> triangles, FunctionsType functions)
         : m_common_entries(move(common_entries))
         , m_vertex_data(move(vertex_data))
+        , m_number_of_components(number_of_components)
         , m_triangles(move(triangles))
         , m_functions(move(functions))
     {
@@ -668,6 +669,7 @@ private:
 
     // Interleaved x, y, c0, c1, c2, ...
     Vector<float> m_vertex_data;
+    size_t m_number_of_components { 0 };
     Vector<Triangle> m_triangles;
     FunctionsType m_functions;
 };
@@ -795,7 +797,7 @@ PDFErrorOr<NonnullRefPtr<FreeFormGouraudShading>> FreeFormGouraudShading::create
         }
     }
 
-    return adopt_ref(*new FreeFormGouraudShading(move(common_entries), move(vertex_data), move(triangles), move(functions)));
+    return adopt_ref(*new FreeFormGouraudShading(move(common_entries), move(vertex_data), number_of_components, move(triangles), move(functions)));
 }
 
 PDFErrorOr<void> FreeFormGouraudShading::draw(Gfx::Painter&, Gfx::AffineTransform const&)
@@ -819,9 +821,10 @@ private:
         u32 c;
     };
 
-    LatticeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, Vector<Triangle> triangles, FunctionsType functions)
+    LatticeFormGouraudShading(CommonEntries common_entries, Vector<float> vertex_data, size_t number_of_components, Vector<Triangle> triangles, FunctionsType functions)
         : m_common_entries(move(common_entries))
         , m_vertex_data(move(vertex_data))
+        , m_number_of_components(number_of_components)
         , m_triangles(move(triangles))
         , m_functions(move(functions))
     {
@@ -831,6 +834,7 @@ private:
 
     // Interleaved x, y, c0, c1, c2, ...
     Vector<float> m_vertex_data;
+    size_t m_number_of_components { 0 };
     Vector<Triangle> m_triangles;
     FunctionsType m_functions;
 };
@@ -948,7 +952,7 @@ PDFErrorOr<NonnullRefPtr<LatticeFormGouraudShading>> LatticeFormGouraudShading::
         }
     }
 
-    return adopt_ref(*new LatticeFormGouraudShading(move(common_entries), move(vertex_data), move(triangles), move(functions)));
+    return adopt_ref(*new LatticeFormGouraudShading(move(common_entries), move(vertex_data), number_of_components, move(triangles), move(functions)));
 }
 
 PDFErrorOr<void> LatticeFormGouraudShading::draw(Gfx::Painter&, Gfx::AffineTransform const&)


### PR DESCRIPTION
Assembles triangle coordinates and colors and calls a new
`draw_gouraud_triangle()` function that will do the actual drawing.
That last function is not implemented yet though, so no behavior
change yet.

---

There are a bunch of options for how to implement `draw_gouraud_triangle()`, so I'd like to put that in its own PR. (I tested the code with the impl in https://github.com/nico/serenity/commit/4f9a7139f765b2fbdae70c5bf79f80e7b32a0b42 but I'm currently not sure that's the right approach.)