### PR TITLE
Kernel: Start reducing the amount of `RecursiveSpinlock`s

### DIFF
--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -40,10 +40,10 @@ struct SingletonInstanceCreator {
 #ifdef KERNEL
 
 template<typename T, Kernel::LockRank Rank>
-struct SingletonInstanceCreator<Kernel::RecursiveSpinlockProtected<T, Rank>> {
-    static Kernel::RecursiveSpinlockProtected<T, Rank>* create()
+struct SingletonInstanceCreator<Kernel::SpinlockProtected<T, Rank>> {
+    static Kernel::SpinlockProtected<T, Rank>* create()
     {
-        return new Kernel::RecursiveSpinlockProtected<T, Rank> {};
+        return new Kernel::SpinlockProtected<T, Rank> {};
     }
 };
 #endif

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -54,7 +54,7 @@ public:
     DeviceIdentifier const& get_device_identifier(Address address) const;
 
     Spinlock<LockRank::None> const& scan_lock() const { return m_scan_lock; }
-    RecursiveSpinlock<LockRank::None> const& access_lock() const { return m_access_lock; }
+    Spinlock<LockRank::None> const& access_lock() const { return m_access_lock; }
 
     ErrorOr<void> add_host_controller_and_scan_for_devices(NonnullOwnPtr<HostController>);
 
@@ -64,7 +64,7 @@ private:
 
     bool find_and_register_pci_host_bridges_from_acpi_mcfg_table(PhysicalAddress mcfg);
 
-    mutable RecursiveSpinlock<LockRank::None> m_access_lock {};
+    mutable Spinlock<LockRank::None> m_access_lock {};
     mutable Spinlock<LockRank::None> m_scan_lock {};
 
     HashMap<u32, NonnullOwnPtr<PCI::HostController>> m_host_controllers;

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -18,9 +18,9 @@
 namespace Kernel {
 
 struct AllDevicesDetails {
-    RecursiveSpinlockProtected<HashMap<u64, BlockDevice*>, LockRank::None> block_devices {};
-    RecursiveSpinlockProtected<HashMap<u64, CharacterDevice*>, LockRank::None> char_devices {};
-    RecursiveSpinlockProtected<CircularQueue<DeviceEvent, 100>, LockRank::None> event_queue {};
+    SpinlockProtected<HashMap<u64, BlockDevice*>, LockRank::None> block_devices {};
+    SpinlockProtected<HashMap<u64, CharacterDevice*>, LockRank::None> char_devices {};
+    SpinlockProtected<CircularQueue<DeviceEvent, 100>, LockRank::None> event_queue {};
     // NOTE: There's no locking on this pointer because we expect to initialize it once
     // and never touch it again.
     OwnPtr<BaseDevices> base_devices;
@@ -28,7 +28,7 @@ struct AllDevicesDetails {
 
 static Singleton<AllDevicesDetails> s_all_details;
 
-RecursiveSpinlockProtected<CircularQueue<DeviceEvent, 100>, LockRank::None>& Device::event_queue()
+SpinlockProtected<CircularQueue<DeviceEvent, 100>, LockRank::None>& Device::event_queue()
 {
     return s_all_details->event_queue;
 }

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -44,7 +44,7 @@ UNMAP_AFTER_INIT void Device::initialize_base_devices()
     s_all_details->base_devices = move(base_devices);
 }
 
-RefPtr<Device> Device::acquire_by_type_and_major_minor_numbers(DeviceNodeType type, MajorNumber major, MinorNumber minor)
+void Device::run_by_type_and_major_minor_numbers(DeviceNodeType type, MajorNumber major, MinorNumber minor, Function<void(RefPtr<Device>)> const& callback)
 {
     VERIFY(type == DeviceNodeType::Block || type == DeviceNodeType::Character);
 
@@ -56,14 +56,14 @@ RefPtr<Device> Device::acquire_by_type_and_major_minor_numbers(DeviceNodeType ty
     };
 
     if (type == DeviceNodeType::Block) {
-        return s_all_details->block_devices.with([&](auto& map) -> RefPtr<Device> {
-            return find_device_in_map(map);
+        s_all_details->block_devices.with([&](auto& map) {
+            callback(find_device_in_map(map));
+        });
+    } else {
+        s_all_details->char_devices.with([&](auto& map) {
+            callback(find_device_in_map(map));
         });
     }
-
-    return s_all_details->char_devices.with([&](auto& map) -> RefPtr<Device> {
-        return find_device_in_map(map);
-    });
 }
 
 void Device::before_will_be_destroyed_remove_from_device_management()

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -66,7 +66,7 @@ public:
         return request;
     }
 
-    static RecursiveSpinlockProtected<CircularQueue<DeviceEvent, 100>, LockRank::None>& event_queue();
+    static SpinlockProtected<CircularQueue<DeviceEvent, 100>, LockRank::None>& event_queue();
     static BaseDevices* base_devices();
     static void after_inserting_device(Badge<Device>, Device&);
     static void before_device_removal(Badge<Device>, Device&);

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -70,7 +70,7 @@ public:
     static BaseDevices* base_devices();
     static void after_inserting_device(Badge<Device>, Device&);
     static void before_device_removal(Badge<Device>, Device&);
-    static RefPtr<Device> acquire_by_type_and_major_minor_numbers(DeviceNodeType, MajorNumber, MinorNumber);
+    static void run_by_type_and_major_minor_numbers(DeviceNodeType type, MajorNumber major, MinorNumber minor, Function<void(RefPtr<Device>)> const& callback);
 
     static void initialize_base_devices();
 

--- a/Kernel/Devices/GPU/Management.h
+++ b/Kernel/Devices/GPU/Management.h
@@ -56,7 +56,7 @@ private:
 
     unsigned m_current_minor_number { 0 };
 
-    RecursiveSpinlockProtected<IntrusiveList<&DisplayConnector::m_list_node>, LockRank::None> m_display_connector_nodes {};
+    SpinlockProtected<IntrusiveList<&DisplayConnector::m_list_node>, LockRank::None> m_display_connector_nodes {};
 };
 
 }

--- a/Kernel/Devices/GPU/VMWare/GraphicsAdapter.h
+++ b/Kernel/Devices/GPU/VMWare/GraphicsAdapter.h
@@ -55,7 +55,7 @@ private:
     RefPtr<VMWareDisplayConnector> m_display_connector;
     mutable NonnullOwnPtr<IOWindow> m_registers_io_window;
     mutable Spinlock<LockRank::None> m_io_access_lock {};
-    mutable RecursiveSpinlock<LockRank::None> m_operation_lock {};
+    mutable Spinlock<LockRank::None> m_operation_lock {};
 };
 
 }

--- a/Kernel/Devices/GPU/VirtIO/Console.cpp
+++ b/Kernel/Devices/GPU/VirtIO/Console.cpp
@@ -15,12 +15,14 @@ constexpr static AK::Duration refresh_interval = AK::Duration::from_milliseconds
 NonnullLockRefPtr<Console> Console::initialize(VirtIODisplayConnector& parent_display_connector)
 {
     auto current_resolution = parent_display_connector.current_mode_setting();
-    return adopt_lock_ref(*new Console(parent_display_connector, current_resolution));
+    auto refresh_timer = adopt_nonnull_ref_or_enomem(new (nothrow) Timer()).release_value_but_fixme_should_propagate_errors();
+    return adopt_lock_ref(*new Console(parent_display_connector, current_resolution, refresh_timer));
 }
 
-Console::Console(VirtIODisplayConnector const& parent_display_connector, DisplayConnector::ModeSetting current_resolution)
+Console::Console(VirtIODisplayConnector const& parent_display_connector, DisplayConnector::ModeSetting current_resolution, NonnullRefPtr<Timer> refresh_timer)
     : GenericFramebufferConsole(current_resolution.horizontal_active, current_resolution.vertical_active, current_resolution.horizontal_stride)
     , m_parent_display_connector(parent_display_connector)
+    , m_refresh_timer(move(refresh_timer))
 {
     // NOTE: Clear the framebuffer, in case it's left with some garbage.
     memset(framebuffer_data(), 0, current_resolution.horizontal_stride * current_resolution.vertical_active);
@@ -67,8 +69,7 @@ void Console::flush(size_t, size_t, size_t, size_t)
 
 void Console::enqueue_refresh_timer()
 {
-    auto refresh_timer = adopt_nonnull_ref_or_enomem(new (nothrow) Timer()).release_value_but_fixme_should_propagate_errors();
-    refresh_timer->setup(CLOCK_MONOTONIC, refresh_interval, [this]() {
+    TimerQueue::the().add_timer_without_id(*m_refresh_timer, CLOCK_MONOTONIC, refresh_interval, [this]() {
         if (m_enabled.load() && m_dirty) {
             MUST(g_io_work->try_queue([this]() {
                 {
@@ -81,7 +82,6 @@ void Console::enqueue_refresh_timer()
         }
         enqueue_refresh_timer();
     });
-    TimerQueue::the().add_timer(move(refresh_timer));
 }
 
 void Console::enable()

--- a/Kernel/Devices/GPU/VirtIO/Console.h
+++ b/Kernel/Devices/GPU/VirtIO/Console.h
@@ -29,8 +29,9 @@ private:
     virtual void hide_cursor() override;
     virtual void show_cursor() override;
 
-    Console(VirtIODisplayConnector const& parent_display_connector, DisplayConnector::ModeSetting current_resolution);
-    NonnullLockRefPtr<VirtIODisplayConnector> m_parent_display_connector;
+    Console(VirtIODisplayConnector const& parent_display_connector, DisplayConnector::ModeSetting current_resolution, NonnullRefPtr<Timer> timer);
+    NonnullRefPtr<VirtIODisplayConnector> m_parent_display_connector;
+    NonnullRefPtr<Timer> m_refresh_timer;
     bool m_dirty { false };
 };
 

--- a/Kernel/Devices/GPU/VirtIO/GPU3DDevice.h
+++ b/Kernel/Devices/GPU/VirtIO/GPU3DDevice.h
@@ -149,7 +149,7 @@ private:
     NonnullLockRefPtr<VirtIOGraphicsAdapter> m_graphics_adapter;
     // Context used for kernel operations (e.g. flushing resources to scanout)
     Graphics::VirtIOGPU::ContextID m_kernel_context_id;
-    RecursiveSpinlockProtected<ContextList, LockRank::None> m_context_state_list;
+    SpinlockProtected<ContextList, LockRank::None> m_context_state_list;
     // Memory management for backing buffers
     NonnullOwnPtr<Memory::Region> m_transfer_buffer_region;
     constexpr static size_t NUM_TRANSFER_REGION_PAGES = 1024;

--- a/Kernel/Devices/GPU/VirtIO/GraphicsAdapter.h
+++ b/Kernel/Devices/GPU/VirtIO/GraphicsAdapter.h
@@ -113,7 +113,7 @@ private:
     VirtIO::Configuration const* m_device_configuration { nullptr };
     // Note: Resource ID 0 is invalid, and we must not allocate 0 as the first resource ID.
     Atomic<u32> m_resource_id_counter { 1 };
-    RecursiveSpinlockProtected<Bitmap, LockRank::None> m_active_context_ids {};
+    SpinlockProtected<Bitmap, LockRank::None> m_active_context_ids {};
     RefPtr<VirtIOGPU3DDevice> m_3d_device;
     bool m_has_virgl_support { false };
 

--- a/Kernel/Devices/Input/Management.h
+++ b/Kernel/Devices/Input/Management.h
@@ -46,7 +46,7 @@ public:
         Keyboard::CharacterMapData character_map;
     };
 
-    RecursiveSpinlockProtected<KeymapData, LockRank::None>& keymap_data() { return m_keymap_data; }
+    SpinlockProtected<KeymapData, LockRank::None>& keymap_data() { return m_keymap_data; }
 
     u32 get_char_from_character_map(KeyEvent, u8) const;
 
@@ -60,16 +60,16 @@ private:
     size_t generate_minor_device_number_for_mouse();
     size_t generate_minor_device_number_for_keyboard();
 
-    RecursiveSpinlockProtected<KeymapData, LockRank::None> m_keymap_data {};
+    SpinlockProtected<KeymapData, LockRank::None> m_keymap_data {};
     size_t m_mouse_minor_number { 0 };
     size_t m_keyboard_minor_number { 0 };
     KeyboardClient* m_client { nullptr };
 
-    RecursiveSpinlockProtected<IntrusiveList<&SerialIOController::m_list_node>, LockRank::None> m_input_serial_io_controllers;
+    SpinlockProtected<IntrusiveList<&SerialIOController::m_list_node>, LockRank::None> m_input_serial_io_controllers;
     // NOTE: This list is used for standalone devices, like USB HID devices
     // (which are not attached via a SerialIO controller in the sense that
     // there's no specific serial IO controller to coordinate their usage).
-    RecursiveSpinlockProtected<IntrusiveList<&InputDevice::m_list_node>, LockRank::None> m_standalone_input_devices;
+    SpinlockProtected<IntrusiveList<&InputDevice::m_list_node>, LockRank::None> m_standalone_input_devices;
     Spinlock<LockRank::None> m_client_lock;
 };
 

--- a/Kernel/Devices/Loop/LoopDevice.cpp
+++ b/Kernel/Devices/Loop/LoopDevice.cpp
@@ -59,11 +59,13 @@ ErrorOr<NonnullRefPtr<LoopDevice>> LoopDevice::create_with_file_description(Open
     if (!custody->inode().fs().supports_backing_loop_devices())
         return Error::from_errno(ENOTSUP);
 
-    return TRY(LoopDevice::all_instances().with([custody](auto& all_instances_list) -> ErrorOr<NonnullRefPtr<LoopDevice>> {
-        NonnullRefPtr<LoopDevice> device = TRY(Device::try_create_device<LoopDevice>(*custody, s_loop_device_id.fetch_add(1)));
+    NonnullRefPtr<LoopDevice> device = TRY(Device::try_create_device<LoopDevice>(*custody, s_loop_device_id.fetch_add(1)));
+
+    LoopDevice::all_instances().with([custody, device](auto& all_instances_list) {
         all_instances_list.append(*device);
-        return device;
-    }));
+    });
+
+    return device;
 }
 
 void LoopDevice::start_request(AsyncBlockDeviceRequest& request)

--- a/Kernel/Devices/Loop/LoopDevice.cpp
+++ b/Kernel/Devices/Loop/LoopDevice.cpp
@@ -21,18 +21,12 @@ RecursiveSpinlockProtected<LoopDevice::List, LockRank::None>& LoopDevice::all_in
     return s_all_instances;
 }
 
-void LoopDevice::remove(Badge<DeviceControlDevice>)
-{
-    LoopDevice::all_instances().with([&](auto&) {
-        m_list_node.remove();
-    });
-}
-
 bool LoopDevice::unref() const
 {
     bool did_hit_zero = LoopDevice::all_instances().with([&](auto&) {
         if (deref_base())
             return false;
+        m_list_node.remove();
         const_cast<LoopDevice&>(*this).revoke_weak_ptrs();
         return true;
     });

--- a/Kernel/Devices/Loop/LoopDevice.cpp
+++ b/Kernel/Devices/Loop/LoopDevice.cpp
@@ -13,10 +13,10 @@
 
 namespace Kernel {
 
-static Singleton<RecursiveSpinlockProtected<LoopDevice::List, LockRank::None>> s_all_instances;
+static Singleton<SpinlockProtected<LoopDevice::List, LockRank::None>> s_all_instances;
 static Atomic<u64> s_loop_device_id { 0 };
 
-RecursiveSpinlockProtected<LoopDevice::List, LockRank::None>& LoopDevice::all_instances()
+SpinlockProtected<LoopDevice::List, LockRank::None>& LoopDevice::all_instances()
 {
     return s_all_instances;
 }

--- a/Kernel/Devices/Loop/LoopDevice.h
+++ b/Kernel/Devices/Loop/LoopDevice.h
@@ -51,7 +51,7 @@ private:
     NonnullRefPtr<Custody> const m_backing_custody;
     unsigned const m_index { 0 };
 
-    mutable IntrusiveListNode<LoopDevice, NonnullRefPtr<LoopDevice>> m_list_node;
+    mutable IntrusiveListNode<LoopDevice> m_list_node;
 
 public:
     using List = IntrusiveList<&LoopDevice::m_list_node>;

--- a/Kernel/Devices/Loop/LoopDevice.h
+++ b/Kernel/Devices/Loop/LoopDevice.h
@@ -56,7 +56,7 @@ private:
 public:
     using List = IntrusiveList<&LoopDevice::m_list_node>;
 
-    static RecursiveSpinlockProtected<LoopDevice::List, LockRank::None>& all_instances();
+    static SpinlockProtected<LoopDevice::List, LockRank::None>& all_instances();
 };
 
 }

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -101,6 +101,7 @@ protected:
     virtual void complete_current_request(u16 cmdid, u16 status);
 
 private:
+    void complete_current_request_impl(u16 cmdid, u16 status, HashMap<u16, NVMeIO>& requests);
     bool cqe_available();
     void update_cqe_head();
     void update_cq_doorbell()

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -113,7 +113,7 @@ private:
     }
 
 protected:
-    RecursiveSpinlockProtected<HashMap<u16, NVMeIO>, LockRank::None> m_requests;
+    SpinlockProtected<HashMap<u16, NVMeIO>, LockRank::None> m_requests;
     NonnullOwnPtr<Memory::Region> m_rw_dma_region;
 
 private:

--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -346,9 +346,10 @@ UNMAP_AFTER_INIT void StorageManagement::determine_block_boot_device()
     // Note: We simply fetch the corresponding BlockDevice with the major and minor parameters.
     // We don't try to accept and resolve a partition number as it will make this code much more
     // complicated. This rule is also explained in the boot_device_addressing(7) manual page.
-    auto device = Device::acquire_by_type_and_major_minor_numbers(DeviceNodeType::Block, parameters_view[0], parameters_view[1]);
-    if (device && device->is_block_device())
-        m_boot_block_device = *static_ptr_cast<BlockDevice>(device);
+    Device::run_by_type_and_major_minor_numbers(DeviceNodeType::Block, parameters_view[0], parameters_view[1], [&](RefPtr<Device> device) {
+        if (device && device->is_block_device())
+            m_boot_block_device = *static_ptr_cast<BlockDevice>(device);
+    });
 }
 
 UNMAP_AFTER_INIT void StorageManagement::determine_boot_device_with_logical_unit_number()

--- a/Kernel/Devices/Storage/VirtIO/VirtIOBlockDevice.h
+++ b/Kernel/Devices/Storage/VirtIO/VirtIOBlockDevice.h
@@ -43,7 +43,7 @@ private:
     OwnPtr<Memory::Region> m_header_buf;
     OwnPtr<Memory::Region> m_data_buf;
 
-    RecursiveSpinlockProtected<RefPtr<AsyncBlockDeviceRequest>, LockRank::None> m_current_request {};
+    SpinlockProtected<RefPtr<AsyncBlockDeviceRequest>, LockRank::None> m_current_request {};
 };
 
 }

--- a/Kernel/Devices/TTY/PTYMultiplexer.h
+++ b/Kernel/Devices/TTY/PTYMultiplexer.h
@@ -35,7 +35,7 @@ private:
     virtual StringView class_name() const override { return "PTYMultiplexer"sv; }
 
     static constexpr size_t max_pty_pairs = 64;
-    RecursiveSpinlockProtected<Vector<unsigned, max_pty_pairs>, LockRank::None> m_freelist {};
+    SpinlockProtected<Vector<unsigned, max_pty_pairs>, LockRank::None> m_freelist {};
 };
 
 }

--- a/Kernel/Devices/TTY/SlavePTY.cpp
+++ b/Kernel/Devices/TTY/SlavePTY.cpp
@@ -13,9 +13,9 @@
 
 namespace Kernel {
 
-static Singleton<RecursiveSpinlockProtected<SlavePTY::List, LockRank::None>> s_all_instances;
+static Singleton<SpinlockProtected<SlavePTY::List, LockRank::None>> s_all_instances;
 
-RecursiveSpinlockProtected<SlavePTY::List, LockRank::None>& SlavePTY::all_instances()
+SpinlockProtected<SlavePTY::List, LockRank::None>& SlavePTY::all_instances()
 {
     return s_all_instances;
 }

--- a/Kernel/Devices/TTY/SlavePTY.h
+++ b/Kernel/Devices/TTY/SlavePTY.h
@@ -58,7 +58,7 @@ private:
 
 public:
     using List = IntrusiveList<&SlavePTY::m_list_node>;
-    static RecursiveSpinlockProtected<SlavePTY::List, LockRank::None>& all_instances();
+    static SpinlockProtected<SlavePTY::List, LockRank::None>& all_instances();
 };
 
 }

--- a/Kernel/Devices/TTY/VirtualConsole.cpp
+++ b/Kernel/Devices/TTY/VirtualConsole.cpp
@@ -29,9 +29,9 @@
 
 namespace Kernel {
 
-static Singleton<RecursiveSpinlockProtected<RefPtr<VirtualConsole>, LockRank::None>> s_active_console;
-static Singleton<RecursiveSpinlockProtected<RefPtr<VirtualConsole>, LockRank::None>> s_debug_console;
-static Singleton<RecursiveSpinlockProtected<Array<RefPtr<VirtualConsole>, VirtualConsole::s_max_virtual_consoles>, LockRank::None>> s_consoles;
+static Singleton<SpinlockProtected<RefPtr<VirtualConsole>, LockRank::None>> s_active_console;
+static Singleton<SpinlockProtected<RefPtr<VirtualConsole>, LockRank::None>> s_debug_console;
+static Singleton<SpinlockProtected<Array<RefPtr<VirtualConsole>, VirtualConsole::s_max_virtual_consoles>, LockRank::None>> s_consoles;
 
 void VirtualConsole::resolution_was_changed()
 {

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -126,8 +126,8 @@ ErrorOr<void> BlockBasedFileSystem::initialize_while_locked()
     VERIFY(m_lock.is_locked());
     VERIFY(!is_initialized_while_locked());
     VERIFY(logical_block_size() != 0);
-    auto cached_block_data = TRY(KBuffer::try_create_with_size("BlockBasedFS: Cache blocks"sv, DiskCache::EntryCount * logical_block_size()));
-    auto entries_data = TRY(KBuffer::try_create_with_size("BlockBasedFS: Cache entries"sv, DiskCache::EntryCount * sizeof(CacheEntry)));
+    auto cached_block_data = TRY(KBuffer::try_create_with_size("BlockBasedFS: Cache blocks"sv, DiskCache::EntryCount * logical_block_size(), Memory::Region::Access::ReadWrite, AllocationStrategy::AllocateNow));
+    auto entries_data = TRY(KBuffer::try_create_with_size("BlockBasedFS: Cache entries"sv, DiskCache::EntryCount * sizeof(CacheEntry), Memory::Region::Access::ReadWrite, AllocationStrategy::AllocateNow));
     auto disk_cache = TRY(adopt_nonnull_own_or_enomem(new (nothrow) DiskCache(*this, move(cached_block_data), move(entries_data))));
 
     m_cache.with_exclusive([&](auto& cache) {

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -16,9 +16,9 @@
 
 namespace Kernel {
 
-class Custody final : public ListedRefCounted<Custody, LockType::Spinlock> {
+class Custody final : public AtomicRefCounted<Custody> {
 public:
-    static ErrorOr<NonnullRefPtr<Custody>> try_create(Custody* parent, StringView name, Inode&, int mount_flags);
+    static ErrorOr<NonnullRefPtr<Custody>> try_create(RefPtr<Custody> parent, StringView name, Inode&, int mount_flags);
 
     ~Custody();
 
@@ -33,18 +33,12 @@ public:
     bool is_readonly() const;
 
 private:
-    Custody(Custody* parent, NonnullOwnPtr<KString> name, Inode&, int mount_flags);
+    Custody(RefPtr<Custody> parent, NonnullOwnPtr<KString> name, Inode&, int mount_flags);
 
     RefPtr<Custody> m_parent;
     NonnullOwnPtr<KString> m_name;
     NonnullRefPtr<Inode> const m_inode;
     int m_mount_flags { 0 };
-
-    mutable IntrusiveListNode<Custody> m_all_custodies_list_node;
-
-public:
-    using AllCustodiesList = IntrusiveList<&Custody::m_all_custodies_list_node>;
-    static RecursiveSpinlockProtected<Custody::AllCustodiesList, LockRank::None>& all_instances();
 };
 
 }

--- a/Kernel/FileSystem/DevLoopFS/Inode.h
+++ b/Kernel/FileSystem/DevLoopFS/Inode.h
@@ -23,7 +23,7 @@ public:
     DevLoopFS const& fs() const { return static_cast<DevLoopFS const&>(Inode::fs()); }
 
 private:
-    DevLoopFSInode(DevLoopFS&, InodeIndex, LoopDevice&);
+    DevLoopFSInode(DevLoopFS&, InodeIndex, LockWeakPtr<LoopDevice>);
 
     // NOTE: This constructor is used for the root inode only.
     DevLoopFSInode(DevLoopFS&);

--- a/Kernel/FileSystem/DevPtsFS/Inode.h
+++ b/Kernel/FileSystem/DevPtsFS/Inode.h
@@ -23,7 +23,7 @@ public:
     DevPtsFS const& fs() const { return static_cast<DevPtsFS const&>(Inode::fs()); }
 
 private:
-    DevPtsFSInode(DevPtsFS&, InodeIndex, SlavePTY&);
+    DevPtsFSInode(DevPtsFS&, InodeIndex, LockWeakPtr<SlavePTY>);
 
     // NOTE: This constructor is used for the root inode only.
     DevPtsFSInode(DevPtsFS&);

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -66,7 +66,7 @@ public:
     // Converts file types that are used internally by the filesystem to DT_* types
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const { return entry.file_type; }
 
-    RecursiveSpinlockProtected<size_t, LockRank::FileSystem>& mounted_count() { return m_attach_count; }
+    SpinlockProtected<size_t, LockRank::FileSystem>& mounted_count() { return m_attach_count; }
 
 protected:
     FileSystem();
@@ -84,14 +84,14 @@ private:
     size_t m_fragment_size { 0 };
     bool m_readonly { false };
 
-    RecursiveSpinlockProtected<size_t, LockRank::FileSystem> m_attach_count { 0 };
+    SpinlockProtected<size_t, LockRank::FileSystem> m_attach_count { 0 };
     IntrusiveListNode<FileSystem> m_file_system_node;
 
 public:
     using List = IntrusiveList<&FileSystem::m_file_system_node>;
 
     // NOTE: This method is implemented in Kernel/FileSystem/VirtualFileSystem.cpp
-    static RecursiveSpinlockProtected<FileSystem::List, LockRank::FileSystem>& all_file_systems_list();
+    static SpinlockProtected<FileSystem::List, LockRank::FileSystem>& all_file_systems_list();
 };
 
 }

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -22,9 +22,9 @@
 
 namespace Kernel {
 
-static Singleton<RecursiveSpinlockProtected<Inode::AllInstancesList, LockRank::None>> s_all_instances;
+static Singleton<SpinlockProtected<Inode::AllInstancesList, LockRank::None>> s_all_instances;
 
-RecursiveSpinlockProtected<Inode::AllInstancesList, LockRank::None>& Inode::all_instances()
+SpinlockProtected<Inode::AllInstancesList, LockRank::None>& Inode::all_instances()
 {
     return s_all_instances;
 }

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -125,6 +125,15 @@ protected:
     virtual ErrorOr<void> truncate_locked(u64) { return {}; }
 
 private:
+    struct Flock {
+        off_t start;
+        off_t len;
+        OpenFileDescription const* owner;
+        pid_t pid;
+        short type;
+    };
+
+    bool can_apply_flock_impl(flock const&, Optional<OpenFileDescription const&>, Vector<Flock> const& flocks) const;
     ErrorOr<bool> try_apply_flock(Process const&, OpenFileDescription const&, flock const&);
 
     FileSystem& m_file_system;
@@ -135,14 +144,6 @@ private:
     bool m_metadata_dirty { false };
     RefPtr<FIFO> m_fifo;
     IntrusiveListNode<Inode> m_inode_list_node;
-
-    struct Flock {
-        off_t start;
-        off_t len;
-        OpenFileDescription const* owner;
-        pid_t pid;
-        short type;
-    };
 
     Thread::FlockBlockerSet m_flock_blocker_set;
     RecursiveSpinlockProtected<Vector<Flock>, LockRank::None> m_flocks {};

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -140,17 +140,17 @@ private:
     InodeIndex m_index { 0 };
     LockWeakPtr<Memory::SharedInodeVMObject> m_shared_vmobject;
     LockWeakPtr<LocalSocket> m_bound_socket;
-    RecursiveSpinlockProtected<HashTable<InodeWatcher*>, LockRank::None> m_watchers {};
+    SpinlockProtected<HashTable<InodeWatcher*>, LockRank::None> m_watchers {};
     bool m_metadata_dirty { false };
     RefPtr<FIFO> m_fifo;
     IntrusiveListNode<Inode> m_inode_list_node;
 
     Thread::FlockBlockerSet m_flock_blocker_set;
-    RecursiveSpinlockProtected<Vector<Flock>, LockRank::None> m_flocks {};
+    SpinlockProtected<Vector<Flock>, LockRank::None> m_flocks {};
 
 public:
     using AllInstancesList = IntrusiveList<&Inode::m_inode_list_node>;
-    static RecursiveSpinlockProtected<Inode::AllInstancesList, LockRank::None>& all_instances();
+    static SpinlockProtected<Inode::AllInstancesList, LockRank::None>& all_instances();
 };
 
 }

--- a/Kernel/FileSystem/InodeWatcher.h
+++ b/Kernel/FileSystem/InodeWatcher.h
@@ -70,7 +70,7 @@ private:
         InodeWatcherEvent::Type type { InodeWatcherEvent::Type::Invalid };
         OwnPtr<KString> path;
     };
-    RecursiveSpinlockProtected<CircularQueue<Event, 32>, LockRank::None> m_queue;
+    SpinlockProtected<CircularQueue<Event, 32>, LockRank::None> m_queue;
     Checked<int> m_wd_counter { 1 };
 
     // NOTE: These two hashmaps provide two different ways of reaching the same
@@ -80,7 +80,7 @@ private:
         HashMap<InodeIdentifier, WatchDescription*> inode_to_watches;
     };
 
-    mutable RecursiveSpinlockProtected<WatchMaps, LockRank::None> m_watch_maps;
+    mutable SpinlockProtected<WatchMaps, LockRank::None> m_watch_maps;
 };
 
 }

--- a/Kernel/FileSystem/Mount.h
+++ b/Kernel/FileSystem/Mount.h
@@ -61,7 +61,7 @@ private:
     Details const m_details;
 
     RefPtr<Custody> const m_host_custody;
-    RecursiveSpinlockProtected<int, LockRank::None> m_flags { 0 };
+    SpinlockProtected<int, LockRank::None> m_flags { 0 };
 
     SetOnce m_immutable;
 

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -159,6 +159,6 @@ private:
         FIFO::Direction fifo_direction : 2 { FIFO::Direction::Neither };
     };
 
-    RecursiveSpinlockProtected<State, LockRank::None> m_state {};
+    SpinlockProtected<State, LockRank::None> m_state {};
 };
 }

--- a/Kernel/FileSystem/SysFS/Component.h
+++ b/Kernel/FileSystem/SysFS/Component.h
@@ -87,7 +87,7 @@ public:
 
     virtual ErrorOr<NonnullRefPtr<SysFSInode>> to_inode(SysFS const& sysfs_instance) const override final;
 
-    using ChildList = RecursiveSpinlockProtected<IntrusiveList<&SysFSComponent::m_list_node>, LockRank::None>;
+    using ChildList = SpinlockProtected<IntrusiveList<&SysFSComponent::m_list_node>, LockRank::None>;
 
 protected:
     virtual bool is_root_directory() const { return false; }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -134,7 +134,7 @@ bool VirtualFileSystem::check_matching_absolute_path_hierarchy(Custody const& fi
     while (custody1->parent()) {
         if (!custody2->parent())
             return false;
-        if (custody1->parent().ptr() != custody2->parent().ptr())
+        if (&custody1->parent()->inode() != &custody2->parent()->inode())
             return false;
         custody1 = custody1->parent();
         custody2 = custody2->parent();

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -54,28 +54,28 @@ struct VirtualFileSystemDetails {
     // need to do disk access (i.e. taking Mutexes in other places) and then register that new filesystem
     // in this list, to avoid TOCTOU bugs.
     MutexProtected<FileBackedFileSystem::List> file_backed_file_systems_list {};
-    RecursiveSpinlockProtected<FileSystem::List, LockRank::FileSystem> file_systems_list {};
-    RecursiveSpinlockProtected<VFSRootContext::List, LockRank::FileSystem> root_contexts {};
+    SpinlockProtected<FileSystem::List, LockRank::FileSystem> file_systems_list {};
+    SpinlockProtected<VFSRootContext::List, LockRank::FileSystem> root_contexts {};
 };
 
 static Singleton<VirtualFileSystemDetails> s_details;
 
-RecursiveSpinlockProtected<FileSystem::List, LockRank::FileSystem>& FileSystem::all_file_systems_list()
+SpinlockProtected<FileSystem::List, LockRank::FileSystem>& FileSystem::all_file_systems_list()
 {
     return s_details->file_systems_list;
 }
 
-RecursiveSpinlockProtected<IntrusiveList<&VFSRootContext::m_list_node>, LockRank::FileSystem>& VFSRootContext::all_root_contexts_list()
+SpinlockProtected<IntrusiveList<&VFSRootContext::m_list_node>, LockRank::FileSystem>& VFSRootContext::all_root_contexts_list()
 {
     return s_details->root_contexts;
 }
 
-RecursiveSpinlockProtected<VFSRootContext::List, LockRank::FileSystem>& VFSRootContext::all_root_contexts_list(Badge<PowerStateSwitchTask>)
+SpinlockProtected<VFSRootContext::List, LockRank::FileSystem>& VFSRootContext::all_root_contexts_list(Badge<PowerStateSwitchTask>)
 {
     return s_details->root_contexts;
 }
 
-RecursiveSpinlockProtected<VFSRootContext::List, LockRank::FileSystem>& VFSRootContext::all_root_contexts_list(Badge<Process>)
+SpinlockProtected<VFSRootContext::List, LockRank::FileSystem>& VFSRootContext::all_root_contexts_list(Badge<Process>)
 {
     return s_details->root_contexts;
 }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -446,7 +446,10 @@ ErrorOr<NonnullRefPtr<OpenFileDescription>> VirtualFileSystem::open(Process cons
         if (custody.mount_flags() & MS_NODEV)
             return EACCES;
         auto device_type = metadata.is_block_device() ? DeviceNodeType::Block : DeviceNodeType::Character;
-        auto device = Device::acquire_by_type_and_major_minor_numbers(device_type, metadata.major_device, metadata.minor_device);
+        RefPtr<Device> device;
+        Device::run_by_type_and_major_minor_numbers(device_type, metadata.major_device, metadata.minor_device, [&](RefPtr<Device> found_device) {
+            device = move(found_device);
+        });
         if (device == nullptr) {
             return ENODEV;
         }

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -200,7 +200,7 @@ size_t AnonymousVMObject::purge()
 
     m_was_purged = true;
 
-    remap_regions();
+    remap_regions_locked();
 
     return total_pages_purged;
 }
@@ -232,7 +232,7 @@ ErrorOr<void> AnonymousVMObject::set_volatile(bool is_volatile, bool& was_purged
         m_volatile = true;
         m_was_purged = false;
 
-        remap_regions();
+        remap_regions_locked();
         return {};
     }
     // When a VMObject is made non-volatile, we try to commit however many pages are not currently available.
@@ -258,7 +258,7 @@ ErrorOr<void> AnonymousVMObject::set_volatile(bool is_volatile, bool& was_purged
 
     m_volatile = false;
     m_was_purged = false;
-    remap_regions();
+    remap_regions_locked();
     return {};
 }
 

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -77,7 +77,7 @@ int InodeVMObject::try_release_clean_pages(int page_amount)
         }
     }
     if (count)
-        remap_regions();
+        remap_regions_locked();
     return count;
 }
 

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -82,7 +82,7 @@ ErrorOr<void> SharedInodeVMObject::sync_impl(off_t offset_in_pages, size_t pages
     if (should_remap) {
         for (auto it = pages_to_flush.begin(); it != pages_to_flush.end(); ++it)
             set_page_dirty(*it, false);
-        remap_regions();
+        remap_regions_locked();
     }
 
     for (auto it = pages_to_flush.begin(); it != pages_to_flush.end(); ++it) {

--- a/Kernel/Memory/VMObject.cpp
+++ b/Kernel/Memory/VMObject.cpp
@@ -38,11 +38,18 @@ VMObject::~VMObject()
     VERIFY(m_regions.is_empty());
 }
 
+void VMObject::remap_regions_locked()
+{
+    VERIFY(m_lock.is_locked());
+    for (auto& region : m_regions) {
+        region.remap_with_locked_vmobject();
+    }
+}
+
 void VMObject::remap_regions()
 {
-    for_each_region([](Region& region) {
-        region.remap();
-    });
+    SpinlockLocker lock(m_lock);
+    remap_regions_locked();
 }
 
 bool VMObject::remap_regions_one_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage> page)

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -63,13 +63,14 @@ protected:
     template<typename Callback>
     void for_each_region(Callback);
 
+    void remap_regions_locked();
     void remap_regions();
     bool remap_regions_one_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage> page);
 
     IntrusiveListNode<VMObject> m_list_node;
     FixedArray<RefPtr<PhysicalRAMPage>> m_physical_pages;
 
-    mutable RecursiveSpinlock<LockRank::None> m_lock {};
+    mutable Spinlock<LockRank::None> m_lock {};
 
 private:
     VMObject& operator=(VMObject const&) = delete;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -138,7 +138,7 @@ private:
 
     PacketList m_packet_queue;
     size_t m_packet_queue_size { 0 };
-    RecursiveSpinlockProtected<PacketList, LockRank::None> m_unused_packets {};
+    SpinlockProtected<PacketList, LockRank::None> m_unused_packets {};
     FixedStringBuffer<IFNAMSIZ> m_name;
     u32 m_packets_in { 0 };
     u32 m_bytes_in { 0 };

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -42,7 +42,7 @@ public:
 private:
     ErrorOr<NonnullRefPtr<NetworkAdapter>> determine_network_device(PCI::DeviceIdentifier const&) const;
 
-    RecursiveSpinlockProtected<Vector<NonnullRefPtr<NetworkAdapter>>, LockRank::None> m_adapters {};
+    SpinlockProtected<Vector<NonnullRefPtr<NetworkAdapter>>, LockRank::None> m_adapters {};
     RefPtr<NetworkAdapter> m_loopback_adapter;
 };
 

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -16,8 +16,8 @@
 
 namespace Kernel {
 
-static Singleton<RecursiveSpinlockProtected<HashMap<IPv4Address, MACAddress>, LockRank::None>> s_arp_table;
-static Singleton<RecursiveSpinlockProtected<Route::RouteList, LockRank::None>> s_routing_table;
+static Singleton<SpinlockProtected<HashMap<IPv4Address, MACAddress>, LockRank::None>> s_arp_table;
+static Singleton<SpinlockProtected<Route::RouteList, LockRank::None>> s_routing_table;
 
 class ARPTableBlocker final : public Thread::Blocker {
 public:
@@ -106,7 +106,7 @@ void ARPTableBlocker::will_unblock_immediately_without_blocking(UnblockImmediate
     }
 }
 
-RecursiveSpinlockProtected<HashMap<IPv4Address, MACAddress>, LockRank::None>& arp_table()
+SpinlockProtected<HashMap<IPv4Address, MACAddress>, LockRank::None>& arp_table()
 {
     return *s_arp_table;
 }
@@ -130,7 +130,7 @@ void update_arp_table(IPv4Address const& ip_addr, MACAddress const& addr, Update
     }
 }
 
-RecursiveSpinlockProtected<Route::RouteList, LockRank::None>& routing_table()
+SpinlockProtected<Route::RouteList, LockRank::None>& routing_table()
 {
     return *s_routing_table;
 }

--- a/Kernel/Net/Routing.h
+++ b/Kernel/Net/Routing.h
@@ -72,7 +72,7 @@ enum class AllowBroadcast {
 
 RoutingDecision route_to(IPv4Address const& target, IPv4Address const& source, RefPtr<NetworkAdapter> const through = nullptr, AllowBroadcast = AllowBroadcast::No, AllowUsingGateway = AllowUsingGateway::Yes);
 
-RecursiveSpinlockProtected<HashMap<IPv4Address, MACAddress>, LockRank::None>& arp_table();
-RecursiveSpinlockProtected<Route::RouteList, LockRank::None>& routing_table();
+SpinlockProtected<HashMap<IPv4Address, MACAddress>, LockRank::None>& arp_table();
+SpinlockProtected<Route::RouteList, LockRank::None>& routing_table();
 
 }

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -90,7 +90,7 @@ public:
     ProcessID acceptor_pid() const { return m_acceptor.pid; }
     UserID acceptor_uid() const { return m_acceptor.uid; }
     GroupID acceptor_gid() const { return m_acceptor.gid; }
-    RecursiveSpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> const& bound_interface() const { return m_bound_interface; }
+    SpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> const& bound_interface() const { return m_bound_interface; }
 
     Mutex& mutex() { return m_mutex; }
 
@@ -123,7 +123,7 @@ protected:
 
     Role m_role { Role::None };
 
-    RecursiveSpinlockProtected<Optional<ErrnoCode>, LockRank::None>& so_error() { return m_so_error; }
+    SpinlockProtected<Optional<ErrnoCode>, LockRank::None>& so_error() { return m_so_error; }
 
     Error set_so_error(ErrnoCode error_code)
     {
@@ -172,13 +172,13 @@ private:
     bool m_shut_down_for_reading { false };
     bool m_shut_down_for_writing { false };
 
-    RecursiveSpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> m_bound_interface;
+    SpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> m_bound_interface;
 
     Duration m_receive_timeout {};
     Duration m_send_timeout {};
     int m_timestamp { 0 };
 
-    RecursiveSpinlockProtected<Optional<ErrnoCode>, LockRank::None> m_so_error;
+    SpinlockProtected<Optional<ErrnoCode>, LockRank::None> m_so_error;
 
     Vector<NonnullRefPtr<Socket>> m_pending;
 };

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -210,7 +210,7 @@ private:
     HashMap<IPv4SocketTuple, NonnullRefPtr<TCPSocket>> m_pending_release_for_accept;
     Direction m_direction { Direction::Unspecified };
     Error m_error { Error::None };
-    RecursiveSpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> m_adapter;
+    SpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> m_adapter;
     u32 m_sequence_number { 0 };
     u32 m_ack_number { 0 };
     State m_state { State::Closed };

--- a/Kernel/Syscalls/prctl.cpp
+++ b/Kernel/Syscalls/prctl.cpp
@@ -12,111 +12,113 @@ namespace Kernel {
 ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, FlatPtr arg2, FlatPtr arg3)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
-    return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        switch (option) {
-        case PR_GET_DUMPABLE:
+    switch (option) {
+    case PR_GET_DUMPABLE:
+        return with_protected_data([&](auto& protected_data) {
             return protected_data.dumpable;
-        case PR_SET_DUMPABLE:
-            if (arg1 != 0 && arg1 != 1)
-                return EINVAL;
+        });
+    case PR_SET_DUMPABLE:
+        if (arg1 != 0 && arg1 != 1)
+            return EINVAL;
+        with_mutable_protected_data([&](auto& protected_data) {
             protected_data.dumpable = arg1;
+        });
+        return 0;
+    case PR_GET_NO_NEW_SYSCALL_REGION_ANNOTATIONS:
+        return address_space().with([&](auto& space) -> ErrorOr<FlatPtr> {
+            return space->enforces_syscall_regions();
+        });
+    case PR_SET_NO_NEW_SYSCALL_REGION_ANNOTATIONS: {
+        if (arg1 != 0)
+            return EINVAL;
+        return address_space().with([&](auto& space) -> ErrorOr<FlatPtr> {
+            space->set_enforces_syscall_regions();
             return 0;
-        case PR_GET_NO_NEW_SYSCALL_REGION_ANNOTATIONS:
-            return address_space().with([&](auto& space) -> ErrorOr<FlatPtr> {
-                return space->enforces_syscall_regions();
-            });
-        case PR_SET_NO_NEW_SYSCALL_REGION_ANNOTATIONS: {
-            if (arg1 != 0)
-                return EINVAL;
-            return address_space().with([&](auto& space) -> ErrorOr<FlatPtr> {
-                space->set_enforces_syscall_regions();
-                return 0;
-            });
-            return 0;
-        }
-        case PR_SET_COREDUMP_METADATA_VALUE: {
-            auto params = TRY(copy_typed_from_user<Syscall::SC_set_coredump_metadata_params>(arg1));
-            if (params.key.length == 0 || params.key.length > 16 * KiB)
-                return EINVAL;
-            if (params.value.length > 16 * KiB)
-                return EINVAL;
-            auto key = TRY(try_copy_kstring_from_user(params.key));
-            auto value = TRY(try_copy_kstring_from_user(params.value));
-            TRY(set_coredump_property(move(key), move(value)));
-            return 0;
-        }
-        case PR_SET_PROCESS_NAME: {
-            TRY(require_promise(Pledge::proc));
-            Userspace<char const*> buffer = arg1;
-            size_t buffer_size = static_cast<size_t>(arg2);
-            Process::Name process_name {};
-            TRY(try_copy_name_from_user_into_fixed_string_buffer(buffer, process_name, buffer_size));
-            // NOTE: Reject empty and whitespace-only names, as they only confuse users.
-            if (process_name.representable_view().is_whitespace())
-                return EINVAL;
-            set_name(process_name.representable_view());
-            return 0;
-        }
-        case PR_GET_PROCESS_NAME: {
-            TRY(require_promise(Pledge::stdio));
-            Userspace<char*> buffer = arg1;
-            size_t buffer_size = static_cast<size_t>(arg2);
-            TRY(m_name.with([&buffer, buffer_size](auto& name) -> ErrorOr<void> {
-                VERIFY(!name.representable_view().is_null());
-                return copy_fixed_string_buffer_including_null_char_to_user(buffer, buffer_size, name);
-            }));
-            return 0;
-        }
-        case PR_SET_THREAD_NAME: {
-            TRY(require_promise(Pledge::stdio));
-            int thread_id = static_cast<int>(arg1);
-            Userspace<char const*> buffer = arg2;
-            size_t buffer_size = static_cast<size_t>(arg3);
+        });
+        return 0;
+    }
+    case PR_SET_COREDUMP_METADATA_VALUE: {
+        auto params = TRY(copy_typed_from_user<Syscall::SC_set_coredump_metadata_params>(arg1));
+        if (params.key.length == 0 || params.key.length > 16 * KiB)
+            return EINVAL;
+        if (params.value.length > 16 * KiB)
+            return EINVAL;
+        auto key = TRY(try_copy_kstring_from_user(params.key));
+        auto value = TRY(try_copy_kstring_from_user(params.value));
+        TRY(set_coredump_property(move(key), move(value)));
+        return 0;
+    }
+    case PR_SET_PROCESS_NAME: {
+        TRY(require_promise(Pledge::proc));
+        Userspace<char const*> buffer = arg1;
+        size_t buffer_size = static_cast<size_t>(arg2);
+        Process::Name process_name {};
+        TRY(try_copy_name_from_user_into_fixed_string_buffer(buffer, process_name, buffer_size));
+        // NOTE: Reject empty and whitespace-only names, as they only confuse users.
+        if (process_name.representable_view().is_whitespace())
+            return EINVAL;
+        set_name(process_name.representable_view());
+        return 0;
+    }
+    case PR_GET_PROCESS_NAME: {
+        TRY(require_promise(Pledge::stdio));
+        Userspace<char*> buffer = arg1;
+        size_t buffer_size = static_cast<size_t>(arg2);
+        TRY(m_name.with([&buffer, buffer_size](auto& name) -> ErrorOr<void> {
+            VERIFY(!name.representable_view().is_null());
+            return copy_fixed_string_buffer_including_null_char_to_user(buffer, buffer_size, name);
+        }));
+        return 0;
+    }
+    case PR_SET_THREAD_NAME: {
+        TRY(require_promise(Pledge::stdio));
+        int thread_id = static_cast<int>(arg1);
+        Userspace<char const*> buffer = arg2;
+        size_t buffer_size = static_cast<size_t>(arg3);
 
-            Thread::Name thread_name {};
-            TRY(try_copy_name_from_user_into_fixed_string_buffer(buffer, thread_name, buffer_size));
-            auto thread = TRY(get_thread_from_thread_list(thread_id));
-            thread->set_name(thread_name.representable_view());
-            return 0;
-        }
-        case PR_GET_THREAD_NAME: {
-            TRY(require_promise(Pledge::thread));
-            int thread_id = static_cast<int>(arg1);
-            Userspace<char*> buffer = arg2;
-            size_t buffer_size = static_cast<size_t>(arg3);
-            auto thread = TRY(get_thread_from_thread_list(thread_id));
+        Thread::Name thread_name {};
+        TRY(try_copy_name_from_user_into_fixed_string_buffer(buffer, thread_name, buffer_size));
+        auto thread = TRY(get_thread_from_thread_list(thread_id));
+        thread->set_name(thread_name.representable_view());
+        return 0;
+    }
+    case PR_GET_THREAD_NAME: {
+        TRY(require_promise(Pledge::thread));
+        int thread_id = static_cast<int>(arg1);
+        Userspace<char*> buffer = arg2;
+        size_t buffer_size = static_cast<size_t>(arg3);
+        auto thread = TRY(get_thread_from_thread_list(thread_id));
 
-            TRY(thread->name().with([&](auto& thread_name) -> ErrorOr<void> {
-                VERIFY(!thread_name.representable_view().is_null());
-                return copy_fixed_string_buffer_including_null_char_to_user(buffer, buffer_size, thread_name);
-            }));
-            return 0;
-        }
-        case PR_SET_NO_TRANSITION_TO_EXECUTABLE_FROM_WRITABLE_PROT: {
-            TRY(require_promise(Pledge::prot_exec));
-            with_mutable_protected_data([](auto& protected_data) {
-                return protected_data.reject_transition_to_executable_from_writable_prot.set();
-            });
-            return 0;
-        }
-        case PR_SET_JAILED_UNTIL_EXIT: {
-            TRY(require_promise(Pledge::proc));
-            with_mutable_protected_data([](auto& protected_values) {
-                protected_values.jailed_until_exit.set();
-            });
-            return 0;
-        }
-        case PR_SET_JAILED_UNTIL_EXEC: {
-            TRY(require_promise(Pledge::proc));
-            with_mutable_protected_data([](auto& protected_values) {
-                protected_values.jailed_until_exec = true;
-            });
-            return 0;
-        }
-        }
+        TRY(thread->name().with([&](auto& thread_name) -> ErrorOr<void> {
+            VERIFY(!thread_name.representable_view().is_null());
+            return copy_fixed_string_buffer_including_null_char_to_user(buffer, buffer_size, thread_name);
+        }));
+        return 0;
+    }
+    case PR_SET_NO_TRANSITION_TO_EXECUTABLE_FROM_WRITABLE_PROT: {
+        TRY(require_promise(Pledge::prot_exec));
+        with_mutable_protected_data([](auto& protected_data) {
+            return protected_data.reject_transition_to_executable_from_writable_prot.set();
+        });
+        return 0;
+    }
+    case PR_SET_JAILED_UNTIL_EXIT: {
+        TRY(require_promise(Pledge::proc));
+        with_mutable_protected_data([](auto& protected_values) {
+            protected_values.jailed_until_exit.set();
+        });
+        return 0;
+    }
+    case PR_SET_JAILED_UNTIL_EXEC: {
+        TRY(require_promise(Pledge::proc));
+        with_mutable_protected_data([](auto& protected_values) {
+            protected_values.jailed_until_exec = true;
+        });
+        return 0;
+    }
+    }
 
-        return EINVAL;
-    });
+    return EINVAL;
 }
 
 }

--- a/Kernel/Syscalls/setpgid.cpp
+++ b/Kernel/Syscalls/setpgid.cpp
@@ -128,18 +128,18 @@ ErrorOr<FlatPtr> Process::sys$setpgid(pid_t specified_pid, pid_t specified_pgid)
     }
     // FIXME: There are more EPERM conditions to check for here..
     auto process_group = TRY(ProcessGroup::find_or_create(new_pgid));
-    return process->with_mutable_protected_data([&process, &process_group, new_pgid](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = process->credentials();
+    return process->with_mutable_protected_data([&process_group, new_pgid](auto& protected_data) -> ErrorOr<FlatPtr> {
+        auto const& credentials = *protected_data.credentials;
 
         auto new_credentials = TRY(Credentials::create(
-            credentials->uid(),
-            credentials->gid(),
-            credentials->euid(),
-            credentials->egid(),
-            credentials->suid(),
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
+            credentials.uid(),
+            credentials.gid(),
+            credentials.euid(),
+            credentials.egid(),
+            credentials.suid(),
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
             new_pgid));
 
         protected_data.credentials = move(new_credentials);

--- a/Kernel/Syscalls/setuid.cpp
+++ b/Kernel/Syscalls/setuid.cpp
@@ -18,23 +18,23 @@ ErrorOr<FlatPtr> Process::sys$seteuid(UserID new_euid)
         return EINVAL;
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
-        if (new_euid != credentials->uid() && new_euid != credentials->suid() && !credentials->is_superuser())
+        if (new_euid != credentials.uid() && new_euid != credentials.suid() && !credentials.is_superuser())
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
-            credentials->uid(),
-            credentials->gid(),
+            credentials.uid(),
+            credentials.gid(),
             new_euid,
-            credentials->egid(),
-            credentials->suid(),
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.egid(),
+            credentials.suid(),
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->euid() != new_euid)
+        if (credentials.euid() != new_euid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -51,23 +51,23 @@ ErrorOr<FlatPtr> Process::sys$setegid(GroupID new_egid)
         return EINVAL;
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
-        if (new_egid != credentials->gid() && new_egid != credentials->sgid() && !credentials->is_superuser())
+        if (new_egid != credentials.gid() && new_egid != credentials.sgid() && !credentials.is_superuser())
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
-            credentials->uid(),
-            credentials->gid(),
-            credentials->euid(),
+            credentials.uid(),
+            credentials.gid(),
+            credentials.euid(),
             new_egid,
-            credentials->suid(),
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.suid(),
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->egid() != new_egid)
+        if (credentials.egid() != new_egid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -84,23 +84,23 @@ ErrorOr<FlatPtr> Process::sys$setuid(UserID new_uid)
         return EINVAL;
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
-        if (new_uid != credentials->uid() && new_uid != credentials->euid() && !credentials->is_superuser())
+        if (new_uid != credentials.uid() && new_uid != credentials.euid() && !credentials.is_superuser())
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
             new_uid,
-            credentials->gid(),
+            credentials.gid(),
             new_uid,
-            credentials->egid(),
+            credentials.egid(),
             new_uid,
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->euid() != new_uid)
+        if (credentials.euid() != new_uid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -117,23 +117,23 @@ ErrorOr<FlatPtr> Process::sys$setgid(GroupID new_gid)
         return EINVAL;
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
-        if (new_gid != credentials->gid() && new_gid != credentials->egid() && !credentials->is_superuser())
+        if (new_gid != credentials.gid() && new_gid != credentials.egid() && !credentials.is_superuser())
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
-            credentials->uid(),
+            credentials.uid(),
             new_gid,
-            credentials->euid(),
+            credentials.euid(),
             new_gid,
-            credentials->suid(),
+            credentials.suid(),
             new_gid,
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->egid() != new_gid)
+        if (credentials.egid() != new_gid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -147,14 +147,14 @@ ErrorOr<FlatPtr> Process::sys$setreuid(UserID new_ruid, UserID new_euid)
     TRY(require_promise(Pledge::id));
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
         if (new_ruid == (uid_t)-1)
-            new_ruid = credentials->uid();
+            new_ruid = credentials.uid();
         if (new_euid == (uid_t)-1)
-            new_euid = credentials->euid();
+            new_euid = credentials.euid();
 
-        auto ok = [&credentials](UserID id) { return id == credentials->uid() || id == credentials->euid() || id == credentials->suid(); };
+        auto ok = [&credentials](UserID id) { return id == credentials.uid() || id == credentials.euid() || id == credentials.suid(); };
         if (!ok(new_ruid) || !ok(new_euid))
             return EPERM;
 
@@ -163,16 +163,16 @@ ErrorOr<FlatPtr> Process::sys$setreuid(UserID new_ruid, UserID new_euid)
 
         auto new_credentials = TRY(Credentials::create(
             new_ruid,
-            credentials->gid(),
+            credentials.gid(),
             new_euid,
-            credentials->egid(),
-            credentials->suid(),
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.egid(),
+            credentials.suid(),
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->euid() != new_euid)
+        if (credentials.euid() != new_euid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -186,31 +186,31 @@ ErrorOr<FlatPtr> Process::sys$setresuid(UserID new_ruid, UserID new_euid, UserID
     TRY(require_promise(Pledge::id));
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
         if (new_ruid == (uid_t)-1)
-            new_ruid = credentials->uid();
+            new_ruid = credentials.uid();
         if (new_euid == (uid_t)-1)
-            new_euid = credentials->euid();
+            new_euid = credentials.euid();
         if (new_suid == (uid_t)-1)
-            new_suid = credentials->suid();
+            new_suid = credentials.suid();
 
-        auto ok = [&credentials](UserID id) { return id == credentials->uid() || id == credentials->euid() || id == credentials->suid(); };
-        if ((!ok(new_ruid) || !ok(new_euid) || !ok(new_suid)) && !credentials->is_superuser())
+        auto ok = [&credentials](UserID id) { return id == credentials.uid() || id == credentials.euid() || id == credentials.suid(); };
+        if ((!ok(new_ruid) || !ok(new_euid) || !ok(new_suid)) && !credentials.is_superuser())
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
             new_ruid,
-            credentials->gid(),
+            credentials.gid(),
             new_euid,
-            credentials->egid(),
+            credentials.egid(),
             new_suid,
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->euid() != new_euid)
+        if (credentials.euid() != new_euid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -224,29 +224,29 @@ ErrorOr<FlatPtr> Process::sys$setregid(GroupID new_rgid, GroupID new_egid)
     TRY(require_promise(Pledge::id));
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
         if (new_rgid == (gid_t)-1)
-            new_rgid = credentials->gid();
+            new_rgid = credentials.gid();
         if (new_egid == (gid_t)-1)
-            new_egid = credentials->egid();
+            new_egid = credentials.egid();
 
-        auto ok = [&credentials](GroupID id) { return id == credentials->gid() || id == credentials->egid() || id == credentials->sgid(); };
+        auto ok = [&credentials](GroupID id) { return id == credentials.gid() || id == credentials.egid() || id == credentials.sgid(); };
         if (!ok(new_rgid) || !ok(new_egid))
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
-            credentials->uid(),
+            credentials.uid(),
             new_rgid,
-            credentials->euid(),
+            credentials.euid(),
             new_egid,
-            credentials->suid(),
-            credentials->sgid(),
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.suid(),
+            credentials.sgid(),
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->egid() != new_egid)
+        if (credentials.egid() != new_egid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -260,31 +260,31 @@ ErrorOr<FlatPtr> Process::sys$setresgid(GroupID new_rgid, GroupID new_egid, Grou
     TRY(require_promise(Pledge::id));
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
         if (new_rgid == (gid_t)-1)
-            new_rgid = credentials->gid();
+            new_rgid = credentials.gid();
         if (new_egid == (gid_t)-1)
-            new_egid = credentials->egid();
+            new_egid = credentials.egid();
         if (new_sgid == (gid_t)-1)
-            new_sgid = credentials->sgid();
+            new_sgid = credentials.sgid();
 
-        auto ok = [&credentials](GroupID id) { return id == credentials->gid() || id == credentials->egid() || id == credentials->sgid(); };
-        if ((!ok(new_rgid) || !ok(new_egid) || !ok(new_sgid)) && !credentials->is_superuser())
+        auto ok = [&credentials](GroupID id) { return id == credentials.gid() || id == credentials.egid() || id == credentials.sgid(); };
+        if ((!ok(new_rgid) || !ok(new_egid) || !ok(new_sgid)) && !credentials.is_superuser())
             return EPERM;
 
         auto new_credentials = TRY(Credentials::create(
-            credentials->uid(),
+            credentials.uid(),
             new_rgid,
-            credentials->euid(),
+            credentials.euid(),
             new_egid,
-            credentials->suid(),
+            credentials.suid(),
             new_sgid,
-            credentials->extra_gids(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.extra_gids(),
+            credentials.sid(),
+            credentials.pgid()));
 
-        if (credentials->egid() != new_egid)
+        if (credentials.egid() != new_egid)
             protected_data.dumpable = false;
 
         protected_data.credentials = move(new_credentials);
@@ -301,22 +301,22 @@ ErrorOr<FlatPtr> Process::sys$setgroups(size_t count, Userspace<GroupID const*> 
         return EINVAL;
 
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
-        auto credentials = this->credentials();
+        auto const& credentials = *protected_data.credentials;
 
-        if (!credentials->is_superuser())
+        if (!credentials.is_superuser())
             return EPERM;
 
         if (!count) {
             protected_data.credentials = TRY(Credentials::create(
-                credentials->uid(),
-                credentials->gid(),
-                credentials->euid(),
-                credentials->egid(),
-                credentials->suid(),
-                credentials->sgid(),
+                credentials.uid(),
+                credentials.gid(),
+                credentials.euid(),
+                credentials.egid(),
+                credentials.suid(),
+                credentials.sgid(),
                 {},
-                credentials->sid(),
-                credentials->pgid()));
+                credentials.sid(),
+                credentials.pgid()));
             return 0;
         }
 
@@ -326,7 +326,7 @@ ErrorOr<FlatPtr> Process::sys$setgroups(size_t count, Userspace<GroupID const*> 
 
         HashTable<GroupID> unique_extra_gids;
         for (auto& extra_gid : new_extra_gids) {
-            if (extra_gid != credentials->gid())
+            if (extra_gid != credentials.gid())
                 TRY(unique_extra_gids.try_set(extra_gid));
         }
 
@@ -336,15 +336,15 @@ ErrorOr<FlatPtr> Process::sys$setgroups(size_t count, Userspace<GroupID const*> 
         }
 
         protected_data.credentials = TRY(Credentials::create(
-            credentials->uid(),
-            credentials->gid(),
-            credentials->euid(),
-            credentials->egid(),
-            credentials->suid(),
-            credentials->sgid(),
+            credentials.uid(),
+            credentials.gid(),
+            credentials.euid(),
+            credentials.egid(),
+            credentials.suid(),
+            credentials.sgid(),
             new_extra_gids.span(),
-            credentials->sid(),
-            credentials->pgid()));
+            credentials.sid(),
+            credentials.pgid()));
         return 0;
     });
 }


### PR DESCRIPTION
The Linux kernel doesn't have any recursive spinlocks at all (well, at least not kernel-wide, IDK about random subsystems), so we certainly don't *need* to have these either. Primarily, these just lead to rather sloppy code (just see all the refactoring in this PR, which could have been fairly easily avoided if we hadn't used these to begin with) and are very SMP-unfriendly (a crash [here](https://github.com/SerenityOS/serenity/blob/93add0a510fe656a56585c124a59efa45b347feb/Kernel/Locking/Spinlock.h#L92) is both commonplace and nigh-impossible to debug).

Historically, the proliferation of `RecursiveSpinlock`s has also been brought forward by the fact that `SpinlockProtected` (since its introduction in 019ad8a5, part of #8851) used a `RecursiveSpinlock` under the hood, which was only recently corrected (in a264a833), though this naturally left a ton of instances of `RecursiveSpinlockProtected` all over the place.

This PR is based off of a branch where I removed `RecursiveSpinlock` entirely, but that didn't really pan out for SMP systems either, because when you put a proper `Spinlock` on the scheduler, only a single thread can run at a time. In the long term, it might prove favorable to rework the scheduling in an xv6-style way, where each CPU has its own instance of the scheduler (at least that would make the locking less of a nightmare).

In conclusion, this PR shouldn't have much of an impact on the behavior of the system, but it should be a good step towards getting rid of `RecursiveSpinlock`s entirely. This probably fixes #22585 because nothing in `Kernel/FileSystem` uses `RecursiveSpinlock`s anymore, but otherwise this shouldn't affect the stability of SMP systems in one way or another.