### PR TITLE
PixelPaint: Allow panning with space

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -4,6 +4,7 @@
  * Copyright (c) 2021-2022, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2021, David Isaksson <davidisaksson93@gmail.com>
  * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
+ * Copyright (c) 2025, TheOnlyASDK <theonlyasdk@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -384,7 +385,6 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Middle) {
         start_panning(event.position());
-        set_override_cursor(Gfx::StandardCursor::Drag);
         return;
     }
 
@@ -497,6 +497,11 @@ void ImageEditor::keydown_event(GUI::KeyEvent& event)
         return;
     }
 
+    if (event.key() == Key_Space) {
+        start_panning(m_mouse_position);
+        return;
+    }
+
     event.ignore();
 }
 
@@ -507,6 +512,9 @@ void ImageEditor::keyup_event(GUI::KeyEvent& event)
 
     if (!m_active_tool->is_overriding_alt() && event.key() == Key_LeftAlt)
         update_tool_cursor();
+
+    if (event.key() == Key_Space)
+        stop_panning();
 
     m_active_tool->on_keyup(event);
 }

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2025, TheOnlyASDK <theonlyasdk@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,6 +54,12 @@ void AbstractZoomPanWidget::scale_centered(float new_scale, Gfx::IntPoint center
 
 void AbstractZoomPanWidget::start_panning(Gfx::IntPoint position)
 {
+    // FIXME: Keyboard events are repeated like in a text input field
+    // thus needing for the following check as start_panning might get
+    // called more than one time.
+    if (m_is_panning)
+        return;
+
     m_saved_cursor = override_cursor();
     set_override_cursor(Gfx::StandardCursor::Drag);
     m_pan_start = m_origin;


### PR DESCRIPTION
I've noticed some image editors allow you to pan with spacebar. So I thought why not bring it to PixelPaint.
This change allows you to drag the canvas by pressing space. It essentially is the same behaviour as dragging with the middle mouse button (this feature is still there).