### PR TITLE
LibGUI: Scroll to cycle tabs

### DIFF
--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
  * Copyright (c) 2022, Cameron Youell <cameronyouell@gmail.com>
+ * Copyright (c) 2025, TheOnlyASDK <theonlyasdk@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -551,6 +552,18 @@ void TabWidget::mousemove_event(MouseEvent& event)
     m_hovered_tab_index = hovered_tab;
     m_hovered_close_button_index = hovered_close_button;
     update_bar();
+}
+
+void TabWidget::mousewheel_event(MouseEvent& event)
+{
+    if (event.shift()) {
+        auto delta = event.wheel_delta_y();
+
+        if (delta < 0)
+            activate_previous_tab();
+        else if (delta > 0)
+            activate_next_tab();
+    }
 }
 
 void TabWidget::leave_event(Core::Event&)

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -111,6 +111,7 @@ protected:
     virtual void mousedown_event(MouseEvent&) override;
     virtual void mouseup_event(MouseEvent&) override;
     virtual void mousemove_event(MouseEvent&) override;
+    virtual void mousewheel_event(MouseEvent&) override;
     virtual void leave_event(Core::Event&) override;
     virtual void keydown_event(KeyEvent&) override;
     virtual void context_menu_event(ContextMenuEvent&) override;


### PR DESCRIPTION
When the user scrolls on a TabWidget, it will cycle through the tabs.

EDIT: Currently, it will cycle when the user tries to scroll anywhere inside the tabwidget. But it will not scroll if the child has a custom scroll handler. I don't find any functional issues but just a reminder.

Also, should it activate with `SHIFT` or `CTRL` to prevent accidental scrolls?