### PR TITLE
LibPDF: Implement draw_gouraud_triangle()

### DIFF
--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -8,11 +8,13 @@
 
 #include <AK/Array.h>
 #include <AK/GenericShorthands.h>
+#include <AK/IntegralMath.h>
 #include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -183,7 +183,7 @@ public:
 protected:
     friend GradientLine;
     friend AntiAliasingPainter;
-    template<unsigned SamplesPerPixel>
+    template<typename SubpixelSample>
     friend class EdgeFlagPathRasterizer;
 
     IntRect to_physical(IntRect const& r) const { return r.translated(translation()) * scale(); }

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -105,7 +105,7 @@ NonnullRefPtr<DeviceGrayColorSpace> DeviceGrayColorSpace::the()
 PDFErrorOr<ColorOrStyle> DeviceGrayColorSpace::style(ReadonlySpan<float> arguments) const
 {
     VERIFY(arguments.size() == 1);
-    auto gray = static_cast<u8>(arguments[0] * 255.0f);
+    auto gray = round_to<u8>(clamp(arguments[0] * 255.0f, 0.0f, 255.0f));
     return Color(gray, gray, gray);
 }
 
@@ -123,9 +123,9 @@ NonnullRefPtr<DeviceRGBColorSpace> DeviceRGBColorSpace::the()
 PDFErrorOr<ColorOrStyle> DeviceRGBColorSpace::style(ReadonlySpan<float> arguments) const
 {
     VERIFY(arguments.size() == 3);
-    auto r = static_cast<u8>(arguments[0] * 255.0f);
-    auto g = static_cast<u8>(arguments[1] * 255.0f);
-    auto b = static_cast<u8>(arguments[2] * 255.0f);
+    auto r = round_to<u8>(clamp(arguments[0] * 255.0f, 0.0f, 255.0f));
+    auto g = round_to<u8>(clamp(arguments[1] * 255.0f, 0.0f, 255.0f));
+    auto b = round_to<u8>(clamp(arguments[2] * 255.0f, 0.0f, 255.0f));
     return Color(r, g, b);
 }
 
@@ -160,10 +160,10 @@ PDFErrorOr<ColorOrStyle> DeviceCMYKColorSpace::style(ReadonlySpan<float> argumen
     VERIFY(arguments.size() == 4);
 
     u8 bytes[4];
-    bytes[0] = static_cast<u8>(arguments[0] * 255.0f);
-    bytes[1] = static_cast<u8>(arguments[1] * 255.0f);
-    bytes[2] = static_cast<u8>(arguments[2] * 255.0f);
-    bytes[3] = static_cast<u8>(arguments[3] * 255.0f);
+    bytes[0] = round_to<u8>(clamp(arguments[0] * 255.0f, 0.0f, 255.0f));
+    bytes[1] = round_to<u8>(clamp(arguments[1] * 255.0f, 0.0f, 255.0f));
+    bytes[2] = round_to<u8>(clamp(arguments[2] * 255.0f, 0.0f, 255.0f));
+    bytes[3] = round_to<u8>(clamp(arguments[3] * 255.0f, 0.0f, 255.0f));
     auto pcs = TRY(s_default_cmyk_profile->to_pcs(bytes));
 
     Array<u8, 3> output;
@@ -384,9 +384,9 @@ PDFErrorOr<ColorOrStyle> CalGrayColorSpace::style(ReadonlySpan<float> arguments)
     auto d65_normalized = convert_to_d65(scaled_black_point_xyz);
     auto srgb = convert_to_srgb(d65_normalized);
 
-    auto red = static_cast<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
-    auto green = static_cast<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
-    auto blue = static_cast<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
+    auto red = round_to<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
+    auto green = round_to<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
+    auto blue = round_to<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
 
     return Color(red, green, blue);
 }
@@ -474,9 +474,9 @@ PDFErrorOr<ColorOrStyle> CalRGBColorSpace::style(ReadonlySpan<float> arguments) 
     auto d65_normalized = convert_to_d65(scaled_black_point_xyz);
     auto srgb = convert_to_srgb(d65_normalized);
 
-    auto red = static_cast<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
-    auto green = static_cast<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
-    auto blue = static_cast<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
+    auto red = round_to<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
+    auto green = round_to<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
+    auto blue = round_to<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
 
     return Color(red, green, blue);
 }
@@ -539,7 +539,7 @@ PDFErrorOr<ColorOrStyle> ICCBasedColorSpace::style(ReadonlySpan<float> arguments
 
     m_bytes.resize(arguments.size());
     for (size_t i = 0; i < arguments.size(); ++i)
-        m_bytes[i] = static_cast<u8>(arguments[i] * 255.0f);
+        m_bytes[i] = static_cast<u8>(arguments[i] * 255.0f); // FIXME: Should probably round and clamp.
 
     auto pcs = TRY(m_profile->to_pcs(m_bytes));
     Array<u8, 3> output;
@@ -651,9 +651,9 @@ PDFErrorOr<ColorOrStyle> LabColorSpace::style(ReadonlySpan<float> arguments) con
     auto d65_normalized = convert_to_d65(scaled_black_point_xyz);
     auto srgb = convert_to_srgb(d65_normalized);
 
-    auto red = static_cast<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
-    auto green = static_cast<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
-    auto blue = static_cast<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
+    auto red = round_to<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
+    auto green = round_to<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
+    auto blue = round_to<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
 
     return Color(red, green, blue);
 }

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -51,8 +51,13 @@ struct CommonEntries {
 
 PDFErrorOr<CommonEntries> read_common_entries(Document* document, DictObject const& shading_dict, Renderer& renderer)
 {
+    // "(Required) The color space in which color values are expressed. This may be
+    //  any device, CIE-based, or special color space except a Pattern space. See
+    //  “Color Space: Special Considerations” on page 306 for further information."
     auto color_space_object = TRY(shading_dict.get_object(document, CommonNames::ColorSpace));
     auto color_space = TRY(ColorSpace::create(document, move(color_space_object), renderer));
+    if (color_space->family() == ColorSpaceFamily::Pattern)
+        return Error::malformed_error("Shading color space must not be pattern");
 
     CommonEntries common_entries { .color_space = color_space };
 


### PR DESCRIPTION
This lets us paint shading types 4 and 5.

A type 4 or type 5 shading consists of a bunch of triangles
that usually share edges. For rendering these well, we need
a "watertight" triangle renderer, meaning that if two triangles
that share an edge are painted, the shared edge is ideally painted
exactly once.

This means we can't just use `Painter::fill_path()`: That will
give each triangle nice anti-aliased edges, but the blending
mode it uses will result in visible seams at the triangle edges.

Options for getting this right:

1. Disable anti-aliasing. This results in jaggy outer triangle edges.
   (But shadings are usually used with a clip mask and the outer
   edges usually aren't visible, so that's probably fine.)

2. Use coverage-to-alpha antialiasing, but draw the shading to
   a temporary, all-0 bitmap, and use a "plus" blending operator
   where all (alpha-premultiplied) channels are added to the
   destination color. For pixels that are on the shared edge,
   pixels are painted twice, but their coverage will add up to
   100%. Pixels on the outer edge will have nice coverage-as-alpha.
   Blending this temporary bitmap will produce nice anti-aliased
   outer edges and solid inner edges. It costs an additional buffer
   and blend. (...but shadings are usually used with a clip mask,
   and once we implement that, we'll use a temporary buffer and
   a blend for the clip mask already, and we could probably
   combine the clip and the shading buffer and blend.)

For now, this goes with option (1). (That's also what 3D APIs
usually do.)

In addition to drawing watertight triangles, we also need to
be able to associate a color with each corner, interpolate
that color in an arbitrary PDF color space (per spec
"Color Space: Special Considerations", only required for
the CIE-based color spaces and optional for the others,
but might as well get it right), and optionally apply
a PDF function per pixel on the interpolated value.

As for how to implement the fill, we have four options:

1. Painter::fill_path() with a custom PaintStyle. The custom
   paint style computes barycentric coordinates per pixel
   and then interpolates colors based on that.
   + This approach could do the fancier antialias option (2) above
   + It handles arbitrary color spaces
   + It supports subpixels
   - It's likely fairly slow (it computes coverage data that
     we end up not using, etc)
   - We need to add a toggle to disable antialiasing
     (done in the previous commit)

2. LibGL. Gouraud triangles are a very "90s fixed function pipeline"
   3D API thing, so this seems fairly natural.
   + It'd be cool to use our OpenGL implementation!
   0 Supporting arbitrary functions would require converting the
     function to a 1D texture
   - It'd need shader support for arbitrary color space interpolation

3. Painter::draw_triangle() can draw triangles. We could teach it to
   associate a color with each corner.
   - Supporting arbitrary functions would be fairly ad-hoc
   - Doesn't do subpixels

4. A basic aliased triangle rasterizer with gouraud support doesn't
   need all that much code; we could have a custom rasterizer in
   Shading.cpp, based on the resources mentioned e.g. in
   https://github.com/aras-p/playdate-dither3d/blob/main/src/rasterizer_halfspace.h
   + Would be fun to write
   - Lacks synergy :P

This uses option 1 for now.