### PR TITLE
WindowServer+Taskbar: Add an optional global menu

### DIFF
--- a/Base/home/anon/.config/Taskbar.ini
+++ b/Base/home/anon/.config/Taskbar.ini
@@ -6,3 +6,6 @@ Browser=0:Browser.af
 FileManager=1:FileManager.af
 Terminal=2:Terminal.af
 TextEditor=3:TextEditor.af
+
+[GlobalMenu]
+Enabled=false

--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -8,6 +8,7 @@ stringify_gml(BackgroundSettings.gml BackgroundSettingsGML.h background_settings
 stringify_gml(DesktopSettings.gml DesktopSettingsGML.h desktop_settings_gml)
 stringify_gml(EffectsSettings.gml EffectsSettingsGML.h effects_settings_gml)
 stringify_gml(FontSettings.gml FontSettingsGML.h font_settings_gml)
+stringify_gml(InterfaceSettings.gml InterfaceSettingsGML.h interface_settings_gml)
 stringify_gml(MonitorSettings.gml MonitorSettingsGML.h monitor_settings_window_gml)
 stringify_gml(ThemesSettings.gml ThemesSettingsGML.h themes_settings_gml)
 
@@ -18,6 +19,7 @@ set(SOURCES
     FontSettingsWidget.cpp
     MonitorSettingsWidget.cpp
     MonitorWidget.cpp
+    InterfaceSettingsWidget.cpp
     ThemePreviewWidget.cpp
     ThemesSettingsWidget.cpp
     main.cpp
@@ -28,6 +30,7 @@ set(GENERATED_SOURCES
     DesktopSettingsGML.h
     EffectsSettingsGML.h
     FontSettingsGML.h
+    InterfaceSettingsGML.h
     MonitorSettingsGML.h
     ThemesSettingsGML.h
 )

--- a/Userland/Applications/DisplaySettings/InterfaceSettings.gml
+++ b/Userland/Applications/DisplaySettings/InterfaceSettings.gml
@@ -1,0 +1,33 @@
+@GUI::Widget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 8
+    }
+
+    @GUI::GroupBox {
+        preferred_height: "shrink"
+        title: "Global menu"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [8]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::Widget {
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [4, 0, 0, 0]
+                }
+
+                @GUI::CheckBox {
+                    name: "global_menu_checkbox"
+                    text: "Enable the global menu"
+                }
+            }
+        }
+    }
+}

--- a/Userland/Applications/DisplaySettings/InterfaceSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/InterfaceSettingsWidget.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "InterfaceSettingsWidget.h"
+#include <Applications/DisplaySettings/InterfaceSettingsGML.h>
+#include <LibConfig/Client.h>
+#include <LibGUI/CheckBox.h>
+
+namespace GUI {
+
+namespace DisplaySettings {
+
+InterfaceSettingsWidget::InterfaceSettingsWidget()
+{
+    load_from_gml(interface_settings_gml).release_value_but_fixme_should_propagate_errors();
+
+    m_global_menu = *find_descendant_of_type_named<GUI::CheckBox>("global_menu_checkbox");
+    load_settings();
+
+    m_global_menu->on_checked = [this](bool) {
+        set_modified(true);
+    };
+}
+
+void InterfaceSettingsWidget::load_settings()
+{
+    m_global_menu->set_checked(Config::read_bool("Taskbar"sv, "GlobalMenu"sv, "Enabled"sv, false));
+}
+
+void InterfaceSettingsWidget::apply_settings()
+{
+    Config::write_bool("Taskbar"sv, "GlobalMenu"sv, "Enabled"sv, m_global_menu->is_checked());
+}
+}
+
+}

--- a/Userland/Applications/DisplaySettings/InterfaceSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/InterfaceSettingsWidget.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/SettingsWindow.h>
+#include <LibGUI/SystemEffects.h>
+
+namespace GUI {
+
+namespace DisplaySettings {
+
+class InterfaceSettingsWidget final : public SettingsWindow::Tab {
+    C_OBJECT(InterfaceSettingsWidget);
+
+public:
+    virtual ~InterfaceSettingsWidget() override = default;
+
+    virtual void apply_settings() override;
+
+private:
+    InterfaceSettingsWidget();
+
+    void load_settings();
+    RefPtr<GUI::CheckBox> m_global_menu;
+};
+}
+
+}

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -10,6 +10,7 @@
 #include "DesktopSettingsWidget.h"
 #include "EffectsSettingsWidget.h"
 #include "FontSettingsWidget.h"
+#include "InterfaceSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
 #include "ThemesSettingsWidget.h"
 #include <LibConfig/Client.h>
@@ -25,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix proc exec"));
 
     auto app = TRY(GUI::Application::create(arguments));
-    Config::pledge_domain("WindowManager");
+    Config::pledge_domains({ "WindowManager", "Taskbar" });
 
     StringView selected_tab;
     Core::ArgsParser args_parser;
@@ -43,9 +44,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"_string, "monitor"sv));
     (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"_string, "workspaces"sv));
     (void)TRY(window->add_tab<GUI::DisplaySettings::EffectsSettingsWidget>("Effects"_string, "effects"sv));
+    (void)TRY(window->add_tab<GUI::DisplaySettings::InterfaceSettingsWidget>("Interface"_string, "interface"sv));
     window->set_active_tab(selected_tab);
 
     window->set_icon(app_icon.bitmap_for_size(16));
+    // FIXME: Support overflowing tabs
+    window->resize(440, 570);
 
     window->show();
     return app->exec();

--- a/Userland/Services/Taskbar/CMakeLists.txt
+++ b/Userland/Services/Taskbar/CMakeLists.txt
@@ -7,6 +7,7 @@ serenity_component(
 set(SOURCES
     main.cpp
     ClockWidget.cpp
+    GlobalMenuWindow.cpp
     QuickLaunchWidget.cpp
     ShutdownDialog.cpp
     TaskbarButton.cpp

--- a/Userland/Services/Taskbar/GlobalMenuWindow.cpp
+++ b/Userland/Services/Taskbar/GlobalMenuWindow.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GlobalMenuWindow.h"
+#include <AK/Debug.h>
+#include <AK/IterationDecision.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/ConnectionToWindowManagerServer.h>
+#include <LibGUI/ConnectionToWindowServer.h>
+#include <LibGUI/Desktop.h>
+#include <LibGUI/Frame.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Palette.h>
+#include <serenity.h>
+#include <stdio.h>
+
+class MenuWidget final : public GUI::Widget {
+    C_OBJECT(MenuWidget);
+
+public:
+    virtual ~MenuWidget() override = default;
+
+private:
+    MenuWidget() = default;
+
+    virtual void paint_event(GUI::PaintEvent&) override
+    {
+        GUI::Painter painter(*this);
+        painter.fill_rect({ 0, 0, width(), GlobalMenuWindow::global_menu_height() }, palette().button());
+        painter.draw_line({ 0, height() - 1 }, { width() - 1, height() - 1 }, palette().threed_highlight());
+    }
+};
+
+GlobalMenuWindow::GlobalMenuWindow()
+{
+    set_window_type(GUI::WindowType::GlobalMenu);
+    set_title("Global Menu");
+
+    auto const& rect = GUI::Desktop::the().rects()[GUI::Desktop::the().main_screen_index()];
+    set_rect({ rect.x(), rect.y(), rect.width(), global_menu_height() });
+
+    auto main_widget = set_main_widget<MenuWidget>();
+    main_widget->set_layout<GUI::HorizontalBoxLayout>();
+    main_widget->layout()->set_margins(GUI::Margins(0, 6, 1, 6));
+    main_widget->set_height(GlobalMenuWindow::global_menu_height());
+
+    m_global_menu_area_container = main_widget->add<GUI::Frame>();
+    m_global_menu_area_container->set_layout<GUI::VerticalBoxLayout>();
+    m_global_menu_area_container->set_frame_style(Gfx::FrameStyle::NoFrame);
+
+    m_enabled = Config::read_bool("Taskbar"sv, "GlobalMenu"sv, "Enabled"sv, false);
+    update_global_menu_enabled();
+}
+
+void GlobalMenuWindow::config_bool_did_change(StringView domain, StringView group, StringView key, bool value)
+{
+    if (domain == "Taskbar"sv && group == "GlobalMenu"sv) {
+        if (key == "Enabled"sv) {
+            m_enabled = value;
+        }
+
+        update_global_menu_enabled();
+        update_global_menu_area();
+    }
+}
+
+void GlobalMenuWindow::update_global_menu_enabled()
+{
+    if (m_enabled)
+        show();
+    else
+        hide();
+
+    GUI::ConnectionToWindowManagerServer::the().async_set_global_menu_area_enabled(m_enabled);
+}
+void GlobalMenuWindow::update_global_menu_area()
+{
+    if (!main_widget())
+        return;
+
+    m_global_menu_area_container->update();
+
+    auto rect = m_global_menu_area_container->window_relative_rect().centered_within(main_widget()->rect());
+    GUI::ConnectionToWindowManagerServer::the().async_set_global_menu_area_rect(rect.translated(-1, 0));
+}
+
+void GlobalMenuWindow::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
+{
+    auto const& rect = event.rects()[event.main_screen_index()];
+    set_rect({ rect.x(), rect.y(), rect.width(), global_menu_height() });
+    update_global_menu_area();
+}

--- a/Userland/Services/Taskbar/GlobalMenuWindow.h
+++ b/Userland/Services/Taskbar/GlobalMenuWindow.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibConfig/Client.h>
+#include <LibConfig/Listener.h>
+#include <LibGUI/Frame.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+
+class GlobalMenuWindow final : public GUI::Window
+    , public Config::Listener {
+    C_OBJECT(GlobalMenuWindow);
+
+public:
+    virtual ~GlobalMenuWindow() override = default;
+
+    static int global_menu_height() { return 26; }
+
+    virtual void config_bool_did_change(StringView, StringView, StringView, bool) override;
+
+private:
+    explicit GlobalMenuWindow();
+
+    void on_screen_rects_change(Vector<Gfx::IntRect, 4> const&, size_t);
+
+    void update_global_menu_area();
+    void update_global_menu_enabled();
+
+    virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
+
+    bool m_enabled { false };
+    Gfx::IntSize m_global_menu_area_size;
+    RefPtr<GUI::Frame> m_global_menu_area_container;
+};

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "GlobalMenuWindow.h"
 #include "ShutdownDialog.h"
 #include "TaskbarWindow.h"
 #include <AK/Debug.h>
@@ -58,19 +59,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));
 
-    auto window = TRY(TaskbarWindow::create());
+    auto taskbar = TRY(TaskbarWindow::create());
 
-    auto menu = TRY(build_system_menu(*window));
+    auto menu = TRY(build_system_menu(*taskbar));
     menu->realize_menu_if_needed();
-    window->add_system_menu(menu);
-
-    window->show();
-
-    window->make_window_manager(
+    taskbar->add_system_menu(menu);
+    taskbar->show();
+    taskbar->make_window_manager(
         WindowServer::WMEventMask::WindowStateChanges
         | WindowServer::WMEventMask::WindowRemovals
         | WindowServer::WMEventMask::WindowIconChanges
         | WindowServer::WMEventMask::WorkspaceChanges);
+
+    auto global_menu = TRY(GlobalMenuWindow::try_create());
 
     return app->exec();
 }

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     Compositor.cpp
     Cursor.cpp
     EventLoop.cpp
+    GlobalMenu.cpp
     main.cpp
     Menu.cpp
     Menubar.cpp

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -692,7 +692,8 @@ void ConnectionFromClient::create_window(i32 window_id, i32 process_id, Gfx::Int
             window->refresh_client_size();
     }
     if (window->type() == WindowType::Desktop) {
-        window->set_rect(Screen::bounding_rect());
+        // FIXME: Use the window's screen.
+        window->set_rect(WindowManager::the().desktop_rect(Screen::main()));
         window->recalculate_rect();
     }
     window->set_alpha_hit_threshold(alpha_hit_threshold);

--- a/Userland/Services/WindowServer/GlobalMenu.cpp
+++ b/Userland/Services/WindowServer/GlobalMenu.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Badge.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/StylePainter.h>
+#include <Services/Taskbar/GlobalMenuWindow.h>
+#include <WindowServer/Compositor.h>
+#include <WindowServer/ConnectionFromClient.h>
+#include <WindowServer/GlobalMenu.h>
+#include <WindowServer/Screen.h>
+#include <WindowServer/WindowManager.h>
+
+namespace WindowServer {
+
+static GlobalMenu* s_the;
+
+GlobalMenu::GlobalMenu()
+{
+    s_the = this;
+    m_ladyball = Gfx::Bitmap::load_from_file("/res/icons/16x16/ladyball.png"sv).release_value_but_fixme_should_propagate_errors();
+}
+
+GlobalMenu::~GlobalMenu()
+{
+}
+
+GlobalMenu& GlobalMenu::the()
+{
+    VERIFY(s_the);
+    return *s_the;
+}
+
+void GlobalMenu::set_enabled(bool enabled)
+{
+    if (enabled == m_enabled)
+        return;
+
+    if (enabled) {
+        m_enabled = true;
+
+        m_window = Window::construct(*this, WindowType::GlobalMenu);
+        m_window->set_title("GlobalMenu");
+        m_window->set_has_alpha_channel(true);
+        m_active_window = nullptr;
+        m_dirty = true;
+        return;
+    }
+
+    m_enabled = false;
+    if (m_window)
+        m_window->destroy();
+
+    m_window = nullptr;
+    m_active_window = nullptr;
+    m_painter = nullptr;
+}
+
+void GlobalMenu::set_rect(Gfx::IntRect const& rect)
+{
+    if (!m_enabled)
+        return;
+
+    m_window->set_rect(rect);
+    m_dirty = true;
+    m_active_window = nullptr;
+    m_painter = nullptr;
+
+    handle_active_window_changed();
+}
+
+void GlobalMenu::invalidate()
+{
+    invalidate(rect());
+}
+
+void GlobalMenu::invalidate(Gfx::IntRect rect)
+{
+    m_window->invalidate(rect, true);
+    m_dirty = true;
+    paint();
+}
+
+int GlobalMenu::paint_title(bool paint)
+{
+    auto text = !m_active_window ? "SerenityOS" : m_active_window->title();
+    auto& icon = !m_active_window ? *m_ladyball : m_active_window->icon();
+
+    auto& wm = WindowManager::the();
+    auto& font = wm.font().bold_variant();
+    auto palette = wm.palette();
+
+    auto icon_rect = icon.rect();
+    icon_rect.center_vertically_within(rect());
+    icon_rect.set_x(rect().x());
+    icon_rect.set_y(icon_rect.y());
+
+    if (paint)
+        m_painter->blit(icon_rect.location(), icon, icon.rect(), 1.0f);
+    auto icon_width = icon_rect.x() + icon_rect.width() + 8;
+
+    Gfx::IntRect text_rect = { icon_width, 0, static_cast<int>(font.width(text)) + 2, m_window->height() };
+    if (paint)
+        m_painter->draw_ui_text(text_rect, text, font, Gfx::TextAlignment::CenterLeft, palette.window_text());
+
+    int component_width = icon_width + text_rect.width();
+    return component_width;
+}
+
+void GlobalMenu::event(Core::Event& event)
+{
+    if (!m_enabled || !m_window || !m_painter)
+        return;
+
+    switch (event.type()) {
+    case Event::MouseMove:
+    case Event::MouseDown:
+    case Event::MouseUp:
+        handle_mouse_event(static_cast<MouseEvent const&>(event));
+        break;
+    case Event::WindowEntered:
+        m_dirty = true;
+        m_hovering = true;
+        break;
+    case Event::WindowLeft:
+        m_dirty = true;
+        m_hovering = false;
+        invalidate();
+        break;
+    default:
+        break;
+    }
+
+    paint();
+}
+
+void GlobalMenu::handle_mouse_event(MouseEvent const& event)
+{
+    if (!m_active_window)
+        return;
+
+    auto active_menu = m_active_window->menubar();
+    if (!active_menu.has_menus())
+        return;
+
+    Menu* hovered_menu = nullptr;
+    active_menu.for_each_menu([&](Menu& menu) {
+        if (menu.rect_in_window_menubar().contains(event.position())) {
+            hovered_menu = &menu;
+            handle_menu_mouse_event(&menu, event);
+            return IterationDecision::Break;
+        } else if (MenuManager::the().hovered_menu() == &menu && event.type() == Event::Type::MouseDown) {
+            // Make sure we only close menus from the menubar
+            if (menu.menu_window() && menu.menu_window()->rect().contains(event.position()))
+                return IterationDecision::Break;
+
+            MenuManager::the().close_everyone();
+            MenuManager::the().set_hovered_menu(nullptr);
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    if (hovered_menu && hovered_menu != MenuManager::the().hovered_menu()) {
+        MenuManager::the().set_hovered_menu(hovered_menu);
+        invalidate();
+    }
+}
+
+bool GlobalMenu::has_active_menu()
+{
+    return m_active_window && m_active_window == WindowManager::the().window_with_active_menu();
+}
+
+void GlobalMenu::handle_menu_mouse_event(Menu* menu, MouseEvent const& event)
+{
+    bool is_hover_with_any_menu_open = m_active_window == WindowManager::the().window_with_active_menu();
+    bool is_mousedown_with_left_button = event.type() == MouseEvent::MouseDown && event.button() == MouseButton::Primary;
+    bool should_open_menu = menu != MenuManager::the().current_menu() && (is_hover_with_any_menu_open || is_mousedown_with_left_button);
+    bool should_close_menu = menu == MenuManager::the().current_menu() && is_mousedown_with_left_button;
+
+    if (should_close_menu) {
+        invalidate();
+        MenuManager::the().close_everyone();
+        return;
+    }
+
+    if (should_open_menu) {
+        open_menubar_menu(menu);
+    }
+}
+
+void GlobalMenu::open_menubar_menu(Menu* menu)
+{
+    MenuManager::the().close_everyone();
+    auto position = menu->rect_in_window_menubar().bottom_left().translated(rect().location());
+    menu->set_unadjusted_position(position);
+    auto& window = menu->ensure_menu_window(position);
+    auto window_rect = window.rect();
+
+    window.set_rect(position.x() + 1, GlobalMenuWindow::global_menu_height(), window_rect.width(), window_rect.height());
+
+    MenuManager::the().open_menu(*menu);
+    WindowManager::the().set_window_with_active_menu(m_active_window);
+    invalidate();
+}
+
+void GlobalMenu::paint()
+{
+    if (!m_enabled || !m_window || rect().is_empty() || !m_dirty)
+        return;
+    if (!m_painter)
+        m_painter = make<Gfx::Painter>(*m_window->backing_store());
+
+    m_dirty = false;
+    m_painter->clear_rect(rect(), Gfx::Color::Transparent);
+
+    paint_title();
+    if (!m_active_window)
+        return;
+
+    auto active_menu = m_active_window->menubar();
+    if (!active_menu.has_menus())
+        return;
+
+    auto& wm = WindowManager::the();
+    auto& font = wm.font();
+    auto palette = wm.palette();
+
+    active_menu.for_each_menu([&](Menu& menu) {
+        auto rect = menu.rect_in_window_menubar();
+
+        auto is_open = menu.is_open();
+        Color text_color = (is_open ? palette.menu_selection_text() : palette.window_text());
+
+        bool paint_as_pressed = is_open;
+        if ((paint_as_pressed)) {
+            m_painter->fill_rect(rect, palette.menu_selection());
+        }
+
+        bool paint_as_hovered = !paint_as_pressed && m_hovering && &menu == MenuManager::the().hovered_menu();
+        if ((paint_as_hovered)) {
+            m_painter->fill_rect(rect, palette.hover_highlight());
+        }
+
+        m_painter->draw_ui_text(rect, menu.name(), is_open ? font.bold_variant() : font, Gfx::TextAlignment::Center, text_color);
+        return IterationDecision::Continue;
+    });
+}
+
+void GlobalMenu::handle_active_window_changed()
+{
+    if (!m_enabled || !m_window)
+        return;
+
+    auto newly_active_window = WindowManager::the().active_window();
+    if (!newly_active_window || newly_active_window->title().is_empty()) {
+        m_active_window = nullptr;
+    } else {
+        if (newly_active_window->type() != WindowType::Normal) {
+            m_active_window = nullptr;
+        } else {
+            m_active_window = newly_active_window;
+            auto active_menu = m_active_window->menubar();
+
+            // Trick the menubar into a relayout.
+            active_menu.font_changed(m_active_window->rect());
+
+            // FIXME: Only run this when needed (like on a new window or when the menu has changed).
+            if (active_menu.has_menus()) {
+                active_menu.for_each_menu([&](Menu& menu) {
+                    auto menu_rect = menu.rect_in_window_menubar().translated(paint_title(false), 0);
+                    menu_rect.center_vertically_within(rect());
+                    menu.set_rect_in_window_menubar({ { rect().left() + menu_rect.left(), rect().y() }, { menu_rect.width(), rect().height() + 1 } });
+                    return IterationDecision::Continue;
+                });
+            }
+        }
+    }
+
+    invalidate();
+}
+
+void GlobalMenu::handle_active_window_closed()
+{
+    if (!m_enabled)
+        return;
+
+    m_active_window = nullptr;
+    handle_active_window_changed();
+}
+}

--- a/Userland/Services/WindowServer/GlobalMenu.h
+++ b/Userland/Services/WindowServer/GlobalMenu.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Menu.h"
+#include "Menubar.h"
+#include "Window.h"
+#include <AK/HashMap.h>
+#include <AK/StringBuilder.h>
+#include <LibGfx/Painter.h>
+
+namespace WindowServer {
+
+class GlobalMenu final : public Core::EventReceiver {
+    C_OBJECT(GlobalMenu);
+
+public:
+    ~GlobalMenu();
+
+    static GlobalMenu& the();
+
+    void set_enabled(bool enabled);
+    bool enabled() const { return m_enabled; }
+
+    void set_rect(Gfx::IntRect const&);
+    Gfx::IntRect rect()
+    {
+        return m_window ? m_window->rect() : Gfx::IntRect(0, 0, 0, 0);
+    }
+
+    Window* window() { return m_window; }
+    Window const* window() const { return m_window; }
+
+    void handle_active_window_changed();
+    void handle_active_window_closed();
+
+    bool has_active_menu();
+    void open_menubar_menu(Menu* menu);
+
+    void invalidate();
+
+protected:
+    virtual void event(Core::Event&) override;
+
+private:
+    GlobalMenu();
+
+    void invalidate(Gfx::IntRect rect);
+
+    int paint_title(bool paint = true);
+
+    void handle_mouse_event(MouseEvent const& event);
+    void handle_menu_mouse_event(Menu* menu, MouseEvent const& event);
+
+    void paint();
+
+    RefPtr<Window> m_window { nullptr };
+    WeakPtr<Window> m_active_window;
+    OwnPtr<Gfx::Painter> m_painter;
+
+    RefPtr<Gfx::Bitmap> m_ladyball;
+
+    bool m_enabled { false };
+    bool m_hovering { false };
+    bool m_dirty { true };
+};
+}

--- a/Userland/Services/WindowServer/WMConnectionFromClient.h
+++ b/Userland/Services/WindowServer/WMConnectionFromClient.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,6 +29,8 @@ public:
     virtual void popup_window_menu(i32, i32, Gfx::IntPoint) override;
     virtual void set_window_taskbar_rect(i32, i32, Gfx::IntRect const&) override;
     virtual void set_applet_area_position(Gfx::IntPoint) override;
+    virtual void set_global_menu_area_enabled(bool) override;
+    virtual void set_global_menu_area_rect(Gfx::IntRect const&) override;
     virtual void set_event_mask(u32) override;
     virtual void set_manager_window(i32) override;
     virtual void set_workspace(u32, u32) override;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -315,7 +315,7 @@ public:
     void set_frameless(bool);
     bool is_frameless() const { return m_frameless; }
 
-    bool should_show_menubar() const { return m_should_show_menubar; }
+    bool should_show_menubar() const;
 
     Optional<int> progress() const { return m_progress; }
     void set_progress(Optional<int>);

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -233,6 +233,8 @@ MultiScaleBitmaps const* WindowFrame::shadow_bitmap() const
         if (!m_window.has_forced_shadow())
             return nullptr;
         return s_active_window_shadow;
+    case WindowType::GlobalMenu:
+        return nullptr;
     default:
         if (!WindowManager::the().system_effects().window_shadow())
             return nullptr;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -535,6 +535,8 @@ inline IterationDecision WindowManager::for_each_visible_window_from_back_to_fro
         return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::Menu>() == IterationDecision::Break)
         return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::GlobalMenu>() == IterationDecision::Break)
+        return IterationDecision::Break;
     return for_each_window.template operator()<WindowType::WindowSwitcher>();
 }
 
@@ -573,6 +575,8 @@ inline IterationDecision WindowManager::for_each_visible_window_from_front_to_ba
     if (for_each_window.template operator()<WindowType::Taskbar>() == IterationDecision::Break)
         return IterationDecision::Break;
     if (for_each_window.template operator()<WindowType::Normal>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::GlobalMenu>() == IterationDecision::Break)
         return IterationDecision::Break;
     return for_each_window.template operator()<WindowType::Desktop>();
 }

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -79,6 +79,7 @@ public:
     void notify_occlusion_state_changed(Window&);
     void notify_progress_changed(Window&);
     void notify_modified_changed(Window&);
+    void notify_menubar_changed(Window&);
 
     Gfx::IntRect tiled_window_rect(Window const&, Optional<Screen const&> = {}, WindowTileType tile_type = WindowTileType::Maximized) const;
 

--- a/Userland/Services/WindowServer/WindowManagerServer.ipc
+++ b/Userland/Services/WindowServer/WindowManagerServer.ipc
@@ -12,6 +12,8 @@ endpoint WindowManagerServer
     popup_window_menu(i32 client_id, i32 window_id, Gfx::IntPoint screen_position) =|
     set_window_taskbar_rect(i32 client_id, i32 window_id, Gfx::IntRect rect) =|
     set_applet_area_position(Gfx::IntPoint position) =|
+    set_global_menu_area_enabled(bool enabled) =|
+    set_global_menu_area_rect(Gfx::IntRect rect) =|
     set_workspace(u32 row, u32 column) =|
     set_keymap([UTF8] ByteString keymap) =|
 }

--- a/Userland/Services/WindowServer/WindowType.h
+++ b/Userland/Services/WindowServer/WindowType.h
@@ -21,6 +21,7 @@ enum class WindowType {
     AppletArea,
     Popup,
     Autocomplete,
+    GlobalMenu,
     _Count
 };
 

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -7,6 +7,7 @@
 #include "AppletManager.h"
 #include "Compositor.h"
 #include "EventLoop.h"
+#include "GlobalMenu.h"
 #include "Screen.h"
 #include "WindowManager.h"
 #include <LibCore/ConfigFile.h>
@@ -148,6 +149,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     WindowServer::Compositor::the();
     auto wm = WindowServer::WindowManager::construct(*palette);
     auto am = WindowServer::AppletManager::construct();
+    auto gm = WindowServer::GlobalMenu::construct();
     auto mm = WindowServer::MenuManager::construct();
 
     TRY(Core::System::unveil("/tmp", ""));


### PR DESCRIPTION
Revival of #16757.

![screenshot](https://github.com/user-attachments/assets/30186c16-ff9c-4919-b1e2-5b18856360ff)

I know this was originally rejected, but given the arguably expanded scope of visual customization in #25537, I feel like it might be a good time to revisit this, but I don't mind at all if this doesn't get merged :^)

This is not just a rebase of the original PR, as I've fixed a few bugs in the original implementation, and somewhat modified the event handling approach in the process.