### PR TITLE
Kernel/FATFS: Don't confuse the root directory with clusterless entries

### DIFF
--- a/Kernel/FileSystem/FATFS/Inode.cpp
+++ b/Kernel/FileSystem/FATFS/Inode.cpp
@@ -710,7 +710,7 @@ ErrorOr<NonnullRefPtr<Inode>> FATInode::create_child(StringView name, mode_t mod
 
         // NOTE: While setting the first cluster of the ".." entry to that of the current entry
         // is _usually_ the right thing to do, we're actually supposed to set it to 0 if we are
-        // dealing with the root directory. This isn't an issues when dealing with FAT12 or FAT16,
+        // dealing with the root directory. This isn't an issue when dealing with FAT12 or FAT16,
         // since the root directory's first cluster is always 0, but it's something to account for
         // when working with FAT32.
         switch (fs().m_fat_version) {

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -64,7 +64,7 @@ private:
     static ErrorOr<void> fill_in_creation_time(FATEntry&, UnixDateTime const&);
 
     ErrorOr<RawPtr<Vector<u32>>> get_cluster_list();
-    ErrorOr<Vector<u32>> compute_cluster_list(FATFS&, u32 first_cluster);
+    ErrorOr<Vector<u32>> compute_cluster_list();
     ErrorOr<Vector<BlockBasedFileSystem::BlockIndex>> get_block_list();
     ErrorOr<NonnullOwnPtr<KBuffer>> read_block_list();
     ErrorOr<RefPtr<FATInode>> traverse(Function<ErrorOr<bool>(RefPtr<FATInode>)> callback);


### PR DESCRIPTION
This makes it possible to work with FAT12/16 filesystems again after the regression in 7fa12df7. The last commit is the actual fix here, while the others (save for the typo fix) are just groundwork.