### PR TITLE
LibPDF: Be stricter about flex size in type 1 fonts

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -493,7 +493,7 @@ ErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes con
                         state.postscript_stack[state.postscript_sp++] = x;
 
                         if (state.flex_index != 14)
-                            break;
+                            return AK::Error::from_string_literal("Unexpected stack size for othersubr 0");
 
                         auto& flex = state.flex_sequence;
 


### PR DESCRIPTION
This should never fail in practice, so hopefully no behavior change.