### PR TITLE
LibPDF: Implement {Coons,TensorProduct}PatchShading::draw()

### DIFF
--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -270,24 +270,6 @@ private:
 using IntPoint = Point<int>;
 using FloatPoint = Point<float>;
 
-template<typename T>
-inline Point<T> linear_interpolate(Point<T> const& p1, Point<T> const& p2, float t)
-{
-    return Point<T> { p1.x() + t * (p2.x() - p1.x()), p1.y() + t * (p2.y() - p1.y()) };
-}
-
-template<typename T>
-inline Point<T> quadratic_interpolate(Point<T> const& p1, Point<T> const& p2, Point<T> const& c1, float t)
-{
-    return linear_interpolate(linear_interpolate(p1, c1, t), linear_interpolate(c1, p2, t), t);
-}
-
-template<typename T>
-inline Point<T> cubic_interpolate(Point<T> const& p1, Point<T> const& p2, Point<T> const& c1, Point<T> const& c2, float t)
-{
-    return linear_interpolate(quadratic_interpolate(p1, c1, c2, t), quadratic_interpolate(c1, c2, p2, t), t);
-}
-
 }
 
 namespace AK {

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -267,6 +267,10 @@ private:
     T m_x { 0 };
     T m_y { 0 };
 };
+
+template<typename T>
+[[nodiscard]] Point<T> operator*(T factor, Point<T> const& p) { return { factor * p.x(), factor * p.y() }; }
+
 using IntPoint = Point<int>;
 using FloatPoint = Point<float>;
 

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -535,11 +535,11 @@ PDFErrorOr<ColorOrStyle> ICCBasedColorSpace::style(ReadonlySpan<float> arguments
     }
 
     if (m_map.has_value())
-        return m_map->map(FloatVector3 { arguments[0], arguments[1], arguments[2] });
+        return m_map->map(FloatVector3 { clamp(arguments[0], 0.0f, 1.0f), clamp(arguments[1], 0.0f, 1.0f), clamp(arguments[2], 0.0f, 1.0f) });
 
     m_bytes.resize(arguments.size());
     for (size_t i = 0; i < arguments.size(); ++i)
-        m_bytes[i] = static_cast<u8>(arguments[i] * 255.0f); // FIXME: Should probably round and clamp.
+        m_bytes[i] = round_to<u8>(clamp(arguments[i] * 255.0f, 0.0f, 255.0f));
 
     auto pcs = TRY(m_profile->to_pcs(m_bytes));
     Array<u8, 3> output;


### PR DESCRIPTION
Coons patches are drawn as special cases of tensor product patches.

With this, we support all shadings that can be passed to `sh` :^)

This is a pretty simple implementation for now: It just subdivides
patches 5 levels deep, then draws them as gouraud triangles.

In a follow-up, we should change the subdivision depth to be
adaptive based on curvature. The main thing to figure out is to
prevent T-junctions, probably by inserting additional triangles
along edges with T-junctions.

In another follow-up, we should probably also use a better technique
for drawing gouraud quads instead of using two gouraud triangles.

Also, this awkwardly writes out all the bezier terms for subdivision.
In yet another follow-up, we probably want to use ✨ loops ✨ or
separable De Casteljau.

Despite all these limitations, this implementation is more spec
compliant when rendering these patches than all other PDF engines
I've tried:

* it gets the boundaries of tensor product patches right even for
  weird shapes (pdf.js gets this mostly right, but Preview.app and
  PDFium currently don't)

* it evaluates functions over the patch per-pixel (only Acrobat Reader
  does this; pdf.js, and PDFium don't, and Preview.app can't render
  patches using functions at all),

* it interpolates in the patch's color space (Preview.app does this,
  and Acrobat Reader on mobile (but not on desktop) does this, the
  rest don't) -- even for more exotic color spaces like Lab
  (Preview.app gets very confused by Lab colors on patches)

* it takes the inner 2x2 control points of a tensor product patch
  into account (Preview.app doesn't do this, and PDFium only does
  this as of very recently. Firefox and Acrobat Reader get this right.)

* (it gets patch continuation flag 3 right, which Preview.app gets
  confused by. The rest gets this right, too.)