### PR TITLE
Toolchain: Add an e2fsprogs build script

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -3,6 +3,10 @@ set -e
 
 SCRIPT_DIR="$(dirname "${0}")"
 
+# Prepend the QEMU and e2fsprogs toolchain directories so we pick up their tools from there
+PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
+PATH="$SCRIPT_DIR/../Toolchain/Local/e2fsprogs/bin:$PATH"
+
 # shellcheck source=/dev/null
 . "${SCRIPT_DIR}/shell_include.sh"
 
@@ -29,9 +33,6 @@ if [ "$(id -u)" != 0 ]; then
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi
-
-# Prepend the toolchain qemu directory so we pick up QEMU from there
-PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
 
 INODE_SIZE=256
 INODE_COUNT=$(($(inode_usage "$SERENITY_SOURCE_DIR/Base") + $(inode_usage Root)))

--- a/Toolchain/BuildE2FSProgs.sh
+++ b/Toolchain/BuildE2FSProgs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eu
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildE2FSProgs.sh as root, parts of your Toolchain directory will become root-owned"
+
+NPROC=$(get_number_of_processing_units)
+[ -z "${MAKEJOBS-}" ] && MAKEJOBS=${NPROC}
+
+# Once b022aca269a5552395393989a4be530cbf7b5e70 is in a released version, use a tarball from https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/.
+GIT_REPO=https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git
+GIT_REV=241dae1b68aabe121974d095c150e7d2f9f33ade
+
+SOURCE_DIR="$DIR/Tarballs/e2fsprogs"
+BUILD_DIR="$DIR"/Build/e2fsprogs
+PREFIX="$DIR/Local/e2fsprogs"
+
+mkdir -p "$DIR"/Tarballs
+pushd "$DIR"/Tarballs
+    [ ! -d e2fsprogs ] && git clone $GIT_REPO
+
+    cd e2fsprogs
+    git fetch origin
+    git checkout $GIT_REV
+popd
+
+mkdir -p "$PREFIX"
+mkdir -p "$BUILD_DIR"
+
+pushd "$BUILD_DIR"
+    "$SOURCE_DIR"/configure --prefix="$PREFIX" --with-udev-rules-dir=no --with-crond-dir=no --with-systemd-unit-dir=no --sbindir="$PREFIX"/bin
+    make -j "$MAKEJOBS"
+    make install
+popd


### PR DESCRIPTION
`O_TRUNC` doesn't work properly in the latest fuse2fs release, causing the sync-local.sh example from AdvancedBuildInstructions.md to not work properly.

Therefore, add a build script that builds a newer git revision including a fix for this bug.

This will unblock #25803.