### PR TITLE
LibPDF: Share function reading code across shading functions

### DIFF
--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -1255,15 +1255,13 @@ public:
     virtual PDFErrorOr<void> draw(Gfx::Painter&, Gfx::AffineTransform const&) override;
 
 private:
-    using FunctionsType = Variant<Empty, NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
-
     // Indexes into m_patch_data.
     struct CoonsPatch {
         u32 control_points[12];
         u32 colors[4];
     };
 
-    CoonsPatchShading(CommonEntries common_entries, Vector<float> patch_data, Vector<CoonsPatch> patches, FunctionsType functions)
+    CoonsPatchShading(CommonEntries common_entries, Vector<float> patch_data, Vector<CoonsPatch> patches, GouraudFunctionsType functions)
         : m_common_entries(move(common_entries))
         , m_patch_data(move(patch_data))
         , m_patches(move(patches))
@@ -1277,7 +1275,7 @@ private:
     // (For flags 1-3, only 8 coordinates and 2 colors.)
     Vector<float> m_patch_data;
     Vector<CoonsPatch> m_patches;
-    FunctionsType m_functions;
+    GouraudFunctionsType m_functions;
 };
 
 PDFErrorOr<NonnullRefPtr<CoonsPatchShading>> CoonsPatchShading::create(Document* document, NonnullRefPtr<StreamObject> shading_stream, CommonEntries common_entries)
@@ -1335,12 +1333,12 @@ PDFErrorOr<NonnullRefPtr<CoonsPatchShading>> CoonsPatchShading::create(Document*
     //  turned by the function for a given color component is out of range, it is
     //  adjusted to the nearest valid value.
     //  This entry may not be used with an Indexed color space."
-    FunctionsType functions;
+    GouraudFunctionsType functions;
     if (shading_dict->contains(CommonNames::Function)) {
         if (common_entries.color_space->family() == ColorSpaceFamily::Indexed)
             return Error::malformed_error("Function cannot be used with Indexed color space");
 
-        functions = TRY([&]() -> PDFErrorOr<FunctionsType> {
+        functions = TRY([&]() -> PDFErrorOr<GouraudFunctionsType> {
             auto function_object = TRY(shading_dict->get_object(document, CommonNames::Function));
             if (function_object->is<ArrayObject>()) {
                 auto function_array = function_object->cast<ArrayObject>();
@@ -1594,8 +1592,6 @@ public:
     virtual PDFErrorOr<void> draw(Gfx::Painter&, Gfx::AffineTransform const&) override;
 
 private:
-    using FunctionsType = Variant<Empty, NonnullRefPtr<Function>, Vector<NonnullRefPtr<Function>>>;
-
     // Indexes into m_patch_data.
     struct TensorProductPatch {
         // Pij (col i, row j) is at index:
@@ -1611,7 +1607,7 @@ private:
         u32 colors[4];
     };
 
-    TensorProductPatchShading(CommonEntries common_entries, Vector<float> patch_data, Vector<TensorProductPatch> patches, FunctionsType functions)
+    TensorProductPatchShading(CommonEntries common_entries, Vector<float> patch_data, Vector<TensorProductPatch> patches, GouraudFunctionsType functions)
         : m_common_entries(move(common_entries))
         , m_patch_data(move(patch_data))
         , m_patches(move(patches))
@@ -1625,7 +1621,7 @@ private:
     // (For flags 1-3, only 12 coordinates and 2 colors.)
     Vector<float> m_patch_data;
     Vector<TensorProductPatch> m_patches;
-    FunctionsType m_functions;
+    GouraudFunctionsType m_functions;
 };
 
 PDFErrorOr<NonnullRefPtr<TensorProductPatchShading>> TensorProductPatchShading::create(Document* document, NonnullRefPtr<StreamObject> shading_stream, CommonEntries common_entries)
@@ -1692,12 +1688,12 @@ PDFErrorOr<NonnullRefPtr<TensorProductPatchShading>> TensorProductPatchShading::
     //  turned by the function for a given color component is out of range, it is
     //  adjusted to the nearest valid value.
     //  This entry may not be used with an Indexed color space."
-    FunctionsType functions;
+    GouraudFunctionsType functions;
     if (shading_dict->contains(CommonNames::Function)) {
         if (common_entries.color_space->family() == ColorSpaceFamily::Indexed)
             return Error::malformed_error("Function cannot be used with Indexed color space");
 
-        functions = TRY([&]() -> PDFErrorOr<FunctionsType> {
+        functions = TRY([&]() -> PDFErrorOr<GouraudFunctionsType> {
             auto function_object = TRY(shading_dict->get_object(document, CommonNames::Function));
             if (function_object->is<ArrayObject>()) {
                 auto function_array = function_object->cast<ArrayObject>();

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -305,14 +305,14 @@ PDFErrorOr<NonnullRefPtr<AxialShading>> AxialShading::create(Document* document,
                 return Error::malformed_error("Function array must have as many elements as color space has components");
             for (size_t i = 0; i < function_array->size(); ++i) {
                 auto function = TRY(Function::create(document, TRY(document->resolve_to<Object>(function_array->at(i)))));
-                if (TRY(function->evaluate(to_array({ 0.0f }))).size() != 1)
+                if (TRY(function->evaluate(to_array({ t0 }))).size() != 1)
                     return Error::malformed_error("Function must have 1 output component");
                 TRY(functions_vector.try_append(move(function)));
             }
             return functions_vector;
         }
         auto function = TRY(Function::create(document, function_object));
-        if (TRY(function->evaluate(to_array({ 0.0f }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+        if (TRY(function->evaluate(to_array({ t0 }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
             return Error::malformed_error("Function must have as many output components as color space");
         return function;
     }());
@@ -476,14 +476,14 @@ PDFErrorOr<NonnullRefPtr<RadialShading>> RadialShading::create(Document* documen
                 return Error::malformed_error("Function array must have as many elements as color space has components");
             for (size_t i = 0; i < function_array->size(); ++i) {
                 auto function = TRY(Function::create(document, TRY(document->resolve_to<Object>(function_array->at(i)))));
-                if (TRY(function->evaluate(to_array({ 0.0f }))).size() != 1)
+                if (TRY(function->evaluate(to_array({ t0 }))).size() != 1)
                     return Error::malformed_error("Function must have 1 output component");
                 TRY(functions_vector.try_append(move(function)));
             }
             return functions_vector;
         }
         auto function = TRY(Function::create(document, function_object));
-        if (TRY(function->evaluate(to_array({ 0.0f }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+        if (TRY(function->evaluate(to_array({ t0 }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
             return Error::malformed_error("Function must have as many output components as color space");
         return function;
     }());

--- a/Userland/Libraries/LibPDF/Shading.cpp
+++ b/Userland/Libraries/LibPDF/Shading.cpp
@@ -1049,7 +1049,7 @@ PDFErrorOr<NonnullRefPtr<FreeFormGouraudShading>> FreeFormGouraudShading::create
                 return functions_vector;
             }
             auto function = TRY(Function::create(document, function_object));
-            if (TRY(function->evaluate(to_array({ decode[0] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+            if (TRY(function->evaluate(to_array({ decode[4] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
                 return Error::malformed_error("Function must have as many output components as color space");
             return function;
         }());
@@ -1202,7 +1202,7 @@ PDFErrorOr<NonnullRefPtr<LatticeFormGouraudShading>> LatticeFormGouraudShading::
                 return functions_vector;
             }
             auto function = TRY(Function::create(document, function_object));
-            if (TRY(function->evaluate(to_array({ decode[0] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+            if (TRY(function->evaluate(to_array({ decode[4] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
                 return Error::malformed_error("Function must have as many output components as color space");
             return function;
         }());
@@ -1354,7 +1354,7 @@ PDFErrorOr<NonnullRefPtr<CoonsPatchShading>> CoonsPatchShading::create(Document*
                 return functions_vector;
             }
             auto function = TRY(Function::create(document, function_object));
-            if (TRY(function->evaluate(to_array({ decode[0] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+            if (TRY(function->evaluate(to_array({ decode[4] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
                 return Error::malformed_error("Function must have as many output components as color space");
             return function;
         }());
@@ -1709,7 +1709,7 @@ PDFErrorOr<NonnullRefPtr<TensorProductPatchShading>> TensorProductPatchShading::
                 return functions_vector;
             }
             auto function = TRY(Function::create(document, function_object));
-            if (TRY(function->evaluate(to_array({ decode[0] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
+            if (TRY(function->evaluate(to_array({ decode[4] }))).size() != static_cast<size_t>(common_entries.color_space->number_of_components()))
                 return Error::malformed_error("Function must have as many output components as color space");
             return function;
         }());


### PR DESCRIPTION
Now that we can paint all shading functions and test that changes don't completely break things, start sharing some code.

Also fixes some minor corner case bugs in the process. But the main motivation is to use less code.