### PR TITLE
Ports: Add gdk-pixbuf

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -95,6 +95,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 | [`gawk`](gawk/)                               | GNU awk                                                       | 5.3.1                    | https://www.gnu.org/software/gawk/                                   |
 | [`gcc`](gcc/)                                 | GNU Compiler Collection                                       | 14.2.0                   | https://gcc.gnu.org/                                                 |
 | [`gdb`](gdb/)                                 | GNU Project Debugger                                          | 11.2                     | https://sourceware.org/gdb                                           |
+| [`gdk-pixbuf`](gdk-pixbuf/)                   | GdkPixbuf                                                     | 2.42.12                  | https://gitlab.gnome.org/GNOME/gdk-pixbuf/                           |
 | [`gemrb`](gemrb/)                             | GemRB                                                         | 0.9.2                    | https://gemrb.org/                                                   |
 | [`genemu`](genemu/)                           | Genesis / MegaDrive Emulator                                  | e39f690                  | https://github.com/rasky/genemu                                      |
 | [`genext2fs`](genext2fs/)                     | genext2fs                                                     | 1.5.0                    | https://github.com/bestouff/genext2fs                                |

--- a/Ports/gdk-pixbuf/package.sh
+++ b/Ports/gdk-pixbuf/package.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='gdk-pixbuf'
+version='2.42.12'
+archive_hash='b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7'
+files=(
+    "https://download.gnome.org/sources/gdk-pixbuf/${version%.*}/gdk-pixbuf-${version}.tar.xz#${archive_hash}"
+)
+useconfigure='true'
+configopts=(
+    "--cross-file=${SERENITY_BUILD_DIR}/meson-cross-file.txt"
+    "--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+    '-Dbuildtype=release'
+    '-Dtests=false'
+    '-Dinstalled_tests=false'
+    '-Dman=false'
+    # gio_sniffing requres shared-mime-info
+    '-Dgio_sniffing=false'
+    # Use patched ports instead of subprojects.
+    '--wrap-mode=nofallback'
+    '-Dtiff=enabled'
+)
+depends=(
+    'glib'
+    'libpng'
+    'libjpeg'
+    'libtiff'
+)
+
+configure() {
+    run meson setup build "${configopts[@]}"
+}
+
+build() {
+    run ninja -C build
+}
+
+install() {
+    run ninja -C build install
+}


### PR DESCRIPTION
[gdk-pixbuf](https://gitlab.gnome.org/GNOME/gdk-pixbuf) is an image loading library for GTK.