### PR TITLE
Shell: Don't use uninitialized termios data

### DIFF
--- a/Userland/Libraries/LibShell/Shell.h
+++ b/Userland/Libraries/LibShell/Shell.h
@@ -330,8 +330,8 @@ public:
 
     bool posix_mode() const { return m_in_posix_mode; }
 
-    struct termios termios;
-    struct termios default_termios;
+    Optional<struct termios> termios;
+    Optional<struct termios> default_termios;
     bool was_interrupted { false };
     bool was_resized { false };
 

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -240,6 +240,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         shell->cache_path();
     }
 
+    editor->initialize();
+    shell->termios = editor->termios();
+    shell->default_termios = editor->default_termios();
+
     Vector<String> args_to_pass;
     TRY(args_to_pass.try_ensure_capacity(script_args.size()));
     for (auto& arg : script_args)
@@ -262,9 +266,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    editor->initialize();
-    shell->termios = editor->termios();
-    shell->default_termios = editor->default_termios();
     shell->add_child(*editor);
 
     Core::EventLoop::current().post_event(*shell, make<Core::CustomEvent>(Shell::Shell::ShellEventType::ReadLine));


### PR DESCRIPTION
1c7233f1481e38de71e537049a444621f32d2526 broke this by moving the initialization later, while still having the shell use the invalid termios data.
Also, this commit makes it so *only* the init script is run without the termios populated, as 'Shell -c ...' should still behave like running the command in the shell.