### PR TITLE
Kernel/aarch64+LibDebug: Add basic debugger functions support

### DIFF
--- a/Kernel/API/POSIX/sys/ptrace.h
+++ b/Kernel/API/POSIX/sys/ptrace.h
@@ -21,11 +21,12 @@ extern "C" {
 #define PT_PEEK 7
 #define PT_POKE 8
 #define PT_SETREGS 9
+#define PT_SINGLESTEP 10
 
 // Serenity extensions:
-#define PT_POKEDEBUG 10
-#define PT_PEEKDEBUG 11
-#define PT_PEEKBUF 12
+#define PT_POKEDEBUG 11
+#define PT_PEEKDEBUG 12
+#define PT_PEEKBUF 13
 
 #define PT_READ_I PT_PEEK
 #define PT_READ_D PT_PEEK

--- a/Kernel/Arch/aarch64/ASM_wrapper.h
+++ b/Kernel/Arch/aarch64/ASM_wrapper.h
@@ -150,4 +150,17 @@ inline void flush_data_cache(FlatPtr start, size_t size)
                      : "memory");
 }
 
+inline FlatPtr get_mdscr_el1()
+{
+    FlatPtr mdscr_el1;
+    asm volatile("mrs %[value], mdscr_el1\n"
+                 : [value] "=r"(mdscr_el1));
+    return mdscr_el1;
+}
+
+inline void set_mdscr_el1(FlatPtr mdscr_el1)
+{
+    asm volatile("msr mdscr_el1, %[value]" ::[value] "r"(mdscr_el1));
+}
+
 }

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -97,14 +97,16 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
         }
     } else if (Aarch64::exception_class_is_svc_instruction_execution(esr_el1.EC)) {
         syscall_handler(trap_frame);
-    } else if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC)) {
+    } else if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC) || Aarch64::exception_class_is_software_step(esr_el1.EC)) {
         if (trap_frame->regs->previous_mode() == ExecutionMode::User) {
             // When breakpoint instruction exception is triggered, the ip is set to the address of the breakpoint instruction,
             // so we need to increase the ip past the breakpoint instruction to stay consistent with the user‑mode debugger’s behavior.
-            if (esr_el1.IL == 0)
-                trap_frame->regs->set_ip(trap_frame->regs->ip() + 2);
-            else
-                trap_frame->regs->set_ip(trap_frame->regs->ip() + 4);
+            if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC)) {
+                if (esr_el1.IL == 0)
+                    trap_frame->regs->set_ip(trap_frame->regs->ip() + 2);
+                else
+                    trap_frame->regs->set_ip(trap_frame->regs->ip() + 4);
+            }
 
             auto* current_thread = Thread::current();
             auto& current_process = current_thread->process();
@@ -115,7 +117,10 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
 
             current_thread->send_urgent_signal_to_self(SIGTRAP);
         } else {
-            handle_crash(*trap_frame->regs, "Unexpected breakpoint instruction exception", SIGTRAP, false);
+            if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC))
+                handle_crash(*trap_frame->regs, "Unexpected breakpoint instruction exception", SIGTRAP, false);
+            if (Aarch64::exception_class_is_software_step(esr_el1.EC))
+                handle_crash(*trap_frame->regs, "Unexpected software step exception", SIGTRAP, false);
         }
     } else {
         handle_crash(*trap_frame->regs, "Unexpected exception", SIGSEGV, false);

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -15,6 +15,9 @@
 #include <Kernel/KSyms.h>
 #include <Kernel/Library/Panic.h>
 #include <Kernel/Library/StdLib.h>
+#include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/Thread.h>
+#include <Kernel/Tasks/ThreadTracer.h>
 
 namespace Kernel {
 
@@ -94,6 +97,26 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
         }
     } else if (Aarch64::exception_class_is_svc_instruction_execution(esr_el1.EC)) {
         syscall_handler(trap_frame);
+    } else if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC)) {
+        if (trap_frame->regs->previous_mode() == ExecutionMode::User) {
+            // When breakpoint instruction exception is triggered, the ip is set to the address of the breakpoint instruction,
+            // so we need to increase the ip past the breakpoint instruction to stay consistent with the user‑mode debugger’s behavior.
+            if (esr_el1.IL == 0)
+                trap_frame->regs->set_ip(trap_frame->regs->ip() + 2);
+            else
+                trap_frame->regs->set_ip(trap_frame->regs->ip() + 4);
+
+            auto* current_thread = Thread::current();
+            auto& current_process = current_thread->process();
+
+            if (auto* tracer = current_process.tracer()) {
+                tracer->set_regs(*trap_frame->regs);
+            }
+
+            current_thread->send_urgent_signal_to_self(SIGTRAP);
+        } else {
+            handle_crash(*trap_frame->regs, "Unexpected breakpoint instruction exception", SIGTRAP, false);
+        }
     } else {
         handle_crash(*trap_frame->regs, "Unexpected exception", SIGSEGV, false);
     }

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -99,17 +99,21 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
         syscall_handler(trap_frame);
     } else if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC) || Aarch64::exception_class_is_software_step(esr_el1.EC)) {
         if (trap_frame->regs->previous_mode() == ExecutionMode::User) {
-            // When breakpoint instruction exception is triggered, the ip is set to the address of the breakpoint instruction,
-            // so we need to increase the ip past the breakpoint instruction to stay consistent with the user‑mode debugger’s behavior.
+            auto* current_thread = Thread::current();
+            auto& current_process = current_thread->process();
+
             if (Aarch64::exception_class_is_breakpoint_instruction(esr_el1.EC)) {
+                // When breakpoint instruction exception is triggered, the ip is set to the address of the
+                // breakpoint instruction, so we need to increase the ip past the breakpoint instruction to
+                // stay consistent with the user‑mode debugger’s behavior.
                 if (esr_el1.IL == 0)
                     trap_frame->regs->set_ip(trap_frame->regs->ip() + 2);
                 else
                     trap_frame->regs->set_ip(trap_frame->regs->ip() + 4);
+            } else {
+                // Clear the software step bit in the MDSCR_EL1 register to disable software step.
+                current_thread->debug_register_state().mdscr_el1 &= ~0x1;
             }
-
-            auto* current_thread = Thread::current();
-            auto& current_process = current_thread->process();
 
             if (auto* tracer = current_process.tracer()) {
                 tracer->set_regs(*trap_frame->regs);

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -441,6 +441,8 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
     Processor::restore_critical(in_critical);
 
     load_fpu_state(&to_thread->fpu_state());
+
+    write_debug_registers_from(to_thread->debug_register_state());
 }
 
 template<typename T>

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -8,10 +8,10 @@
 
 #include <sys/arch/aarch64/regs.h>
 
-#include <Kernel/Security/ExecutionMode.h>
-
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
+#include <Kernel/Arch/aarch64/ASM_wrapper.h>
+#include <Kernel/Security/ExecutionMode.h>
 
 VALIDATE_IS_AARCH64()
 
@@ -82,6 +82,22 @@ inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_re
 }
 
 struct DebugRegisterState {
+    u64 mdscr_el1;
 };
+
+inline void read_debug_registers_into(DebugRegisterState& state)
+{
+    state.mdscr_el1 = Aarch64::Asm::get_mdscr_el1();
+}
+
+inline void write_debug_registers_from(DebugRegisterState const& state)
+{
+    Aarch64::Asm::set_mdscr_el1(state.mdscr_el1);
+}
+
+inline void clear_debug_registers()
+{
+    Aarch64::Asm::set_mdscr_el1(0);
+}
 
 }

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -36,6 +36,11 @@ struct alignas(16) RegisterState {
         elr_el1 = value;
     }
     FlatPtr bp() const { return x[29]; }
+    FlatPtr pstate() const { return spsr_el1; }
+    void set_pstate(FlatPtr value)
+    {
+        spsr_el1 = value;
+    }
 
     ExecutionMode previous_mode() const
     {
@@ -63,6 +68,7 @@ inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_
 
     ptrace_regs.sp = kernel_regs.userspace_sp();
     ptrace_regs.pc = kernel_regs.ip();
+    ptrace_regs.spsr_el1 = kernel_regs.pstate();
 }
 
 inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_regs, PtraceRegisters const& ptrace_regs)
@@ -72,6 +78,7 @@ inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_re
 
     kernel_regs.set_userspace_sp(ptrace_regs.sp);
     kernel_regs.set_ip(ptrace_regs.pc);
+    kernel_regs.set_pstate(ptrace_regs.spsr_el1);
 }
 
 struct DebugRegisterState {

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -82,7 +82,7 @@ inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_re
 }
 
 struct DebugRegisterState {
-    u64 mdscr_el1;
+    u64 mdscr_el1 = 0;
 };
 
 inline void read_debug_registers_into(DebugRegisterState& state)

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -1314,6 +1314,11 @@ static inline bool exception_class_is_svc_instruction_execution(u8 exception_cla
     return exception_class == 0x11 || exception_class == 0x15;
 }
 
+static inline bool exception_class_is_breakpoint_instruction(u8 exception_class)
+{
+    return exception_class == 0x38 || exception_class == 0x3c;
+}
+
 // D17.2.37 ESR_EL1, Exception Syndrome Register (EL1)
 // ISS encoding for an exception from a Data Abort
 // DFSC, bits [5:0]

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -1319,6 +1319,11 @@ static inline bool exception_class_is_breakpoint_instruction(u8 exception_class)
     return exception_class == 0x38 || exception_class == 0x3c;
 }
 
+static inline bool exception_class_is_software_step(u8 exception_class)
+{
+    return exception_class == 0x32;
+}
+
 // D17.2.37 ESR_EL1, Exception Syndrome Register (EL1)
 // ISS encoding for an exception from a Data Abort
 // DFSC, bits [5:0]

--- a/Kernel/Arch/aarch64/mcontext.h
+++ b/Kernel/Arch/aarch64/mcontext.h
@@ -16,6 +16,7 @@ struct __attribute__((packed)) __mcontext {
     uint64_t x[31];
     uint64_t sp;
     uint64_t pc;
+    uint64_t spsr_el1;
 };
 
 #ifdef __cplusplus

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -116,6 +116,41 @@ static ErrorOr<FlatPtr> handle_ptrace(Kernel::Syscall::SC_ptrace_params const& p
         break;
     }
 
+    case PT_SINGLESTEP: {
+        if (!tracer->has_regs())
+            return EINVAL;
+
+        auto regs = tracer->regs();
+#if ARCH(X86_64)
+        // Single stepping works by setting the x86 TRAP flag bit in the eflags register.
+        // This flag causes the cpu to enter single-stepping mode, which causes
+        // Interrupt 1 (debug interrupt) to be emitted after every instruction.
+        // To single step the program, we set the TRAP flag and continue the debuggee.
+        constexpr u32 TRAP_FLAG = 0x100;
+        regs.rflags |= TRAP_FLAG;
+#elif ARCH(AARCH64)
+        // Single stepping on AArch64 works by setting the SS flag in the SPSR_EL1 register.
+        // When an exception return is executed in EL1, the value of SPSR_EL1.SS is copied
+        // to PSTATE.SS. To enable single stepping, the MDSCR_EL1.SS must also be set to 1.
+        constexpr u32 SS_FLAG = 0x200000;
+        regs.spsr_el1 |= SS_FLAG;
+        peer->debug_register_state().mdscr_el1 |= 0x1;
+#elif ARCH(RISCV64)
+        TODO_RISCV64();
+#else
+#    error Unknown architecture
+#endif
+
+        auto& peer_saved_registers = peer->get_register_dump_from_stack();
+        // Verify that the saved registers are in usermode context
+        if (peer_saved_registers.previous_mode() != ExecutionMode::User)
+            return EFAULT;
+
+        tracer->set_regs(regs);
+        copy_ptrace_registers_into_kernel_registers(peer_saved_registers, regs);
+        break;
+    }
+
     case PT_PEEK: {
         auto data = TRY(peer->process().peek_user_data(Userspace<FlatPtr const*> { (FlatPtr)params.addr }));
         TRY(copy_to_user((FlatPtr*)params.data, &data));

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -257,7 +257,8 @@ ErrorOr<FlatPtr> Thread::peek_debug_register(u32 register_index)
     return data;
 #elif ARCH(AARCH64)
     (void)register_index;
-    TODO_AARCH64();
+    dbgln("FIXME: Implement Thread::peek_debug_register on AARCH64");
+    return ENOTSUP;
 #elif ARCH(RISCV64)
     (void)register_index;
     dbgln("FIXME: Implement Thread::peek_debug_register on RISC-V");
@@ -293,7 +294,8 @@ ErrorOr<void> Thread::poke_debug_register(u32 register_index, FlatPtr data)
 #elif ARCH(AARCH64)
     (void)register_index;
     (void)data;
-    TODO_AARCH64();
+    dbgln("FIXME: Implement Thread::poke_debug_register on AARCH64");
+    return ENOTSUP;
 #elif ARCH(RISCV64)
     (void)register_index;
     (void)data;

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -256,8 +256,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #if ARCH(X86_64)
         FlatPtr const ip = regs.rip;
 #elif ARCH(AARCH64)
-        FlatPtr const ip = 0; // FIXME
-        TODO_AARCH64();
+        FlatPtr const ip = regs.pc;
 #elif ARCH(RISCV64)
         FlatPtr const ip = regs.pc;
 #else

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -134,8 +134,18 @@ public:
 private:
     explicit DebugSession(pid_t, ByteString source_root, Function<void(float)> on_initialization_progress = {});
 
+#if ARCH(X86_64)
     // x86 breakpoint instruction "int3"
     static constexpr u8 BREAKPOINT_INSTRUCTION = 0xcc;
+#elif ARCH(AARCH64)
+    // AArch64 breakpoint instruction "brk #0"
+    static constexpr u32 BREAKPOINT_INSTRUCTION = 0xd4200000;
+#elif ARCH(RISCV64)
+    TODO_RISCV64();
+#else
+#    error Unknown architecture
+#endif
+    static constexpr FlatPtr BREAKPOINT_INSTRUCTION_MASK = (1ull << (sizeof(BREAKPOINT_INSTRUCTION) * 8)) - 1;
 
     ErrorOr<void> update_loaded_libs();
 
@@ -191,8 +201,7 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
 #if ARCH(X86_64)
         FlatPtr current_instruction = regs.rip;
 #elif ARCH(AARCH64)
-        FlatPtr current_instruction;
-        TODO_AARCH64();
+        FlatPtr current_instruction = regs.pc;
 #elif ARCH(RISCV64)
         FlatPtr current_instruction = regs.pc;
 #else
@@ -217,8 +226,7 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
 #if ARCH(X86_64)
                 FlatPtr current_ebp = regs.rbp;
 #elif ARCH(AARCH64)
-                FlatPtr current_ebp;
-                TODO_AARCH64();
+                FlatPtr current_ebp = regs.bp();
 #elif ARCH(RISCV64)
                 FlatPtr current_ebp = regs.bp();
 #else
@@ -250,7 +258,7 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
         Optional<BreakPoint> current_breakpoint;
 
         if (state == State::FreeRun || state == State::Syscall) {
-            current_breakpoint = m_breakpoints.get(current_instruction - 1).copy();
+            current_breakpoint = m_breakpoints.get(current_instruction - sizeof(BREAKPOINT_INSTRUCTION)).copy();
             if (current_breakpoint.has_value())
                 state = State::FreeRun;
         } else {
@@ -260,17 +268,14 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
         if (current_breakpoint.has_value()) {
             // We want to make the breakpoint transparent to the user of the debugger.
             // To achieve this, we perform two rollbacks:
-            // 1. Set regs.eip to point at the actual address of the instruction we broke on.
-            //    regs.eip currently points to one byte after the address of the original instruction,
-            //    because the cpu has just executed the INT3 we patched into the instruction.
-            // 2. We restore the original first byte of the instruction,
-            //    because it was patched with INT3.
+            // 1. Set instruction pointer to point at the actual address of the instruction we broke on.
+            //    Instruction pointer currently points to the instruction after the original instruction.
+            // 2. We restore the original instruction, because it was patched with breakpoint instruction.
             auto breakpoint_addr = bit_cast<FlatPtr>(current_breakpoint.value().address);
 #if ARCH(X86_64)
             regs.rip = breakpoint_addr;
 #elif ARCH(AARCH64)
-            (void)breakpoint_addr;
-            TODO_AARCH64();
+            regs.pc = breakpoint_addr;
 #elif ARCH(RISCV64)
             regs.pc = breakpoint_addr;
 #else
@@ -304,13 +309,13 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
             if (m_breakpoints.contains(current_breakpoint_address)) {
                 // The current breakpoint was removed to make it transparent to the user.
                 // We now want to re-enable it - the code execution flow could hit it again.
-                // To re-enable the breakpoint, we first perform a single step and execute the
-                // instruction of the breakpoint, and then redo the INT3 patch in its first byte.
+                // To re-enable the breakpoint, we first perform a single step to execute the
+                // original instruction, and then redo the breakpoint instruction patch.
 
                 // If the user manually inserted a breakpoint at the current instruction,
                 // we need to disable that breakpoint because we want to singlestep over that
                 // instruction (we re-enable it again later anyways).
-                if (m_breakpoints.contains(current_breakpoint_address) && m_breakpoints.get(current_breakpoint_address).value().state == BreakPointState::Enabled) {
+                if (m_breakpoints.get(current_breakpoint_address).value().state == BreakPointState::Enabled) {
                     disable_breakpoint(current_breakpoint.value().address);
                 }
                 auto stopped_address = single_step();

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -141,7 +141,8 @@ private:
     // AArch64 breakpoint instruction "brk #0"
     static constexpr u32 BREAKPOINT_INSTRUCTION = 0xd4200000;
 #elif ARCH(RISCV64)
-    TODO_RISCV64();
+    // RISC-V breakpoint instruction "ebreak"
+    static constexpr u32 BREAKPOINT_INSTRUCTION = 0x00100073;
 #else
 #    error Unknown architecture
 #endif


### PR DESCRIPTION
This patch adds the following basic debugger capabilities for AArch64:
1. Breakpoint insertion (software breakpoints)
2. Single-step execution
3. Continue execution

<img width="1023" alt="截屏2025-06-01 10 26 34" src="https://github.com/user-attachments/assets/cf73c9cf-0373-407c-a9ee-129ac794197b" />
