### PR TITLE
LibPDF: Read some transparency imaging model graphics state dict entries

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -45,6 +45,9 @@
     X(CalGray)                    \
     X(CalRGB)                     \
     X(CharProcs)                  \
+    X(Color)                      \
+    X(ColorBurn)                  \
+    X(ColorDodge)                 \
     X(ColorSpace)                 \
     X(Colors)                     \
     X(Columns)                    \
@@ -60,6 +63,7 @@
     X(DW)                         \
     X(DW2)                        \
     X(DamagedRowsBeforeError)     \
+    X(Darken)                     \
     X(Decode)                     \
     X(DecodeParms)                \
     X(DescendantFonts)            \
@@ -69,6 +73,7 @@
     X(DeviceGray)                 \
     X(DeviceN)                    \
     X(DeviceRGB)                  \
+    X(Difference)                 \
     X(Differences)                \
     X(Domain)                     \
     X(E)                          \
@@ -80,6 +85,7 @@
     X(EncryptMetadata)            \
     X(EndOfBlock)                 \
     X(EndOfLine)                  \
+    X(Exclusion)                  \
     X(ExtGState)                  \
     X(Extend)                     \
     X(F)                          \
@@ -110,7 +116,9 @@
     X(H)                          \
     X(HT)                         \
     X(HTO)                        \
+    X(HardLight)                  \
     X(Height)                     \
+    X(Hue)                        \
     X(ICCBased)                   \
     X(ID)                         \
     X(Image)                      \
@@ -137,17 +145,21 @@
     X(Length1)                    \
     X(Length2)                    \
     X(Length3)                    \
+    X(Lighten)                    \
     X(Limits)                     \
     X(Linearized)                 \
+    X(Luminosity)                 \
     X(ML)                         \
     X(Mask)                       \
     X(Matrix)                     \
     X(MediaBox)                   \
     X(MissingWidth)               \
     X(ModDate)                    \
+    X(Multiply)                   \
     X(N)                          \
     X(Names)                      \
     X(Next)                       \
+    X(Normal)                     \
     X(O)                          \
     X(OE)                         \
     X(OP)                         \
@@ -155,6 +167,7 @@
     X(Order)                      \
     X(Ordering)                   \
     X(Outlines)                   \
+    X(Overlay)                    \
     X(P)                          \
     X(Pages)                      \
     X(Parent)                     \
@@ -177,10 +190,13 @@
     X(SM)                         \
     X(SMask)                      \
     X(SMaskInData)                \
+    X(Saturation)                 \
+    X(Screen)                     \
     X(Separation)                 \
     X(Shading)                    \
     X(ShadingType)                \
     X(Size)                       \
+    X(SoftLight)                  \
     X(StmF)                       \
     X(StrF)                       \
     X(Subject)                    \

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -103,8 +103,8 @@
     X(FontFile2)                  \
     X(FontFile3)                  \
     X(FontMatrix)                 \
-    X(FunctionType)               \
     X(Function)                   \
+    X(FunctionType)               \
     X(Functions)                  \
     X(Gamma)                      \
     X(H)                          \
@@ -169,8 +169,8 @@
     X(Registry)                   \
     X(Resources)                  \
     X(Root)                       \
-    X(Rows)                       \
     X(Rotate)                     \
+    X(Rows)                       \
     X(RunLengthDecode)            \
     X(S)                          \
     X(SA)                         \

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1085,6 +1085,7 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     if (dict->contains(CommonNames::RI))
         TRY(handle_set_color_rendering_intent(Array { dict->get_value(CommonNames::RI) }));
 
+    // Overprint control.
     // FIXME: OP
     // FIXME: op
     // FIXME: OPM
@@ -1092,12 +1093,19 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     if (dict->contains(CommonNames::Font))
         return Error::rendering_unsupported_error("Setting font via graphics state dictionary not yet supported");
 
+    // Black generation.
     // FIXME: BG
     // FIXME: BG2
+
+    // Undercolor removal.
     // FIXME: UCR
     // FIXME: UCR2
+
+    // Transfer function.
     // FIXME: TR
     // FIXME: TR2
+
+    // Halftone dictionary.
     // FIXME: HT
 
     if (dict->contains(CommonNames::FL))
@@ -1105,12 +1113,16 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
 
     // FIXME: SM
     // FIXME: SA
+
+    // Transparent imaging model.
     // FIXME: BM
     // FIXME: SMask
     // FIXME: CA
     // FIXME: ca
     // FIXME: AIS
     // FIXME: TK
+
+    // PDF 2.0 additions.
     // FIXME: UseBlackPtComp
     // FIXME: HTO
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1117,10 +1117,18 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     // Transparent imaging model.
     // FIXME: BM
     // FIXME: SMask
-    // FIXME: CA
-    // FIXME: ca
-    // FIXME: AIS
-    // FIXME: TK
+
+    if (dict->contains(CommonNames::CA))
+        state().stroke_alpha_constant = dict->get_value(CommonNames::CA).to_float();
+
+    if (dict->contains(CommonNames::ca))
+        state().paint_alpha_constant = dict->get_value(CommonNames::ca).to_float();
+
+    if (dict->contains(CommonNames::AIS)) // "alpha is shape"
+        state().alpha_source = dict->get_value(CommonNames::AIS).get<bool>() ? AlphaSource::Shape : AlphaSource::Opacity;
+
+    if (dict->contains(CommonNames::TK))
+        state().text_state.knockout = dict->get_value(CommonNames::TK).get<bool>();
 
     // PDF 2.0 additions.
     // FIXME: UseBlackPtComp

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -530,6 +530,81 @@ RENDERER_HANDLER(text_set_font)
     return set_font(font_dictionary, args[1].to_float());
 }
 
+PDFErrorOr<void> Renderer::set_blend_mode(ReadonlySpan<Value> args)
+{
+    // "the application should use the first blend mode in the array that it recognizes (or Normal if it recognizes none of them)."
+    for (auto const& arg : args) {
+        auto name = TRY(m_document->resolve_to<NameObject>(arg))->name();
+        if (name == CommonNames::Normal) {
+            state().blend_mode = BlendMode::Normal;
+            return {};
+        }
+        if (name == CommonNames::Multiply) {
+            state().blend_mode = BlendMode::Multiply;
+            return {};
+        }
+        if (name == CommonNames::Screen) {
+            state().blend_mode = BlendMode::Screen;
+            return {};
+        }
+        if (name == CommonNames::Overlay) {
+            state().blend_mode = BlendMode::Overlay;
+            return {};
+        }
+        if (name == CommonNames::Darken) {
+            state().blend_mode = BlendMode::Darken;
+            return {};
+        }
+        if (name == CommonNames::Lighten) {
+            state().blend_mode = BlendMode::Lighten;
+            return {};
+        }
+        if (name == CommonNames::ColorDodge) {
+            state().blend_mode = BlendMode::ColorDodge;
+            return {};
+        }
+        if (name == CommonNames::ColorBurn) {
+            state().blend_mode = BlendMode::ColorBurn;
+            return {};
+        }
+        if (name == CommonNames::HardLight) {
+            state().blend_mode = BlendMode::HardLight;
+            return {};
+        }
+        if (name == CommonNames::SoftLight) {
+            state().blend_mode = BlendMode::SoftLight;
+            return {};
+        }
+        if (name == CommonNames::Difference) {
+            state().blend_mode = BlendMode::Difference;
+            return {};
+        }
+        if (name == CommonNames::Exclusion) {
+            state().blend_mode = BlendMode::Exclusion;
+            return {};
+        }
+        if (name == CommonNames::Hue) {
+            state().blend_mode = BlendMode::Hue;
+            return {};
+        }
+        if (name == CommonNames::Saturation) {
+            state().blend_mode = BlendMode::Saturation;
+            return {};
+        }
+        if (name == CommonNames::Color) {
+            state().blend_mode = BlendMode::Color;
+            return {};
+        }
+        if (name == CommonNames::Luminosity) {
+            state().blend_mode = BlendMode::Luminosity;
+            return {};
+        }
+        dbgln("Unknown blend mode: {}", name);
+    }
+    state().blend_mode = BlendMode::Normal;
+    return {};
+}
+
 RENDERER_HANDLER(text_set_rendering_mode)
 {
     text_state().rendering_mode = static_cast<TextRenderingMode>(args[0].get<int>());
@@ -1115,7 +1190,15 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     // FIXME: SA
 
     // Transparent imaging model.
-    // FIXME: BM
+
+    if (dict->contains(CommonNames::BM)) {
+        auto args = TRY(dict->get_object(m_document, CommonNames::BM));
+        if (args->is<ArrayObject>())
+            TRY(set_blend_mode(args->cast<ArrayObject>()->elements()));
+        else
+            TRY(set_blend_mode(Array { Value { args->cast<NameObject>() } }));
+    }
+
     // FIXME: SMask
 
     if (dict->contains(CommonNames::CA))

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -69,6 +69,28 @@ struct ClippingPaths {
     Gfx::Path next;
 };
 
+enum class BlendMode {
+    // TABLE 7.2 Standard separable blend modes
+    Normal,
+    Multiply,
+    Screen,
+    Overlay,
+    Darken,
+    Lighten,
+    ColorDodge,
+    ColorBurn,
+    HardLight,
+    SoftLight,
+    Difference,
+    Exclusion,
+
+    // TABLE 7.3 Standard nonseparable blend modes
+    Hue,
+    Saturation,
+    Color,
+    Luminosity,
+};
+
 enum class AlphaSource {
     Opacity,
     Shape,
@@ -90,6 +112,7 @@ struct GraphicsState {
     LineDashPattern line_dash_pattern { {}, 0 };
     TextState text_state {};
 
+    BlendMode blend_mode { BlendMode::Normal };
     float stroke_alpha_constant { 1.0f };
     float paint_alpha_constant { 1.0f };
     AlphaSource alpha_source { AlphaSource::Opacity };
@@ -200,6 +223,8 @@ private:
 
     PDFErrorOr<NonnullRefPtr<PDFFont>> get_font(FontCacheKey const&);
     PDFErrorOr<void> set_font(NonnullRefPtr<DictObject> font_dictionary, float font_size);
+
+    PDFErrorOr<void> set_blend_mode(ReadonlySpan<Value>);
 
     class ScopedState;
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -77,7 +77,7 @@ struct GraphicsState {
     ColorOrStyle stroke_style { Color::Black };
     ColorOrStyle paint_style { Color::Black };
     ByteString color_rendering_intent { "RelativeColorimetric"sv };
-    float flatness_tolerance { 0.0f };
+    float flatness_tolerance { 1.0f };
     float line_width { 1.0f };
     LineCapStyle line_cap_style { LineCapStyle::ButtCap };
     LineJoinStyle line_join_style { LineJoinStyle::Miter };

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -69,6 +69,11 @@ struct ClippingPaths {
     Gfx::Path next;
 };
 
+enum class AlphaSource {
+    Opacity,
+    Shape,
+};
+
 struct GraphicsState {
     Gfx::AffineTransform ctm;
     ClippingPaths clipping_paths;
@@ -84,6 +89,10 @@ struct GraphicsState {
     float miter_limit { 10.0f };
     LineDashPattern line_dash_pattern { {}, 0 };
     TextState text_state {};
+
+    float stroke_alpha_constant { 1.0f };
+    float paint_alpha_constant { 1.0f };
+    AlphaSource alpha_source { AlphaSource::Opacity };
 };
 
 struct RenderingPreferences {

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -189,8 +189,8 @@ private:
 
     Gfx::AffineTransform calculate_image_space_transformation(Gfx::IntSize);
 
-    PDFErrorOr<void> set_font(NonnullRefPtr<DictObject> font_dictionary, float font_size);
     PDFErrorOr<NonnullRefPtr<PDFFont>> get_font(FontCacheKey const&);
+    PDFErrorOr<void> set_font(NonnullRefPtr<DictObject> font_dictionary, float font_size);
 
     class ScopedState;
 


### PR DESCRIPTION
Not used for anything yet, so no behavior change.

Some other very minor cleanups too, also behavior-preserving.