### PR TITLE
LibPDF: Read /SMask from graphics state dicts

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -17,6 +17,7 @@
     X(AntiAlias)                  \
     X(Author)                     \
     X(BBox)                       \
+    X(BC)                         \
     X(BG)                         \
     X(BG2)                        \
     X(BM)                         \
@@ -112,6 +113,7 @@
     X(Function)                   \
     X(FunctionType)               \
     X(Functions)                  \
+    X(G)                          \
     X(Gamma)                      \
     X(H)                          \
     X(HT)                         \
@@ -121,6 +123,7 @@
     X(Hue)                        \
     X(ICCBased)                   \
     X(ID)                         \
+    X(Identity)                   \
     X(Image)                      \
     X(ImageMask)                  \
     X(Index)                      \
@@ -159,6 +162,7 @@
     X(N)                          \
     X(Names)                      \
     X(Next)                       \
+    X(None)                       \
     X(Normal)                     \
     X(O)                          \
     X(OE)                         \

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -113,6 +113,20 @@ struct GraphicsState {
     TextState text_state {};
 
     BlendMode blend_mode { BlendMode::Normal };
+
+    struct SMask {
+        // TABLE 7.10 Entries in a soft-mask dictionary
+        enum class Type {
+            Alpha,
+            Luminosity,
+        };
+        Type type { Type::Alpha };
+        NonnullRefPtr<StreamObject> group;
+        Vector<float, 4> background_color { 0.0f, 0.0f, 0.0f, 0.0f };
+        RefPtr<Function> transfer_function {}; // nullptr means identity function.
+    };
+    Optional<SMask> soft_mask {};
+
     float stroke_alpha_constant { 1.0f };
     float paint_alpha_constant { 1.0f };
     AlphaSource alpha_source { AlphaSource::Opacity };


### PR DESCRIPTION
This adds support for loading the smask mode parameter of the transparent image model described in chapter 7 of the PDF 1.7 spec. With this, we read all transparency-related entries in graphics state dicts as far as I can tell :^)

(...but an /SMask dict refers to a transparency group XObject, and we don't read the /Group subdirectory entries at all yet. See 7.5.5 and TABLE 7.13 in the PDF 1.7 spec.)

We don't use it for anything yet, so no behavior change.