### PR TITLE
Kernel/riscv64: Add V support

### DIFF
--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -21,6 +21,17 @@ namespace Kernel::RISCV64::CSR {
 
 // 2.2 CSR Listing
 enum class Address : u16 {
+    // Unprivileged Vector CSRs
+    VSTART_ = 0x008,
+    VCSR = 0x00f,
+    VL = 0xc20,
+    VTYPE = 0xc21,
+    VLENB = 0xc22,
+
+    // Unprivileged Counters/Timers
+    CYCLE = 0xc00,
+    TIME = 0xc01,
+
     // Supervisor Trap Setup
     SSTATUS = 0x100,
     SIE = 0x104,
@@ -28,10 +39,6 @@ enum class Address : u16 {
 
     // Supervisor Protection and Translation
     SATP = 0x180,
-
-    // Unprivileged Counters/Timers
-    CYCLE = 0xc00,
-    TIME = 0xc01,
 };
 
 template<Address address>

--- a/Kernel/Arch/riscv64/FPUState.h
+++ b/Kernel/Arch/riscv64/FPUState.h
@@ -13,12 +13,22 @@ VALIDATE_IS_RISCV64()
 
 namespace Kernel {
 
+static constexpr size_t MAX_SUPPORTED_VLENB = 1024 / 8;
+
 // This struct will get pushed on the stack by the signal handling code.
 // Therefore, it has to be aligned to a 16-byte boundary.
 struct [[gnu::aligned(16)]] FPUState {
     // FIXME: Add support for the Q extension.
     u64 f[32];
     u64 fcsr;
+
+    u64 vstart;
+    u64 vcsr;
+    u64 vl;
+    u64 vtype;
+
+    // 32 v* registers of vlenb bytes each.
+    u8 v[MAX_SUPPORTED_VLENB * 32];
 };
 
 }

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -623,6 +623,10 @@ void Processor::find_and_parse_devicetree_node()
         }
 
         m_features = isa_extensions_property_to_cpu_features(isa_extensions.value());
+
+        m_info->build_isa_string(*this);
+        dmesgln("CPU[{}]: ISA: {}", id(), m_info->isa_string());
+
         generate_userspace_extension_bitmask();
 
         break;

--- a/Kernel/Arch/riscv64/ProcessorInfo.cpp
+++ b/Kernel/Arch/riscv64/ProcessorInfo.cpp
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringBuilder.h>
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/Arch/riscv64/CPUID.h>
 #include <Kernel/Arch/riscv64/ProcessorInfo.h>
 #include <Kernel/Arch/riscv64/SBI.h>
 
@@ -16,6 +19,29 @@ ProcessorInfo::ProcessorInfo()
         m_marchid = MUST(SBI::Base::get_marchid());
         m_mimpid = MUST(SBI::Base::get_mimpid());
     }
+}
+
+void ProcessorInfo::build_isa_string(Processor const& processor)
+{
+    StringBuilder builder;
+
+    MUST(builder.try_append("RV64"sv));
+
+    bool first_multi_letter_extension = true;
+    for (auto extension = CPUFeature::Type(1u); extension != CPUFeature::__End; extension <<= 1u) {
+        if (processor.has_feature(extension)) {
+            auto extension_name = cpu_feature_to_name(extension);
+            if (extension_name.length() > 1) {
+                if (first_multi_letter_extension)
+                    first_multi_letter_extension = false;
+                else
+                    MUST(builder.try_append('_'));
+            }
+            MUST(builder.try_append(extension_name));
+        }
+    }
+
+    m_isa_string = KString::must_create(builder.string_view());
 }
 
 }

--- a/Kernel/Arch/riscv64/ProcessorInfo.h
+++ b/Kernel/Arch/riscv64/ProcessorInfo.h
@@ -7,11 +7,14 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <Kernel/Library/KString.h>
 
 #include <AK/Platform.h>
 VALIDATE_IS_RISCV64()
 
 namespace Kernel {
+
+class Processor;
 
 class ProcessorInfo {
 public:
@@ -21,11 +24,17 @@ public:
     FlatPtr marchid() const { return m_marchid; }
     FlatPtr mimpid() const { return m_mimpid; }
 
+    StringView isa_string() const { return m_isa_string->view(); }
+
+    void build_isa_string(Processor const&);
+
 private:
     // mvendorid, marchid, and mimpid can all be zero if they aren't implemented.
     u32 m_mvendorid { 0 };
     FlatPtr m_marchid { 0 };
     FlatPtr m_mimpid { 0 };
+
+    OwnPtr<KString> m_isa_string;
 };
 
 }

--- a/Kernel/Arch/riscv64/ThreadRegisters.h
+++ b/Kernel/Arch/riscv64/ThreadRegisters.h
@@ -60,6 +60,9 @@ struct ThreadRegisters {
 
         sstatus.FS = RISCV64::CSR::SSTATUS::FloatingPointStatus::Initial;
 
+        if (Processor::current().has_feature(CPUFeature::V))
+            sstatus.VS = RISCV64::CSR::SSTATUS::VectorStatus::Initial;
+
         sstatus.SPP = is_kernel_process ? RISCV64::CSR::SSTATUS::PrivilegeMode::Supervisor : RISCV64::CSR::SSTATUS::PrivilegeMode::User;
         sstatus.UXL = RISCV64::CSR::SSTATUS::XLEN::Bits64;
     }

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -484,7 +484,8 @@ void signal_trampoline_dummy()
         "asm_signal_trampoline:\n"
 
         // Store a0 (return value from a syscall) into the register slot, such that we can return the correct value in sys$sigreturn.
-        "sd a0, %[offset_to_return_value_slot](sp)\n"
+        "lui t0, %%hi(%[offset_to_return_value_slot])\n" // FIXME: Move the return value slot before the FPUState to avoid having an extra lui here.
+        "sd a0, %%lo(%[offset_to_return_value_slot])(sp)\n"
         // Load the handler address into t0.
         "ld t0, 0(sp)\n"
         // Load the signal number into the first argument.


### PR DESCRIPTION
This PR enables the V extension (if supported) and adds context switching for vector registers.