### PR TITLE
Kernel/riscv64: Add Sstc support

### DIFF
--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -36,6 +36,7 @@ enum class Address : u16 {
     SSTATUS = 0x100,
     SIE = 0x104,
     STVEC = 0x105,
+    STIMECMP = 0x14d,
 
     // Supervisor Protection and Translation
     SATP = 0x180,

--- a/Kernel/Arch/riscv64/Timer.cpp
+++ b/Kernel/Arch/riscv64/Timer.cpp
@@ -82,6 +82,11 @@ u64 Timer::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool que
 
 void Timer::set_compare(u64 compare)
 {
+    if (Processor::current().has_feature(CPUFeature::Sstc)) {
+        RISCV64::CSR::write<RISCV64::CSR::Address::STIMECMP>(compare);
+        return;
+    }
+
     if (SBI::Timer::set_timer(compare).is_error())
         MUST(SBI::Legacy::set_timer(compare));
 }


### PR DESCRIPTION
This means that we no longer need to make an SBI call to start the timer if Sstc is supported.