### PR TITLE
Toolchain: Build "driver-aarch64.o" for native SerenityOS GCC

### DIFF
--- a/Toolchain/Patches/gcc/0001-Add-a-gcc-driver-for-SerenityOS.patch
+++ b/Toolchain/Patches/gcc/0001-Add-a-gcc-driver-for-SerenityOS.patch
@@ -20,11 +20,12 @@ Co-Authored-By: Philip Herron <herron.philip@googlemail.com>
 Co-Authored-By: Shannon Booth <shannon@serenityos.org>
 ---
  gcc/config.gcc               | 23 +++++++++++++++++
+ gcc/config.host              |  2 +-
  gcc/config/i386/serenity.h   |  7 +++++
  gcc/config/serenity.h        | 50 ++++++++++++++++++++++++++++++++++++
  gcc/config/serenity.opt      | 35 +++++++++++++++++++++++++
  gcc/config/serenity.opt.urls |  1 +
- 5 files changed, 116 insertions(+)
+ 6 files changed, 117 insertions(+), 1 deletion(-)
  create mode 100644 gcc/config/i386/serenity.h
  create mode 100644 gcc/config/serenity.h
  create mode 100644 gcc/config/serenity.opt
@@ -71,6 +72,19 @@ index 40b50dc969ede4418b305ca01869ec157e054283..550573f66da4982f21334a16157220c6
  aarch64*-*-elf | aarch64*-*-fuchsia* | aarch64*-*-rtems*)
  	tm_file="${tm_file} elfos.h newlib-stdint.h"
  	tm_file="${tm_file} aarch64/aarch64-elf.h aarch64/aarch64-errata.h aarch64/aarch64-elf-raw.h"
+diff --git a/gcc/config.host b/gcc/config.host
+index 4c1a5e9910c8181a7dce9159da43139ec9accc8a..49128b1e2e791bdb810c74e9f6f5fd082f82e997 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -100,7 +100,7 @@ esac
+ 
+ case ${host} in
+   aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia* |\
+-  aarch64*-*-darwin*)
++  aarch64*-*-darwin* | aarch64-*-serenity*)
+     case ${target} in
+       aarch64*-*-*)
+ 	host_extra_gcc_objs="driver-aarch64.o"
 diff --git a/gcc/config/i386/serenity.h b/gcc/config/i386/serenity.h
 new file mode 100644
 index 0000000000000000000000000000000000000000..53a4b8e93b74b4808a4bfed91c4d5558217c584a


### PR DESCRIPTION
The GCC port would otherwise fail to link for AArch64:
"undefined reference to `host_detect_local_cpu(int, char const**)'".

`host_detect_local_cpu` won't actually work in serenity though since we don't have a `/proc/cpuinfo` file. This simply means `-march=native`, `-mcpu=native` and `-mtune=native` will be ignored.