### PR TITLE
LibPDF+PDFViewer: Move diagnostics setting bool into PDFViewer

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -49,10 +49,11 @@ PDFViewer::PDFViewer()
     m_rendering_preferences.show_clipping_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowClippingPaths"sv, false);
     m_rendering_preferences.show_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowImages"sv, true);
     m_rendering_preferences.show_hidden_text = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowHiddenText"sv, false);
-    m_rendering_preferences.show_diagnostics = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, false);
     m_rendering_preferences.clip_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipImages"sv, true);
     m_rendering_preferences.clip_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipPaths"sv, true);
     m_rendering_preferences.clip_text = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipText"sv, true);
+
+    m_show_rendering_diagnostics = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, false);
 }
 
 PDF::PDFErrorOr<void> PDFViewer::set_document(RefPtr<PDF::Document> document)
@@ -174,7 +175,7 @@ void PDFViewer::set_current_page(u32 current_page)
 
 void PDFViewer::set_show_rendering_diagnostics(bool show_diagnostics)
 {
-    m_rendering_preferences.show_diagnostics = show_diagnostics;
+    m_show_rendering_diagnostics = show_diagnostics;
     Config::write_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, show_diagnostics);
     update();
 }

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -63,7 +63,7 @@ public:
 
     PageViewMode page_view_mode() const { return m_page_view_mode; }
     void set_page_view_mode(PageViewMode);
-    bool show_rendering_diagnostics() const { return m_rendering_preferences.show_diagnostics; }
+    bool show_rendering_diagnostics() const { return m_show_rendering_diagnostics; }
     void set_show_rendering_diagnostics(bool);
     bool show_clipping_paths() const { return m_rendering_preferences.show_clipping_paths; }
     void set_show_clipping_paths(bool);
@@ -107,6 +107,7 @@ private:
     PageDimensionCache m_page_dimension_cache;
     PageViewMode m_page_view_mode;
     PDF::RenderingPreferences m_rendering_preferences;
+    bool m_show_rendering_diagnostics { false };
 
     Gfx::IntPoint m_pan_starting_position;
     int m_rotations { 0 };

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -136,7 +136,6 @@ struct RenderingPreferences {
     bool show_clipping_paths { false };
     bool show_images { true };
     bool show_hidden_text { false };
-    bool show_diagnostics { false };
 
     bool clip_images { true };
     bool clip_paths { true };


### PR DESCRIPTION
LibPDF didn't do anything with RenderingPreferences::show_diagnostics. It is only used in PDFViewer, so move it to there.

No behavior change.