### PR TITLE
LibShell: Increase program-aware completion timeout

### DIFF
--- a/Userland/Libraries/LibShell/Shell.cpp
+++ b/Userland/Libraries/LibShell/Shell.cpp
@@ -1997,7 +1997,7 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
         true);
 
     Vector<Line::CompletionSuggestion> suggestions;
-    auto timer = Core::Timer::create_single_shot(300, [&] {
+    auto timer = Core::Timer::create_single_shot(3000, [&] {
         Core::EventLoop::current().quit(1);
     });
     timer->start();


### PR DESCRIPTION
The old timeout was too low when running in riscv64 QEMU (with TCG).