### PR TITLE
Everywhere: Replace discord.gg/serenityos with serenityos.org/discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Everyone is welcome to work on the project, and while we have lots of fun, it's 
 
 ## Communication
 
-Join our Discord server: [SerenityOS Discord](https://discord.gg/serenityos)
+Join our Discord server: [SerenityOS Discord](https://serenityos.org/discord)
 
 ## Issue policy
 

--- a/Documentation/Links.md
+++ b/Documentation/Links.md
@@ -30,7 +30,7 @@ This is a roughly categorized list of pages relating to SerenityOS and its subpr
 
 ## Social
 
--   [Discord Server](https://discord.gg/serenityos)
+-   [Discord Server](https://serenityos.org/discord)
 -   [serenityos.social](https://serenityos.social/), unofficial Mastodon instance run by [networkException](https://serenityos.social/@networkexception) and [Linus Groh](https://serenityos.social/@linusg)
 -   [Map of Developers and Users](https://usermap.serenityos.org/)
 -   YouTube Channels

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Graphical Unix-like operating system for 64-bit x86, Arm, and RISC-V computers.
 
 [![GitHub Actions Status](https://github.com/SerenityOS/serenity/workflows/Build,%20lint,%20and%20test/badge.svg)](https://github.com/SerenityOS/serenity/actions?query=workflow%3A"Build%2C%20lint%2C%20and%20test")
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://issues.oss-fuzz.com/issues?q=project:serenity)
-[![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/serenityos)
+[![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://serenityos.org/discord)
 
 [FAQ](Documentation/FAQ.md) | [Documentation](#how-do-i-read-the-documentation) | [Build Instructions](#how-do-i-build-and-run-this)
 
@@ -64,7 +64,7 @@ Ladybird runs on the same platforms that can be the host for a cross build of Se
 
 ## Get in touch and participate!
 
-Join our Discord server: [SerenityOS Discord](https://discord.gg/serenityos)
+Join our Discord server: [SerenityOS Discord](https://serenityos.org/discord)
 
 Before opening an issue, please see the [issue policy](https://github.com/SerenityOS/serenity/blob/master/CONTRIBUTING.md#issue-policy).
 


### PR DESCRIPTION
This redirect should be more stable than the current discord.gg/serenityos custom invite link.

Depends on https://github.com/SerenityOS/serenityos.org/pull/5.