### PR TITLE
Kernel/Net: Remove broken Nagle's algorithm implementation

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -234,18 +234,6 @@ ErrorOr<size_t> TCPSocket::protocol_send(UserOrKernelBuffer const& data, size_t 
         return set_so_error(EHOSTUNREACH);
     size_t mss = routing_decision.adapter->mtu() - sizeof(IPv4Packet) - sizeof(TCPPacket);
 
-    if (!m_no_delay) {
-        // RFC 896 (Nagle’s algorithm): https://www.ietf.org/rfc/rfc0896
-        // "The solution is to inhibit the sending of new TCP  segments when
-        //  new  outgoing  data  arrives  from  the  user  if  any previously
-        //  transmitted data on the connection remains unacknowledged.   This
-        //  inhibition  is  to be unconditional; no timers, tests for size of
-        //  data received, or other conditions are required."
-        auto has_unacked_data = m_unacked_packets.with_shared([&](auto const& packets) { return packets.size > 0; });
-        if (has_unacked_data && data_length < mss)
-            return set_so_error(EAGAIN);
-    }
-
     data_length = min(data_length, mss);
     TRY(send_tcp_packet(TCPFlags::PSH | TCPFlags::ACK, &data, data_length, &routing_decision));
     return data_length;
@@ -471,15 +459,6 @@ ErrorOr<void> TCPSocket::setsockopt(int level, int option, Userspace<void const*
     MutexLocker locker(mutex());
 
     switch (option) {
-    case TCP_NODELAY:
-        if (user_value_size < sizeof(int))
-            return EINVAL;
-        int value;
-        TRY(copy_from_user(&value, static_ptr_cast<int const*>(user_value)));
-        if (value != 0 && value != 1)
-            return EINVAL;
-        m_no_delay = value;
-        return {};
     default:
         dbgln("setsockopt({}) at IPPROTO_TCP not implemented.", option);
         return ENOPROTOOPT;
@@ -497,14 +476,6 @@ ErrorOr<void> TCPSocket::getsockopt(OpenFileDescription& description, int level,
     TRY(copy_from_user(&size, value_size.unsafe_userspace_ptr()));
 
     switch (option) {
-    case TCP_NODELAY: {
-        int nodelay = m_no_delay ? 1 : 0;
-        if (size < sizeof(nodelay))
-            return EINVAL;
-        TRY(copy_to_user(static_ptr_cast<int*>(value), &nodelay));
-        size = sizeof(nodelay);
-        return copy_to_user(value_size, &size);
-    }
     default:
         dbgln("getsockopt({}) at IPPROTO_TCP not implemented.", option);
         return ENOPROTOOPT;

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -252,8 +252,6 @@ private:
     bool m_window_scaling_supported { false };
     size_t m_send_window_scale { 0 };
 
-    bool m_no_delay { false };
-
     IntrusiveListNode<TCPSocket> m_retransmit_list_node;
 
     Optional<IPv4SocketTuple> m_registered_socket_tuple;


### PR DESCRIPTION
This implementation currently aborts the whole transfer instead of caching pending packets in the kernel (see also #22524). We currently don't have a mechanism for caching pending packets in general and instead rely on userspace retrying the sendmsg syscall if the returned number of bytes sent is smaller than expected. However, 2bec281ddc3 made sys$sendmsg return an error (sys$write and sys$pwritev catch this error and retry), causing applications like WebServer to print an error instead of retrying the send operation.

So fixing Nagle's algorithm for sys$sendmsg requires adding a pending packet cache in the kernel.

For sys$write and sys$pwritev we currently busy loop in the kernel until we sent all bytes of the packet. This isn't really ideal either and especially problematic for Nagle's algorithm.