### PR TITLE
LibPDF+PDFViewer+MacPDF: Add an option to disable using global alpha

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
@@ -30,6 +30,7 @@
 - (IBAction)toggleClipImages:(id)sender;
 - (IBAction)toggleClipPaths:(id)sender;
 - (IBAction)toggleClipText:(id)sender;
+- (IBAction)toggleUseConstantAlpha:(id)sender;
 - (IBAction)toggleShowImages:(id)sender;
 - (IBAction)toggleShowHiddenText:(id)sender;
 

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -181,6 +181,10 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
         [item setState:_preferences.clip_text ? NSControlStateValueOn : NSControlStateValueOff];
         return _doc ? YES : NO;
     }
+    if ([item action] == @selector(toggleUseConstantAlpha:)) {
+        [item setState:_preferences.use_constant_alpha ? NSControlStateValueOn : NSControlStateValueOff];
+        return _doc ? YES : NO;
+    }
     if ([item action] == @selector(toggleShowImages:)) {
         [item setState:_preferences.show_images ? NSControlStateValueOn : NSControlStateValueOff];
         return _doc ? YES : NO;
@@ -220,6 +224,14 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
 {
     if (_doc) {
         _preferences.clip_text = !_preferences.clip_text;
+        [self invalidateCachedBitmap];
+    }
+}
+
+- (IBAction)toggleUseConstantAlpha:(id)sender
+{
+    if (_doc) {
+        _preferences.use_constant_alpha = !_preferences.use_constant_alpha;
         [self invalidateCachedBitmap];
     }
 }

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)toggleClipImages:(id)sender;
 - (IBAction)toggleClipPaths:(id)sender;
 - (IBAction)toggleClipText:(id)sender;
+- (IBAction)toggleUseConstantAlpha:(id)sender;
 - (IBAction)toggleShowImages:(id)sender;
 - (IBAction)toggleShowHiddenText:(id)sender;
 - (IBAction)showGoToPageDialog:(id)sender;

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -161,6 +161,11 @@
     [_pdfView toggleClipText:sender];
 }
 
+- (IBAction)toggleUseConstantAlpha:(id)sender
+{
+    [_pdfView toggleUseConstantAlpha:sender];
+}
+
 - (IBAction)toggleShowImages:(id)sender
 {
     [_pdfView toggleShowImages:sender];

--- a/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
+++ b/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -686,6 +686,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleClipText:" target="-1" id="qxg-tH-KXd"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Use Constant Alpha" state="on" id="DXr-ru-y6D">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleUseConstantAlpha:" target="-1" id="jSg-GC-40X"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Show Images" state="on" id="ArW-nr-ktv">

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -52,6 +52,7 @@ PDFViewer::PDFViewer()
     m_rendering_preferences.clip_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipImages"sv, true);
     m_rendering_preferences.clip_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipPaths"sv, true);
     m_rendering_preferences.clip_text = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipText"sv, true);
+    m_rendering_preferences.use_constant_alpha = Config::read_bool("PDFViewer"sv, "Rendering"sv, "UseConstantAlpha"sv, true);
 
     m_show_rendering_diagnostics = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, false);
 }
@@ -219,6 +220,13 @@ void PDFViewer::set_clip_text(bool clip_text)
 {
     m_rendering_preferences.clip_text = clip_text;
     Config::write_bool("PDFViewer"sv, "Rendering"sv, "ClipText"sv, clip_text);
+    update();
+}
+
+void PDFViewer::set_use_constant_alpha(bool use_constant_alpha)
+{
+    m_rendering_preferences.use_constant_alpha = use_constant_alpha;
+    Config::write_bool("PDFViewer"sv, "Rendering"sv, "UseConstantAlpha"sv, use_constant_alpha);
     update();
 }
 

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -77,6 +77,8 @@ public:
     void set_clip_paths(bool);
     bool clip_text() const { return m_rendering_preferences.clip_text; }
     void set_clip_text(bool);
+    bool use_constant_alpha() const { return m_rendering_preferences.use_constant_alpha; }
+    void set_use_constant_alpha(bool);
 
 protected:
     PDFViewer();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -295,6 +295,11 @@ ErrorOr<void> PDFViewerWidget::initialize_menubar(GUI::Window& window)
     });
     toggle_clip_text->set_checked(m_viewer->clip_text());
     debug_menu->add_action(toggle_clip_text);
+    auto toggle_use_constant_alpha = GUI::Action::create_checkable("Use &Constant Alpha", [&](auto& action) {
+        m_viewer->set_use_constant_alpha(action.is_checked());
+    });
+    toggle_use_constant_alpha->set_checked(m_viewer->use_constant_alpha());
+    debug_menu->add_action(toggle_use_constant_alpha);
 
     auto help_menu = window.add_menu("&Help"_string);
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(&window));

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1255,12 +1255,12 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
         }
     }
 
-    if (dict->contains(CommonNames::CA)) {
+    if (dict->contains(CommonNames::CA) && m_rendering_preferences.use_constant_alpha) {
         state().stroke_alpha_constant = dict->get_value(CommonNames::CA).to_float();
         state().stroke_style = style_with_alpha(state().stroke_style, state().stroke_alpha_constant);
     }
 
-    if (dict->contains(CommonNames::ca)) {
+    if (dict->contains(CommonNames::ca) && m_rendering_preferences.use_constant_alpha) {
         state().paint_alpha_constant = dict->get_value(CommonNames::ca).to_float();
         state().paint_style = style_with_alpha(state().paint_style, state().paint_alpha_constant);
     }

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -140,6 +140,8 @@ struct RenderingPreferences {
     bool clip_paths { true };
     bool clip_text { true };
 
+    bool use_constant_alpha { true };
+
     unsigned hash() const
     {
         return static_cast<unsigned>(show_clipping_paths) | static_cast<unsigned>(show_images) << 1;


### PR DESCRIPTION
This disables global alpha for all things that currently support it: Images, paths, and text.

"Global alpha" is alpha set on the graphics state. It is *not* alpha from SMasks (that is, images with per-pixel alpha use per-pixel alpha even with this setting unchecked).