### PR TITLE
LibPDF+Clients+LibGfx: Some prep commits for path clipping

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
@@ -27,9 +27,7 @@
 - (IBAction)goToPreviousPage:(id)sender;
 
 - (IBAction)toggleShowClippingPaths:(id)sender;
-- (IBAction)toggleClipImages:(id)sender;
-- (IBAction)toggleClipPaths:(id)sender;
-- (IBAction)toggleClipText:(id)sender;
+- (IBAction)toggleApplyClip:(id)sender;
 - (IBAction)toggleUseConstantAlpha:(id)sender;
 - (IBAction)toggleShowImages:(id)sender;
 - (IBAction)toggleShowHiddenText:(id)sender;

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -169,16 +169,8 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
         [item setState:_preferences.show_clipping_paths ? NSControlStateValueOn : NSControlStateValueOff];
         return _doc ? YES : NO;
     }
-    if ([item action] == @selector(toggleClipImages:)) {
-        [item setState:_preferences.clip_images ? NSControlStateValueOn : NSControlStateValueOff];
-        return _doc ? YES : NO;
-    }
-    if ([item action] == @selector(toggleClipPaths:)) {
-        [item setState:_preferences.clip_paths ? NSControlStateValueOn : NSControlStateValueOff];
-        return _doc ? YES : NO;
-    }
-    if ([item action] == @selector(toggleClipText:)) {
-        [item setState:_preferences.clip_text ? NSControlStateValueOn : NSControlStateValueOff];
+    if ([item action] == @selector(toggleApplyClip:)) {
+        [item setState:_preferences.apply_clip ? NSControlStateValueOn : NSControlStateValueOff];
         return _doc ? YES : NO;
     }
     if ([item action] == @selector(toggleUseConstantAlpha:)) {
@@ -204,26 +196,10 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
     }
 }
 
-- (IBAction)toggleClipImages:(id)sender
+- (IBAction)toggleApplyClip:(id)sender
 {
     if (_doc) {
-        _preferences.clip_images = !_preferences.clip_images;
-        [self invalidateCachedBitmap];
-    }
-}
-
-- (IBAction)toggleClipPaths:(id)sender
-{
-    if (_doc) {
-        _preferences.clip_paths = !_preferences.clip_paths;
-        [self invalidateCachedBitmap];
-    }
-}
-
-- (IBAction)toggleClipText:(id)sender
-{
-    if (_doc) {
-        _preferences.clip_text = !_preferences.clip_text;
+        _preferences.apply_clip = !_preferences.apply_clip;
         [self invalidateCachedBitmap];
     }
 }

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
@@ -22,9 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)goToNextPage:(id)sender;
 - (IBAction)goToPreviousPage:(id)sender;
 - (IBAction)toggleShowClippingPaths:(id)sender;
-- (IBAction)toggleClipImages:(id)sender;
-- (IBAction)toggleClipPaths:(id)sender;
-- (IBAction)toggleClipText:(id)sender;
+- (IBAction)toggleApplyClip:(id)sender;
 - (IBAction)toggleUseConstantAlpha:(id)sender;
 - (IBAction)toggleShowImages:(id)sender;
 - (IBAction)toggleShowHiddenText:(id)sender;

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -146,19 +146,9 @@
     [_pdfView toggleShowClippingPaths:sender];
 }
 
-- (IBAction)toggleClipImages:(id)sender
+- (IBAction)toggleApplyClip:(id)sender
 {
-    [_pdfView toggleClipImages:sender];
-}
-
-- (IBAction)toggleClipPaths:(id)sender
-{
-    [_pdfView toggleClipPaths:sender];
-}
-
-- (IBAction)toggleClipText:(id)sender
-{
-    [_pdfView toggleClipText:sender];
+    [_pdfView toggleApplyClip:sender];
 }
 
 - (IBAction)toggleUseConstantAlpha:(id)sender

--- a/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
+++ b/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
@@ -670,22 +670,10 @@
                                     <action selector="toggleShowClippingPaths:" target="-1" id="ZXz-gM-52n"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Clip Images" state="on" id="os0-En-UkL">
+                            <menuItem title="Apply Clip" state="on" id="os0-En-UkL">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="toggleClipImages:" target="-1" id="bHz-O3-V8K"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Clip Paths" state="on" id="KB8-Ld-jv8">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="toggleClipPaths:" target="-1" id="pZu-tJ-RFh"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Clip Text" state="on" id="u58-eB-op8">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="toggleClipText:" target="-1" id="qxg-tH-KXd"/>
+                                    <action selector="toggleApplyClip:" target="-1" id="bHz-O3-V8K"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Use Constant Alpha" state="on" id="DXr-ru-y6D">

--- a/Tests/LibGfx/TestPath.cpp
+++ b/Tests/LibGfx/TestPath.cpp
@@ -155,3 +155,31 @@ TEST_CASE(path_to_string)
         EXPECT_EQ(path.to_byte_string(), "M 10,10 L 20,20 Q 30,30 40,40 C 50,50 60,60 10,10");
     }
 }
+
+TEST_CASE(as_rect)
+{
+    {
+        Gfx::FloatRect rect { 10, 20, 30, 40 };
+        Gfx::Path path;
+        path.rect(rect);
+        EXPECT_EQ(path.as_rect(), rect);
+    }
+
+    {
+        Gfx::Path path;
+        path.move_to({ 10, 20 });
+        path.line_to({ 40, 20 });
+        path.line_to({ 40, 60 });
+        path.line_to({ 10, 60 });
+        path.close();
+        EXPECT_EQ(path.as_rect(), Gfx::FloatRect(10, 20, 30, 40));
+    }
+
+    {
+        Gfx::Path path;
+        path.move_to({ 10, 10 });
+        path.line_to({ 20, 10 });
+        path.line_to({ 20, 20 });
+        EXPECT(!path.as_rect().has_value());
+    }
+}

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -49,9 +49,7 @@ PDFViewer::PDFViewer()
     m_rendering_preferences.show_clipping_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowClippingPaths"sv, false);
     m_rendering_preferences.show_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowImages"sv, true);
     m_rendering_preferences.show_hidden_text = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowHiddenText"sv, false);
-    m_rendering_preferences.clip_images = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipImages"sv, true);
-    m_rendering_preferences.clip_paths = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipPaths"sv, true);
-    m_rendering_preferences.clip_text = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ClipText"sv, true);
+    m_rendering_preferences.apply_clip = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ApplyClip"sv, true);
     m_rendering_preferences.use_constant_alpha = Config::read_bool("PDFViewer"sv, "Rendering"sv, "UseConstantAlpha"sv, true);
 
     m_show_rendering_diagnostics = Config::read_bool("PDFViewer"sv, "Rendering"sv, "ShowDiagnostics"sv, false);
@@ -202,24 +200,10 @@ void PDFViewer::set_show_hidden_text(bool show_hidden_text)
     update();
 }
 
-void PDFViewer::set_clip_images(bool clip_images)
+void PDFViewer::set_apply_clip(bool apply_clip)
 {
-    m_rendering_preferences.clip_images = clip_images;
-    Config::write_bool("PDFViewer"sv, "Rendering"sv, "ClipImages"sv, clip_images);
-    update();
-}
-
-void PDFViewer::set_clip_paths(bool clip_paths)
-{
-    m_rendering_preferences.clip_paths = clip_paths;
-    Config::write_bool("PDFViewer"sv, "Rendering"sv, "ClipPaths"sv, clip_paths);
-    update();
-}
-
-void PDFViewer::set_clip_text(bool clip_text)
-{
-    m_rendering_preferences.clip_text = clip_text;
-    Config::write_bool("PDFViewer"sv, "Rendering"sv, "ClipText"sv, clip_text);
+    m_rendering_preferences.apply_clip = apply_clip;
+    Config::write_bool("PDFViewer"sv, "Rendering"sv, "ApplyClip"sv, apply_clip);
     update();
 }
 

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -71,12 +71,8 @@ public:
     void set_show_images(bool);
     bool show_hidden_text() const { return m_rendering_preferences.show_hidden_text; }
     void set_show_hidden_text(bool);
-    bool clip_images() const { return m_rendering_preferences.clip_images; }
-    void set_clip_images(bool);
-    bool clip_paths() const { return m_rendering_preferences.clip_paths; }
-    void set_clip_paths(bool);
-    bool clip_text() const { return m_rendering_preferences.clip_text; }
-    void set_clip_text(bool);
+    bool apply_clip() const { return m_rendering_preferences.apply_clip; }
+    void set_apply_clip(bool);
     bool use_constant_alpha() const { return m_rendering_preferences.use_constant_alpha; }
     void set_use_constant_alpha(bool);
 

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -265,7 +265,7 @@ ErrorOr<void> PDFViewerWidget::initialize_menubar(GUI::Window& window)
     });
     toggle_show_diagnostics->set_checked(m_viewer->show_rendering_diagnostics());
     debug_menu->add_action(toggle_show_diagnostics);
-    auto toggle_show_clipping_paths = GUI::Action::create_checkable("Show &Clipping Paths", [&](auto& action) {
+    auto toggle_show_clipping_paths = GUI::Action::create_checkable("Show Clipping &Paths", [&](auto& action) {
         m_viewer->set_show_clipping_paths(action.is_checked());
     });
     toggle_show_clipping_paths->set_checked(m_viewer->show_clipping_paths());
@@ -280,22 +280,12 @@ ErrorOr<void> PDFViewerWidget::initialize_menubar(GUI::Window& window)
     });
     toggle_show_hidden_text->set_checked(m_viewer->show_hidden_text());
     debug_menu->add_action(toggle_show_hidden_text);
-    auto toggle_clip_images = GUI::Action::create_checkable("Clip I&mages", [&](auto& action) {
-        m_viewer->set_clip_images(action.is_checked());
+    auto toggle_apply_clip = GUI::Action::create_checkable("Apply &Clip", [&](auto& action) {
+        m_viewer->set_apply_clip(action.is_checked());
     });
-    toggle_clip_images->set_checked(m_viewer->clip_images());
-    debug_menu->add_action(toggle_clip_images);
-    auto toggle_clip_paths = GUI::Action::create_checkable("Clip &Paths", [&](auto& action) {
-        m_viewer->set_clip_paths(action.is_checked());
-    });
-    toggle_clip_paths->set_checked(m_viewer->clip_paths());
-    debug_menu->add_action(toggle_clip_paths);
-    auto toggle_clip_text = GUI::Action::create_checkable("Clip &Text", [&](auto& action) {
-        m_viewer->set_clip_text(action.is_checked());
-    });
-    toggle_clip_text->set_checked(m_viewer->clip_text());
-    debug_menu->add_action(toggle_clip_text);
-    auto toggle_use_constant_alpha = GUI::Action::create_checkable("Use &Constant Alpha", [&](auto& action) {
+    toggle_apply_clip->set_checked(m_viewer->apply_clip());
+    debug_menu->add_action(toggle_apply_clip);
+    auto toggle_use_constant_alpha = GUI::Action::create_checkable("Use Constant &Alpha", [&](auto& action) {
         m_viewer->set_use_constant_alpha(action.is_checked());
     });
     toggle_use_constant_alpha->set_checked(m_viewer->use_constant_alpha());

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -371,6 +371,26 @@ ByteString Path::to_byte_string() const
     return builder.to_byte_string();
 }
 
+Optional<FloatRect> Path::as_rect() const
+{
+    if (m_commands.size() != 6 || m_points.size() != 5)
+        return {};
+    if (m_commands[0] != PathSegment::MoveTo
+        || m_commands[1] != PathSegment::LineTo
+        || m_commands[2] != PathSegment::LineTo
+        || m_commands[3] != PathSegment::LineTo
+        || m_commands[4] != PathSegment::LineTo
+        || m_commands[5] != PathSegment::ClosePath)
+        return {};
+    VERIFY(m_points[0] == m_points[4]);
+    if (m_points[0].y() != m_points[1].y()
+        || m_points[1].x() != m_points[2].x()
+        || m_points[2].y() != m_points[3].y()
+        || m_points[3].x() != m_points[0].x())
+        return {};
+    return FloatRect::from_two_points(m_points[0], m_points[2]);
+}
+
 void Path::segmentize_path()
 {
     Vector<FloatLine> segments;

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -306,6 +306,8 @@ public:
         invalidate_split_lines();
     }
 
+    Optional<FloatRect> as_rect() const;
+
 private:
     void approximate_elliptical_arc_with_cubic_beziers(FloatPoint center, FloatSize radii, float x_axis_rotation, float theta, float theta_delta);
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -104,10 +104,16 @@ Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitm
 void Renderer::show_clipping_paths()
 {
     Gfx::Path::StrokeStyle stroke_style;
-    stroke_style.thickness = 1.0f;
-    for (auto const& path : m_clip_paths_to_show_for_debugging)
-        m_anti_aliasing_painter.stroke_path(path, Color::Black, stroke_style);
-    m_clip_paths_to_show_for_debugging.clear();
+    stroke_style.thickness = 6.0f;
+
+    auto dash_style = stroke_style;
+    dash_style.cap_style = Gfx::Path::CapStyle::Butt;
+    dash_style.dash_pattern = { 12, 12 };
+
+    for (auto const& path : m_clip_paths_to_show_for_debugging) {
+        m_anti_aliasing_painter.stroke_path(path, Gfx::Color { 0xff, 0x6b, 0x6b }, stroke_style);
+        m_anti_aliasing_painter.stroke_path(path, Gfx::Color { 0x4e, 0xcd, 0xc4 }, dash_style);
+    }
 }
 
 PDFErrorsOr<void> Renderer::render()

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -302,7 +302,7 @@ void Renderer::deactivate_clip()
 
 void Renderer::begin_path_paint()
 {
-    if (m_rendering_preferences.clip_paths)
+    if (m_rendering_preferences.apply_clip)
         activate_clip();
     m_current_path.transform(state().ctm);
 }
@@ -321,7 +321,7 @@ void Renderer::end_path_paint()
     // "Once a path has been painted, it is no longer defined; there is then no current path
     //  until a new one is begun with the m or re operator."
     m_current_path.clear();
-    if (m_rendering_preferences.clip_paths)
+    if (m_rendering_preferences.apply_clip)
         deactivate_clip();
 }
 
@@ -1238,7 +1238,7 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
         return Error::rendering_unsupported_error("Can't draw text because an invalid font was in use");
 
     OwnPtr<ClipRAII> clip_raii;
-    if (m_rendering_preferences.clip_text)
+    if (m_rendering_preferences.apply_clip)
         clip_raii = make<ClipRAII>(*this);
 
     auto start_position = Gfx::FloatPoint { 0.0f, 0.0f };
@@ -1625,7 +1625,7 @@ PDFErrorOr<void> Renderer::paint_image_xobject(NonnullRefPtr<StreamObject> image
     auto image_dict = image->dict();
 
     OwnPtr<ClipRAII> clip_raii;
-    if (m_rendering_preferences.clip_images)
+    if (m_rendering_preferences.apply_clip)
         clip_raii = make<ClipRAII>(*this);
 
     if (!m_rendering_preferences.show_images) {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -34,7 +34,8 @@ public:
     }
     ~ScopedState()
     {
-        m_renderer.m_graphics_state_stack.shrink(m_starting_stack_depth);
+        while (m_renderer.m_graphics_state_stack.size() > m_starting_stack_depth)
+            MUST(m_renderer.handle_restore_state({}));
     }
 
 private:

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -233,6 +233,9 @@ private:
     ALWAYS_INLINE GraphicsState& state() { return m_graphics_state_stack.last(); }
     ALWAYS_INLINE TextState& text_state() { return state().text_state; }
 
+    Gfx::Painter& painter();
+    Gfx::AntiAliasingPainter& anti_aliasing_painter();
+
     template<typename T>
     ALWAYS_INLINE Gfx::Point<T> map(T x, T y) const;
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -286,6 +286,10 @@ private:
     Gfx::AffineTransform mutable m_text_rendering_matrix;
 
     HashMap<FontCacheKey, NonnullRefPtr<PDFFont>> m_font_cache;
+
+    // Only used for m_rendering_preferences.show_clipping_paths.
+    void show_clipping_paths();
+    Vector<Gfx::Path> m_clip_paths_to_show_for_debugging;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -142,9 +142,7 @@ struct RenderingPreferences {
     bool show_images { true };
     bool show_hidden_text { false };
 
-    bool clip_images { true };
-    bool clip_paths { true };
-    bool clip_text { true };
+    bool apply_clip { true };
 
     bool use_constant_alpha { true };
 


### PR DESCRIPTION
Visible changes: The Debug menu now only has "Apply Clip" instead of "Clip Text", "Cip Paths", and "Clip Images" (see the commit for that for details). "Show Clipping Paths" is now implemented differently, and looks different (see that commit for details there).

Also, some minor no-op adjustments.