### PR TITLE
LibPDF: Implement support for clipping to arbitrary paths

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -316,7 +316,7 @@ void Renderer::add_clip_path(Gfx::WindingRule)
         return;
 
     // FIXME: Support arbitrary path clipping in Path and use that here
-    auto next_clipping_bbox = m_current_path.bounding_box().to_type<int>();
+    auto next_clipping_bbox = Gfx::enclosing_int_rect(m_current_path.bounding_box());
     next_clipping_bbox.intersect(state().clipping_state.clip_bounding_box);
     state().clipping_state.clip_bounding_box = next_clipping_bbox;
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -158,13 +158,13 @@ PDFErrorOr<void> Renderer::handle_operator(Operator const& op, Optional<NonnullR
 RENDERER_HANDLER(save_state)
 {
     m_graphics_state_stack.append(state());
-    state().clipping_paths.has_own_clip = false;
+    state().clipping_state.has_own_clip = false;
     return {};
 }
 
 RENDERER_HANDLER(restore_state)
 {
-    bool popped_state_had_own_clip = state().clipping_paths.has_own_clip;
+    bool popped_state_had_own_clip = state().clipping_state.has_own_clip;
     if (popped_state_had_own_clip)
         finalize_clip_before_graphics_state_restore();
 
@@ -317,11 +317,11 @@ void Renderer::add_clip_path(Gfx::WindingRule)
 
     // FIXME: Support arbitrary path clipping in Path and use that here
     auto next_clipping_bbox = m_current_path.bounding_box();
-    next_clipping_bbox.intersect(state().clipping_paths.current.bounding_box());
-    state().clipping_paths.current = rect_path(next_clipping_bbox);
+    next_clipping_bbox.intersect(state().clipping_state.current.bounding_box());
+    state().clipping_state.current = rect_path(next_clipping_bbox);
 
-    state().clipping_paths.has_own_clip = true;
-    auto bounding_box = state().clipping_paths.current.bounding_box().to_type<int>();
+    state().clipping_state.has_own_clip = true;
+    auto bounding_box = state().clipping_state.current.bounding_box().to_type<int>();
     m_painter.add_clip_rect(bounding_box);
 }
 
@@ -332,7 +332,7 @@ void Renderer::finalize_clip_before_graphics_state_restore()
 
 void Renderer::restore_previous_clip_after_graphics_state_restore()
 {
-    auto bounding_box = state().clipping_paths.current.bounding_box().to_type<int>();
+    auto bounding_box = state().clipping_state.current.bounding_box().to_type<int>();
     m_painter.add_clip_rect(bounding_box);
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -311,6 +311,17 @@ void Renderer::deactivate_clip()
     m_painter.clear_clip_rect();
 }
 
+void Renderer::add_clip_path(Gfx::WindingRule)
+{
+    if (m_rendering_preferences.show_clipping_paths)
+        m_clip_paths_to_show_for_debugging.append(m_current_path);
+
+    // FIXME: Support arbitrary path clipping in Path and use that here
+    auto next_clipping_bbox = m_current_path.bounding_box();
+    next_clipping_bbox.intersect(state().clipping_paths.current.bounding_box());
+    state().clipping_paths.current = rect_path(next_clipping_bbox);
+}
+
 ///
 // Path painting operations
 ///
@@ -325,14 +336,7 @@ void Renderer::begin_path_paint()
 void Renderer::end_path_paint()
 {
     if (m_add_path_as_clip != AddPathAsClip::No) {
-        if (m_rendering_preferences.show_clipping_paths)
-            m_clip_paths_to_show_for_debugging.append(m_current_path);
-
-        // FIXME: Support arbitrary path clipping in Path and use that here
-        auto next_clipping_bbox = m_current_path.bounding_box();
-        next_clipping_bbox.intersect(state().clipping_paths.current.bounding_box());
-        state().clipping_paths.current = rect_path(next_clipping_bbox);
-
+        add_clip_path(m_add_path_as_clip == AddPathAsClip::Nonzero ? Gfx::WindingRule::Nonzero : Gfx::WindingRule::EvenOdd);
         m_add_path_as_clip = AddPathAsClip::No;
     }
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -65,7 +65,7 @@ struct TextState {
 };
 
 struct ClippingState {
-    Gfx::Path current;
+    Gfx::IntRect clip_bounding_box;
     bool has_own_clip { false };
 };
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -67,6 +67,7 @@ struct TextState {
 struct ClippingState {
     Gfx::IntRect clip_bounding_box;
     bool has_own_clip { false };
+    RefPtr<Gfx::Bitmap> clip_path_alpha {};
 };
 
 struct TransparencyGroupAttributes {
@@ -188,6 +189,9 @@ private:
     PDFErrorOr<void> handle_text_next_line_show_string(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
     PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
 
+    PDFErrorOr<void> prepare_clipped_bitmap_painter();
+    void copy_current_clip_path_content_to_output();
+
     PDFErrorOr<void> add_clip_path(Gfx::WindingRule);
     void finalize_clip_before_graphics_state_restore();
     PDFErrorOr<void> restore_previous_clip_after_graphics_state_restore();
@@ -253,6 +257,11 @@ private:
 
     RefPtr<Document> m_document;
     RefPtr<Gfx::Bitmap> m_bitmap;
+
+    RefPtr<Gfx::Bitmap> m_clipped_bitmap;
+    Optional<Gfx::Painter> m_clipped_bitmap_painter;
+    Optional<Gfx::AntiAliasingPainter> m_clipped_bitmap_anti_aliasing_painter;
+
     Page const& m_page;
     Gfx::Painter m_painter;
     Gfx::AntiAliasingPainter m_anti_aliasing_painter;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -202,6 +202,8 @@ private:
     void activate_clip();
     void deactivate_clip();
 
+    void add_clip_path(Gfx::WindingRule);
+
     void begin_path_paint();
     void end_path_paint();
     void stroke_current_path();

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -188,12 +188,12 @@ private:
     PDFErrorOr<void> handle_text_next_line_show_string(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
     PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
 
-    void add_clip_path(Gfx::WindingRule);
+    PDFErrorOr<void> add_clip_path(Gfx::WindingRule);
     void finalize_clip_before_graphics_state_restore();
-    void restore_previous_clip_after_graphics_state_restore();
+    PDFErrorOr<void> restore_previous_clip_after_graphics_state_restore();
 
     void begin_path_paint();
-    void end_path_paint();
+    PDFErrorOr<void> end_path_paint();
     void stroke_current_path();
     void fill_current_path(Gfx::WindingRule);
     void fill_and_stroke_current_path(Gfx::WindingRule);

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -66,6 +66,7 @@ struct TextState {
 
 struct ClippingPaths {
     Gfx::Path current;
+    bool has_own_clip { false };
 };
 
 struct TransparencyGroupAttributes {
@@ -187,22 +188,9 @@ private:
     PDFErrorOr<void> handle_text_next_line_show_string(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
     PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
 
-    class ClipRAII {
-    public:
-        ClipRAII(Renderer& renderer)
-            : m_renderer(renderer)
-        {
-            m_renderer.activate_clip();
-        }
-        ~ClipRAII() { m_renderer.deactivate_clip(); }
-
-    private:
-        Renderer& m_renderer;
-    };
-    void activate_clip();
-    void deactivate_clip();
-
     void add_clip_path(Gfx::WindingRule);
+    void finalize_clip_before_graphics_state_restore();
+    void restore_previous_clip_after_graphics_state_restore();
 
     void begin_path_paint();
     void end_path_paint();

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -64,7 +64,7 @@ struct TextState {
     bool knockout { true };
 };
 
-struct ClippingPaths {
+struct ClippingState {
     Gfx::Path current;
     bool has_own_clip { false };
 };
@@ -104,7 +104,7 @@ enum class AlphaSource {
 
 struct GraphicsState {
     Gfx::AffineTransform ctm;
-    ClippingPaths clipping_paths;
+    ClippingState clipping_state;
     RefPtr<ColorSpace> stroke_color_space { DeviceGrayColorSpace::the() };
     RefPtr<ColorSpace> paint_color_space { DeviceGrayColorSpace::the() };
     ColorOrStyle stroke_style { Color::Black };


### PR DESCRIPTION
While a clip is active, we now paint into a single additional bitmap
(m_clipped_bitmap, allocated once at first use, same size as the output
bitmap, but has a clip rect equal to the clip's bounding box applied for
efficiency). When the clip is popped, or when a new clip becomes active,
we paint this background buffer to the main output, using the clip path
as alpha channel.

The clip path is rasterized eagerly to graphics state.

m_clipped_bitmap_painter and m_clipped_bitmap_anti_aliasing_painter
are non-null if a clip is active, and painter()  and
anti_aliasing_painter() return those in that case.

(m_clipped_bitmap can be non-null even if there's no clip, since
it's allocated when the first clipping path is added and then kept
around for future clips.)

The rasterized clipping path is state().clipping_state.clip_path_alpha.

Transparent contents work by initializing the clip color buffer to the
current page contents each time a new clip is added.

Not super duper optimized, but also not super expensive: ~5-10%
overhead compared to before (for pages with complex clips), and
a big progression visually.

…and a few prep commits.

Continuation of #26032.

---

Improvement opportunities for follow-ups:

* if the active clip is an axis-aligned rect, we could keep setting
  a clip on the main painter and omit the two additional buffers.
  This is very common for painting images: they virtually always
  are surrounded by a (technically useless) rectangular clip.
  However, if the rect coordinates aren't ints (they usually aren't),
  this has slightly different aliasing behavior at the edge of the
  clip rect. So punt on this for now.

* This could be lazier with rasterizing the clip path until it's
  needed (main use: if several intersecting clips are set in
  sequence, could intersect their bounding boxes first)

* Clips are applied as a side effect of painting a path. We just
  paint the path a 2nd time for the clip. Most clips are applied
  with the `n` ("just add clip, don't paint") operator, so in
  that case there's no redundant work. But if the path is actually
  painted, using the same winding rule, there's potentially some
  work to save here by rasterizing the path just once. (This one doesn't
  really feel worth it to me tbh.)
