### PR TITLE
LibPDF: Read transparency group attribs for graphics state smask group

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -129,6 +129,7 @@ struct GraphicsState {
         };
         Type type { Type::Alpha };
         NonnullRefPtr<StreamObject> group;
+        TransparencyGroupAttributes group_attributes;
         Vector<float, 4> background_color { 0.0f, 0.0f, 0.0f, 0.0f };
         RefPtr<Function> transfer_function {}; // nullptr means identity function.
     };
@@ -201,6 +202,7 @@ private:
     void stroke_current_path();
     void fill_current_path(Gfx::WindingRule);
     void fill_and_stroke_current_path(Gfx::WindingRule);
+    PDFErrorOr<GraphicsState::SMask> read_smask_dict(NonnullRefPtr<DictObject> dict);
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     PDFErrorOr<void> show_text(ByteString const&);
 


### PR DESCRIPTION
Make read_smask_dict() a member function of Renderer for this.

Not yet used for anything, so no behavior change.

Also add a few spec comments.