### PR TITLE
Meta: Mark jbig2_to_pdf.py's -o flag as required

### DIFF
--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -110,7 +110,8 @@ def main():
         epilog=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("image", help="Input image")
-    parser.add_argument("-o", "--output", help="Path to output PDF")
+    parser.add_argument("-o", "--output", help="Path to output PDF",
+                        required=True)
     args = parser.parse_args()
 
     with open(args.image, 'rb') as f:


### PR DESCRIPTION
Makes for nicer --help output, and for a nicer error message when forgetting to specify the flag.