### PR TITLE
Kernel/aarch64: Add missing "cc" clobber in read_rndrrs()

### DIFF
--- a/Kernel/Arch/aarch64/ASM_wrapper.h
+++ b/Kernel/Arch/aarch64/ASM_wrapper.h
@@ -126,7 +126,7 @@ inline u64 read_rndrrs()
         "1:\n"
         "mrs %[value], s3_3_c2_c4_1 \n" // encoded RNDRRS register
         "b.eq 1b\n"
-        : [value] "=r"(value));
+        : [value] "=r"(value)::"cc");
 
     return value;
 }


### PR DESCRIPTION
Reading RNDRRS sets the NZCV condition flags.

This unbreaks booting on AArch64 Clang after c5d713864b5.