### PR TITLE
LibGfx/JBIG2: Let lossless halftone handler call regular one

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -2125,6 +2125,16 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     return {};
 }
 
+static ErrorOr<void> decode_immediate_lossless_text_region(JBIG2LoadingContext& context, SegmentData const& segment)
+{
+    // 7.4.3 Text region segment syntax
+    // "The data parts of all three of the text region segment types ("intermediate text region", "immediate text region" and
+    //  "immediate lossless text region") are coded identically, but are acted upon differently, see 8.2."
+    // But 8.2 only describes a difference between intermediate and immediate regions as far as I can tell,
+    // and calling the immediate text region handler for immediate lossless text regions seems to do the right thing (?).
+    return decode_immediate_text_region(context, segment);
+}
+
 static ErrorOr<void> decode_pattern_dictionary(JBIG2LoadingContext&, SegmentData& segment)
 {
     // 7.4.4 Pattern dictionary segment syntax
@@ -2371,6 +2381,16 @@ static ErrorOr<void> decode_immediate_generic_region(JBIG2LoadingContext& contex
     return {};
 }
 
+static ErrorOr<void> decode_immediate_lossless_generic_region(JBIG2LoadingContext& context, SegmentData const& segment)
+{
+    // 7.4.6 Generic region segment syntax
+    // "The data parts of all three of the generic region segment types ("intermediate generic region", "immediate generic region" and
+    //  "immediate lossless generic region") are coded identically, but are acted upon differently, see 8.2."
+    // But 8.2 only describes a difference between intermediate and immediate regions as far as I can tell,
+    // and calling the immediate generic region handler for immediate generic lossless regions seems to do the right thing (?).
+    return decode_immediate_generic_region(context, segment);
+}
+
 static ErrorOr<void> decode_intermediate_generic_refinement_region(JBIG2LoadingContext&, SegmentData const&)
 {
     return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode intermediate generic refinement region yet");
@@ -2551,13 +2571,10 @@ static ErrorOr<void> decode_data(JBIG2LoadingContext& context)
             TRY(decode_intermediate_text_region(context, segment));
             break;
         case SegmentType::ImmediateTextRegion:
-        case SegmentType::ImmediateLosslessTextRegion:
-            // 7.4.3 Text region segment syntax
-            // "The data parts of all three of the text region segment types ("intermediate text region", "immediate text region" and
-            //  "immediate lossless text region") are coded identically, but are acted upon differently, see 8.2."
-            // But 8.2 only describes a difference between intermediate and immediate regions as far as I can tell,
-            // and calling the immediate text region handler for immediate lossless text regions seems to do the right thing (?).
             TRY(decode_immediate_text_region(context, segment));
+            break;
+        case SegmentType::ImmediateLosslessTextRegion:
+            TRY(decode_immediate_lossless_text_region(context, segment));
             break;
         case SegmentType::PatternDictionary:
             TRY(decode_pattern_dictionary(context, segment));
@@ -2575,13 +2592,10 @@ static ErrorOr<void> decode_data(JBIG2LoadingContext& context)
             TRY(decode_intermediate_generic_region(context, segment));
             break;
         case SegmentType::ImmediateGenericRegion:
-        case SegmentType::ImmediateLosslessGenericRegion:
-            // 7.4.6 Generic region segment syntax
-            // "The data parts of all three of the generic region segment types ("intermediate generic region", "immediate generic region" and
-            //  "immediate lossless generic region") are coded identically, but are acted upon differently, see 8.2."
-            // But 8.2 only describes a difference between intermediate and immediate regions as far as I can tell,
-            // and calling the immediate generic region handler for immediate generic lossless regions seems to do the right thing (?).
             TRY(decode_immediate_generic_region(context, segment));
+            break;
+        case SegmentType::ImmediateLosslessGenericRegion:
+            TRY(decode_immediate_lossless_generic_region(context, segment));
             break;
         case SegmentType::IntermediateGenericRefinementRegion:
             TRY(decode_intermediate_generic_refinement_region(context, segment));

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -2291,9 +2291,14 @@ static ErrorOr<void> decode_immediate_halftone_region(JBIG2LoadingContext& conte
     return {};
 }
 
-static ErrorOr<void> decode_immediate_lossless_halftone_region(JBIG2LoadingContext&, SegmentData const&)
+static ErrorOr<void> decode_immediate_lossless_halftone_region(JBIG2LoadingContext& context, SegmentData const& segment)
 {
-    return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode immediate lossless halftone region yet");
+    // 7.4.5 Halftone region segment syntax
+    // "The data parts of all three of the halftone region segment types ("intermediate halftone region", "immediate halftone
+    //  region" and "immediate lossless halftone region") are coded identically, but are acted upon differently, see 8.2."
+    // But 8.2 only describes a difference between intermediate and immediate regions as far as I can tell,
+    // and calling the immediate generic region handler for immediate generic lossless regions seems to do the right thing (?).
+    return decode_immediate_halftone_region(context, segment);
 }
 
 static ErrorOr<void> decode_intermediate_generic_region(JBIG2LoadingContext&, SegmentData const&)

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -57,9 +57,10 @@ static PDF::PDFErrorOr<void> print_document_info(PDF::Document& document, bool j
 
 static PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_page(PDF::Document& document, PDF::Page const& page)
 {
-    auto page_size = Gfx::IntSize { 800, round_to<int>(800 * page.media_box.height() / page.media_box.width()) };
+    int const size = 800;
+    auto page_size = Gfx::IntSize { size, round_to<int>(size * page.media_box.height() / page.media_box.width()) };
     if (int rotation_count = (page.rotate / 90) % 4; rotation_count % 2 == 1)
-        page_size = Gfx::IntSize { round_to<int>(800 * page.media_box.width() / page.media_box.height()), 800 };
+        page_size = Gfx::IntSize { round_to<int>(size * page.media_box.width() / page.media_box.height()), size };
 
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
 


### PR DESCRIPTION
This matches what we do in the lossless symbol and text region handlers.

Like in https://github.com/SerenityOS/serenity/pull/23864, no test yet since I still haven't found a way to create
halftone jbig2 files.

But this lets us decode the jbig2 file in castle_halftone.pdf linked
to from https://github.com/mozilla/pdf.js/pull/8491