### PR TITLE
LibGfx/JBIG2: Implement support for USESKIP in generic regions

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1730,7 +1730,7 @@ static ErrorOr<NonnullOwnPtr<BitBuffer>> halftone_region_decoding_procedure(Half
         // FIXME: This is untested; I haven't found a sample that uses HENABLESKIP yet.
         //        But generic_region_decoding_procedure() currently doesn't implement skip_pattern anyways
         //        and errors out on it, so we'll notice when this gets hit.
-        skip_pattern_storage = TRY(BitBuffer::create(inputs.pattern_width, inputs.pattern_height));
+        skip_pattern_storage = TRY(BitBuffer::create(inputs.grayscale_width, inputs.grayscale_height));
         skip_pattern = *skip_pattern_storage;
 
         // 6.6.5.1 Computing HSKIP


### PR DESCRIPTION
As mentioned in https://github.com/SerenityOS/serenity/pull/23864, halftone region decoding is the only way
to call the generic region decoding procedure with USESKIP set.

With this, we can decode 25 of the jbig2 files in t89-halftone.zip,
up from 2 before this patch. For example, one file that errored out
previously and decodes fine now is 200-6-45.jb2.

---

And two prep commits:

[LibGfx/JBIG2: Don't crash on halftone regions with HENABLESKIP](https://github.com/SerenityOS/serenity/commit/85b7147713d471292185b59cb3f5933369f8bfe5) 

This is used by most files in t89-halftone.zip in
https://github.com/nico/power-jbig2-tests. They now fail with

    Runtime error: JBIG2ImageDecoderPlugin: Cannot decode USESKIP yet

instead of crashing.


[LibGfx/JBIG2: Add spec comments to generic_region_decoding_procedure()](https://github.com/SerenityOS/serenity/commit/3185105c7157a432db1458c3eaf711f2177d1237) 

...and move `result` down a bit, to a place where it matches the
comments better. Apparently there was no reason to have it so far up.

No behavior change.