### PR TITLE
LibGfx/JBIG2: Fix incorrect composition with negative coordinates

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -365,14 +365,10 @@ static void composite_bitbuffer(BitBuffer& out, BitBuffer const& bitmap, Gfx::In
 
     size_t start_x = 0, end_x = bitmap.width();
     size_t start_y = 0, end_y = bitmap.height();
-    if (position.x() < 0) {
+    if (position.x() < 0)
         start_x = -position.x();
-        position.set_x(0);
-    }
-    if (position.y() < 0) {
+    if (position.y() < 0)
         start_y = -position.y();
-        position.set_y(0);
-    }
     if (position.x() + bitmap.width() > out.width())
         end_x = out.width() - position.x();
     if (position.y() + bitmap.height() > out.height())


### PR DESCRIPTION
If a pattern was drawn with a negative x but was still wide enough to reach into the frame (and analogously for y), we both increased the start x that the pattern was drawn at and set the origin x to 0. But then, `position.x() + x` didn't start at 0 but at the absolute value of the negative offset.

Instead, only increase the start offset in the pattern, but don't change the negative x coordinate. This way, `position.x() + x` will start at 0.

Improves e.g. the appearance of the upper left image edges of 200-20-45.jb2.