### PR TITLE
Meta: Several tweaks to jbig2_to_pdf.py

### DIFF
--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -122,10 +122,11 @@ def main():
 
     # strip jbig2 header
     image_data = image_data[8:]
-    is_random_access = image_data[0] & 1 == 0
-    if image_data[0] & 2 == 0:
-        image_data = image_data[4:]
+    flags = image_data[0]
     image_data = image_data[1:]
+    is_random_access = flags & 1 == 0
+    if flags & 2 == 0:
+        image_data = image_data[4:]
 
     segment_headers = read_segment_headers(image_data, is_random_access)
 

--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -16,6 +16,7 @@ import textwrap
 
 
 PageInformation = 48
+EndOfPage = 49
 EndOfFile = 51
 
 
@@ -130,7 +131,20 @@ def main():
 
     segment_headers = read_segment_headers(image_data, is_random_access)
 
-    segment_headers = [h for h in segment_headers if h.associated_page in [0, 1]]
+    # "The JBIG2 file header, end-of-page segments, and end-of-file segment are not
+    #  used in PDF. These should be removed before the PDF objects described below
+    #  are created."
+    # [...]
+    # FIXME: "In the image XObject, however, the
+    #  segment’s page number should always be 1; that is, when each such segment is
+    #  written to the XObject, the value of its segment page association field should be
+    #  set to 1."
+    # [...]
+    # FIXME: "If the bit stream contains global segments (segments whose segment page asso-
+    #  ciation field contains 0), these segments must be placed in a separate PDF
+    #  stream, and the filter parameter listed in Table 3.10 should refer to that stream."
+    segment_headers = [h for h in segment_headers
+                       if h.associated_page in [0, 1] and h.type not in [EndOfFile, EndOfPage]]
 
     width, height = get_dimensions(segment_headers)
     print(f'dims {width}x{height}')

--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -27,6 +27,7 @@ def dedent(b):
 class SegmentHeader:
     segment_header_size: int
     type: int
+    associated_page: int
     bytes: bytes
     data_size: int
     data: bytes
@@ -51,8 +52,10 @@ def read_segment_header(data, offset):
     segment_header_size = 4 + 1 + 1 + ref_size * referred_segments_count
 
     if segment_page_association_size_is_32_bits:
+        page, = struct.unpack_from('>I', data, offset + segment_header_size)
         segment_header_size += 4
     else:
+        page = data[offset + segment_header_size]
         segment_header_size += 1
 
     data_size, = struct.unpack_from('>I', data, offset + segment_header_size)
@@ -61,7 +64,7 @@ def read_segment_header(data, offset):
     segment_header_size += 4
 
     bytes = data[offset:offset + segment_header_size]
-    return SegmentHeader(segment_header_size, type, bytes, data_size, None)
+    return SegmentHeader(segment_header_size, type, page, bytes, data_size, None)
 
 
 def read_segment_headers(data, is_random_access):

--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -92,7 +92,7 @@ def read_segment_headers(data, is_random_access):
     return segment_headers
 
 
-def random_access_to_sequential(segment_headers):
+def reserialize(segment_headers):
     out_data = bytes()
     for segment_header in segment_headers:
         out_data += segment_header.bytes
@@ -130,11 +130,12 @@ def main():
 
     segment_headers = read_segment_headers(image_data, is_random_access)
 
+    segment_headers = [h for h in segment_headers if h.associated_page in [0, 1]]
+
     width, height = get_dimensions(segment_headers)
     print(f'dims {width}x{height}')
 
-    if is_random_access:
-        image_data = random_access_to_sequential(segment_headers)
+    image_data = reserialize(segment_headers)
 
     start = dedent(b'''\
               %PDF-1.4

--- a/Meta/jbig2_to_pdf.py
+++ b/Meta/jbig2_to_pdf.py
@@ -52,6 +52,7 @@ def read_segment_header(data, offset):
     else:
         ref_size = 4
     segment_header_size = 4 + 1 + 1 + ref_size * referred_segments_count
+    pre_page_size = segment_header_size
 
     if segment_page_association_size_is_32_bits:
         page, = struct.unpack_from('>I', data, offset + segment_header_size)
@@ -66,6 +67,11 @@ def read_segment_header(data, offset):
     segment_header_size += 4
 
     bytes = data[offset:offset + segment_header_size]
+    if page != 0:
+        if segment_page_association_size_is_32_bits:
+            bytes = bytes[:pre_page_size] + b'\0\0\0\1' + bytes[pre_page_size + 4:]
+        else:
+            bytes = bytes[:pre_page_size] + b'\1' + bytes[pre_page_size + 1:]
     return SegmentHeader(segment_header_size, type, page, bytes, data_size, None)
 
 
@@ -136,7 +142,7 @@ def main():
     #  used in PDF. These should be removed before the PDF objects described below
     #  are created."
     # [...]
-    # FIXME: "In the image XObject, however, the
+    # "In the image XObject, however, the
     #  segment’s page number should always be 1; that is, when each such segment is
     #  written to the XObject, the value of its segment page association field should be
     #  set to 1."


### PR DESCRIPTION
This teaches Meta/jbig2_to_pdf.py these things:

- It now writes segments associated with page 0 (i.e. global segments) into the JBIG2Globals stream
- For multi-page jbig2 files, it now creates one PDF page per jbig2 page
- For each jbig2 stream, it rewrites the page numbers in the PDF to 1, as required by the PDF spec
- It drops EndOfPage and EndOfPage segments
- It can now handle striped jbig2 files

Except for the last bullet, this is all things described on page 81 in the PDF 1.7 spec.