### PR TITLE
CI: Set CTest timeout to 30 minutes

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -159,9 +159,8 @@ jobs:
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}/Meta/Lagom/Build
-        run: ninja test
+        run: ctest --output-on-failure --timeout 1800
         env:
-          CTEST_OUTPUT_ON_FAILURE: 1
           ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
           TESTS_ONLY: 1


### PR DESCRIPTION
All recent macOS CI jobs have been reaching the GitHub actions time limit.
Set the CTest timeout to 30 minutes to hopefully get more info about which test is timing out.