### PR TITLE
LibC: Clean up exported symbols a bit

### DIFF
--- a/Toolchain/Patches/binutils/0001-Add-support-for-SerenityOS.patch
+++ b/Toolchain/Patches/binutils/0001-Add-support-for-SerenityOS.patch
@@ -20,11 +20,11 @@ On AArch64, we set `COMMONPAGESIZE` to enable RELRO support.
  ld/Makefile.am                       |  3 +++
  ld/Makefile.in                       |  6 ++++++
  ld/configure.tgt                     |  9 +++++++++
- ld/emulparams/aarch64serenity.sh     |  5 +++++
+ ld/emulparams/aarch64serenity.sh     |  6 ++++++
  ld/emulparams/elf64lriscvserenity.sh |  2 ++
  ld/emulparams/elf_serenity.sh        |  1 +
  ld/emulparams/elf_x86_64_serenity.sh |  2 ++
- 11 files changed, 46 insertions(+), 1 deletion(-)
+ 11 files changed, 47 insertions(+), 1 deletion(-)
  create mode 100644 gas/config/te-serenity.h
  create mode 100644 ld/emulparams/aarch64serenity.sh
  create mode 100644 ld/emulparams/elf64lriscvserenity.sh
@@ -226,15 +226,16 @@ index ea01ccf9a1b7f959b25768397057e33a990541cb..c0f81114d44aef3deccd63c6325c60fa
  			targ_extra_libpath=$targ_extra_emuls
 diff --git a/ld/emulparams/aarch64serenity.sh b/ld/emulparams/aarch64serenity.sh
 new file mode 100644
-index 0000000000000000000000000000000000000000..23aed1440a033e2ac06536f43c1bacaf98832b92
+index 0000000000000000000000000000000000000000..8c037db13bf0f3808aac497572e5ea3dc2a6f92d
 --- /dev/null
 +++ b/ld/emulparams/aarch64serenity.sh
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,6 @@
 +source_sh ${srcdir}/emulparams/aarch64elf.sh
 +source_sh ${srcdir}/emulparams/elf_serenity.sh
 +
 +COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
 +unset EMBEDDED
++unset STACK_ADDR
 diff --git a/ld/emulparams/elf64lriscvserenity.sh b/ld/emulparams/elf64lriscvserenity.sh
 new file mode 100644
 index 0000000000000000000000000000000000000000..8bcbea812b49363cf4e2e94e1554998277b21cb1

--- a/Userland/Libraries/LibC/arch/aarch64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/aarch64/setjmp.S
@@ -17,6 +17,8 @@
 // int _setjmp(jmp_buf env)
 .global _setjmp
 .global setjmp
+.type _setjmp, @function
+.type setjmp, @function
 _setjmp:
 setjmp:
     mov x1, #0                               // Set savemask argument to 0
@@ -24,6 +26,7 @@ setjmp:
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigsetjmp.html
 // int sigsetjmp(sigjmp_buf env, int savemask)
 .global sigsetjmp
+.type sigsetjmp, @function
 sigsetjmp:
     str w1, [x0, #DID_SAVE_SIGNAL_MASK_SLOT] // Store savemask into did_save_signal_mask
     str wzr, [x0, #SAVED_SIGNAL_MASK_SLOT]   // Clear saved_signal_mask
@@ -59,6 +62,8 @@ sigsetjmp:
 
 .global _longjmp
 .global longjmp
+.type _longjmp, @function
+.type longjmp, @function
 _longjmp:
 longjmp:
     ldp x19, x20, [x0, #(0 * 8)]             // Restore registers

--- a/Userland/Libraries/LibC/arch/riscv64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/riscv64/setjmp.S
@@ -16,6 +16,8 @@
 // int _setjmp(jmp_buf env)
 .global _setjmp
 .global setjmp
+.type _setjmp, @function
+.type setjmp, @function
 _setjmp:
 setjmp:
     li a1, 0                             // Set savemask argument to 0
@@ -23,6 +25,7 @@ setjmp:
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigsetjmp.html
 // int sigsetjmp(sigjmp_buf env, int savemask)
 .global sigsetjmp
+.type sigsetjmp, @function
 sigsetjmp:
     sw a1, DID_SAVE_SIGNAL_MASK_SLOT(a0) // Store savemask into did_save_signal_mask
     sw zero, SAVED_SIGNAL_MASK_SLOT(a0)  // Clear saved_signal_mask
@@ -79,6 +82,8 @@ sigsetjmp:
 // void _longjmp(jmp_buf env, int val)
 .global _longjmp
 .global longjmp
+.type _longjmp, @function
+.type longjmp, @function
 _longjmp:
 longjmp:
     ld s0, 0*8(a0)                       // Restore registers

--- a/Userland/Libraries/LibC/arch/x86_64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/x86_64/setjmp.S
@@ -10,11 +10,14 @@
 
 .global _setjmp
 .global setjmp
+.type _setjmp, @function
+.type setjmp, @function
 _setjmp:
 setjmp:
     mov $0, %esi            // Set val argument to 0
 
 .global sigsetjmp
+.type sigsetjmp, @function
 sigsetjmp:
     mov %esi, 64(%rdi)      // Store val into did_save_signal_mask
     movl $0, 68(%rdi)       // Clear saved_signal_mask
@@ -46,6 +49,8 @@ sigsetjmp:
 
 .global _longjmp
 .global longjmp
+.type _longjmp, @function
+.type longjmp, @function
 _longjmp:
 longjmp:
     mov %esi, %eax


### PR DESCRIPTION
The `_stack` symbol change will only work after a manual toolchain rebuild (or the next forced toolchain update).