### PR TITLE
LibGfx/JBIG2: Support huffman-encoded symbol regions

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -388,11 +388,11 @@ TEST_CASE(test_jbig2_decode)
         // - halftone (code support added in #23864)
         // - lossless halftone (code support added in #26043)
         // - rotated halftone (code support added in #26044)
+        // - huffman symbol regions (code support added in #26068)
         // - coverage for different segment combination operators (or and xor xnor replace),
         //   with both background colors
         // Missing tests for things that aren't implemented yet:
         // - striping, especially with initially unknown page height
-        // - huffman symbol regions
         // - symbols with REFAGGNINST > 1
         // - huffman text regions
         // - intermediate regions
@@ -425,9 +425,13 @@ TEST_CASE(test_annex_h_jbig2)
 
     EXPECT_EQ(decoder->frame_count(), 3u);
 
-    // FIXME: Decode these successfully.
+    // FIXME: Decode this successfully.
     EXPECT(decoder->frame(0).is_error());
-    EXPECT(decoder->frame(1).is_error());
+
+    auto frame_2 = TRY_OR_FAIL(decoder->frame(1));
+    EXPECT_EQ(frame_2.image->size(), Gfx::IntSize(64, 56));
+
+    // FIXME: Decode this successfully.
     EXPECT(decoder->frame(2).is_error());
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -244,6 +244,7 @@ constexpr Array common_make_up_codes = {
 template<typename T, size_t Size>
 Optional<T> get_code_from_table(Array<T, Size> const& array, u16 code_word, u8 code_size)
 {
+    // FIXME: Use an approach that doesn't require a full scan for every bit. See Compress::CanonicalCodes.
     for (auto const& code : array) {
         if (code.code_length == code_size && code.code == code_word)
             return code;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -2725,13 +2725,13 @@ ErrorOr<ImageFrameDescriptor> JBIG2ImageDecoderPlugin::frame(size_t index, Optio
     if (index >= frame_count())
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid frame index");
 
-    if (m_context->state == JBIG2LoadingContext::State::Error)
-        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Decoding failed");
-
     if (m_context->current_page_number != m_context->page_numbers[index]) {
         m_context->current_page_number = m_context->page_numbers[index];
         m_context->state = JBIG2LoadingContext::State::NotDecoded;
     }
+
+    if (m_context->state == JBIG2LoadingContext::State::Error)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Decoding failed");
 
     if (m_context->state < JBIG2LoadingContext::State::Decoded) {
         auto result = decode_data(*m_context);


### PR DESCRIPTION
Most JBIG2 files that use huffman-encoded symbol regions also use
huffman-encoded text regions, which we don't yet support.

But page 2 of annex-h.jbig2 uses a huffman-encoded global symbol
dictionary and arithmetic coding for everything else, so this
is enough to let us decode page 2 of annex-h.jbig2 :^)

---

Progress towards https://library.sciencemadness.org/library/books/ignition.pdf