### PR TITLE
LibGfx/JBIG2: Add (some) support for huffman-coded text segments

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -391,12 +391,12 @@ TEST_CASE(test_jbig2_decode)
         // - halftone with graymap with > 256 entries (code support added in #26044 too)
         // - striping, especially with initially unknown page height (code support added in #26067)
         // - huffman symbol regions (code support added in #26068)
+        // - huffman text regions (code support added in #26075)
         // - coverage for different segment combination operators (or and xor xnor replace),
         //   with both background colors
         // Missing tests for things that aren't implemented yet:
         // - halftone with MMR graymap
         // - symbols with REFAGGNINST > 1
-        // - huffman text regions
         // - intermediate regions
         // - standalone refinement regions
         // - exttemplate

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -152,7 +152,7 @@ u32 ArithmeticIntegerIDDecoder::decode()
 }
 
 struct Code {
-    u16 prefix_length {};         // "PREFLEN" in spec.
+    u16 prefix_length {};         // "PREFLEN" in spec. High bit set for lower range table line.
     u8 range_length {};           // "RANGELEN" in spec.
     Optional<i32> first_value {}; // First number in "VAL" in spec.
     u16 code {};                  // "Encoding" in spec.
@@ -185,6 +185,111 @@ constexpr Array standard_huffman_table_D = {
     Code { 4, 3, 4, 0b1110 },
     Code { 5, 6, 12, 0b11110 },
     Code { 5, 32, 76, 0b11111 },
+};
+
+// Table B.6 – Standard Huffman table F
+constexpr Array standard_huffman_table_F = {
+    Code { 5, 10, -2048, 0b11100 },
+    Code { 4, 9, -1024, 0b1000 },
+    Code { 4, 8, -512, 0b1001 },
+    Code { 4, 7, -256, 0b1010 },
+    Code { 5, 6, -128, 0b11101 },
+    Code { 5, 5, -64, 0b11110 },
+    Code { 4, 5, -32, 0b1011 },
+    Code { 2, 7, 0, 0b00 },
+    Code { 3, 7, 128, 0b010 },
+    Code { 3, 8, 256, 0b011 },
+    Code { 4, 9, 512, 0b1100 },
+    Code { 4, 10, 1024, 0b1101 },
+    Code { 6 | 0x8000, 32, -2049, 0b111110 },
+    Code { 6, 32, 2048, 0b111111 },
+};
+
+// Table B.7 – Standard Huffman table G
+constexpr Array standard_huffman_table_G = {
+    Code { 4, 9, -1024, 0b1000 },
+    Code { 3, 8, -512, 0b000 },
+    Code { 4, 7, -256, 0b1001 },
+    Code { 5, 6, -128, 0b11010 },
+    Code { 5, 5, -64, 0b11011 },
+    Code { 4, 5, -32, 0b1010 },
+    Code { 4, 5, 0, 0b1011 },
+    Code { 5, 5, 32, 0b11100 },
+    Code { 5, 6, 64, 0b11101 },
+    Code { 4, 7, 128, 0b1100 },
+    Code { 3, 8, 256, 0b001 },
+    Code { 3, 9, 512, 0b010 },
+    Code { 3, 10, 1024, 0b011 },
+    Code { 5 | 0x8000, 32, -1025, 0b11110 },
+    Code { 5, 32, 2048, 0b11111 },
+};
+
+// Table B.8 – Standard Huffman table H
+constexpr Array standard_huffman_table_H = {
+    Code { 8, 3, -15, 0b11111100 },
+    Code { 9, 1, -7, 0b111111100 },
+    Code { 8, 1, -5, 0b11111101 },
+    Code { 9, 0, -3, 0b111111101 },
+    Code { 7, 0, -2, 0b1111100 },
+    Code { 4, 0, -1, 0b1010 },
+    Code { 2, 1, 0, 0b00 },
+    Code { 5, 0, 2, 0b11010 },
+    Code { 6, 0, 3, 0b111010 },
+    Code { 3, 4, 4, 0b100 },
+    Code { 6, 1, 20, 0b111011 },
+    Code { 4, 4, 22, 0b1011 },
+    Code { 4, 5, 38, 0b1100 },
+    Code { 5, 6, 70, 0b11011 },
+    Code { 5, 7, 134, 0b11100 },
+    Code { 6, 7, 262, 0b111100 },
+    Code { 7, 8, 390, 0b1111101 },
+    Code { 6, 10, 646, 0b111101 },
+    Code { 9 | 0x8000, 32, -16, 0b111111110 },
+    Code { 9, 32, 1670, 0b111111111 },
+    Code { 2, 0, OptionalNone {}, 0b01 },
+};
+
+// Table B.11 – Standard Huffman table K
+constexpr Array standard_huffman_table_K = {
+    Code { 1, 0, 1, 0b0 },
+    Code { 2, 1, 2, 0b10 },
+    Code { 4, 0, 4, 0b1100 },
+    Code { 4, 1, 5, 0b1101 },
+    Code { 5, 1, 7, 0b11100 },
+    Code { 5, 2, 9, 0b11101 },
+    Code { 6, 2, 13, 0b111100 },
+    Code { 7, 2, 17, 0b1111010 },
+    Code { 7, 3, 21, 0b1111011 },
+    Code { 7, 4, 29, 0b1111100 },
+    Code { 7, 5, 45, 0b1111101 },
+    Code { 7, 6, 77, 0b1111110 },
+    Code { 7, 32, 141, 0b1111111 },
+};
+
+// Table B.12 – Standard Huffman table L
+constexpr Array standard_huffman_table_L = {
+    Code { 1, 0, 1, 0b0 },
+    Code { 2, 0, 2, 0b10 },
+    Code { 3, 1, 3, 0b110 },
+    Code { 5, 0, 5, 0b11100 },
+    Code { 5, 1, 6, 0b11101 },
+    Code { 6, 1, 8, 0b111100 },
+    Code { 7, 0, 10, 0b1111010 },
+    Code { 7, 1, 11, 0b1111011 },
+    Code { 7, 2, 13, 0b1111100 },
+    Code { 7, 3, 17, 0b1111101 },
+    Code { 7, 4, 25, 0b1111110 },
+    Code { 8, 5, 41, 0b11111110 },
+    Code { 8, 32, 73, 0b11111111 },
+};
+
+// Table B.14 – Standard Huffman table N
+constexpr Array standard_huffman_table_N = {
+    Code { 3, 0, -2, 0b100 },
+    Code { 3, 0, -1, 0b101 },
+    Code { 1, 0, 0, 0b0 },
+    Code { 3, 0, 1, 0b110 },
+    Code { 3, 0, 2, 0b111 },
 };
 
 class HuffmanTable {
@@ -246,24 +351,36 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
     }
     case StandardTable::B_5:
         return Error::from_string_literal("Standard table E not yet supported");
-    case StandardTable::B_6:
-        return Error::from_string_literal("Standard table F not yet supported");
-    case StandardTable::B_7:
-        return Error::from_string_literal("Standard table G not yet supported");
-    case StandardTable::B_8:
-        return Error::from_string_literal("Standard table H not yet supported");
+    case StandardTable::B_6: {
+        static HuffmanTable standard_table_F(standard_huffman_table_F);
+        return &standard_table_F;
+    }
+    case StandardTable::B_7: {
+        static HuffmanTable standard_table_G(standard_huffman_table_G);
+        return &standard_table_G;
+    }
+    case StandardTable::B_8: {
+        static HuffmanTable standard_table_H(standard_huffman_table_H, true);
+        return &standard_table_H;
+    }
     case StandardTable::B_9:
         return Error::from_string_literal("Standard table I not yet supported");
     case StandardTable::B_10:
         return Error::from_string_literal("Standard table J not yet supported");
-    case StandardTable::B_11:
-        return Error::from_string_literal("Standard table K not yet supported");
-    case StandardTable::B_12:
-        return Error::from_string_literal("Standard table L not yet supported");
+    case StandardTable::B_11: {
+        static HuffmanTable standard_table_K(standard_huffman_table_K);
+        return &standard_table_K;
+    }
+    case StandardTable::B_12: {
+        static HuffmanTable standard_table_L(standard_huffman_table_L);
+        return &standard_table_L;
+    }
     case StandardTable::B_13:
         return Error::from_string_literal("Standard table M not yet supported");
-    case StandardTable::B_14:
-        return Error::from_string_literal("Standard table N not yet supported");
+    case StandardTable::B_14: {
+        static HuffmanTable standard_table_N(standard_huffman_table_N);
+        return &standard_table_N;
+    }
     case StandardTable::B_15:
         return Error::from_string_literal("Standard table O not yet supported");
     }
@@ -279,13 +396,16 @@ ErrorOr<Optional<i32>> HuffmanTable::read_symbol_internal(BigEndianInputBitStrea
         code_word = (code_word << 1) | TRY(stream.read_bit());
         code_size++;
         for (auto const& code : m_codes) {
-            if (code.prefix_length == code_size && code.code == code_word) {
+            if ((code.prefix_length & 0x7fff) == code_size && code.code == code_word) {
                 if (!code.first_value.has_value())
                     return code.first_value; // OOB
 
-                i32 value = 0;
+                i32 value = 0; // "HTOFFSET" in spec.
                 for (u8 i = 0; i < code.range_length; ++i)
                     value = (value << 1) | TRY(stream.read_bit());
+
+                if (code.prefix_length & 0x8000)
+                    return code.first_value.value() - value;
                 return value + code.first_value.value();
             }
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1329,7 +1329,16 @@ struct TextRegionDecodingInputParameters {
     Corner reference_corner { Corner::TopLeft }; // "REFCORNER" in spec.
 
     i8 delta_s_offset { 0 }; // "SBDSOFFSET" in spec.
-    // FIXME: SBHUFFFS, SBHUFFFDS, SBHUFFDT, SBHUFFRDW, SBHUFFRDH, SBHUFFRDX, SBHUFFRDY, SBHUFFRSIZE
+
+    // Only set if uses_huffman_encoding is true.
+    JBIG2::HuffmanTable const* first_s_table { nullptr };                 // "SBHUFFFS" in spec.
+    JBIG2::HuffmanTable const* subsequent_s_table { nullptr };            // "SBHUFFDS" in spec.
+    JBIG2::HuffmanTable const* delta_t_table { nullptr };                 // "SBHUFFDT" in spec.
+    JBIG2::HuffmanTable const* refinement_delta_width_table { nullptr };  // "SBHUFFRDW" in spec.
+    JBIG2::HuffmanTable const* refinement_delta_height_table { nullptr }; // "SBHUFFRDH" in spec.
+    JBIG2::HuffmanTable const* refinement_x_offset_table { nullptr };     // "SBHUFFRDX" in spec.
+    JBIG2::HuffmanTable const* refinement_y_offset_table { nullptr };     // "SBHUFFRDY" in spec.
+    JBIG2::HuffmanTable const* refinement_size_table { nullptr };         // "SBHUFFRSIZE" in spec.
 
     u8 refinement_template { 0 };                                        // "SBRTEMPLATE" in spec.
     Array<AdaptiveTemplatePixel, 2> refinement_adaptive_template_pixels; // "SBRATX" / "SBRATY" in spec.
@@ -2470,7 +2479,100 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
 
     // 7.4.3.1.2 Text region segment Huffman flags
     // "This field is only present if SBHUFF is 1."
-    // FIXME: Support this eventually.
+    JBIG2::HuffmanTable const* first_s_table = nullptr;
+    JBIG2::HuffmanTable const* subsequent_s_table = nullptr;
+    JBIG2::HuffmanTable const* delta_t_table = nullptr;
+    JBIG2::HuffmanTable const* refinement_delta_width_table = nullptr;
+    JBIG2::HuffmanTable const* refinement_delta_height_table = nullptr;
+    JBIG2::HuffmanTable const* refinement_x_offset_table = nullptr;
+    JBIG2::HuffmanTable const* refinement_y_offset_table = nullptr;
+    JBIG2::HuffmanTable const* refinement_size_table = nullptr;
+    if (uses_huffman_encoding) {
+        u16 huffman_flags = TRY(stream.read_value<BigEndian<u16>>());
+
+        auto first_s_selection = (huffman_flags >> 0) & 0b11; // "SBHUFFFS" in spec.
+        if (first_s_selection == 0)
+            first_s_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_6));
+        else if (first_s_selection == 1)
+            first_s_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_7));
+        else if (first_s_selection == 2)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid first_s_table");
+        else if (first_s_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        auto subsequent_s_selection = (huffman_flags >> 2) & 0b11; // "SBHUFFDS" in spec.
+        if (subsequent_s_selection == 0)
+            subsequent_s_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_8));
+        else if (subsequent_s_selection == 1)
+            subsequent_s_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_9));
+        else if (subsequent_s_selection == 2)
+            subsequent_s_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_10));
+        else if (subsequent_s_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        auto delta_t_selection = (huffman_flags >> 4) & 0b11; // "SBHUFFDT" in spec.
+        if (delta_t_selection == 0)
+            delta_t_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_11));
+        else if (delta_t_selection == 1)
+            delta_t_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_12));
+        else if (delta_t_selection == 2)
+            delta_t_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_13));
+        else if (delta_t_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        if (!uses_refinement_coding && (huffman_flags & 0x7fc0) != 0)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Huffman flags have refinement bits set but refinement bit is not set");
+
+        auto refinement_delta_width_selection = (huffman_flags >> 6) & 0b11; // "SBHUFFRDW" in spec.
+        if (refinement_delta_width_selection == 0)
+            refinement_delta_width_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_14));
+        else if (refinement_delta_width_selection == 1)
+            refinement_delta_width_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_15));
+        else if (refinement_delta_width_selection == 2)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid refinement_delta_width_table");
+        else if (refinement_delta_width_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        auto refinement_delta_height_selection = (huffman_flags >> 8) & 0b11; // "SBHUFFRDH" in spec.
+        if (refinement_delta_height_selection == 0)
+            refinement_delta_height_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_14));
+        else if (refinement_delta_height_selection == 1)
+            refinement_delta_height_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_15));
+        else if (refinement_delta_height_selection == 2)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid refinement_delta_height_table");
+        else if (refinement_delta_height_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        auto refinement_x_offset_selection = (huffman_flags >> 10) & 0b11; // "SBHUFFRDX" in spec.
+        if (refinement_x_offset_selection == 0)
+            refinement_x_offset_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_14));
+        else if (refinement_x_offset_selection == 1)
+            refinement_x_offset_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_15));
+        else if (refinement_x_offset_selection == 2)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid refinement_x_offset_table");
+        else if (refinement_x_offset_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        auto refinement_y_offset_selection = (huffman_flags >> 12) & 0b11; // "SBHUFFRDY" in spec.
+        if (refinement_y_offset_selection == 0)
+            refinement_y_offset_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_14));
+        else if (refinement_y_offset_selection == 1)
+            refinement_y_offset_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_15));
+        else if (refinement_y_offset_selection == 2)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid refinement_y_offset_table");
+        else if (refinement_y_offset_selection == 3)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        auto refinement_size_selection = (huffman_flags >> 14) & 0b1; // "SBHUFFRSIZE" in spec.
+        if (refinement_size_selection == 0)
+            refinement_size_table = TRY(JBIG2::HuffmanTable::standard_huffman_table(JBIG2::HuffmanTable::StandardTable::B_1));
+        else if (refinement_size_selection == 1)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Custom Huffman tables not yet supported");
+
+        if (huffman_flags & 0x8000)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid text region segment Huffman flags");
+    }
+
     if (uses_huffman_encoding)
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Cannot decode huffman text regions yet");
 
@@ -2530,7 +2632,14 @@ static ErrorOr<void> decode_immediate_text_region(JBIG2LoadingContext& context, 
     inputs.size_of_symbol_instance_strips = strip_size;
     inputs.id_symbol_code_length = ceil(log2(symbols.size()));
     inputs.symbols = move(symbols);
-    // FIXME: Huffman tables.
+    inputs.first_s_table = first_s_table;
+    inputs.subsequent_s_table = subsequent_s_table;
+    inputs.delta_t_table = delta_t_table;
+    inputs.refinement_delta_width_table = refinement_delta_width_table;
+    inputs.refinement_delta_height_table = refinement_delta_height_table;
+    inputs.refinement_x_offset_table = refinement_x_offset_table;
+    inputs.refinement_y_offset_table = refinement_y_offset_table;
+    inputs.refinement_size_table = refinement_size_table;
     inputs.refinement_template = refinement_template;
     inputs.refinement_adaptive_template_pixels = adaptive_refinement_template;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -249,6 +249,32 @@ constexpr Array standard_huffman_table_H = {
     Code { 2, 0, OptionalNone {}, 0b01 },
 };
 
+// Table B.9 – Standard Huffman table I
+constexpr Array standard_huffman_table_I = {
+    Code { 8, 4, -31, 0b11111100 },
+    Code { 9, 2, -15, 0b111111100 },
+    Code { 8, 2, -11, 0b11111101 },
+    Code { 9, 1, -7, 0b111111101 },
+    Code { 7, 1, -5, 0b1111100 },
+    Code { 4, 1, -3, 0b1010 },
+    Code { 3, 1, -1, 0b010 },
+    Code { 3, 1, 1, 0b011 },
+    Code { 5, 1, 3, 0b11010 },
+    Code { 6, 1, 5, 0b111010 },
+    Code { 3, 5, 7, 0b100 },
+    Code { 6, 2, 39, 0b111011 },
+    Code { 4, 5, 43, 0b1011 },
+    Code { 4, 6, 75, 0b1100 },
+    Code { 5, 7, 139, 0b11011 },
+    Code { 5, 8, 267, 0b11100 },
+    Code { 6, 8, 523, 0b111100 },
+    Code { 7, 9, 779, 0b1111101 },
+    Code { 6, 11, 1291, 0b111101 },
+    Code { 9 | 0x8000, 32, -32, 0b111111110 },
+    Code { 9, 32, 3339, 0b111111111 },
+    Code { 2, 0, OptionalNone {}, 0b00 },
+};
+
 // Table B.11 – Standard Huffman table K
 constexpr Array standard_huffman_table_K = {
     Code { 1, 0, 1, 0b0 },
@@ -380,8 +406,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_H(standard_huffman_table_H, true);
         return &standard_table_H;
     }
-    case StandardTable::B_9:
-        return Error::from_string_literal("Standard table I not yet supported");
+    case StandardTable::B_9: {
+        static HuffmanTable standard_table_I(standard_huffman_table_I, true);
+        return &standard_table_I;
+    }
     case StandardTable::B_10:
         return Error::from_string_literal("Standard table J not yet supported");
     case StandardTable::B_11: {

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -275,6 +275,31 @@ constexpr Array standard_huffman_table_I = {
     Code { 2, 0, OptionalNone {}, 0b00 },
 };
 
+// Table B.10 – Standard Huffman table J
+constexpr Array standard_huffman_table_J = {
+    Code { 7, 4, -21, 0b1111010 },
+    Code { 8, 0, -5, 0b11111100 },
+    Code { 7, 0, -4, 0b1111011 },
+    Code { 5, 0, -3, 0b11000 },
+    Code { 2, 2, -2, 0b00 },
+    Code { 5, 0, 2, 0b11001 },
+    Code { 6, 0, 3, 0b110110 },
+    Code { 7, 0, 4, 0b1111100 },
+    Code { 8, 0, 5, 0b11111101 },
+    Code { 2, 6, 6, 0b01 },
+    Code { 5, 5, 70, 0b11010 },
+    Code { 6, 5, 102, 0b110111 },
+    Code { 6, 6, 134, 0b111000 },
+    Code { 6, 7, 198, 0b111001 },
+    Code { 6, 8, 326, 0b111010 },
+    Code { 6, 9, 582, 0b111011 },
+    Code { 6, 10, 1094, 0b111100 },
+    Code { 7, 11, 2118, 0b1111101 },
+    Code { 8 | 0x8000, 32, -22, 0b11111110 },
+    Code { 8, 32, 4166, 0b11111111 },
+    Code { 2, 0, OptionalNone {}, 0b10 },
+};
+
 // Table B.11 – Standard Huffman table K
 constexpr Array standard_huffman_table_K = {
     Code { 1, 0, 1, 0b0 },
@@ -410,8 +435,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_I(standard_huffman_table_I, true);
         return &standard_table_I;
     }
-    case StandardTable::B_10:
-        return Error::from_string_literal("Standard table J not yet supported");
+    case StandardTable::B_10: {
+        static HuffmanTable standard_table_J(standard_huffman_table_J, true);
+        return &standard_table_J;
+    }
     case StandardTable::B_11: {
         static HuffmanTable standard_table_K(standard_huffman_table_K);
         return &standard_table_K;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -283,6 +283,23 @@ constexpr Array standard_huffman_table_L = {
     Code { 8, 32, 73, 0b11111111 },
 };
 
+// Table B.13 – Standard Huffman table M
+constexpr Array standard_huffman_table_M = {
+    Code { 1, 0, 1, 0b0 },
+    Code { 3, 0, 2, 0b100 },
+    Code { 4, 0, 3, 0b1100 },
+    Code { 5, 0, 4, 0b11100 },
+    Code { 4, 1, 5, 0b1101 },
+    Code { 3, 3, 7, 0b101 },
+    Code { 6, 1, 15, 0b111010 },
+    Code { 6, 2, 17, 0b111011 },
+    Code { 6, 3, 21, 0b111100 },
+    Code { 6, 4, 29, 0b111101 },
+    Code { 6, 5, 45, 0b111110 },
+    Code { 7, 6, 77, 0b1111110 },
+    Code { 7, 32, 141, 0b1111111 },
+};
+
 // Table B.14 – Standard Huffman table N
 constexpr Array standard_huffman_table_N = {
     Code { 3, 0, -2, 0b100 },
@@ -375,8 +392,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_L(standard_huffman_table_L);
         return &standard_table_L;
     }
-    case StandardTable::B_13:
-        return Error::from_string_literal("Standard table M not yet supported");
+    case StandardTable::B_13: {
+        static HuffmanTable standard_table_M(standard_huffman_table_M);
+        return &standard_table_M;
+    }
     case StandardTable::B_14: {
         static HuffmanTable standard_table_N(standard_huffman_table_N);
         return &standard_table_N;


### PR DESCRIPTION
With this, we can decode 144 of ignition.pdf's 233 pages (up from 9 – and most of the 9 pages we previously were able to decode were empty).

Somewhat similar to #26068.