### PR TITLE
LibGfx/JBIG2: Decode custom huffman tables and use them in the text segment

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -392,6 +392,7 @@ TEST_CASE(test_jbig2_decode)
         // - striping, especially with initially unknown page height (code support added in #26067)
         // - huffman symbol regions (code support added in #26068)
         // - huffman text regions (code support added in #26075)
+        // - huffman regions with custom huffman tables (code support added in #26078)
         // - coverage for different segment combination operators (or and xor xnor replace),
         //   with both background colors
         // Missing tests for things that aren't implemented yet:


### PR DESCRIPTION
With this, we can decode all pages of ignition.pdf :^)

---

We now can read https://library.sciencemadness.org/library/books/ignition.pdf with LibPDF!