### PR TITLE
LibGfx/JBIG2: Support using custom tables in symbol segment

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -392,7 +392,7 @@ TEST_CASE(test_jbig2_decode)
         // - striping, especially with initially unknown page height (code support added in #26067)
         // - huffman symbol regions (code support added in #26068)
         // - huffman text regions (code support added in #26075)
-        // - huffman regions with custom huffman tables (code support added in #26078)
+        // - huffman regions with custom huffman tables (code support added in #26078, #26081)
         // - coverage for different segment combination operators (or and xor xnor replace),
         //   with both background colors
         // Missing tests for things that aren't implemented yet:


### PR DESCRIPTION
This is basically identical to the commit that added support for this
in text segments in https://github.com/SerenityOS/serenity/pull/26078 (https://github.com/SerenityOS/serenity/commit/160b06eccb287bfa9a82e27a15d2a18fd9de5bca).

This is used on most, maybe all, pages of Mellor_ACTITC_10.pdf,
and on at least some pages of most files of the PDFs at
https://library.sciencemadness.org/library/books/.