### PR TITLE
EFIPrekernel: Read cmdline from cmdline.txt if load options are empty

### DIFF
--- a/Kernel/EFIPrekernel/CMakeLists.txt
+++ b/Kernel/EFIPrekernel/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
 
     ConfigurationTable.cpp
     DebugOutput.cpp
+    Filesystem.cpp
     GOP.cpp
     Panic.cpp
     Relocation.cpp

--- a/Kernel/EFIPrekernel/Filesystem.cpp
+++ b/Kernel/EFIPrekernel/Filesystem.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <Kernel/EFIPrekernel/Filesystem.h>
+#include <Kernel/EFIPrekernel/Globals.h>
+
+namespace Kernel {
+
+EFIErrorOr<EFI::FileProtocol*> open_root_directory(EFI::LoadedImageProtocol* loaded_image_protocol)
+{
+    // EFI_LOADED_IMAGE_PROTOCOL.DeviceHandle is the device handle where we were loaded from.
+    auto simple_file_system_protocol_guid = EFI::SimpleFileSystemProtocol::guid;
+    EFI::SimpleFileSystemProtocol* root_fs;
+    if (auto status = g_efi_system_table->boot_services->handle_protocol(loaded_image_protocol->device_handle, &simple_file_system_protocol_guid, reinterpret_cast<void**>(&root_fs)); status != EFI::Status::Success)
+        return status;
+
+    EFI::FileProtocol* root_dir;
+    if (auto status = root_fs->open_volume(root_fs, &root_dir); status != EFI::Status::Success)
+        return status;
+
+    return root_dir;
+}
+
+EFIErrorOr<EFI::FileProtocol*> open_file(EFI::FileProtocol* base_directory, char16_t const* path, EFI::FileOpenMode open_mode, EFI::FileAttribute attributes)
+{
+    EFI::FileProtocol* file = nullptr;
+    if (auto status = base_directory->open(base_directory, &file, const_cast<char16_t*>(path), open_mode, attributes); status != EFI::Status::Success)
+        return status;
+
+    return file;
+}
+
+EFIErrorOr<void> close_file(EFI::FileProtocol* file)
+{
+    if (auto status = file->close(file); status != EFI::Status::Success)
+        return status;
+    return {};
+}
+
+EFIErrorOr<ByteBuffer> read_entire_file(EFI::FileProtocol* file)
+{
+    auto file_info_guid = EFI::FileInfo::guid;
+
+    // The file size can be retrieved via EFI_FILE_PROTOCOL.GetInfo().
+    // To get the EFI_FILE_INFO, we first need to determine the size of it and then allocate a buffer of that size.
+    FlatPtr file_info_size = 0;
+    if (auto status = file->get_info(file, &file_info_guid, &file_info_size, nullptr); status != EFI::Status::BufferTooSmall)
+        return status;
+
+    ByteBuffer file_info_buffer;
+    if (file_info_buffer.try_resize(file_info_size).is_error())
+        return EFI::Status::OutOfResources;
+
+    // Get the EFI_FILE_INFO for this file.
+    if (auto status = file->get_info(file, &file_info_guid, &file_info_size, file_info_buffer.data()); status != EFI::Status::Success)
+        return status;
+
+    auto const* file_info = reinterpret_cast<EFI::FileInfo const*>(file_info_buffer.data());
+
+    ByteBuffer file_data;
+    if (file_data.try_resize(file_info->file_size).is_error())
+        return EFI::Status::OutOfResources;
+
+    // Read the entire file.
+    FlatPtr file_size = file_info->file_size;
+    if (auto status = file->read(file, &file_size, file_data.data()); status != EFI::Status::Success)
+        return status;
+
+    VERIFY(file_size == file_info->file_size);
+    return file_data;
+}
+
+}

--- a/Kernel/EFIPrekernel/Filesystem.h
+++ b/Kernel/EFIPrekernel/Filesystem.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <Kernel/EFIPrekernel/Error.h>
+#include <Kernel/Firmware/EFI/Protocols/LoadedImage.h>
+#include <Kernel/Firmware/EFI/Protocols/MediaAccess.h>
+
+namespace Kernel {
+
+EFIErrorOr<EFI::FileProtocol*> open_root_directory(EFI::LoadedImageProtocol* loaded_image_protocol);
+EFIErrorOr<EFI::FileProtocol*> open_file(EFI::FileProtocol* base_directory, char16_t const* path, EFI::FileOpenMode open_mode, EFI::FileAttribute attributes = EFI::FileAttribute::None);
+EFIErrorOr<void> close_file(EFI::FileProtocol*);
+EFIErrorOr<ByteBuffer> read_entire_file(EFI::FileProtocol* file);
+
+}

--- a/Kernel/Firmware/EFI/EFI.cpp
+++ b/Kernel/Firmware/EFI/EFI.cpp
@@ -13,73 +13,73 @@ Optional<StringView> status_description(Status status)
     using enum Kernel::EFI::Status;
     switch (status) {
     case Success:
-        return "The operation completed successfully."sv;
+        return "The operation completed successfully"sv;
     case LoadError:
-        return "The image failed to load."sv;
+        return "The image failed to load"sv;
     case InvalidParameter:
-        return "A parameter was incorrect."sv;
+        return "A parameter was incorrect"sv;
     case Unsupported:
-        return "The operation is not supported."sv;
+        return "The operation is not supported"sv;
     case BadBufferSize:
-        return "The buffer was not the proper size for the request."sv;
+        return "The buffer was not the proper size for the request"sv;
     case BufferTooSmall:
-        return "The buffer is not large enough to hold the requested data. The required buffer size is returned in the appropriate parameter when this error occurs."sv;
+        return "The buffer is not large enough to hold the requested data"sv;
     case NotReady:
-        return "There is no data pending upon return."sv;
+        return "There is no data pending upon return"sv;
     case DeviceError:
-        return "The physical device reported an error while attempting the operation."sv;
+        return "The physical device reported an error while attempting the operation"sv;
     case WriteProtected:
-        return "The device cannot be written to."sv;
+        return "The device cannot be written to"sv;
     case OutOfResources:
-        return "A resource has run out."sv;
+        return "A resource has run out"sv;
     case VolumeCorrupted:
-        return "An inconstancy was detected on the file system causing the operating to fail."sv;
+        return "An inconstancy was detected on the file system causing the operating to fail"sv;
     case VolumeFull:
-        return "There is no more space on the file system."sv;
+        return "There is no more space on the file system"sv;
     case NoMedia:
-        return "The device does not contain any medium to perform the operation."sv;
+        return "The device does not contain any medium to perform the operation"sv;
     case MediaChanged:
-        return "The medium in the device has changed since the last access."sv;
+        return "The medium in the device has changed since the last access"sv;
     case NotFound:
-        return "The item was not found."sv;
+        return "The item was not found"sv;
     case AccessDenied:
-        return "Access was denied."sv;
+        return "Access was denied"sv;
     case NoResponse:
-        return "The server was not found or did not respond to the request."sv;
+        return "The server was not found or did not respond to the request"sv;
     case NoMapping:
-        return "A mapping to a device does not exist."sv;
+        return "A mapping to a device does not exist"sv;
     case Timeout:
-        return "The timeout time expired."sv;
+        return "The timeout time expired"sv;
     case NotStarted:
-        return "The protocol has not been started."sv;
+        return "The protocol has not been started"sv;
     case AlreadyStarted:
-        return "The protocol has already been started."sv;
+        return "The protocol has already been started"sv;
     case Aborted:
-        return "The operation was aborted."sv;
+        return "The operation was aborted"sv;
     case ICMPError:
-        return "An ICMP error occurred during the network operation."sv;
+        return "An ICMP error occurred during the network operation"sv;
     case TFTPError:
-        return "A TFTP error occurred during the network operation."sv;
+        return "A TFTP error occurred during the network operation"sv;
     case ProtocolError:
-        return "A protocol error occurred during the network operation."sv;
+        return "A protocol error occurred during the network operation"sv;
     case IncompatibleVersion:
-        return "The function encountered an internal version that was incompatible with a version requested by the caller."sv;
+        return "The function encountered an internal version that was incompatible with a version requested by the caller"sv;
     case SecurityViolation:
-        return "The function was not performed due to a security violation."sv;
+        return "The function was not performed due to a security violation"sv;
     case CRCError:
-        return "A CRC error was detected."sv;
+        return "A CRC error was detected"sv;
     case EndOfMedia:
         return "Beginning or end of media was reached"sv;
     case EndOfFile:
-        return "The end of the file was reached."sv;
+        return "The end of the file was reached"sv;
     case InvalidLanguage:
-        return "The language specified was invalid."sv;
+        return "The language specified was invalid"sv;
     case CompromisedData:
-        return "The security status of the data is unknown or compromised and the data must be updated or replaced to restore a valid security status."sv;
+        return "The security status of the data is unknown or compromised and the data must be updated or replaced to restore a valid security status"sv;
     case IPAddressConflict:
         return "There is an address conflict address allocation"sv;
     case HTTPError:
-        return "A HTTP error occurred during the network operation."sv;
+        return "A HTTP error occurred during the network operation"sv;
     }
 
     return {};


### PR DESCRIPTION
This makes it possible to install Serenity to removable media without using GRUB or having to manually pass the cmdline in the UEFI shell.

We always need a cmdline for finding the correct root drive.

There is no way to set the load options when booting from automatically generated boot menu entries for `\EFI\BOOT\BOOT<ARCH>.EFI`.