### PR TITLE
LibGfx/JPEGXL: Try to unbreak the oss-fuzz bot

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLCommon.h
@@ -68,10 +68,15 @@ ALWAYS_INLINE ErrorOr<u64> U64(LittleEndianInputBitStream& stream)
 
 ALWAYS_INLINE ErrorOr<f32> F16(LittleEndianInputBitStream& stream)
 {
+#if defined(OSS_FUZZ)
+    // FIXME: Use the below code path on oss-fuzz once it supports _Float16.
+    return Error::from_string_literal("oss-fuzz does not yet support _Float16");
+#else
     u16 const bits16 = TRY(stream.read_bits(16));
     auto const biased_exp = (bits16 >> 10) & 0x1F;
     VERIFY(biased_exp != 31);
     return bit_cast<_Float16>(bits16);
+#endif
 }
 
 template<Enum E>


### PR DESCRIPTION
oss-fuzz's clang does not yet support _Float16.

We don't currently have a jpeg xl fuzzer, so this code should currently be unreachable anyways.