### PR TITLE
Meta: Add targets for building UEFI images for the Pi 4 and generic UEFI systems without GRUB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,12 @@ add_custom_target(qemu-image
     USES_TERMINAL
 )
 
+add_custom_target(uefi-image
+    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-uefi.sh"
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/uefi_disk_image
+    USES_TERMINAL
+)
+
 if("${SERENITY_ARCH}" STREQUAL "x86_64")
     add_custom_target(grub-image
         COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-grub.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if("${SERENITY_ARCH}" STREQUAL "x86_64")
 elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
     add_custom_target(raspberry-pi-image
         COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-raspberry-pi.sh"
-        BYPRODUCTS ${CMAKE_BINARY_DIR}/raspberry_pi_image
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/raspberry_pi_disk_image
         USES_TERMINAL
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,11 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         BYPRODUCTS ${CMAKE_BINARY_DIR}/raspberry_pi_disk_image
         USES_TERMINAL
     )
+    add_custom_target(raspberry-pi-4-edk2-image
+        COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-raspberry-pi.sh" "rpi4-edk2"
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/raspberry_pi_4_uefi_disk_image
+        USES_TERMINAL
+    )
 endif()
 
 add_custom_target(install-native-partition

--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -3,18 +3,9 @@
 Serenity currently boots to the desktop on Raspberry Pi 4 and 5 when using a USB drive.
 USB mice and keyboards are supported.
 
-On the Raspberry Pi 4, only the USB-C port is supported at this time. This means you’ll need to either:
-
--   Use a docking station that can both power the Pi and function as a USB hub, or
--   Provide power through another method while connecting your USB drive.
-
-To use this USB-C port, you need to set [`otg_mode=1`](https://www.raspberrypi.com/documentation/computers/config_txt.html#otg_mode-raspberry-pi-4-only) in config.txt.
-The Raspberry Pi 4 firmware doesn't seem to support booting from this port, so you need to put the kernel and boot files
-on another USB drive or SD card (or just the entire `Build/aarch64/raspberry_pi_disk_image` image).
-
 The SD host controller driver currently does not work on any of the supported Raspberry Pi models when running on real hardware.
 
-We also lack a USB host controller driver for the Raspberry Pi 3, so it currently fails to boot and displays a "Couldn't find a suitable device to boot from" panic message.
+We lack a USB host controller driver for the Raspberry Pi 3, so it currently fails to boot and displays a "Couldn't find a suitable device to boot from" panic message.
 
 32-bit Raspberry Pi models are not supported.
 
@@ -46,22 +37,37 @@ SERENITY_RUN=raspi3b Meta/serenity.sh gdb aarch64
 
 ### Step 0: Build a SerenityOS disk image for Raspberry Pis
 
-You can build a disk image for the Raspberry Pi 3, 4, and 5 with:
+In order to create a disk image, you first need to build SerenityOS by running
+
+```console
+Meta/serenity.sh build aarch64
+```
+
+To create a disk image for the Raspberry Pi 3 and 5, run
 
 ```console
 ninja -C Build/aarch64 raspberry-pi-image
 ```
 
-Note that this command doesn't (re)build the system, so you need to run `Meta/serenity.sh build aarch64` first.
+For the Pi 4, booting with EDK II is currently required to enable USB support.
+Start by building EDK II for the Pi 4 with
 
-The generated disk image will be written to `Build/aarch64/raspberry_pi_disk_image`.
+```console
+Toolchain/BuildEDK2.sh rpi4
+```
+
+After you built EDK II, you can create a SerenityOS disk image with EDK II by running
+
+```console
+ninja -C Build/aarch64 raspberry-pi-4-edk2-image
+```
+
+The generated disk image will be written to `Build/aarch64/raspberry_pi_disk_image` or `Build/aarch64/raspberry_pi_4_uefi_disk_image`.
 Write this image to the USB drive you want to use to boot Serenity using a command such as:
 
 ```console
-sudo cp Build/aarch64/raspberry_pi_disk_image /dev/sdx && sync
+sudo cp Build/aarch64/<disk image> /dev/<usb drive> && sync
 ```
-
-(Replace `/dev/sdx` with your USB drive device file)
 
 ### Step 1: Connect your Raspberry Pi to your PC using a UART cable
 

--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -35,8 +35,6 @@ SERENITY_RUN=raspi3b Meta/serenity.sh gdb aarch64
 
 ## Running on real hardware using a USB drive
 
-### Step 0: Build a SerenityOS disk image for Raspberry Pis
-
 In order to create a disk image, you first need to build SerenityOS by running
 
 ```console
@@ -68,6 +66,11 @@ Write this image to the USB drive you want to use to boot Serenity using a comma
 ```console
 sudo cp Build/aarch64/<disk image> /dev/<usb drive> && sync
 ```
+
+## Serial debug output
+
+Debug output is written to the serial console if `serial_debug` is included in the cmdline.
+If you followed the above instructions, this option should already be enabled.
 
 ### Step 1: Connect your Raspberry Pi to your PC using a UART cable
 

--- a/Meta/build-image-raspberry-pi.sh
+++ b/Meta/build-image-raspberry-pi.sh
@@ -23,6 +23,8 @@ if [ "$1" != "in-sudo" ]; then # Avoid making the repo root-owned when recursive
         git pull --ff-only
         popd >/dev/null
     fi
+else
+    shift
 fi
 
 # Remove unnecessary linux kernel images.
@@ -30,7 +32,7 @@ rm -f raspberry-pi-firmware/boot/kernel*.img
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -- "${SHELL}" -c "\"$0\" in-sudo || exit 42"
+    ${SUDO} -- "${SHELL}" -c "\"$0\" in-sudo $1 || exit 42"
     case $? in
         1)
             die "this script needs to run as root"
@@ -46,13 +48,19 @@ else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi
 
+if [ "$1" = "rpi4-edk2" ]; then
+    DISK_IMAGE_NAME=raspberry_pi_4_uefi_disk_image
+else
+    DISK_IMAGE_NAME=raspberry_pi_disk_image
+fi
+
 printf "setting up disk image... "
-dd if=/dev/zero of=raspberry_pi_disk_image bs=1M count="${DISK_SIZE}" status=none || die "couldn't create disk image"
-chown "$SUDO_UID":"$SUDO_GID" raspberry_pi_disk_image || die "couldn't adjust permissions on disk image"
+dd if=/dev/zero of=$DISK_IMAGE_NAME bs=1M count="${DISK_SIZE}" status=none || die "couldn't create disk image"
+chown "$SUDO_UID":"$SUDO_GID" $DISK_IMAGE_NAME || die "couldn't adjust permissions on disk image"
 echo "done"
 
 printf "creating loopback device... "
-dev=$(losetup --find --partscan --show raspberry_pi_disk_image)
+dev=$(losetup --find --partscan --show $DISK_IMAGE_NAME)
 if [ -z "$dev" ]; then
     die "couldn't mount loopback device"
 fi
@@ -101,7 +109,27 @@ echo "done"
 
 cp -r raspberry-pi-firmware/boot/* boot/
 
-cat <<EOF >boot/config.txt
+if [ "$1" = "rpi4-edk2" ]; then
+    cp "$SERENITY_SOURCE_DIR/Toolchain/Build/edk2/Build/RPi4/RELEASE_GCC5/FV/RPI_EFI.fd" boot/ || die "RPI_EFI.fd not found. Please run 'Toolchain/BuildEDK2.sh rpi4' to build it."
+
+    # Based on https://github.com/tianocore/edk2-platforms/tree/master/Platform/RaspberryPi/RPi4#booting-the-firmware.
+    cat <<EOF >boot/config.txt
+arm_64bit=1
+enable_uart=1
+enable_gic=1
+armstub=RPI_EFI.fd
+disable_commandline_tags=2
+device_tree_address=0x3e0000
+device_tree_end=0x400000
+
+# We use UART0 as the console.
+dtoverlay=disable-bt
+EOF
+
+    mkdir -p boot/EFI/BOOT
+    cp mnt/boot/Kernel.efi boot/EFI/BOOT/BOOTAA64.EFI
+else
+    cat <<EOF >boot/config.txt
 # We only support AArch64.
 arm_64bit=1
 
@@ -121,7 +149,8 @@ dtoverlay=disable-bt
 framebuffer_depth=32
 EOF
 
-echo "serial_debug root=block100:1" >boot/cmdline.txt
+    # FIXME: Mount the boot partition on /boot (both here and in serenity), so we don't need to move the kernel image to the boot filesystem.
+    mv mnt/boot/Kernel.bin boot/
+fi
 
-# FIXME: Mount the boot partition on /boot (both here and in serenity), so we don't need to move the kernel image to the boot filesystem.
-mv mnt/boot/Kernel.bin boot/
+echo "serial_debug root=block100:1" >boot/cmdline.txt

--- a/Meta/build-image-uefi.sh
+++ b/Meta/build-image-uefi.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+. "${script_path}/shell_include.sh"
+
+if [ "$(id -u)" != 0 ]; then
+    set +e
+    ${SUDO} -- "${SHELL}" -c "\"$0\" $* || exit 42"
+    case $? in
+        1)
+            die "this script needs to run as root"
+            ;;
+        42)
+            exit 1
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
+else
+    : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
+fi
+
+DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 512 + 300))
+
+printf "setting up disk image... "
+dd if=/dev/zero of=uefi_disk_image bs=1M count="${DISK_SIZE}" status=none || die "couldn't create disk image"
+chown "$SUDO_UID":"$SUDO_GID" uefi_disk_image || die "couldn't adjust permissions on disk image"
+echo "done"
+
+printf "creating loopback device... "
+dev=$(losetup --find --partscan --show uefi_disk_image)
+if [ -z "$dev" ]; then
+    die "couldn't mount loopback device"
+fi
+echo "loopback device is at ${dev}"
+
+cleanup() {
+    if [ -d esp ]; then
+        printf "unmounting EFI system partition... "
+        umount esp || ( sleep 1 && sync && umount esp )
+        rmdir esp
+        echo "done"
+    fi
+
+    if [ -d mnt ]; then
+        printf "unmounting root filesystem... "
+        umount mnt || ( sleep 1 && sync && umount mnt )
+        rmdir mnt
+        echo "done"
+    fi
+
+    if [ -e "${dev}" ]; then
+        printf "cleaning up loopback device... "
+        losetup -d "${dev}"
+        echo "done"
+    fi
+}
+trap cleanup EXIT
+
+printf "creating partition table... "
+parted -s "${dev}" mklabel gpt mkpart EFI fat32 0% 512MB mkpart SerenityOS ext2 512MB 100% set 1 esp on || die "couldn't partition disk"
+echo "done"
+
+printf "creating new filesystems... "
+mkfs.vfat -F 32 -n EFI "${dev}p1" >/dev/null || die "couldn't create EFI system partition filesystem"
+mke2fs -q -L SerenityOS "${dev}p2" || die "couldn't create root filesystem"
+echo "done"
+
+printf "mounting filesystems... "
+mkdir -p esp
+mount "${dev}p1" esp || die "couldn't mount EFI system partition"
+mkdir -p mnt
+mount "${dev}p2" mnt || die "couldn't mount root filesystem"
+echo "done"
+
+"$script_path/build-root-filesystem.sh"
+
+case $SERENITY_ARCH in
+    aarch64)
+        BOOT_FILE_NAME=BOOTAA64.EFI
+        ;;
+    riscv64)
+        BOOT_FILE_NAME=BOOTRISCV64.EFI
+        ;;
+    x86_64)
+        BOOT_FILE_NAME=BOOTX64.EFI
+        ;;
+    *)
+        die "unknown architecture: $SERENITY_ARCH"
+        ;;
+esac
+
+root_uuid=$(blkid -o export "${dev}p2" | grep ^PARTUUID | cut -d= -f2)
+
+cat <<EOF >esp/cmdline.txt
+root=PARTUUID:${root_uuid}
+EOF
+
+mkdir -p esp/EFI/BOOT
+cp mnt/boot/Kernel.efi esp/EFI/BOOT/$BOOT_FILE_NAME


### PR DESCRIPTION
These targets use the new cmdline.txt reading support introduced by #26084.

The `uefi-image` target can be used to build a UEFI image suitable for removable media if you don't want to use GRUB. This target could also be used for Raspberry Pis, but you would need to install the Raspberry Pi firmware files and EDK II manually.

That's why I added the `raspberry-pi-4-edk2-image` target.
Like `raspberry-pi-image`, it installs the Raspberry Pi firmware files next to SerenityOS. But unlike that target, it also installs EDK II. Since USB support currently requires booting with EDK II, this makes it a lot easier to boot SerenityOS on the Pi 4.
I also updated RunningOnRaspberryPi.md to mention this new target.