### PR TITLE
LibGfx/JBIG2+CCITT: Support decoding MMR-coded JBIG2 graymaps

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -428,11 +428,16 @@ TEST_CASE(test_annex_h_jbig2)
 
     EXPECT_EQ(decoder->frame_count(), 3u);
 
-    // FIXME: Decode this successfully.
-    EXPECT(decoder->frame(0).is_error());
+    auto frame_1 = TRY_OR_FAIL(decoder->frame(0));
+    EXPECT_EQ(frame_1.image->size(), Gfx::IntSize(64, 56));
 
     auto frame_2 = TRY_OR_FAIL(decoder->frame(1));
     EXPECT_EQ(frame_2.image->size(), Gfx::IntSize(64, 56));
+
+    // The first two frames decode to the same image.
+    for (int y = 0; y < frame_1.image->height(); ++y)
+        for (int x = 0; x < frame_1.image->width(); ++x)
+            EXPECT_EQ(frame_1.image->get_pixel(x, y), frame_2.image->get_pixel(x, y));
 
     // FIXME: Decode this successfully.
     EXPECT(decoder->frame(2).is_error());

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -664,8 +664,13 @@ ErrorOr<ByteBuffer> decode_ccitt_group3(ReadonlyBytes bytes, u32 image_width, u3
 
 ErrorOr<ByteBuffer> decode_ccitt_group4(ReadonlyBytes bytes, u32 image_width, u32 image_height, Group4Options const& options)
 {
-    auto strip_stream = make<FixedMemoryStream>(bytes);
-    auto bit_stream = make<BigEndianInputBitStream>(MaybeOwned<Stream>(*strip_stream));
+    auto stream = make<FixedMemoryStream>(bytes);
+    return decode_ccitt_group4(*stream, image_width, image_height, options);
+}
+
+ErrorOr<ByteBuffer> decode_ccitt_group4(Stream& stream, u32 image_width, u32 image_height, Group4Options const& options)
+{
+    auto bit_stream = make<BigEndianInputBitStream>(MaybeOwned<Stream>(stream));
 
     auto output_stream = make<AllocatingMemoryStream>();
     auto decoded_bits = make<BigEndianOutputBitStream>(MaybeOwned<Stream>(*output_stream));

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.cpp
@@ -681,10 +681,9 @@ ErrorOr<ByteBuffer> decode_ccitt_group4(Stream& stream, u32 image_width, u32 ima
     TRY(status.current_line.try_empend(ccitt_black, image_width));
 
     for (u32 i = 0; !status.has_reached_eol && (image_height == 0 || i < image_height); ++i) {
+        status = TRY(decode_single_ccitt_2d_line(*bit_stream, *decoded_bits, move(status.current_line), image_width, options));
         if (options.encoded_byte_aligned == EncodedByteAligned::Yes)
             bit_stream->align_to_byte_boundary();
-
-        status = TRY(decode_single_ccitt_2d_line(*bit_stream, *decoded_bits, move(status.current_line), image_width, options));
     }
 
     return output_stream->read_until_eof();

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTDecoder.h
@@ -76,5 +76,6 @@ struct Group4Options {
 };
 
 ErrorOr<ByteBuffer> decode_ccitt_group4(ReadonlyBytes bytes, u32 image_width, u32 image_height, Group4Options const& = {});
+ErrorOr<ByteBuffer> decode_ccitt_group4(Stream&, u32 image_width, u32 image_height, Group4Options const& = {});
 
 }


### PR DESCRIPTION
The main motivation for this is that it's used in page 1 of the test
bitstram in Annex H. Pages 1 and 2 decode to the same bitmap, so
having support for this allows us to compare the two bitmaps, and
we get test coverage for quite a few JBIG2 features that way.

This can also decode amb_2.jb2 from the power jbig2 test dataset.
I'm not aware of any other files using this feature.

An MMR graymap is the only case where the size of the a generic region
is not known in advance, and where the data is immediately followed by
more MMR data. We need to have the MMR decoder skip the EOFB marker at
the end, so that the following bitplanes can be decoded.

To make this possible, we teach the CCITT group 4 decoder to optionally
require the EOFB marker at the end of a stream (to make sure it's
consumed) and let the JBIG2 decoder opt in to that -- but only for
MMR graymaps, since the spec says that the marker is optional in
basically all other cases.

---

See #26093 for more discussion. I think I like this approach more?

@LucasChollet