### PR TITLE
LibGfx/JBIG2: Add missing built-in huffman tables C, E, O

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -198,6 +198,18 @@ constexpr Array standard_huffman_table_D = {
     Code { 5, 32, 76, 0b11111 },
 };
 
+// Table B.5 – Standard Huffman table E
+constexpr Array standard_huffman_table_E = {
+    Code { 7, 8, -255, 0b1111110 },
+    Code { 1, 0, 1, 0b0 },
+    Code { 2, 0, 2, 0b10 },
+    Code { 3, 0, 3, 0b110 },
+    Code { 4, 3, 4, 0b1110 },
+    Code { 5, 6, 12, 0b11110 },
+    Code { 7 | Code::LowerRangeBit, 32, -256, 0b1111111 },
+    Code { 5, 32, 76, 0b111110 },
+};
+
 // Table B.6 – Standard Huffman table F
 constexpr Array standard_huffman_table_F = {
     Code { 5, 10, -2048, 0b11100 },
@@ -432,8 +444,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_D(standard_huffman_table_D);
         return &standard_table_D;
     }
-    case StandardTable::B_5:
-        return Error::from_string_literal("Standard table E not yet supported");
+    case StandardTable::B_5: {
+        static HuffmanTable standard_table_E(standard_huffman_table_E);
+        return &standard_table_E;
+    }
     case StandardTable::B_6: {
         static HuffmanTable standard_table_F(standard_huffman_table_F);
         return &standard_table_F;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -383,6 +383,23 @@ constexpr Array standard_huffman_table_N = {
     Code { 3, 0, 2, 0b111 },
 };
 
+// Table B.15 – Standard Huffman table O
+constexpr Array standard_huffman_table_O = {
+    Code { 7, 4, -24, 0b1111100 },
+    Code { 6, 2, -8, 0b111100 },
+    Code { 5, 1, -4, 0b11100 },
+    Code { 4, 0, -2, 0b1100 },
+    Code { 3, 0, -1, 0b100 },
+    Code { 1, 0, 0, 0b0 },
+    Code { 3, 0, 1, 0b101 },
+    Code { 4, 0, 2, 0b1101 },
+    Code { 5, 1, 3, 0b11101 },
+    Code { 6, 2, 5, 0b111101 },
+    Code { 7, 4, 9, 0b1111101 },
+    Code { 7 | Code::LowerRangeBit, 32, -25, 0b1111110 },
+    Code { 7, 32, 25, 0b1111111 },
+};
+
 class HuffmanTable {
 public:
     enum class StandardTable {
@@ -484,8 +501,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_N(standard_huffman_table_N);
         return &standard_table_N;
     }
-    case StandardTable::B_15:
-        return Error::from_string_literal("Standard table O not yet supported");
+    case StandardTable::B_15: {
+        static HuffmanTable standard_table_O(standard_huffman_table_O);
+        return &standard_table_O;
+    }
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -175,6 +175,19 @@ constexpr Array standard_huffman_table_B = {
     Code { 6, 0, OptionalNone {}, 0b111111 },
 };
 
+// Table B.3 – Standard Huffman table C
+constexpr Array standard_huffman_table_C = {
+    Code { 8, 8, -256, 0b11111110 },
+    Code { 1, 0, 0, 0b0 },
+    Code { 2, 0, 1, 0b10 },
+    Code { 3, 0, 2, 0b110 },
+    Code { 4, 3, 3, 0b1110 },
+    Code { 5, 6, 11, 0b11110 },
+    Code { 8 | Code::LowerRangeBit, 32, -257, 0b11111111 },
+    Code { 7, 32, 75, 0b1111110 },
+    Code { 6, 0, OptionalNone {}, 0b111110 },
+};
+
 // Table B.4 – Standard Huffman table D
 constexpr Array standard_huffman_table_D = {
     Code { 1, 0, 1, 0b0 },
@@ -411,8 +424,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_B(standard_huffman_table_B, true);
         return &standard_table_B;
     }
-    case StandardTable::B_3:
-        return Error::from_string_literal("Standard table C not yet supported");
+    case StandardTable::B_3: {
+        static HuffmanTable standard_table_C(standard_huffman_table_C, true);
+        return &standard_table_C;
+    }
     case StandardTable::B_4: {
         static HuffmanTable standard_table_D(standard_huffman_table_D);
         return &standard_table_D;


### PR DESCRIPTION
I haven't found a single file that uses them, and I haven't found a way to make synthetic files using them.

I don't like landing completely untested code, so I figured I'd upload this as a PR but let it go stale, and then add a comment like "// If you need this, find the code at #26104"?