### PR TITLE
LibGfx/JBIG2: Implement support for multi-refinement in symbol procedure

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -394,10 +394,10 @@ TEST_CASE(test_jbig2_decode)
         // - huffman symbol regions (code support added in #26068)
         // - huffman text regions (code support added in #26075)
         // - huffman regions with custom huffman tables (code support added in #26078, #26081)
+        // - symbols with REFAGGNINST > 1 (code support added in #26107)
         // - coverage for different segment combination operators (or and xor xnor replace),
         //   with both background colors
         // Missing tests for things that aren't implemented yet:
-        // - symbols with REFAGGNINST > 1
         // - intermediate regions
         // - standalone refinement regions
         //   - TPGRON set in refinement region (only reachable in standalone refinement regions)
@@ -440,8 +440,13 @@ TEST_CASE(test_annex_h_jbig2)
         for (int x = 0; x < frame_1.image->width(); ++x)
             EXPECT_EQ(frame_1.image->get_pixel(x, y), frame_2.image->get_pixel(x, y));
 
-    // FIXME: Decode this successfully.
-    EXPECT(decoder->frame(2).is_error());
+    auto frame_3 = TRY_OR_FAIL(decoder->frame(2));
+    EXPECT_EQ(frame_3.image->size(), Gfx::IntSize(37, 8));
+
+    // The third frame is a subrect of the first two.
+    for (int y = 0; y < frame_3.image->height(); ++y)
+        for (int x = 0; x < frame_3.image->width(); ++x)
+            EXPECT_EQ(frame_3.image->get_pixel(x, y), frame_2.image->get_pixel(x + 4, y + 1));
 }
 
 TEST_CASE(test_qm_arithmetic_decoder)

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -3809,6 +3809,7 @@ ErrorOr<ImageFrameDescriptor> JBIG2ImageDecoderPlugin::frame(size_t index, Optio
     if (m_context->current_page_number != m_context->page_numbers[index]) {
         m_context->current_page_number = m_context->page_numbers[index];
         m_context->state = JBIG2LoadingContext::State::NotDecoded;
+        TRY(scan_for_page_size(*m_context));
     }
 
     if (m_context->state == JBIG2LoadingContext::State::Error)

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1577,7 +1577,6 @@ static ErrorOr<NonnullOwnPtr<BitBuffer>> text_region_decoding_procedure(TextRegi
     Optional<FixedMemoryStream> stream;
     Optional<BigEndianInputBitStream> bit_stream;
     Optional<QMArithmeticDecoder> decoder;
-    Vector<QMArithmeticDecoder::Context> contexts;
     if (inputs.uses_huffman_encoding) {
         stream = FixedMemoryStream { data };
         bit_stream = BigEndianInputBitStream { MaybeOwned { stream.value() } };


### PR DESCRIPTION
With this, we can decode all pages of annex-h.jbig2 :^)

----

…and some prep commits.

With this, we can also decode pages 2 389 395 713 of disquisitionesa00gaus.pdf (from https://archive.org/details/disquisitionesa00gaus), which is what sent me back to the JBIG2 mines in the first place. (We used to be able to decode all pages except those 4, now we can do all.)