### PR TITLE
Tests+LibC: Add tests for `sig2str()` and `str2sig()`

### DIFF
--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_SOURCES
     TestRealpath.cpp
     TestScanf.cpp
     TestSearch.cpp
+    TestSignal.cpp
     TestSnprintf.cpp
     TestStackSmash.cpp
     TestStdio.cpp

--- a/Tests/LibC/TestSignal.cpp
+++ b/Tests/LibC/TestSignal.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <signal.h>
+
+TEST_CASE(signal_string_mapping)
+{
+    char signal_name[SIG2STR_MAX] = { 0 };
+    for (int i = 1; i < NSIG; ++i) {
+        if (sig2str(i, signal_name) != 0)
+            continue;
+        size_t name_length = strlen(signal_name);
+        EXPECT(name_length < SIG2STR_MAX);
+        EXPECT(name_length > 0);
+    }
+}
+
+TEST_CASE(negative_sig2str)
+{
+    char signal_name[SIG2STR_MAX] = { 0 };
+    for (int i = -10; i < 0; ++i) {
+        EXPECT_EQ(sig2str(i, signal_name), -1);
+        EXPECT_EQ(signal_name[0], 0);
+    }
+}
+
+// Tests the following requirement for str2sig (from POSIX):
+// "If str points to a string returned by a previous successful call to
+// sig2str(signum,str), the value stored in the location pointed to by pnum
+// shall be equal to signum."
+TEST_CASE(signal_string_identity)
+{
+    char mappings[NSIG][SIG2STR_MAX] = {};
+    bool success[NSIG] = { 0 };
+    // Includes signal #0 for the sake of testing.
+    for (int i = 0; i < NSIG; ++i) {
+        success[i] = (sig2str(i, mappings[i]) == 0);
+    }
+
+    for (int i = 0; i < NSIG; ++i) {
+        if (!success[i])
+            continue;
+        int signal = 0;
+        EXPECT_EQ(str2sig(mappings[i], &signal), 0);
+        EXPECT_EQ(signal, i);
+    }
+}

--- a/Userland/Libraries/LibC/signal.cpp
+++ b/Userland/Libraries/LibC/signal.cpp
@@ -258,6 +258,9 @@ int sig2str(int signum, char* str)
     // name of the symbolic constant without the SIG prefix.
     if (sys_signame[signum]) {
         size_t signal_string_length = strlen(sys_signame[signum]);
+        // SIG2STR_MAX includes the null terminator while strlen does not,
+        // so the length must be at most SIG2STR_MAX - 1.
+        VERIFY(signal_string_length < SIG2STR_MAX);
         memcpy(str, sys_signame[signum], signal_string_length);
         str[signal_string_length] = 0;
         return 0;


### PR DESCRIPTION
Now we also assert that signal names fit within SIG2STR_MAX.