### PR TITLE
Tests/LibWeb: Skip Text/input/css/FontFace-load-urls.html

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,5 +20,6 @@ Text/input/Worker/Worker-postMessage-transfer.html
 
 ; Fail on CI.
 ; https://github.com/SerenityOS/serenity/issues/26072
+Text/input/css/FontFace-load-urls.html
 Text/input/ServiceWorker/service-worker-register.html
 Text/input/scroll-to-fragment.html


### PR DESCRIPTION
It's currently failing consistently on the mac CI bot.