### PR TITLE
Tests/LibWeb: Re-skip recently re-enabled tests

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -22,3 +22,5 @@ Text/input/Worker/Worker-postMessage-transfer.html
 ; https://github.com/SerenityOS/serenity/issues/26072
 Text/input/DOM/Document-named-properties.html
 Text/input/HTML/SVGImageElement-load-and-error-events.html
+Text/input/ServiceWorker/service-worker-register.html
+Text/input/scroll-to-fragment.html


### PR DESCRIPTION
I optimistically enabled them in #25134, but they're still flaking. See #26072.