### PR TITLE
Meta: Fix uutils coreutils `du` detection

### DIFF
--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -83,9 +83,11 @@ get_number_of_processing_units() {
   ($number_of_processing_units)
 }
 
-# Discover how to get apparent size from `du`. GNU/BusyBox du has --apparent-size / -b, BSD/Darwin du has `-A`.
+# Discover how to get apparent size from `du`. GNU/BusyBox du has --apparent-size / -b, uutils has to use --apparent-size due to a -b bug, BSD/Darwin du has `-A`.
 if du --help 2>&1 | grep -qE "GNU coreutils|BusyBox"; then
     DU_APPARENT_SIZE_FLAG="-b"
+elif du -V 2>&1 | grep -qE "uutils"; then
+    DU_APPARENT_SIZE_FLAG="--apparent-size"
 else
     DU_APPARENT_SIZE_FLAG="-A"
 fi


### PR DESCRIPTION
As [uutils coreutils](https://github.com/uutils/coreutils) (a Rust GNU coreutils reimplementation) `du --help` doesn't include any information where it comes from, but `du -V` does:
```
[starterx4@doadgrz ~]$ du -V
du (uutils coreutils) 0.1.0
```

We have to use it then to detect uutils correctly as the BSD `-A` argument fails (uutils is not BSD-compatible):
```
error: unexpected argument '-A' found

  tip: to pass '-A' as a value, use '-- -A'

Usage: du [OPTION]... [FILE]...
       du [OPTION]... --files0-from=F
error: unexpected argument '-A' found

  tip: to pass '-A' as a value, use '-- -A'

Usage: du [OPTION]... [FILE]...
       du [OPTION]... --files0-from=F
```