### PR TITLE
Meta: Cap DISK_SIZE_BYTES max to 2TB

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -39,6 +39,13 @@ INODE_COUNT=$((INODE_COUNT + 2000))  # Some additional inodes for toolchain file
 DISK_SIZE_BYTES=$((($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) ) * 1024 * 1024))
 DISK_SIZE_BYTES=$((DISK_SIZE_BYTES + (INODE_COUNT * INODE_SIZE)))
 
+# Cap disk size to 2TB (2 * 1024^4 bytes)
+MAX_DISK_SIZE_BYTES=$((2 * 1024 * 1024 * 1024 * 1024))
+if [ "$DISK_SIZE_BYTES" -gt "$MAX_DISK_SIZE_BYTES" ]; then
+    echo "Capping disk size to 2TB to avoid mke2fs overflow"
+    DISK_SIZE_BYTES=$MAX_DISK_SIZE_BYTES
+fi
+
 if [ -z "$SERENITY_DISK_SIZE_BYTES" ]; then
     # Try to use heuristics to guess a good disk size and inode count.
     # The disk must notably fit:


### PR DESCRIPTION
In the case if it would somehow been too large.
I've got this issue during build, either due to building on tmpfs, or due to some uutils coreutils bug, no idea.
```
-- Install configuration: ""
ninja: Entering directory `/tmp/serenity/Build/x86_64'
[0/1] cd /tmp/serenity/Build/x86_64 && /usr/bin/cmake -E env SER...N=GNU LLVM_VERSION=15.1.0 /tmp/serenity/Meta/build-image-qemu.sh
checking existing image
e2fsck 1.47.3 (8-Jul-2025)
ext2fs_open2: Bad magic number in super-block
/usr/bin/e2fsck: Superblock invalid, trying backup blocks...
/usr/bin/e2fsck: Bad magic number in super-block while trying to open _disk_image

The superblock could not be read or does not describe a valid ext2/ext3/ext4
filesystem.  If the device is valid and it really contains an ext2/ext3/ext4
filesystem (and not swap or ufs or something else), then the superblock
is corrupt, and you might try running e2fsck with an alternate superblock:
    e2fsck -b 8193 <device>
 or
    e2fsck -b 32768 <device>

failed, not using existing image
setting up disk image... done
creating new filesystem... mke2fs: Size of device (0x5847bf9f47 blocks) _disk_image too big to be expressed
        in 32 bits using a blocksize of 4096.
die: could not create filesystem
FAILED: CMakeFiles/qemu-image _disk_image /tmp/serenity/Build/x86_64/CMakeFiles/qemu-image /tmp/serenity/Build/x86_64/_disk_image 
cd /tmp/serenity/Build/x86_64 && /usr/bin/cmake -E env SERENITY_SOURCE_DIR=/tmp/serenity SERENITY_ARCH=x86_64 SERENITY_TOOLCHAIN=GNU LLVM_VERSION=15.1.0 /tmp/serenity/Meta/build-image-qemu.sh
ninja: build stopped: subcommand failed.

```
But setting a DISK_SIZE_BYTES max fixed the issue.