### PR TITLE
Cherry-pick 1 ladybird PR and 1 ladybird commit

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,13 +1,20 @@
 [Skipped]
+; Consistently hang on macOS, see LadybirdBrowser/ladybird#1306
+Text/input/HTML/cross-origin-window-properties.html
+Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
+Text/input/window-scrollTo.html
+
+; Flaky on CI
 Ref/css-keyframe-fill-forwards.html
 Ref/unicode-range.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/css/transition-basics.html
-Text/input/HTML/cross-origin-window-properties.html
-Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
+
+; Flaky on CI, see LadybirdBrowser/ladybird#19
 Text/input/WebAnimations/misc/DocumentTimeline.html
-Text/input/window-scrollTo.html
+
+; Worker tests are flaky on CI
 Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-close-after-postMessage.html
 Text/input/Worker/Worker-crypto.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -2,6 +2,7 @@
 ; Consistently hang on macOS, see LadybirdBrowser/ladybird#1306
 Text/input/HTML/cross-origin-window-properties.html
 Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
+Text/input/HTML/MessagePort-MessageEvents-should-be-trusted.html
 Text/input/window-scrollTo.html
 
 ; Flaky on CI


### PR DESCRIPTION
https://github.com/LadybirdBrowser/ladybird/pull/2198 commit 1
https://github.com/LadybirdBrowser/ladybird/pull/2620

Effectively makes us skip MessagePort-MessageEvents-should-be-trusted.html, which flaked in https://github.com/SerenityOS/serenity/actions/runs/16906174647/job/47896368015?pr=26120#step:15:1743