### PR TITLE
LibPDF: Unregress using horizontal_scaling

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1376,8 +1376,9 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
 
     // Update text matrix.
     auto delta = end_position - start_position;
-    m_text_rendering_matrix_is_dirty = true;
+    delta.set_x(delta.x() * text_state().horizontal_scaling);
     m_text_matrix.translate(delta);
+    m_text_rendering_matrix_is_dirty = true;
     return {};
 }
 


### PR DESCRIPTION
Using horizontal_scaling here was added in #22819, but then accidentally dropped in #23417 (2nd-to-last commit). Put it back in.

Fixes #26129.