### PR TITLE
WindowServer: Fix inconsistency in previewed window dimensions during tiling operations

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2125,6 +2125,15 @@ Gfx::IntRect WindowManager::tiled_window_rect(Window const& window, Optional<Scr
         rect.set_y(rect.y() + window_rect.y() - window_frame_rect.y());
         rect.set_height(rect.height() - window_frame_rect.height() + window_rect.height());
     }
+
+    Gfx::IntSize minimum_size = window.minimum_size();
+    if (rect.height() < minimum_size.height()) {
+        rect.set_height(minimum_size.height());
+    }
+    if (rect.width() < minimum_size.width()) {
+        rect.set_width(minimum_size.width());
+    }
+
     return rect;
 }
 


### PR DESCRIPTION
This PR fixes an inconsistency where the previewed window dimensions during tiling operations differ from the final window size, caused by `tiled_window_rect()` not taking into account the windows minimum size.

Before:

https://github.com/user-attachments/assets/4f4ee10e-7511-4439-8c2f-fabf8551f660

After:

https://github.com/user-attachments/assets/042dc823-d76e-4aa1-98a7-d0e5e83e4391


