### PR TITLE
LibGfx/JBIG2: Fix off-by-one in max stripe height computation

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1121,6 +1121,7 @@ static ErrorOr<void> scan_for_page_size(JBIG2LoadingContext& context)
 
             int stripe_height = new_height - height_at_end_of_last_stripe.value_or(0);
             VERIFY(stripe_height >= 0);
+            dbgln_if(JBIG2_DEBUG, "stripe_height={}, max_stripe_height={}", stripe_height, max_stripe_height);
             if (stripe_height > max_stripe_height)
                 return Error::from_string_literal("JBIG2ImageDecoderPlugin: EndOfStripe Y coordinate larger than maximum stripe height");
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1024,7 +1024,7 @@ struct [[gnu::packed]] PageInformationSegment {
     bool might_contain_coloured_segments() const { return (flags >> 7) & 1; }
 
     bool page_is_striped() const { return (striping_information & 0x8000) != 0; }
-    u16 maximum_stripe_height() const { return striping_information & 0x7FFF; }
+    u16 maximum_stripe_size() const { return striping_information & 0x7FFF; }
 };
 static_assert(AssertSize<PageInformationSegment, 19>());
 
@@ -1096,7 +1096,7 @@ static ErrorOr<void> scan_for_page_size(JBIG2LoadingContext& context)
 
             auto page_information = TRY(decode_page_information_segment(segment.data));
             page_is_striped = page_information.page_is_striped();
-            max_stripe_height = page_information.maximum_stripe_height();
+            max_stripe_height = page_information.maximum_stripe_size() + 1;
 
             context.page.size = { page_information.bitmap_width, page_information.bitmap_height };
             has_initially_unknown_height = page_information.bitmap_height == 0xffff'ffff;
@@ -3477,7 +3477,7 @@ static ErrorOr<void> decode_page_information(JBIG2LoadingContext& context, Segme
     if (page_information.bitmap_height == 0xffff'ffff && !page_information.page_is_striped())
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Non-striped bitmaps of indeterminate height not allowed");
 
-    dbgln_if(JBIG2_DEBUG, "Page information: width={}, height={}, is_striped={}, max_stripe_height={}", page_information.bitmap_width, page_information.bitmap_height, page_information.page_is_striped(), page_information.maximum_stripe_height());
+    dbgln_if(JBIG2_DEBUG, "Page information: width={}, height={}, is_striped={}, max_stripe_size={}", page_information.bitmap_width, page_information.bitmap_height, page_information.page_is_striped(), page_information.maximum_stripe_size());
     dbgln_if(JBIG2_DEBUG, "Page information flags: {:#02x}", page_information.flags);
     dbgln_if(JBIG2_DEBUG, "    is_eventually_lossless={}", page_information.is_eventually_lossless());
     dbgln_if(JBIG2_DEBUG, "    might_contain_refinements={}", page_information.might_contain_refinements());


### PR DESCRIPTION
Rename field in page information segment to maximum_stripe_size
to match its name in the spec.

7.4.8.6 Page striping information:

> the maximum size of each stripe (the distance between an end of stripe
> segment's end row and the end row of the previous end of stripe
> segment, or 0 in the case of the first end of stripe segment) must be
> no more than the page's maximum stripe size.

That means that the maximum stripe _height_ is one more than the
maximum strip size, so update the code accordingly.

This lets us decode https://github.com/SerenityOS/serenity/commit/0001341cd6dfcbf6a6b92ed0901f0dcff892693b.pdf page 6, which has a page information
segment with height=1408 and max_stripe_size=1407.