### PR TITLE
LibPDF: Diagnose more unimplemented features

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1436,6 +1436,12 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
         return Error::rendering_unsupported_error("Text rendering mode Clip not yet supported");
     }
 
+    {
+        auto text_matrix = calculate_text_rendering_matrix();
+        if (text_matrix.b() != 0.0f || text_matrix.c() != 0.0f)
+            return Error::rendering_unsupported_error("Non-diagonal text rendering matrix not yet supported");
+    }
+
     auto start_position = Gfx::FloatPoint { 0.0f, 0.0f };
     auto end_position = TRY(text_state().font->draw_string(painter(), start_position, string, *this));
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1377,6 +1377,7 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
             state().soft_mask = {};
         } else {
             state().soft_mask = TRY(read_smask_dict(smask->cast<DictObject>()));
+            return Error::rendering_unsupported_error("/SMask in graphics state dict not yet supported");
         }
     }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -936,6 +936,9 @@ RENDERER_HANDLER(shade)
         TRY(add_clip_path(bbox_path, Gfx::WindingRule::Nonzero));
     }
 
+    if (state().paint_alpha_constant < 1.0f)
+        return Error::rendering_unsupported_error("Non-opaque shadings not yet supported");
+
     return shading->draw(painter(), state().ctm);
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1488,6 +1488,7 @@ PDFErrorOr<void> Renderer::paint_form_xobject(NonnullRefPtr<StreamObject> form)
     if (form->dict()->contains(CommonNames::Group)) {
         auto group = TRY(form->dict()->get_dict(m_document, CommonNames::Group));
         transparency_group_attributes = TRY(read_transparency_group_attributes(group));
+        return Error::rendering_unsupported_error("Transparency groups not yet supported");
     }
 
     // FIXME: If transparency_group_attributes.has_value(), paint as transparency group.

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -668,6 +668,43 @@ PDFErrorOr<void> Renderer::set_blend_mode(ReadonlySpan<Value> args)
         }
         return BlendMode::Normal;
     }());
+
+    switch (state().blend_mode) {
+    case BlendMode::Normal:
+        // Handled below.
+        break;
+    case BlendMode::Multiply:
+        return Error::rendering_unsupported_error("Blend mode Multiply not yet implemented");
+    case BlendMode::Screen:
+        return Error::rendering_unsupported_error("Blend mode Screen not yet implemented");
+    case BlendMode::Overlay:
+        return Error::rendering_unsupported_error("Blend mode Overlay not yet implemented");
+    case BlendMode::Darken:
+        return Error::rendering_unsupported_error("Blend mode Darken not yet implemented");
+    case BlendMode::Lighten:
+        return Error::rendering_unsupported_error("Blend mode Lighten not yet implemented");
+    case BlendMode::ColorDodge:
+        return Error::rendering_unsupported_error("Blend mode ColorDodge not yet implemented");
+    case BlendMode::ColorBurn:
+        return Error::rendering_unsupported_error("Blend mode ColorBurn not yet implemented");
+    case BlendMode::HardLight:
+        return Error::rendering_unsupported_error("Blend mode HardLight not yet implemented");
+    case BlendMode::SoftLight:
+        return Error::rendering_unsupported_error("Blend mode SoftLight not yet implemented");
+    case BlendMode::Difference:
+        return Error::rendering_unsupported_error("Blend mode Difference not yet implemented");
+    case BlendMode::Exclusion:
+        return Error::rendering_unsupported_error("Blend mode Exclusion not yet implemented");
+    case BlendMode::Hue:
+        return Error::rendering_unsupported_error("Blend mode Hue not yet implemented");
+    case BlendMode::Saturation:
+        return Error::rendering_unsupported_error("Blend mode Saturation not yet implemented");
+    case BlendMode::Color:
+        return Error::rendering_unsupported_error("Blend mode Color not yet implemented");
+    case BlendMode::Luminosity:
+        return Error::rendering_unsupported_error("Blend mode Luminosity not yet implemented");
+    }
+
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1371,6 +1371,27 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
     if (!text_state().font)
         return Error::rendering_unsupported_error("Can't draw text because an invalid font was in use");
 
+    switch (text_state().rendering_mode) {
+    case TextRenderingMode::Fill:
+        // Handled below.
+        break;
+    case TextRenderingMode::Stroke:
+        return Error::rendering_unsupported_error("Text rendering mode Stroke not yet supported");
+    case TextRenderingMode::FillThenStroke:
+        return Error::rendering_unsupported_error("Text rendering mode FillThenStroke not yet supported");
+    case TextRenderingMode::Invisible:
+        // Handled below.
+        break;
+    case TextRenderingMode::FillAndClip:
+        return Error::rendering_unsupported_error("Text rendering mode FillAndClip not yet supported");
+    case TextRenderingMode::StrokeAndClip:
+        return Error::rendering_unsupported_error("Text rendering mode StrokeAndClip not yet supported");
+    case TextRenderingMode::FillStrokeAndClip:
+        return Error::rendering_unsupported_error("Text rendering mode FillStrokeAndClip not yet supported");
+    case TextRenderingMode::Clip:
+        return Error::rendering_unsupported_error("Text rendering mode Clip not yet supported");
+    }
+
     auto start_position = Gfx::FloatPoint { 0.0f, 0.0f };
     auto end_position = TRY(text_state().font->draw_string(painter(), start_position, string, *this));
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -201,7 +201,7 @@ private:
     PDFErrorOr<void> end_path_paint();
     void stroke_current_path();
     void fill_current_path(Gfx::WindingRule);
-    void fill_and_stroke_current_path(Gfx::WindingRule);
+    PDFErrorOr<void> fill_and_stroke_current_path(Gfx::WindingRule);
     PDFErrorOr<GraphicsState::SMask> read_smask_dict(NonnullRefPtr<DictObject> dict);
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
     PDFErrorOr<void> show_text(ByteString const&);


### PR DESCRIPTION
Our test_pdf.py report currently looks pretty decent, but that's in part because we silently don't support a bunch of features. This here makes us fail on these things instead.

I don't intend to merge this, since for most of these things, silently rendering without the feature seems better than not rendering – for example, blending with the wrong blend mode seems better than not drawing something, drawing non-rotated text seems better than not drawing text, drawing a solid shading arguably seems better than not drawing a shading, etc.

But it still produces interesting output, so I'm uploading it so I can refer to it.

For my 1000-file-test-set, this brings us from 880 files without issues (88.0%) to just 637 files without issues (63.7%), and from 21 distinct issues, in 110 files (11.0%) to 37 distinct issues, in 353 files (35.3%).

Here's `time Meta/test_pdf.py ~/Downloads/0000` with this applied:

[pdf-report-86-truth.txt](https://github.com/user-attachments/files/21804764/pdf-report-86-truth.txt)
