### PR TITLE
LibPDF: Diagnose type 0 issues later

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -60,16 +60,16 @@ PDFErrorOr<NonnullOwnPtr<CIDFontType0>> CIDFontType0::create(Document* document,
         }
     }
 
-    if (!font_program) {
-        // FIXME: Should we use a fallback font? How common is this for type 0 fonts?
-        return Error::malformed_error("CIDFontType0: missing FontFile3");
-    }
-
     return TRY(adopt_nonnull_own_or_enomem(new (nothrow) CIDFontType0(move(font_program))));
 }
 
 PDFErrorOr<void> CIDFontType0::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u32 cid, Renderer const& renderer)
 {
+    if (!m_font_program) {
+        // FIXME: Should we use a fallback font? How common is this for type 0 fonts?
+        return Error::malformed_error("CIDFontType0: missing FontFile3");
+    }
+
     // ISO 32000 (PDF 2.0) 9.7.4.2 Glyph selection in CIDFonts
     // "When the CIDFont contains an embedded font program that is represented in the Compact Font Format (CFF),
     //  the FontFile3 entry in the font descriptor (...) shall be either CIDFontType0C or OpenType.

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -282,6 +282,8 @@ static PDFErrorOr<NonnullOwnPtr<Type0CMap>> make_cmap(NonnullRefPtr<Object> cons
     if (!cmap_value->is<NameObject>())
         return Error::rendering_unsupported_error("Type0 font: support for general type 0 cmaps not yet implemented");
 
+    // FIXME: Add additional encodings from https://github.com/adobe-type-tools/cmap-resources
+    // Spec: https://adobe-type-tools.github.io/font-tech-notes/pdfs/5014.CIDFont_Spec.pdf (5 CMap Tutorial, page 41 onwards)
     auto cmap_name = cmap_value->cast<NameObject>()->name();
     if (cmap_name != CommonNames::IdentityH && cmap_name != CommonNames::IdentityV)
         return Error::rendering_unsupported_error("Type0 font: unimplemented named type 0 cmap {}", cmap_name);


### PR DESCRIPTION
If Type0Font::initialize() returns an error,  PDFFont::create() will
fail and Renderer::set_font() will keep the previous font object as
current font. But the previous font object will likely be a simple font,
and the simple font will have a hard time with the multi-byte text
encoding usually used with type 0 fonts, leading to attempts to look up
e.g. char_code 0 for every second byte in an UCS2 string.

Instead, let Type0Font::initialize() succeed and then error out later,
either at decode or paint time.

---

Doesn't change the number of files with diagnostics, but reduces the number of bogus follow-on diagnostics in files that already emitted "Type0 font: unimplemented named type 0 cmap", "support for general type 0 cmaps not yet implemented", or "CIDFontType0: missing FontFile3":

From

```
Rendering of feature not supported: Looking up glyph in 'post' table not yet implemented., in 49 files, on 390 pages, 7714 times
```
to

```
Rendering of feature not supported: Looking up glyph in 'post' table not yet implemented., in 36 files, on 180 pages, 4474 times
```

and from

```
Rendering of feature not supported: Can't draw text because an invalid font was in use, in 5 files, on 17 pages, 1640 times
```

to

```
Rendering of feature not supported: Can't draw text because an invalid font was in use, in 3 files, on 12 pages, 771 times
```

(These 3 files are the ones with `Internal error while processing PDF file: No suitable cmap subtable found, in 3 files, on 13 pages, 248 times` -- might want to defer that error from font construction time to paint time as well.)