### PR TITLE
LibPDF: Make CIDFontType2 fonts without FontFile2 error out later too

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -119,7 +119,7 @@ PDFErrorOr<void> TrueTypePainter::draw_glyph(Gfx::Painter& painter, Gfx::FloatPo
         // "In either of the cases above, if the glyph name cannot be mapped as specified, the glyph name is looked up
         //  in the font program’s “post” table (if one is present) and the associated glyph description is used."
         // FIXME: Implement this.
-        return Error::rendering_unsupported_error("Looking up glyph in 'post' table not yet implemented.");
+        return Error::rendering_unsupported_error("Looking up glyph in 'post' table not yet implemented");
     } else if (m_high_byte.has_value()) {
         // "When the font has no Encoding entry, or the font descriptor’s Symbolic flag is set (in which case the
         //  Encoding entry is ignored), the following occurs:

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -187,16 +187,16 @@ PDFErrorOr<NonnullOwnPtr<CIDFontType2>> CIDFontType2::create(Document* document,
         font = adopt_ref(*new Gfx::ScaledFont(*ttf_font, point_size, point_size));
     }
 
-    if (!font) {
-        // FIXME: Should we use a fallback font? How common is this for type 0 fonts?
-        return Error::malformed_error("CIDFontType2: missing FontFile2");
-    }
-
     return TRY(adopt_nonnull_own_or_enomem(new (nothrow) CIDFontType2(move(font))));
 }
 
 PDFErrorOr<void> CIDFontType2::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u32 char_code, Renderer const& renderer)
 {
+    if (!m_font) {
+        // FIXME: Should we use a fallback font? How common is this for type 0 fonts?
+        return Error::malformed_error("CIDFontType2: missing FontFile2");
+    }
+
     // ISO 32000 (PDF 2.0) 9.7.4.2 Glyph selection in CIDFonts
     // "For Type 2, the CIDFont program is actually a TrueType font program, which has no native notion of CIDs.
     //  In a TrueType font program, glyph descriptions are identified by glyph index values.
@@ -231,7 +231,8 @@ PDFErrorOr<void> CIDFontType2::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint
 
 void CIDFontType2::set_font_size(float font_size)
 {
-    m_font = m_font->scaled_with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
+    if (m_font)
+        m_font = m_font->scaled_with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
 }
 
 Type0Font::Type0Font() = default;


### PR DESCRIPTION
Like https://github.com/SerenityOS/serenity/commit/daa1a19ae4c5b4a80593d6b732f601b70928d33d but for CIDFontType2.

Happens e.g. on page 1 of 0000228.pdf and 0000080.pdf.

---

From

```
Rendering of feature not supported: Looking up glyph in 'post' table not yet implemented., in 36 files, on 180 pages, 4474 times
```

to

```
Rendering of feature not supported: Looking up glyph in 'post' table not yet implemented, in 34 files, on 176 pages, 4465 times
```

(due to 2 fewer files showing this diagnostic incorrectly due to sending type0 multibyte encoded text to a simple font)