### PR TITLE
LibGfx+LibPDF: For TrueType, look up by postscript name after unicode value

### DIFF
--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -62,11 +62,14 @@ public:
 
     Glyph glyph(u32 code_point) const override;
     Glyph glyph(u32 code_point, GlyphSubpixelOffset) const override { return glyph(code_point); }
+    Optional<Glyph> glyph_for_postscript_name(StringView, GlyphSubpixelOffset) const override { return {}; }
 
     float glyph_left_bearing(u32) const override { return 0; }
+    Optional<float> glyph_left_bearing_for_postscript_name(StringView) const override { return {}; }
 
     Glyph raw_glyph(u32 code_point) const;
     bool contains_glyph(u32 code_point) const override;
+    bool contains_glyph_for_postscript_name(StringView) const override { return false; }
     bool contains_raw_glyph(u32 code_point) const { return m_glyph_widths[code_point] > 0; }
 
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const override;
@@ -78,6 +81,7 @@ public:
     virtual float preferred_line_height() const override { return glyph_height() + m_line_gap; }
 
     virtual float glyph_width(u32 code_point) const override;
+    virtual Optional<float> glyph_width_for_postscript_name(StringView) const override { return {}; }
     u8 raw_glyph_width(u32 code_point) const { return m_glyph_widths[code_point]; }
 
     u8 min_glyph_width() const override { return m_min_glyph_width; }

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -175,10 +175,14 @@ public:
     virtual u16 weight() const = 0;
     virtual Glyph glyph(u32 code_point) const = 0;
     virtual Glyph glyph(u32 code_point, GlyphSubpixelOffset) const = 0;
+    virtual Optional<Glyph> glyph_for_postscript_name(StringView, GlyphSubpixelOffset) const = 0;
     virtual bool contains_glyph(u32 code_point) const = 0;
+    virtual bool contains_glyph_for_postscript_name(StringView name) const = 0;
 
     virtual float glyph_left_bearing(u32 code_point) const = 0;
+    virtual Optional<float> glyph_left_bearing_for_postscript_name(StringView) const = 0;
     virtual float glyph_width(u32 code_point) const = 0;
+    virtual Optional<float> glyph_width_for_postscript_name(StringView) const = 0;
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const = 0;
     virtual float glyph_or_emoji_width(Utf32CodePointIterator&) const = 0;
     virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const = 0;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -704,6 +704,12 @@ u32 Font::glyph_id_for_code_point(u32 code_point) const
     return glyph_page(code_point / GlyphPage::glyphs_per_page).glyph_ids[code_point % GlyphPage::glyphs_per_page];
 }
 
+Optional<u32> Font::glyph_id_for_postscript_name(StringView) const
+{
+    // FIXME: Look at 'post' or 'CFF ' data if present.
+    return {};
+}
+
 Font::GlyphPage const& Font::glyph_page(size_t page_index) const
 {
     if (page_index == 0) {

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -123,6 +123,7 @@ private:
         Optional<OS2> os2,
         Optional<Kern>&& kern,
         Optional<Fpgm> fpgm,
+        Optional<Post> post,
         Optional<Prep> prep,
         Optional<CBLC> cblc,
         Optional<CBDT> cbdt,
@@ -138,6 +139,7 @@ private:
         , m_os2(move(os2))
         , m_kern(move(kern))
         , m_fpgm(move(fpgm))
+        , m_post(move(post))
         , m_prep(move(prep))
         , m_cblc(move(cblc))
         , m_cbdt(move(cbdt))
@@ -159,6 +161,7 @@ private:
     Optional<OS2> m_os2;
     Optional<Kern> m_kern;
     Optional<Fpgm> m_fpgm;
+    Optional<Post> m_post;
     Optional<Prep> m_prep;
     Optional<CBLC> m_cblc;
     Optional<CBDT> m_cbdt;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -62,6 +62,7 @@ public:
     virtual u32 glyph_count() const override;
     virtual u16 units_per_em() const override;
     virtual u32 glyph_id_for_code_point(u32 code_point) const override;
+    virtual Optional<u32> glyph_id_for_postscript_name(StringView) const override;
     virtual String family() const override;
     virtual String variant() const override;
     virtual u16 weight() const override;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
@@ -777,4 +777,343 @@ Optional<i16> GPOS::glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
     return {};
 }
 
+ErrorOr<Post> Post::from_slice(ReadonlyBytes slice)
+{
+    if (slice.size() < sizeof(Header))
+        return Error::from_string_literal("Could not load post: Not enough data");
+
+    auto const& header = *bit_cast<Header const*>(slice.data());
+    bool is_valid_version = (header.version.major == 1 && header.version.minor == 0)
+        || (header.version.major == 2 && (header.version.minor == 0 || header.version.minor == 5))
+        || (header.version.major == 3 && header.version.minor == 0);
+    if (!is_valid_version)
+        return Error::from_string_literal("'post' table: Invalid version");
+
+    if (header.version.major == 2 && header.version.minor == 0) {
+        if (slice.size() < sizeof(Header) + sizeof(Uint16))
+            return Error::from_string_literal("'post' table: Not enough data for version 2.0");
+
+        Uint16 num_glyphs = *bit_cast<Uint16 const*>(slice.offset_pointer(sizeof(Header)));
+        if (slice.size() < sizeof(Header) + (1 + num_glyphs) * sizeof(Uint16))
+            return Error::from_string_literal("'post' table: Not enough data for version 2.0");
+    }
+
+    // FIXME: Support version 2.5
+    if (header.version.major == 2 && header.version.minor == 5)
+        return Error::from_string_literal("'post' table: Support for format 2.5 not yet implemented");
+
+    return Post(header, slice);
+}
+
+Optional<u32> Post::glyph_id_for_postscript_name(StringView name) const
+{
+    if (m_header.version.major == 3 && m_header.version.minor == 0)
+        return {};
+
+    if (m_glyph_ids.is_empty())
+        load_glyph_names();
+
+    return m_glyph_ids.get(name).copy();
+}
+
+void Post::load_glyph_names() const
+{
+    Vector<StringView> names;
+    names.resize(258);
+
+// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6post.html
+#define FORMAT1(A)               \
+    A(0, ".notdef"sv)            \
+    A(1, ".null"sv)              \
+    A(2, "nonmarkingreturn"sv)   \
+    A(3, "space"sv)              \
+    A(4, "exclam"sv)             \
+    A(5, "quotedbl"sv)           \
+    A(6, "numbersign"sv)         \
+    A(7, "dollar"sv)             \
+    A(8, "percent"sv)            \
+    A(9, "ampersand"sv)          \
+    A(10, "quotesingle"sv)       \
+    A(11, "parenleft"sv)         \
+    A(12, "parenright"sv)        \
+    A(13, "asterisk"sv)          \
+    A(14, "plus"sv)              \
+    A(15, "comma"sv)             \
+    A(16, "hyphen"sv)            \
+    A(17, "period"sv)            \
+    A(18, "slash"sv)             \
+    A(19, "zero"sv)              \
+    A(20, "one"sv)               \
+    A(21, "two"sv)               \
+    A(22, "three"sv)             \
+    A(23, "four"sv)              \
+    A(24, "five"sv)              \
+    A(25, "six"sv)               \
+    A(26, "seven"sv)             \
+    A(27, "eight"sv)             \
+    A(28, "nine"sv)              \
+    A(29, "colon"sv)             \
+    A(30, "semicolon"sv)         \
+    A(31, "less"sv)              \
+    A(32, "equal"sv)             \
+    A(33, "greater"sv)           \
+    A(34, "question"sv)          \
+    A(35, "at"sv)                \
+    A(36, "A"sv)                 \
+    A(37, "B"sv)                 \
+    A(38, "C"sv)                 \
+    A(39, "D"sv)                 \
+    A(40, "E"sv)                 \
+    A(41, "F"sv)                 \
+    A(42, "G"sv)                 \
+    A(43, "H"sv)                 \
+    A(44, "I"sv)                 \
+    A(45, "J"sv)                 \
+    A(46, "K"sv)                 \
+    A(47, "L"sv)                 \
+    A(48, "M"sv)                 \
+    A(49, "N"sv)                 \
+    A(50, "O"sv)                 \
+    A(51, "P"sv)                 \
+    A(52, "Q"sv)                 \
+    A(53, "R"sv)                 \
+    A(54, "S"sv)                 \
+    A(55, "T"sv)                 \
+    A(56, "U"sv)                 \
+    A(57, "V"sv)                 \
+    A(58, "W"sv)                 \
+    A(59, "X"sv)                 \
+    A(60, "Y"sv)                 \
+    A(61, "Z"sv)                 \
+    A(62, "bracketleft"sv)       \
+    A(63, "backslash"sv)         \
+    A(64, "bracketright"sv)      \
+    A(65, "asciicircum"sv)       \
+    A(66, "underscore"sv)        \
+    A(67, "grave"sv)             \
+    A(68, "a"sv)                 \
+    A(69, "b"sv)                 \
+    A(70, "c"sv)                 \
+    A(71, "d"sv)                 \
+    A(72, "e"sv)                 \
+    A(73, "f"sv)                 \
+    A(74, "g"sv)                 \
+    A(75, "h"sv)                 \
+    A(76, "i"sv)                 \
+    A(77, "j"sv)                 \
+    A(78, "k"sv)                 \
+    A(79, "l"sv)                 \
+    A(80, "m"sv)                 \
+    A(81, "n"sv)                 \
+    A(82, "o"sv)                 \
+    A(83, "p"sv)                 \
+    A(84, "q"sv)                 \
+    A(85, "r"sv)                 \
+    A(86, "s"sv)                 \
+    A(87, "t"sv)                 \
+    A(88, "u"sv)                 \
+    A(89, "v"sv)                 \
+    A(90, "w"sv)                 \
+    A(91, "x"sv)                 \
+    A(92, "y"sv)                 \
+    A(93, "z"sv)                 \
+    A(94, "braceleft"sv)         \
+    A(95, "bar"sv)               \
+    A(96, "braceright"sv)        \
+    A(97, "asciitilde"sv)        \
+    A(98, "Adieresis"sv)         \
+    A(99, "Aring"sv)             \
+    A(100, "Ccedilla"sv)         \
+    A(101, "Eacute"sv)           \
+    A(102, "Ntilde"sv)           \
+    A(103, "Odieresis"sv)        \
+    A(104, "Udieresis"sv)        \
+    A(105, "aacute"sv)           \
+    A(106, "agrave"sv)           \
+    A(107, "acircumflex"sv)      \
+    A(108, "adieresis"sv)        \
+    A(109, "atilde"sv)           \
+    A(110, "aring"sv)            \
+    A(111, "ccedilla"sv)         \
+    A(112, "eacute"sv)           \
+    A(113, "egrave"sv)           \
+    A(114, "ecircumflex"sv)      \
+    A(115, "edieresis"sv)        \
+    A(116, "iacute"sv)           \
+    A(117, "igrave"sv)           \
+    A(118, "icircumflex"sv)      \
+    A(119, "idieresis"sv)        \
+    A(120, "ntilde"sv)           \
+    A(121, "oacute"sv)           \
+    A(122, "ograve"sv)           \
+    A(123, "ocircumflex"sv)      \
+    A(124, "odieresis"sv)        \
+    A(125, "otilde"sv)           \
+    A(126, "uacute"sv)           \
+    A(127, "ugrave"sv)           \
+    A(128, "ucircumflex"sv)      \
+    A(129, "udieresis"sv)        \
+    A(130, "dagger"sv)           \
+    A(131, "degree"sv)           \
+    A(132, "cent"sv)             \
+    A(133, "sterling"sv)         \
+    A(134, "section"sv)          \
+    A(135, "bullet"sv)           \
+    A(136, "paragraph"sv)        \
+    A(137, "germandbls"sv)       \
+    A(138, "registered"sv)       \
+    A(139, "copyright"sv)        \
+    A(140, "trademark"sv)        \
+    A(141, "acute"sv)            \
+    A(142, "dieresis"sv)         \
+    A(143, "notequal"sv)         \
+    A(144, "AE"sv)               \
+    A(145, "Oslash"sv)           \
+    A(146, "infinity"sv)         \
+    A(147, "plusminus"sv)        \
+    A(148, "lessequal"sv)        \
+    A(149, "greaterequal"sv)     \
+    A(150, "yen"sv)              \
+    A(151, "mu"sv)               \
+    A(152, "partialdiff"sv)      \
+    A(153, "summation"sv)        \
+    A(154, "product"sv)          \
+    A(155, "pi"sv)               \
+    A(156, "integral"sv)         \
+    A(157, "ordfeminine"sv)      \
+    A(158, "ordmasculine"sv)     \
+    A(159, "Omega"sv)            \
+    A(160, "ae"sv)               \
+    A(161, "oslash"sv)           \
+    A(162, "questiondown"sv)     \
+    A(163, "exclamdown"sv)       \
+    A(164, "logicalnot"sv)       \
+    A(165, "radical"sv)          \
+    A(166, "florin"sv)           \
+    A(167, "approxequal"sv)      \
+    A(168, "Delta"sv)            \
+    A(169, "guillemotleft"sv)    \
+    A(170, "guillemotright"sv)   \
+    A(171, "ellipsis"sv)         \
+    A(172, "nonbreakingspace"sv) \
+    A(173, "Agrave"sv)           \
+    A(174, "Atilde"sv)           \
+    A(175, "Otilde"sv)           \
+    A(176, "OE"sv)               \
+    A(177, "oe"sv)               \
+    A(178, "endash"sv)           \
+    A(179, "emdash"sv)           \
+    A(180, "quotedblleft"sv)     \
+    A(181, "quotedblright"sv)    \
+    A(182, "quoteleft"sv)        \
+    A(183, "quoteright"sv)       \
+    A(184, "divide"sv)           \
+    A(185, "lozenge"sv)          \
+    A(186, "ydieresis"sv)        \
+    A(187, "Ydieresis"sv)        \
+    A(188, "fraction"sv)         \
+    A(189, "currency"sv)         \
+    A(190, "guilsinglleft"sv)    \
+    A(191, "guilsinglright"sv)   \
+    A(192, "fi"sv)               \
+    A(193, "fl"sv)               \
+    A(194, "daggerdbl"sv)        \
+    A(195, "periodcentered"sv)   \
+    A(196, "quotesinglbase"sv)   \
+    A(197, "quotedblbase"sv)     \
+    A(198, "perthousand"sv)      \
+    A(199, "Acircumflex"sv)      \
+    A(200, "Ecircumflex"sv)      \
+    A(201, "Aacute"sv)           \
+    A(202, "Edieresis"sv)        \
+    A(203, "Egrave"sv)           \
+    A(204, "Iacute"sv)           \
+    A(205, "Icircumflex"sv)      \
+    A(206, "Idieresis"sv)        \
+    A(207, "Igrave"sv)           \
+    A(208, "Oacute"sv)           \
+    A(209, "Ocircumflex"sv)      \
+    A(210, "apple"sv)            \
+    A(211, "Ograve"sv)           \
+    A(212, "Uacute"sv)           \
+    A(213, "Ucircumflex"sv)      \
+    A(214, "Ugrave"sv)           \
+    A(215, "dotlessi"sv)         \
+    A(216, "circumflex"sv)       \
+    A(217, "tilde"sv)            \
+    A(218, "macron"sv)           \
+    A(219, "breve"sv)            \
+    A(220, "dotaccent"sv)        \
+    A(221, "ring"sv)             \
+    A(222, "cedilla"sv)          \
+    A(223, "hungarumlaut"sv)     \
+    A(224, "ogonek"sv)           \
+    A(225, "caron"sv)            \
+    A(226, "Lslash"sv)           \
+    A(227, "lslash"sv)           \
+    A(228, "Scaron"sv)           \
+    A(229, "scaron"sv)           \
+    A(230, "Zcaron"sv)           \
+    A(231, "zcaron"sv)           \
+    A(232, "brokenbar"sv)        \
+    A(233, "Eth"sv)              \
+    A(234, "eth"sv)              \
+    A(235, "Yacute"sv)           \
+    A(236, "yacute"sv)           \
+    A(237, "Thorn"sv)            \
+    A(238, "thorn"sv)            \
+    A(239, "minus"sv)            \
+    A(240, "multiply"sv)         \
+    A(241, "onesuperior"sv)      \
+    A(242, "twosuperior"sv)      \
+    A(243, "threesuperior"sv)    \
+    A(244, "onehalf"sv)          \
+    A(245, "onequarter"sv)       \
+    A(246, "threequarters"sv)    \
+    A(247, "franc"sv)            \
+    A(248, "Gbreve"sv)           \
+    A(249, "gbreve"sv)           \
+    A(250, "Idotaccent"sv)       \
+    A(251, "Scedilla"sv)         \
+    A(252, "scedilla"sv)         \
+    A(253, "Cacute"sv)           \
+    A(254, "cacute"sv)           \
+    A(255, "Ccaron"sv)           \
+    A(256, "ccaron"sv)           \
+    A(257, "dcroat"sv)
+
+#define INSERT(num, name) \
+    names[num] = name;
+    FORMAT1(INSERT)
+#undef INSERT
+
+    Vector<u16> glyph_name_index;
+
+    if (m_header.version.major == 1 && m_header.version.minor == 0) {
+        glyph_name_index.ensure_capacity(258);
+        for (int i = 0; i < 258; ++i)
+            glyph_name_index.append(i);
+    } else if (m_header.version.major == 2 && m_header.version.minor == 0) {
+        Uint16 num_glyphs = *bit_cast<Uint16 const*>(m_slice.offset_pointer(sizeof(Header)));
+        ReadonlySpan<Uint16> glyph_name_index_data = { bit_cast<Uint16 const*>(m_slice.offset_pointer(sizeof(Header) + sizeof(Uint16))), num_glyphs };
+        glyph_name_index.ensure_capacity(num_glyphs);
+        for (auto index : glyph_name_index_data)
+            glyph_name_index.append(index);
+
+        ReadonlyBytes glyph_names_data = m_slice.slice(sizeof(Header) + (1 + num_glyphs) * sizeof(Uint16));
+        while (!glyph_names_data.is_empty()) {
+            auto name_length = glyph_names_data[0];
+            names.append(glyph_names_data.slice(1, name_length));
+            glyph_names_data = glyph_names_data.slice(1 + name_length);
+        }
+    } else {
+        VERIFY(m_header.version.major == 2 && m_header.version.minor == 5);
+        // FIXME: Support version 2.5 (currently rejected in from_slice())
+        VERIFY_NOT_REACHED();
+    }
+
+    for (int i = (int)glyph_name_index.size() - 1; i >= 0; --i)
+        m_glyph_ids.set(names[glyph_name_index[i]], i);
+}
+
 }

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -104,12 +104,25 @@ Gfx::Glyph ScaledFont::glyph(u32 code_point) const
     return glyph(code_point, GlyphSubpixelOffset { 0, 0 });
 }
 
-Gfx::Glyph ScaledFont::glyph(u32 code_point, GlyphSubpixelOffset subpixel_offset) const
+Glyph ScaledFont::glyph_for_id(u32 id, GlyphSubpixelOffset subpixel_offset) const
 {
-    auto id = glyph_id_for_code_point(code_point);
     auto bitmap = rasterize_glyph(id, subpixel_offset);
     auto metrics = glyph_metrics(id);
     return Gfx::Glyph(bitmap, metrics.left_side_bearing, metrics.advance_width, metrics.ascender, m_font->has_color_bitmaps());
+}
+
+Gfx::Glyph ScaledFont::glyph(u32 code_point, GlyphSubpixelOffset subpixel_offset) const
+{
+    auto id = glyph_id_for_code_point(code_point);
+    return glyph_for_id(id, subpixel_offset);
+}
+
+Optional<Glyph> ScaledFont::glyph_for_postscript_name(StringView name, GlyphSubpixelOffset subpixel_offset) const
+{
+    auto id = glyph_id_for_postscript_name(name);
+    if (!id.has_value())
+        return {};
+    return glyph_for_id(id.value(), subpixel_offset);
 }
 
 float ScaledFont::glyph_left_bearing(u32 code_point) const
@@ -118,10 +131,26 @@ float ScaledFont::glyph_left_bearing(u32 code_point) const
     return glyph_metrics(id).left_side_bearing;
 }
 
+Optional<float> ScaledFont::glyph_left_bearing_for_postscript_name(StringView name) const
+{
+    auto id = glyph_id_for_postscript_name(name);
+    if (!id.has_value())
+        return {};
+    return glyph_metrics(id.value()).left_side_bearing;
+}
+
 float ScaledFont::glyph_width(u32 code_point) const
 {
     auto id = glyph_id_for_code_point(code_point);
     return m_font->glyph_advance(id, m_x_scale, m_y_scale, m_point_width, m_point_height);
+}
+
+Optional<float> ScaledFont::glyph_width_for_postscript_name(StringView name) const
+{
+    auto id = glyph_id_for_postscript_name(name);
+    if (!id.has_value())
+        return {};
+    return m_font->glyph_advance(id.value(), m_x_scale, m_y_scale, m_point_width, m_point_height);
 }
 
 template<typename CodePointIterator>

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -25,6 +25,7 @@ class ScaledFont final : public Gfx::Font {
 public:
     ScaledFont(NonnullRefPtr<VectorFont>, float point_width, float point_height, unsigned dpi_x = DEFAULT_DPI, unsigned dpi_y = DEFAULT_DPI);
     u32 glyph_id_for_code_point(u32 code_point) const { return m_font->glyph_id_for_code_point(code_point); }
+    Optional<u32> glyph_id_for_postscript_name(StringView name) const { return m_font->glyph_id_for_postscript_name(name); }
     ScaledFontMetrics metrics() const { return m_font->metrics(m_x_scale, m_y_scale); }
     ScaledGlyphMetrics glyph_metrics(u32 glyph_id) const { return m_font->glyph_metrics(glyph_id, m_x_scale, m_y_scale, m_point_width, m_point_height); }
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, GlyphSubpixelOffset) const;
@@ -43,9 +44,13 @@ public:
     virtual u16 weight() const override { return m_font->weight(); }
     virtual Gfx::Glyph glyph(u32 code_point) const override;
     virtual float glyph_left_bearing(u32 code_point) const override;
+    Optional<float> glyph_left_bearing_for_postscript_name(StringView) const override;
     virtual Glyph glyph(u32 code_point, GlyphSubpixelOffset) const override;
+    Optional<Glyph> glyph_for_postscript_name(StringView, GlyphSubpixelOffset) const override;
     virtual bool contains_glyph(u32 code_point) const override { return m_font->glyph_id_for_code_point(code_point) > 0; }
+    virtual bool contains_glyph_for_postscript_name(StringView name) const override { return m_font->glyph_id_for_postscript_name(name).has_value(); }
     virtual float glyph_width(u32 code_point) const override;
+    virtual Optional<float> glyph_width_for_postscript_name(StringView) const override;
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const override;
     virtual float glyph_or_emoji_width(Utf32CodePointIterator&) const override;
     virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const override;
@@ -75,6 +80,8 @@ public:
     virtual bool has_color_bitmaps() const override { return m_font->has_color_bitmaps(); }
 
 private:
+    Glyph glyph_for_id(u32 id, GlyphSubpixelOffset) const;
+
     NonnullRefPtr<VectorFont> m_font;
     float m_x_scale { 0.0f };
     float m_y_scale { 0.0f };

--- a/Userland/Libraries/LibGfx/Font/VectorFont.h
+++ b/Userland/Libraries/LibGfx/Font/VectorFont.h
@@ -52,6 +52,7 @@ public:
     virtual u32 glyph_count() const = 0;
     virtual u16 units_per_em() const = 0;
     virtual u32 glyph_id_for_code_point(u32 code_point) const = 0;
+    virtual Optional<u32> glyph_id_for_postscript_name(StringView) const = 0;
     virtual String family() const = 0;
     virtual String variant() const = 0;
     virtual u16 weight() const = 0;

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.h
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.h
@@ -34,6 +34,7 @@ public:
     virtual u32 glyph_count() const override { return m_input_font->glyph_count(); }
     virtual u16 units_per_em() const override { return m_input_font->units_per_em(); }
     virtual u32 glyph_id_for_code_point(u32 code_point) const override { return m_input_font->glyph_id_for_code_point(code_point); }
+    virtual Optional<u32> glyph_id_for_postscript_name(StringView name) const override { return m_input_font->glyph_id_for_postscript_name(name); }
     virtual String family() const override { return m_input_font->family(); }
     virtual String variant() const override { return m_input_font->variant(); }
     virtual u16 weight() const override { return m_input_font->weight(); }

--- a/Userland/Libraries/LibGfx/Font/WOFF2/Font.h
+++ b/Userland/Libraries/LibGfx/Font/WOFF2/Font.h
@@ -37,6 +37,7 @@ public:
     virtual u32 glyph_count() const override { return m_input_font->glyph_count(); }
     virtual u16 units_per_em() const override { return m_input_font->units_per_em(); }
     virtual u32 glyph_id_for_code_point(u32 code_point) const override { return m_input_font->glyph_id_for_code_point(code_point); }
+    virtual Optional<u32> glyph_id_for_postscript_name(StringView name) const override { return m_input_font->glyph_id_for_postscript_name(name); }
     virtual String family() const override { return m_input_font->family(); }
     virtual String variant() const override { return m_input_font->variant(); }
     virtual u16 weight() const override { return m_input_font->weight(); }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1365,7 +1365,22 @@ FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Font const& f
     auto top_left = point + FloatPoint(font.glyph_left_bearing(code_point), 0);
     auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(top_left);
     auto glyph = font.glyph(code_point, glyph_position.subpixel_offset);
+    draw_glyph_internal(point, glyph_position, top_left, glyph, color);
+}
 
+FLATTEN void Painter::draw_glyph_with_postscript_name(FloatPoint point, StringView name, Font const& font, Color color)
+{
+    auto left_bearing = font.glyph_left_bearing_for_postscript_name(name);
+    if (!left_bearing.has_value())
+        return;
+    auto top_left = point + FloatPoint(left_bearing.value(), 0);
+    auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(top_left);
+    auto glyph = font.glyph_for_postscript_name(name, glyph_position.subpixel_offset).value();
+    draw_glyph_internal(point, glyph_position, top_left, glyph, color);
+}
+
+FLATTEN void Painter::draw_glyph_internal(FloatPoint point, GlyphRasterPosition const& glyph_position, FloatPoint top_left, Glyph const& glyph, Color color)
+{
     if (glyph.is_glyph_bitmap()) {
         draw_bitmap(top_left.to_type<int>(), glyph.glyph_bitmap(), color);
     } else if (glyph.is_color_bitmap()) {

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -114,6 +114,7 @@ public:
     void draw_glyph_or_emoji(IntPoint, Utf8CodePointIterator&, Font const&, Color);
     void draw_glyph(FloatPoint, u32, Color);
     void draw_glyph(FloatPoint, u32, Font const&, Color);
+    void draw_glyph_with_postscript_name(FloatPoint point, StringView name, Font const& font, Color color);
     void draw_glyph_or_emoji(FloatPoint, u32, Font const&, Color);
     void draw_glyph_or_emoji(FloatPoint, Utf8CodePointIterator&, Font const&, Color);
     void draw_circle_arc_intersecting(IntRect const&, IntPoint, int radius, Color, int thickness);
@@ -225,6 +226,7 @@ protected:
     Vector<State, 4> m_state_stack;
 
 private:
+    void draw_glyph_internal(FloatPoint point, GlyphRasterPosition const&, FloatPoint top_left, Glyph const& glyph, Color color);
     Vector<DirectionalRun> split_text_into_directional_runs(Utf8View const&, TextDirection initial_direction);
     bool text_contains_bidirectional_text(Utf8View const&, TextDirection);
     template<typename DrawGlyphFunction>


### PR DESCRIPTION
Addresses a long-standing FIXME in TrueTypePainter::draw_glyph(), and
gets us from 880 files without issues (88.0%) to 905 files without
issues (90.5%) for my 1000 file test set :^)

---

Based on a branch that's nearly 2 years old.

It's nice to be over 90% now, but see #26133 for a disclaimer. With #26133 patched in, this gets us from 63.7% to 65.1%.