### PR TITLE
LibPDF+LibGfx: Do not try to read "kern" table for PDFs

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -323,7 +323,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
     }
 
     Optional<Kern> kern {};
-    if (opt_kern_slice.has_value())
+    if (!(options.skip_tables & Options::SkipTables::Kern) && opt_kern_slice.has_value())
         kern = TRY(Kern::from_slice(opt_kern_slice.value()));
 
     Optional<Fpgm> fpgm;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -41,6 +41,9 @@ struct FontOptions {
 
         // If set, tolerate a missing or broken 'OS/2' table. metrics(), resolve_ascender_and_descender(), weight(), width(), and slope() will return different values.
         OS2 = 1 << 2,
+
+        // If set, do not try to read the 'kern' table. glyphs_horizontal_kerning() will return 0.
+        Kern = 1 << 3,
     };
     u32 skip_tables { 0 };
 };

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -36,7 +36,7 @@ struct FontOptions {
         // If set, do not try to read the 'name' table. family() and variant() will return empty strings.
         Name = 1 << 0,
 
-        // If set, tolerate a missing or broken 'hmtx' table. This will make glyph_metrics() return 0 for everyting and is_fixed_width() return true.
+        // If set, tolerate a missing or broken 'hmtx' table. This will make glyph_metrics() return 0 for everything and is_fixed_width() return true.
         Hmtx = 1 << 1,
 
         // If set, tolerate a missing or broken 'OS/2' table. metrics(), resolve_ascender_and_descender(), weight(), width(), and slope() will return different values.

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -20,7 +20,8 @@ class Renderer;
 // these tables in some cases. Skip reading these tables.
 constexpr u32 pdf_skipped_opentype_tables = OpenType::FontOptions::SkipTables::Name
     | OpenType::FontOptions::SkipTables::Hmtx
-    | OpenType::FontOptions::SkipTables::OS2;
+    | OpenType::FontOptions::SkipTables::OS2
+    | OpenType::FontOptions::SkipTables::Kern;
 
 enum class WritingMode {
     Horizontal,

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -18,7 +18,9 @@ class Renderer;
 
 // PDF files don't need most of the data in OpenType fonts, and even contain invalid data for
 // these tables in some cases. Skip reading these tables.
-constexpr u32 pdf_skipped_opentype_tables = OpenType::FontOptions::SkipTables::Name | OpenType::FontOptions::SkipTables::Hmtx | OpenType::FontOptions::SkipTables::OS2;
+constexpr u32 pdf_skipped_opentype_tables = OpenType::FontOptions::SkipTables::Name
+    | OpenType::FontOptions::SkipTables::Hmtx
+    | OpenType::FontOptions::SkipTables::OS2;
 
 enum class WritingMode {
     Horizontal,


### PR DESCRIPTION
It is sometimes truncated in fonts embedded in PDFs, and the data
is not needed to render PDFs. Fixes "Offset past the end of the stream
memory" for 0000028.pdf.

Similar to the changes in #23276.