### PR TITLE
Piano: Fix exporting while paused

### DIFF
--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -130,7 +130,6 @@ ErrorOr<void> AudioPlayerLoop::write_wav_if_needed()
         m_audio_client->async_pause_playback();
         TRY(m_wav_writer.with_locked([this](auto& wav_writer) -> ErrorOr<void> {
             m_track_manager.reset();
-            m_track_manager.set_should_loop(false);
             do {
                 // FIXME: This progress detection is crude, but it works for now.
                 m_wav_percent_written.store(static_cast<int>(static_cast<float>(m_track_manager.transport()->time()) / roll_length * 100.0f));
@@ -140,7 +139,6 @@ ErrorOr<void> AudioPlayerLoop::write_wav_if_needed()
             // FIXME: Make sure that the new TrackManager APIs aren't as bad.
             m_wav_percent_written.store(100);
             m_track_manager.reset();
-            m_track_manager.set_should_loop(true);
             TRY(wav_writer.finalize());
 
             return {};

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -46,16 +46,13 @@ struct AudioLoopDeferredInvoker final : public IPC::DeferredInvoker {
     Vector<Function<void()>, INLINE_FUNCTIONS> deferred_functions;
 };
 
-AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, Atomic<bool>& need_to_write_wav, Atomic<int>& wav_percent_written, Threading::MutexProtected<Audio::WavWriter>& wav_writer)
+AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager)
     : m_track_manager(track_manager)
     , m_buffer(FixedArray<DSP::Sample>::must_create_but_fixme_should_propagate_errors(sample_count))
     , m_pipeline_thread(Threading::Thread::construct([this]() {
         return this->pipeline_thread_main();
     },
           "Audio pipeline"sv))
-    , m_need_to_write_wav(need_to_write_wav)
-    , m_wav_percent_written(wav_percent_written)
-    , m_wav_writer(wav_writer)
 {
     m_audio_client = Audio::ConnectionToServer::try_create().release_value_but_fixme_should_propagate_errors();
     m_audio_client->set_self_sample_rate(sample_rate);
@@ -85,17 +82,18 @@ intptr_t AudioPlayerLoop::pipeline_thread_main()
     while (!m_exit_requested.load()) {
         deferred_invoker.run_functions();
 
-        // The track manager guards against allocations itself.
-        m_track_manager.fill_buffer(m_buffer);
+        {
+            Threading::MutexLocker lock(m_track_manager.playback_lock());
+            // The track manager guards against allocations itself.
+            m_track_manager.fill_buffer(m_buffer);
+        }
 
         // Tolerate errors in the audio pipeline; we don't want this thread to crash the program. This might likely happen with OOM.
         if (auto result = send_audio_to_server(); result.is_error()) [[unlikely]] {
             dbgln("Error in audio pipeline: {}", result.error());
+            Threading::MutexLocker lock(m_track_manager.playback_lock());
             m_track_manager.reset();
         }
-
-        if (auto result = write_wav_if_needed(); result.is_error()) [[unlikely]]
-            dbgln("Error writing WAV: {}", result.error());
     }
     m_audio_client->async_pause_playback();
     return static_cast<intptr_t>(0);
@@ -119,32 +117,6 @@ ErrorOr<void> AudioPlayerLoop::send_audio_to_server()
     }
     // The buffer has to have been constructed with a size of an integer multiple of the audio buffer size.
     VERIFY(start_of_chunk_to_write == m_buffer.size());
-
-    return {};
-}
-
-ErrorOr<void> AudioPlayerLoop::write_wav_if_needed()
-{
-    bool _true = true;
-    if (m_need_to_write_wav.compare_exchange_strong(_true, false)) {
-        m_audio_client->async_pause_playback();
-        TRY(m_wav_writer.with_locked([this](auto& wav_writer) -> ErrorOr<void> {
-            m_track_manager.reset();
-            do {
-                // FIXME: This progress detection is crude, but it works for now.
-                m_wav_percent_written.store(static_cast<int>(static_cast<float>(m_track_manager.transport()->time()) / roll_length * 100.0f));
-                m_track_manager.fill_buffer(m_buffer);
-                TRY(wav_writer.write_samples(m_buffer.span()));
-            } while (m_track_manager.transport()->time());
-            // FIXME: Make sure that the new TrackManager APIs aren't as bad.
-            m_wav_percent_written.store(100);
-            m_track_manager.reset();
-            TRY(wav_writer.finalize());
-
-            return {};
-        }));
-        m_audio_client->async_start_playback();
-    }
 
     return {};
 }

--- a/Userland/Applications/Piano/AudioPlayerLoop.h
+++ b/Userland/Applications/Piano/AudioPlayerLoop.h
@@ -11,7 +11,6 @@
 #include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/Resampler.h>
 #include <LibAudio/Sample.h>
-#include <LibAudio/WavWriter.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventReceiver.h>
 #include <LibDSP/Music.h>
@@ -31,11 +30,10 @@ public:
     bool is_playing() const { return m_should_play_audio; }
 
 private:
-    AudioPlayerLoop(TrackManager& track_manager, Atomic<bool>& need_to_write_wav, Atomic<int>& wav_percent_written, Threading::MutexProtected<Audio::WavWriter>& wav_writer);
+    AudioPlayerLoop(TrackManager& track_manager);
 
     intptr_t pipeline_thread_main();
     ErrorOr<void> send_audio_to_server();
-    ErrorOr<void> write_wav_if_needed();
 
     TrackManager& m_track_manager;
     FixedArray<DSP::Sample> m_buffer;
@@ -44,8 +42,4 @@ private:
 
     Atomic<bool> m_should_play_audio { true };
     Atomic<bool> m_exit_requested { false };
-
-    Atomic<bool>& m_need_to_write_wav;
-    Atomic<int>& m_wav_percent_written;
-    Threading::MutexProtected<Audio::WavWriter>& m_wav_writer;
 };

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -43,7 +43,6 @@ public:
 
     void fill_buffer(FixedArray<DSP::Sample>&);
     void reset();
-    void set_should_loop(bool b) { m_should_loop = b; }
     void add_track();
     int next_track_index() const;
 
@@ -54,6 +53,4 @@ private:
     size_t m_current_track { 0 };
 
     FixedArray<DSP::Sample> m_temporary_track_buffer;
-
-    bool m_should_loop { true };
 };

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -17,6 +17,7 @@
 #include <AK/Vector.h>
 #include <LibDSP/Keyboard.h>
 #include <LibDSP/Track.h>
+#include <LibThreading/Mutex.h>
 
 class TrackManager {
     AK_MAKE_NONCOPYABLE(TrackManager);
@@ -41,6 +42,7 @@ public:
     // Legacy API, do not add new users.
     void time_forward(int amount);
 
+    Threading::Mutex& playback_lock() { return m_playback_mutex; }
     void fill_buffer(FixedArray<DSP::Sample>&);
     void reset();
     void add_track();
@@ -51,6 +53,7 @@ private:
     NonnullRefPtr<DSP::Transport> m_transport;
     NonnullRefPtr<DSP::Keyboard> m_keyboard;
     size_t m_current_track { 0 };
+    Threading::Mutex m_playback_mutex;
 
     FixedArray<DSP::Sample> m_temporary_track_buffer;
 };


### PR DESCRIPTION
For actually testing this, I highly recommend decreasing the internal volume in Piano before exporting or playing anything, because apparently the various synths tend to clip quite easily. The clipping is even more pronouced in exported files, because those don't get extra headroom from AudioServer.

Fixes #26123.