### PR TITLE
Kernel/Ext2FS: Clean up inode size calculations

### DIFF
--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -78,6 +78,7 @@ private:
     u64 inodes_per_group() const;
     u64 blocks_per_group() const;
     u64 inode_size() const;
+    u64 usable_inode_size(ext2_inode_large const&) const;
 
     ErrorOr<NonnullRefPtr<Ext2FSInode>> build_root_inode() const;
 

--- a/Kernel/FileSystem/Ext2FS/Inode.h
+++ b/Kernel/FileSystem/Ext2FS/Inode.h
@@ -46,8 +46,6 @@ private:
     virtual ErrorOr<void> truncate_locked(u64) override;
     virtual ErrorOr<int> get_block_address(int) override;
 
-    bool is_within_inode_bounds(FlatPtr base, FlatPtr value_offset, size_t value_size) const;
-
     static u8 to_ext2_file_type(mode_t mode);
 
     static time_t decode_seconds_with_extra(i32 seconds, u32 extra) { return (extra & EXT4_EPOCH_MASK) ? static_cast<time_t>(seconds) + (static_cast<time_t>(extra & EXT4_EPOCH_MASK) << 32) : static_cast<time_t>(seconds); }


### PR DESCRIPTION
These calculations were introduced in 0e368bb7, but in retrospect, the logic in write_ext2_inode() and is_within_inode_bounds() was quite questionable, so this commit cleans that up and documents how the physical and logical inode sizes are supposed to be handled.