### PR TITLE
Kernel: Rewrite WaitQueue

### DIFF
--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -12,6 +12,7 @@
 #include <Kernel/Bus/USB/xHCI/xHCIRootHub.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel::USB {
 

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -12,7 +12,7 @@
 #include <Kernel/Bus/USB/xHCI/xHCIRootHub.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Memory/TypedMapping.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 
 namespace Kernel::USB {
 
@@ -1063,7 +1063,7 @@ private:
         u32 end_index { 0 };
     };
     struct SyncPendingTransfer : public PendingTransfer {
-        WaitQueue wait_queue;
+        DeprecatedWaitQueue wait_queue;
         TransferRequestBlock::CompletionCode completion_code { TransferRequestBlock::CompletionCode::Invalid };
         u32 remainder { 0 };
     };
@@ -1170,7 +1170,7 @@ private:
     DoorbellRegisters volatile& m_doorbell_registers;
 
     RefPtr<Process> m_process;
-    WaitQueue m_event_queue;
+    DeprecatedWaitQueue m_event_queue;
 
     bool m_using_message_signalled_interrupts { false };
     bool m_large_contexts { false };
@@ -1182,7 +1182,7 @@ private:
     Vector<NonnullOwnPtr<PeriodicPendingTransfer>> m_active_periodic_transfers;
 
     Spinlock<LockRank::None> m_command_lock;
-    WaitQueue m_command_completion_queue;
+    DeprecatedWaitQueue m_command_completion_queue;
     TransferRequestBlock m_command_result_transfer_request_block {};
     u32 m_command_ring_enqueue_index { 0 };
     u8 m_command_ring_producer_cycle_state { 1 };

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -380,6 +380,7 @@ set(KERNEL_SOURCES
     Devices/TTY/VirtualConsole.cpp
     Tasks/Coredump.cpp
     Tasks/CrashHandler.cpp
+    Tasks/DeprecatedWaitQueue.cpp
     Tasks/FinalizerTask.cpp
     Tasks/FutexQueue.cpp
     Tasks/HostnameContext.cpp
@@ -393,7 +394,6 @@ set(KERNEL_SOURCES
     Tasks/Thread.cpp
     Tasks/ThreadBlockers.cpp
     Tasks/ThreadTracer.cpp
-    Tasks/WaitQueue.cpp
     Tasks/WorkQueue.cpp
     Time/TimeManagement.cpp
     Time/TimerQueue.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -394,6 +394,7 @@ set(KERNEL_SOURCES
     Tasks/Thread.cpp
     Tasks/ThreadBlockers.cpp
     Tasks/ThreadTracer.cpp
+    Tasks/WaitQueue.cpp
     Tasks/WorkQueue.cpp
     Time/TimeManagement.cpp
     Time/TimerQueue.cpp

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -10,9 +10,9 @@
 #include <Kernel/Library/NonnullLockRefPtr.h>
 #include <Kernel/Library/UserOrKernelBuffer.h>
 #include <Kernel/Memory/ScopedAddressSpaceSwitcher.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 #include <Kernel/Tasks/Process.h>
 #include <Kernel/Tasks/Thread.h>
-#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 
@@ -160,7 +160,7 @@ private:
 
     AsyncDeviceSubRequestList m_sub_requests_pending;
     AsyncDeviceSubRequestList m_sub_requests_complete;
-    WaitQueue m_queue;
+    DeprecatedWaitQueue m_queue;
     LockWeakPtr<Process> const m_process;
     void* m_private { nullptr };
     mutable Spinlock<LockRank::None> m_lock {};

--- a/Kernel/Devices/Audio/AC97/AC97.h
+++ b/Kernel/Devices/Audio/AC97/AC97.h
@@ -182,7 +182,7 @@ private:
     bool m_double_rate_pcm_enabled { false };
     NonnullOwnPtr<IOWindow> m_mixer_io_window;
     NonnullOwnPtr<IOWindow> m_bus_io_window;
-    WaitQueue m_irq_queue;
+    DeprecatedWaitQueue m_irq_queue;
     OwnPtr<Memory::Region> m_output_buffer;
     u8 m_output_buffer_page_count { 4 };
     u8 m_output_buffer_page_index { 0 };

--- a/Kernel/Devices/Audio/IntelHDA/Stream.h
+++ b/Kernel/Devices/Audio/IntelHDA/Stream.h
@@ -14,7 +14,7 @@
 #include <Kernel/Devices/Audio/IntelHDA/Format.h>
 #include <Kernel/Library/IOWindow.h>
 #include <Kernel/Locking/SpinlockProtected.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 
 namespace Kernel::Audio::IntelHDA {
 
@@ -91,7 +91,7 @@ protected:
     OwnPtr<Memory::Region> m_buffer_descriptor_list;
     RecursiveSpinlockProtected<OwnPtr<Memory::Region>, LockRank::None> m_buffers;
     size_t m_buffer_position { 0 };
-    WaitQueue m_irq_queue;
+    DeprecatedWaitQueue m_irq_queue;
     bool m_running { false };
     FormatParameters m_format_parameters;
 };

--- a/Kernel/Devices/Serial/VirtIO/Console.h
+++ b/Kernel/Devices/Serial/VirtIO/Console.h
@@ -73,7 +73,7 @@ private:
     OwnPtr<Memory::RingBuffer> m_control_transmit_buffer;
     OwnPtr<Memory::RingBuffer> m_control_receive_buffer;
 
-    WaitQueue m_control_wait_queue;
+    DeprecatedWaitQueue m_control_wait_queue;
 
     static unsigned next_device_id;
 };

--- a/Kernel/Devices/Storage/AHCI/InterruptHandler.h
+++ b/Kernel/Devices/Storage/AHCI/InterruptHandler.h
@@ -17,7 +17,6 @@
 #include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Security/Random.h>
-#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/Devices/Storage/AHCI/Port.h
+++ b/Kernel/Devices/Storage/AHCI/Port.h
@@ -23,7 +23,6 @@
 #include <Kernel/Memory/ScatterGatherList.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Security/Random.h>
-#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
@@ -160,7 +160,7 @@ u16 NVMeQueue::submit_sync_sqe(NVMeSubmission& sub)
     });
     submit_sqe(sub);
 
-    // FIXME: Only sync submissions (usually used for admin commands) use a WaitQueue based IO. Eventually we need to
+    // FIXME: Only sync submissions (usually used for admin commands) use a DeprecatedWaitQueue based IO. Eventually we need to
     //  move this logic into the block layer instead of sprinkling them in the driver code.
     m_sync_wait_queue.wait_forever("NVMe sync submit"sv);
     return cmd_status;

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -18,6 +18,7 @@
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -18,7 +18,7 @@
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/TypedMapping.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 
 namespace Kernel {
 
@@ -130,7 +130,7 @@ private:
     Span<NVMeSubmission> m_sqe_array;
     OwnPtr<Memory::Region> m_sq_dma_region;
     Span<NVMeCompletion> m_cqe_array;
-    WaitQueue m_sync_wait_queue;
+    DeprecatedWaitQueue m_sync_wait_queue;
     Doorbell m_db_regs;
     NonnullRefPtr<Memory::PhysicalRAMPage const> const m_rw_dma_page;
 };

--- a/Kernel/Devices/Storage/StorageController.h
+++ b/Kernel/Devices/Storage/StorageController.h
@@ -15,7 +15,6 @@
 #include <Kernel/Memory/PhysicalAddress.h>
 #include <Kernel/Memory/PhysicalRAMPage.h>
 #include <Kernel/Security/Random.h>
-#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -9,7 +9,7 @@
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/Library/DoubleBuffer.h>
 #include <Kernel/Locking/Mutex.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {
@@ -54,8 +54,8 @@ private:
 
     int m_fifo_id { 0 };
 
-    WaitQueue m_read_open_queue;
-    WaitQueue m_write_open_queue;
+    DeprecatedWaitQueue m_read_open_queue;
+    DeprecatedWaitQueue m_write_open_queue;
     Mutex m_open_lock;
 };
 

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -71,6 +71,7 @@ class RAMFSInode;
 class UDPSocket;
 class UserOrKernelBuffer;
 class VFSRootContext;
+class WaitQueue;
 class WorkQueue;
 
 namespace Memory {

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -19,6 +19,7 @@ class Coredump;
 class Credentials;
 class CustodyBase;
 class Custody;
+class DeprecatedWaitQueue;
 class Device;
 class DeviceControlDevice;
 class DiskCache;
@@ -70,7 +71,6 @@ class RAMFSInode;
 class UDPSocket;
 class UserOrKernelBuffer;
 class VFSRootContext;
-class WaitQueue;
 class WorkQueue;
 
 namespace Memory {

--- a/Kernel/Locking/Mutex.h
+++ b/Kernel/Locking/Mutex.h
@@ -14,7 +14,8 @@
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/LockLocation.h>
 #include <Kernel/Locking/LockMode.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Locking/SpinlockProtected.h>
+#include <Kernel/Tasks/Thread.h>
 
 namespace Kernel {
 

--- a/Kernel/Locking/SpinlockProtectedBase.h
+++ b/Kernel/Locking/SpinlockProtectedBase.h
@@ -10,10 +10,13 @@
 
 namespace Kernel {
 
+class WaitQueue;
+
 template<typename T, typename Lock>
 class SpinlockProtectedBase {
     AK_MAKE_NONCOPYABLE(SpinlockProtectedBase);
     AK_MAKE_NONMOVABLE(SpinlockProtectedBase);
+    friend class WaitQueue;
 
 private:
     template<typename U>

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -105,6 +105,6 @@ protected:
     bool m_link_up { false };
     EntropySource m_entropy_source;
 
-    WaitQueue m_wait_queue;
+    DeprecatedWaitQueue m_wait_queue;
 };
 }

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -62,7 +62,7 @@ void NetworkTask_main(void*)
 {
     delayed_ack_sockets = new HashTable<NonnullRefPtr<TCPSocket>>;
 
-    WaitQueue packet_wait_queue;
+    DeprecatedWaitQueue packet_wait_queue;
     int pending_packets = 0;
     NetworkingManagement::the().for_each([&](auto& adapter) {
         dmesgln("NetworkTask: {} network adapter found: hw={}", adapter.class_name(), adapter.mac_address().to_string());

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -219,6 +219,6 @@ private:
     u16 m_tx_free_index { 0 };
     bool m_link_up { false };
     EntropySource m_entropy_source;
-    WaitQueue m_wait_queue;
+    DeprecatedWaitQueue m_wait_queue;
 };
 }

--- a/Kernel/Security/Random.h
+++ b/Kernel/Security/Random.h
@@ -13,7 +13,7 @@
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Library/StdLib.h>
 #include <Kernel/Locking/Mutex.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 #include <LibCrypto/Cipher/AES.h>
 #include <LibCrypto/Cipher/Cipher.h>
 #include <LibCrypto/Hash/SHA2.h>
@@ -132,7 +132,7 @@ public:
     void wake_if_ready();
 
 private:
-    WaitQueue m_seed_queue;
+    DeprecatedWaitQueue m_seed_queue;
 };
 
 class EntropySource {

--- a/Kernel/Security/Random.h
+++ b/Kernel/Security/Random.h
@@ -13,6 +13,7 @@
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Library/StdLib.h>
 #include <Kernel/Locking/Mutex.h>
+#include <Kernel/Tasks/WaitQueue.h>
 #include <LibCrypto/Cipher/AES.h>
 #include <LibCrypto/Cipher/Cipher.h>
 #include <LibCrypto/Hash/SHA2.h>

--- a/Kernel/Tasks/DeprecatedWaitQueue.cpp
+++ b/Kernel/Tasks/DeprecatedWaitQueue.cpp
@@ -5,33 +5,33 @@
  */
 
 #include <Kernel/Debug.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 #include <Kernel/Tasks/Thread.h>
-#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 
-bool WaitQueue::should_add_blocker(Thread::Blocker& b, void*)
+bool DeprecatedWaitQueue::should_add_blocker(Thread::Blocker& b, void*)
 {
     VERIFY(m_lock.is_locked());
     VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
     if (m_wake_requested) {
         m_wake_requested = false;
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: do not block thread {}", this, b.thread());
+        dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: do not block thread {}", this, b.thread());
         return false;
     }
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: should block thread {}", this, b.thread());
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: should block thread {}", this, b.thread());
     return true;
 }
 
-u32 WaitQueue::wake_one()
+u32 DeprecatedWaitQueue::wake_one()
 {
     u32 did_wake = 0;
     SpinlockLocker lock(m_lock);
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one", this);
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_one", this);
     bool did_unblock_one = unblock_all_blockers_whose_conditions_are_met_locked([&](Thread::Blocker& b, void*, bool& stop_iterating) {
         VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
-        auto& blocker = static_cast<Thread::WaitQueueBlocker&>(b);
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one unblocking {}", this, blocker.thread());
+        auto& blocker = static_cast<Thread::DeprecatedWaitQueueBlocker&>(b);
+        dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_one unblocking {}", this, blocker.thread());
         if (blocker.unblock()) {
             stop_iterating = true;
             did_wake = 1;
@@ -40,22 +40,22 @@ u32 WaitQueue::wake_one()
         return false;
     });
     m_wake_requested = !did_unblock_one;
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one woke {} threads", this, did_wake);
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_one woke {} threads", this, did_wake);
     return did_wake;
 }
 
-u32 WaitQueue::wake_n(u32 wake_count)
+u32 DeprecatedWaitQueue::wake_n(u32 wake_count)
 {
     if (wake_count == 0)
         return 0; // should we assert instead?
     SpinlockLocker lock(m_lock);
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n({})", this, wake_count);
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_n({})", this, wake_count);
     u32 did_wake = 0;
 
     bool did_unblock_some = unblock_all_blockers_whose_conditions_are_met_locked([&](Thread::Blocker& b, void*, bool& stop_iterating) {
         VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
-        auto& blocker = static_cast<Thread::WaitQueueBlocker&>(b);
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n unblocking {}", this, blocker.thread());
+        auto& blocker = static_cast<Thread::DeprecatedWaitQueueBlocker&>(b);
+        dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_n unblocking {}", this, blocker.thread());
         VERIFY(did_wake < wake_count);
         if (blocker.unblock()) {
             if (++did_wake >= wake_count)
@@ -65,22 +65,22 @@ u32 WaitQueue::wake_n(u32 wake_count)
         return false;
     });
     m_wake_requested = !did_unblock_some;
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n({}) woke {} threads", this, wake_count, did_wake);
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_n({}) woke {} threads", this, wake_count, did_wake);
     return did_wake;
 }
 
-u32 WaitQueue::wake_all()
+u32 DeprecatedWaitQueue::wake_all()
 {
     SpinlockLocker lock(m_lock);
 
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all", this);
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_all", this);
     u32 did_wake = 0;
 
     bool did_unblock_any = unblock_all_blockers_whose_conditions_are_met_locked([&](Thread::Blocker& b, void*, bool&) {
         VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
-        auto& blocker = static_cast<Thread::WaitQueueBlocker&>(b);
+        auto& blocker = static_cast<Thread::DeprecatedWaitQueueBlocker&>(b);
 
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all unblocking {}", this, blocker.thread());
+        dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_all unblocking {}", this, blocker.thread());
 
         if (blocker.unblock()) {
             did_wake++;
@@ -89,7 +89,7 @@ u32 WaitQueue::wake_all()
         return false;
     });
     m_wake_requested = !did_unblock_any;
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all woke {} threads", this, did_wake);
+    dbgln_if(WAITQUEUE_DEBUG, "DeprecatedWaitQueue @ {}: wake_all woke {} threads", this, did_wake);
     return did_wake;
 }
 

--- a/Kernel/Tasks/DeprecatedWaitQueue.h
+++ b/Kernel/Tasks/DeprecatedWaitQueue.h
@@ -12,7 +12,7 @@
 
 namespace Kernel {
 
-class WaitQueue final : public Thread::BlockerSet {
+class DeprecatedWaitQueue final : public Thread::BlockerSet {
 public:
     u32 wake_one();
     u32 wake_n(u32 wake_count);
@@ -21,13 +21,13 @@ public:
     template<class... Args>
     Thread::BlockResult wait_on(Thread::BlockTimeout const& timeout, Args&&... args)
     {
-        return Thread::current()->block<Thread::WaitQueueBlocker>(timeout, *this, forward<Args>(args)...);
+        return Thread::current()->block<Thread::DeprecatedWaitQueueBlocker>(timeout, *this, forward<Args>(args)...);
     }
 
     template<class... Args>
     void wait_forever(Args&&... args)
     {
-        (void)Thread::current()->block<Thread::WaitQueueBlocker>({}, *this, forward<Args>(args)...);
+        (void)Thread::current()->block<Thread::DeprecatedWaitQueueBlocker>({}, *this, forward<Args>(args)...);
     }
 
 protected:

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Tasks/FinalizerTask.h>
 #include <Kernel/Tasks/Process.h>
 #include <Kernel/Tasks/Scheduler.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 
@@ -17,12 +18,13 @@ static void finalizer_task(void*)
 {
     Thread::current()->set_priority(THREAD_PRIORITY_LOW);
     while (!Process::current().is_dying()) {
-        // The order of this if-else is important: We want to continue trying to finalize the threads in case
-        // Thread::finalize_dying_threads set g_finalizer_has_work back to true due to OOM conditions
-        if (g_finalizer_has_work.exchange(false, AK::MemoryOrder::memory_order_acq_rel) == true)
-            Thread::finalize_dying_threads();
-        else
-            g_finalizer_wait_queue->wait_forever(finalizer_task_name);
+        MUST(g_finalizer_wait_queue->wait_until(g_finalizer_has_work, [](bool& has_work) -> bool {
+            if (!has_work)
+                return false;
+            has_work = false;
+            return true;
+        }));
+        Thread::finalize_dying_threads();
     }
     Process::current().sys$exit(0);
     VERIFY_NOT_REACHED();

--- a/Kernel/Tasks/Scheduler.cpp
+++ b/Kernel/Tasks/Scheduler.cpp
@@ -32,7 +32,7 @@ static u32 time_slice_for(Thread const& thread)
 }
 
 READONLY_AFTER_INIT Thread* g_finalizer;
-READONLY_AFTER_INIT WaitQueue* g_finalizer_wait_queue;
+READONLY_AFTER_INIT DeprecatedWaitQueue* g_finalizer_wait_queue;
 Atomic<bool> g_finalizer_has_work { false };
 READONLY_AFTER_INIT static Process* s_colonel_process;
 
@@ -376,7 +376,7 @@ UNMAP_AFTER_INIT void Scheduler::initialize()
     VERIFY(Processor::is_initialized()); // sanity check
     VERIFY(TimeManagement::is_initialized());
 
-    g_finalizer_wait_queue = new WaitQueue;
+    g_finalizer_wait_queue = new DeprecatedWaitQueue;
 
     g_finalizer_has_work.store(false, AK::MemoryOrder::memory_order_release);
     auto [colonel_process, idle_thread] = MUST(Process::create_kernel_process("colonel"sv, idle_loop, nullptr, 1, Process::RegisterProcess::No));

--- a/Kernel/Tasks/Scheduler.h
+++ b/Kernel/Tasks/Scheduler.h
@@ -12,6 +12,7 @@
 #include <AK/Types.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/Time/TimeManagement.h>
 #include <Kernel/UnixTypes.h>
 
@@ -20,8 +21,8 @@ namespace Kernel {
 struct RegisterState;
 
 extern Thread* g_finalizer;
-extern DeprecatedWaitQueue* g_finalizer_wait_queue;
-extern Atomic<bool> g_finalizer_has_work;
+extern WaitQueue* g_finalizer_wait_queue;
+extern SpinlockProtected<bool, LockRank::None> g_finalizer_has_work;
 extern RecursiveSpinlock<LockRank::None> g_scheduler_lock;
 
 struct TotalTimeScheduled {

--- a/Kernel/Tasks/Scheduler.h
+++ b/Kernel/Tasks/Scheduler.h
@@ -20,7 +20,7 @@ namespace Kernel {
 struct RegisterState;
 
 extern Thread* g_finalizer;
-extern WaitQueue* g_finalizer_wait_queue;
+extern DeprecatedWaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
 extern RecursiveSpinlock<LockRank::None> g_scheduler_lock;
 

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -577,8 +577,11 @@ void Thread::finalize_dying_threads()
             auto result = dying_threads.try_append(&thread);
             // We ignore allocation failures above the first 32 guaranteed thread slots, and
             // just flag our future-selves to finalize these threads at a later point
-            if (result.is_error())
-                g_finalizer_has_work.store(true, AK::MemoryOrder::memory_order_release);
+            if (result.is_error()) {
+                g_finalizer_has_work.with([](bool& has_work) {
+                    has_work = true;
+                });
+            }
         });
     }
     for (auto* thread : dying_threads) {

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -519,7 +519,6 @@ StringView Thread::state_string() const
             return "Mutex"sv;
         if (m_blocker)
             return m_blocker->state_string();
-        VERIFY_NOT_REACHED();
     }
     return state_string(thread_state);
 }

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -888,6 +888,9 @@ public:
 
     [[nodiscard]] bool is_in_alternative_signal_stack() const;
 
+    [[nodiscard]] bool was_interrupted() const { return m_was_interrupted; }
+    void clear_interrupted() { m_was_interrupted = false; }
+
     FPUState& fpu_state() { return m_fpu_state; }
 
     unsigned syscall_count() const { return m_syscall_count; }
@@ -1233,6 +1236,7 @@ private:
     bool m_is_crashing { false };
     bool m_is_promise_violation_pending { false };
     Atomic<bool> m_have_any_unmasked_pending_signals { false };
+    Atomic<bool> m_was_interrupted { false };
     Atomic<u32> m_nested_profiler_calls { 0 };
 
     NonnullRefPtr<Timer> const m_block_timer;

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -442,10 +442,10 @@ public:
         bool m_did_unblock { false };
     };
 
-    class WaitQueueBlocker final : public Blocker {
+    class DeprecatedWaitQueueBlocker final : public Blocker {
     public:
-        explicit WaitQueueBlocker(WaitQueue&, StringView block_reason = {});
-        virtual ~WaitQueueBlocker();
+        explicit DeprecatedWaitQueueBlocker(DeprecatedWaitQueue&, StringView block_reason = {});
+        virtual ~DeprecatedWaitQueueBlocker();
 
         virtual Type blocker_type() const override { return Type::Queue; }
         virtual StringView state_string() const override { return m_block_reason.is_null() ? m_block_reason : "Queue"sv; }
@@ -455,7 +455,7 @@ public:
         bool unblock();
 
     protected:
-        WaitQueue& m_wait_queue;
+        DeprecatedWaitQueue& m_wait_queue;
         StringView m_block_reason;
         bool m_did_unblock { false };
     };
@@ -825,10 +825,10 @@ public:
     void unblock(u8 signal = 0);
 
     template<class... Args>
-    Thread::BlockResult wait_on(WaitQueue& wait_queue, Thread::BlockTimeout const& timeout, Args&&... args)
+    Thread::BlockResult wait_on(DeprecatedWaitQueue& wait_queue, Thread::BlockTimeout const& timeout, Args&&... args)
     {
         VERIFY(this == Thread::current());
-        return block<Thread::WaitQueueBlocker>(timeout, wait_queue, forward<Args>(args)...);
+        return block<Thread::DeprecatedWaitQueueBlocker>(timeout, wait_queue, forward<Args>(args)...);
     }
 
     BlockResult sleep(clockid_t, Duration const&, Duration* = nullptr);
@@ -1094,7 +1094,7 @@ private:
     IntrusiveListNode<Thread> m_process_thread_list_node;
     int m_runnable_priority { -1 };
 
-    friend class WaitQueue;
+    friend class DeprecatedWaitQueue;
 
     class JoinBlockerSet final : public BlockerSet {
     public:

--- a/Kernel/Tasks/ThreadBlockers.cpp
+++ b/Kernel/Tasks/ThreadBlockers.cpp
@@ -120,20 +120,20 @@ bool Thread::JoinBlocker::unblock(void* value, bool from_add_blocker)
     return true;
 }
 
-Thread::WaitQueueBlocker::WaitQueueBlocker(WaitQueue& wait_queue, StringView block_reason)
+Thread::DeprecatedWaitQueueBlocker::DeprecatedWaitQueueBlocker(DeprecatedWaitQueue& wait_queue, StringView block_reason)
     : m_wait_queue(wait_queue)
     , m_block_reason(block_reason)
 {
 }
 
-bool Thread::WaitQueueBlocker::setup_blocker()
+bool Thread::DeprecatedWaitQueueBlocker::setup_blocker()
 {
     return add_to_blocker_set(m_wait_queue);
 }
 
-Thread::WaitQueueBlocker::~WaitQueueBlocker() = default;
+Thread::DeprecatedWaitQueueBlocker::~DeprecatedWaitQueueBlocker() = default;
 
-bool Thread::WaitQueueBlocker::unblock()
+bool Thread::DeprecatedWaitQueueBlocker::unblock()
 {
     {
         SpinlockLocker lock(m_lock);

--- a/Kernel/Tasks/WaitQueue.cpp
+++ b/Kernel/Tasks/WaitQueue.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Badge.h>
+#include <Kernel/Tasks/Scheduler.h>
+#include <Kernel/Tasks/WaitQueue.h>
+
+// This is essentially an implementation of https://read.seas.harvard.edu/cs1610/2025/doc/wait-queues
+
+namespace Kernel {
+
+void WaitQueue::notify_all()
+{
+    SpinlockLocker queue_lock { m_lock };
+    while (!m_waiters.is_empty()) {
+        Waiter& waiter = *m_waiters.take_first();
+        waiter.notify({});
+    }
+}
+
+void WaitQueue::notify_one()
+{
+    SpinlockLocker queue_lock { m_lock };
+    if (m_waiters.is_empty())
+        return;
+
+    Waiter& waiter = *m_waiters.take_first();
+    waiter.notify({});
+}
+
+void WaitQueue::Waiter::notify(Badge<WaitQueue>)
+{
+    VERIFY(m_association.has_value());
+    SpinlockLocker scheduler_lock(g_scheduler_lock);
+    auto& thread = *m_association->thread;
+
+    VERIFY(thread.state() == Thread::State::Blocked);
+    thread.set_state(Thread::State::Runnable);
+}
+
+void WaitQueue::Waiter::prepare(WaitQueue& wait_queue)
+{
+    auto* current_thread = Thread::current();
+    VERIFY(current_thread);
+
+    m_association = { wait_queue, *current_thread };
+    SpinlockLocker queue_lock { wait_queue.m_lock };
+    {
+        SpinlockLocker scheduler_lock(g_scheduler_lock);
+        current_thread->set_state(Thread::State::Blocked);
+    }
+    wait_queue.m_waiters.append(*this);
+}
+
+void WaitQueue::Waiter::maybe_remove_self_from_queue()
+{
+    VERIFY(m_association.has_value());
+    auto& wait_queue = m_association->wait_queue;
+    VERIFY(wait_queue.m_lock.is_locked());
+
+    if (m_wait_queue_list_node.is_in_list())
+        m_wait_queue_list_node.remove();
+}
+
+void WaitQueue::Waiter::maybe_block()
+{
+    VERIFY(m_association.has_value());
+
+    bool blocked = false;
+    {
+        SpinlockLocker scheduler_lock(g_scheduler_lock);
+        blocked = m_association->thread->state() == Thread::State::Blocked;
+    }
+    if (blocked)
+        Scheduler::yield();
+
+    SpinlockLocker queue_lock { m_association->wait_queue.m_lock };
+    maybe_remove_self_from_queue();
+}
+
+void WaitQueue::Waiter::clear()
+{
+    VERIFY(m_association.has_value());
+
+    SpinlockLocker queue_lock { m_association->wait_queue.m_lock };
+    maybe_remove_self_from_queue();
+
+    auto& thread = *m_association->thread;
+    SpinlockLocker scheduler_lock(g_scheduler_lock);
+    if (thread.state() == Thread::State::Blocked)
+        thread.set_state(Thread::State::Runnable);
+
+    m_association = {};
+}
+
+}

--- a/Kernel/Tasks/WaitQueue.h
+++ b/Kernel/Tasks/WaitQueue.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntrusiveList.h>
+#include <AK/Optional.h>
+#include <Kernel/Forward.h>
+#include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Locking/SpinlockProtected.h>
+#include <Kernel/Tasks/Thread.h>
+
+namespace Kernel {
+
+class WaitQueue {
+    friend class Waiter;
+    class Waiter {
+    public:
+        template<LockRank Rank, CallableAs<bool> F>
+        ErrorOr<void> wait_until(WaitQueue& wait_queue, Spinlock<Rank>& lock, F should_wake)
+        {
+            bool was_interrupted = false;
+            auto interrupt_state = lock.lock();
+            while (true) {
+                prepare(wait_queue);
+                if (should_wake())
+                    break;
+                if (was_interrupted = Thread::current()->was_interrupted(); was_interrupted)
+                    break;
+                lock.unlock(interrupt_state);
+                maybe_block();
+                interrupt_state = lock.lock();
+            }
+            clear();
+            lock.unlock(interrupt_state);
+            // This is always cleared since the thread might have been both interrupted and woken up.
+            // If both of those occurred during the same cycle, then we won't report the interrupt,
+            // but we still need to clear it.
+            Thread::current()->clear_interrupted();
+            if (was_interrupted) {
+                return EINTR;
+            }
+
+            return {};
+        }
+
+        template<typename T, LockRank Rank, CallableAs<bool, T&> F>
+        ErrorOr<void> wait_until(WaitQueue& wait_queue, SpinlockProtected<T, Rank>& spinlock_protected, F should_wake)
+        {
+            bool was_interrupted = false;
+            auto interrupt_state = spinlock_protected.m_spinlock.lock();
+            while (true) {
+                prepare(wait_queue);
+                if (should_wake(spinlock_protected.m_value))
+                    break;
+                if (was_interrupted = Thread::current()->was_interrupted(); was_interrupted)
+                    break;
+                spinlock_protected.m_spinlock.unlock(interrupt_state);
+                maybe_block();
+                interrupt_state = spinlock_protected.m_spinlock.lock();
+            }
+            clear();
+            spinlock_protected.m_spinlock.unlock(interrupt_state);
+            // See the note in the above function.
+            Thread::current()->clear_interrupted();
+            if (was_interrupted) {
+                return EINTR;
+            }
+
+            return {};
+        }
+
+        void notify(Badge<WaitQueue>);
+
+    private:
+        struct Association {
+            WaitQueue& wait_queue;
+            NonnullRefPtr<Thread> thread;
+        };
+
+        void prepare(WaitQueue&);
+        void maybe_remove_self_from_queue();
+        void maybe_block();
+        void clear();
+
+        Spinlock<LockRank::Thread> m_lock {};
+        Optional<Association> m_association;
+        IntrusiveListNode<Waiter> m_wait_queue_list_node;
+
+    public:
+        using ListInWaitQueue = IntrusiveList<&Waiter::m_wait_queue_list_node>;
+    };
+
+public:
+    void notify_all();
+    void notify_one();
+
+    template<LockRank Rank, CallableAs<bool> F>
+    ErrorOr<void> wait_until(Spinlock<Rank>& lock, F should_wake)
+    {
+        Waiter waiter;
+        return waiter.wait_until(*this, lock, move(should_wake));
+    }
+
+    template<typename T, LockRank Rank, CallableAs<bool, T&> F>
+    ErrorOr<void> wait_until(SpinlockProtected<T, Rank>& spinlock_protected, F should_wake)
+    {
+        Waiter waiter;
+        return waiter.wait_until(*this, spinlock_protected, move(should_wake));
+    }
+
+private:
+    Spinlock<LockRank::Thread> m_lock {};
+    Waiter::ListInWaitQueue m_waiters;
+};
+
+}

--- a/Kernel/Tasks/WorkQueue.cpp
+++ b/Kernel/Tasks/WorkQueue.cpp
@@ -7,8 +7,8 @@
 
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Sections.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 #include <Kernel/Tasks/Process.h>
-#include <Kernel/Tasks/WaitQueue.h>
 #include <Kernel/Tasks/WorkQueue.h>
 
 namespace Kernel {

--- a/Kernel/Tasks/WorkQueue.h
+++ b/Kernel/Tasks/WorkQueue.h
@@ -11,7 +11,7 @@
 #include <AK/IntrusiveList.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/SpinlockProtected.h>
-#include <Kernel/Tasks/WaitQueue.h>
+#include <Kernel/Tasks/DeprecatedWaitQueue.h>
 
 namespace Kernel {
 
@@ -62,7 +62,7 @@ private:
     void do_queue(WorkItem&);
 
     RefPtr<Thread> m_thread;
-    WaitQueue m_wait_queue;
+    DeprecatedWaitQueue m_wait_queue;
     RecursiveSpinlockProtected<IntrusiveList<&WorkItem::m_node>, LockRank::None> m_items {};
 };
 

--- a/Kernel/Tasks/WorkQueue.h
+++ b/Kernel/Tasks/WorkQueue.h
@@ -11,7 +11,7 @@
 #include <AK/IntrusiveList.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/SpinlockProtected.h>
-#include <Kernel/Tasks/DeprecatedWaitQueue.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 
@@ -62,8 +62,8 @@ private:
     void do_queue(WorkItem&);
 
     RefPtr<Thread> m_thread;
-    DeprecatedWaitQueue m_wait_queue;
-    RecursiveSpinlockProtected<IntrusiveList<&WorkItem::m_node>, LockRank::None> m_items {};
+    WaitQueue m_wait_queue;
+    SpinlockProtected<IntrusiveList<&WorkItem::m_node>, LockRank::None> m_items {};
 };
 
 }


### PR DESCRIPTION
Part of #26108.

The old `WaitQueue` is still around (it's just been renamed to `DeprecatedWaitQueue`) since not everything has been ported to the new `WaitQueue`.
There's now also a `ConditionWaiter` class (can be renamed if we can think of a better name) which allows blocking on a specific (atomic) boolean in a slightly less verbose way as compared to using a `Waiter` directly.

Porting to the new `WaitQueue` shouldn't be too hard (there's two such ports in this PR already), though at least `KernelRng` will require special attention (not done in this PR) because it currently deadlocks when entropy exhaustion occurs.