### PR TITLE
LibGfx/JBIG2: Check that referred-to segment numbers are small enough

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -3482,7 +3482,7 @@ static ErrorOr<void> decode_page_information(JBIG2LoadingContext& context, Segme
     if (page_information.bitmap_height == 0xffff'ffff && !page_information.page_is_striped())
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Non-striped bitmaps of indeterminate height not allowed");
 
-    dbgln_if(JBIG2_DEBUG, "Page information: width={}, height={}, is_striped={}, max_stripe_size={}", page_information.bitmap_width, page_information.bitmap_height, page_information.page_is_striped(), page_information.maximum_stripe_size());
+    dbgln_if(JBIG2_DEBUG, "Page information: width={}, height={}, x_resolution={}, y_resolution={}, is_striped={}, max_stripe_size={}", page_information.bitmap_width, page_information.bitmap_height, page_information.page_x_resolution, page_information.page_y_resolution, page_information.page_is_striped(), page_information.maximum_stripe_size());
     dbgln_if(JBIG2_DEBUG, "Page information flags: {:#02x}", page_information.flags);
     dbgln_if(JBIG2_DEBUG, "    is_eventually_lossless={}", page_information.is_eventually_lossless());
     dbgln_if(JBIG2_DEBUG, "    might_contain_refinements={}", page_information.might_contain_refinements());

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -839,6 +839,11 @@ static ErrorOr<SegmentHeader> decode_segment_header(SeekableStream& stream)
             referred_to_segment_number = TRY(stream.read_value<BigEndian<u16>>());
         else
             referred_to_segment_number = TRY(stream.read_value<BigEndian<u32>>());
+
+        // "If a segment refers to other segments, it must refer to only segments with lower segment numbers."
+        if (referred_to_segment_number >= segment_number)
+            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Referred-to segment number too large");
+
         referred_to_segment_numbers.append(referred_to_segment_number);
         dbgln_if(JBIG2_DEBUG, "Referred-to segment number: {}", referred_to_segment_number);
     }


### PR DESCRIPTION
They have to be smaller than the current segment's segment number.

No real behavior change, just a bit stricter.

---

Also log a tiny bit more in JBIG2_DEBUG mode.