### PR TITLE
LibGUI: Force shadows in emoji input dialog and command palette

### DIFF
--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -179,6 +179,7 @@ CommandPalette::CommandPalette(GUI::Window& parent_window, ScreenPosition screen
     set_window_type(GUI::WindowType::Popup);
     set_window_mode(GUI::WindowMode::Modeless);
     set_blocks_emoji_input(true);
+    set_forced_shadow(true);
     resize(450, 300);
 
     collect_actions(parent_window);

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -54,6 +54,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     set_window_type(GUI::WindowType::Popup);
     set_window_mode(GUI::WindowMode::Modeless);
     set_blocks_emoji_input(true);
+    set_forced_shadow(true);
     resize(410, 300);
 
     auto& scrollable_container = *main_widget->find_descendant_of_type_named<GUI::ScrollableContainerWidget>("scrollable_container"sv);


### PR DESCRIPTION
I saw there was no shadow behind the emoji input dialog and command palette so I have decided to enable it by calling `set_forced_shadow()` so hopefully it'll be more distinct from it's background and easier to see :^)

#### Before:
<img width="934" height="788" alt="image" src="https://github.com/user-attachments/assets/8a050e78-2a7b-42ec-b100-52833a2e91f6" />

#### After:
<img width="934" height="788" alt="image" src="https://github.com/user-attachments/assets/bd151fd1-d7b7-4203-a80c-00fb3bc08a14" />

#### Same has been applied to the emoji input dialog:
<img width="934" height="788" alt="image" src="https://github.com/user-attachments/assets/d3f0eaa9-b397-4328-9781-5bb1df1b7f5c" />
