### PR TITLE
AK+LibC: Optimize time component conversion

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
+#include <AK/Tuple.h>
 #include <AK/TypedTransfer.h>
 
 namespace AK {
@@ -61,6 +62,30 @@ struct Array {
     {
         VERIFY(index < size());
         return __data[index];
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T& get() &
+    {
+        return at(S);
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T const& get() const&
+    {
+        return at(S);
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T&& get() &&
+    {
+        return move(at(S));
+    }
+
+    template<size_t S>
+    [[nodiscard]] constexpr T const&& get() const&&
+    {
+        return move(at(S));
     }
 
     [[nodiscard]] constexpr T const& first() const { return at(0); }
@@ -182,6 +207,16 @@ constexpr auto to_array(Array<T, 0>)
     return Array<T, 0> {};
 }
 
+}
+
+namespace std {
+template<size_t I, typename T, size_t N>
+struct tuple_element<I, AK::Array<T, N>> {
+    using type = T;
+};
+
+template<typename T, size_t N>
+struct tuple_size<AK::Array<T, N>> : AK::Detail::IntegralConstant<size_t, N> { };
 }
 
 #if USING_AK_GLOBALLY

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -305,6 +305,12 @@ inline constexpr bool IsConst = false;
 template<class T>
 inline constexpr bool IsConst<T const> = true;
 
+template<class T>
+inline constexpr bool IsVolatile = false;
+
+template<class T>
+inline constexpr bool IsVolatile<T volatile> = true;
+
 template<typename T>
 inline constexpr bool IsEnum = __is_enum(T);
 
@@ -678,6 +684,7 @@ using AK::Detail::IsTriviallyMoveConstructible;
 using AK::Detail::IsUnion;
 using AK::Detail::IsUnsigned;
 using AK::Detail::IsVoid;
+using AK::Detail::IsVolatile;
 using AK::Detail::MakeIndexSequence;
 using AK::Detail::MakeIntegerSequence;
 using AK::Detail::MakeSigned;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -124,6 +124,7 @@ constexpr i64 days_since_epoch(int year, int month, int day)
     return years_to_days_since_epoch(year) + day_of_year(year, month, day);
 }
 
+#ifndef KERNEL
 constexpr i64 seconds_since_epoch_to_year(i64 seconds)
 {
     constexpr double seconds_per_year = 60.0 * 60.0 * 24.0 * 365.2425;
@@ -140,6 +141,7 @@ constexpr i64 seconds_since_epoch_to_year(i64 seconds)
     auto years_since_epoch = static_cast<double>(seconds) / seconds_per_year;
     return 1970 + round_down(years_since_epoch);
 }
+#endif
 
 // Represents a duration in a "safe" way.
 // Minimum: -(2**63) seconds, 0 nanoseconds
@@ -676,7 +678,9 @@ using AK::days_since_epoch;
 using AK::Duration;
 using AK::is_leap_year;
 using AK::MonotonicTime;
+#    ifndef KERNEL
 using AK::seconds_since_epoch_to_year;
+#    endif
 using AK::timespec_add;
 using AK::timespec_add_timeval;
 using AK::timespec_sub;

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -141,27 +141,51 @@ struct Tuple : Detail::Tuple<Ts...> {
     }
 
     template<typename T>
-    auto& get()
+    auto& get() &
     {
         return Detail::Tuple<Ts...>::template get<T>();
-    }
-
-    template<size_t index>
-    auto& get()
-    {
-        return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
     }
 
     template<typename T>
-    auto& get() const
+    auto&& get() &&
+    {
+        return move(Detail::Tuple<Ts...>::template get<T>());
+    }
+
+    template<size_t index>
+    auto& get() &
+    {
+        return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
+    }
+
+    template<size_t index>
+    auto&& get() &&
+    {
+        return move(Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>());
+    }
+
+    template<typename T>
+    auto& get() const&
     {
         return Detail::Tuple<Ts...>::template get<T>();
     }
 
+    template<typename T>
+    auto&& get() const&&
+    {
+        return move(Detail::Tuple<Ts...>::template get<T>());
+    }
+
     template<size_t index>
-    auto& get() const
+    auto& get() const&
     {
         return Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>();
+    }
+
+    template<size_t index>
+    auto&& get() const&&
+    {
+        return move(Detail::Tuple<Ts...>::template get_with_index<typename Types::template Type<index>, index>());
     }
 
     template<typename F>

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -235,6 +235,16 @@ struct TupleSize<Tuple<Ts...>> : Detail::IntegralConstant<size_t, sizeof...(Ts)>
 
 }
 
+namespace std {
+template<size_t I, typename... Ts>
+struct tuple_element<I, AK::Tuple<Ts...>> {
+    using type = AK::TupleElement<I, AK::Tuple<Ts...>>::Type;
+};
+
+template<typename... Ts>
+struct tuple_size<AK::Tuple<Ts...>> : AK::TupleSize<AK::Tuple<Ts...>> { };
+}
+
 #if USING_AK_GLOBALLY
 using AK::Tuple;
 using AK::TupleElement;

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -219,8 +219,24 @@ private:
 template<class... Args>
 Tuple(Args... args) -> Tuple<Args...>;
 
+template<size_t I, typename T>
+struct TupleElement;
+
+template<size_t I, typename... Ts>
+struct TupleElement<I, Tuple<Ts...>> {
+    using Type = TypeListElement<I, typename Tuple<Ts...>::Types>::Type;
+};
+
+template<typename T>
+struct TupleSize;
+
+template<typename... Ts>
+struct TupleSize<Tuple<Ts...>> : Detail::IntegralConstant<size_t, sizeof...(Ts)> { };
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::Tuple;
+using AK::TupleElement;
+using AK::TupleSize;
 #endif

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -55,3 +55,13 @@ TEST_CASE(to_array)
     static_assert(array[1] == 2);
     static_assert(array[2] == 1);
 }
+
+TEST_CASE(structured_binding)
+{
+    Array<int, 4> array = { 2, 3, 5, 7 };
+    auto const& [a, b, c, d] = array;
+    EXPECT_EQ(a, 2);
+    EXPECT_EQ(b, 3);
+    EXPECT_EQ(c, 5);
+    EXPECT_EQ(d, 7);
+}

--- a/Tests/AK/TestTuple.cpp
+++ b/Tests/AK/TestTuple.cpp
@@ -107,3 +107,12 @@ TEST_CASE(apply)
         EXPECT(was_called);
     }
 }
+
+TEST_CASE(structured_binding)
+{
+    Tuple<int, int, ByteString> tuple { 1, 2, "foo" };
+    auto const& [a, b, c] = tuple;
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 2);
+    EXPECT_EQ(c, "foo");
+}


### PR DESCRIPTION
Fixes #26079 (#12729 should probably also be closed at this point even without this PR, because I don't think there's been a noticable performance issue with `time_to_tm()` since at least #16760. Also, the existing loop based approaches were pretty fast already to be fair, but this does slightly speed those up).

The newly added `AK::days_to_time()` returns a `Tuple` (since this seems better to me than returning a disposable struct), but that sent me on a yak shave since I quickly ran into the fact that we don't really have support for structured bindings in AK. Thus this also brings back #24993 (rebased for 2025 and updated to include for more `namespace std` stuff that's needed in the Kernel).