### PR TITLE
ThemeEditor: Add pledge and remove unveils to fix GUI:FilePicker crash

### DIFF
--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::create(arguments));
 
-    Config::pledge_domain("ThemeEditor");
+    Config::pledge_domains({ "ThemeEditor", "FileManager" });
     app->set_config_domain("ThemeEditor"_string);
 
     StringView file_to_edit;
@@ -43,9 +43,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         path = error_or_path.release_value();
 
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix"));
-    TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
-    TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-theme-editor"sv);
     IGNORE_USE_IN_ESCAPING_LAMBDA auto window = GUI::Window::construct();


### PR DESCRIPTION
The ThemeEditor uses `GUI::FilePicker` directly this results in a crash because of the unveils and the missing config pledge_domain. This pr fixes the crash by removing the unveils for now, this is not very elegant but I'm thinking about unifying the `GUI::FilePicker` and `FileSystemAccessServer` API's so that always will work in restricted processes.