### PR TITLE
LibGfx/JBIG2: Read row count in ImmediateGenericRegion of unknown size

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -398,6 +398,8 @@ TEST_CASE(test_jbig2_decode)
         // - symbols with REFAGGNINST > 1 (code support added in #26107)
         // - coverage for different segment combination operators (or and xor xnor replace),
         //   with both background colors
+        // - immediate generic region of unknown size and larger height in region segment information field
+        //   than in number of rows stored after data (code support added in #26173)
         // Missing tests for things that aren't implemented yet:
         // - intermediate regions
         // - standalone refinement regions


### PR DESCRIPTION
...and only allow regions of unknown size for immediate generic regions. (We might have to allow this for ImmediateLosslessGenericRegion in the future if that's used in practice, but I haven't seen it so far. The spec seems to only allow it for ImmediateGenericRegion though.)

The two files with segments with unknown size (0000033.pdf pages 1-2, and 0000600.pdf pages 1-3) store the same height in the region segment information field and after the data.

The four bytes with the actual row count are only present in immediate generic regions of unknown size. Immediate generic regions with known size (the common case) don't store these four bytes.

---

No test since I currently don't know how to make a file with a immediate generic region segment of unknown size (but JBIG2Writer will hopefully be able to create them soon – in fact, the motivation for this PR here is that I wanted to figure out when the writer has to write these extra four bytes as the spec isn't super clear on this. I haven't seen this PR here have an effect in practice).

I checked that these four bytes aren't there for files with known size by also adding

```cpp
    } else {
        auto end_sequence = (data[sizeof(information_field)] & 1) ? to_array<u8>({ 0x00, 0x00 }) : to_array<u8>({ 0xFF, 0xAC });
        u8 const* end = static_cast<u8 const*>(memmem(data.data() + 19, data.size() - 19, end_sequence.data(), end_sequence.size()));
        if (!end)
            return Error::from_string_literal("JBIG2ImageDecoderPlugin: Could not find end sequence in segment data, reloaded");
        size_t size = end - data.data() + end_sequence.size();
        if (size != data.size()) {
            dbgln_if(JBIG2_DEBUG, "Immediate generic region: scanned size {} does not match data size {}, reloading", size, data.size());
            return Error::from_string_literal("JBIG2ImageDecoderPlugin: scanned size does not match data size, reloaded");
        }
```

after the last `if` I'm adding in this commit. For my test files, this never fired.