### PR TITLE
HexEditor+Weather: Cleanup detached windows on main window close

### DIFF
--- a/Base/usr/share/man/man5/GML/Widget/DynamicWidgetContainer.md
+++ b/Base/usr/share/man/man5/GML/Widget/DynamicWidgetContainer.md
@@ -18,6 +18,17 @@ Defines a container widget that will group its child widgets together so that th
 
 `@GUI::DynamicWidgetContainer`
 
+## Detached Window Cleanup
+
+It is important to close all open detached windows when the main application window is closed:
+
+```cpp
+window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
+    GUI::DynamicWidgetContainer::close_all_detached_windows();
+    return GUI::Window::CloseRequestDecision::Close;
+};
+```
+
 ## Examples
 
 Simple container:

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -51,8 +51,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_main_widget(hex_editor_widget);
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
-        if (hex_editor_widget->request_close())
+        if (hex_editor_widget->request_close()) {
+            GUI::DynamicWidgetContainer::close_all_detached_windows();
             return GUI::Window::CloseRequestDecision::Close;
+        }
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 

--- a/Userland/Applications/Weather/main.jakt
+++ b/Userland/Applications/Weather/main.jakt
@@ -194,6 +194,11 @@ fn main() {
     mut view = window.set_main_widget<UnderlyingClassTypeOf<View>>().self()
     window.resize(width: 800, height: 600)
 
+    window.on_close_request = fn() -> GUI::Window::CloseRequestDecision {
+        GUI::DynamicWidgetContainer::close_all_detached_windows()
+        return GUI::Window::CloseRequestDecision::Close
+    }
+
     view.initialize()
     window.show()
 


### PR DESCRIPTION
When working on #26170 I saw that the `HexEditor` app didn't close the detach windows after the main window was closed. This was caused because `close_all_detached_windows()` wasn't called. So I've added the call to all apps that use `DynamicWidgetContainer`, I've also added a paragraph to the GML manual.