### PR TITLE
LibGfx: Teach JBIG2Writer to write generic immediate regions 

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
@@ -68,6 +68,7 @@ shared_library("LibGfx") {
     "ImageFormats/AnimationWriter.cpp",
     "ImageFormats/BMPLoader.cpp",
     "ImageFormats/BMPWriter.cpp",
+    "ImageFormats/BilevelImage.cpp",
     "ImageFormats/BooleanDecoder.cpp",
     "ImageFormats/CCITTDecoder.cpp",
     "ImageFormats/DDSLoader.cpp",

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -472,7 +472,7 @@ TEST_CASE(test_qm_arithmetic_decoder)
     // clang-format on
 
     // "For this entire test, a single value of CX is used. I(CX) is initially 0 and MPS(CX) is initially 0."
-    Gfx::QMArithmeticDecoder::Context context { 0, 0 };
+    Gfx::QMArithmeticCoderContext context { 0, 0 };
     auto decoder = MUST(Gfx::QMArithmeticDecoder::initialize(input));
 
     for (auto expected : output) {

--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -197,7 +197,15 @@ TEST_CASE(test_jbig2)
     bilevel_bitmap->fill(Gfx::Color::NamedColor::White);
     TRY_OR_FAIL((test_roundtrip<Gfx::JBIG2Writer, Gfx::JBIG2ImageDecoderPlugin>(bilevel_bitmap)));
 
-    // FIXME: Implement and test roundtripping more than purely white bitmaps.
+    bilevel_bitmap->fill(Gfx::Color::NamedColor::Black);
+    TRY_OR_FAIL((test_roundtrip<Gfx::JBIG2Writer, Gfx::JBIG2ImageDecoderPlugin>(bilevel_bitmap)));
+
+    for (int y = 0; y < bilevel_bitmap->height(); ++y) {
+        for (int x = 0; x < bilevel_bitmap->width(); ++x) {
+            bilevel_bitmap->set_pixel(x, y, (x + y) % 2 == 0 ? Gfx::Color::NamedColor::Black : Gfx::Color::NamedColor::White);
+        }
+    }
+    TRY_OR_FAIL((test_roundtrip<Gfx::JBIG2Writer, Gfx::JBIG2ImageDecoderPlugin>(bilevel_bitmap)));
 }
 
 TEST_CASE(test_jpeg)

--- a/Tests/LibGfx/TestImageWriter.cpp
+++ b/Tests/LibGfx/TestImageWriter.cpp
@@ -326,7 +326,7 @@ TEST_CASE(test_qm_arithmetic_encoder)
     // clang-format on
 
     // "For this entire test, a single value of CX is used. I(CX) is initially 0 and MPS(CX) is initially 0."
-    Gfx::QMArithmeticEncoder::Context context { 0, 0 };
+    Gfx::QMArithmeticCoderContext context { 0, 0 };
 
     // "The value of the byte before the first byte in the output buffer is assumed to be 0x00, making the initial value of B 0x00."
     auto encoder = TRY_OR_FAIL(Gfx::QMArithmeticEncoder::initialize(0x00));

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     ICC/TagTypes.cpp
     ICC/WellKnownProfiles.cpp
     ImageFormats/AnimationWriter.cpp
+    ImageFormats/BilevelImage.cpp
     ImageFormats/BMPLoader.cpp
     ImageFormats/BMPWriter.cpp
     ImageFormats/BooleanDecoder.cpp

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -38,7 +38,7 @@ static ErrorOr<NonnullRefPtr<XYZTagData>> XYZ_data(XYZ xyz)
     return try_make_ref_counted<XYZTagData>(0, 0, move(xyzs));
 }
 
-ErrorOr<NonnullRefPtr<TagData>> sRGB_curve()
+ErrorOr<NonnullRefPtr<ParametricCurveTagData>> sRGB_curve()
 {
     // Numbers from https://en.wikipedia.org/wiki/SRGB#From_sRGB_to_CIE_XYZ
     Array<S15Fixed16, 7> curve_parameters = { 2.4, 1 / 1.055, 0.055 / 1.055, 1 / 12.92, 0.04045 };

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
@@ -12,10 +12,10 @@
 namespace Gfx::ICC {
 
 class Profile;
-class TagData;
+class ParametricCurveTagData;
 
 ErrorOr<NonnullRefPtr<Profile>> sRGB();
 
-ErrorOr<NonnullRefPtr<TagData>> sRGB_curve();
+ErrorOr<NonnullRefPtr<ParametricCurveTagData>> sRGB_curve();
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NonnullOwnPtr.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/ImageFormats/BilevelImage.h>
+
+namespace Gfx {
+
+ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::create(size_t width, size_t height)
+{
+    size_t pitch = ceil_div(width, static_cast<size_t>(8));
+    auto bits = TRY(ByteBuffer::create_uninitialized(pitch * height));
+    return adopt_nonnull_own_or_enomem(new (nothrow) BilevelImage(move(bits), width, height, pitch));
+}
+
+bool BilevelImage::get_bit(size_t x, size_t y) const
+{
+    VERIFY(x < m_width);
+    VERIFY(y < m_height);
+    size_t byte_offset = x / 8;
+    size_t bit_offset = x % 8;
+    u8 byte = m_bits[y * m_pitch + byte_offset];
+    byte = (byte >> (8 - 1 - bit_offset)) & 1;
+    return byte != 0;
+}
+
+void BilevelImage::set_bit(size_t x, size_t y, bool b)
+{
+    VERIFY(x < m_width);
+    VERIFY(y < m_height);
+    size_t byte_offset = x / 8;
+    size_t bit_offset = x % 8;
+    u8 byte = m_bits[y * m_pitch + byte_offset];
+    u8 mask = 1u << (8 - 1 - bit_offset);
+    if (b)
+        byte |= mask;
+    else
+        byte &= ~mask;
+    m_bits[y * m_pitch + byte_offset] = byte;
+}
+
+void BilevelImage::fill(bool b)
+{
+    u8 fill_byte = b ? 0xff : 0;
+    for (auto& byte : m_bits.bytes())
+        byte = fill_byte;
+}
+
+ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::subbitmap(Gfx::IntRect const& rect) const
+{
+    VERIFY(rect.x() >= 0);
+    VERIFY(rect.width() >= 0);
+    VERIFY(static_cast<size_t>(rect.right()) <= width());
+
+    VERIFY(rect.y() >= 0);
+    VERIFY(rect.height() >= 0);
+    VERIFY(static_cast<size_t>(rect.bottom()) <= height());
+
+    auto subbitmap = TRY(create(rect.width(), rect.height()));
+    for (int y = 0; y < rect.height(); ++y)
+        for (int x = 0; x < rect.width(); ++x)
+            subbitmap->set_bit(x, y, get_bit(rect.x() + x, rect.y() + y));
+    return subbitmap;
+}
+
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> BilevelImage::to_gfx_bitmap() const
+{
+    auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { m_width, m_height }));
+    for (size_t y = 0; y < m_height; ++y) {
+        for (size_t x = 0; x < m_width; ++x) {
+            auto color = get_bit(x, y) ? Color::Black : Color::White;
+            bitmap->set_pixel(x, y, color);
+        }
+    }
+    return bitmap;
+}
+
+ErrorOr<ByteBuffer> BilevelImage::to_byte_buffer() const
+{
+    return ByteBuffer::copy(m_bits);
+}
+
+BilevelImage::BilevelImage(ByteBuffer bits, size_t width, size_t height, size_t pitch)
+    : m_bits(move(bits))
+    , m_width(width)
+    , m_height(height)
+    , m_pitch(pitch)
+{
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
@@ -6,6 +6,8 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/ICC/TagTypes.h>
+#include <LibGfx/ICC/WellKnownProfiles.h>
 #include <LibGfx/ImageFormats/BilevelImage.h>
 
 namespace Gfx {
@@ -90,6 +92,113 @@ BilevelImage::BilevelImage(ByteBuffer bits, size_t width, size_t height, size_t 
     , m_height(height)
     , m_pitch(pitch)
 {
+}
+
+static Array<u32, 256> compute_luminosity_histogram(ByteBuffer const& bitmap)
+{
+    Array<u32, 256> histogram {};
+    for (u8 value : bitmap.span())
+        histogram[value]++;
+    return histogram;
+}
+
+static u8 compute_otsu_threshold(Array<u32, 256> const& histogram)
+{
+    // https://en.wikipedia.org/wiki/Otsu%27s_method#Otsu's_method
+    // All multiplied through with number of pixels, since p(i) * number_of_pixels == histogram[i]
+    // and it all cancels out when just looking for the max, as far as I can tell.
+
+    u32 histogram_sum = 0;
+    u32 mu_T = 0;
+    for (int i = 0; i < 256; ++i) {
+        histogram_sum += histogram[i];
+        mu_T += i * histogram[i];
+    }
+
+    u32 sum_0 = 0;
+    u32 omega_0 = 0;
+    f32 max_inter_class_variance = 0;
+    u8 threshold = 0;
+
+    for (int i = 0; i < 256; ++i) {
+        omega_0 += histogram[i];
+        u32 omega_1 = histogram_sum - omega_0;
+        if (omega_0 == 0 || omega_1 == 0)
+            continue;
+
+        sum_0 += i * histogram[i];
+        u32 sum_1 = mu_T - sum_0;
+        f32 mu_0 = static_cast<f32>(sum_0) / omega_0;
+        f32 mu_1 = static_cast<f32>(sum_1) / omega_1;
+        f32 inter_class_variance = static_cast<f32>(omega_0) * static_cast<f32>(omega_1) * (mu_0 - mu_1) * (mu_0 - mu_1);
+        if (inter_class_variance > max_inter_class_variance) {
+            threshold = i;
+            max_inter_class_variance = inter_class_variance;
+        }
+    }
+    return threshold;
+}
+
+ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::create_from_bitmap(Gfx::Bitmap const& bitmap, DitheringAlgorithm dithering_algorithm)
+{
+    auto gray_bitmap = TRY(ByteBuffer::create_uninitialized(bitmap.width() * bitmap.height()));
+    for (int y = 0, i = 0; y < bitmap.height(); ++y) {
+        for (int x = 0; x < bitmap.width(); ++x, ++i) {
+            auto color = bitmap.get_pixel(x, y);
+            gray_bitmap[i] = color.luminosity();
+        }
+    }
+
+    auto srgb_curve = TRY(Gfx::ICC::sRGB_curve());
+    for (u8& v : gray_bitmap.span())
+        v = round_to<u8>(srgb_curve->evaluate(v / 255.0f) * 255.0f);
+
+    // For now, do global thresholding with Otsu's method.
+    // https://en.wikipedia.org/wiki/Otsu%27s_method
+    // FIXME: Add an option to use average as threshold instead of Otsu?
+    auto histogram = compute_luminosity_histogram(gray_bitmap);
+    u8 threshold = compute_otsu_threshold(histogram);
+
+    auto bilevel_image = TRY(BilevelImage::create(bitmap.width(), bitmap.height()));
+
+    switch (dithering_algorithm) {
+    case DitheringAlgorithm::None:
+        for (int y = 0, i = 0; y < bitmap.height(); ++y) {
+            for (int x = 0; x < bitmap.width(); ++x, ++i) {
+                bilevel_image->set_bit(x, y, gray_bitmap[i] > threshold ? 0 : 1);
+            }
+        }
+        break;
+    case DitheringAlgorithm::FloydSteinberg: {
+        struct Factor {
+            int offset;
+            u8 factor;
+        };
+        auto factors = Array {
+            Factor { 1, 7 },
+            Factor { -1 + bitmap.width(), 3 },
+            Factor { 0 + bitmap.width(), 5 },
+            Factor { 1 + bitmap.width(), 1 },
+        };
+        for (int y = 0, i = 0; y < bitmap.height(); ++y) {
+            for (int x = 0; x < bitmap.width(); ++x, ++i) {
+                u8 old_pixel = gray_bitmap[i];
+                u8 new_pixel = old_pixel > threshold ? 255 : 0;
+                bilevel_image->set_bit(x, y, new_pixel == 255 ? 0 : 1);
+                int error = static_cast<int>(old_pixel) - static_cast<int>(new_pixel);
+                for (auto const& factor : factors) {
+                    int index = i + factor.offset;
+                    if (index >= static_cast<int>(gray_bitmap.size()))
+                        continue;
+                    int new_value = static_cast<int>(gray_bitmap[index]) + (error * factor.factor) / 16;
+                    gray_bitmap[index] = clamp(new_value, 0, 255);
+                }
+            }
+        }
+        break;
+    }
+    }
+    return bilevel_image;
 }
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <LibGfx/Forward.h>
+
+namespace Gfx {
+
+class BilevelImage {
+public:
+    static ErrorOr<NonnullOwnPtr<BilevelImage>> create(size_t width, size_t height);
+    bool get_bit(size_t x, size_t y) const;
+    void set_bit(size_t x, size_t y, bool b);
+    void fill(bool b);
+
+    ErrorOr<NonnullOwnPtr<BilevelImage>> subbitmap(Gfx::IntRect const& rect) const;
+
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_gfx_bitmap() const;
+    ErrorOr<ByteBuffer> to_byte_buffer() const;
+
+    size_t width() const { return m_width; }
+    size_t height() const { return m_height; }
+
+    Bytes bytes() { return m_bits.bytes(); }
+
+private:
+    BilevelImage(ByteBuffer, size_t width, size_t height, size_t pitch);
+
+    ByteBuffer m_bits;
+    size_t m_width { 0 };
+    size_t m_height { 0 };
+    size_t m_pitch { 0 };
+};
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -11,9 +11,19 @@
 
 namespace Gfx {
 
+enum class DitheringAlgorithm {
+    None,
+    FloydSteinberg,
+    // FIXME: Add Atkinson, Bayer in 2-3 sizes, BlueNoise, Hilbert / Peano space-filling, ...
+    // https://surma.dev/things/ditherpunk/
+    // https://tannerhelland.com/2012/12/28/dithering-eleven-algorithms-source-code.html
+};
+
 class BilevelImage {
 public:
     static ErrorOr<NonnullOwnPtr<BilevelImage>> create(size_t width, size_t height);
+    static ErrorOr<NonnullOwnPtr<BilevelImage>> create_from_bitmap(Gfx::Bitmap const& bitmap, DitheringAlgorithm dithering_algorithm);
+
     bool get_bit(size_t x, size_t y) const;
     void set_bit(size_t x, size_t y, bool b);
     void fill(bool b);

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -799,33 +799,12 @@ static ErrorOr<void> decode_segment_headers(JBIG2LoadingContext& context, Readon
     return {};
 }
 
-// 7.4.1 Region segment information field
-struct [[gnu::packed]] RegionSegmentInformationField {
-    BigEndian<u32> width;
-    BigEndian<u32> height;
-    BigEndian<u32> x_location;
-    BigEndian<u32> y_location;
-    u8 flags;
-
-    JBIG2::CombinationOperator external_combination_operator() const
-    {
-        VERIFY((flags & 0x7) <= 4);
-        return static_cast<JBIG2::CombinationOperator>(flags & 0x7);
-    }
-
-    bool is_color_bitmap() const
-    {
-        return (flags & 0x8) != 0;
-    }
-};
-static_assert(AssertSize<RegionSegmentInformationField, 17>());
-
-static ErrorOr<RegionSegmentInformationField> decode_region_segment_information_field(ReadonlyBytes data)
+static ErrorOr<JBIG2::RegionSegmentInformationField> decode_region_segment_information_field(ReadonlyBytes data)
 {
     // 7.4.8 Page information segment syntax
-    if (data.size() < sizeof(RegionSegmentInformationField))
+    if (data.size() < sizeof(JBIG2::RegionSegmentInformationField))
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid region segment information field size");
-    auto result = *(RegionSegmentInformationField const*)data.data();
+    auto result = *(JBIG2::RegionSegmentInformationField const*)data.data();
     if ((result.flags & 0b1111'0000) != 0)
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Invalid region segment information field flags");
     if ((result.flags & 0x7) > 4)
@@ -849,7 +828,7 @@ static ErrorOr<JBIG2::PageInformationSegment> decode_page_information_segment(Re
     return *(JBIG2::PageInformationSegment const*)data.data();
 }
 
-static ErrorOr<void> validate_segment_combination_operator_consistency(JBIG2LoadingContext& context, RegionSegmentInformationField const& information_field)
+static ErrorOr<void> validate_segment_combination_operator_consistency(JBIG2LoadingContext& context, JBIG2::RegionSegmentInformationField const& information_field)
 {
     // 7.4.8.5 Page segment flags
     // "NOTE 1 – All region segments, except for refinement region segments, are direct region segments. Because of the requirements

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -9,6 +9,7 @@
 #include <AK/Enumerate.h>
 #include <AK/IntegralMath.h>
 #include <AK/Utf16View.h>
+#include <LibGfx/ImageFormats/BilevelImage.h>
 #include <LibGfx/ImageFormats/CCITTDecoder.h>
 #include <LibGfx/ImageFormats/JBIG2Loader.h>
 #include <LibGfx/ImageFormats/JBIG2Shared.h>
@@ -504,114 +505,6 @@ ErrorOr<i32> HuffmanTable::read_symbol_non_oob(BigEndianInputBitStream& stream) 
     return result.value();
 }
 
-}
-
-class BilevelImage {
-public:
-    static ErrorOr<NonnullOwnPtr<BilevelImage>> create(size_t width, size_t height);
-    bool get_bit(size_t x, size_t y) const;
-    void set_bit(size_t x, size_t y, bool b);
-    void fill(bool b);
-
-    ErrorOr<NonnullOwnPtr<BilevelImage>> subbitmap(Gfx::IntRect const& rect) const;
-
-    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_gfx_bitmap() const;
-    ErrorOr<ByteBuffer> to_byte_buffer() const;
-
-    size_t width() const { return m_width; }
-    size_t height() const { return m_height; }
-
-    Bytes bytes() { return m_bits.bytes(); }
-
-private:
-    BilevelImage(ByteBuffer, size_t width, size_t height, size_t pitch);
-
-    ByteBuffer m_bits;
-    size_t m_width { 0 };
-    size_t m_height { 0 };
-    size_t m_pitch { 0 };
-};
-
-ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::create(size_t width, size_t height)
-{
-    size_t pitch = ceil_div(width, static_cast<size_t>(8));
-    auto bits = TRY(ByteBuffer::create_uninitialized(pitch * height));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BilevelImage(move(bits), width, height, pitch));
-}
-
-bool BilevelImage::get_bit(size_t x, size_t y) const
-{
-    VERIFY(x < m_width);
-    VERIFY(y < m_height);
-    size_t byte_offset = x / 8;
-    size_t bit_offset = x % 8;
-    u8 byte = m_bits[y * m_pitch + byte_offset];
-    byte = (byte >> (8 - 1 - bit_offset)) & 1;
-    return byte != 0;
-}
-
-void BilevelImage::set_bit(size_t x, size_t y, bool b)
-{
-    VERIFY(x < m_width);
-    VERIFY(y < m_height);
-    size_t byte_offset = x / 8;
-    size_t bit_offset = x % 8;
-    u8 byte = m_bits[y * m_pitch + byte_offset];
-    u8 mask = 1u << (8 - 1 - bit_offset);
-    if (b)
-        byte |= mask;
-    else
-        byte &= ~mask;
-    m_bits[y * m_pitch + byte_offset] = byte;
-}
-
-void BilevelImage::fill(bool b)
-{
-    u8 fill_byte = b ? 0xff : 0;
-    for (auto& byte : m_bits.bytes())
-        byte = fill_byte;
-}
-
-ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::subbitmap(Gfx::IntRect const& rect) const
-{
-    VERIFY(rect.x() >= 0);
-    VERIFY(rect.width() >= 0);
-    VERIFY(static_cast<size_t>(rect.right()) <= width());
-
-    VERIFY(rect.y() >= 0);
-    VERIFY(rect.height() >= 0);
-    VERIFY(static_cast<size_t>(rect.bottom()) <= height());
-
-    auto subbitmap = TRY(create(rect.width(), rect.height()));
-    for (int y = 0; y < rect.height(); ++y)
-        for (int x = 0; x < rect.width(); ++x)
-            subbitmap->set_bit(x, y, get_bit(rect.x() + x, rect.y() + y));
-    return subbitmap;
-}
-
-ErrorOr<NonnullRefPtr<Gfx::Bitmap>> BilevelImage::to_gfx_bitmap() const
-{
-    auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { m_width, m_height }));
-    for (size_t y = 0; y < m_height; ++y) {
-        for (size_t x = 0; x < m_width; ++x) {
-            auto color = get_bit(x, y) ? Color::Black : Color::White;
-            bitmap->set_pixel(x, y, color);
-        }
-    }
-    return bitmap;
-}
-
-ErrorOr<ByteBuffer> BilevelImage::to_byte_buffer() const
-{
-    return ByteBuffer::copy(m_bits);
-}
-
-BilevelImage::BilevelImage(ByteBuffer bits, size_t width, size_t height, size_t pitch)
-    : m_bits(move(bits))
-    , m_width(width)
-    , m_height(height)
-    , m_pitch(pitch)
-{
 }
 
 class Symbol : public RefCounted<Symbol> {

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -48,7 +48,7 @@ public:
 
 private:
     u16 PREV { 0 };
-    Vector<QMArithmeticDecoder::Context> contexts;
+    Vector<QMArithmeticCoderContext> contexts;
 };
 
 ArithmeticIntegerDecoder::ArithmeticIntegerDecoder()
@@ -127,7 +127,7 @@ public:
 
 private:
     u32 m_code_length { 0 };
-    Vector<QMArithmeticDecoder::Context> contexts;
+    Vector<QMArithmeticCoderContext> contexts;
 };
 
 ArithmeticIntegerIDDecoder::ArithmeticIntegerIDDecoder(u32 code_length)
@@ -1156,7 +1156,7 @@ struct GenericContexts {
         contexts.resize(1 << number_of_context_bits_for_template(template_));
     }
 
-    Vector<QMArithmeticDecoder::Context> contexts; // "GB" (+ binary suffix) in spec.
+    Vector<QMArithmeticCoderContext> contexts; // "GB" (+ binary suffix) in spec.
 
 private:
     static u8 number_of_context_bits_for_template(u8 template_)
@@ -1384,7 +1384,7 @@ struct RefinementContexts {
         contexts.resize(1 << (refinement_template == 0 ? 13 : 10));
     }
 
-    Vector<QMArithmeticDecoder::Context> contexts; // "GR" (+ binary suffix) in spec.
+    Vector<QMArithmeticCoderContext> contexts; // "GR" (+ binary suffix) in spec.
 };
 
 // 6.3 Generic Refinement Region Decoding Procedure

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibGfx/ImageFormats/QMArithmeticCoder.h>
 
 namespace Gfx::JBIG2 {
 
@@ -111,6 +112,26 @@ inline ErrorOr<void> check_valid_adaptive_template_pixel(AdaptiveTemplatePixel c
         return Error::from_string_literal("JBIG2ImageDecoderPlugin: Adaptive pixel x too big");
     return {};
 }
+
+struct GenericContexts {
+    GenericContexts(u8 template_)
+    {
+        contexts.resize(1 << number_of_context_bits_for_template(template_));
+    }
+
+    Vector<QMArithmeticCoderContext> contexts; // "GB" (+ binary suffix) in spec.
+
+private:
+    static u8 number_of_context_bits_for_template(u8 template_)
+    {
+        if (template_ == 0)
+            return 16;
+        if (template_ == 1)
+            return 13;
+        VERIFY(template_ == 2 || template_ == 3);
+        return 10;
+    }
+};
 
 // 7.4.8 Page information segment syntax
 struct [[gnu::packed]] PageInformationSegment {

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
@@ -75,6 +75,27 @@ enum class CombinationOperator {
     Replace = 4,
 };
 
+// 7.4.1 Region segment information field
+struct [[gnu::packed]] RegionSegmentInformationField {
+    BigEndian<u32> width;
+    BigEndian<u32> height;
+    BigEndian<u32> x_location;
+    BigEndian<u32> y_location;
+    u8 flags;
+
+    CombinationOperator external_combination_operator() const
+    {
+        VERIFY((flags & 0x7) <= 4);
+        return static_cast<CombinationOperator>(flags & 0x7);
+    }
+
+    bool is_color_bitmap() const
+    {
+        return (flags & 0x8) != 0;
+    }
+};
+static_assert(AssertSize<RegionSegmentInformationField, 17>());
+
 // 7.4.8 Page information segment syntax
 struct [[gnu::packed]] PageInformationSegment {
     BigEndian<u32> bitmap_width;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
@@ -96,6 +96,22 @@ struct [[gnu::packed]] RegionSegmentInformationField {
 };
 static_assert(AssertSize<RegionSegmentInformationField, 17>());
 
+struct AdaptiveTemplatePixel {
+    i8 x { 0 };
+    i8 y { 0 };
+};
+
+// Figure 7 – Field to which AT pixel locations are restricted
+inline ErrorOr<void> check_valid_adaptive_template_pixel(AdaptiveTemplatePixel const& adaptive_template_pixel)
+{
+    // Don't have to check < -127 or > 127: The offsets are stored in an i8, so they can't be out of those bounds.
+    if (adaptive_template_pixel.y > 0)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Adaptive pixel y too big");
+    if (adaptive_template_pixel.y == 0 && adaptive_template_pixel.x > -1)
+        return Error::from_string_literal("JBIG2ImageDecoderPlugin: Adaptive pixel x too big");
+    return {};
+}
+
 // 7.4.8 Page information segment syntax
 struct [[gnu::packed]] PageInformationSegment {
     BigEndian<u32> bitmap_width;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.cpp
@@ -8,18 +8,224 @@
 // https://www.itu.int/rec/T-REC-T.88-201808-I
 // JBIG2Loader.cpp has many spec notes.
 
+#include <AK/NonnullOwnPtr.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Stream.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/ImageFormats/BilevelImage.h>
 #include <LibGfx/ImageFormats/JBIG2Writer.h>
+#include <LibGfx/ImageFormats/QMArithmeticCoder.h>
 
 namespace Gfx {
 
 namespace {
 
+// Similar to 6.2.2 Input parameters, but with an input image.
+struct GenericRegionEncodingInputParameters {
+    bool is_modified_modified_read { false }; // "MMR" in spec.
+    BilevelImage const& image;                // Of dimensions "GBW" x "GBH" in spec terms.
+    u8 gb_template { 0 };
+    bool is_typical_prediction_used { false };          // "TPGDON" in spec.
+    bool is_extended_reference_template_used { false }; // "EXTTEMPLATE" in spec.
+    Optional<BilevelImage const&> skip_pattern {};      // "USESKIP", "SKIP" in spec.
+
+    Array<JBIG2::AdaptiveTemplatePixel, 12> adaptive_template_pixels {}; // "GBATX" / "GBATY" in spec.
+    // FIXME: GBCOLS, GBCOMBOP, COLEXTFLAG
+
+    enum RequireEOFBAfterMMR {
+        No,
+        Yes,
+    } require_eof_after_mmr { RequireEOFBAfterMMR::No };
+};
+
+}
+
+// 6.2 Generic region decoding procedure, but in backwards.
+static ErrorOr<ByteBuffer> generic_region_encoding_procedure(GenericRegionEncodingInputParameters const& inputs, Optional<JBIG2::GenericContexts>& maybe_contexts)
+{
+    // FIXME: Try to come up with a way to share more code with generic_region_decoding_procedure().
+    auto width = inputs.image.width();
+    auto height = inputs.image.height();
+
+    if (inputs.is_modified_modified_read)
+        return Error::from_string_literal("JBIG2Writer: Cannot encode MMR yet");
+
+    auto& contexts = maybe_contexts.value();
+
+    // 6.2.5 Decoding using a template and arithmetic coding
+    if (inputs.is_extended_reference_template_used)
+        return Error::from_string_literal("JBIG2Writer: Cannot encode EXTTEMPLATE yet");
+
+    int number_of_adaptive_template_pixels = inputs.gb_template == 0 ? 4 : 1;
+    for (int i = 0; i < number_of_adaptive_template_pixels; ++i)
+        TRY(check_valid_adaptive_template_pixel(inputs.adaptive_template_pixels[i]));
+
+    if (inputs.skip_pattern.has_value() && (inputs.skip_pattern->width() != width || inputs.skip_pattern->height() != height))
+        return Error::from_string_literal("JBIG2Writer: Invalid USESKIP dimensions");
+
+    if (inputs.skip_pattern.has_value())
+        return Error::from_string_literal("JBIG2Writer: Cannot encode USESKIP yet");
+
+    static constexpr auto get_pixel = [](BilevelImage const& buffer, int x, int y) -> bool {
+        if (x < 0 || x >= (int)buffer.width() || y < 0)
+            return false;
+        return buffer.get_bit(x, y);
+    };
+
+    // Figure 3(a) – Template when GBTEMPLATE = 0 and EXTTEMPLATE = 0,
+    constexpr auto compute_context_0 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
+        u16 result = 0;
+        for (int i = 0; i < 4; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[i].x, y + adaptive_pixels[i].y);
+        for (int i = 0; i < 3; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 1 + i, y - 2);
+        for (int i = 0; i < 5; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y - 1);
+        for (int i = 0; i < 4; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 4 + i, y);
+        return result;
+    };
+
+    // Figure 4 – Template when GBTEMPLATE = 1
+    auto compute_context_1 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
+        u16 result = 0;
+        result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[0].x, y + adaptive_pixels[0].y);
+        for (int i = 0; i < 4; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 1 + i, y - 2);
+        for (int i = 0; i < 5; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y - 1);
+        for (int i = 0; i < 3; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 3 + i, y);
+        return result;
+    };
+
+    // Figure 5 – Template when GBTEMPLATE = 2
+    auto compute_context_2 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
+        u16 result = 0;
+        result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[0].x, y + adaptive_pixels[0].y);
+        for (int i = 0; i < 3; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 1 + i, y - 2);
+        for (int i = 0; i < 4; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y - 1);
+        for (int i = 0; i < 2; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y);
+        return result;
+    };
+
+    // Figure 6 – Template when GBTEMPLATE = 3
+    auto compute_context_3 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
+        u16 result = 0;
+        result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[0].x, y + adaptive_pixels[0].y);
+        for (int i = 0; i < 5; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 3 + i, y - 1);
+        for (int i = 0; i < 4; ++i)
+            result = (result << 1) | (u16)get_pixel(buffer, x - 4 + i, y);
+        return result;
+    };
+
+    u16 (*compute_context)(BilevelImage const&, ReadonlySpan<JBIG2::AdaptiveTemplatePixel>, int, int);
+    if (inputs.gb_template == 0)
+        compute_context = compute_context_0;
+    else if (inputs.gb_template == 1)
+        compute_context = compute_context_1;
+    else if (inputs.gb_template == 2)
+        compute_context = compute_context_2;
+    else {
+        VERIFY(inputs.gb_template == 3);
+        compute_context = compute_context_3;
+    }
+
+    // "The values of the pixels in this neighbourhood define a context. Each context has its own adaptive probability estimate
+    //  used by the arithmetic coder (see Annex E)."
+    // "* Decode the current pixel by invoking the arithmetic entropy decoding procedure, with CX set to the value formed by
+    //    concatenating the label "GB" and the 10-16 pixel values gathered in CONTEXT."
+    // Implementor's note: What this is supposed to mean is that we have a bunch of independent contexts, and we pick the
+    // context for the current pixel based on pixel values in the neighborhood. The "GB" part just means this context is
+    // independent from other contexts in the spec. They are passed in to this function.
+
+    // Figure 8 – Reused context for coding the SLTP value when GBTEMPLATE is 0
+    constexpr u16 sltp_context_for_template_0 = 0b10011'0110010'0101;
+
+    // Figure 9 – Reused context for coding the SLTP value when GBTEMPLATE is 1
+    constexpr u16 sltp_context_for_template_1 = 0b0011'110010'101;
+
+    // Figure 10 – Reused context for coding the SLTP value when GBTEMPLATE is 2
+    constexpr u16 sltp_context_for_template_2 = 0b001'11001'01;
+
+    // Figure 11 – Reused context for coding the SLTP value when GBTEMPLATE is 3
+    constexpr u16 sltp_context_for_template_3 = 0b011001'0101;
+
+    u16 sltp_context = [](u8 gb_template) {
+        if (gb_template == 0)
+            return sltp_context_for_template_0;
+        if (gb_template == 1)
+            return sltp_context_for_template_1;
+        if (gb_template == 2)
+            return sltp_context_for_template_2;
+        VERIFY(gb_template == 3);
+        return sltp_context_for_template_3;
+    }(inputs.gb_template);
+
+    // 6.2.5.7 Decoding the bitmap
+    QMArithmeticEncoder encoder = TRY(QMArithmeticEncoder::initialize(0));
+
+    // "1) Set:
+    //         LTP = 0"
+    bool ltp = false; // "Line (uses) Typical Prediction" maybe?
+
+    // " 2) Create a bitmap GBREG of width GBW and height GBH pixels."
+    // auto result = TRY(BilevelImage::create(inputs.region_width, inputs.region_height));
+
+    // "3) Decode each row as follows:"
+    for (size_t y = 0; y < height; ++y) {
+        // "a) If all GBH rows have been decoded then the decoding is complete; proceed to step 4)."
+        // "b) If TPGDON is 1, then decode a bit using the arithmetic entropy coder..."
+        if (inputs.is_typical_prediction_used) {
+            bool is_line_identical_to_previous_line = false;
+            if (y > 0) {
+                // "i) If the current row of GBREG is identical to the row immediately above, then SLTP = 1; otherwise SLTP = 0."
+                is_line_identical_to_previous_line = true;
+                for (size_t x = 0; x < width; ++x) {
+                    if (inputs.image.get_bit(x, y) != inputs.image.get_bit(x, y - 1)) {
+                        is_line_identical_to_previous_line = false;
+                        break;
+                    }
+                }
+            }
+
+            // "SLTP" in spec. "Swap LTP" or "Switch LTP" maybe?
+            bool sltp = ltp ^ is_line_identical_to_previous_line;
+            encoder.encode_bit(sltp, contexts.contexts[sltp_context]);
+            ltp = is_line_identical_to_previous_line;
+            if (ltp)
+                continue;
+        }
+
+        // "d) If LTP = 0 then, from left to right, decode each pixel of the current row of GBREG. The procedure for each
+        //     pixel is as follows:"
+        for (size_t x = 0; x < width; ++x) {
+            // "i) If USESKIP is 1 and the pixel in the bitmap SKIP at the location corresponding to the current pixel is 1,
+            //     then set the current pixel to 0."
+            if (inputs.skip_pattern.has_value() && inputs.skip_pattern->get_bit(x, y))
+                continue;
+
+            // "ii) Otherwise:"
+            u16 context = compute_context(inputs.image, inputs.adaptive_template_pixels, x, y);
+            encoder.encode_bit(inputs.image.get_bit(x, y), contexts.contexts[context]);
+        }
+    }
+
+    // "4) After all the rows have been decoded, the current contents of the bitmap GBREG are the results that shall be
+    //     obtained by every decoder, whether it performs this exact sequence of steps or not."
+    // In the encoding case, this means the compressed data is complete.
+    return encoder.finalize();
+}
+
+namespace {
+
 struct JBIG2WritingContext {
     JBIG2Writer::Options options;
-    Gfx::Bitmap const& bitmap;
+    Gfx::BilevelImage const& bilevel_image;
     u32 next_segment_number { 0 };
 };
 
@@ -126,6 +332,87 @@ static ErrorOr<void> encode_segment_header(Stream& stream, JBIG2::SegmentHeader 
     return {};
 }
 
+static ErrorOr<void> encode_region_segment_information_field(Stream& stream, JBIG2::RegionSegmentInformationField const& region_information)
+{
+    // 7.4.8 Page information segment syntax
+    TRY(stream.write_value<BigEndian<u32>>(region_information.width));
+    TRY(stream.write_value<BigEndian<u32>>(region_information.height));
+    TRY(stream.write_value<BigEndian<u32>>(region_information.x_location));
+    TRY(stream.write_value<BigEndian<u32>>(region_information.y_location));
+    TRY(stream.write_value<u8>(region_information.flags));
+
+    return {};
+}
+
+static ErrorOr<void> encode_immediate_lossless_generic_region(JBIG2WritingContext& context, Stream& stream)
+{
+    // FIXME: Add options for MMR, GBTEMPLATE, TPGDON, EXTTEMPLATE, USESKIP, GBATX/GBATY.
+    GenericRegionEncodingInputParameters inputs { .image = context.bilevel_image };
+    inputs.is_modified_modified_read = false;
+    inputs.gb_template = 0;
+    inputs.is_typical_prediction_used = true;
+    inputs.is_extended_reference_template_used = false;
+    inputs.adaptive_template_pixels[0] = { -1, -1 };
+    inputs.adaptive_template_pixels[1] = { 0, -1 };
+    inputs.adaptive_template_pixels[2] = { -1, 0 };
+    inputs.adaptive_template_pixels[3] = { 1, -1 };
+    inputs.require_eof_after_mmr = GenericRegionEncodingInputParameters::RequireEOFBAfterMMR::No;
+
+    int number_of_adaptive_template_pixels = inputs.gb_template == 0 ? 4 : 1;
+
+    Optional<JBIG2::GenericContexts> contexts = JBIG2::GenericContexts { inputs.gb_template };
+    auto data = TRY(generic_region_encoding_procedure(inputs, contexts));
+
+    // 7.4.6 Generic region segment syntax
+    JBIG2::SegmentHeader generic_region_segment_header;
+    generic_region_segment_header.segment_number = context.next_segment_number++;
+    generic_region_segment_header.type = JBIG2::SegmentType::ImmediateLosslessGenericRegion;
+    generic_region_segment_header.page_association = 1;
+
+    // FIXME: Add option to set size to OptionalNone for immediate generic regions (7.2.7).
+    // FIXME: Add option to write too-high height in region information field if data_length is OptionalNone
+    //        (the actual height is written after the data then).
+    generic_region_segment_header.data_length = sizeof(JBIG2::RegionSegmentInformationField) + 1 + 2 * number_of_adaptive_template_pixels + data.size();
+    TRY(encode_segment_header(stream, generic_region_segment_header));
+
+    JBIG2::RegionSegmentInformationField region_information;
+    region_information.width = context.bilevel_image.width();
+    region_information.height = context.bilevel_image.height();
+    region_information.x_location = 0;
+    region_information.y_location = 0;
+    region_information.flags = 0;
+
+    JBIG2::CombinationOperator combination_operator = context.options.default_combination_operator;
+    region_information.flags |= static_cast<u8>(combination_operator);
+    bool is_color_bitmap = false; // FIXME: Add support for colors one day.
+    if (is_color_bitmap)
+        region_information.flags |= 0x8;
+
+    TRY(encode_region_segment_information_field(stream, region_information));
+
+    u8 flags = 0;
+    bool uses_mmr = false; // FIXME: Add an option for this.
+    if (uses_mmr)
+        flags |= 1;
+    flags |= (inputs.gb_template & 3) << 1;
+    if (inputs.is_typical_prediction_used)
+        flags |= 0x8;
+    if (inputs.is_extended_reference_template_used)
+        flags |= 0x10;
+    TRY(stream.write_value<u8>(flags));
+
+    for (int i = 0; i < number_of_adaptive_template_pixels; ++i) {
+        TRY(stream.write_value<i8>(inputs.adaptive_template_pixels[i].x));
+        TRY(stream.write_value<i8>(inputs.adaptive_template_pixels[i].y));
+    }
+    TRY(stream.write_until_depleted(data));
+
+    if (!generic_region_segment_header.data_length.has_value())
+        TRY(stream.write_value<BigEndian<u32>>(region_information.height));
+
+    return {};
+}
+
 static ErrorOr<void> encode_page_information(JBIG2WritingContext& context, Stream& stream, JBIG2::PageInformationSegment const& page_information)
 {
     // 7.4.8 Page information segment syntax
@@ -159,8 +446,8 @@ static ErrorOr<void> encode_end_of_page(JBIG2WritingContext& context, Stream& st
 
 static ErrorOr<void> fill_page_information(JBIG2WritingContext& context, JBIG2::PageInformationSegment& page_information)
 {
-    page_information.bitmap_width = context.bitmap.width();
-    page_information.bitmap_height = context.bitmap.height();
+    page_information.bitmap_width = context.bilevel_image.width();
+    page_information.bitmap_height = context.bilevel_image.height();
     page_information.page_x_resolution = 0;
     page_information.page_y_resolution = 0;
 
@@ -198,12 +485,16 @@ static ErrorOr<void> fill_page_information(JBIG2WritingContext& context, JBIG2::
 
 ErrorOr<void> JBIG2Writer::encode(Stream& stream, Bitmap const& bitmap, Options const& options)
 {
-    JBIG2WritingContext context { .options = options, .bitmap = bitmap };
+    auto bilevel_image = TRY(BilevelImage::create_from_bitmap(bitmap, DitheringAlgorithm::FloydSteinberg));
+
+    JBIG2WritingContext context { .options = options, .bilevel_image = *bilevel_image };
     TRY(encode_jbig2_header(stream));
 
     JBIG2::PageInformationSegment page_info;
     TRY(fill_page_information(context, page_info));
     TRY(encode_page_information(context, stream, page_info));
+
+    TRY(encode_immediate_lossless_generic_region(context, stream));
 
     TRY(encode_end_of_page(context, stream));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEG2000BitplaneDecoding.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEG2000BitplaneDecoding.h
@@ -102,9 +102,9 @@ inline ErrorOr<void> decode_code_block(Span2D<float> result, SubBand sub_band, i
 
     int pass { 0 };
 
-    QMArithmeticDecoder::Context uniform_context;
-    QMArithmeticDecoder::Context run_length_context;
-    Array<QMArithmeticDecoder::Context, 17> all_other_contexts {};
+    QMArithmeticCoderContext uniform_context;
+    QMArithmeticCoderContext run_length_context;
+    Array<QMArithmeticCoderContext, 17> all_other_contexts {};
 
     QMArithmeticDecoder arithmetic_decoder = TRY(QMArithmeticDecoder::initialize(segments[0]));
 

--- a/Userland/Libraries/LibGfx/ImageFormats/QMArithmeticCoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/QMArithmeticCoder.cpp
@@ -69,6 +69,8 @@ constexpr auto qe_table = to_array<QeEntry>({
     { 0x5601, 46, 46, 0 },
 });
 
+static u8& I(QMArithmeticCoderContext* cx) { return cx->I; }
+static u8& MPS(QMArithmeticCoderContext* cx) { return cx->is_mps; }
 static u16 Qe(u16 index) { return qe_table[index].qe; }
 static u8 NMPS(u16 index) { return qe_table[index].nmps; }
 static u8 NLPS(u16 index) { return qe_table[index].nlps; }
@@ -81,7 +83,7 @@ ErrorOr<QMArithmeticEncoder> QMArithmeticEncoder::initialize(u8 byte_before_firs
     return encoder;
 }
 
-void QMArithmeticEncoder::encode_bit(u8 bit, Context& context)
+void QMArithmeticEncoder::encode_bit(u8 bit, QMArithmeticCoderContext& context)
 {
     CX = &context;
 
@@ -289,7 +291,7 @@ ErrorOr<QMArithmeticDecoder> QMArithmeticDecoder::initialize(ReadonlyBytes data)
     return decoder;
 }
 
-bool QMArithmeticDecoder::get_next_bit(Context& context)
+bool QMArithmeticDecoder::get_next_bit(QMArithmeticCoderContext& context)
 {
     CX = &context;
     // Useful for comparing to Table H.1 – Encoder and decoder trace data.

--- a/Userland/Libraries/LibGfx/ImageFormats/QMArithmeticCoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QMArithmeticCoder.h
@@ -17,17 +17,17 @@ namespace Gfx {
 // It's also used in JPEG2000 and also described in Annex C of the JPEG2000 spec.
 // See JPEG2000Loader.cpp for the JPEG2000 spec link.
 
+struct QMArithmeticCoderContext {
+    u8 I { 0 };      // Index I stored for context CX (E.2.4)
+    u8 is_mps { 0 }; // "More probable symbol" (E.1.1). 0 or 1.
+};
+
 // E.2 Description of the arithmetic encoder
 class QMArithmeticEncoder {
 public:
-    struct Context {
-        u8 I { 0 };      // Index I stored for context CX (E.2.4)
-        u8 is_mps { 0 }; // "More probable symbol" (E.1.1). 0 or 1.
-    };
-
     static ErrorOr<QMArithmeticEncoder> initialize(u8 byte_before_first_encoded_byte);
 
-    void encode_bit(u8 bit, Context& context);
+    void encode_bit(u8 bit, QMArithmeticCoderContext& context);
     ErrorOr<ByteBuffer> finalize();
 
 private:
@@ -61,9 +61,7 @@ private:
 
     u8 CT { 0 }; // Count of the number of bits in C.
 
-    Context* CX { nullptr };
-    static u8& I(Context* cx) { return cx->I; }
-    static u8& MPS(Context* cx) { return cx->is_mps; }
+    QMArithmeticCoderContext* CX { nullptr };
 };
 
 // E.3 Arithmetic decoding procedure, but with the changes described in
@@ -71,14 +69,9 @@ private:
 // Exposed for testing.
 class QMArithmeticDecoder {
 public:
-    struct Context {
-        u8 I { 0 };      // Index I stored for context CX (E.2.4)
-        u8 is_mps { 0 }; // "More probable symbol" (E.1.1). 0 or 1.
-    };
-
     static ErrorOr<QMArithmeticDecoder> initialize(ReadonlyBytes data);
 
-    bool get_next_bit(Context& context);
+    bool get_next_bit(QMArithmeticCoderContext& context);
 
 private:
     QMArithmeticDecoder(ReadonlyBytes data)
@@ -113,9 +106,7 @@ private:
 
     u8 CT { 0 }; // Count of the number of bits in C.
 
-    Context* CX { nullptr };
-    static u8& I(Context* cx) { return cx->I; }
-    static u8& MPS(Context* cx) { return cx->is_mps; }
+    QMArithmeticCoderContext* CX { nullptr };
 };
 
 }


### PR DESCRIPTION
JBIG2Writer can now write arithmetically-coded image data.
This lets it write basically all images; all remaining stuff is
just for better compression (and for adding more test files for
the decoder, which is the main motivation here, really).

generic_region_encoding_procedure() is very similar to
generic_region_decoding_procedure(), only the loop at the end is
different (to compress data instead of to decompress it). Maybe
we can find a way to share more code in the future. Quite a bit
of support code is already shared, though.

I also need to come up with a way to pass many, many options to
the encoder. For now, this just hardcodes all the options to
somewhat useful defaults.

Likewise, we also need a mechanism to manually pick which segments
to write. A fully white or fully black image does not need an
immediate generic region, for example. (But for normal `image`
use, we should also automatically generate a schedule that makes
sense for a given image.)

---

And a bunch of prep commits. Most move code from JBIG2Loader.cpp to JBIG2Shared.h, but we now also have a BilevelImage class in ImageFormats, with a Floyd-Steinberg error diffusion dither implementation.

We should hook up that dithering as a jbig2-independent effect in `image` and PixelPaint :^)

(…and come up with a way to use it, or something like it, for palette conversion too.)