### PR TITLE
LoginServer: Check if user is in window group before login

### DIFF
--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -95,6 +95,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
         }
 
+        if (!account.value().extra_gids().contains_slow(getgrnam("window")->gr_gid)) {
+            window->set_fail_message("Can't log in: user is not in 'window' group."sv);
+            dbgln("failed graphical login for user {}: not in 'window' group", username);
+            return;
+        }
+
         window->set_username(""sv);
         window->hide();
 


### PR DESCRIPTION
This is a very small pr that checks if user is in `window` group before login. This prevents a broken desktop with failing services when a user that isn't part of that group logs in.