### PR TITLE
Kernel: Be more strict about thread states

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -998,7 +998,7 @@ ErrorOr<FlatPtr> Process::sys$execve(Userspace<Syscall::SC_execve_params const*>
         VERIFY(!g_scheduler_lock.is_locked_by_current_processor());
         VERIFY(Processor::in_critical() == 1);
         g_scheduler_lock.lock();
-        current_thread->set_state(Thread::State::Running);
+        VERIFY(current_thread->state() == Thread::State::Running);
         Processor::assume_context(*current_thread, previous_interrupts_state);
         VERIFY_NOT_REACHED();
     }

--- a/Kernel/Tasks/Scheduler.h
+++ b/Kernel/Tasks/Scheduler.h
@@ -29,6 +29,11 @@ struct TotalTimeScheduled {
     u64 total_kernel { 0 };
 };
 
+enum class [[nodiscard]] ShouldYield {
+    Yes,
+    No,
+};
+
 class Scheduler {
 public:
     static void initialize();
@@ -36,9 +41,9 @@ public:
     static void set_idle_thread(Thread* idle_thread);
     static void timer_tick();
     [[noreturn]] static void start();
-    static void pick_next();
+    static ShouldYield pick_next();
     static void yield();
-    static void context_switch(Thread*);
+    static ShouldYield context_switch(Thread*);
     static void enter_current(Thread& prev_thread);
     static void leave_on_first_switch(InterruptsState);
     static void prepare_after_exec();

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -1199,24 +1199,13 @@ ErrorOr<NonnullRefPtr<Thread>> Thread::clone(NonnullRefPtr<Process> process)
 
 void Thread::set_state(State new_state, u8 stop_signal)
 {
-    State previous_state;
     VERIFY(g_scheduler_lock.is_locked_by_current_processor());
     if (new_state == m_state)
         return;
 
-    {
-        previous_state = m_state;
-        if (previous_state == Thread::State::Invalid) {
-            // If we were *just* created, we may have already pending signals
-            if (has_unmasked_pending_signals()) {
-                dbgln_if(THREAD_DEBUG, "Dispatch pending signals to new thread {}", *this);
-                dispatch_one_pending_signal();
-            }
-        }
-
-        m_state = new_state;
-        dbgln_if(THREAD_DEBUG, "Set thread {} state to {}", *this, state_string());
-    }
+    State previous_state = m_state;
+    m_state = new_state;
+    dbgln_if(THREAD_DEBUG, "Set thread {} state to {}", *this, state_string());
 
     if (previous_state == Thread::State::Runnable) {
         Scheduler::dequeue_runnable_thread(*this);

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -779,16 +779,6 @@ DispatchSignalResult Thread::dispatch_one_pending_signal()
     return dispatch_signal(signal);
 }
 
-DispatchSignalResult Thread::try_dispatch_one_pending_signal(u8 signal)
-{
-    VERIFY(signal != 0);
-    SpinlockLocker scheduler_lock(g_scheduler_lock);
-    u32 signal_candidates = pending_signals_for_state() & ~m_signal_mask;
-    if ((signal_candidates & (1 << (signal - 1))) == 0)
-        return DispatchSignalResult::Continue;
-    return dispatch_signal(signal);
-}
-
 enum class DefaultSignalAction {
     Terminate,
     Ignore,

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -1226,8 +1226,6 @@ private:
     RecursiveSpinlockProtected<Name, LockRank::None> m_name;
     u32 m_priority { THREAD_PRIORITY_NORMAL };
 
-    State m_stop_state { Thread::State::Invalid };
-
     bool m_dump_backtrace_on_finalization { false };
     bool m_should_die { false };
     bool m_initialized { false };

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -876,7 +876,6 @@ public:
     void set_dump_backtrace_on_finalization() { m_dump_backtrace_on_finalization = true; }
 
     DispatchSignalResult dispatch_one_pending_signal();
-    DispatchSignalResult try_dispatch_one_pending_signal(u8 signal);
     DispatchSignalResult dispatch_signal(u8 signal);
     void check_dispatch_pending_signal();
     [[nodiscard]] bool has_unmasked_pending_signals() const { return m_have_any_unmasked_pending_signals.load(AK::memory_order_consume); }

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -41,7 +41,7 @@ namespace Kernel {
 
 class Timer;
 
-enum class DispatchSignalResult {
+enum class [[nodiscard]] DispatchSignalResult {
     Deferred = 0,
     Yield,
     Terminate,

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -787,6 +787,7 @@ public:
     ThreadRegisters const& regs() const { return m_regs; }
 
     State state() const { return m_state; }
+    static StringView state_string(State);
     StringView state_string() const;
 
     ArchSpecificThreadData& arch_specific_data() { return m_arch_specific_data; }

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -669,7 +669,6 @@ public:
         ErrorOr<siginfo_t>& m_result;
         Variant<Empty, NonnullRefPtr<Process>, NonnullRefPtr<ProcessGroup>> const m_waitee;
         bool m_did_unblock { false };
-        bool m_got_sigchild { false };
     };
 
     class WaitBlockerSet final : public BlockerSet {

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -61,6 +61,7 @@ set(LIBTEST_BASED_SOURCES
     TestSigHandler.cpp
     TestSigWait.cpp
     TestTCPSocket.cpp
+    TestWait.cpp
     TestWXProtection.cpp
 )
 

--- a/Tests/Kernel/TestWait.cpp
+++ b/Tests/Kernel/TestWait.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+
+static bool volatile s_received_sigchld = false;
+
+static void sigchld_handler(int)
+{
+    s_received_sigchld = true;
+}
+
+TEST_CASE(wait)
+{
+    signal(SIGCHLD, sigchld_handler);
+    pid_t pid = fork();
+    if (pid == 0) {
+        exit(0);
+        VERIFY_NOT_REACHED();
+    }
+    pid_t result = wait(NULL);
+    EXPECT_EQ(result, pid);
+    EXPECT_EQ(s_received_sigchld, true);
+}


### PR DESCRIPTION
As discussed in #26160, it isn't possible for a thread to go right from being blocked to being stopped (or the other way around), so this PR codifes that invariant. This PR also disallows calling `Thread::set_state()` when that would turn out to be a no-op.