### PR TITLE
Base: Add a new `disk` group for limiting direct storage device access

### DIFF
--- a/Base/etc/DeviceMapper.ini
+++ b/Base/etc/DeviceMapper.ini
@@ -51,7 +51,7 @@ Name=storage
 DevTmpFSPath=hd%c
 Type=BlockDevice
 MajorNumber=3
-GroupPermissions=phys
+GroupPermissions=root
 CreatePermissions=0660
 
 [VirtualConsole]


### PR DESCRIPTION
Unlike with the `phys` group, no users are a part of this one by default. This means that anon can no longer bypass filesystem access restrictions by directly modifying the underlying block device.