### PR TITLE
Taskbar: Inhibit accidental dragging of quick launchers

### DIFF
--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -193,7 +193,9 @@ void QuickLaunchWidget::mousemove_event(GUI::MouseEvent& event)
     m_mouse_pos = event.position();
     for_each_entry([&](NonnullOwnPtr<QuickLaunchEntry> const& entry, Gfx::IntRect rect) {
         entry->set_hovered(rect.contains(event.position()));
-        if (entry->is_pressed())
+
+        int drag_distance = AK::abs(event.x() - (rect.x() - m_grab_offset));
+        if (entry->is_pressed() && drag_distance > MINIMUM_DRAG_DISTANCE)
             m_dragging = true;
 
         if (entry->is_hovered())

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -124,6 +124,7 @@ private:
     static constexpr StringView CONFIG_DOMAIN = "Taskbar"sv;
     static constexpr StringView CONFIG_GROUP_ENTRIES = "QuickLaunch_Entries"sv;
     static constexpr StringView OLD_CONFIG_GROUP_ENTRIES = "QuickLaunch"sv;
+    static constexpr int MINIMUM_DRAG_DISTANCE = 6;
     static constexpr int BUTTON_SIZE = 24;
 
     explicit QuickLaunchWidget();


### PR DESCRIPTION
When clicking on one of the quick launchers, if you accidentally moved the mouse it would immediately start dragging the quick launcher. This PR adds a minimum distance that you have to move to start dragging it.



https://github.com/user-attachments/assets/4e1a5896-c3b0-4d8a-a388-96ea37e050f3

