### PR TITLE
LibGfx/JBIG2: Give SegmentData a constructor

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -527,6 +527,12 @@ private:
 };
 
 struct SegmentData {
+    SegmentData(JBIG2::SegmentHeader header, ReadonlyBytes data)
+        : header(header)
+        , data(data)
+    {
+    }
+
     JBIG2::SegmentHeader header;
     ReadonlyBytes data;
 
@@ -1099,7 +1105,7 @@ static ErrorOr<void> decode_segment_headers(JBIG2LoadingContext& context, Readon
 
     HashMap<u32, u32> segments_by_number;
     for (size_t i = 0; i < segment_headers.size(); ++i) {
-        context.segments.append({ segment_headers[i], segment_datas[i], {}, {}, {}, {}, {} });
+        context.segments.append({ segment_headers[i], segment_datas[i] });
 
         if (segments_by_number.set(segment_headers[i].segment_number, context.segments.size() - 1) != HashSetResult::InsertedNewEntry)
             return Error::from_string_literal("JBIG2ImageDecoderPlugin: Duplicate segment number");


### PR DESCRIPTION
* If we don't have in-struct explicit initializers (` {}`) for Vector and the Optionals, `-Wmissing-field-initializers` complains if we don't have a bunch of `{}, ` when creating one
* If we do have them, readability-redundant-member-init complains about them (http://llvm.org/PR90235)

With a ctor, we don't need all the initializers and both compiler and clangd stay happy.

No behavior change.