### PR TITLE
LibGfx/JBIG2: Fix cross-chunk segment refs in embedded organization

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -407,6 +407,7 @@ TEST_CASE(test_jbig2_decode)
         // - immediate refinement regions referring to a direct region (code support added in #26197)
         // - immediate refinement regions referring to a direct region (code support added in #26197)
         //   - TPGRON set in refinement region (only reachable in standalone refinement regions)
+        // - in embedded organization, reference from segment in one chunk to segment in another chunk
         // Missing tests for things that aren't implemented yet:
         // - immediate refinement regions not referring to a direct region (i.e. refining the page)
         // - immediate lossless refinement regions


### PR DESCRIPTION
The extra validation in #26191 was added at the end of decode_segment_headers(). But in decode_embedded(), that can be called several times, once for each data chunk.

We want to decode segment headers from all chunks first before we do validation, so that segments in later chunks can refer to segments in earlier chunks.

Add a new complete_decoding_all_segment_headers() to house the validation code, and call it after all segment chunks have been decoded.

Unbreaks rendering 0000372.pdf page 11 and 0000857.pdf pages 1-4.