### PR TITLE
Everywhere: Default to using double buffering

### DIFF
--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -913,7 +913,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..64f956a456730cfd99998566810c04df64a1bfa0
 --- /dev/null
 +++ b/src/video/serenity/SDL_serenityvideo.cpp
-@@ -0,0 +1,659 @@
+@@ -0,0 +1,658 @@
 +/*
 +  Simple DirectMedia Layer
 +  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
@@ -1345,7 +1345,6 @@ index 0000000000000000000000000000000000000000..64f956a456730cfd99998566810c04df
 +
 +    auto w = new SerenityPlatformWindow(window);
 +    window->driverdata = w;
-+    w->window()->set_double_buffering_enabled(false);
 +    w->widget()->set_fill_with_background_color(false);
 +    w->window()->set_main_widget(w->widget());
 +    w->window()->on_close_request = [window] {

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -366,7 +366,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("3D File Viewer");
     window->resize(640 + 4, 480 + 4);
     window->set_resizable(false);
-    window->set_double_buffering_enabled(true);
     auto widget = window->set_main_widget<GLContextWidget>();
 
     auto& time = widget->add<GUI::Label>();

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -65,7 +65,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     auto window = GUI::Window::construct();
-    window->set_double_buffering_enabled(true);
     window->resize(300, 200);
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Image Viewer");

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -192,7 +192,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = GUI::Window::construct();
-    window->set_double_buffering_enabled(true);
     window->set_title("LibGfx Demo");
     window->set_resizable(false);
     window->resize(WIDTH, HEIGHT);

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -445,7 +445,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = GUI::Window::construct();
-    window->set_double_buffering_enabled(false);
     window->set_title("Mandelbrot");
     window->set_obey_widget_min_size(false);
     window->set_minimum_size(320, 240);

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -44,7 +44,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
 
-    window->set_double_buffering_enabled(false);
     window->set_title(title.bytes_as_string_view());
     window->resize(360, 462);
     window->set_resizable(false);

--- a/Userland/Games/ColorLines/main.cpp
+++ b/Userland/Games/ColorLines/main.cpp
@@ -43,7 +43,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
 
-    window->set_double_buffering_enabled(false);
     window->set_title(title.bytes_as_string_view());
     window->resize(436, 481);
     window->set_resizable(false);

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -41,7 +41,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-flappybug"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Flappy Bug");
-    window->set_double_buffering_enabled(false);
     window->set_resizable(false);
     auto widget = window->set_main_widget<FlappyBug::Game>(TRY(FlappyBug::Game::Bug::construct()), TRY(FlappyBug::Game::Cloud::construct()));
 

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -79,7 +79,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::write_i32("Flood"sv, ""sv, "board_rows"sv, board_rows);
     Config::write_i32("Flood"sv, ""sv, "board_columns"sv, board_columns);
 
-    window->set_double_buffering_enabled(false);
     window->set_title("Flood");
     window->resize(304, 325);
 

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -50,7 +50,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     size_t board_columns = 35;
     size_t board_rows = 35;
 
-    window->set_double_buffering_enabled(false);
     window->set_title("Game of Life");
 
     auto main_widget = TRY(GameOfLife::MainWidget::try_create());

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -43,7 +43,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     window->set_icon(app_icon.bitmap_for_size(16));
-    window->set_double_buffering_enabled(false);
     window->set_title("MasterWord");
     window->set_resizable(true);
     window->set_auto_shrink(true);

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -48,7 +48,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
 
-    window->set_double_buffering_enabled(false);
     window->set_title("Snake");
     window->resize(324, 345);
 

--- a/Userland/Games/TwentyFourtyEight/main.cpp
+++ b/Userland/Games/TwentyFourtyEight/main.cpp
@@ -61,7 +61,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::write_i32("2048"sv, ""sv, "target_tile"sv, target_tile);
     Config::write_bool("2048"sv, ""sv, "evil_ai"sv, evil_ai);
 
-    window->set_double_buffering_enabled(false);
     window->set_title("2048");
     window->resize(315, 336);
 

--- a/Userland/Libraries/LibDesktop/Screensaver.cpp
+++ b/Userland/Libraries/LibDesktop/Screensaver.cpp
@@ -15,7 +15,6 @@ static constexpr int mouse_tracking_delay_milliseconds = 750;
 ErrorOr<NonnullRefPtr<GUI::Window>> Screensaver::create_window(StringView title, StringView icon)
 {
     auto window = GUI::Window::construct();
-    window->set_double_buffering_enabled(false);
     window->set_frameless(true);
     window->set_fullscreen(true);
     window->set_minimizable(false);


### PR DESCRIPTION
On slow (emulated) systems, this will slow down the affected programs slightly in exchange for getting rid of tearing/flickering that was making them nearly unusable.

The SDL2 port seems to work fine with this change (I tested that with the ClassiCube port - which was rather busted, though that may or may not have been related to the fact that I had to bump it to 1.3.7 to make it build again - but the core rendering seemed to work fine).

(I'm not sure why some programs were doing `set_double_buffering_enabled(true)` in `serenity_main()` - I believe that's effectively been a no-op for years, if not always).