### PR TITLE
LibGfx/JBIG2: Disable quirks handling by default

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -361,6 +361,23 @@ constexpr Array standard_huffman_table_N = {
     Code { 3, 0, 2, 0b111 },
 };
 
+// Table B.15 – Standard Huffman table O
+constexpr Array standard_huffman_table_O = {
+    Code { 7, 4, -24, 0b1111100 },
+    Code { 6, 2, -8, 0b111100 },
+    Code { 5, 1, -4, 0b11100 },
+    Code { 4, 0, -2, 0b1100 },
+    Code { 3, 0, -1, 0b100 },
+    Code { 1, 0, 0, 0b0 },
+    Code { 3, 0, 1, 0b101 },
+    Code { 4, 0, 2, 0b1101 },
+    Code { 5, 1, 3, 0b11101 },
+    Code { 6, 2, 5, 0b111101 },
+    Code { 7, 4, 9, 0b1111101 },
+    Code { 7 | Code::LowerRangeBit, 32, -25, 0b1111110 },
+    Code { 7, 32, 25, 0b1111111 },
+};
+
 class HuffmanTable {
 public:
     enum class StandardTable {
@@ -460,9 +477,10 @@ ErrorOr<HuffmanTable*> HuffmanTable::standard_huffman_table(StandardTable kind)
         static HuffmanTable standard_table_N(standard_huffman_table_N);
         return &standard_table_N;
     }
-    case StandardTable::B_15:
-        // If you find a file using this, get the table from #26104.
-        return Error::from_string_literal("Standard table O not yet supported");
+    case StandardTable::B_15: {
+        static HuffmanTable standard_table_O(standard_huffman_table_O);
+        return &standard_table_O;
+    }
     }
     VERIFY_NOT_REACHED();
 }


### PR DESCRIPTION
Instead, detect files from the Power JBIG2 test set and enable
_more_ quirks for those, and disable all quirks for all other files.

Happily, the files in the Power JBIG2 test stet contain an extension
segment with an identifying string.

Sadly, it contained a typo that's fixed in some of the t89-halftone/
files, so we need to check for two different signatures.

This lets us decode 042_22.jb2 and, with a second commit to add standard huffman table O, 042_11.jb2.

We can now decode all files from the Power JBIG2 test set except for 042_13.jb2 and 042_14.jb2, which PDFium, Preview.app, and pdf.js all can't decode either. (PDFium also fails decoding 042_3.jb2, and Preview.app shows that one slightly wrong, but we get it right. PDFium can only decode the t89-halftone files with rotation recently; Preview.app and Firefox can't handle those. We get them all right.)