### PR TITLE
GamesSettings: Unveil portal/image

### DIFF
--- a/Userland/Applications/GamesSettings/main.cpp
+++ b/Userland/Applications/GamesSettings/main.cpp
@@ -25,6 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(selected_tab, "Tab, one of 'cards' or 'chess'", "open-tab", 't', "tab");
     args_parser.parse(arguments);
 
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     // Both of these are used by the GUI::FileSystemModel in CardSettingsWidget.
     TRY(Core::System::unveil("/etc/passwd", "r"));


### PR DESCRIPTION
The CardSettingsWidget uses ImageDecoder for decoding bitmaps for card backs, and that requires this unveil.