### PR TITLE
Everywhere: Fix a few unreachable-return / unreachable-break warnings

### DIFF
--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -290,9 +290,10 @@ ErrorOr<bool> Process::is_being_debugged()
 #    elif defined(AK_OS_FREEBSD)
     return ((info.ki_flag & P_TRACED) != 0);
 #    endif
-#endif
+#else
     // FIXME: Implement this for more platforms.
     return Error::from_string_literal("Platform does not support checking for debugger");
+#endif
 }
 
 // Forces the process to sleep until a debugger is attached, then breaks.

--- a/Userland/Libraries/LibMedia/Video/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibMedia/Video/VP9/Decoder.cpp
@@ -1231,16 +1231,12 @@ DecoderErrorOr<void> Decoder::reconstruct(u8 plane, BlockContext const& block_co
     switch (log2_of_block_size) {
     case 2:
         return reconstruct_templated<2>(plane, block_context, transform_block_x, transform_block_y, transform_set);
-        break;
     case 3:
         return reconstruct_templated<3>(plane, block_context, transform_block_x, transform_block_y, transform_set);
-        break;
     case 4:
         return reconstruct_templated<4>(plane, block_context, transform_block_x, transform_block_y, transform_set);
-        break;
     case 5:
         return reconstruct_templated<5>(plane, block_context, transform_block_x, transform_block_y, transform_set);
-        break;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Userland/Libraries/LibWasm/WASI/Wasi.cpp
@@ -688,7 +688,6 @@ ErrorOr<Result<Timestamp>> Implementation::impl$clock_time_get(Configuration&, C
     case ClockID::ProcessCPUTimeID:
     case ClockID::ThreadCPUTimeID:
         return Errno::NoSys;
-        break;
     }
 
     struct timespec ts;

--- a/Userland/Libraries/LibWeb/CSS/Transformation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Transformation.cpp
@@ -63,13 +63,11 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
                 0, 1, 0, 0,
                 0, 0, 1, 0,
                 0, 0, -1 / (distance <= 0 ? 1 : distance), 1);
-        } else {
-            return Gfx::FloatMatrix4x4(1, 0, 0, 0,
-                0, 1, 0, 0,
-                0, 0, 1, 0,
-                0, 0, 0, 1);
         }
-        break;
+        return Gfx::FloatMatrix4x4(1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1);
     case CSS::TransformFunction::Matrix:
         if (count == 6)
             return Gfx::FloatMatrix4x4(TRY(value(0)), TRY(value(2)), 0, TRY(value(4)),
@@ -101,7 +99,6 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
             0, 1, 0, TRY(value(1, height)),
             0, 0, 1, TRY(value(2)),
             0, 0, 0, 1);
-        break;
     case CSS::TransformFunction::TranslateX:
         if (count == 1)
             return Gfx::FloatMatrix4x4(1, 0, 0, TRY(value(0, width)),


### PR DESCRIPTION
I was playing with clang's -Wunreachable-code-aggressive a bit. This fixes a handful uncontroversial things it flags.

No behavior change.

---

Also at https://github.com/LadybirdBrowser/ladybird/pull/6171