### PR TITLE
LibGfx+image+PixelPaint: Add ordered bayer dither for bilevel conversion

### DIFF
--- a/Userland/Applications/PixelPaint/ModeBilevelDialog.cpp
+++ b/Userland/Applications/PixelPaint/ModeBilevelDialog.cpp
@@ -27,11 +27,17 @@ ModeBilevelDialog::ModeBilevelDialog(GUI::Window* parent_window)
 
     enum class DitheringMethodIndex {
         None = 0,
+        Bayer2x2,
+        Bayer4x4,
+        Bayer8x8,
         FloydSteinberg,
     };
 
     static constexpr AK::Array dithering_strings = {
         "Global Threshold"sv,
+        "Bayer 2x2"sv,
+        "Bayer 4x4"sv,
+        "Bayer 8x8"sv,
         "Floyd-Steinberg"sv
     };
 
@@ -39,6 +45,12 @@ ModeBilevelDialog::ModeBilevelDialog(GUI::Window* parent_window)
         switch (m_dithering_algorithm) {
         case Gfx::DitheringAlgorithm::None:
             return DitheringMethodIndex::None;
+        case Gfx::DitheringAlgorithm::Bayer2x2:
+            return DitheringMethodIndex::Bayer2x2;
+        case Gfx::DitheringAlgorithm::Bayer4x4:
+            return DitheringMethodIndex::Bayer4x4;
+        case Gfx::DitheringAlgorithm::Bayer8x8:
+            return DitheringMethodIndex::Bayer8x8;
         case Gfx::DitheringAlgorithm::FloydSteinberg:
             return DitheringMethodIndex::FloydSteinberg;
         }
@@ -55,6 +67,12 @@ ModeBilevelDialog::ModeBilevelDialog(GUI::Window* parent_window)
             switch (dithering_method_index) {
             case DitheringMethodIndex::None:
                 return Gfx::DitheringAlgorithm::None;
+            case DitheringMethodIndex::Bayer2x2:
+                return Gfx::DitheringAlgorithm::Bayer2x2;
+            case DitheringMethodIndex::Bayer4x4:
+                return Gfx::DitheringAlgorithm::Bayer4x4;
+            case DitheringMethodIndex::Bayer8x8:
+                return Gfx::DitheringAlgorithm::Bayer8x8;
             case DitheringMethodIndex::FloydSteinberg:
                 return Gfx::DitheringAlgorithm::FloydSteinberg;
             }

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -13,8 +13,14 @@ namespace Gfx {
 
 enum class DitheringAlgorithm {
     None,
+
+    Bayer2x2,
+    Bayer4x4,
+    Bayer8x8,
+
     FloydSteinberg,
-    // FIXME: Add Atkinson, Bayer in 2-3 sizes, BlueNoise, Hilbert / Peano space-filling, ...
+
+    // FIXME: Add Atkinson, BlueNoise, Hilbert / Peano space-filling, ...
     // https://surma.dev/things/ditherpunk/
     // https://tannerhelland.com/2012/12/28/dithering-eleven-algorithms-source-code.html
 };

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -325,12 +325,18 @@ static ErrorOr<Options> parse_options(Main::Arguments arguments)
         "Convert to bilevel image, with optionally explicit dithering algorithm",
         "to-bilevel",
         {},
-        "global-threshold, floyd-steinberg",
+        "global-threshold, bayer2x2, bayer4x4, bayer8x8, floyd-steinberg",
         [&to_bilevel](StringView s) {
             if (s.is_empty())
                 to_bilevel = Gfx::DitheringAlgorithm::FloydSteinberg;
             else if (s == "global-threshold"sv)
                 to_bilevel = Gfx::DitheringAlgorithm::None;
+            else if (s == "bayer2x2"sv)
+                to_bilevel = Gfx::DitheringAlgorithm::Bayer2x2;
+            else if (s == "bayer4x4"sv)
+                to_bilevel = Gfx::DitheringAlgorithm::Bayer4x4;
+            else if (s == "bayer8x8"sv)
+                to_bilevel = Gfx::DitheringAlgorithm::Bayer8x8;
             else if (s == "floyd-steinberg"sv)
                 to_bilevel = Gfx::DitheringAlgorithm::FloydSteinberg;
             else


### PR DESCRIPTION
2x2, 4x4, 8x8 for now. Might want to add 16x16 later.

---

In part to see what's up with mac CI :P

Details for 2x2:

<img width="710" height="555" alt="image" src="https://github.com/user-attachments/assets/4d36d143-ce5e-4eb5-b452-5b043f59d0f9" />

4x4:

<img width="734" height="600" alt="image" src="https://github.com/user-attachments/assets/2f461c47-9967-4d62-b012-b511369d605c" />

8x8:

<img width="752" height="576" alt="image" src="https://github.com/user-attachments/assets/7954bc8c-2ed7-447e-81f7-832e18b045b9" />