### PR TITLE
LibGUI: Don't render trailing whitespace when cursor is at last column

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -850,14 +850,14 @@ void TextEditor::paint_event(PaintEvent& event)
                 }
             }
 
-            if (m_visualize_trailing_whitespace && line.ends_in_whitespace()) {
+            size_t end_of_visual_line = (start_of_visual_line + visual_line_text.length());
+            if (m_visualize_trailing_whitespace && line.ends_in_whitespace() && (cursor().line() != line_index || cursor().column() < end_of_visual_line)) {
                 size_t physical_column;
                 auto last_non_whitespace_column = line.last_non_whitespace_column();
                 if (last_non_whitespace_column.has_value())
                     physical_column = last_non_whitespace_column.value() + 1;
                 else
                     physical_column = 0;
-                size_t end_of_visual_line = (start_of_visual_line + visual_line_text.length());
                 if (physical_column < end_of_visual_line) {
                     physical_column -= multiline_trailing_space_offset.value_or(0);
 


### PR DESCRIPTION
Previously it was pretty annoying to type on programs like LineEditor because after every space the trailing whitespace visualizer kicked in and a red square showed up right where the cursor was.

Now it's only rendered when the cursor is not at the end of the line, which makes typing feel better!

Before:

https://github.com/user-attachments/assets/3e468bb6-fbae-4ec7-96df-f89eb85d920e

After:

https://github.com/user-attachments/assets/2b0c3c03-ae7f-46d6-82fc-6633b7ae4278



