### PR TITLE
Shell: Don't try to become session leader on macos

### DIFF
--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -200,11 +200,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             dbgln("{}", res.release_error());
     } else if (sid != pid) {
         if (getpgid(pid) != pid) {
+#ifdef AK_OS_MACOS
+            // The best we can do is start a new process group and forget about being a session leader,
+            // As MacOS (or rather, `login` refuses to hand over the terminal.
+            if (auto res = Core::System::setpgid(pid, pid); res.is_error())
+                dbgln("{}", res.release_error());
+#else
             if (auto res = Core::System::setpgid(pid, sid); res.is_error())
                 dbgln("{}", res.release_error());
-
             if (auto res = Core::System::setsid(); res.is_error())
                 dbgln("{}", res.release_error());
+#endif
         }
     }
 


### PR DESCRIPTION
I finally got sick of not using Shell on mac, so here's the singular fix needed to make it work as my login shell.