### PR TITLE
LibGfx/JBIG2: Re-implement JBIG2Writer::encode(), use nominal AT pixel locations

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Shared.h
@@ -86,7 +86,7 @@ struct [[gnu::packed]] RegionSegmentInformationField {
     BigEndian<u32> height;
     BigEndian<u32> x_location;
     BigEndian<u32> y_location;
-    u8 flags;
+    u8 flags { 0 };
 
     CombinationOperator external_combination_operator() const
     {
@@ -143,7 +143,7 @@ struct [[gnu::packed]] PageInformationSegment {
     BigEndian<u32> bitmap_height;
     BigEndian<u32> page_x_resolution; // In pixels/meter.
     BigEndian<u32> page_y_resolution; // In pixels/meter.
-    u8 flags;
+    u8 flags { 0 };
     BigEndian<u16> striping_information;
 
     bool is_eventually_lossless() const { return flags & 1; }

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.cpp
@@ -387,10 +387,10 @@ ErrorOr<void> JBIG2Writer::encode(Stream& stream, Bitmap const& bitmap, Options 
     generic_region.region_segment_information.width = generic_region.image->width();
     generic_region.region_segment_information.height = generic_region.image->height();
     generic_region.region_segment_information.flags = 0;
-    generic_region.adaptive_template_pixels[0] = { -1, -1 };
-    generic_region.adaptive_template_pixels[1] = { 0, -1 };
-    generic_region.adaptive_template_pixels[2] = { -1, 0 };
-    generic_region.adaptive_template_pixels[3] = { 1, -1 };
+    generic_region.adaptive_template_pixels[0] = { 3, -1 };
+    generic_region.adaptive_template_pixels[1] = { -3, -1 };
+    generic_region.adaptive_template_pixels[2] = { 2, -2 };
+    generic_region.adaptive_template_pixels[3] = { -2, -2 };
     generic_region.flags = 1u << 3; // TPGDON, gb_template 0.
     jbig2.segments.append(JBIG2::SegmentData {
         .header = next_segment_header(),

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.h
@@ -16,7 +16,6 @@
 namespace Gfx {
 
 struct JBIG2EncoderOptions {
-    JBIG2::CombinationOperator default_combination_operator { JBIG2::CombinationOperator::Or };
 };
 
 // Structs in this namespace can be used to explicitly construct JBIG2 files with a certain structure.


### PR DESCRIPTION
Mostly a no-op, much less code, slightly better compression.