### PR TITLE
Kernel: Assert that MAXPAGESIZE == 4K in all linker scripts

### DIFF
--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -1,5 +1,7 @@
 ENTRY(init)
 
+ASSERT(CONSTANT(MAXPAGESIZE) == 4K, "The aarch64 Kernel linker script assumes a max page size of 4K");
+
 #define PF_X 0x1
 #define PF_W 0x2
 #define PF_R 0x4

--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -6,6 +6,8 @@
 
 ENTRY(init)
 
+ASSERT(CONSTANT(MAXPAGESIZE) == 4K, "The riscv64 Kernel linker script assumes a max page size of 4K");
+
 #define PF_X 0x1
 #define PF_W 0x2
 #define PF_R 0x4

--- a/Kernel/Arch/x86_64/linker.ld
+++ b/Kernel/Arch/x86_64/linker.ld
@@ -1,5 +1,7 @@
 ENTRY(init)
 
+ASSERT(CONSTANT(MAXPAGESIZE) == 4K, "The x86_64 Kernel linker script assumes a max page size of 4K");
+
 #define PF_X 0x1
 #define PF_W 0x2
 #define PF_R 0x4

--- a/Kernel/EFIPrekernel/linker.ld
+++ b/Kernel/EFIPrekernel/linker.ld
@@ -1,5 +1,7 @@
 ENTRY(init)
 
+ASSERT(CONSTANT(MAXPAGESIZE) == 4K, "The EFIPrekernel linker script only supports a max page size of 4K, as the UEFI spec requires 4K pages.");
+
 SECTIONS
 {
     /* This is symbol is used to tell the PrekernelPEImageGenerator that the PE base address is 0 */

--- a/Kernel/Prekernel/linker.ld
+++ b/Kernel/Prekernel/linker.ld
@@ -1,5 +1,7 @@
 ENTRY(start)
 
+ASSERT(CONSTANT(MAXPAGESIZE) == 4K, "The Prekernel linker script assumes a max page size of 4K");
+
 PHDRS
 {
   boot_text PT_LOAD ;


### PR DESCRIPTION
All of these linker scripts assume 4K pages.
If these linker scripts would be used with MAXPAGESIZE > 4K, the sections would not be aligned correctly.