### PR TITLE
LibGfx: Decode Mellor_ACTITC_10.pdf faster, again

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
@@ -61,16 +61,20 @@ void BilevelImage::fill(bool b)
 template<BilevelImage::CompositionType operator_>
 void BilevelImage::composite_onto(BilevelImage& out, IntPoint position) const
 {
-    static constexpr auto combine = [](bool dst, bool src) -> bool {
+    static constexpr auto combine = [](auto dst, auto src) -> decltype(dst) {
         switch (operator_) {
         case CompositionType::Or:
-            return dst || src;
+            return dst | src;
         case CompositionType::And:
-            return dst && src;
+            return dst & src;
         case CompositionType::Xor:
             return dst ^ src;
         case CompositionType::XNor:
-            return !(dst ^ src);
+            // Clang is not happy with using ~ on a bool, even if it's fine with our use case.
+            if constexpr (SameAs<decltype(dst), bool>)
+                return !(dst ^ src);
+            else
+                return ~(dst ^ src);
         case CompositionType::Replace:
             return src;
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
@@ -58,10 +58,11 @@ void BilevelImage::fill(bool b)
         byte = fill_byte;
 }
 
-void BilevelImage::composite_onto(BilevelImage& out, IntPoint position, CompositionType operator_) const
+template<BilevelImage::CompositionType operator_>
+void BilevelImage::composite_onto(BilevelImage& out, IntPoint position) const
 {
-    static constexpr auto combine = [](bool dst, bool src, CompositionType op) -> bool {
-        switch (op) {
+    static constexpr auto combine = [](bool dst, bool src) -> bool {
+        switch (operator_) {
         case CompositionType::Or:
             return dst || src;
         case CompositionType::And:
@@ -84,8 +85,29 @@ void BilevelImage::composite_onto(BilevelImage& out, IntPoint position, Composit
         for (int x = clip_rect.left(); x < clip_rect.right(); ++x) {
             bool src_bit = get_bit(x - position.x(), y - position.y());
             bool dst_bit = out.get_bit(x, y);
-            out.set_bit(x, y, combine(dst_bit, src_bit, operator_));
+            out.set_bit(x, y, combine(dst_bit, src_bit));
         }
+    }
+}
+
+void BilevelImage::composite_onto(BilevelImage& out, IntPoint position, CompositionType operator_) const
+{
+    switch (operator_) {
+    case CompositionType::Or:
+        composite_onto<CompositionType::Or>(out, position);
+        break;
+    case CompositionType::And:
+        composite_onto<CompositionType::And>(out, position);
+        break;
+    case CompositionType::Xor:
+        composite_onto<CompositionType::Xor>(out, position);
+        break;
+    case CompositionType::XNor:
+        composite_onto<CompositionType::XNor>(out, position);
+        break;
+    case CompositionType::Replace:
+        composite_onto<CompositionType::Replace>(out, position);
+        break;
     }
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -58,6 +58,9 @@ public:
 private:
     BilevelImage(ByteBuffer, size_t width, size_t height, size_t pitch);
 
+    template<CompositionType>
+    void composite_onto(BilevelImage& out, IntPoint position) const;
+
     ByteBuffer m_bits;
     size_t m_width { 0 };
     size_t m_height { 0 };

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -35,6 +35,16 @@ public:
     void set_bit(size_t x, size_t y, bool b);
     void fill(bool b);
 
+    enum class CompositionType : u8 {
+        Or = 0,
+        And = 1,
+        Xor = 2,
+        XNor = 3,
+        Replace = 4,
+    };
+
+    void composite_onto(BilevelImage& out, IntPoint position, CompositionType) const;
+
     ErrorOr<NonnullOwnPtr<BilevelImage>> subbitmap(Gfx::IntRect const& rect) const;
 
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_gfx_bitmap() const;


### PR DESCRIPTION
Related to #26082

This is only about making blending `BilevelImage`s faster. Taking it from ~20% of the profile to ~2% :^)

From:
```
Benchmark 1: BuildLagom/bin/pdf --render out.png PDF/Mellor_ACTITC_10.pdf --page 4
  Time (mean ± σ):     630.9 ms ±   9.7 ms    [User: 582.8 ms, System: 47.7 ms]
  Range (min … max):   622.1 ms … 655.9 ms    10 runs
```

To:
```
Benchmark 1: BuildLagom/bin/pdf --render out.png PDF/Mellor_ACTITC_10.pdf --page 4
  Time (mean ± σ):     521.2 ms ±   4.0 ms    [User: 475.4 ms, System: 45.5 ms]
  Range (min … max):   516.3 ms … 527.9 ms    10 runs
```