### PR TITLE
LibGfx: Decode Mellor_ACTITC_10.pdf faster [3/N]

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
@@ -12,17 +12,17 @@
 
 namespace Gfx {
 
-ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::create(size_t width, size_t height)
+ErrorOr<NonnullRefPtr<BilevelImage>> BilevelImage::create(size_t width, size_t height)
 {
     size_t pitch = ceil_div(width, static_cast<size_t>(8));
     auto bits = TRY(ByteBuffer::create_uninitialized(pitch * height));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BilevelImage(move(bits), width, height, pitch));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) BilevelImage(move(bits), width, height, pitch));
 }
 
-ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::create_from_byte_buffer(ByteBuffer bitmap, size_t width, size_t height)
+ErrorOr<NonnullRefPtr<BilevelImage>> BilevelImage::create_from_byte_buffer(ByteBuffer bitmap, size_t width, size_t height)
 {
     size_t pitch = ceil_div(width, static_cast<size_t>(8));
-    return adopt_nonnull_own_or_enomem(new (nothrow) BilevelImage(move(bitmap), width, height, pitch));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) BilevelImage(move(bitmap), width, height, pitch));
 }
 
 void BilevelImage::fill(bool b)
@@ -96,7 +96,7 @@ void BilevelImage::composite_onto(BilevelImage& out, IntPoint position, Composit
     }
 }
 
-ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::subbitmap(Gfx::IntRect const& rect) const
+ErrorOr<NonnullRefPtr<BilevelImage>> BilevelImage::subbitmap(Gfx::IntRect const& rect) const
 {
     VERIFY(rect.x() >= 0);
     VERIFY(rect.width() >= 0);
@@ -206,7 +206,7 @@ static constexpr auto bayer_matrix_2x2 = make_bayer_matrix<1>();
 static constexpr auto bayer_matrix_4x4 = make_bayer_matrix<2>();
 static constexpr auto bayer_matrix_8x8 = make_bayer_matrix<3>();
 
-ErrorOr<NonnullOwnPtr<BilevelImage>> BilevelImage::create_from_bitmap(Gfx::Bitmap const& bitmap, DitheringAlgorithm dithering_algorithm)
+ErrorOr<NonnullRefPtr<BilevelImage>> BilevelImage::create_from_bitmap(Gfx::Bitmap const& bitmap, DitheringAlgorithm dithering_algorithm)
 {
     auto gray_bitmap = TRY(ByteBuffer::create_uninitialized(bitmap.width() * bitmap.height()));
     for (int y = 0, i = 0; y < bitmap.height(); ++y) {

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/RefCounted.h>
 #include <LibGfx/Forward.h>
 
 namespace Gfx {
@@ -25,11 +26,11 @@ enum class DitheringAlgorithm {
     // https://tannerhelland.com/2012/12/28/dithering-eleven-algorithms-source-code.html
 };
 
-class BilevelImage {
+class BilevelImage : public RefCounted<BilevelImage> {
 public:
-    static ErrorOr<NonnullOwnPtr<BilevelImage>> create(size_t width, size_t height);
-    static ErrorOr<NonnullOwnPtr<BilevelImage>> create_from_byte_buffer(ByteBuffer bitmap, size_t width, size_t height);
-    static ErrorOr<NonnullOwnPtr<BilevelImage>> create_from_bitmap(Gfx::Bitmap const& bitmap, DitheringAlgorithm dithering_algorithm);
+    static ErrorOr<NonnullRefPtr<BilevelImage>> create(size_t width, size_t height);
+    static ErrorOr<NonnullRefPtr<BilevelImage>> create_from_byte_buffer(ByteBuffer bitmap, size_t width, size_t height);
+    static ErrorOr<NonnullRefPtr<BilevelImage>> create_from_bitmap(Gfx::Bitmap const& bitmap, DitheringAlgorithm dithering_algorithm);
 
     ALWAYS_INLINE bool get_bit(size_t x, size_t y) const
     {
@@ -69,7 +70,7 @@ public:
 
     void composite_onto(BilevelImage& out, IntPoint position, CompositionType) const;
 
-    ErrorOr<NonnullOwnPtr<BilevelImage>> subbitmap(Gfx::IntRect const& rect) const;
+    ErrorOr<NonnullRefPtr<BilevelImage>> subbitmap(Gfx::IntRect const& rect) const;
 
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_gfx_bitmap() const;
     ErrorOr<ByteBuffer> to_byte_buffer() const;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.h
@@ -44,7 +44,7 @@ struct GenericRegionSegmentData {
     RegionSegmentInformationField region_segment_information {};
     u8 flags { 0 };
     Array<AdaptiveTemplatePixel, 12> adaptive_template_pixels {};
-    NonnullOwnPtr<BilevelImage> image;
+    NonnullRefPtr<BilevelImage> image;
     Optional<u32> real_height_for_generic_region_of_initially_unknown_size {};
     MQArithmeticEncoder::Trailing7FFFHandling trailing_7fff_handling { MQArithmeticEncoder::Trailing7FFFHandling::Keep };
 };

--- a/Userland/Utilities/jbig2-from-json.cpp
+++ b/Userland/Utilities/jbig2-from-json.cpp
@@ -156,9 +156,9 @@ static ErrorOr<JSONRect> jbig2_rect_from_json(JsonObject const& object)
     return rect;
 }
 
-static ErrorOr<NonnullOwnPtr<Gfx::BilevelImage>> jbig2_image_from_json(ToJSONOptions const& options, JsonObject const& object)
+static ErrorOr<NonnullRefPtr<Gfx::BilevelImage>> jbig2_image_from_json(ToJSONOptions const& options, JsonObject const& object)
 {
-    OwnPtr<Gfx::BilevelImage> image;
+    RefPtr<Gfx::BilevelImage> image;
     JSONRect crop_rect;
     bool invert = false;
 
@@ -405,7 +405,7 @@ static ErrorOr<Gfx::JBIG2::GenericRegionSegmentData> jbig2_generic_region_from_j
     u8 flags = 0;
     Vector<i8> adaptive_template_pixels;
     Gfx::MQArithmeticEncoder::Trailing7FFFHandling trailing_7fff_handling { Gfx::MQArithmeticEncoder::Trailing7FFFHandling::Keep };
-    OwnPtr<Gfx::BilevelImage> image;
+    RefPtr<Gfx::BilevelImage> image;
     TRY(object->try_for_each_member([&](StringView key, JsonValue const& value) -> ErrorOr<void> {
         if (key == "region_segment_information"sv) {
             if (value.is_object()) {


### PR DESCRIPTION
Related to #26082

Before:
``` bash
Benchmark 1: BuildLagom/bin/pdf --render out.png PDF/Mellor_ACTITC_10.pdf --page 4
  Time (mean ± σ):     427.7 ms ±   8.4 ms    [User: 381.2 ms, System: 46.3 ms]
  Range (min … max):   410.3 ms … 438.6 ms    10 runs
```

After:
``` bash
Benchmark 1: BuildLagom/bin/pdf --render out.png PDF/Mellor_ACTITC_10.pdf --page 4
  Time (mean ± σ):     337.2 ms ±   3.0 ms    [User: 295.2 ms, System: 41.8 ms]
  Range (min … max):   332.0 ms … 340.7 ms    10 runs
```