### PR TITLE
LibGfx: Add BilevelImage::as_subbitmap()

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.cpp
@@ -132,6 +132,11 @@ BilevelSubImage BilevelImage::subbitmap(Gfx::IntRect const& rect) const
     return BilevelSubImage { *this, rect };
 }
 
+BilevelSubImage BilevelImage::as_subbitmap() const
+{
+    return subbitmap(IntRect(0, 0, m_width, m_height));
+}
+
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> BilevelImage::to_gfx_bitmap() const
 {
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { m_width, m_height }));

--- a/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BilevelImage.h
@@ -74,6 +74,7 @@ public:
     void composite_onto(BilevelImage& out, IntPoint position, CompositionType) const;
 
     BilevelSubImage subbitmap(Gfx::IntRect const& rect) const;
+    BilevelSubImage as_subbitmap() const;
 
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_gfx_bitmap() const;
     ErrorOr<ByteBuffer> to_byte_buffer() const;

--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.cpp
@@ -1956,7 +1956,7 @@ static ErrorOr<NonnullRefPtr<BilevelImage>> text_region_decoding_procedure(TextR
         refinement_inputs.is_typical_prediction_used = false;
         refinement_inputs.adaptive_template_pixels = inputs.refinement_adaptive_template_pixels;
         auto result = TRY(generic_refinement_region_decoding_procedure(refinement_inputs, *decoder, refinement_contexts.value()));
-        refinement_result = result->subbitmap(IntRect(0, 0, result->width(), result->height()));
+        refinement_result = result->as_subbitmap();
         return &refinement_result.value();
     };
 
@@ -2380,7 +2380,7 @@ static ErrorOr<Vector<BilevelSubImage>> symbol_dictionary_decoding_procedure(Sym
             // FIXME: Doing this eagerly is pretty wasteful. Decode on demand instead?
             if (!inputs.uses_huffman_encoding || inputs.uses_refinement_or_aggregate_coding) {
                 auto bitmap = TRY(read_symbol_bitmap(symbol_width, height_class_height));
-                new_symbols.append(bitmap->subbitmap(IntRect(0, 0, bitmap->width(), bitmap->height())));
+                new_symbols.append(bitmap->as_subbitmap());
             }
 
             // "iii) If SDHUFF is 1 and SDREFAGG is 0, then set:
@@ -3764,7 +3764,7 @@ static ErrorOr<void> decode_immediate_generic_refinement_region(JBIG2LoadingCont
     inputs.region_width = information_field.width;
     inputs.region_height = information_field.height;
     inputs.gr_template = arithmetic_coding_template;
-    auto subbitmap = reference_bitmap->subbitmap(IntRect(0, 0, reference_bitmap->width(), reference_bitmap->height()));
+    auto subbitmap = reference_bitmap->as_subbitmap();
     inputs.reference_bitmap = &subbitmap;
     inputs.reference_x_offset = 0;
     inputs.reference_y_offset = 0;


### PR DESCRIPTION
This allows a simple conversion to the `BilevelSubImage` type.

@nico 