### PR TITLE
Kernel: Use `git describe` to generate git hash

### DIFF
--- a/Kernel/generate-version-file.sh
+++ b/Kernel/generate-version-file.sh
@@ -4,20 +4,7 @@ set -e
 
 OUTPUT_FILE=$1
 
-if command -v git >/dev/null; then
-    if git status >/dev/null 2>&1; then
-        GIT_HASH=$( (git log --pretty=format:'%h' -n 1 | cut -c1-7) || true )
-        # There is at least one modified file as reported by git.
-        if git status --porcelain=v2 | head | grep -Ei '^1' >/dev/null; then
-            GIT_HASH="${GIT_HASH}-modified"
-        fi
-    else
-        GIT_HASH=unknown
-    fi
-else
-    GIT_HASH=unknown
-fi
-
+GIT_HASH=$(git describe --exclude '*' --always --dirty=-modified 2>/dev/null || echo "unknown")
 
 cat << EOF > "$OUTPUT_FILE"
 /*


### PR DESCRIPTION
Instead of manually creating the git hash string, we can simply use `git describe` with appropriate options:

- `--exclude '*'` to exclude any git tags
- `--always` to make `git describe` print a uniquely abbreviated commit hash if no tag is matching
- `--dirty=-modified` to add a "-modified" suffix if the working tree has local modifications

This should also guarantee now that the abbreviated commit hash is always unique. Previously, we always abbreviated the commit hash to 7 characters.