### PR TITLE
LibGfx/JBIG2Writer: Use get_bits()

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Writer.cpp
@@ -84,17 +84,26 @@ static ErrorOr<ByteBuffer> generic_region_encoding_procedure(GenericRegionEncodi
         return buffer.get_bit(x, y);
     };
 
+    static constexpr auto get_pixels = [](NonnullRefPtr<BilevelImage> const& buffer, int x, int y, u8 width) -> u8 {
+        if (x + width < 0 || x >= (int)buffer->width() || y < 0)
+            return 0;
+        auto corrected_x = max(x, 0);
+        auto right_end = x + width;
+        auto corrected_right_end = min(right_end, buffer->width());
+        auto in_bounds = corrected_right_end - corrected_x;
+        auto res = buffer->get_bits(corrected_x, y, in_bounds);
+        res <<= (right_end - corrected_right_end);
+        return res;
+    };
+
     // Figure 3(a) – Template when GBTEMPLATE = 0 and EXTTEMPLATE = 0,
     constexpr auto compute_context_0 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
         u16 result = 0;
         for (int i = 0; i < 4; ++i)
             result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[i].x, y + adaptive_pixels[i].y);
-        for (int i = 0; i < 3; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 1 + i, y - 2);
-        for (int i = 0; i < 5; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y - 1);
-        for (int i = 0; i < 4; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 4 + i, y);
+        result = (result << 3) | get_pixels(buffer, x - 1, y - 2, 3);
+        result = (result << 5) | get_pixels(buffer, x - 2, y - 1, 5);
+        result = (result << 4) | get_pixels(buffer, x - 4, y, 4);
         return result;
     };
 
@@ -102,12 +111,9 @@ static ErrorOr<ByteBuffer> generic_region_encoding_procedure(GenericRegionEncodi
     auto compute_context_1 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
         u16 result = 0;
         result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[0].x, y + adaptive_pixels[0].y);
-        for (int i = 0; i < 4; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 1 + i, y - 2);
-        for (int i = 0; i < 5; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y - 1);
-        for (int i = 0; i < 3; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 3 + i, y);
+        result = (result << 4) | get_pixels(buffer, x - 1, y - 2, 4);
+        result = (result << 5) | get_pixels(buffer, x - 2, y - 1, 5);
+        result = (result << 3) | get_pixels(buffer, x - 3, y, 3);
         return result;
     };
 
@@ -115,12 +121,9 @@ static ErrorOr<ByteBuffer> generic_region_encoding_procedure(GenericRegionEncodi
     auto compute_context_2 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
         u16 result = 0;
         result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[0].x, y + adaptive_pixels[0].y);
-        for (int i = 0; i < 3; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 1 + i, y - 2);
-        for (int i = 0; i < 4; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y - 1);
-        for (int i = 0; i < 2; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 2 + i, y);
+        result = (result << 3) | get_pixels(buffer, x - 1, y - 2, 3);
+        result = (result << 4) | get_pixels(buffer, x - 2, y - 1, 4);
+        result = (result << 2) | get_pixels(buffer, x - 2, y, 2);
         return result;
     };
 
@@ -128,10 +131,8 @@ static ErrorOr<ByteBuffer> generic_region_encoding_procedure(GenericRegionEncodi
     auto compute_context_3 = [](BilevelImage const& buffer, ReadonlySpan<JBIG2::AdaptiveTemplatePixel> adaptive_pixels, int x, int y) -> u16 {
         u16 result = 0;
         result = (result << 1) | (u16)get_pixel(buffer, x + adaptive_pixels[0].x, y + adaptive_pixels[0].y);
-        for (int i = 0; i < 5; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 3 + i, y - 1);
-        for (int i = 0; i < 4; ++i)
-            result = (result << 1) | (u16)get_pixel(buffer, x - 4 + i, y);
+        result = (result << 5) | get_pixels(buffer, x - 3, y - 1, 5);
+        result = (result << 4) | get_pixels(buffer, x - 4, y, 4);
         return result;
     };
 


### PR DESCRIPTION
This ports the JBIG2Loader changes from #26260 to the writer.

Takes

    Build/lagom/bin/image -o tmp.jbig2 \
        Tests/LibGfx/test-inputs/jpg/big_image.jpg

from 460.3 ms ± 5.0 ms to 445.3 ms ± 3.3 ms on my system, according to hyperfine.

The main motivation is to keep the loading and writing paths similar, not performance.

No behavior change.