### PR TITLE
LibGfx/JPEGXL: Make Channel non default-copyable

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLChannel.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLChannel.h
@@ -26,6 +26,9 @@ struct ChannelInfo {
 };
 
 class Channel {
+    AK_MAKE_NONCOPYABLE(Channel);
+    AK_MAKE_DEFAULT_MOVABLE(Channel);
+
 public:
     static ErrorOr<Channel> create(ChannelInfo const& info)
     {
@@ -125,6 +128,8 @@ public:
     }
 
 private:
+    Channel() = default;
+
     u32 m_width {};
     u32 m_height {};
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1659,9 +1659,9 @@ struct ModularData {
             }
         }
 
-        TRY(channels.try_resize(channel_infos.size()));
-        for (u32 i = 0; i < channels.size(); ++i)
-            channels[i] = TRY(Channel::create(channel_infos[i]));
+        TRY(channels.try_ensure_capacity(channel_infos.size()));
+        for (u32 i = 0; i < channel_infos.size(); ++i)
+            channels.append(TRY(Channel::create(channel_infos[i])));
 
         return {};
     }


### PR DESCRIPTION
This will prevent any future non-explicit copy. The change in `ModularData::create_channels` is needed as `Channel`'s default constructor is now private.
No behavior change.