### PR TITLE
Toolchain: Set some ABI-related CMake variables

### DIFF
--- a/Toolchain/CMake/ClangToolchain.txt.in
+++ b/Toolchain/CMake/ClangToolchain.txt.in
@@ -33,8 +33,16 @@ set(SERENITY_CXXFILT ${TOOLCHAIN_PATH}/llvm-cxxfilt)
 #        which doesn't work when using static linking.
 #        Instead, just tell CMake directly that the compiler works fine, so that it doesn't have to run
 #        a compile check before the build.
+#        This also means that the "Detecting C{,XX} compiler ABI info" step fails, so we need to set
+#        some variables manually. There may be more variables that aren't set, but those don't seem to be
+#        necessary at the time of writing this. We only support 64-bit little endian systems, so set the
+#        values accordingly.
 set(CMAKE_C_COMPILER_WORKS TRUE)
+set(CMAKE_C_SIZEOF_DATA_PTR 8)
+set(CMAKE_C_BYTE_ORDER LITTLE_ENDIAN)
 set(CMAKE_CXX_COMPILER_WORKS TRUE)
+set(CMAKE_CXX_SIZEOF_DATA_PTR 8)
+set(CMAKE_CXX_BYTE_ORDER LITTLE_ENDIAN)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/Toolchain/CMake/GNUToolchain.txt.in
+++ b/Toolchain/CMake/GNUToolchain.txt.in
@@ -30,8 +30,16 @@ set(SERENITY_CXXFILT ${TOOLCHAIN_PREFIX}c++filt)
 #        which doesn't work when using static linking.
 #        Instead, just tell CMake directly that the compiler works fine, so that it doesn't have to run
 #        a compile check before the build.
+#        This also means that the "Detecting C{,XX} compiler ABI info" step fails, so we need to set
+#        some variables manually. There may be more variables that aren't set, but those don't seem to be
+#        necessary at the time of writing this. We only support 64-bit little endian systems, so set the
+#        values accordingly.
 set(CMAKE_C_COMPILER_WORKS TRUE)
+set(CMAKE_C_SIZEOF_DATA_PTR 8)
+set(CMAKE_C_BYTE_ORDER LITTLE_ENDIAN)
 set(CMAKE_CXX_COMPILER_WORKS TRUE)
+set(CMAKE_CXX_SIZEOF_DATA_PTR 8)
+set(CMAKE_CXX_BYTE_ORDER LITTLE_ENDIAN)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
Without these variables being set, CMake prints this warning:

  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language
  before including GNUInstallDirs.

This occurs every time `GNUInstallDirs.cmake` is included since https://gitlab.kitware.com/cmake/cmake/-/commit/42dfcbf1a50d74defa88bbed313e869f8beacf41 as CMAKE_SIZEOF_VOID_P isn't set. (CMAKE_SIZEOF_VOID_P is set to CMAKE_C_SIZEOF_DATA_PTR.)