### PR TITLE
LibPDF: Add "slow path" for text rendering that can handle transforms

### DIFF
--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -30,6 +30,7 @@ public:
     ScaledGlyphMetrics glyph_metrics(u32 glyph_id) const { return m_font->glyph_metrics(glyph_id, m_x_scale, m_y_scale, m_point_width, m_point_height); }
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, GlyphSubpixelOffset) const;
     bool append_glyph_path_to(Gfx::Path&, u32 glyph_id) const;
+    Optional<Glyph> glyph_for_id(u32 id, GlyphSubpixelOffset) const;
 
     // ^Gfx::Font
     virtual NonnullRefPtr<Font> clone() const override { return MUST(try_clone()); } // FIXME: clone() should not need to be implemented
@@ -80,8 +81,6 @@ public:
     virtual bool has_color_bitmaps() const override { return m_font->has_color_bitmaps(); }
 
 private:
-    Optional<Glyph> glyph_for_id(u32 id, GlyphSubpixelOffset) const;
-
     NonnullRefPtr<VectorFont> m_font;
     float m_x_scale { 0.0f };
     float m_y_scale { 0.0f };

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -27,6 +27,7 @@
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibGfx/CharacterBitmap.h>
+#include <LibGfx/Font/ScaledFont.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Quad.h>
@@ -1371,14 +1372,14 @@ FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Font const& f
     draw_glyph_internal(point, glyph_position, top_left, glyph, color);
 }
 
-FLATTEN void Painter::draw_glyph_with_postscript_name(FloatPoint point, StringView name, Font const& font, Color color)
+FLATTEN void Painter::draw_glyph_via_glyph_id(FloatPoint point, Gfx::ScaledFont const& font, u32 glyph_id, Color color)
 {
-    auto left_bearing = font.glyph_left_bearing_for_postscript_name(name);
-    if (!left_bearing.has_value())
-        return;
-    auto top_left = point + FloatPoint(left_bearing.value(), 0);
+    auto top_left = point + Gfx::FloatPoint(font.glyph_metrics(glyph_id).left_side_bearing, 0);
     auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(top_left);
-    auto glyph = font.glyph_for_postscript_name(name, glyph_position.subpixel_offset).value();
+    auto maybe_glyph = font.glyph_for_id(glyph_id, glyph_position.subpixel_offset);
+    if (!maybe_glyph.has_value())
+        return;
+    auto glyph = maybe_glyph.release_value();
     draw_glyph_internal(point, glyph_position, top_left, glyph, color);
 }
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -114,9 +114,9 @@ public:
     void draw_glyph_or_emoji(IntPoint, Utf8CodePointIterator&, Font const&, Color);
     void draw_glyph(FloatPoint, u32, Color);
     void draw_glyph(FloatPoint, u32, Font const&, Color);
-    void draw_glyph_with_postscript_name(FloatPoint point, StringView name, Font const& font, Color color);
     void draw_glyph_or_emoji(FloatPoint, u32, Font const&, Color);
     void draw_glyph_or_emoji(FloatPoint, Utf8CodePointIterator&, Font const&, Color);
+    void draw_glyph_via_glyph_id(FloatPoint, Gfx::ScaledFont const&, u32, Color);
     void draw_circle_arc_intersecting(IntRect const&, IntPoint, int radius, Color, int thickness);
 
     // Streamlined text drawing routine that does no wrapping/elision/alignment.

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -36,10 +36,6 @@ public:
 
     virtual void set_font_size(float font_size) = 0;
     virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&) = 0;
-    virtual PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&)
-    {
-        return Error { Error::Type::RenderingUnsupported, "append_text_path not implemented for font" };
-    }
 
     virtual WritingMode writing_mode() const { return WritingMode::Horizontal; }
 

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -36,6 +36,10 @@ public:
 
     virtual void set_font_size(float font_size) = 0;
     virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&) = 0;
+    virtual PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&)
+    {
+        return Error { Error::Type::RenderingUnsupported, "append_text_path not implemented for font" };
+    }
 
     virtual WritingMode writing_mode() const { return WritingMode::Horizontal; }
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -14,12 +14,12 @@ namespace PDF {
 class SimpleFont : public PDFFont {
 public:
     PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&) override;
-    PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&) override;
 
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;
     virtual Optional<float> get_glyph_width(u8 char_code) const = 0;
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) = 0;
+
     virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, u8, Renderer const&)
     {
         return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
@@ -33,6 +33,10 @@ protected:
 private:
     template<typename Callback>
     PDFErrorOr<Gfx::FloatPoint> for_each_glyph_position(Gfx::FloatPoint, ByteString const&, Renderer const&, Callback callback);
+
+    PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&);
+    PDFErrorOr<Gfx::FloatPoint> draw_transformed_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
+    PDFErrorOr<Gfx::FloatPoint> draw_axis_aligned_glyphs(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&);
 
     RefPtr<Encoding> m_encoding;
     RefPtr<StreamObject> m_to_unicode;

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -14,17 +14,26 @@ namespace PDF {
 class SimpleFont : public PDFFont {
 public:
     PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, ByteString const&, Renderer const&) override;
+    PDFErrorOr<Gfx::FloatPoint> append_text_path(Gfx::Path&, Gfx::FloatPoint, ByteString const&, Renderer const&) override;
 
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;
     virtual Optional<float> get_glyph_width(u8 char_code) const = 0;
     virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) = 0;
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint, u8, Renderer const&)
+    {
+        return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
+    }
+
     RefPtr<Encoding>& encoding() { return m_encoding; }
     RefPtr<Encoding> const& encoding() const { return m_encoding; }
 
     Gfx::AffineTransform& font_matrix() { return m_font_matrix; }
 
 private:
+    template<typename Callback>
+    PDFErrorOr<Gfx::FloatPoint> for_each_glyph_position(Gfx::FloatPoint, ByteString const&, Renderer const&, Callback callback);
+
     RefPtr<Encoding> m_encoding;
     RefPtr<StreamObject> m_to_unicode;
     HashMap<u8, u16> m_widths;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -148,6 +148,16 @@ PDFErrorOr<void> TrueTypePainter::draw_glyph(Gfx::Painter& painter, Gfx::FloatPo
     return {};
 }
 
+PDFErrorOr<void> TrueTypePainter::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const&)
+{
+    auto glyph_id = TRY(resolve_glyph_id_for_char_code(char_code));
+    if (glyph_id.has_value()) {
+        path.move_to(point.translated(m_font->glyph_metrics(*glyph_id).left_side_bearing, -m_font->pixel_metrics().ascent));
+        m_font->append_glyph_path_to(path, *glyph_id);
+    }
+    return {};
+}
+
 Optional<float> TrueTypePainter::get_glyph_width(u8 char_code) const
 {
     // FIXME: Make this use the full char_code lookup method used in draw_glyph() once that's complete.
@@ -206,6 +216,11 @@ void TrueTypeFont::set_font_size(float font_size)
 PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const& renderer)
 {
     return m_font_painter->draw_glyph(painter, point, width, char_code, renderer);
+}
+
+PDFErrorOr<void> TrueTypeFont::append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer)
+{
+    return m_font_painter->append_glyph_path(path, point, char_code, renderer);
 }
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -20,6 +20,8 @@ public:
     Optional<float> get_glyph_width(u8 char_code) const;
     void set_font_size(float font_size);
 
+    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, u8 char_code, Renderer const&);
+
 private:
     TrueTypePainter(AK::NonnullRefPtr<Gfx::ScaledFont>, NonnullRefPtr<Encoding>, bool encoding_is_mac_roman_or_win_ansi, bool is_nonsymbolic, Optional<u8> high_byte, bool is_zapf_dingbats);
 
@@ -39,6 +41,8 @@ public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Renderer const&) override;
+
+    PDFErrorOr<void> append_glyph_path(Gfx::Path&, Gfx::FloatPoint point, u8 char_code, Renderer const&) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -23,6 +23,9 @@ public:
 private:
     TrueTypePainter(AK::NonnullRefPtr<Gfx::ScaledFont>, NonnullRefPtr<Encoding>, bool encoding_is_mac_roman_or_win_ansi, bool is_nonsymbolic, Optional<u8> high_byte, bool is_zapf_dingbats);
 
+    using GlyphID = Optional<u32>;
+    PDFErrorOr<GlyphID> resolve_glyph_id_for_char_code(u8 char_code);
+
     NonnullRefPtr<Gfx::ScaledFont> m_font;
     NonnullRefPtr<Encoding> m_encoding;
     bool m_encoding_is_mac_roman_or_win_ansi { false };

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -27,6 +27,13 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
+    virtual PDFErrorOr<void> append_glyph_path(Gfx::Path& path, Gfx::FloatPoint point, u8 char_code, Renderer const& renderer) override
+    {
+        if (!m_font_program)
+            return m_fallback_font_painter->append_glyph_path(path, point, char_code, renderer);
+        return Error { Error::Type::RenderingUnsupported, "append_glyph_path not implemented for font" };
+    }
+
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 
 protected:

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -451,15 +451,20 @@ void Renderer::stroke_current_path()
     }
 }
 
+static void do_fill_path(Gfx::AntiAliasingPainter& painter, Gfx::Path const& path, ColorOrStyle const& style, float paint_style_opacity = 1.0f, Gfx::WindingRule winding_rule = Gfx::WindingRule::Nonzero)
+{
+    if (auto* paint_style = style.get_pointer<NonnullRefPtr<Gfx::PaintStyle>>()) {
+        painter.fill_path(path, *paint_style, paint_style_opacity, winding_rule);
+    } else {
+        painter.fill_path(path, style.get<Color>(), winding_rule);
+    }
+}
+
 void Renderer::fill_current_path(Gfx::WindingRule winding_rule)
 {
     auto path_end = m_current_path.end();
     m_current_path.close_all_subpaths();
-    if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
-        anti_aliasing_painter().fill_path(m_current_path, state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), state().paint_alpha_constant, winding_rule);
-    } else {
-        anti_aliasing_painter().fill_path(m_current_path, state().paint_style.get<Color>(), winding_rule);
-    }
+    do_fill_path(anti_aliasing_painter(), m_current_path, state().paint_style, state().paint_alpha_constant, winding_rule);
     // .close_all_subpaths() only adds to the end of the path, so we can .trim() the path to remove any changes.
     m_current_path.trim(path_end);
 }
@@ -1375,7 +1380,28 @@ PDFErrorOr<void> Renderer::show_text(ByteString const& string)
         return Error::rendering_unsupported_error("Can't draw text because an invalid font was in use");
 
     auto start_position = Gfx::FloatPoint { 0.0f, 0.0f };
-    auto end_position = TRY(text_state().font->draw_string(painter(), start_position, string, *this));
+    auto end_position = start_position;
+
+    if (m_text_rendering_matrix.is_identity_or_translation_or_scale(Gfx::AffineTransform::AllowNegativeScaling::No)) {
+        // Fast path: Use cached bitmap glyphs.
+        end_position = TRY(text_state().font->draw_string(painter(), start_position, string, *this));
+    } else {
+        Gfx::Path text_path;
+        // Slow path: Create a Gfx::Path for the string, transform it, then draw it. This handles arbitrary transforms.
+        if (auto maybe_end = text_state().font->append_text_path(text_path, start_position, string, *this); !maybe_end.is_error()) {
+            end_position = maybe_end.release_value();
+            // FIXME: This is a bit janky, but the font is already scaled by `m_text_rendering_matrix.x_scale() / horizontal_scaling`,
+            // which is included in `m_text_rendering_matrix`. So, we must scale it by the reciprocal. Also, the y-axis is flipped.
+            text_path.transform(m_text_rendering_matrix.multiply(
+                Gfx::AffineTransform {}
+                    .set_scale(1 / m_text_rendering_matrix.x_scale() * text_state().horizontal_scaling,
+                        -1 / m_text_rendering_matrix.x_scale() * text_state().horizontal_scaling)));
+            do_fill_path(anti_aliasing_painter(), text_path, state().paint_style, state().paint_alpha_constant);
+        } else {
+            // Fallback to the fast path in case `append_path` is unimplemented.
+            end_position = TRY(text_state().font->draw_string(painter(), start_position, string, *this));
+        }
+    }
 
     // Update text matrix.
     auto delta = end_position - start_position;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -179,6 +179,15 @@ public:
 
     bool show_hidden_text() const { return m_rendering_preferences.show_hidden_text; }
 
+    static void fill_path_with_style(Gfx::AntiAliasingPainter& painter, Gfx::Path const& path, ColorOrStyle const& style, float paint_style_opacity = 1.0f, Gfx::WindingRule winding_rule = Gfx::WindingRule::Nonzero)
+    {
+        if (auto* paint_style = style.get_pointer<NonnullRefPtr<Gfx::PaintStyle>>()) {
+            painter.fill_path(path, *paint_style, paint_style_opacity, winding_rule);
+        } else {
+            painter.fill_path(path, style.get<Color>(), winding_rule);
+        }
+    }
+
 private:
     Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, Color background_color, RenderingPreferences);
 


### PR DESCRIPTION
See commits for details:

Progression `rotated.pdf`:
**Before**: 
<img width="659" height="467" alt="rotate.pdf_p1_before" src="https://github.com/user-attachments/assets/baf6d41e-fe67-4712-9fea-8dcb7a40787c" />
**After**: 
<img width="659" height="467" alt="rotate.pdf_p1_after" src="https://github.com/user-attachments/assets/ede2e1ce-83be-4be1-9a74-99dec683879c" />
