### PR TITLE
Reland "LibPDF: Add basic tiled, coloured pattern rendering"

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -177,8 +177,10 @@
     X(Overlay)                    \
     X(P)                          \
     X(Pages)                      \
+    X(PaintType)                  \
     X(Parent)                     \
     X(Pattern)                    \
+    X(PatternType)                \
     X(Perms)                      \
     X(Predictor)                  \
     X(Prev)                       \

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -156,6 +156,8 @@ struct RenderingPreferences {
 };
 
 class Renderer {
+    friend class PatternColorSpace;
+
 public:
     static PDFErrorsOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, Color background_color, RenderingPreferences preferences);
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -293,6 +293,8 @@ private:
     // Only used for m_rendering_preferences.show_clipping_paths.
     void show_clipping_paths();
     Vector<Gfx::Path> m_clip_paths_to_show_for_debugging;
+    // Used to offset the PaintStyle's origin when rendering a pattern.
+    RefPtr<Gfx::PaintStyle> m_original_paint_style;
 };
 
 }


### PR DESCRIPTION
While working on https://github.com/SerenityOS/serenity/pull/26292, I noticed that while fills/strokes can be `Gfx::PaintStyles` in LibPDF, currently they never are, which confused me.

It turns out that a few years ago, tiled patterns were implemented in PR https://github.com/SerenityOS/serenity/pull/22197, but were partially reverted due to crashes in https://github.com/SerenityOS/serenity/pull/22364, leaving around a partial implementation.

It appears the author was going to look into the crashes, but never got around to it. So, this patch resolves all the crashes on `0000.zip`, mainly by checking types and not assuming dictionary keys exist.

Summary of `./Meta/test_pdf.py ~/Downloads/0000`:

```
Stacks:
0 crashes (0.0%)
0 distinct crash stacks

7 failed to open (0.7%)
    /home/macdue/Downloads/0000/0000346.pdf
    /home/macdue/Downloads/0000/0000202.pdf
    /home/macdue/Downloads/0000/0000399.pdf
    /home/macdue/Downloads/0000/0000421.pdf
    /home/macdue/Downloads/0000/0000480.pdf
    /home/macdue/Downloads/0000/0000920.pdf
    /home/macdue/Downloads/0000/0000819.pdf

3 files with password (0.3%)

909 files without issues (90.9%)