### PR TITLE
LibGUI: Don't convert JSON numbers to strings in JsonArrayModel

### DIFF
--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -139,7 +139,7 @@ Variant JsonArrayModel::data(ModelIndex const& index, ModelRole role) const
         if (!data.has_value())
             return "";
         if (data->is_number())
-            return data->serialized<StringBuilder>();
+            return data->as_number();
         return data->as_string();
     }
 


### PR DESCRIPTION
This makes sorting the memory map entries by size in the process info window work properly. Previously, the memory region sizes were strings, so we sorted them in alphabetical order.

This likely regressed in 0388c828be.