### PR TITLE
AK: Remove unused and unintuitive Trait for char*

### DIFF
--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -75,13 +75,6 @@ struct Traits<T> : public DefaultTraits<T> {
     static constexpr bool is_trivially_serializable() { return Traits<UnderlyingType<T>>::is_trivially_serializable(); }
 };
 
-template<typename T>
-requires(Detail::IsPointerOfType<char, T>) struct Traits<T> : public DefaultTraits<T> {
-    static unsigned hash(T const value) { return string_hash(value, strlen(value)); }
-    static constexpr bool equals(T const a, T const b) { return strcmp(a, b); }
-    static constexpr bool is_trivial() { return true; }
-};
-
 }
 
 #if USING_AK_GLOBALLY


### PR DESCRIPTION
We don't use char* in containers, and the expectation would be a pointer compare instead of a string compare; so remove this specialisation entirely.

Fixes #26267.

(Also in ladybird: https://github.com/LadybirdBrowser/ladybird/pull/6531)

Checked for usage by:
```
diff --git a/AK/Traits.h b/AK/Traits.h
index 31053f6bcd2..2f608cff509 100644
--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -86,7 +86,7 @@ struct Traits<T> : public DefaultTraits<T> {
 template<typename T>
 requires(Detail::IsPointerOfType<char, T>) struct Traits<T> : public DefaultTraits<T> {
     static unsigned hash(T const value) { return string_hash(value, strlen(value)); }
-    static constexpr bool equals(T const a, T const b) { return strcmp(a, b); }
+    static constexpr bool equals(T const, T const) { static_assert(DependentFalse<T>, "No!!!"); return false; }
     static constexpr bool is_trivial() { return true; }
     // NOTE: Trivial types always have fast equality checks.
     static constexpr bool may_have_slow_equality_check() { return false; }
```