### PR TITLE
LibGfx/CCITT: Make the first EOL always be a valid color change

### DIFF
--- a/Tests/LibGfx/TestCCITT.cpp
+++ b/Tests/LibGfx/TestCCITT.cpp
@@ -93,3 +93,13 @@ TEST_CASE(round_trip_sunset)
     });
     test_roundtrip(encoded, 1024, 5);
 }
+
+TEST_CASE(round_trip_jbig2_crash)
+{
+    auto encoded = to_array<u8>({
+        // clang-format off
+        0x23, 0xe5, 0xf2, 0xf8, 0x25, 0x00, 0x10, 0x01
+        // clang-format on
+    });
+    test_roundtrip(encoded, 16, 1);
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/CCITTEncoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/CCITTEncoder.cpp
@@ -208,6 +208,7 @@ ErrorOr<void> Group4Encoder::encode(Stream& stream, Bitmap const& bitmap, Group4
     ReferenceLine last_line;
     // "White reference line."
     TRY(last_line.try_empend(ccitt_black, static_cast<u32>(bitmap.width())));
+    TRY(last_line.try_empend(ccitt_white, static_cast<u32>(bitmap.width())));
 
     for (u32 y = 0; y < static_cast<u32>(bitmap.height()); ++y) {
         auto current_line = TRY(get_reference_line(bitmap, y));


### PR DESCRIPTION
Fixes #26289.

This commit makes db4eb571 apply to the first line of the image.

The test case was generated by:
 - Using the reproducer from #26289.
 - Patching JBIG2Writer.cpp so it dumps the `Gfx::Bitmap` as a PNG before trying to call the CCITT encoder.
 - Encoding this new PNG as CCITT bytes with the patched CCITT encoder.

After this patch I guess that you could simply dump the CCITT bytes once they are encoded in JBIG2Writer.cpp.