### PR TITLE
Meta+CI: Check jbig2 json files

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -180,10 +180,12 @@ jobs:
         run: |
           set -e
           ./Meta/check-markdown.sh
+          ./Meta/check-jbig2-json.sh
           ./Meta/lint-gml-format.sh
           git ls-files '*.ipc' | xargs ./Meta/Lagom/Build/bin/IPCMagicLinter
         env:
           MARKDOWN_CHECK_BINARY: ./Meta/Lagom/Build/bin/markdown-check
           GML_FORMAT: ./Meta/Lagom/Build/bin/gml-format
+          JBIG2_FROM_JSON_BINARY: ./Meta/Lagom/Build/bin/jbig2-from-json
           ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'

--- a/Meta/check-jbig2-json.sh
+++ b/Meta/check-jbig2-json.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+trap 'git diff --exit-code' EXIT
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.."
+
+if [ -z "${JBIG2_FROM_JSON_BINARY:-}" ] ; then
+    if ! [ -d Build/lagom/ ] ; then
+        echo "Directory Build/lagom/ does not exist. Skipping JBIG2 json check."
+        exit 0
+    fi
+    if ! [ -r Build/lagom/bin/jbig2-from-json ] ; then
+        echo "Lagom executable jbig2-from-json was not built. Skipping JBIG2 json check."
+        echo "To enable this check, you may need to run './Meta/serenity.sh build lagom' first."
+        exit 0
+    fi
+    JBIG2_FROM_JSON_BINARY="Build/lagom/bin/jbig2-from-json"
+fi
+
+for f in Tests/LibGfx/test-inputs/jbig2/json/*.json; do
+  f_jb2=Tests/LibGfx/test-inputs/jbig2/$(basename "${f%.json}.jbig2")
+  "$JBIG2_FROM_JSON_BINARY" -o "$f_jb2" "$f"
+done

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -24,6 +24,7 @@ for cmd in \
         Meta/check-debug-flags.sh \
         Meta/check-emoji.py \
         Meta/check-idl-files.py \
+        Meta/check-jbig2-json.sh \
         Meta/check-markdown.sh \
         Meta/check-newlines-at-eof.py \
         Meta/check-png-sizes.sh \


### PR DESCRIPTION
This adds a check that makes sure that:

1. All json files below Tests/LibGfx/test-inputs/jbig2/json/ can be compiled by `jbig2-from-json`

2. The output of `jbig2-from-json` is identical to the corresponding jbig2 file in Tests/LibGfx/test-inputs/jbig2/

This makes sure we don't forget to update the checked-in jbig2 files (e.g. with Tests/LibGfx/test-inputs/jbig2/json/compile.sh) after changing json files, and that we don't forget to update the json files after updating jbig2-from-json.

The implementation follows what other lint steps that need lagom binaries do: There's a new check-jbig2-json.sh script that does nothing if the binary does not yet exist, and it's called from both lint-ci.sh and the GitHub actions lagom workflow. People who have built jbig2-from-json locally and run lint-ci.sh as a precommit hook will run the script that way, while the lint step on CI will skip this script and then run it later after lagom has been built.