### PR TITLE
LibGfx/JPEG: Add a deringing pass to the encoder

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.h
@@ -12,8 +12,14 @@
 namespace Gfx {
 
 struct JPEGEncoderOptions {
+    enum class UseDeringing : u8 {
+        Yes,
+        No,
+    };
+
     Optional<ReadonlyBytes> icc_data;
     u8 quality { 75 };
+    UseDeringing use_deringing { UseDeringing::Yes };
 };
 
 class JPEGWriter {


### PR DESCRIPTION
The idea is described here https://kornel.ski/deringing/. And allows reducing the noise around sharp white edges. This is visible when encoding an image like `buggie.png`. One nice aspect of the optimization is that it only affects macroblocks where it can help.

---

Before:
![buggie_master](https://github.com/user-attachments/assets/ff357e30-5c4c-49fa-97f5-37e3a9fa1a9b)

After:
![buggie](https://github.com/user-attachments/assets/c616cacb-974c-46bf-a078-0db5e8078724)

Diff:
<img width="64" height="138" alt="diff" src="https://github.com/user-attachments/assets/cb2b8339-b329-4ff5-9c66-e3a24d1941ee" />
