### PR TITLE
LibGfx/JPEG: Make JPEGWriter's `Mode` an enum class

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -17,7 +17,7 @@ namespace Gfx {
 
 namespace {
 
-enum Mode {
+enum class Mode {
     RGB,
     CMYK,
 };


### PR DESCRIPTION
This avoids name collisions with the `Gfx::CMYK` struct.