### PR TITLE
Ports: Configure bdwgc to not depend on libatomic_ops

### DIFF
--- a/Ports/bdwgc/package.sh
+++ b/Ports/bdwgc/package.sh
@@ -4,11 +4,10 @@ version='8.2.10'
 files=(
     "https://github.com/bdwgc/bdwgc/releases/download/v${version}/gc-${version}.tar.gz#832cf4f7cf676b59582ed3b1bbd90a8d0e0ddbc3b11cb3b2096c5177ce39cc47"
 )
-depends=(
-    'libatomic_ops'
-)
 workdir="gc-${version}"
 useconfigure='true'
 configopts=(
     '--enable-threads=posix'
+    # libatomic_ops is not needed when using a modern compiler, but the automatic detection does not work when cross-compiling.
+    '--with-libatomic_ops=none'
 )


### PR DESCRIPTION
As pointed out in https://github.com/SerenityOS/serenity/pull/26318#discussion_r2462680283.