### PR TITLE
Revert "LibGfx: Do not draw U+FFFD for unknown glyphs"

### DIFF
--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -234,9 +234,19 @@ DrawGlyphOrEmoji prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIter
         };
     }
 
+    // If that failed, but we have a text glyph fallback, draw that.
+    if (font_contains_glyph) {
+        return DrawGlyph {
+            .position = point,
+            .code_point = code_point,
+        };
+    }
+
+    // No suitable glyph found, draw a replacement character.
+    dbgln_if(EMOJI_DEBUG, "Failed to find a glyph or emoji for code_point {}", code_point);
     return DrawGlyph {
         .position = point,
-        .code_point = code_point,
+        .code_point = 0xFFFD,
     };
 }
 


### PR DESCRIPTION
This reverts commit 9ad28f3eefa27503b6b70c2a5fd6017064254bd5.

(As discussed in #26316).