### PR TITLE
AK: Make `Default` be the default formatting mode for Bytes

### DIFF
--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -397,6 +397,18 @@ TEST_CASE(vector_format)
     }
 }
 
+TEST_CASE(read_only_bytes_format)
+{
+    {
+        Vector<u8> v { 1, 2, 3, 4 };
+        EXPECT_EQ(ByteString::formatted("{}", v), "[ 1, 2, 3, 4 ]");
+    }
+    {
+        Vector<u8> v { 1, 2, 3, 4 };
+        EXPECT_EQ(ByteString::formatted("{:hex-dump}", v), "01020304");
+    }
+}
+
 TEST_CASE(format_wchar)
 {
     EXPECT_EQ(ByteString::formatted("{}", L'a'), "a");


### PR DESCRIPTION
There is no way to opt out of the HexDump formatting mode. So let's use the default `Span` formatter and allow the user to opt in the HexDump mode for `Span<u8>` aka `Bytes`.

This is mainly useful to print `Vector<u8>`, as the `Vector` formatter is implemented on top of the `Span` formatter.