### PR TITLE
LibGfx/JBIG2+jbig2-from-image: Do not log comment contents

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JBIG2Loader.h
@@ -14,10 +14,19 @@ namespace Gfx {
 
 struct JBIG2LoadingContext;
 
+struct JBIG2DecoderOptions {
+    enum class LogComments {
+        No,
+        Yes,
+    };
+    LogComments log_comments { LogComments::Yes };
+};
+
 class JBIG2ImageDecoderPlugin : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create_with_options(ReadonlyBytes, JBIG2DecoderOptions);
 
     virtual ~JBIG2ImageDecoderPlugin() override;
 
@@ -29,7 +38,7 @@ public:
     static ErrorOr<ByteBuffer> decode_embedded(Vector<ReadonlyBytes>);
 
 private:
-    JBIG2ImageDecoderPlugin();
+    JBIG2ImageDecoderPlugin(JBIG2DecoderOptions);
 
     OwnPtr<JBIG2LoadingContext> m_context;
 };

--- a/Userland/Utilities/jbig2-from-json.cpp
+++ b/Userland/Utilities/jbig2-from-json.cpp
@@ -2271,7 +2271,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto jbig2_data = TRY(stream.read_until_eof());
 
     // Only write images that decode correctly.
-    TRY(TRY(Gfx::JBIG2ImageDecoderPlugin::create(jbig2_data))->frame(0));
+    Gfx::JBIG2DecoderOptions decoder_options;
+    decoder_options.log_comments = Gfx::JBIG2DecoderOptions::LogComments::No;
+    TRY(TRY(Gfx::JBIG2ImageDecoderPlugin::create_with_options(jbig2_data, decoder_options))->frame(0));
 
     auto output_stream = TRY(Core::File::open(out_path, Core::File::OpenMode::Write));
     auto buffered_output = TRY(Core::OutputBufferedFile::create(move(output_stream)));


### PR DESCRIPTION
Introduce JBIG2DecoderOptions with a toggle to turn off logging of comments in extension segments, and turn it off for jbig2-from-image. (`image` will still log comments from extension segments.)

This makes the output of Meta/check-jbig2-json.sh less noisy.