### PR TITLE
LibGfx/JPEGXL: Make the decoding steps independent of the TOC structure

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2769,7 +2769,8 @@ static ErrorOr<Frame> read_frame(LittleEndianInputBitStream& stream,
         if (frame.num_groups == 1 && frame.frame_header.passes.num_passes == 1)
             return MaybeOwned(stream);
         auto section_size = frame.toc.entries[section_index];
-        VERIFY(stream.align_to_byte_boundary() == 0);
+        if (stream.align_to_byte_boundary() != 0)
+            return Error::from_string_literal("JPEGXLLoader: Padding bits between sections must all be zeros");
         auto constrained_stream = make<AutoDepletingConstrainedStream>(MaybeOwned<Stream>(stream), section_size);
         return TRY(try_make<LittleEndianInputBitStream>(move(constrained_stream)));
     };


### PR DESCRIPTION
That's something that bugged me for a while as I always had to modify the two versions when I'm working on this decoder. After loosing time chasing a bug that was due to us silently skipping the HFGlobal section in the "single TOC entry" mode, I decided that it was time for me to put it to a stop.

So this commit is a NFC for files with multiple TOC entries, and we now actually fail on HFGlobal for single entry files.