### PR TITLE
Kernel+LibC+Profiler: Replace readv syscall with preadv

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -145,8 +145,8 @@ enum class NeedsBigProcessLock {
     S(purge, NeedsBigProcessLock::Yes)                     \
     S(read, NeedsBigProcessLock::Yes)                      \
     S(pread, NeedsBigProcessLock::Yes)                     \
+    S(preadv, NeedsBigProcessLock::Yes)                    \
     S(readlink, NeedsBigProcessLock::No)                   \
-    S(readv, NeedsBigProcessLock::Yes)                     \
     S(realpath, NeedsBigProcessLock::No)                   \
     S(recvfd, NeedsBigProcessLock::No)                     \
     S(recvmsg, NeedsBigProcessLock::Yes)                   \

--- a/Kernel/Tasks/PerformanceEventBuffer.cpp
+++ b/Kernel/Tasks/PerformanceEventBuffer.cpp
@@ -319,11 +319,12 @@ ErrorOr<void> PerformanceEventBuffer::to_json_impl(Serializer& object) const
                 TRY(event_object.add("filename_index"sv, close.filename_index));
                 break;
             }
-            case FilesystemEventType::Readv: {
-                auto const& readv = event.data.filesystem.data.readv;
-                TRY(event_object.add("fs_event_type"sv, "readv"sv));
-                TRY(event_object.add("fd"sv, readv.fd));
-                TRY(event_object.add("filename_index"sv, readv.filename_index));
+            case FilesystemEventType::Preadv: {
+                auto const& preadv = event.data.filesystem.data.preadv;
+                TRY(event_object.add("fs_event_type"sv, "preadv"sv));
+                TRY(event_object.add("fd"sv, preadv.fd));
+                TRY(event_object.add("filename_index"sv, preadv.filename_index));
+                TRY(event_object.add("offset"sv, preadv.offset));
                 break;
             }
             case FilesystemEventType::Read: {

--- a/Kernel/Tasks/PerformanceEventBuffer.h
+++ b/Kernel/Tasks/PerformanceEventBuffer.h
@@ -80,7 +80,7 @@ struct [[gnu::packed]] ReadPerformanceEvent {
 enum class FilesystemEventType : u8 {
     Open,
     Close,
-    Readv,
+    Preadv,
     Read,
     Pread
 };
@@ -97,11 +97,12 @@ struct [[gnu::packed]] CloseEventData {
     size_t filename_index;
 };
 
-struct [[gnu::packed]] ReadvEventData {
+struct [[gnu::packed]] PreadvEventData {
     int fd;
     size_t filename_index;
     // struct iovec* iov; // TODO: Implement
     // int iov_count; // TODO: Implement
+    off_t offset;
 };
 
 struct [[gnu::packed]] ReadEventData {
@@ -131,7 +132,7 @@ struct [[gnu::packed]] FilesystemEvent {
     union {
         OpenEventData open;
         CloseEventData close;
-        ReadvEventData readv;
+        PreadvEventData preadv;
         ReadEventData read;
         PreadEventData pread;
     } data;

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -376,7 +376,7 @@ public:
     ErrorOr<FlatPtr> sys$close(int fd);
     ErrorOr<FlatPtr> sys$read(int fd, Userspace<u8*>, size_t);
     ErrorOr<FlatPtr> sys$pread(int fd, Userspace<u8*>, size_t, off_t);
-    ErrorOr<FlatPtr> sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count);
+    ErrorOr<FlatPtr> sys$preadv(int fd, Userspace<const struct iovec*> iov, int iov_count, off_t);
     ErrorOr<FlatPtr> sys$write(int fd, Userspace<u8 const*>, size_t);
     ErrorOr<FlatPtr> sys$pwritev(int fd, Userspace<const struct iovec*> iov, int iov_count, off_t);
     ErrorOr<FlatPtr> sys$fstat(int fd, Userspace<stat*>);
@@ -747,7 +747,7 @@ private:
     ErrorOr<FlatPtr> close_impl(int fd);
     ErrorOr<FlatPtr> read_impl(int fd, Userspace<u8*> buffer, size_t size);
     ErrorOr<FlatPtr> pread_impl(int fd, Userspace<u8*>, size_t, off_t);
-    ErrorOr<FlatPtr> readv_impl(int fd, Userspace<const struct iovec*> iov, int iov_count);
+    ErrorOr<FlatPtr> preadv_impl(int fd, Userspace<const struct iovec*> iov, int iov_count, off_t);
 
 public:
     ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)> callback) const;

--- a/Tests/Kernel/fuzz-syscalls.cpp
+++ b/Tests/Kernel/fuzz-syscalls.cpp
@@ -40,7 +40,7 @@ static bool is_bad_idea(int fn, size_t const* direct_sc_args, size_t const* fake
         // This would mess with future tests or crash the fuzzer.
         return direct_sc_args[0] == (size_t)fake_sc_params || direct_sc_args[0] == (size_t)some_string;
     case SC_read:
-    case SC_readv:
+    case SC_preadv:
         // FIXME: Known bug: https://github.com/SerenityOS/serenity/issues/5328
         return direct_sc_args[0] == 1;
     case SC_write:

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -419,6 +419,31 @@ TEST_CASE(rmdir_while_inside_dir)
     VERIFY(rc == 0);
 }
 
+TEST_CASE(readv)
+{
+    int pipefds[2];
+    int rc = pipe(pipefds);
+    EXPECT(rc == 0);
+
+    int nwritten = write(pipefds[1], "HelloFriends", 12);
+    EXPECT_EQ(nwritten, 12);
+
+    char buffer0[6] {};
+    char buffer1[8] {};
+    iovec iov[2];
+    iov[0].iov_base = buffer0;
+    iov[0].iov_len = sizeof(buffer0) - 1;
+    iov[1].iov_base = buffer1;
+    iov[1].iov_len = sizeof(buffer1) - 1;
+    int nread = readv(pipefds[0], iov, 2);
+    EXPECT_EQ(nread, 12);
+    EXPECT_EQ(buffer0, "Hello"sv);
+    EXPECT_EQ(buffer1, "Friends"sv);
+
+    close(pipefds[0]);
+    close(pipefds[1]);
+}
+
 TEST_CASE(writev)
 {
     int pipefds[2];

--- a/Userland/DevTools/Profiler/FilesystemEventModel.cpp
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.cpp
@@ -168,10 +168,10 @@ ErrorOr<String> FileEventModel::column_name(int column) const
         return "Close Count"_string;
     case Column::CloseDuration:
         return "Close Duration [ms]"_string;
-    case Column::ReadvCount:
-        return "Readv Count"_string;
-    case Column::ReadvDuration:
-        return "Readv Duration [ms]"_string;
+    case Column::PreadvCount:
+        return "Preadv Count"_string;
+    case Column::PreadvDuration:
+        return "Preadv Duration [ms]"_string;
     case Column::ReadCount:
         return "Read Count"_string;
     case Column::ReadDuration:
@@ -211,10 +211,10 @@ GUI::Variant FileEventModel::data(GUI::ModelIndex const& index, GUI::ModelRole r
             return node->close().count;
         case Column::CloseDuration:
             return static_cast<f32>(node->close().duration.to_nanoseconds()) / 1'000'000;
-        case Column::ReadvCount:
-            return node->readv().count;
-        case Column::ReadvDuration:
-            return static_cast<f32>(node->readv().duration.to_nanoseconds()) / 1'000'000;
+        case Column::PreadvCount:
+            return node->preadv().count;
+        case Column::PreadvDuration:
+            return static_cast<f32>(node->preadv().duration.to_nanoseconds()) / 1'000'000;
         case Column::ReadCount:
             return node->read().count;
         case Column::ReadDuration:

--- a/Userland/DevTools/Profiler/FilesystemEventModel.h
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.h
@@ -46,7 +46,7 @@ public:
 
     FileEventType& open() { return m_open; }
     FileEventType& close() { return m_close; }
-    FileEventType& readv() { return m_readv; }
+    FileEventType& preadv() { return m_readv; }
     FileEventType& read() { return m_read; }
     FileEventType& pread() { return m_pread; }
 
@@ -84,8 +84,8 @@ public:
         OpenDuration,
         CloseCount,
         CloseDuration,
-        ReadvCount,
-        ReadvDuration,
+        PreadvCount,
+        PreadvDuration,
         ReadCount,
         ReadDuration,
         PreadCount,

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -216,7 +216,7 @@ void Profile::rebuild_tree()
                 [&](Event::CloseEventData const& data) {
                     return data.path;
                 },
-                [&](Event::ReadvEventData const& data) {
+                [&](Event::PreadvEventData const& data) {
                     return data.path;
                 },
                 [&](Event::ReadEventData const& data) {
@@ -240,9 +240,9 @@ void Profile::rebuild_tree()
                         node.close().duration += duration;
                         node.close().count++;
                     },
-                    [&](Event::ReadvEventData const&) {
-                        node.readv().duration += duration;
-                        node.readv().count++;
+                    [&](Event::PreadvEventData const&) {
+                        node.preadv().duration += duration;
+                        node.preadv().count++;
                     },
                     [&](Event::ReadEventData const&) {
                         node.read().duration += duration;
@@ -440,12 +440,13 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
                     .fd = perf_event.get_integer<int>("fd"sv).value_or(0),
                     .path = filename,
                 };
-            } else if (filesystem_event_type == "readv"sv) {
+            } else if (filesystem_event_type == "preadv"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);
                 auto const filename = profile_strings.get(string_index).value();
-                fsdata.data = Event::ReadvEventData {
+                fsdata.data = Event::PreadvEventData {
                     .fd = perf_event.get_integer<int>("fd"sv).value_or(0),
                     .path = filename,
+                    .offset = perf_event.get_integer<off_t>("offset"sv).value_or(0),
                 };
             } else if (filesystem_event_type == "read"sv) {
                 auto const string_index = perf_event.get_addr("filename_index"sv).value_or(0);

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -237,11 +237,12 @@ public:
             ByteString path;
         };
 
-        struct ReadvEventData {
+        struct PreadvEventData {
             int fd;
             ByteString path;
             // struct iovec* iov; // TODO: Implement
             // int iov_count; // TODO: Implement
+            off_t offset;
         };
 
         struct ReadEventData {
@@ -259,7 +260,7 @@ public:
 
         struct FilesystemEventData {
             Duration duration;
-            Variant<OpenEventData, CloseEventData, ReadvEventData, ReadEventData, PreadEventData> data;
+            Variant<OpenEventData, CloseEventData, PreadvEventData, ReadEventData, PreadEventData> data;
         };
 
         Variant<nullptr_t, SampleData, MallocData, FreeData, SignpostData, MmapData, MunmapData, ProcessCreateData, ProcessExecData, ThreadCreateData, FilesystemEventData> data { nullptr };

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -99,7 +99,7 @@ GUI::Variant SamplesModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
                     [&](Profile::Event::CloseEventData const& data) {
                         return data.path;
                     },
-                    [&](Profile::Event::ReadvEventData const& data) {
+                    [&](Profile::Event::PreadvEventData const& data) {
                         return data.path;
                     },
                     [&](Profile::Event::ReadEventData const& data) {

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -268,7 +268,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     filesystem_events_tree_view.set_model(profile->file_event_model());
     filesystem_events_tree_view.set_column_visible(FileEventModel::Column::OpenDuration, false);
     filesystem_events_tree_view.set_column_visible(FileEventModel::Column::CloseDuration, false);
-    filesystem_events_tree_view.set_column_visible(FileEventModel::Column::ReadvDuration, false);
+    filesystem_events_tree_view.set_column_visible(FileEventModel::Column::PreadvDuration, false);
     filesystem_events_tree_view.set_column_visible(FileEventModel::Column::ReadDuration, false);
     filesystem_events_tree_view.set_column_visible(FileEventModel::Column::PreadDuration, false);
 

--- a/Userland/Libraries/LibC/sys/uio.cpp
+++ b/Userland/Libraries/LibC/sys/uio.cpp
@@ -11,17 +11,22 @@
 
 extern "C" {
 
-ssize_t writev(int fd, const struct iovec* iov, int iov_count)
+ssize_t readv(int fd, const struct iovec* iov, int iov_count)
 {
-    return pwritev(fd, iov, iov_count, -1);
+    return preadv(fd, iov, iov_count, -1);
 }
 
-ssize_t readv(int fd, const struct iovec* iov, int iov_count)
+ssize_t preadv(int fd, const struct iovec* iov, int iov_count, off_t offset)
 {
     __pthread_maybe_cancel();
 
-    int rc = syscall(SC_readv, fd, iov, iov_count);
+    int rc = syscall(SC_preadv, fd, iov, iov_count, offset);
     __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+ssize_t writev(int fd, const struct iovec* iov, int iov_count)
+{
+    return pwritev(fd, iov, iov_count, -1);
 }
 
 ssize_t pwritev(int fd, struct iovec const* iov, int iov_count, off_t offset)

--- a/Userland/Libraries/LibC/sys/uio.h
+++ b/Userland/Libraries/LibC/sys/uio.h
@@ -11,8 +11,9 @@
 
 __BEGIN_DECLS
 
-ssize_t writev(int fd, const struct iovec*, int iov_count);
 ssize_t readv(int fd, const struct iovec*, int iov_count);
+ssize_t preadv(int fd, const struct iovec*, int iov_count, off_t);
+ssize_t writev(int fd, const struct iovec*, int iov_count);
 ssize_t pwritev(int fd, const struct iovec*, int iov_count, off_t);
 
 __END_DECLS


### PR DESCRIPTION
Tested using the added `readv` test and this snippet thrown into `Userland/Utilities/`:

```cpp
#include <LibMain/Main.h>
#include <fcntl.h>
#include <stdio.h>
#include <sys/uio.h>

ErrorOr<int> serenity_main(Main::Arguments)
{
    // write file
    FILE* file = fopen("example.txt", "a");
    fprintf(file, "Hello, World!");
    fclose(file);

    // preadv test
    int fd = open("example.txt", O_RDONLY);
    iovec iov[2];
    char buffer1[6] {};
    char buffer2[5] {};
    iov[0].iov_base = buffer1;
    iov[0].iov_len = sizeof(buffer1) - 1;
    iov[1].iov_base = buffer2;
    iov[1].iov_len = sizeof(buffer2) - 1;
    ssize_t nread = preadv(fd, iov, 2, 4);
    printf("Read %zd bytes\n", nread);
    printf("Buffer 1: %s\n", buffer1);
    printf("Buffer 2: %s\n", buffer2);
    return 0;
}
```