### PR TITLE
LibGfx/JPEGXL: Force users of EntropyDecoder to ensure the end state

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXL/EntropyDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXL/EntropyDecoder.h
@@ -55,7 +55,7 @@ class EntropyDecoder {
 
 public:
     EntropyDecoder() = default;
-    ~EntropyDecoder() = default;
+    ~EntropyDecoder() { VERIFY(!m_state.has_value()); }
 
     static ErrorOr<EntropyDecoder> create(LittleEndianInputBitStream& stream, u32 initial_num_distrib);
 


### PR DESCRIPTION
This makes the program crash if the developer forgets to call ensure_end_state().

---

I had that a long time ago, and @nico also suggested something similar [here](https://github.com/SerenityOS/serenity/pull/25838#discussion_r2013269220).

It seems fine to use now, I suppose that the decoder is now mature enough to have this check without turning it into a red herring.