### PR TITLE
Kernel/LibC: Implement rfork()

### DIFF
--- a/Kernel/API/POSIX/unistd.h
+++ b/Kernel/API/POSIX/unistd.h
@@ -33,6 +33,11 @@ extern "C" {
 #define MS_SRCHIDDEN (1 << 9)
 #define MS_IMMUTABLE (1 << 10)
 
+#define RFFDG (1u << 2)
+#define RFPROC (1u << 4)
+#define RFNOWAIT (1u << 7)
+#define RFCFDG (1u << 12)
+
 enum {
     _SC_MONOTONIC_CLOCK,
     _SC_NPROCESSORS_CONF,

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -78,6 +78,7 @@ enum class NeedsBigProcessLock {
     S(fchown, NeedsBigProcessLock::No)                     \
     S(fcntl, NeedsBigProcessLock::No)                      \
     S(fork, NeedsBigProcessLock::No)                       \
+    S(rfork, NeedsBigProcessLock::No)                      \
     S(fstat, NeedsBigProcessLock::No)                      \
     S(fstatvfs, NeedsBigProcessLock::No)                   \
     S(fsopen, NeedsBigProcessLock::No)                     \

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -315,6 +315,7 @@ set(KERNEL_SOURCES
     Syscalls/fallocate.cpp
     Syscalls/fcntl.cpp
     Syscalls/fork.cpp
+    Syscalls/rfork.cpp
     Syscalls/fsync.cpp
     Syscalls/ftruncate.cpp
     Syscalls/futex.cpp
@@ -387,6 +388,7 @@ set(KERNEL_SOURCES
     Tasks/PerformanceEventBuffer.cpp
     Tasks/PowerStateSwitchTask.cpp
     Tasks/Process.cpp
+    Tasks/ProcessFork.cpp
     Tasks/ProcessGroup.cpp
     Tasks/ScopedProcessList.cpp
     Tasks/Scheduler.cpp

--- a/Kernel/FileSystem/ProcFS/ProcessExposed.cpp
+++ b/Kernel/FileSystem/ProcFS/ProcessExposed.cpp
@@ -178,7 +178,7 @@ ErrorOr<NonnullRefPtr<Inode>> Process::lookup_file_descriptions_directory(ProcFS
     if (!maybe_index.has_value())
         return ENOENT;
 
-    if (!m_fds.with_shared([&](auto& fds) { return fds.get_if_valid(*maybe_index); }))
+    if (!fds().with_shared([&](auto& fds) { return fds.get_if_valid(*maybe_index); }))
         return ENOENT;
 
     // NOTE: All property numbers should start from 1 as 0 is reserved for the directory itself.

--- a/Kernel/Syscalls/SyscallHandler.cpp
+++ b/Kernel/Syscalls/SyscallHandler.cpp
@@ -87,7 +87,7 @@ ErrorOr<FlatPtr> handle(RegisterState& regs, FlatPtr function, FlatPtr arg1, Fla
     }
 
     ErrorOr<FlatPtr> result { FlatPtr(nullptr) };
-    if (function == SC_fork || function == SC_sigreturn) {
+    if (function == SC_fork || function == SC_rfork || function == SC_sigreturn) {
         // These syscalls want the RegisterState& rather than individual parameters.
         auto handler = bit_cast<HandlerWithRegisterState>(syscall_metadata.handler);
         result = (process.*(handler))(regs);

--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -36,7 +36,7 @@ ErrorOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     if (options & O_CLOEXEC)
         fd_flags |= FD_CLOEXEC;
 
-    return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
+    return fds().with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
         auto new_fd = TRY(fds.allocate());
         fds[new_fd.fd].set(description, fd_flags);
         return new_fd.fd;

--- a/Kernel/Syscalls/dup2.cpp
+++ b/Kernel/Syscalls/dup2.cpp
@@ -13,7 +13,7 @@ ErrorOr<FlatPtr> Process::sys$dup2(int old_fd, int new_fd)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
-    return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
+    return fds().with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
         auto description = TRY(fds.open_file_description(old_fd));
         if (old_fd == new_fd)
             return new_fd;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -574,7 +574,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
 
     clear_futex_queues_on_exec();
 
-    m_fds.with_exclusive([&](auto& fds) {
+    fds().with_exclusive([&](auto& fds) {
         fds.change_each([&](auto& file_description_metadata) {
             if (file_description_metadata.is_valid() && file_description_metadata.flags() & FD_CLOEXEC)
                 file_description_metadata = {};
@@ -583,7 +583,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
 
     if (main_program_fd_allocation.has_value()) {
         main_program_description->set_readable(true);
-        m_fds.with_exclusive([&](auto& fds) { fds[main_program_fd_allocation->fd].set(move(main_program_description), FD_CLOEXEC); });
+        fds().with_exclusive([&](auto& fds) { fds[main_program_fd_allocation->fd].set(move(main_program_description), FD_CLOEXEC); });
     }
 
     new_main_thread = nullptr;

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -24,16 +24,16 @@ ErrorOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, uintptr_t arg)
         int arg_fd = (int)arg;
         if (arg_fd < 0)
             return EINVAL;
-        return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
+        return fds().with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
             auto fd_allocation = TRY(fds.allocate(arg_fd));
             fds[fd_allocation.fd].set(*description, (cmd == F_DUPFD_CLOEXEC) ? FD_CLOEXEC : 0);
             return fd_allocation.fd;
         });
     }
     case F_GETFD:
-        return m_fds.with_exclusive([fd](auto& fds) { return fds[fd].flags(); });
+        return fds().with_exclusive([fd](auto& fds) { return fds[fd].flags(); });
     case F_SETFD:
-        m_fds.with_exclusive([fd, arg](auto& fds) { fds[fd].set_flags(arg); });
+        fds().with_exclusive([fd, arg](auto& fds) { fds[fd].set_flags(arg); });
         break;
     case F_GETFL:
         return description->file_flags();

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -1,18 +1,14 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2023, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2025, Kusekushi <0kusekushi0@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Debug.h>
-#include <Kernel/Devices/TTY/TTY.h>
-#include <Kernel/FileSystem/Custody.h>
-#include <Kernel/Memory/Region.h>
-#include <Kernel/Tasks/PerformanceManager.h>
+#include <AK/Types.h>
+#include <Kernel/API/POSIX/unistd.h>
 #include <Kernel/Tasks/Process.h>
-#include <Kernel/Tasks/Scheduler.h>
-#include <Kernel/Tasks/ScopedProcessList.h>
 
 namespace Kernel {
 
@@ -21,152 +17,6 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::proc));
 
-    auto credentials = this->credentials();
-    auto child_and_first_thread = TRY(Process::create_with_forked_name(credentials->uid(), credentials->gid(), pid(), m_is_kernel_process, vfs_root_context(), hostname_context(), current_directory(), executable(), tty(), this));
-    auto& child = child_and_first_thread.process;
-    auto& child_first_thread = child_and_first_thread.first_thread;
-
-    ArmedScopeGuard thread_finalizer_guard = [&child_first_thread]() {
-        SpinlockLocker lock(g_scheduler_lock);
-        child_first_thread->detach();
-        child_first_thread->set_state(Thread::State::Dying);
-    };
-
-    TRY(m_unveil_data.with([&](auto& parent_unveil_data) -> ErrorOr<void> {
-        return child->m_unveil_data.with([&](auto& child_unveil_data) -> ErrorOr<void> {
-            child_unveil_data.state = parent_unveil_data.state;
-            child_unveil_data.paths = TRY(parent_unveil_data.paths.deep_copy());
-            return {};
-        });
-    }));
-
-    TRY(m_exec_unveil_data.with([&](auto& parent_exec_unveil_data) -> ErrorOr<void> {
-        return child->m_exec_unveil_data.with([&](auto& child_exec_unveil_data) -> ErrorOr<void> {
-            child_exec_unveil_data.state = parent_exec_unveil_data.state;
-            child_exec_unveil_data.paths = TRY(parent_exec_unveil_data.paths.deep_copy());
-            return {};
-        });
-    }));
-
-    TRY(child->m_fds.with_exclusive([&](auto& child_fds) {
-        return m_fds.with_exclusive([&](auto& parent_fds) {
-            return child_fds.try_clone(parent_fds);
-        });
-    }));
-
-    with_protected_data([&](auto& my_protected_data) {
-        child->with_mutable_protected_data([&](auto& child_protected_data) {
-            child_protected_data.promises = my_protected_data.promises;
-            child_protected_data.execpromises = my_protected_data.execpromises;
-            child_protected_data.has_promises = my_protected_data.has_promises;
-            child_protected_data.has_execpromises = my_protected_data.has_execpromises;
-            child_protected_data.credentials = my_protected_data.credentials;
-            child_protected_data.umask = my_protected_data.umask;
-            child_protected_data.signal_trampoline = my_protected_data.signal_trampoline;
-            child_protected_data.dumpable = my_protected_data.dumpable;
-            child_protected_data.process_group = my_protected_data.process_group;
-            // NOTE: Propagate jailed_until_exit property to child processes.
-            // The jailed_until_exec property is also propagated, but will be
-            // set to false once the child process is calling the execve syscall.
-            if (my_protected_data.jailed_until_exit.was_set())
-                child_protected_data.jailed_until_exit.set();
-            child_protected_data.jailed_until_exec = my_protected_data.jailed_until_exec;
-        });
-    });
-
-    dbgln_if(FORK_DEBUG, "fork: child={}", child);
-
-    // A child created via fork(2) inherits a copy of its parent's signal mask
-    child_first_thread->update_signal_mask(Thread::current()->signal_mask());
-
-    // A child process created via fork(2) inherits a copy of its parent's alternate signal stack settings.
-    child_first_thread->m_alternative_signal_stack = Thread::current()->m_alternative_signal_stack;
-
-    auto& child_regs = child_first_thread->m_regs;
-#if ARCH(X86_64)
-    child_regs.rax = 0; // fork() returns 0 in the child :^)
-    child_regs.rbx = regs.rbx;
-    child_regs.rcx = regs.rcx;
-    child_regs.rdx = regs.rdx;
-    child_regs.rbp = regs.rbp;
-    child_regs.rsp = regs.userspace_rsp;
-    child_regs.rsi = regs.rsi;
-    child_regs.rdi = regs.rdi;
-    child_regs.r8 = regs.r8;
-    child_regs.r9 = regs.r9;
-    child_regs.r10 = regs.r10;
-    child_regs.r11 = regs.r11;
-    child_regs.r12 = regs.r12;
-    child_regs.r13 = regs.r13;
-    child_regs.r14 = regs.r14;
-    child_regs.r15 = regs.r15;
-    child_regs.rflags = regs.rflags;
-    child_regs.rip = regs.rip;
-    child_regs.cs = regs.cs;
-
-    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:p}, kstack {:p}",
-        child_regs.cs, child_regs.rip, child_regs.rsp, child_regs.rsp0);
-#elif ARCH(AARCH64)
-    child_regs.x[0] = 0; // fork() returns 0 in the child :^)
-    for (size_t i = 1; i < array_size(child_regs.x); ++i)
-        child_regs.x[i] = regs.x[i];
-    child_regs.spsr_el1 = regs.spsr_el1;
-    child_regs.elr_el1 = regs.elr_el1;
-    child_regs.sp_el0 = regs.sp_el0;
-    child_regs.tpidr_el0 = regs.tpidr_el0;
-#elif ARCH(RISCV64)
-    for (size_t i = 0; i < array_size(child_regs.x); ++i)
-        child_regs.x[i] = regs.x[i];
-    child_regs.x[9] = 0; // fork() returns 0 in the child :^)
-    child_regs.sstatus = regs.sstatus;
-    child_regs.pc = regs.sepc;
-    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:p} with stack {:p}, kstack {:p}",
-        child_regs.pc, child_regs.sp(), child_regs.kernel_sp);
-#else
-#    error Unknown architecture
-#endif
-
-    Processor::store_fpu_state(child_first_thread->fpu_state());
-
-    TRY(address_space().with([&](auto& parent_space) {
-        return child->address_space().with([&](auto& child_space) -> ErrorOr<void> {
-            if (parent_space->enforces_syscall_regions())
-                child_space->set_enforces_syscall_regions();
-            for (auto& region : parent_space->region_tree().regions()) {
-                dbgln_if(FORK_DEBUG, "fork: cloning Region '{}' @ {}", region.name(), region.vaddr());
-                auto region_clone = TRY(region.try_clone());
-                TRY(region_clone->map(child_space->page_directory(), Memory::ShouldFlushTLB::No));
-                TRY(child_space->region_tree().place_specifically(*region_clone, region.range()));
-                (void)region_clone.leak_ptr();
-            }
-            return {};
-        });
-    }));
-
-    thread_finalizer_guard.disarm();
-
-    m_scoped_process_list.with([&](auto& list_ptr) {
-        if (list_ptr) {
-            child->m_scoped_process_list.with([&](auto& child_list_ptr) {
-                child_list_ptr = list_ptr;
-            });
-            list_ptr->attach(*child);
-        }
-    });
-
-    Process::register_new(*child);
-
-    // NOTE: All user processes have a leaked ref on them. It's balanced by Thread::WaitBlockerSet::finalize().
-    child->ref();
-
-    PerformanceManager::add_process_created_event(*child);
-
-    SpinlockLocker lock(g_scheduler_lock);
-    child_first_thread->set_affinity(Thread::current()->affinity());
-    child_first_thread->set_state(Thread::State::Runnable);
-
-    auto child_pid = child->pid().value();
-
-    return child_pid;
+    return do_fork_common(regs, RFPROC | RFFDG);
 }
 }

--- a/Kernel/Syscalls/inode_watcher.cpp
+++ b/Kernel/Syscalls/inode_watcher.cpp
@@ -26,7 +26,7 @@ ErrorOr<FlatPtr> Process::sys$create_inode_watcher(u32 flags)
     if (flags & static_cast<unsigned>(InodeWatcherFlags::Nonblock))
         description->set_blocking(false);
 
-    return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
+    return fds().with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
         auto fd_allocation = TRY(fds.allocate());
         fds[fd_allocation.fd].set(move(description));
 

--- a/Kernel/Syscalls/ioctl.cpp
+++ b/Kernel/Syscalls/ioctl.cpp
@@ -20,13 +20,13 @@ ErrorOr<FlatPtr> Process::sys$ioctl(int fd, unsigned request, FlatPtr arg)
         return 0;
     }
     if (request == FIOCLEX) {
-        m_fds.with_exclusive([&](auto& fds) {
+        fds().with_exclusive([&](auto& fds) {
             fds[fd].set_flags(fds[fd].flags() | FD_CLOEXEC);
         });
         return 0;
     }
     if (request == FIONCLEX) {
-        m_fds.with_exclusive([&](auto& fds) {
+        fds().with_exclusive([&](auto& fds) {
             fds[fd].set_flags(fds[fd].flags() & ~FD_CLOEXEC);
         });
         return 0;

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -62,7 +62,7 @@ ErrorOr<FlatPtr> Process::sys$fsopen(Userspace<Syscall::SC_fsopen_params const*>
     VERIFY(fs_type_initializer);
     auto mount_file = TRY(MountFile::create(*fs_type_initializer, params.flags));
     auto description = TRY(OpenFileDescription::try_create(move(mount_file)));
-    return m_fds.with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
+    return fds().with_exclusive([&](auto& fds) -> ErrorOr<FlatPtr> {
         auto new_fd = TRY(fds.allocate());
         fds[new_fd.fd].set(move(description), FD_CLOEXEC);
         return new_fd.fd;

--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -32,7 +32,7 @@ ErrorOr<FlatPtr> Process::sys$pipe(Userspace<int*> pipefd, int flags)
         writer_description->set_blocking(false);
     }
 
-    TRY(m_fds.with_exclusive([&](auto& fds) -> ErrorOr<void> {
+    TRY(fds().with_exclusive([&](auto& fds) -> ErrorOr<void> {
         auto reader_fd_allocation = TRY(fds.allocate());
         auto writer_fd_allocation = TRY(fds.allocate());
 

--- a/Kernel/Syscalls/poll.cpp
+++ b/Kernel/Syscalls/poll.cpp
@@ -48,7 +48,7 @@ ErrorOr<FlatPtr> Process::sys$poll(Userspace<Syscall::SC_poll_params const*> use
     Thread::SelectBlocker::FDVector fds_info;
     TRY(fds_info.try_ensure_capacity(params.nfds));
 
-    TRY(m_fds.with_shared([&](auto& fds) -> ErrorOr<void> {
+    TRY(fds().with_shared([&](auto& fds) -> ErrorOr<void> {
         for (size_t i = 0; i < params.nfds; i++) {
             auto& pfd = fds_copy[i];
             RefPtr<OpenFileDescription> description;

--- a/Kernel/Syscalls/posix_spawn.cpp
+++ b/Kernel/Syscalls/posix_spawn.cpp
@@ -75,7 +75,7 @@ ErrorOr<FlatPtr> Process::sys$posix_spawn(Userspace<Syscall::SC_posix_spawn_para
     // We don't run them, as they are currently implemented in LibC.
 
     TRY(child->m_fds.with_exclusive([&](auto& child_fds) {
-        return m_fds.with_exclusive([&](auto const& parent_fds) {
+        return fds().with_exclusive([&](auto const& parent_fds) {
             return child_fds.try_clone(parent_fds);
         });
 

--- a/Kernel/Syscalls/rfork.cpp
+++ b/Kernel/Syscalls/rfork.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Kusekushi <0kusekushi0@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::sys$rfork(RegisterState& regs)
+{
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
+    TRY(require_promise(Pledge::proc));
+
+    FlatPtr syscall_function = 0;
+    FlatPtr arg1 = 0;
+    FlatPtr arg2 = 0;
+    FlatPtr arg3 = 0;
+    FlatPtr arg4 = 0;
+    regs.capture_syscall_params(syscall_function, arg1, arg2, arg3, arg4);
+    FlatPtr rfork_flags = arg1;
+
+    return do_fork_common(regs, rfork_flags);
+}
+
+} // namespace Kernel

--- a/Kernel/Syscalls/sendfd.cpp
+++ b/Kernel/Syscalls/sendfd.cpp
@@ -40,7 +40,7 @@ ErrorOr<FlatPtr> Process::sys$recvfd(int sockfd, int options)
     if (!socket.is_local())
         return EAFNOSUPPORT;
 
-    auto fd_allocation = TRY(m_fds.with_exclusive([](auto& fds) { return fds.allocate(); }));
+    auto fd_allocation = TRY(fds().with_exclusive([](auto& fds) { return fds.allocate(); }));
 
     auto& local_socket = static_cast<LocalSocket&>(socket);
     auto received_description = TRY(local_socket.recvfd(*socket_description));
@@ -49,7 +49,7 @@ ErrorOr<FlatPtr> Process::sys$recvfd(int sockfd, int options)
     if (options & O_CLOEXEC)
         fd_flags |= FD_CLOEXEC;
 
-    m_fds.with_exclusive([&](auto& fds) { fds[fd_allocation.fd].set(move(received_description), fd_flags); });
+    fds().with_exclusive([&](auto& fds) { fds[fd_allocation.fd].set(move(received_description), fd_flags); });
     return fd_allocation.fd;
 }
 

--- a/Kernel/Tasks/FileDescriptionTable.h
+++ b/Kernel/Tasks/FileDescriptionTable.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, Kusekushi <0kusekushi0@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+class FileDescriptionTable : public RefCounted<FileDescriptionTable> {
+public:
+    FileDescriptionTable() = default;
+
+    template<typename F>
+    auto with_exclusive(F&& f) { return m_fds.with_exclusive(forward<F>(f)); }
+
+    template<typename F>
+    auto with_shared(F&& f) const { return m_fds.with_shared(forward<F>(f)); }
+
+    ErrorOr<void> try_clone_from(MutexProtected<Process::OpenFileDescriptions> const& other)
+    {
+        return other.with_shared([&](auto& parent_fds) -> ErrorOr<void> {
+            return m_fds.with_exclusive([&](auto& my_fds) -> ErrorOr<void> {
+                return my_fds.try_clone(parent_fds);
+            });
+        });
+    }
+
+private:
+    MutexProtected<Process::OpenFileDescriptions> m_fds;
+};
+
+}

--- a/Kernel/Tasks/ProcessFork.cpp
+++ b/Kernel/Tasks/ProcessFork.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2025, Kusekushi <0kusekushi0@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+#include <Kernel/API/POSIX/unistd.h>
+#include <Kernel/API/Syscall.h>
+#include <Kernel/Debug.h>
+#include <Kernel/Devices/TTY/TTY.h>
+#include <Kernel/FileSystem/Custody.h>
+#include <Kernel/Memory/Region.h>
+#include <Kernel/Tasks/PerformanceManager.h>
+#include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/Scheduler.h>
+#include <Kernel/Tasks/ScopedProcessList.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::do_fork_common(RegisterState& regs, FlatPtr rfork_flags)
+{
+    // RFCFDG and RFFDG are mutually exclusive.
+    if ((rfork_flags & RFCFDG) && (rfork_flags & RFFDG))
+        return EINVAL;
+    // rfork without RFPROC affects the calling process rather than creating a new process — we don't support that behavior yet.
+    if (!(rfork_flags & RFPROC))
+        return ENOTSUP;
+
+    auto credentials = this->credentials();
+    auto child_and_first_thread = TRY(Process::create_with_forked_name(credentials->uid(), credentials->gid(), pid(), m_is_kernel_process, vfs_root_context(), hostname_context(), current_directory(), executable(), tty(), this));
+    auto& child = child_and_first_thread.process;
+    auto& child_first_thread = child_and_first_thread.first_thread;
+
+    ArmedScopeGuard thread_finalizer_guard = [&child_first_thread]() {
+        SpinlockLocker lock(g_scheduler_lock);
+        child_first_thread->detach();
+        child_first_thread->set_state(Thread::State::Dying);
+    };
+
+    TRY(m_unveil_data.with([&](auto& parent_unveil_data) -> ErrorOr<void> {
+        return child->m_unveil_data.with([&](auto& child_unveil_data) -> ErrorOr<void> {
+            child_unveil_data.state = parent_unveil_data.state;
+            child_unveil_data.paths = TRY(parent_unveil_data.paths.deep_copy());
+            return {};
+        });
+    }));
+
+    TRY(m_exec_unveil_data.with([&](auto& parent_exec_unveil_data) -> ErrorOr<void> {
+        return child->m_exec_unveil_data.with([&](auto& child_exec_unveil_data) -> ErrorOr<void> {
+            child_exec_unveil_data.state = parent_exec_unveil_data.state;
+            child_exec_unveil_data.paths = TRY(parent_exec_unveil_data.paths.deep_copy());
+            return {};
+        });
+    }));
+
+    if (rfork_flags & RFFDG) {
+        child->m_shared_fds = nullptr;
+        TRY(child->m_fds.with_exclusive([&](auto& child_fds) -> ErrorOr<void> {
+            return fds().with_shared([&](auto& parent_fds) -> ErrorOr<void> {
+                auto result = child_fds.try_clone(parent_fds);
+                return result;
+            });
+        }));
+    } else if (rfork_flags & RFCFDG) {
+        child->m_shared_fds = nullptr;
+        (void)child->m_fds.with_exclusive([](auto& child_fds) -> ErrorOr<void> {
+            child_fds.clear();
+            return {};
+        });
+    } else {
+        if (m_shared_fds) {
+            child->m_shared_fds = m_shared_fds;
+        } else {
+            auto shared = adopt_ref(*new SharedFDs());
+            (void)shared->fds.with_exclusive([&](auto& target_fds) -> ErrorOr<void> {
+                return m_fds.with_exclusive([&](auto& source_fds) -> ErrorOr<void> {
+                    return target_fds.try_clone(source_fds);
+                });
+            });
+            m_shared_fds = shared;
+            child->m_shared_fds = shared;
+            (void)shared->fds.with_shared([&](auto& _) {
+                (void)_;
+                return ErrorOr<void> {};
+            });
+        }
+    }
+
+    with_protected_data([&](auto& my_protected_data) {
+        child->with_mutable_protected_data([&](auto& child_protected_data) {
+            child_protected_data.promises = my_protected_data.promises;
+            child_protected_data.execpromises = my_protected_data.execpromises;
+            child_protected_data.has_promises = my_protected_data.has_promises;
+            child_protected_data.has_execpromises = my_protected_data.has_execpromises;
+            child_protected_data.credentials = my_protected_data.credentials;
+            child_protected_data.umask = my_protected_data.umask;
+            child_protected_data.signal_trampoline = my_protected_data.signal_trampoline;
+            child_protected_data.dumpable = my_protected_data.dumpable;
+            child_protected_data.process_group = my_protected_data.process_group;
+            // NOTE: Propagate jailed_until_exit property to child processes.
+            // The jailed_until_exec property is also propagated, but will be
+            // set to false once the child process is calling the execve syscall.
+            if (my_protected_data.jailed_until_exit.was_set())
+                child_protected_data.jailed_until_exit.set();
+            child_protected_data.jailed_until_exec = my_protected_data.jailed_until_exec;
+        });
+    });
+
+    dbgln_if(FORK_DEBUG, "fork: child={}", child);
+
+    // A child created via fork(2) inherits a copy of its parent's signal mask
+    child_first_thread->update_signal_mask(Thread::current()->signal_mask());
+
+    // A child process created via fork(2) inherits a copy of its parent's alternate signal stack settings.
+    child_first_thread->m_alternative_signal_stack = Thread::current()->m_alternative_signal_stack;
+
+    auto& child_regs = child_first_thread->m_regs;
+#if ARCH(X86_64)
+    child_regs.rax = 0; // fork() returns 0 in the child :^)
+    child_regs.rbx = regs.rbx;
+    child_regs.rcx = regs.rcx;
+    child_regs.rdx = regs.rdx;
+    child_regs.rbp = regs.rbp;
+    child_regs.rsp = regs.userspace_rsp;
+    child_regs.rsi = regs.rsi;
+    child_regs.rdi = regs.rdi;
+    child_regs.r8 = regs.r8;
+    child_regs.r9 = regs.r9;
+    child_regs.r10 = regs.r10;
+    child_regs.r11 = regs.r11;
+    child_regs.r12 = regs.r12;
+    child_regs.r13 = regs.r13;
+    child_regs.r14 = regs.r14;
+    child_regs.r15 = regs.r15;
+    child_regs.rflags = regs.rflags;
+    child_regs.rip = regs.rip;
+    child_regs.cs = regs.cs;
+
+    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:p}, kstack {:p}",
+        child_regs.cs, child_regs.rip, child_regs.rsp, child_regs.rsp0);
+#elif ARCH(AARCH64)
+    child_regs.x[0] = 0; // fork() returns 0 in the child :^)
+    for (size_t i = 1; i < array_size(child_regs.x); ++i)
+        child_regs.x[i] = regs.x[i];
+    child_regs.spsr_el1 = regs.spsr_el1;
+    child_regs.elr_el1 = regs.elr_el1;
+    child_regs.sp_el0 = regs.sp_el0;
+    child_regs.tpidr_el0 = regs.tpidr_el0;
+#elif ARCH(RISCV64)
+    for (size_t i = 0; i < array_size(child_regs.x); ++i)
+        child_regs.x[i] = regs.x[i];
+    child_regs.x[9] = 0; // fork() returns 0 in the child :^)
+    child_regs.sstatus = regs.sstatus;
+    child_regs.pc = regs.sepc;
+    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:p} with stack {:p}, kstack {:p}",
+        child_regs.pc, child_regs.sp(), child_regs.kernel_sp);
+#else
+#    error Unknown architecture
+#endif
+
+    Processor::store_fpu_state(child_first_thread->fpu_state());
+
+    TRY(address_space().with([&](auto& parent_space) {
+        return child->address_space().with([&](auto& child_space) -> ErrorOr<void> {
+            if (parent_space->enforces_syscall_regions())
+                child_space->set_enforces_syscall_regions();
+            for (auto& region : parent_space->region_tree().regions()) {
+                dbgln_if(FORK_DEBUG, "rfork: cloning Region '{}' @ {}", region.name(), region.vaddr());
+                auto region_clone = TRY(region.try_clone());
+                TRY(region_clone->map(child_space->page_directory(), Memory::ShouldFlushTLB::No));
+                TRY(child_space->region_tree().place_specifically(*region_clone, region.range()));
+                (void)region_clone.leak_ptr();
+            }
+            return {};
+        });
+    }));
+
+    thread_finalizer_guard.disarm();
+
+    m_scoped_process_list.with([&](auto& list_ptr) {
+        if (list_ptr) {
+            child->m_scoped_process_list.with([&](auto& child_list_ptr) {
+                child_list_ptr = list_ptr;
+            });
+            list_ptr->attach(*child);
+        }
+    });
+
+    Process::register_new(*child);
+
+    // NOTE: All user processes have a leaked ref on them. It's balanced by Thread::WaitBlockerSet::finalize().
+    child->ref();
+
+    if (rfork_flags & RFNOWAIT) {
+        auto set_ppid_result = child->with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<void> {
+            protected_data.ppid = 0;
+            return {};
+        });
+        if (set_ppid_result.is_error()) {
+            dbgln("rfork: failed to set child ppid to 0: {}", set_ppid_result.error());
+            return set_ppid_result.release_error();
+        }
+        child->disowned_by_waiter(*this);
+    }
+
+    PerformanceManager::add_process_created_event(*child);
+
+    SpinlockLocker lock(g_scheduler_lock);
+    child_first_thread->set_affinity(Thread::current()->affinity());
+    child_first_thread->set_state(Thread::State::Runnable);
+
+    return child->pid().value();
+}
+
+} // namespace Kernel

--- a/Kernel/Tasks/SharedFDs.h
+++ b/Kernel/Tasks/SharedFDs.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025, Kusekushi <0kusekushi0@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+class SharedFDs;
+
+}

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -111,6 +111,23 @@ pid_t vfork()
     return fork();
 }
 
+// Non-POSIX, but present in BSDs
+// https://man.freebsd.org/cgi/man.cgi?query=rfork&sektion=2
+pid_t rfork(int flags)
+{
+    __pthread_fork_prepare();
+
+    int rc = syscall(SC_rfork, flags);
+    if (rc == 0) {
+        s_cached_tid = 0;
+        s_cached_pid = 0;
+        __pthread_fork_child();
+    } else if (rc != -1) {
+        __pthread_fork_parent();
+    }
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 // Non-POSIX, but present in BSDs and Linux
 // https://man.openbsd.org/daemon.3
 int daemon(int nochdir, int noclose)

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -40,6 +40,7 @@ int gettid(void);
 int getpagesize(void);
 pid_t fork(void);
 pid_t vfork(void);
+pid_t rfork(int flags);
 int daemon(int nochdir, int noclose);
 int execv(char const* path, char* const argv[]);
 int execve(char const* filename, char* const argv[], char* const envp[]);

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -180,6 +180,7 @@ set(CMD_SOURCES_CPP
     test-imap.cpp
     test-jpeg-roundtrip.cpp
     test-pthread.cpp
+    test-rfork.cpp
     test-unveil.cpp
     test.cpp
     test_env.cpp

--- a/Userland/Utilities/test-rfork.cpp
+++ b/Userland/Utilities/test-rfork.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2025, Kusekushi <0kusekushi0@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void dump_fd_table(char const* tag)
+{
+    printf("test-rfork: %s fd table:\n", tag);
+    for (int fd = 0; fd <= 20; ++fd) {
+        if (fcntl(fd, F_GETFD) != -1) {
+            printf("  fd %d: valid\n", fd);
+        } else {
+            printf("  fd %d: invalid (errno=%d %s)\n", fd, errno, strerror(errno));
+        }
+    }
+    fflush(stdout);
+}
+
+int main()
+{
+    printf("test-rfork: starting\n");
+
+    printf("test-rfork: Running basic RFPROC test\n");
+    pid_t pid = rfork(RFPROC);
+    if (pid < 0) {
+        perror("rfork");
+        return 1;
+    }
+    if (pid == 0) {
+        // child
+        printf("test-rfork: child: exiting with 42\n");
+        _exit(42);
+    }
+    // parent
+    int status = 0;
+    pid_t w = waitpid(pid, &status, 0);
+    if (w < 0) {
+        perror("waitpid");
+        return 1;
+    }
+    if (!(WIFEXITED(status) && WEXITSTATUS(status) == 42)) {
+        printf("test-rfork: basic RFPROC test FAILED\n");
+        return 1;
+    }
+    printf("test-rfork: basic RFPROC test SUCCESS\n");
+
+    printf("test-rfork: Running RFCFDG test\n");
+    int pipefd[2];
+    if (pipe(pipefd) < 0) {
+        perror("pipe");
+        return 1;
+    }
+    printf("test-rfork: parent pipe fds = [%d, %d]\n", pipefd[0], pipefd[1]);
+    fflush(stdout);
+    dump_fd_table("before RFCFDG");
+    pid = rfork(RFPROC | RFCFDG);
+    if (pid < 0) {
+        perror("rfork");
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return 1;
+    }
+    if (pid == 0) {
+        if (fcntl(pipefd[0], F_GETFD) == -1 && errno == EBADF) {
+            printf("test-rfork: child (RFCFDG): no inherited fds - OK\n");
+            _exit(0);
+        }
+        printf("test-rfork: child (RFCFDG): unexpectedly inherited fds (fcntl returned %d errno=%d %s)\n", -1, errno, strerror(errno));
+        _exit(2);
+    }
+    int status2 = 0;
+    pid_t w2 = waitpid(pid, &status2, 0);
+    if (w2 < 0) {
+        perror("waitpid");
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return 1;
+    }
+    if (WIFEXITED(status2) && WEXITSTATUS(status2) == 0) {
+        printf("test-rfork: RFCFDG test SUCCESS\n");
+    } else {
+        printf("test-rfork: RFCFDG test FAILURE (child exit=%d)\n", WIFEXITED(status2) ? WEXITSTATUS(status2) : -1);
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return 1;
+    }
+    close(pipefd[0]);
+    close(pipefd[1]);
+
+    printf("test-rfork: Running RFFDG test\n");
+    int pipefd2[2];
+    if (pipe(pipefd2) < 0) {
+        perror("pipe");
+        return 1;
+    }
+    printf("test-rfork: parent pipe2 fds = [%d, %d]\n", pipefd2[0], pipefd2[1]);
+    fflush(stdout);
+    dump_fd_table("before RFFDG");
+    pid = rfork(RFPROC | RFFDG);
+    if (pid < 0) {
+        perror("rfork");
+        close(pipefd2[0]);
+        close(pipefd2[1]);
+        return 1;
+    }
+    if (pid == 0) {
+        if (fcntl(pipefd2[0], F_GETFD) != -1) {
+            printf("test-rfork: child (RFFDG): inherited fds - OK\n");
+            _exit(0);
+        }
+        printf("test-rfork: child (RFFDG): did not inherit fds (fcntl returned %d errno=%d %s)\n", -1, errno, strerror(errno));
+        _exit(3);
+    }
+    int status2b = 0;
+    pid_t w2b = waitpid(pid, &status2b, 0);
+    if (w2b < 0) {
+        perror("waitpid");
+        close(pipefd2[0]);
+        close(pipefd2[1]);
+        return 1;
+    }
+    if (WIFEXITED(status2b) && WEXITSTATUS(status2b) == 0) {
+        printf("test-rfork: RFFDG test SUCCESS\n");
+    } else {
+        printf("test-rfork: RFFDG test FAILURE (child exit=%d)\n", WIFEXITED(status2b) ? WEXITSTATUS(status2b) : -1);
+        close(pipefd2[0]);
+        close(pipefd2[1]);
+        return 1;
+    }
+    close(pipefd2[0]);
+    close(pipefd2[1]);
+
+    printf("test-rfork: Running shared FD table mutation test\n");
+    int mainpipe[2];
+    int syncpipe[2];
+    if (pipe(mainpipe) < 0) {
+        perror("pipe");
+        return 1;
+    }
+    if (pipe(syncpipe) < 0) {
+        perror("pipe");
+        close(mainpipe[0]);
+        close(mainpipe[1]);
+        return 1;
+    }
+    printf("test-rfork: parent mainpipe fds = [%d, %d], syncpipe fds = [%d, %d]\n", mainpipe[0], mainpipe[1], syncpipe[0], syncpipe[1]);
+    fflush(stdout);
+    dump_fd_table("before shared-rfork");
+    pid = rfork(RFPROC);
+    if (pid < 0) {
+        perror("rfork");
+        close(mainpipe[0]);
+        close(mainpipe[1]);
+        close(syncpipe[0]);
+        close(syncpipe[1]);
+        return 1;
+    }
+    if (pid == 0) {
+        char b;
+        if (read(syncpipe[0], &b, 1) != 1) {
+            perror("read");
+            _exit(6);
+        }
+        if (fcntl(mainpipe[0], F_GETFD) == -1 && errno == EBADF) {
+            printf("test-rfork: shared mutation: child sees parent's close - OK\n");
+            _exit(0);
+        }
+        printf("test-rfork: shared mutation: child still sees fd - FAILURE (fcntl returned %d errno=%d %s)\n", -1, errno, strerror(errno));
+        _exit(7);
+    }
+    if (close(mainpipe[0]) < 0) {
+        perror("close");
+        close(mainpipe[1]);
+        close(syncpipe[0]);
+        close(syncpipe[1]);
+        return 1;
+    }
+    if (write(syncpipe[1], "x", 1) != 1) {
+        perror("write");
+        close(mainpipe[1]);
+        close(syncpipe[0]);
+        close(syncpipe[1]);
+        return 1;
+    }
+    int status_shared = 0;
+    pid_t w_shared = waitpid(pid, &status_shared, 0);
+    if (w_shared < 0) {
+        perror("waitpid");
+        close(mainpipe[1]);
+        close(syncpipe[0]);
+        close(syncpipe[1]);
+        return 1;
+    }
+    if (WIFEXITED(status_shared) && WEXITSTATUS(status_shared) == 0)
+        printf("test-rfork: shared FD mutation test SUCCESS\n");
+    else {
+        printf("test-rfork: shared FD mutation test FAILURE (child exit=%d)\n", WIFEXITED(status_shared) ? WEXITSTATUS(status_shared) : -1);
+        close(mainpipe[1]);
+        close(syncpipe[0]);
+        close(syncpipe[1]);
+        return 1;
+    }
+    close(mainpipe[1]);
+    close(syncpipe[0]);
+    close(syncpipe[1]);
+
+    printf("test-rfork: Running RFNOWAIT test\n");
+    pid = rfork(RFPROC | RFNOWAIT);
+    if (pid < 0) {
+        perror("rfork");
+        return 1;
+    }
+    if (pid == 0) {
+        _exit(77);
+    }
+    errno = 0;
+    int status3 = 0;
+    pid_t w3 = waitpid(pid, &status3, 0);
+    if (w3 == -1 && errno == ECHILD) {
+        printf("test-rfork: RFNOWAIT test SUCCESS (waitpid failed with ECHILD)\n");
+    } else {
+        if (w3 == -1)
+            printf("test-rfork: RFNOWAIT test FAILURE (waitpid returned -1 errno=%d %s)\n", errno, strerror(errno));
+        else
+            printf("test-rfork: RFNOWAIT test FAILURE (waitpid returned %d)\n", (int)w3);
+        return 1;
+    }
+
+    printf("test-rfork: all tests PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
This should close #1483 unless other flags are deemed neccessary/useful. 

For flags refer to https://man.freebsd.org/cgi/man.cgi?query=rfork&sektion=2
This implements
- RFPROC (not really, we just check if this is present to be somewhat BSD compatible)
- RFNOWAIT
- RFFDG
- RFCFDG