### PR TITLE
Toolchain: Add lzip to nix shell

### DIFF
--- a/Toolchain/default.nix
+++ b/Toolchain/default.nix
@@ -33,6 +33,7 @@ mkShell.override { stdenv = gccStdenv; } {
     gperf
     imagemagick
     libtool
+    lzip
     meson
     nasm
     wayland-scanner


### PR DESCRIPTION
The ed port requires it for unpacking a .tar.lz file:

```
[ed/fetch] tar (child): lzip: Cannot exec: No such file or directory
[ed/fetch] tar (child): Error is not recoverable: exiting now
[ed/fetch] tar: Child returned status 2
[ed/fetch] tar: Error is not recoverable: exiting now
```