### PR TITLE
Documentation: Clarify macOS build requirements and improve instructions

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -2,13 +2,15 @@
 
 # Prerequisites
 
-This installation guide assumes that you have [Homebrew](https://brew.sh) and Xcode installed. You need to open Xcode at least once for it to install the required tools.
+This installation guide assumes that you have [Homebrew](https://brew.sh) and either Xcode or the Xcode Command Line Tools installed.
 
-Before you build, you must set your command line tools to Xcode's tools instead of the ones installed via Homebrew:
+**Note:** If you have the full Xcode application installed, you should set your command line tools to use Xcode's tools instead of Homebrew's:
 
 ```console
 sudo xcode-select --switch /Applications/Xcode.app
 ```
+
+If you only have the Command Line Tools installed (which is sufficient for building SerenityOS), you can skip this step.
 
 Make sure you also have all the following dependencies installed:
 
@@ -49,9 +51,9 @@ nix --extra-experimental-features "nix-command flakes" develop
 You can use both Intel and Apple Silicon Macs to run a native architecture version of SerenityOS.
 If Rosetta 2 is installed on an Apple Silicon Mac, it should be disabled in order to build the native aarch64 version.
 
-Installing macfuse for the first time requires enabling its system extension in System Preferences and then restarting your machine. The output from installing macfuse with brew says this, but it's easy to miss.
+Installing macfuse for the first time requires enabling its system extension in System Settings (previously System Preferences on older macOS versions) and then restarting your machine. The output from installing macfuse with brew says this, but it's easy to miss.
 
-It's important to make sure that Xcode is not only installed but also accordingly updated, otherwise CMake will run into incompatibilities with GCC.
+Xcode or Xcode Command Line Tools are required for building. The Command Line Tools alone are sufficient - you don't need the full Xcode application. However, if you do have the full Xcode installed, make sure it's updated to avoid CMake compatibility issues with GCC.
 
 Homebrew is known to ship bleeding edge CMake versions, but building CMake from source with homebrew
 gcc or llvm may not work. If homebrew does not offer cmake 3.25.x+ on your platform, it may be necessary
@@ -59,3 +61,7 @@ to manually run Toolchain/BuildCMake.sh with Apple clang from Xcode as the first
 
 If you want to debug the x86-64 kernel on an Apple Silicon machine, you can install the `x86_64-elf-gdb`
 package to get a native build of GDB that can cross-debug x86-64 code.
+
+## Next Steps
+
+Once you have all dependencies installed, return to the main [BuildInstructions.md](BuildInstructions.md#build) to build and run SerenityOS.


### PR DESCRIPTION
- Clarify that Command Line Tools are sufficient without full Xcode
- Update 'System Preferences' to 'System Settings' for modern macOS
- Add 'Next Steps' section linking to main build instructions
- Improve wording around Xcode requirements