### PR TITLE
Documentation: Fix grammar and update CMake version in Troubleshootin…

### DIFF
--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -1,12 +1,12 @@
 # Troubleshooting
 
-In case of an error, you might find an answer of how to deal it here.
+If you encounter an error, you might find a solution here.
 
 ## Building SerenityOS
 
 ### CMake fails to configure the build because it's outdated
 
-Ensure your CMake version is >= 3.16 with `cmake --version`. If your system doesn't provide a suitable
+Ensure your CMake version is >= 3.25 with `cmake --version`. If your system doesn't provide a suitable
 version of CMake, you can download a binary release from the [CMake website](https://cmake.org/download).
 
 ### QEMU is missing or is outdated


### PR DESCRIPTION


- Fix grammar: 'In case of an error, you might find an answer of how to deal it here' -> 'If you encounter an error, you might find a solution here'
- Update minimum CMake version from 3.16 to 3.25 to match current requirements in BuildInstructions.md