### PR TITLE
AK: Avoid copying the iterable container in AK::enumerate

### DIFF
--- a/AK/Enumerate.h
+++ b/AK/Enumerate.h
@@ -11,8 +11,9 @@
 namespace AK {
 
 namespace Detail {
+
 template<typename Iterable>
-class Enumerator {
+struct Enumerator {
     using IteratorType = decltype(declval<Iterable>().begin());
     using ValueType = decltype(*declval<IteratorType>());
 
@@ -21,35 +22,28 @@ class Enumerator {
         ValueType value;
     };
 
-public:
-    Enumerator(Iterable&& iterable)
-        : m_iterable(forward<Iterable>(iterable))
-        , m_iterator(m_iterable.begin())
-        , m_end(m_iterable.end())
-    {
-    }
+    struct Iterator {
+        Enumeration operator*() { return { index, *iterator }; }
+        Enumeration operator*() const { return { index, *iterator }; }
 
-    Enumerator const& begin() const { return *this; }
-    Enumerator const& end() const { return *this; }
+        bool operator!=(Iterator const& other) const { return iterator != other.iterator; }
 
-    Enumeration operator*() { return { m_index, *m_iterator }; }
-    Enumeration operator*() const { return { m_index, *m_iterator }; }
+        void operator++()
+        {
+            ++index;
+            ++iterator;
+        }
 
-    bool operator!=(Enumerator const&) const { return m_iterator != m_end; }
+        size_t index { 0 };
+        IteratorType iterator;
+    };
 
-    void operator++()
-    {
-        ++m_index;
-        ++m_iterator;
-    }
+    Iterator begin() { return { 0, iterable.begin() }; }
+    Iterator end() { return { 0, iterable.end() }; }
 
-private:
-    Iterable m_iterable;
-
-    size_t m_index { 0 };
-    IteratorType m_iterator;
-    IteratorType const m_end;
+    Iterable iterable;
 };
+
 }
 
 template<typename T>


### PR DESCRIPTION
There are actually a couple of issues here:

1. We are not properly perfect-forwarding the iterable to the Enumerator member. We are using the class template as the constructor type, but we would actually have to do something like this to achieve perfect forwarding:
```c++
   template <typname Iter = Iterable>
   Enumerator(Iter&&)
```

2. The begin / end methods on Enumerator (although they return by const- ref) are making copies during for-each loops. The compiler basically generates this when we call enumerate:
```c++
   for (auto it = Enumerator::begin(); it != Enumerator::end(); ++it)
```
   The creation of `it` above actually creates a copy of the returned Enumerator instance.

To avoid all of this, let's create an intermediate structure to act as the enumerated iterator. This structure does not hold the iterable and thus is fine to copy. We can then let the compiler handle forwarding the iterable to the Enumerator.