### PR TITLE
sed: Support strict POSIX regexes

### DIFF
--- a/Tests/Utilities/TestSed.cpp
+++ b/Tests/Utilities/TestSed.cpp
@@ -77,3 +77,10 @@ TEST_CASE(complex)
 {
     run_sed({ "h; x; s/./*/gp; x; h; p; x; s/./*/gp", "-n" }, "hello serenity"sv, "**************\nhello serenity\n**************\n"sv);
 }
+
+TEST_CASE(strict_posix)
+{
+    run_sed({ "--posix", "s/(.)/b/" }, "foo\n"sv, "foo\n"sv);
+    run_sed({ "--posix", "s/\\(.\\)/b/" }, "foo\n"sv, "boo\n"sv);
+    run_sed({ "--posix", "s/\\(.\\)\\(.*\\)/\\1\\2\\1/" }, "foo\n"sv, "foof\n"sv);
+}


### PR DESCRIPTION
Adds command line flags to `sed` to require strict POSIX behavior. Extended regexes are still used by default but an ignored -E flag is added for compatibility with other sed versions.