### PR TITLE
Kernel: Remove a pointless semicolon

### DIFF
--- a/Kernel/Arch/x86_64/SafeMem.cpp
+++ b/Kernel/Arch/x86_64/SafeMem.cpp
@@ -298,7 +298,6 @@ NEVER_INLINE Optional<bool> safe_atomic_compare_exchange_relaxed(u32 volatile* v
 bool handle_safe_access_fault(RegisterState& regs, FlatPtr fault_address)
 {
     FlatPtr ip = regs.ip();
-    ;
     if (ip >= (FlatPtr)&start_of_safemem_text && ip < (FlatPtr)&end_of_safemem_text) {
         // If we detect that the fault happened in safe_memcpy() safe_strnlen(),
         // or safe_memset() then resume at the appropriate _faulted label


### PR DESCRIPTION
This got accidentally inserted in 1cffecbe8d08.

No behavior change.