### PR TITLE
Kernel: Prevent lost wakeups in the idle loop

### DIFF
--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -75,7 +75,7 @@ public:
     ALWAYS_INLINE static bool is_initialized();
 
     [[noreturn]] static void halt();
-    void wait_for_interrupt() const;
+    void idle() const;
     ALWAYS_INLINE static void pause();
     ALWAYS_INLINE static void wait_check();
 

--- a/Kernel/Tasks/Scheduler.h
+++ b/Kernel/Tasks/Scheduler.h
@@ -30,6 +30,13 @@ struct TotalTimeScheduled {
     u64 total_kernel { 0 };
 };
 
+enum class ScheduleResult {
+    Success,
+    NoRunnableThreadFound,
+    Delayed,
+    YieldAgain, // Only returned by pick_next().
+};
+
 enum class [[nodiscard]] ShouldYield {
     Yes,
     No,
@@ -42,8 +49,8 @@ public:
     static void set_idle_thread(Thread* idle_thread);
     static void timer_tick();
     [[noreturn]] static void start();
-    static ShouldYield pick_next();
-    static void yield();
+    static ScheduleResult pick_next();
+    static ScheduleResult yield();
     static ShouldYield context_switch(Thread*);
     static void enter_current(Thread& prev_thread);
     static void leave_on_first_switch(InterruptsState);


### PR DESCRIPTION
In the old idle loop implementation, lost wakeups can happen when the processor receives an interrupt immediately before wait_for_interrupt(). In that situation, we still go to sleep, even if the interrupt caused a thread to be runnable or we got notified of a runnable thread.

This new idle loop implementation instead runs with interrupts disabled. The only place in this new idle loop where we can get interrupts is during Processor::idle(). After that, we will only go to sleep if there are still no runnable threads.

With this new idle loop, boot time is reduced from 4 seconds down to 3 seconds on my x86-64 system when running in KVM. If I remove this busy wait, boot time is reduced down to 2 seconds (#26444): https://github.com/SerenityOS/serenity/blob/cef72c74c375a84652bf7fcd7016936ac506a8f6/Userland/Services/SystemServer/main.cpp#L135