### PR TITLE
Meta: Add clang-19 support to compiler detection

### DIFF
--- a/Meta/find_compiler.sh
+++ b/Meta/find_compiler.sh
@@ -56,7 +56,7 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler clang clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang
+    find_newest_compiler clang clang-{17..21} /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/clang/clang++}"


### PR DESCRIPTION
Extended the compiler detection logic by adding clang-19 support.
This allows the build system to correctly locate and use clang-19 and aligns with the logic for clang-17 and 18.
This also fixes #25123.
