### PR TITLE
LibGfx/ICC+icc: Add --stdin-u8-to-pcs / --stdin-u8-from-pcs flags

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1513,12 +1513,17 @@ ErrorOr<void> Profile::from_pcs_b_to_a(TagData const& tag_data, FloatVector3 con
 
 ErrorOr<void> Profile::from_pcs(Profile const& source_profile, FloatVector3 pcs, Bytes color) const
 {
-    if (source_profile.connection_space() != connection_space()) {
-        if (source_profile.connection_space() == ColorSpace::PCSLAB) {
+    return from_pcs(source_profile.connection_space(), source_profile.pcs_illuminant(), pcs, color);
+}
+
+ErrorOr<void> Profile::from_pcs(ColorSpace source_connection_space, XYZ const& source_illuminant, FloatVector3 pcs, Bytes color) const
+{
+    if (source_connection_space != connection_space()) {
+        if (source_connection_space == ColorSpace::PCSLAB) {
             VERIFY(connection_space() == ColorSpace::PCSXYZ);
-            pcs = xyz_from_lab(pcs, source_profile.pcs_illuminant());
+            pcs = xyz_from_lab(pcs, source_illuminant);
         } else {
-            VERIFY(source_profile.connection_space() == ColorSpace::PCSXYZ);
+            VERIFY(source_connection_space == ColorSpace::PCSXYZ);
             VERIFY(connection_space() == ColorSpace::PCSLAB);
             pcs = lab_from_xyz(pcs, pcs_illuminant());
         }

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -288,6 +288,7 @@ public:
     // Converts from the profile connection space to an 8-bits-per-channel color.
     // The notes on `to_pcs()` apply to this too.
     ErrorOr<void> from_pcs(Profile const& source_profile, FloatVector3, Bytes) const;
+    ErrorOr<void> from_pcs(ColorSpace source_connection_space, XYZ const& source_illuminant, FloatVector3, Bytes) const;
 
     ErrorOr<CIELAB> to_lab(ReadonlyBytes) const;
 


### PR DESCRIPTION
This allows inspecting profile conversion intermediate results, and running things like:

    echo '255, 0, 0' |
        icc profile1.icc --stdin-u8-to-pcs |
        icc profile2.icc --stdin-u8-from-pcs |
        icc profile2.icc --stdin-u8-to-pcs |
        icc profile1.icc --stdin-u8-from-pcs

The output of --stdin-u8-to-pcs prints data in the profile connection space, which is either XYZ or LAB:

    % echo '255, 255, 255' | \
         Build/lagom/bin/icc -n sRGB --stdin-u8-to-pcs
    pcsxyz(0.9642, 0.99999994, 0.8249001)

    % echo '255, 255, 255, 128' | \
         Build/lagom/bin/icc \
           Build/lagom/Root/res/icc/Adobe/CMYK/USWebCoatedSWOP.icc \
           --stdin-u8-to-pcs
    pcslab(6.606001, 2.4342346, -1.8503876)

Which one of the two is printed is a property of the used .icc file.

--stdin-u8-from-pcs parses these two formats and prints bytes in the data color space of the passed-in color profile.

This is useful for converting single colors from one profile to another, and for inspecting internal LibGfx state (the PCS values).

As a comment in the code points out, the PCS->data conversion is a tiny bit fishy as it also depends on the illuminant of the _source_ profile. To be 100% correct, I think (but I'm not sure) that we'd also have to write the illuminant to the output (`pcsxyz(a, b, c, illuminant=d, e, f)` or something). But the V4 ICC spec mandates that the illuminant is the D50 illuminant, and for most V2 profiles that's true too. So this takes a shortcut, at least for now.