### PR TITLE
CI: Set the Buggie token when checking out the SerenityOS repo

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,9 +13,22 @@ jobs:
     if: github.repository == 'SerenityOS/serenity'
     strategy:
       fail-fast: false
+
+    permissions:
+      contents: write
+
     steps:
+      # The BUGGIEBOT_TOKEN is not available on PRs from forks. See:
+      # https://github.com/actions/checkout/issues/298#issuecomment-664976337
       - name: Checkout SerenityOS/serenity
         uses: actions/checkout@v6
+        if: github.repository == github.event.pull_request.head.repo.full_name
+        with:
+          token: ${{ secrets.BUGGIEBOT_TOKEN }}
+
+      - name: Checkout SerenityOS/serenity
+        uses: actions/checkout@v6
+        if: github.repository != github.event.pull_request.head.repo.full_name
 
       - name: Checkout SerenityOS/libjs-data libjs-wasm
         uses: actions/checkout@v6


### PR DESCRIPTION
This is based on:
https://github.com/LadybirdBrowser/ladybird/compare/e0dd182..46ce9b0

For more info, see:
https://github.com/orgs/community/discussions/26694

Note that although we use this token when pushing to the libjs-data repo, it needs to be set when checking out the Serenity repo, as that is where git operations are ultimately performed with JamesIves/github-pages-deploy-action.

It's not clear to me if the permissions added here are needed. I think it depends on repo settings I can't access. But it's not incorrect to add them anyways.