### PR TITLE
LibGfx/ICC+image: Implement conversion to CMYK color spaces :^)

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -295,6 +295,9 @@ public:
     ErrorOr<void> convert_image(Bitmap&, Profile const& source_profile) const;
     ErrorOr<void> convert_cmyk_image(Bitmap&, CMYKBitmap const&, Profile const& source_profile) const;
 
+    ErrorOr<void> convert_cmyk_image_to_cmyk_image(CMYKBitmap&, Profile const& source_profile) const;
+    ErrorOr<void> convert_image_to_cmyk_image(CMYKBitmap&, Bitmap const&, Profile const& source_profile) const;
+
     // Only call these if you know that this is an RGB matrix-based profile.
     XYZ const& red_matrix_column() const;
     XYZ const& green_matrix_column() const;


### PR DESCRIPTION
This used to fail:

    % Build/lagom/bin/image \
        --assign-color-profile serenity-sRGB.icc \
        --convert-to-color-profile \
            ./Build/lagom/Root/res/icc/Adobe/CMYK/USWebCoatedSWOP.icc \
        -o buggie-cmyk.jpg \
        Base/res/graphics/buggie.png
    Runtime error: Can only convert to RGB at the moment,
        but destination color space is not RGB

Now it works.

It only works for CMYK profiles that use an mft1 tag for the BToA tags, because #26452 added support for converting from PCS to mft1.

Most CMYK profiles use mft1, but not all of them. Support for `mft2` and `mBA ` tag types will be in a (straightforward) follow-up.

Implementation-wise, Profile grows two more methods for converting RGB and CMYK bitmaps to CMYK. We now have 2x2 implementations for {RGB,CMYK} -> {RGB,CMYK}. For N different channel types, we need O(N^2) of these methods.

Instead, we could have conversion methods between RGB bitmap and PCS bitmap and between CMYK and PCS bitmap. With this approach, we'd only need O(N) (2*N) of these methods. Concretely, that'd be 2x2 methods too though, and since there are two PCS types, depending on how it's implemented it's actually 4*N (i.e. 8 for RGB and CMYK).

So the current 2x2 approach seems not terrible. It *is* a bit repetitive.

We then call the right of these 4 methods in `image`.

See the PR that added this commit for rough quantitative quality evaluation of the implementation.