### PR TITLE
LibGfx/TIFFWriter: Write CMYK bitmaps in one call

### DIFF
--- a/Userland/Libraries/LibGfx/CMYKBitmap.h
+++ b/Userland/Libraries/LibGfx/CMYKBitmap.h
@@ -35,6 +35,7 @@ public:
 
     [[nodiscard]] CMYK* begin();
     [[nodiscard]] CMYK* end();
+    [[nodiscard]] ReadonlyBytes data() const { return m_data; }
     [[nodiscard]] size_t data_size() const { return m_data.size(); }
 
     ErrorOr<RefPtr<Bitmap>> to_low_quality_rgb() const;

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFWriter.cpp
@@ -297,15 +297,7 @@ ErrorOr<void> TIFFWriter::encode(Stream& stream, CMYKBitmap const& bitmap, Optio
     auto ifd_entries = make_cmyk_ifd(bitmap.size().width(), bitmap.size().height(), image_data_size, move(icc_data));
     TRY(encode_ifd(stream, ifd_offset, move(ifd_entries)));
 
-    for (int y = 0; y < bitmap.size().height(); ++y) {
-        for (int x = 0; x < bitmap.size().width(); ++x) {
-            CMYK const& pixel = bitmap.scanline(y)[x];
-            TRY(stream.write_value<u8>(pixel.c));
-            TRY(stream.write_value<u8>(pixel.m));
-            TRY(stream.write_value<u8>(pixel.y));
-            TRY(stream.write_value<u8>(pixel.k));
-        }
-    }
+    TRY(stream.write_until_depleted(bitmap.data()));
     return {};
 }
 


### PR DESCRIPTION
Reduces the time for

    Build/lagom/bin/image -o burst-out-serenity-cmyk.tiff \
        --assign-color-profile serenity-sRGB.icc \
        --convert-to-color-profile serenity-CMYK.icc \
        burst.png

from 3s to 2.6s on my system, with tiff writing going from 12.5% of the profile to 0.1%.

burst.png is a 4096x4096 image (https://allrgb.com/images/burst.png), serenity-sRGB.icc is the output of
`icc -n sRGB --reencode-to serenity-sRGB.icc`, and serenity-CMYK.icc is Build/lagom/Root/res/icc/Adobe/CMYK/USWebCoatedSWOP.icc.

---

Requires #26459 for the command to work.

I'm not sure *why* calling write_value often is so slow. Here's the relevant part of the profile (before this PR):

<img width="1100" height="399" alt="Screenshot 2025-12-05 at 9 43 12 PM" src="https://github.com/user-attachments/assets/9be245e7-9a06-4b4d-810d-166d6009219e" />

`image.cpp` does use an OutputBufferedFile. @timschumi, is it expected that write_value has such high overhead? I suppose it's one virtual call per byte, but that alone shouldn't be *that* expensive.