### PR TITLE
CI: Don't use timestamps as cache keys for TimeZone and Unicode caches

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -154,22 +154,16 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.download_cache_path }}/TZDB
-        key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
-        restore-keys: |
-          TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
+        key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
 
     - name: 'UnicodeData cache'
       uses: actions/cache@v4
       with:
           path: ${{ inputs.download_cache_path }}/UCD
-          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
-          restore-keys: |
-            UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
+          key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
 
     - name: 'UnicodeLocale cache'
       uses: actions/cache@v4
       with:
           path: ${{ inputs.download_cache_path }}/CLDR
-          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
-          restore-keys: |
-              UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+          key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}


### PR DESCRIPTION
Since e5f361500e7 we included a timestamp in these cache keys. But doing so should be unnecessary, since hashing the respective CMake scripts should be enough as they already include the expected SHA256 hashes of the files to download.

This should cause less duplicate caches, since we now get exact matches of the cache key instead of falling back to the restore key. If no exact cache key match was found, GitHub actions creates a new cache.