### PR TITLE
CI: Add a label-triggered workflow for coverage builds

### DIFF
--- a/.github/workflows/pull-requests-label-workflows.yml
+++ b/.github/workflows/pull-requests-label-workflows.yml
@@ -1,0 +1,15 @@
+name: Label Workflows
+
+on:
+  pull_request:
+    types: [ labeled, opened, synchronize, reopened ]
+
+jobs:
+  Coverage:
+    if: github.repository == 'SerenityOS/serenity' && contains(github.event.pull_request.labels.*.name, '📑 pr-run-coverage-build')
+    uses: ./.github/workflows/serenity-template.yml
+    with:
+      toolchain: 'Clang'
+      os: ubuntu-24.04
+      arch: 'x86_64'
+      coverage: 'ON'

--- a/.github/workflows/serenity-template.yml
+++ b/.github/workflows/serenity-template.yml
@@ -208,7 +208,7 @@ jobs:
       # Note: tmp_profile_data/Coverage.profdata has the entire combined profile data, but creating the raw txt requires
       #       all of the instrumented binaries and the profdata file.
       - name: Upload Coverage Results
-        if: ${{ inputs.coverage == 'ON' }}
+        if: ${{ inputs.coverage == 'ON' && github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v5
         with:
           name: serenity-coverage


### PR DESCRIPTION
~Once this has landed on master~ (edit: seems to be already working), we will be able to trigger coverage builds on PR branches when adding the corresponding label.

Note that we don't upload the coverage results for these builds.

---

I tested that on my fork but it seems that we can also test it right here as the job is already picked up.