### PR TITLE
CI: Don't save caches for coverage builds

### DIFF
--- a/.github/workflows/serenity-template.yml
+++ b/.github/workflows/serenity-template.yml
@@ -140,6 +140,7 @@ jobs:
           CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
 
       - name: Save Caches
+        if: ${{ inputs.coverage == 'OFF' }}
         uses: ./.github/actions/cache-save
         with:
           arch: ${{ inputs.arch }}


### PR DESCRIPTION
This cache is our largest, at 1GiB, and quite useless as it isn't necessary to worry about the execution time of a nightly job.

---

I suppose you're interested @spholz.

Also, it might be nice to merge #26473 first so we can properly test this.