### PR TITLE
CI: Don't save ccache caches from pull requests

### DIFF
--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: 'Serenity Compiler Cache'
       uses: actions/cache/save@v4
-      if: ${{ inputs.serenity_ccache_path != '' }}
+      if: ${{ github.event_name != 'pull_request' && inputs.serenity_ccache_path != '' }}
       with:
         path: ${{ inputs.serenity_ccache_path }}
         key: ${{ inputs.serenity_ccache_primary_key }}


### PR DESCRIPTION
These caches have been squatting the repo's storage for no good reasons. They can only be reused by the same PR and due to our big cache sizes, their addition to the repo's storage can easily evict some good entries from the master branch.