### PR TITLE
Kernel: Don't context-switch when dispatching signals in exit_trap

### DIFF
--- a/Kernel/Arch/Processor.cpp
+++ b/Kernel/Arch/Processor.cpp
@@ -288,7 +288,7 @@ void ProcessorBase::exit_trap(TrapFrame& trap)
     auto* current_thread = Processor::current_thread();
     if (current_thread) {
         SpinlockLocker thread_lock(current_thread->get_lock());
-        current_thread->check_dispatch_pending_signal();
+        current_thread->check_dispatch_pending_signal(YieldBehavior::FlagYield);
     }
 
     // Process the deferred call queue. Among other things, this ensures

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -48,6 +48,11 @@ enum class [[nodiscard]] DispatchSignalResult {
     Continue
 };
 
+enum class YieldBehavior {
+    DoYield,
+    FlagYield
+};
+
 struct ThreadSpecificData {
     ThreadSpecificData* self;
 };
@@ -878,7 +883,7 @@ public:
 
     DispatchSignalResult dispatch_one_pending_signal();
     DispatchSignalResult dispatch_signal(u8 signal);
-    void check_dispatch_pending_signal();
+    void check_dispatch_pending_signal(YieldBehavior yield_behavior = YieldBehavior::DoYield);
     [[nodiscard]] bool has_unmasked_pending_signals() const { return m_have_any_unmasked_pending_signals.load(AK::memory_order_consume); }
     [[nodiscard]] bool should_ignore_signal(u8 signal) const;
     [[nodiscard]] bool has_signal_handler(u8 signal) const;


### PR DESCRIPTION
We shouldn't be context-switching before the very end of this function. The increment to m_in_critical is meant to prevent that, but Thread::yield_without_releasing_big_lock() (potentially called by Thread::check_dispatch_pending_signal) temporarily clears m_in_critical and forces a context-switch regardless.

To avoid inadvertently context-switching, this patch adds a new argument to Thread::check_dispatch_pending_signal() which can optionally make it call Scheduler::yield() directly (which won't context switch while we're in a critical section).