### PR TITLE
PixelPaint/Median: Replace quick_sort with insertion_sort 

### DIFF
--- a/Userland/Applications/PixelPaint/Filters/Median.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Median.cpp
@@ -31,7 +31,7 @@ void Median::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap)
                     values.unchecked_append(source_bitmap.get_pixel(i, j));
                 }
             }
-            // FIXME: If there was an insertion sort in AK, we should better use that here.
+
             // Sort the values to be able to extract the median. The median is determined by grey value (luminosity).
             quick_sort(values, [](auto& a, auto& b) { return a.luminosity() < b.luminosity(); });
             target->set_pixel(x, y, values[values.size() / 2]);


### PR DESCRIPTION
Replace `quick_sort` with `insertion_sort` in the median filter.

The median filter sorts small arrays (typically 9-25 elements) for each pixel. Insertion sort has lower overhead than quick sort for small inputs due to simpler implementation and no recursion overhead.

The FIXME comment mentioned that insertion sort should be used if it existed in AK. Since `AK::insertion_sort` was added in 2022, this change addresses that suggestion.