### PR TITLE
LibC: Improve error handling for unimplemented functions

### DIFF
--- a/Userland/Libraries/LibC/fnmatch.cpp
+++ b/Userland/Libraries/LibC/fnmatch.cpp
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <fnmatch.h>
 
-int fnmatch(char const*, char const*, int)
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html
+int fnmatch([[maybe_unused]] char const* pattern, [[maybe_unused]] char const* string, [[maybe_unused]] int flags)
 {
-    dbgln("FIXME: Implement fnmatch()");
-    return 0;
+    // FIXME: Implement fnmatch()
+    // Returning FNM_NOMATCH is safer than returning 0 (match) for unimplemented function
+    return FNM_NOMATCH;
 }

--- a/Userland/Libraries/LibC/priority.cpp
+++ b/Userland/Libraries/LibC/priority.cpp
@@ -4,20 +4,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
+#include <errno.h>
 #include <sys/resource.h>
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpriority.html
 int getpriority([[maybe_unused]] int which, [[maybe_unused]] id_t who)
 {
-    dbgln("FIXME: Implement getpriority()");
+    // FIXME: Implement getpriority()
+    errno = ENOSYS;
     return -1;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpriority.html
 int setpriority([[maybe_unused]] int which, [[maybe_unused]] id_t who, [[maybe_unused]] int value)
 {
-    dbgln("FIXME: Implement setpriority()");
+    // FIXME: Implement setpriority()
+    errno = ENOSYS;
     return -1;
 }
 }

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -1110,9 +1110,10 @@ int pause()
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/chroot.html
-int chroot(char const* path)
+int chroot([[maybe_unused]] char const* path)
 {
-    dbgln("FIXME: chroot(\"{}\")", path);
+    // FIXME: Implement chroot()
+    errno = ENOSYS;
     return -1;
 }
 
@@ -1125,10 +1126,11 @@ int getdtablesize()
 }
 
 // https://pubs.opengroup.org/onlinepubs/007904975/functions/nice.html
-int nice(int incr)
+int nice([[maybe_unused]] int incr)
 {
-    dbgln("FIXME: nice was called with: {}, not implemented", incr);
-    return incr;
+    // FIXME: Implement nice()
+    errno = ENOSYS;
+    return -1;
 }
 
 int brk(void* addr)


### PR DESCRIPTION
This PR improves error handling for several unimplemented LibC functions:

- **getpriority()/setpriority()**: Set errno to ENOSYS before returning -1
- **chroot()**: Set errno to ENOSYS before returning -1  
- **nice()**: Set errno to ENOSYS and return -1 (was incorrectly returning the `incr` argument)
- **fnmatch()**: Return FNM_NOMATCH instead of 0 (which falsely indicates a match)

These functions now properly indicate they are not implemented by setting errno to ENOSYS, following POSIX conventions.