### PR TITLE
Kernel/Input: Use atomic operations for device minor number generation

### DIFF
--- a/Kernel/Devices/Input/Management.cpp
+++ b/Kernel/Devices/Input/Management.cpp
@@ -87,13 +87,12 @@ void InputManagement::set_client(KeyboardClient* client)
 
 size_t InputManagement::generate_minor_device_number_for_mouse()
 {
-    // FIXME: Lock this to prevent race conditions with hot-plugging devices!
-    return m_mouse_minor_number++;
+    return m_mouse_minor_number.fetch_add(1);
 }
+
 size_t InputManagement::generate_minor_device_number_for_keyboard()
 {
-    // FIXME: Lock this to prevent race conditions with hot-plugging devices!
-    return m_keyboard_minor_number++;
+    return m_keyboard_minor_number.fetch_add(1);
 }
 
 UNMAP_AFTER_INIT InputManagement::KeymapData::KeymapData()

--- a/Kernel/Devices/Input/Management.h
+++ b/Kernel/Devices/Input/Management.h
@@ -62,8 +62,8 @@ private:
     size_t generate_minor_device_number_for_keyboard();
 
     SpinlockProtected<KeymapData, LockRank::None> m_keymap_data {};
-    size_t m_mouse_minor_number { 0 };
-    size_t m_keyboard_minor_number { 0 };
+    Atomic<size_t> m_mouse_minor_number { 0 };
+    Atomic<size_t> m_keyboard_minor_number { 0 };
     KeyboardClient* m_client { nullptr };
 
     SpinlockProtected<IntrusiveList<&SerialIOController::m_list_node>, LockRank::None> m_input_serial_io_controllers;


### PR DESCRIPTION
Replace plain `size_t` with `Atomic<size_t>` for mouse and keyboard minor number counters.

This prevents race conditions during hot-plugging of input devices, where concurrent calls to `generate_minor_device_number` could result in duplicate minor numbers being assigned.

The `fetch_add` operation ensures each device gets a unique minor number even when multiple devices are being initialized concurrently.