### PR TITLE
Kernel/ACPI: Add explicit allocation failure check in ACPISysFSComponent

### DIFF
--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -40,9 +40,8 @@ void Parser::must_initialize(PhysicalAddress rsdp, PhysicalAddress fadt, u8 irq_
 
 UNMAP_AFTER_INIT NonnullLockRefPtr<ACPISysFSComponent> ACPISysFSComponent::create(StringView name, PhysicalAddress paddr, size_t table_size)
 {
-    // FIXME: Handle allocation failure gracefully
     auto table_name = KString::must_create(name);
-    return adopt_lock_ref(*new (nothrow) ACPISysFSComponent(move(table_name), paddr, table_size));
+    return MUST(adopt_nonnull_lock_ref_or_enomem(new (nothrow) ACPISysFSComponent(move(table_name), paddr, table_size)));
 }
 
 ErrorOr<size_t> ACPISysFSComponent::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription*) const


### PR DESCRIPTION
Replace implicit dereference of potentially null pointer with explicit `VERIFY` check.

This makes the error handling explicit and prevents undefined behavior if the allocation fails.

Since this is boot-time initialization code where ACPI tables are essential for system operation, panicking on allocation failure is the appropriate behavior.