### PR TITLE
tar: Return error instead of panic for XZ compression

### DIFF
--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -238,7 +238,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             output_stream = TRY(Compress::LzmaCompressor::create_container(move(output_stream), {}));
 
         if (xz)
-            TODO();
+            return Error::from_string_literal("Creating XZ compressed archives is not supported");
 
         Archive::TarOutputStream tar_stream(move(output_stream));
 


### PR DESCRIPTION
Return a clear error message instead of TODO() panic when attempting to create XZ-compressed archives since compression is not yet implemented.

Note: XZ decompression works, only compression is not yet implemented.