### PR TITLE
LibC: Clean up stub function debug output and return values

### DIFF
--- a/Userland/Libraries/LibC/fnmatch.cpp
+++ b/Userland/Libraries/LibC/fnmatch.cpp
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <fnmatch.h>
 
 int fnmatch(char const*, char const*, int)
 {
-    dbgln("FIXME: Implement fnmatch()");
-    return 0;
+    // FIXME: Implement fnmatch()
+    return FNM_NOMATCH;
 }

--- a/Userland/Libraries/LibC/mntent.cpp
+++ b/Userland/Libraries/LibC/mntent.cpp
@@ -4,33 +4,31 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
-#include <assert.h>
 #include <mntent.h>
 
 extern "C" {
 
-struct mntent* getmntent(FILE*)
+struct mntent* getmntent([[maybe_unused]] FILE* stream)
 {
-    dbgln("FIXME: Implement getmntent()");
+    // FIXME: Implement getmntent()
     return nullptr;
 }
 
-FILE* setmntent(char const*, char const*)
+FILE* setmntent([[maybe_unused]] char const* filename, [[maybe_unused]] char const* type)
 {
-    dbgln("FIXME: Implement setmntent()");
+    // FIXME: Implement setmntent()
     return nullptr;
 }
 
-int endmntent(FILE*)
+int endmntent([[maybe_unused]] FILE* stream)
 {
-    dbgln("FIXME: Implement endmntent()");
-    return 0;
+    // FIXME: Implement endmntent()
+    return 1;
 }
 
-struct mntent* getmntent_r(FILE*, struct mntent*, char*, int)
+struct mntent* getmntent_r([[maybe_unused]] FILE* stream, [[maybe_unused]] struct mntent* mntbuf, [[maybe_unused]] char* buf, [[maybe_unused]] int buflen)
 {
-    dbgln("FIXME: Implement getmntent_r()");
-    return 0;
+    // FIXME: Implement getmntent_r()
+    return nullptr;
 }
 }

--- a/Userland/Libraries/LibC/priority.cpp
+++ b/Userland/Libraries/LibC/priority.cpp
@@ -4,20 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
+#include <errno.h>
 #include <sys/resource.h>
 
 extern "C" {
 
 int getpriority([[maybe_unused]] int which, [[maybe_unused]] id_t who)
 {
-    dbgln("FIXME: Implement getpriority()");
+    // FIXME: Implement getpriority()
+    errno = ENOSYS;
     return -1;
 }
 
 int setpriority([[maybe_unused]] int which, [[maybe_unused]] id_t who, [[maybe_unused]] int value)
 {
-    dbgln("FIXME: Implement setpriority()");
+    // FIXME: Implement setpriority()
+    errno = ENOSYS;
     return -1;
 }
 }

--- a/Userland/Libraries/LibC/resolv.cpp
+++ b/Userland/Libraries/LibC/resolv.cpp
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <resolv.h>
 
 extern "C" {
 
-int res_query(char const*, int, int, unsigned char*, int)
+int res_query([[maybe_unused]] char const* dname, [[maybe_unused]] int class_, [[maybe_unused]] int type, [[maybe_unused]] unsigned char* answer, [[maybe_unused]] int anslen)
 {
-    dbgln("FIXME: Implement res_query()");
-    return 0;
+    // FIXME: Implement res_query()
+    return -1;
 }
 }

--- a/Userland/Libraries/LibC/search.cpp
+++ b/Userland/Libraries/LibC/search.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <bits/search.h>
 #include <search.h>
 
@@ -93,9 +92,9 @@ void* tfind(void const* key, void* const* rootp, int (*comparator)(void const*, 
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/tdelete.html
-void* tdelete(void const*, void**, int (*)(void const*, void const*))
+void* tdelete([[maybe_unused]] void const* key, [[maybe_unused]] void** rootp, [[maybe_unused]] int (*compar)(void const*, void const*))
 {
-    dbgln("FIXME: Implement tdelete()");
+    // FIXME: Implement tdelete()
     return nullptr;
 }
 

--- a/Userland/Libraries/LibC/sys/mman.cpp
+++ b/Userland/Libraries/LibC/sys/mman.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <bits/pthread_cancel.h>
 #include <errno.h>
 #include <stdio.h>
@@ -85,16 +84,16 @@ int posix_madvise(void* address, size_t len, int advice)
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/mlock.html
-int mlock(void const*, size_t)
+int mlock([[maybe_unused]] void const* addr, [[maybe_unused]] size_t len)
 {
-    dbgln("FIXME: Implement mlock()");
+    // FIXME: Implement mlock()
     return 0;
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/munlock.html
-int munlock(void const*, size_t)
+int munlock([[maybe_unused]] void const* addr, [[maybe_unused]] size_t len)
 {
-    dbgln("FIXME: Implement munlock()");
+    // FIXME: Implement munlock()
     return 0;
 }
 

--- a/Userland/Libraries/LibC/ulimit.cpp
+++ b/Userland/Libraries/LibC/ulimit.cpp
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <assert.h>
+#include <errno.h>
 #include <sys/resource.h>
 #include <syscall.h>
 #include <ulimit.h>
@@ -15,8 +15,8 @@ extern "C" {
 
 long ulimit([[maybe_unused]] int cmd, [[maybe_unused]] long newlimit)
 {
-    dbgln("FIXME: Implement ulimit()");
-    TODO();
+    // FIXME: Implement ulimit()
+    errno = ENOSYS;
     return -1;
 }
 


### PR DESCRIPTION
## Summary
- Replace `dbgln()` calls in stub functions with FIXME comments to reduce runtime noise
- Fix incorrect return values in unimplemented functions:
  - `fnmatch()`: Return `FNM_NOMATCH` instead of 0 (which falsely indicates a match)
  - `ulimit()`: Return -1 with `errno=ENOSYS` instead of calling `TODO()` which panics
  - `getpriority()`/`setpriority()`: Set `errno=ENOSYS` for proper error reporting
  - `endmntent()`: Return 1 per glibc documentation (always succeeds)
  - `res_query()`: Return -1 (error) instead of 0
- Remove now-unused `AK/Format.h` includes
- Add `[[maybe_unused]]` attribute to function parameters