### PR TITLE
Kernel/Storage: Fix null pointer dereference and TODO panic in partition

### DIFF
--- a/Kernel/Devices/Storage/StorageDevicePartition.cpp
+++ b/Kernel/Devices/Storage/StorageDevicePartition.cpp
@@ -35,12 +35,16 @@ Partition::DiskPartitionMetadata const& StorageDevicePartition::metadata() const
 void StorageDevicePartition::start_request(AsyncBlockDeviceRequest& request)
 {
     auto device = m_device.strong_ref();
-    if (!device)
+    if (!device) {
         request.complete(AsyncBlockDeviceRequest::RequestResult::Failure);
+        return;
+    }
     auto sub_request_or_error = device->try_make_request<AsyncBlockDeviceRequest>(request.request_type(),
         request.block_index() + m_metadata.start_block(), request.block_count(), request.buffer(), request.buffer_size());
-    if (sub_request_or_error.is_error())
-        TODO();
+    if (sub_request_or_error.is_error()) {
+        request.complete(AsyncBlockDeviceRequest::RequestResult::Failure);
+        return;
+    }
     request.add_sub_request(sub_request_or_error.release_value());
 }
 


### PR DESCRIPTION
## Summary
Fix two issues in `StorageDevicePartition::start_request()`:

1. **Bug fix**: Add missing `return` statement after completing request with Failure when the underlying device is gone. Without this, the code would continue and dereference the null device pointer on the next line.

2. **Replace TODO() panic**: When subrequest creation fails (e.g., OOM), complete the request with Failure instead of crashing the kernel.

## Analysis

The bug was a missing return after request completion:
```cpp
if (!device)
    request.complete(Failure);
// Missing return - continues to dereference null device!
auto sub_request_or_error = device->try_make_request<...>();
```

This could occur if the underlying storage device was removed while a partition request was in flight.