### PR TITLE
Everywhere: Fix spelling errors in comments

### DIFF
--- a/Userland/Libraries/LibGUI/DynamicWidgetContainer.cpp
+++ b/Userland/Libraries/LibGUI/DynamicWidgetContainer.cpp
@@ -241,13 +241,13 @@ ErrorOr<void> DynamicWidgetContainer::detach_widgets()
         root_container->set_fill_with_background_color(true);
         root_container->set_layout<GUI::VerticalBoxLayout>();
         root_container->set_frame_style(Gfx::FrameStyle::Window);
-        auto transfer_children = [this](auto reciever, auto children) {
+        auto transfer_children = [this](auto receiver, auto children) {
             for (NonnullRefPtr<GUI::Widget> widget : children) {
                 if (widget == m_controls_widget)
                     continue;
                 widget->remove_from_parent();
                 widget->set_visible(true);
-                reciever->add_child(widget);
+                receiver->add_child(widget);
             }
         };
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -857,7 +857,7 @@ bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigne
     if (!layout_box().is_user_scrollable())
         return false;
 
-    // TODO: Vertical and horizontal scroll overflow should be handled seperately.
+    // TODO: Vertical and horizontal scroll overflow should be handled separately.
     if (!has_scrollable_overflow())
         return false;
 

--- a/Userland/Services/SpiceAgent/FileTransferOperation.h
+++ b/Userland/Services/SpiceAgent/FileTransferOperation.h
@@ -36,7 +36,7 @@ public:
     // Fired by SpiceAgent when we have received all of the data needed for this transfer.
     ErrorOr<void> complete_transfer(SpiceAgent& agent);
 
-    // Fired by the SpiceAgent when it recieves data related to this transfer.
+    // Fired by the SpiceAgent when it receives data related to this transfer.
     ErrorOr<void> on_data_received(FileTransferDataMessage& message);
 
 private:

--- a/Userland/Services/SpiceAgent/Message.h
+++ b/Userland/Services/SpiceAgent/Message.h
@@ -225,7 +225,7 @@ private:
     Metadata m_metadata;
 };
 
-// Sent/recieved to indicate the status of the current file transfer.
+// Sent/received to indicate the status of the current file transfer.
 class FileTransferStatusMessage : public Message {
 public:
     FileTransferStatusMessage(u32 id, FileTransferStatus status)

--- a/Userland/Services/SpiceAgent/SpiceAgent.h
+++ b/Userland/Services/SpiceAgent/SpiceAgent.h
@@ -20,7 +20,7 @@
 namespace SpiceAgent {
 
 // The maximum amount of data that can be contained within a message's buffer.
-// If the buffer's length is equal to this, then the next data recieved will be more data from the same buffer.
+// If the buffer's length is equal to this, then the next data received will be more data from the same buffer.
 constexpr u32 message_buffer_threshold = 2048;
 
 // The maximum amount of data that can be received in one file transfer message


### PR DESCRIPTION
Fix common spelling mistakes in comments:

- `recieved` -> `received` (SpiceAgent)
- `recieves` -> `receives` (SpiceAgent)
- `reciever` -> `receiver` (LibGUI)
- `seperately` -> `separately` (LibWeb)