### PR TITLE
Revert "Kernel/VirtIO: Require VIRTIO_F_IN_ORDER for Console device"

### DIFF
--- a/Kernel/Devices/Serial/VirtIO/Console.cpp
+++ b/Kernel/Devices/Serial/VirtIO/Console.cpp
@@ -26,16 +26,6 @@ UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<Console>> Console::create_for_pci_instanc
 UNMAP_AFTER_INIT ErrorOr<void> Console::initialize_virtio_resources()
 {
     TRY(Device::initialize_virtio_resources());
-
-    // NOTE: We require the VIRTIO_F_IN_ORDER feature to ensure that buffers are used by the device
-    // in the same order they were made available. Without this guarantee, the RingBuffer's
-    // reclaim_space() would fail its FIFO assertion when buffers are returned out-of-order.
-    // See GitHub issue #26210 for more details.
-    if (!is_feature_accepted(VIRTIO_F_IN_ORDER)) {
-        dmesgln("VirtIO::Console: VIRTIO_F_IN_ORDER feature is required but not supported by device");
-        return ENOTSUP;
-    }
-
     auto const* cfg = TRY(transport_entity().get_config(VirtIO::ConfigurationType::Device));
     TRY(negotiate_features([&](u64 supported_features) {
         u64 negotiated = 0;


### PR DESCRIPTION
This is not the correct way to negotiate virtio features and causes this panic when running on a machine with a virtio-serial device, such as the default non-CI machine:
"ASSERTION FAILED: m_did_accept_features.was_set()"

Additionally, I don't think this is the correct way to fix this, as QEMU never seems to have advertised VIRTIO_F_IN_ORDER.

A correct fix would be to handle descriptors being processed out of order correctly.

This reverts commit 0d9a095f5ad3615ee62e07959eec1c7a040a7284.