### PR TITLE
Meta: Update copyright year in license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018-2025, the SerenityOS developers.
+Copyright (c) 2018-2026, the SerenityOS developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Brief Explanation:
Only the copyright year in license headers was updated from 2025 to 2026.

Changes:
No code, data, or functionality files were modified. This is my first PR to SerenityOS.
