### PR TITLE
LibGfx: Support reading JXL data from jxlp boxes

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Enums.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Enums.h
@@ -22,6 +22,7 @@ namespace Gfx::ISOBMFF {
     ENUMERATE_ONE(JPEG2000ColorSpecificationBox, "colr")       \
     ENUMERATE_ONE(JPEGXLCodestreamBox, "jxlc")                 \
     ENUMERATE_ONE(JPEGXLLevelBox, "jxll")                      \
+    ENUMERATE_ONE(JPEGXLPartialCodestreamBox, "jxlp")          \
     ENUMERATE_ONE(JPEGXLSignatureBox, "JXL ")                  \
     ENUMERATE_ONE(FreeBox, "free")                             \
     ENUMERATE_ONE(FileTypeBox, "ftyp")                         \

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEGXLBoxes.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEGXLBoxes.cpp
@@ -46,4 +46,21 @@ void JPEGXLCodestreamBox::dump(String const& prepend) const
     outln("{}- size = {}", prepend, codestream.size());
 }
 
+ErrorOr<void> JPEGXLPartialCodestreamBox::read_from_stream(ConstrainedStream& stream)
+{
+    part_index = TRY(stream.read_value<BigEndian<u32>>());
+
+    // FIXME: Prevent the copy.
+    TRY(codestream.try_resize(stream.remaining()));
+    TRY(stream.read_until_filled(codestream.span()));
+    return {};
+}
+
+void JPEGXLPartialCodestreamBox::dump(String const& prepend) const
+{
+    Box::dump(prepend);
+    outln("{}- index = {}{}", prepend, index(), is_last() ? " (last)" : "");
+    outln("{}- size = {}", prepend, codestream.size());
+}
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEGXLBoxes.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/JPEGXLBoxes.h
@@ -34,4 +34,15 @@ struct JPEGXLCodestreamBox final : public Box {
     Vector<u8> codestream;
 };
 
+// 9.10 - JPEG XL Partial Codestream box (jxlp)
+struct JPEGXLPartialCodestreamBox final : public Box {
+    BOX_SUBTYPE(JPEGXLPartialCodestreamBox);
+
+    u32 index() const { return part_index & 0x7FFF'FFFF; }
+    bool is_last() const { return (part_index & 0x8000'0000) != 0; }
+
+    u32 part_index { 0 };
+    Vector<u8> codestream;
+};
+
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
@@ -42,6 +42,8 @@ ErrorOr<BoxList> Reader::read_entire_file()
             return TRY(JPEGXLLevelBox::create_from_stream(stream));
         case BoxType::JPEGXLSignatureBox:
             return TRY(JPEGXLSignatureBox::create_from_stream(stream));
+        case BoxType::JPEGXLPartialCodestreamBox:
+            return TRY(JPEGXLPartialCodestreamBox::create_from_stream(stream));
         case BoxType::UserExtensionBox:
             return TRY(UserExtensionBox::create_from_stream(stream));
         default:


### PR DESCRIPTION
Per format_overview.md:

> The codestream can optionally be split into multiple jxlp boxes;
> conceptually, this is equivalent to a single jxlc box that contains
> the concatenation of all partial codestream boxes.

It looks like the data is preceded by a u32 that's incrementing,
and has its highest bit set at the end.

Naively implement this by just appending the data from all jxlp
into a single vector.

With this, decoding the output of

    cjxl Tests/LibGfx/test-inputs/jpg/big_image.jpg big_image.jxl

gets a bit farther.