### PR TITLE
LibPDF: Do not crash on deflate stream with too little data

### DIFF
--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -226,6 +226,8 @@ PDFErrorOr<ByteBuffer> Filter::decode_lzw(ReadonlyBytes bytes, RefPtr<DictObject
 
 PDFErrorOr<ByteBuffer> Filter::decode_flate(ReadonlyBytes bytes, RefPtr<DictObject> decode_parms)
 {
+    if (bytes.size() < 2)
+        return Error::malformed_error("FlateDecode input too small to contain zlib header");
     auto buff = TRY(Compress::DeflateDecompressor::decompress_all(bytes.slice(2)));
     return handle_lzw_and_flate_parameters(move(buff), decode_parms);
 }


### PR DESCRIPTION
With this, LibPDF can render ISO-IEC-18181-2-2021-en.pdf from https://www.normsplash.com/ISO/146298163/ISO-IEC-18181-2