### PR TITLE
Meta: Generate per-library coverage reports

### DIFF
--- a/.github/workflows/serenity-template.yml
+++ b/.github/workflows/serenity-template.yml
@@ -167,7 +167,7 @@ jobs:
         working-directory: ${{ steps.build-parameters.outputs.build_directory }}
         env:
           SERENITY_QEMU_CPU: "max,vmx=off"
-          SERENITY_KERNEL_CMDLINE: "graphics_subsystem_mode=off panic=shutdown system_mode=self-test"
+          SERENITY_KERNEL_CMDLINE: "graphics_subsystem_mode=off panic=shutdown system_mode=self-test${{ inputs.coverage == 'ON' && '-coverage' || '' }}"
           SERENITY_RUN: "ci"
         run: |
           echo "::group::ninja run # Qemu output"

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -1,6 +1,6 @@
 [NetworkServer]
 User=root
-SystemModes=text,graphical,self-test
+SystemModes=text,graphical,self-test,self-test-coverage
 
 [LookupServer]
 Socket=/tmp/portal/lookup
@@ -8,7 +8,7 @@ SocketPermissions=660
 Priority=low
 KeepAlive=true
 User=lookup
-SystemModes=text,graphical,self-test
+SystemModes=text,graphical,self-test,self-test-coverage
 
 [WindowServer]
 Socket=/tmp/portal/window,/tmp/portal/wm
@@ -50,6 +50,14 @@ Environment=DO_SHUTDOWN_AFTER_TESTS=1 TERM=xterm PATH=/bin:/usr/bin:/usr/local/b
 User=anon
 WorkingDirectory=/home/anon
 SystemModes=self-test
+
+[CoverageRunner@ttyS0]
+Executable=/home/anon/Tests/run-tests-and-shutdown.sh
+StdIO=/dev/ttyS0
+Environment=COVERAGE_RUN=1 DO_SHUTDOWN_AFTER_TESTS=1 TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin
+User=anon
+WorkingDirectory=/home/anon
+SystemModes=self-test-coverage
 
 [GenerateManpages@ttyS0]
 Executable=/root/generate_manpages.sh

--- a/Base/home/anon/Tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/Tests/run-tests-and-shutdown.sh
@@ -9,11 +9,8 @@ if [ "$(uname -m)" = "aarch64" -o "$(uname -m)" = "riscv64" ] && [ "$1" != "--fo
     fail_count=0
 }
 else {
-    mkdir -p "$HOME/profiles"
-    export LLVM_PROFILE_FILE="$HOME/profiles/%p-profile.profraw"
     run-tests --show-progress=false --unlink-coredumps
     fail_count=$?
-    unset LLVM_PROFILE_FILE
 }
 
 echo "Failed: $fail_count" > ./test-results.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,22 @@ elseif("${SERENITY_ARCH}" STREQUAL "x86_64")
     add_link_options(LINKER:-z,pack-relative-relocs)
 endif()
 
+# Escape hatch target to prevent runtime startup libraries from having coverage enabled
+# at awkward points in program initialization
+add_library(NoCoverage INTERFACE)
+
+if (ENABLE_USERSPACE_COVERAGE_COLLECTION)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+        add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+
+        target_compile_options(NoCoverage INTERFACE -fno-profile-generate -fno-profile-instr-use -fno-profile-instr-generate -fno-coverage-mapping)
+        target_link_options(NoCoverage INTERFACE -fno-profile-generate -fno-profile-instr-use -fno-profile-instr-generate -fno-coverage-mapping)
+    else()
+        message(FATAL_ERROR "ENABLE_USERSPACE_COVERAGE_COLLECTION not supported yet for ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+endif()
+
 add_subdirectory(Userland)
 add_subdirectory(Tests)
 

--- a/Meta/analyze-qemu-coverage.sh
+++ b/Meta/analyze-qemu-coverage.sh
@@ -38,7 +38,7 @@ mv "$TEMP_PROFDATA"/profiles/* "$TEMP_PROFDATA/"
 
 echo "Discovering all binaries and shared libraries in $BUILD_DIR/Root"
 # shellcheck disable=SC2156 # The recommended fix on the Shellcheck github page for this warning causes the script to not find any files at all
-mapfile -d '\n' all_binaries < <(find "$BUILD_DIR"/Root -type f -exec sh -c "file {} | grep -vi relocatable | grep -Eiq ': elf (32|64)-bit'" \; -print | grep -Ev '(usr\/Tests|usr\/local|boot\/|Loader.so)')
+mapfile -d '\n' all_binaries < <(find "$BUILD_DIR"/Root -type f -executable -exec sh -c "file {} | grep -vi relocatable | grep -Eiq ': elf (32|64)-bit'" \; -print | grep -Ev '(usr\/Tests|usr\/local|boot\/|Loader.so)')
 
 # FIXME: Come up with our own coverage prep script instead of using llvm's
 COVERAGE_PREPARE="$BUILD_DIR/prepare-code-coverage-artifact.py"

--- a/Meta/analyze-qemu-coverage.sh
+++ b/Meta/analyze-qemu-coverage.sh
@@ -32,11 +32,6 @@ echo "[ELEVATED] Unmounting _disk_image, this requires elevated privileges..."
 echo "[ELEVATED] Making sure profile data files are owned by the current user, this requires elevated privileges..."
 "$ELEVATE" chown -R "$(id -u)":"$(id -g)" "$TEMP_PROFDATA/"
 
-
-echo "Discovering all binaries and shared libraries in $BUILD_DIR/Root"
-# shellcheck disable=SC2156 # The recommended fix on the Shellcheck github page for this warning causes the script to not find any files at all
-all_binaries=$(find "$BUILD_DIR"/Root -type f -executable -exec sh -c "file {} | grep -vi relocatable | grep -Eiq ': elf (32|64)-bit'" \; -printf "-object %p\n" | grep -Ev '(usr\/local|boot\/|Loader.so)')
-
 CLANG_BINDIR="${SERENITY_ROOT}/Toolchain/Local/clang/bin"
 LLVM_PROFDATA="$CLANG_BINDIR/llvm-profdata"
 PROFDATA_INVOCATION="$LLVM_PROFDATA merge -sparse"
@@ -58,6 +53,10 @@ GLOBAL_PROFILE="$TEMP_PROFDATA/global_coverage.profdata"
 PROF_DATA_FILES=$(find "$TEMP_PROFDATA/profiles/" -name "*.profdata")
 # shellcheck disable=SC2086
 $PROFDATA_INVOCATION $PROF_DATA_FILES -o "$GLOBAL_PROFILE"
+
+echo "Discovering all binaries and shared libraries in $BUILD_DIR/Root"
+# shellcheck disable=SC2156 # The recommended fix on the Shellcheck github page for this warning causes the script to not find any files at all
+all_binaries=$(find "$BUILD_DIR"/Root -type f -executable -exec sh -c "file {} | grep -vi relocatable | grep -Eiq ': elf (32|64)-bit'" \; -printf "-object %p\n" | grep -Ev '(usr\/local|boot\/|Loader.so)')
 
 echo "Generating global html report"
 # shellcheck disable=SC2086

--- a/Meta/analyze-qemu-coverage.sh
+++ b/Meta/analyze-qemu-coverage.sh
@@ -17,7 +17,7 @@ fi
 BUILD_DIR="${SERENITY_ROOT}/Build/${SERENITY_ARCH}${toolchain_suffix}"
 TEMP_PROFDATA="$BUILD_DIR/tmp_profile_data"
 
-mkdir -p "$TEMP_PROFDATA"
+mkdir "$TEMP_PROFDATA"
 mkdir -p "$BUILD_DIR/mnt"
 
 [ -z "${ELEVATE+x}" ] && ELEVATE="sudo"

--- a/Meta/analyze-qemu-coverage.sh
+++ b/Meta/analyze-qemu-coverage.sh
@@ -35,7 +35,7 @@ echo "[ELEVATED] Making sure profile data files are owned by the current user, t
 
 echo "Discovering all binaries and shared libraries in $BUILD_DIR/Root"
 # shellcheck disable=SC2156 # The recommended fix on the Shellcheck github page for this warning causes the script to not find any files at all
-all_binaries=$(find "$BUILD_DIR"/Root -type f -executable -exec sh -c "file {} | grep -vi relocatable | grep -Eiq ': elf (32|64)-bit'" \; -printf "-object %p\n" | grep -Ev '(usr\/Tests|usr\/local|boot\/|Loader.so)')
+all_binaries=$(find "$BUILD_DIR"/Root -type f -executable -exec sh -c "file {} | grep -vi relocatable | grep -Eiq ': elf (32|64)-bit'" \; -printf "-object %p\n" | grep -Ev '(usr\/local|boot\/|Loader.so)')
 
 CLANG_BINDIR="${SERENITY_ROOT}/Toolchain/Local/clang/bin"
 LLVM_PROFDATA="$CLANG_BINDIR/llvm-profdata"

--- a/Userland/CMakeLists.txt
+++ b/Userland/CMakeLists.txt
@@ -1,21 +1,5 @@
 add_compile_options(-O2)
 
-# Escape hatch target to prevent runtime startup libraries from having coverage enabled
-# at awkward points in program initialization
-add_library(NoCoverage INTERFACE)
-
-if (ENABLE_USERSPACE_COVERAGE_COLLECTION)
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
-        add_link_options(-fprofile-instr-generate -fcoverage-mapping)
-
-        target_compile_options(NoCoverage INTERFACE -fno-profile-generate -fno-profile-instr-use -fno-profile-instr-generate -fno-coverage-mapping)
-        target_link_options(NoCoverage INTERFACE -fno-profile-generate -fno-profile-instr-use -fno-profile-instr-generate -fno-coverage-mapping)
-    else()
-        message(FATAL_ERROR "ENABLE_USERSPACE_COVERAGE_COLLECTION not supported yet for ${CMAKE_CXX_COMPILER_ID}")
-    endif()
-endif()
-
 add_subdirectory(Applications)
 add_subdirectory(Demos)
 add_subdirectory(DevTools)


### PR DESCRIPTION
Having per-library reports remove the bias due to the usage of a library outside its own tests. This is of course most visible with `AK` and `LibCore`.

Here is AK within the global report:
<img width="1692" height="130" alt="image" src="https://github.com/user-attachments/assets/589543ec-4fdd-45d9-ba3c-1494ca39be7d" />

And here when only considering `Tests/AK`:
<img width="1562" height="130" alt="image" src="https://github.com/user-attachments/assets/76b8c02f-f289-4a2c-82b7-da060c8d34e2" />


Of course, "standalone" library doesn't have that issue and for example `LibEDID` reports the same results in both reports.

---

This is a draft because in order to generate the per-library reports, I had to patch `llvm-cov` to teach it to only include files matching a given regex in the source folder (the `-include-filename-regex` option). Here is the patch:
[llvm-cov-include-filename.patch](https://github.com/user-attachments/files/24492245/llvm-cov-include-filename.patch)

@nico What do you think of this approach? (And if you think I should upstream the patch, can you give it a quick look?)