### PR TITLE
Kernel: Define TIMER_ABSTIME as 1

### DIFF
--- a/Kernel/API/POSIX/time.h
+++ b/Kernel/API/POSIX/time.h
@@ -35,7 +35,7 @@ enum {
     CLOCK_ID_COUNT,
 };
 
-#define TIMER_ABSTIME 99
+#define TIMER_ABSTIME 1
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The value of 99 has been unchanged since being first introduced in commit cc68654a4, and is completely arbitrary. Other systems define this as 1, which makes more sense given it's one of (in theory) multiple flags.

The specific motivation behind this change is integration into the Zig standard library where it's easier to use a single bit flag.

See: https://codeberg.org/ziglang/zig/pulls/30746