### PR TITLE
PixelPaint: Respect editing mask in EraseTool pencil mode

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -33,9 +33,13 @@ void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint 
     if (m_draw_mode == DrawMode::Pencil) {
         int radius = size() / 2;
         Gfx::IntRect rect { point.x() - radius, point.y() - radius, size(), size() };
-        GUI::Painter painter(bitmap);
-        // FIXME: Currently this mode does not respect the editing mask if present.
-        painter.clear_rect(rect, color);
+        for (int y = rect.top(); y < rect.bottom(); ++y) {
+            for (int x = rect.left(); x < rect.right(); ++x) {
+                if (x < 0 || x >= bitmap.width() || y < 0 || y >= bitmap.height())
+                    continue;
+                set_pixel_with_possible_mask(x, y, color, bitmap);
+            }
+        }
     } else {
         for (int y = point.y() - size(); y < point.y() + size(); y++) {
             for (int x = point.x() - size(); x < point.x() + size(); x++) {


### PR DESCRIPTION
PixelPaint: Respect editing mask in EraseTool pencil mode

The Erase Tool in pencil mode was ignoring active editing masks because it used GUI::Painter::clear_rect(), which writes directly to the bitmap and bypasses the layer’s mask logic. As a result, pixels were erased even in masked-out (protected) regions (already noted with a FIXME).

Replace the *clear_rect()* call with manual per-pixel iteration over the eraser bounds, and update each valid (x, y) *using set_pixel_with_possible_mask()* instead of modifying the bitmap directly.

This makes the eraser respect editing masks properly. Mask alpha values are handled as expected: "255" fully erases, "0" leaves the pixel untouched, and intermediate values apply partial erasing. Pencil-mode behavior is now consistent with other mask-aware tools.