### PR TITLE
Meta: Prefer `sudo`'s `--preserve-env` over `-E`

### DIFF
--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -14,7 +14,9 @@ die() {
 if [ "$(uname -s)" = "SerenityOS" ]; then
     SUDO="pls -E"
 elif command -v sudo >/dev/null; then
-    SUDO="sudo -E"
+    # Preserve all environment variables starting with SERENITY_.
+    SERENITY_VARS=$(env | cut -d= -f1 | grep '^SERENITY' | tr '\n' ',' | sed 's/,$//')
+    SUDO="sudo --preserve-env=$SERENITY_VARS"
 elif command -v doas >/dev/null; then
     if [ "$SUDO_UID" = '' ]; then
         SUDO_UID=$(id -u)


### PR DESCRIPTION
The `-E` option is not supported by `sudo-rs` so give it the list of all our environment variables.

Fix building on Ubuntu 25.10.