### PR TITLE
LibLine: Write history file atomically

### DIFF
--- a/Userland/Libraries/LibLine/CMakeLists.txt
+++ b/Userland/Libraries/LibLine/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 )
 
 serenity_lib(LibLine line)
-target_link_libraries(LibLine PRIVATE LibCoreMinimal LibCoreBasic LibUnicode)
+target_link_libraries(LibLine PRIVATE LibCoreMinimal LibCoreBasic LibUnicode LibFileSystem)


### PR DESCRIPTION
It's possible to end up with a garbled history file if two or more users try to write the history out at once if we don't write the file atomically.