### PR TITLE
LibVT: Clamp repeat count in REP sequence

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -577,8 +577,13 @@ void Terminal::REP(Parameters params)
     if (params.size() >= 1 && params[0] != 0)
         count = params[0];
 
-    for (unsigned i = 0; i < count; ++i)
-        put_character_at(m_current_state.cursor.row, m_current_state.cursor.column++, m_last_code_point);
+    count = min<unsigned>(count, columns() - cursor_column());
+
+    for (unsigned i = 0; i < count; ++i) {
+        put_character_at(m_current_state.cursor.row, m_current_state.cursor.column, m_last_code_point);
+        if (m_current_state.cursor.column < (size_t)columns() - 1)
+            m_current_state.cursor.column++;
+    }
 }
 
 void Terminal::VPA(Parameters params)


### PR DESCRIPTION
I noticed that LibVT crashes when it gets a REP (Repeat Last Character) sequence with a count that's bigger than the remaining line width. For example, running printf 'x\e[100b' in a default-sized terminal triggers a VERIFY failure in 
put_character_at()
 because it tries to write off the screen.

I've updated the logic to clamp the repeat count to whatever is left on the line and added a check to make sure the cursor stays within the terminal bounds during the character loop. This is similar to how we handle the ICH sequence.

Fixes #26533