### PR TITLE
Kernel+LibC: Implement posix_spawn file actions in kernel

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -495,6 +495,7 @@ struct SC_posix_spawn_params {
     size_t attr_data_size;
     Userspace<void const*> serialized_file_actions_data;
     size_t serialized_file_actions_data_size;
+    u8 file_action_types_present;
 };
 
 struct SC_futimens_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -495,7 +495,6 @@ struct SC_posix_spawn_params {
     size_t attr_data_size;
     Userspace<void const*> serialized_file_actions_data;
     size_t serialized_file_actions_data_size;
-    u8 file_action_types_present;
 };
 
 struct SC_futimens_params {

--- a/Kernel/API/spawn.h
+++ b/Kernel/API/spawn.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Fırat Kızılboğa <firatkizilboga11@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+#include <AK/Types.h>
+#include <Kernel/API/POSIX/sys/types.h>
+
+namespace Kernel {
+
+enum class SpawnFileActionType : u8 {
+    Dup2 = 0,
+    Open = 1,
+    Close = 2,
+    Chdir = 3,
+    Fchdir = 4,
+};
+
+struct SpawnFileActionHeader {
+    SpawnFileActionType type;
+    u16 record_length;
+};
+
+struct SpawnFileActionDup2 {
+    SpawnFileActionHeader header;
+    i32 old_fd;
+    i32 new_fd;
+};
+
+struct SpawnFileActionOpen {
+    SpawnFileActionHeader header;
+    i32 fd;
+    i32 flags;
+    mode_t mode;
+    u16 path_length;
+    char path[];
+};
+
+struct SpawnFileActionClose {
+    SpawnFileActionHeader header;
+    i32 fd;
+};
+
+struct SpawnFileActionChdir {
+    SpawnFileActionHeader header;
+    u16 path_length;
+    char path[];
+};
+
+struct SpawnFileActionFchdir {
+    SpawnFileActionHeader header;
+    i32 fd;
+};
+
+inline constexpr size_t SPAWN_FILE_ACTION_ALIGNMENT = max(
+    max(alignof(SpawnFileActionHeader), alignof(SpawnFileActionDup2)),
+    max(max(alignof(SpawnFileActionOpen), alignof(SpawnFileActionClose)),
+        max(alignof(SpawnFileActionChdir), alignof(SpawnFileActionFchdir))));
+
+}

--- a/Kernel/Syscalls/posix_spawn.cpp
+++ b/Kernel/Syscalls/posix_spawn.cpp
@@ -125,6 +125,24 @@ ErrorOr<void> Process::execute_file_actions(ReadonlyBytes file_actions_data)
             });
             break;
         }
+        case SpawnFileActionType::Fchdir: {
+            if (header->record_length < sizeof(SpawnFileActionFchdir))
+                return EINVAL;
+
+            auto const* action = reinterpret_cast<SpawnFileActionFchdir const*>(header);
+            auto description = TRY(open_file_description(action->fd));
+            if (!description->is_directory())
+                return ENOTDIR;
+
+            // Check for search (+x) permission on the directory
+            if (!description->metadata().may_execute(credentials()))
+                return EACCES;
+
+            m_current_directory.with([&](auto& current_directory) {
+                current_directory = description->custody();
+            });
+            break;
+        }
         default:
             return EINVAL;
         }
@@ -157,7 +175,7 @@ ErrorOr<FlatPtr> Process::sys$posix_spawn(Userspace<Syscall::SC_posix_spawn_para
     OwnPtr<KBuffer> file_actions_buffer;
     if (params.serialized_file_actions_data.ptr() != 0 && params.serialized_file_actions_data_size != 0) {
         // Check for unsupported file actions
-        constexpr u8 SUPPORTED_SPAWN_ACTIONS = (1 << static_cast<u8>(SpawnFileActionType::Dup2)) | (1 << static_cast<u8>(SpawnFileActionType::Close)) | (1 << static_cast<u8>(SpawnFileActionType::Open)) | (1 << static_cast<u8>(SpawnFileActionType::Chdir));
+        constexpr u8 SUPPORTED_SPAWN_ACTIONS = (1 << static_cast<u8>(SpawnFileActionType::Dup2)) | (1 << static_cast<u8>(SpawnFileActionType::Close)) | (1 << static_cast<u8>(SpawnFileActionType::Open)) | (1 << static_cast<u8>(SpawnFileActionType::Chdir)) | (1 << static_cast<u8>(SpawnFileActionType::Fchdir));
         if (params.file_action_types_present & ~SUPPORTED_SPAWN_ACTIONS)
             return ENOTSUP;
 

--- a/Kernel/Syscalls/posix_spawn.cpp
+++ b/Kernel/Syscalls/posix_spawn.cpp
@@ -47,6 +47,7 @@ ErrorOr<void> Process::execute_file_actions(ReadonlyBytes file_actions_data)
 
                 auto description = TRY(fds.open_file_description(action->old_fd));
                 if (action->old_fd != action->new_fd) {
+
                     if (fds.m_fds_metadatas[action->new_fd].is_allocated()) {
                         if (auto* old_description = fds[action->new_fd].description())
                             (void)old_description->close();
@@ -109,6 +110,7 @@ ErrorOr<void> Process::execute_file_actions(ReadonlyBytes file_actions_data)
             }));
             break;
         }
+
         case SpawnFileActionType::Chdir: {
             if (header->record_length < sizeof(SpawnFileActionChdir))
                 return EINVAL;
@@ -134,7 +136,7 @@ ErrorOr<void> Process::execute_file_actions(ReadonlyBytes file_actions_data)
             if (!description->is_directory())
                 return ENOTDIR;
 
-            // Check for search (+x) permission on the directory
+            // Check for search (+x) permission on the directory.
             if (!description->metadata().may_execute(credentials()))
                 return EACCES;
 
@@ -174,10 +176,6 @@ ErrorOr<FlatPtr> Process::sys$posix_spawn(Userspace<Syscall::SC_posix_spawn_para
     // Copy file actions buffer from userspace
     OwnPtr<KBuffer> file_actions_buffer;
     if (params.serialized_file_actions_data.ptr() != 0 && params.serialized_file_actions_data_size != 0) {
-        // Check for unsupported file actions
-        constexpr u8 SUPPORTED_SPAWN_ACTIONS = (1 << static_cast<u8>(SpawnFileActionType::Dup2)) | (1 << static_cast<u8>(SpawnFileActionType::Close)) | (1 << static_cast<u8>(SpawnFileActionType::Open)) | (1 << static_cast<u8>(SpawnFileActionType::Chdir)) | (1 << static_cast<u8>(SpawnFileActionType::Fchdir));
-        if (params.file_action_types_present & ~SUPPORTED_SPAWN_ACTIONS)
-            return ENOTSUP;
 
         if (params.serialized_file_actions_data_size > 1 * MiB)
             return E2BIG;

--- a/Kernel/Syscalls/posix_spawn.cpp
+++ b/Kernel/Syscalls/posix_spawn.cpp
@@ -36,6 +36,31 @@ ErrorOr<void> Process::execute_file_actions(ReadonlyBytes file_actions_data)
             return EINVAL;
 
         switch (header->type) {
+        case SpawnFileActionType::Dup2: {
+            if (header->record_length < sizeof(SpawnFileActionDup2))
+                return EINVAL;
+
+            auto const* action = reinterpret_cast<SpawnFileActionDup2 const*>(header);
+            TRY(m_fds.with_exclusive([&](auto& fds) -> ErrorOr<void> {
+                if (action->new_fd < 0 || static_cast<size_t>(action->new_fd) >= fds.max_open())
+                    return EINVAL;
+
+                auto description = TRY(fds.open_file_description(action->old_fd));
+                if (action->old_fd != action->new_fd) {
+                    if (fds.m_fds_metadatas[action->new_fd].is_allocated()) {
+                        if (auto* old_description = fds[action->new_fd].description())
+                            (void)old_description->close();
+                        fds[action->new_fd].clear();
+                    } else {
+                        fds.m_fds_metadatas[action->new_fd].allocate();
+                    }
+
+                    fds[action->new_fd].set(move(description));
+                }
+                return {};
+            }));
+            break;
+        }
         default:
             return EINVAL;
         }
@@ -68,7 +93,7 @@ ErrorOr<FlatPtr> Process::sys$posix_spawn(Userspace<Syscall::SC_posix_spawn_para
     OwnPtr<KBuffer> file_actions_buffer;
     if (params.serialized_file_actions_data.ptr() != 0 && params.serialized_file_actions_data_size != 0) {
         // Check for unsupported file actions
-        constexpr u8 SUPPORTED_SPAWN_ACTIONS = 0;
+        constexpr u8 SUPPORTED_SPAWN_ACTIONS = (1 << static_cast<u8>(SpawnFileActionType::Dup2));
         if (params.file_action_types_present & ~SUPPORTED_SPAWN_ACTIONS)
             return ENOTSUP;
 

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -753,6 +753,7 @@ private:
 
     ErrorOr<FlatPtr> open_impl(Userspace<Syscall::SC_open_params const*>);
     ErrorOr<FlatPtr> close_impl(int fd);
+    ErrorOr<void> execute_file_actions(ReadonlyBytes file_actions_data);
     ErrorOr<FlatPtr> read_impl(int fd, Userspace<u8*> buffer, size_t size);
     ErrorOr<FlatPtr> pread_impl(int fd, Userspace<u8*>, size_t, off_t);
     ErrorOr<FlatPtr> preadv_impl(int fd, Userspace<const struct iovec*> iov, int iov_count, off_t);

--- a/Tests/Kernel/TestPosixSpawn.cpp
+++ b/Tests/Kernel/TestPosixSpawn.cpp
@@ -1,27 +1,623 @@
 /*
  * Copyright (c) 2025, Tomás Simões <tomasprsimoes@tecnico.ulisboa.pt>
+ * Copyright (c) 2026, Fırat Kızılboğa <firatkizilboga11@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteString.h>
 #include <AK/StringView.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibTest/TestCase.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <spawn.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
-TEST_CASE(test_posix_spawn_bin_true_success)
+static void spawn_and_wait(posix_spawn_file_actions_t* file_actions, posix_spawnattr_t* attr, StringView path, char* const argv[], int expected_exit_code = 0)
 {
-    // Arguments for the spawned process. argv[0] is the program name.
-    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    pid_t pid;
+    extern char** environ;
+    int rc = posix_spawn(&pid, ByteString(path).characters(), file_actions, attr, argv, environ);
+    EXPECT_EQ(rc, 0);
+
     int status;
+    rc = waitpid(pid, &status, 0);
+    EXPECT_EQ(rc, pid);
+    EXPECT(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), expected_exit_code);
+}
 
-    // Attempt to spawn /bin/true with no fileactions or spawnattr
-    constexpr StringView path_argument = "/bin/true"sv;
+static ByteString read_file_content(char const* path)
+{
+    auto file_or_error = Core::File::open(StringView { path, strlen(path) }, Core::File::OpenMode::Read);
+    EXPECT(!file_or_error.is_error());
+    auto file = file_or_error.release_value();
+    auto content_or_error = file->read_until_eof();
+    EXPECT(!content_or_error.is_error());
+    return ByteString::copy(content_or_error.value());
+}
 
-    auto pid = TRY_OR_FAIL(Core::System::posix_spawn(path_argument, nullptr, nullptr, argv, environ));
+static posix_spawnattr_t* get_attr_for_path(bool use_slow_path, posix_spawnattr_t& attr)
+{
+    if (!use_slow_path)
+        return nullptr;
+    posix_spawnattr_init(&attr);
+    posix_spawnattr_setflags(&attr, 0);
+    return &attr;
+}
 
-    // Wait for the child process to terminate.
-    pid_t waited_pid = waitpid(pid, &status, 0);
-    EXPECT_EQ(waited_pid, pid);
+static void cleanup_attr(bool use_slow_path, posix_spawnattr_t& attr)
+{
+    if (use_slow_path)
+        posix_spawnattr_destroy(&attr);
+}
 
-    EXPECT_EQ(WEXITSTATUS(status), 0);
+static void test_spawn_without_file_actions_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    spawn_and_wait(nullptr, attr_ptr, "/bin/true"sv, argv, 0);
+
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_addopen_redirect_stdout_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char path[] = "/tmp/spawn_test_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+    close(fd);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO, path, O_WRONLY | O_TRUNC, 0644), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/echo"), const_cast<char*>("hello"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/echo"sv, argv, 0);
+
+    auto content = read_file_content(path);
+    EXPECT_EQ(content.trim_whitespace(), "hello");
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_addopen_redirect_stdin_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char path[] = "/tmp/spawn_test_in_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+    ByteString input_data = "data_from_file";
+    write(fd, input_data.characters(), input_data.length());
+    close(fd);
+
+    char out_path[] = "/tmp/spawn_test_out_XXXXXX";
+    fd = mkstemp(out_path);
+    close(fd);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDIN_FILENO, path, O_RDONLY, 0), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO, out_path, O_WRONLY | O_TRUNC, 0644), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/cat"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/cat"sv, argv, 0);
+
+    auto content = read_file_content(out_path);
+    EXPECT_EQ(content, input_data);
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(path);
+    unlink(out_path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_adddup2_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char path[] = "/tmp/spawn_dup2_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, fd, STDOUT_FILENO), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/echo"), const_cast<char*>("dup2_test"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/echo"sv, argv, 0);
+
+    close(fd);
+    auto content = read_file_content(path);
+    EXPECT_EQ(content.trim_whitespace(), "dup2_test");
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_adddup2_same_fd_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO, STDOUT_FILENO), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/true"sv, argv, 0);
+
+    posix_spawn_file_actions_destroy(&actions);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_addclose_stdin_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addclose(&actions, STDIN_FILENO), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/true"sv, argv, 0);
+
+    posix_spawn_file_actions_destroy(&actions);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_addchdir_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char out_path[] = "/tmp/spawn_cwd_XXXXXX";
+    int fd = mkstemp(out_path);
+    close(fd);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addchdir(&actions, "/tmp"), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO, out_path, O_WRONLY | O_TRUNC, 0644), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/pwd"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/pwd"sv, argv, 0);
+
+    auto content = read_file_content(out_path);
+    EXPECT(content.trim_whitespace() == "/tmp" || content.trim_whitespace() == "/private/tmp");
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(out_path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_addfchdir_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    int dir_fd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    EXPECT(dir_fd >= 0);
+
+    char out_path[] = "/tmp/spawn_fchdir_XXXXXX";
+    int fd = mkstemp(out_path);
+    close(fd);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addfchdir(&actions, dir_fd), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO, out_path, O_WRONLY | O_TRUNC, 0644), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/pwd"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/pwd"sv, argv, 0);
+
+    auto content = read_file_content(out_path);
+    EXPECT(content.trim_whitespace() == "/tmp" || content.trim_whitespace() == "/private/tmp");
+
+    posix_spawn_file_actions_destroy(&actions);
+    close(dir_fd);
+    unlink(out_path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_multiple_actions_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char path[] = "/tmp/spawn_seq_XXXXXX";
+    int dummy = mkstemp(path);
+    close(dummy);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+
+    int target_fd = 10;
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, target_fd, path, O_WRONLY | O_TRUNC, 0644), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, target_fd, STDOUT_FILENO), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addclose(&actions, target_fd), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/echo"), const_cast<char*>("sequence"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/echo"sv, argv, 0);
+
+    auto content = read_file_content(path);
+    EXPECT_EQ(content.trim_whitespace(), "sequence");
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_high_fd_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char path[] = "/tmp/spawn_highfd_XXXXXX";
+    int dummy = mkstemp(path);
+    close(dummy);
+
+    int high_fd = 100;
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, high_fd, path, O_WRONLY | O_TRUNC, 0644), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, high_fd, STDOUT_FILENO), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/echo"), const_cast<char*>("high"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/echo"sv, argv, 0);
+
+    auto content = read_file_content(path);
+    EXPECT_EQ(content.trim_whitespace(), "high");
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(path);
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_parent_unchanged_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    int start_fds = 0;
+    for (int i = 0; i < 1024; ++i) {
+        if (fcntl(i, F_GETFD) != -1)
+            start_fds++;
+    }
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addopen(&actions, 20, "/dev/null", O_RDONLY, 0);
+    posix_spawn_file_actions_addclose(&actions, STDOUT_FILENO);
+
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/true"sv, argv, 0);
+    posix_spawn_file_actions_destroy(&actions);
+
+    int end_fds = 0;
+    for (int i = 0; i < 1024; ++i) {
+        if (fcntl(i, F_GETFD) != -1)
+            end_fds++;
+    }
+    EXPECT_EQ(start_fds, end_fds);
+
+    cleanup_attr(use_slow_path, attr);
+}
+
+static void test_parent_cwd_unchanged_impl(bool use_slow_path)
+{
+    posix_spawnattr_t attr;
+    auto* attr_ptr = get_attr_for_path(use_slow_path, attr);
+
+    char original_cwd[PATH_MAX];
+    EXPECT(getcwd(original_cwd, sizeof(original_cwd)) != nullptr);
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addchdir(&actions, "/tmp");
+
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    spawn_and_wait(&actions, attr_ptr, "/bin/true"sv, argv, 0);
+    posix_spawn_file_actions_destroy(&actions);
+
+    char new_cwd[PATH_MAX];
+    EXPECT(getcwd(new_cwd, sizeof(new_cwd)) != nullptr);
+    EXPECT_EQ(strcmp(original_cwd, new_cwd), 0);
+
+    cleanup_attr(use_slow_path, attr);
+}
+
+TEST_CASE(fast_spawn_without_file_actions) { test_spawn_without_file_actions_impl(false); }
+TEST_CASE(fast_addopen_redirect_stdout) { test_addopen_redirect_stdout_impl(false); }
+TEST_CASE(fast_addopen_redirect_stdin) { test_addopen_redirect_stdin_impl(false); }
+TEST_CASE(fast_adddup2) { test_adddup2_impl(false); }
+TEST_CASE(fast_adddup2_same_fd) { test_adddup2_same_fd_impl(false); }
+TEST_CASE(fast_addclose_stdin) { test_addclose_stdin_impl(false); }
+TEST_CASE(fast_addchdir) { test_addchdir_impl(false); }
+TEST_CASE(fast_addfchdir) { test_addfchdir_impl(false); }
+TEST_CASE(fast_multiple_actions) { test_multiple_actions_impl(false); }
+TEST_CASE(fast_high_fd) { test_high_fd_impl(false); }
+TEST_CASE(fast_parent_unchanged) { test_parent_unchanged_impl(false); }
+TEST_CASE(fast_parent_cwd_unchanged) { test_parent_cwd_unchanged_impl(false); }
+
+TEST_CASE(slow_spawn_without_file_actions) { test_spawn_without_file_actions_impl(true); }
+TEST_CASE(slow_addopen_redirect_stdout) { test_addopen_redirect_stdout_impl(true); }
+TEST_CASE(slow_addopen_redirect_stdin) { test_addopen_redirect_stdin_impl(true); }
+TEST_CASE(slow_adddup2) { test_adddup2_impl(true); }
+TEST_CASE(slow_adddup2_same_fd) { test_adddup2_same_fd_impl(true); }
+TEST_CASE(slow_addclose_stdin) { test_addclose_stdin_impl(true); }
+TEST_CASE(slow_addchdir) { test_addchdir_impl(true); }
+TEST_CASE(slow_addfchdir) { test_addfchdir_impl(true); }
+TEST_CASE(slow_multiple_actions) { test_multiple_actions_impl(true); }
+TEST_CASE(slow_high_fd) { test_high_fd_impl(true); }
+TEST_CASE(slow_parent_unchanged) { test_parent_unchanged_impl(true); }
+TEST_CASE(slow_parent_cwd_unchanged) { test_parent_cwd_unchanged_impl(true); }
+
+TEST_CASE(error_enoent_for_missing_file)
+{
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDIN_FILENO, "/does/not/exist", O_RDONLY, 0), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, ENOENT);
+
+    posix_spawn_file_actions_destroy(&actions);
+}
+
+TEST_CASE(error_enoent_for_missing_directory)
+{
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addchdir(&actions, "/does/not/exist/dir"), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, ENOENT);
+
+    posix_spawn_file_actions_destroy(&actions);
+}
+
+TEST_CASE(error_enotdir_for_fchdir_on_file)
+{
+    char path[] = "/tmp/spawn_not_dir_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addfchdir(&actions, fd), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, ENOTDIR);
+
+    posix_spawn_file_actions_destroy(&actions);
+    close(fd);
+    unlink(path);
+}
+
+TEST_CASE(error_ebadf_for_invalid_dup2_source)
+{
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, 999, STDOUT_FILENO), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, EBADF);
+
+    posix_spawn_file_actions_destroy(&actions);
+}
+
+TEST_CASE(error_ebadf_for_invalid_close)
+{
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addclose(&actions, 999), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, EBADF);
+
+    posix_spawn_file_actions_destroy(&actions);
+}
+
+TEST_CASE(error_eacces_for_fchdir_no_permission)
+{
+    char dir_path[] = "/tmp/spawn_noexec_XXXXXX";
+    EXPECT(mkdtemp(dir_path) != nullptr);
+    EXPECT_EQ(chmod(dir_path, 0600), 0);
+
+    int dir_fd = open(dir_path, O_RDONLY | O_DIRECTORY);
+    EXPECT(dir_fd >= 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addfchdir(&actions, dir_fd), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, EACCES);
+
+    posix_spawn_file_actions_destroy(&actions);
+    close(dir_fd);
+    rmdir(dir_path);
+}
+
+TEST_CASE(action_order_matters)
+{
+    char path[] = "/tmp/spawn_order_XXXXXX";
+    int dummy = mkstemp(path);
+    close(dummy);
+
+    int target_fd = 15;
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, target_fd, STDOUT_FILENO), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, target_fd, path, O_WRONLY | O_TRUNC, 0644), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, nullptr, argv, environ);
+    EXPECT_EQ(rc, EBADF);
+
+    posix_spawn_file_actions_destroy(&actions);
+    unlink(path);
+}
+
+TEST_CASE(empty_file_actions)
+{
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    spawn_and_wait(&actions, nullptr, "/bin/true"sv, argv, 0);
+
+    posix_spawn_file_actions_destroy(&actions);
+}
+
+TEST_CASE(slow_error_enoent_for_missing_file)
+{
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+    posix_spawnattr_setflags(&attr, 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addopen(&actions, STDIN_FILENO, "/does/not/exist", O_RDONLY, 0), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    // Slow path: spawn succeeds but child exits with 127
+    int rc = posix_spawn(&pid, "/bin/true", &actions, &attr, argv, environ);
+    EXPECT_EQ(rc, 0);
+
+    int status;
+    waitpid(pid, &status, 0);
+    EXPECT(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 127);
+
+    posix_spawn_file_actions_destroy(&actions);
+    posix_spawnattr_destroy(&attr);
+}
+
+TEST_CASE(slow_error_enoent_for_missing_directory)
+{
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+    posix_spawnattr_setflags(&attr, 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addchdir(&actions, "/does/not/exist/dir"), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, &attr, argv, environ);
+    EXPECT_EQ(rc, 0);
+
+    int status;
+    waitpid(pid, &status, 0);
+    EXPECT(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 127);
+
+    posix_spawn_file_actions_destroy(&actions);
+    posix_spawnattr_destroy(&attr);
+}
+
+TEST_CASE(slow_error_ebadf_for_invalid_dup2)
+{
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+    posix_spawnattr_setflags(&attr, 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_adddup2(&actions, 999, STDOUT_FILENO), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, &attr, argv, environ);
+    EXPECT_EQ(rc, 0);
+
+    int status;
+    waitpid(pid, &status, 0);
+    EXPECT(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 127);
+
+    posix_spawn_file_actions_destroy(&actions);
+    posix_spawnattr_destroy(&attr);
+}
+
+TEST_CASE(slow_error_ebadf_for_invalid_close)
+{
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+    posix_spawnattr_setflags(&attr, 0);
+
+    posix_spawn_file_actions_t actions;
+    EXPECT_EQ(posix_spawn_file_actions_init(&actions), 0);
+    EXPECT_EQ(posix_spawn_file_actions_addclose(&actions, 999), 0);
+
+    pid_t pid;
+    char* argv[] = { const_cast<char*>("/bin/true"), nullptr };
+    extern char** environ;
+
+    int rc = posix_spawn(&pid, "/bin/true", &actions, &attr, argv, environ);
+    EXPECT_EQ(rc, 0);
+
+    int status;
+    waitpid(pid, &status, 0);
+    EXPECT(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 127);
+
+    posix_spawn_file_actions_destroy(&actions);
+    posix_spawnattr_destroy(&attr);
 }


### PR DESCRIPTION
This commit implements the FIXME left by Tomás Simões to handle file actions directly in the kernel during posix_spawn, avoiding the expensive fork() path.

Changes include:

- Define serialized file action structures in Kernel/API/POSIX/spawn.h
- Serialize file actions to a ByteBuffer in LibC instead of lambdas
- Add Process::execute_file_actions() to apply actions in the kernel
- Update posix_spawn to pass serialized buffer to kernel syscall
- Fall back to fork() only when spawnattr is present

Supported actions: addopen, addclose, adddup2, addchdir, addfchdir