### PR TITLE
AK+Kernel: Remove AK_COMPILER_APPLE_CLANG workarounds

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -150,15 +150,6 @@ requires(IsConstructible<T, Args...>) inline NonnullOwnPtr<T> make(Args&&... arg
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T(forward<Args>(args)...));
 }
 
-#    ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<class T, class... Args>
-inline NonnullOwnPtr<T> make(Args&&... args)
-{
-    return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T { forward<Args>(args)... });
-}
-#    endif
-
 #endif
 
 // Use like `adopt_nonnull_own_or_enomem(new (nothrow) T(args...))`.
@@ -175,16 +166,6 @@ requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullOwnPtr<T>> try_make(
 {
     return adopt_nonnull_own_or_enomem(new (nothrow) T(forward<Args>(args)...));
 }
-
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
-
-{
-    return adopt_nonnull_own_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-#endif
 
 template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public DefaultTraits<NonnullOwnPtr<T>> {

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -240,15 +240,6 @@ requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullRefPtr<T>> try_make_
     return adopt_nonnull_ref_or_enomem(new (nothrow) T(forward<Args>(args)...));
 }
 
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
-{
-    return adopt_nonnull_ref_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-#endif
-
 template<Formattable T>
 struct Formatter<NonnullRefPtr<T>> : Formatter<T> {
     ErrorOr<void> format(FormatBuilder& builder, NonnullRefPtr<T> const& value)
@@ -278,15 +269,6 @@ requires(IsConstructible<T, Args...>) inline NonnullRefPtr<T> make_ref_counted(A
 {
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T(forward<Args>(args)...));
 }
-
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline NonnullRefPtr<T> make_ref_counted(Args&&... args)
-{
-    return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T { forward<Args>(args)... });
-}
-#endif
 
 template<typename T>
 struct Traits<NonnullRefPtr<T>> : public DefaultTraits<NonnullRefPtr<T>> {

--- a/Kernel/Library/LockRefPtr.h
+++ b/Kernel/Library/LockRefPtr.h
@@ -500,15 +500,6 @@ requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullLockRefPtr<T>> try_m
     return adopt_nonnull_lock_ref_or_enomem(new (nothrow) T(forward<Args>(args)...));
 }
 
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullLockRefPtr<T>> try_make_lock_ref_counted(Args&&... args)
-{
-    return adopt_nonnull_lock_ref_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-#endif
-
 template<typename T>
 inline ErrorOr<NonnullLockRefPtr<T>> adopt_nonnull_lock_ref_or_enomem(T* object)
 {


### PR DESCRIPTION
Xcode's clang is now new enough to no longer need these.

---

Seems to work locally at least; let's see what CI thinks.

Ref #24345.