### PR TITLE
Ports: Add tree-sitter port

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -342,6 +342,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 | [`tinyxml2`](tinyxml2/)                       | TinyXML-2                                                     | 11.0.0                    | https://github.com/leethomason/tinyxml2                              |
 | [`tr`](tr/)                                   | tr (OpenBSD)                                                  | 6.7                       | https://github.com/ibara/libpuffy                                    |
 | [`tree`](tree/)                               | tree                                                          | 2.1.3                     | https://github.com/Old-Man-Programmer/tree                           |
+| [`tree-sitter`](tree-sitter/)                 | tree-sitter                                                   | 0.26.3                    | https://tree-sitter.github.io/                                       |
 | [`tuxracer`](tuxracer/)                       | Tux Racer                                                     | 0.61                      | http://tuxracer.sourceforge.net/                                     |
 | [`vim`](vim/)                                 | Vim                                                           | 8.2.5056                  | https://www.vim.org/                                                 |
 | [`vitetris`](vitetris/)                       | vitetris                                                      | 0.59.1                    | https://github.com/vicgeralds/vitetris                               |

--- a/Ports/tree-sitter/package.sh
+++ b/Ports/tree-sitter/package.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='tree-sitter'
+version='0.26.3'
+useconfigure='true'
+files=(
+    "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v${version}.tar.gz#7f4a7cf0a2cd217444063fe2a4d800bc9d21ed609badc2ac20c0841d67166550"
+)
+
+configopts=(
+    '-DCMAKE_BUILD_TYPE=Release'
+    "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
+)
+
+configure() {
+    run cmake -G Ninja -B build -S . "${configopts[@]}"
+}
+
+build() {
+    run cmake --build build --parallel "${MAKEJOBS}"
+}
+
+install() {
+    run cmake --install build
+}

--- a/Ports/tree-sitter/patches/0001-Add-serenity-to-endian.h.patch
+++ b/Ports/tree-sitter/patches/0001-Add-serenity-to-endian.h.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Thu, 29 Jan 2026 13:45:58 +0530
+Subject: [PATCH] Add serenity to endian.h
+
+---
+ lib/src/portable/endian.h | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lib/src/portable/endian.h b/lib/src/portable/endian.h
+index a6560826..c3bfe029 100644
+--- a/lib/src/portable/endian.h
++++ b/lib/src/portable/endian.h
+@@ -26,12 +26,17 @@
+     defined(__MSYS__) || \
+     defined(__EMSCRIPTEN__) || \
+     defined(__wasi__) || \
+-    defined(__wasm__)
++    defined(__wasm__) || \
++    defined(__serenity__)
+ 
+ #if defined(__NetBSD__)
+ #define _NETBSD_SOURCE 1
+ #endif
+ 
++#if defined(__serenity__)
++#define _GNU_SOURCE
++#endif
++
+ # include <endian.h>
+ 
+ #elif defined(HAVE_SYS_ENDIAN_H) || \
+-- 
+2.51.0
+

--- a/Ports/tree-sitter/patches/ReadMe.md
+++ b/Ports/tree-sitter/patches/ReadMe.md
@@ -1,0 +1,5 @@
+# Patches for tree-sitter on SerenityOS
+
+## `0001-Add-serenity-to-endian.h.patch`
+
+Add the __serenity__ identifier and define _GNU_SOURCE


### PR DESCRIPTION
This adds the `tree-sitter` port. Since cargo is required to build the `tree-sitter` CLI, it only builds the C library `libtree-sitter`