### PR TITLE
LibGfx/ICC: Let lerp_nd() take `sample` as template arg, not `Function`

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -36,7 +36,8 @@ float lerp_1d(ReadonlySpan<T> values, float x)
 // Does multi-dimensional linear interpolation over a lookup table.
 // `size(i)` should returns the number of samples in the i'th dimension.
 // `sample()` gets a vector where 0 <= i'th coordinate < size(i) and should return the value of the look-up table at that position.
-inline FloatVector3 lerp_nd(Function<unsigned(size_t)> size, Function<FloatVector3(ReadonlySpan<unsigned> const&)> sample, ReadonlySpan<float> x)
+template<CallableAs<unsigned, size_t> SizeFunc, CallableAs<FloatVector3, ReadonlySpan<unsigned> const&> SampleFunc>
+inline FloatVector3 lerp_nd(SizeFunc const& size, SampleFunc const& sample, ReadonlySpan<float> x)
 {
     unsigned left_index[x.size()];
     float factor[x.size()];
@@ -64,7 +65,8 @@ inline FloatVector3 lerp_nd(Function<unsigned(size_t)> size, Function<FloatVecto
 }
 
 // Same as above, but 3D->ND instead of ND->3D.
-inline void lerp_nd(IntVector3 size, Function<void(IntVector3 const&, Span<float>)> sample, FloatVector3 const& x, Span<float> scratch, Span<float> out)
+template<CallableAs<void, IntVector3 const&, Span<float>> SampleFunc>
+inline void lerp_nd(IntVector3 size, SampleFunc const& sample, FloatVector3 const& x, Span<float> scratch, Span<float> out)
 {
     unsigned left_index[3];
     float factor[3];


### PR DESCRIPTION
Reduces the time for

    Build/lagom/bin/image --no-output \
        --convert-to-color-profile sRGB out-cmyk.tiff

from 3.2s to 2.5s on my machine, a 22% speedup (!).

out-cmyk.tiff is one of the CMYK outputs described in https://github.com/SerenityOS/serenity/pull/26459#issuecomment-3619058241

Before, the lambdas got passed as an AK::Fuction, and the optimizer apparently isn't able to undo that after inlining, requiring a virtual dispatch per call.

---

Should also speed up displaying PDFs containing CMYK bitmaps, and RGB->CMYK conversion. But I haven't measured that.