### PR TITLE
Ports: Add rizin

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -294,6 +294,7 @@ This list is also available at [ports.serenityos.net](https://ports.serenityos.n
 | [`readline`](readline/)                       | GNU Readline Library                                          | 8.2.13                    | https://tiswww.case.edu/php/chet/readline/rltop.html                 |
 | [`RetroArch`](RetroArch/)                     | RetroArch                                                     | 1.19.1                    | https://www.retroarch.com                                            |
 | [`RISCVEmu`](RISCVEmu/)                       | A Basic C++ RISC-V Emulator                                   | ad8ad6a                   | https://github.com/IdanHo/RISCVEmu                                   |
+| [`rizin`](rizin/)                             | Rizin                                                         | 0.9.0-dev.515+20769ea     | https://rizin.re/                                                    |
 | [`rsync`](rsync/)                             | rsync                                                         | 3.4.1                     | https://rsync.samba.org/                                             |
 | [`rubberband`](rubberband/)                   | Rubberband                                                    | 3.3.0                     | https://breakfastquay.com/rubberband/                                |
 | [`ruby`](ruby/)                               | Ruby                                                          | 3.2.2                     | https://www.ruby-lang.org/                                           |

--- a/Ports/rizin/package.sh
+++ b/Ports/rizin/package.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port='rizin'
+commit_hash='20769eaaa73660994b740a4ae0bdfa23a8d02d31'
+version="0.9.0-dev.515+20769ea"
+workdir="rizin-${commit_hash}"
+useconfigure='true'
+files=(
+    "https://github.com/rizinorg/rizin/archive/${commit_hash}.tar.gz#69335598e215e2f3e8208b96941810076db34a93805b2827aa0dc5fcfe0f6d7d"
+)
+
+configopts=(
+    "--cross-file=${SERENITY_BUILD_DIR}/meson-cross-file.txt"
+    "--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+    '--buildtype=release'
+    '-Duse_sys_tree_sitter=enabled'
+    '-Duse_sys_libzstd=enabled'
+    '-Duse_sys_zlib=enabled'
+    '-Duse_sys_lz4=enabled'
+    '-Duse_sys_openssl=enabled'
+    '-Duse_sys_libzip_openssl=true'
+    '-Duse_sys_libzip=enabled'
+    '-Duse_sys_lz4=enabled'
+    '-Duse_sys_pcre2=enabled'
+    '-Ddebugger=false'
+)
+
+depends=(
+    'libzip'
+    'lz4'
+    'openssl'
+    'pcre2'
+    'tree-sitter'
+    'zlib'
+    'zstd'
+)
+
+configure() {
+    run meson setup build "${configopts[@]}"
+}
+
+build() {
+    run ninja -C build
+}
+
+install() {
+    run ninja -C build install
+}

--- a/Ports/rizin/patches/0001-Add-serenity-to-lrt-whitelist.patch
+++ b/Ports/rizin/patches/0001-Add-serenity-to-lrt-whitelist.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Sat, 7 Feb 2026 03:49:15 +0530
+Subject: [PATCH] Add serenity to librt whitelist
+
+This patch adds serenity to the list of operating systems that dont require librt to be explicity linked
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 3160fcbba60cc678f56cf9def947bafb9d7467a5..dbae4c42e92b44f846e2c0877f304144f1c2cd93 100644
+--- a/meson.build
++++ b/meson.build
+@@ -399,7 +399,7 @@ foreach it : ccs
+   if not it_cc.has_function('clock_gettime', prefix: '#include <time.h>') and it_cc.has_header_symbol('features.h', '__GLIBC__')
+     it_lrt = it_cc.find_library('rt', required: true, static: is_static_build)
+   endif
+-  have_lrt = not ['windows', 'darwin', 'openbsd', 'android', 'haiku'].contains(it_machine.system())
++  have_lrt = not ['windows', 'darwin', 'openbsd', 'android', 'haiku', 'serenity'].contains(it_machine.system())
+   if have_lrt and not it_lrt.found()
+     it_lrt = it_cc.find_library('rt', required: true, static: is_static_build)
+   endif

--- a/Ports/rizin/patches/0002-Disable-PCRE2-JIT-compilation.patch
+++ b/Ports/rizin/patches/0002-Disable-PCRE2-JIT-compilation.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Sat, 7 Feb 2026 03:58:36 +0530
+Subject: [PATCH] Disable PCRE2 JIT compilation
+
+---
+ meson.build                                             | 2 +-
+ subprojects/packagefiles/pcre2/meson.build              | 2 +-
+ subprojects/packagefiles/pcre2_cross_native/meson.build | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index dbae4c42e92b44f846e2c0877f304144f1c2cd93..9ba3f174d8fd01e43f4f036bc53c962a66199535 100644
+--- a/meson.build
++++ b/meson.build
+@@ -213,7 +213,7 @@ endif
+ 
+ # Handle PCRE2
+ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
+-pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() != 'darwin'
++pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() not in ['darwin', 'serenity']
+ if pcre2_jit_supported
+   add_project_arguments(['-DSUPPORTS_PCRE2_JIT'], language: 'c')
+ endif
+diff --git a/subprojects/packagefiles/pcre2/meson.build b/subprojects/packagefiles/pcre2/meson.build
+index 3ea72e00a9c8ae5be719345769a91092b09e1adc..4aebe1c0cce84bfde02d9c7626f3d6e093974c03 100644
+--- a/subprojects/packagefiles/pcre2/meson.build
++++ b/subprojects/packagefiles/pcre2/meson.build
+@@ -66,7 +66,7 @@ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv
+ # tcc doesn't support the MSVC asm syntax PCRE2 uses (`__asm { ... }`).
+ # Darwin kernel not as well, because of forbidden wx memory.
+ # It is used in the JIT compiler code.
+-if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() != 'darwin'
++if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() not in ['darwin', 'serenity']
+   libpcre2_c_args += ['-DSUPPORT_JIT']
+   pcre2_files += ['src/pcre2_jit_compile.c']
+ endif
+diff --git a/subprojects/packagefiles/pcre2_cross_native/meson.build b/subprojects/packagefiles/pcre2_cross_native/meson.build
+index 50835b03c92ed22a7fe781b200975aabff6a0b42..c428668f063c8e3fe298953b610da470972f9f56 100644
+--- a/subprojects/packagefiles/pcre2_cross_native/meson.build
++++ b/subprojects/packagefiles/pcre2_cross_native/meson.build
+@@ -66,7 +66,7 @@ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv
+ # tcc doesn't support the MSVC asm syntax PCRE2 uses (`__asm { ... }`).
+ # Darwin kernel not as well, because of forbidden wx memory.
+ # It is used in the JIT compiler code.
+-if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() != 'darwin'
++if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() not in ['darwin', 'serenity']
+   libpcre2_c_args += ['-DSUPPORT_JIT']
+   pcre2_files += ['src/pcre2_jit_compile.c']
+ endif

--- a/Ports/rizin/patches/0003-Remove-resolve_heap_tcache_implementation-for-serenity.patch
+++ b/Ports/rizin/patches/0003-Remove-resolve_heap_tcache_implementation-for-serenity.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Sat, 7 Feb 2026 04:12:26 +0530
+Subject: [PATCH] Remove resolve_heap_tcache implementation
+
+Serenity doesn't implement thread caching in its memory allocator, so tcache resolution is not applicable.
+---
+ librz/core/linux_heap_glibc.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/librz/core/linux_heap_glibc.c b/librz/core/linux_heap_glibc.c
+index 23d3d795d9156b1a4fdd0e4731efda2a8bb2283c..abb1a74f267b1fec5509facd5c19b4f163e9922a 100644
+--- a/librz/core/linux_heap_glibc.c
++++ b/librz/core/linux_heap_glibc.c
+@@ -920,7 +920,7 @@ static void GH(resolve_tcache_perthread)(RZ_NONNULL RzCore *core) {
+ 		}
+ 	}
+ }
+-
++#if !defined(__serenity__)
+ RZ_API RZ_OWN bool GH(resolve_heap_tcache)(RZ_NONNULL RzCore *core, GHT arena_base) {
+ 	RzDebug *dbg = core->dbg;
+ 
+@@ -935,7 +935,7 @@ RZ_API RZ_OWN bool GH(resolve_heap_tcache)(RZ_NONNULL RzCore *core, GHT arena_ba
+ 
+ 	return true;
+ }
+-
++#endif
+ void GH(print_heap_chunk)(RzCore *core, GHT chunk) {
+ 	GH(RzHeapChunk) *cnk = RZ_NEW0(GH(RzHeapChunk));
+ 	RzConsPrintablePalette *pal = &rz_cons_singleton()->context->pal;
+@@ -2626,11 +2626,11 @@ RZ_IPI RzCmdStatus GH(rz_cmd_heap_tcache_print_handler)(RzCore *core, int argc,
+ 		rz_cons_printf("No tcache present in this version of libc\n");
+ 		return RZ_CMD_STATUS_ERROR;
+ 	}
+-
++#if !defined(__serenity__)
+ 	if (!GH(resolve_heap_tcache)(core, m_arena)) {
+ 		return RZ_CMD_STATUS_ERROR;
+ 	}
+-
++#endif
+ 	return RZ_CMD_STATUS_OK;
+ }
+ 

--- a/Ports/rizin/patches/0004-Define-rz_sys_pipe-as-pipe2-for-serenity.patch
+++ b/Ports/rizin/patches/0004-Define-rz_sys_pipe-as-pipe2-for-serenity.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Sat, 7 Feb 2026 04:15:41 +0530
+Subject: [PATCH] Define rz_sys_pipe as pipe2 for serenity
+
+---
+ librz/include/rz_util/rz_sys.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/librz/include/rz_util/rz_sys.h b/librz/include/rz_util/rz_sys.h
+index f5a35ce6bc05e2ec5897a9e756743056d610a9e4..bea47ff1e735602f51345031e1b630225e331da0 100644
+--- a/librz/include/rz_util/rz_sys.h
++++ b/librz/include/rz_util/rz_sys.h
+@@ -57,6 +57,9 @@ RZ_API int rz_sys_getpid(void);
+ #if !HAVE_PIPE || (__UNIX__ && HAVE_PIPE)
+ RZ_API int rz_sys_pipe(int pipefd[2], bool close_on_exec);
+ RZ_API int rz_sys_pipe_close(int fd);
++#elif defined(__serenity__)
++#define rz_sys_pipe       pipe2
++#define rz_sys_pipe_close close
+ #else
+ #define rz_sys_pipe       pipe
+ #define rz_sys_pipe_close close

--- a/Ports/rizin/patches/0005-Add-serenity-identifier-to-rz_types.h.patch
+++ b/Ports/rizin/patches/0005-Add-serenity-identifier-to-rz_types.h.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Sat, 7 Feb 2026 04:16:51 +0530
+Subject: [PATCH] Add serenity identifier to rz_types.h
+
+Define serenity as __UNIX__ like, and set RZ_SYS_OS to 'serenity' if __serenity__ identifier is defined
+---
+ librz/include/rz_types.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/librz/include/rz_types.h b/librz/include/rz_types.h
+index 1d3468b7fe3b4cef3fd9aafb26ff090d5f63e610..3b9a513bd9f6a624e7e1f00265a36d7e56582ab0 100644
+--- a/librz/include/rz_types.h
++++ b/librz/include/rz_types.h
+@@ -127,7 +127,7 @@ extern "C" {
+ #define __WINDOWS__ 1
+ #endif
+ 
+-#if defined(EMSCRIPTEN) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__)
++#if defined(EMSCRIPTEN) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__) || defined(__serenity__)
+ #define __BSD__  0
+ #define __UNIX__ 1
+ #endif
+@@ -601,6 +601,8 @@ typedef enum {
+ #define RZ_SYS_OS "freebsd"
+ #elif defined(__HAIKU__)
+ #define RZ_SYS_OS "haiku"
++#elif defined(__serenity__)
++#define RZ_SYS_OS "serenity"
+ #else
+ #define RZ_SYS_OS "unknown"
+ #endif

--- a/Ports/rizin/patches/0006-Add-zlib-dependency-for-libzip.patch
+++ b/Ports/rizin/patches/0006-Add-zlib-dependency-for-libzip.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Naren Sirigere <sirigere.naren@gmail.com>
+Date: Sat, 7 Feb 2026 05:03:11 +0530
+Subject: [PATCH] Add zlib dependency for libzip
+
+---
+ meson.build | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 9ba3f174d8fd01e43f4f036bc53c962a66199535..69b421d0c17397c1950eb63690a6b40c16520af7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -680,6 +680,13 @@ if not libzip_dep.found()
+   libzip_dep = libzip_proj.get_variable('libzip_dep')
+ endif
+ 
++if host_machine.system() == 'serenity' and libzip_dep.found()
++  zlib_dep = dependency('zlib', required: true, static: is_static_build)
++  libzip_dep = declare_dependency(
++    dependencies: [libzip_dep, zlib_dep]
++  )
++endif
++
+ # handle zstd dependency
+ r = run_command(py3_exe, check_meson_subproject_py, 'zstd', check: false)
+ if r.returncode() == 1 and get_option('subprojects_check')

--- a/Ports/rizin/patches/ReadMe.md
+++ b/Ports/rizin/patches/ReadMe.md
@@ -1,0 +1,35 @@
+# Patches for rizin on SerenityOS
+
+## `0001-Add-serenity-to-lrt-whitelist.patch`
+
+Add serenity to librt whitelist
+
+This patch adds serenity to the list of operating systems that dont require librt to be explicity linked
+
+## `0002-Disable-PCRE2-JIT-compilation.patch`
+
+Disable PCRE2 JIT compilation
+
+
+## `0003-Remove-resolve_heap_tcache_implementation-for-serenity.patch`
+
+Remove resolve_heap_tcache implementation
+
+Serenity doesn't implement thread caching in its memory allocator, so tcache resolution is not applicable.
+
+## `0004-Define-rz_sys_pipe-as-pipe2-for-serenity.patch`
+
+Define rz_sys_pipe as pipe2 for serenity
+
+
+## `0005-Add-serenity-identifier-to-rz_types.h.patch`
+
+Add serenity identifier to rz_types.h
+
+Define serenity as __UNIX__ like, and set RZ_SYS_OS to 'serenity' if __serenity__ identifier is defined
+
+## `0006-Add-zlib-dependency-for-libzip.patch`
+
+Add zlib dependency for libzip
+
+


### PR DESCRIPTION
This adds a [rizin](https://github.com/rizinorg/rizin) port. Since there is no native debugger implemented yet, rizin displays an "Unsupported platform" error message after every command, so I have disabled the debugger.

<img width="596" height="286" alt="image" src="https://github.com/user-attachments/assets/4fb11675-06e1-4e73-a204-717eae1119f6" />