### PR TITLE
LibGfx/ICC: Allow two more "primary platform" entries

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Enums.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Enums.cpp
@@ -156,6 +156,10 @@ StringView primary_platform_name(PrimaryPlatform primary_platform)
         return "Silicon Graphics"sv;
     case PrimaryPlatform::Sun:
         return "Sun"sv;
+    case PrimaryPlatform::V2_Only_Taligent:
+        return "Taligent (only valid in v2 profiles)"sv;
+    case PrimaryPlatform::NotSpecCompliant_Unix:
+        return "Unix (not valid per spec)"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibGfx/ICC/Enums.h
+++ b/Userland/Libraries/LibGfx/ICC/Enums.h
@@ -62,6 +62,13 @@ enum class PrimaryPlatform : u32 {
     Microsoft = 0x4D534654,       // 'MSFT'
     SiliconGraphics = 0x53474920, // 'SGI '
     Sun = 0x53554E57,             // 'SUNW'
+
+    // v2-only, in ICC v2, 6.1.7 Primary Platform signature, Table 15 — Primary platform signature
+    V2_Only_Taligent = 0x54474E54, // 'TGNT'
+
+    // Argyll writes a non-spec-compliant value,
+    // https://www.freelists.org/post/argyllcms/targen-writes-an-invalid-value-for-primary-platform
+    NotSpecCompliant_Unix = 0x2A6E6978, // '*nix'
 };
 StringView primary_platform_name(PrimaryPlatform);
 

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -180,6 +180,8 @@ ErrorOr<Optional<PrimaryPlatform>> parse_primary_platform(ICCHeader const& heade
     case PrimaryPlatform::Microsoft:
     case PrimaryPlatform::SiliconGraphics:
     case PrimaryPlatform::Sun:
+    case PrimaryPlatform::V2_Only_Taligent:
+    case PrimaryPlatform::NotSpecCompliant_Unix:
         return header.primary_platform;
     }
     return Error::from_string_literal("ICC::Profile: Invalid primary platform");


### PR DESCRIPTION
argyll's `targen` writes '*nix' to this value. This is not allowed per spec as far as I understand (see included link), but argyll- created profiles are encountered in the wild, for example here: https://www.thregr.org/wavexx/rnd/20260201-remarkable_pro_colors/#downloadable-files

So allow it. With this, `icc` can dump the profile at that URL.

The v2 spec allows 'TGNT', so allow that too while here.