### PR TITLE
LibPDF: Do not drop characters in strings with octal escapes

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -267,6 +267,7 @@ PDFErrorOr<NonnullRefPtr<StringObject>> Parser::parse_string()
 
 PDFErrorOr<ByteString> Parser::parse_literal_string()
 {
+    // PDF 1.7 spec, 3.2.3 String Objects, Literal Strings
     VERIFY(m_reader.consume('('));
     StringBuilder builder;
     auto opened_parens = 0;
@@ -321,12 +322,11 @@ PDFErrorOr<ByteString> Parser::parse_literal_string()
                 builder.append('\\');
                 break;
             default: {
-                if (ch >= '0' && ch <= '7') {
+                // "The number ddd may consist of one, two, or three octal digits"
+                if (is_ascii_octal_digit(ch)) {
                     int octal_value = ch - '0';
-                    for (int i = 0; i < 2; i++) {
+                    for (int i = 0; i < 2 && is_ascii_octal_digit(m_reader.peek()); i++) {
                         auto octal_ch = m_reader.consume();
-                        if (octal_ch < '0' || octal_ch > '7')
-                            break;
                         octal_value = octal_value * 8 + (octal_ch - '0');
                     }
                     builder.append(static_cast<char>(octal_value));


### PR DESCRIPTION
PDF literal strings can contain escaped octal characters looking like `\ddd`, where there can be one to three digits. We used to check if a digit was octal after consuming it, which meant we dropped the character following an octal escape code with fewer than three digits.

Instead of unconditionally consuming octal digits, peek that the next character is indeed octal first.

Also switch to calling `is_ascii_octal_digit()` instead of doing that check manually while here, and add a spec comment.

Gets us from failing to render 125 of 139 pages of the official make magazine 96 PDF to rendering all pages pretty much perfect.

Previously, most pages would fail with
"unterminated string literal" because most pages contain something like `[(\37) 6] TJ`. We used to drop the string literal closing delimiter `)`. This caused most pages to render as completely white.