### PR TITLE
LibCrypto: Build with -fzero-call-used-regs=used

### DIFF
--- a/Userland/Libraries/LibCrypto/CMakeLists.txt
+++ b/Userland/Libraries/LibCrypto/CMakeLists.txt
@@ -36,3 +36,8 @@ set(SOURCES
 
 serenity_lib(LibCrypto crypto)
 target_link_libraries(LibCrypto PRIVATE LibCore)
+
+if(NOT EMSCRIPTEN)
+    # This should prevent sensitive data from leaking through registers.
+    target_compile_options(LibCrypto PRIVATE -fzero-call-used-regs=used)
+endif ()


### PR DESCRIPTION
By zeroing registers when returning from crypto functions, we prevent attackers from accessing sensitive information that could otherwise be left in these registers.

Note that we currently have no safety regarding the same kind of leakage but with stack or heap memory.

From some small experiments, the performance cost should be under 5%. This could probably be optimized by only applying it to the public API.

---

Before:
<img width="675" height="903" alt="image" src="https://github.com/user-attachments/assets/5ac0e1a1-cc7c-423b-afd9-70ba6cb2b1dd" />
