### PR TITLE
Terminal: Add tab support

### DIFF
--- a/Base/usr/share/man/man1/Applications/Terminal.md
+++ b/Base/usr/share/man/man1/Applications/Terminal.md
@@ -12,23 +12,31 @@ $ Terminal [options]
 
 ## Description
 
-Terminal is a terminal emulator application for Serenity.
+Terminal is a terminal emulator application for Serenity. It supports multiple tabs within a single window.
 
 It can be launched from the System Menu or the quick access icon to its right, via the `Open in Terminal` action in File Manager and on the Desktop. You can also click on the `Open` link above to launch Terminal.
+
+### Tabs
+
+-   Open a new tab with `Ctrl+Shift+T` or via `File → New Tab`, or by clicking the `+` button in the tab bar.
+-   Close a tab by clicking the `×` button on it or via `File → Quit` when only one tab is open.
+-   The tab bar is hidden when only a single tab is open and shown automatically when more tabs are added.
+
+### Settings
 
 Select `File → Terminal Settings` to launch the Terminal Settings dialog and display user configurable application properties. This dialog box contains two tabs: View and Terminal.
 
 The _View_ tab provides the most frequently sought options:
 
--   Adjust the Terminal font (turn off `Use system default` to select a custom font.
+-   Adjust the Terminal font (turn off `Use system default` to select a custom font).
 -   Specify background opacity, i.e. the amount to which the Terminal's background is transparent, displaying what's underneath.
--   Change the shape of the cursor from Block, to Underscore or to Vertical bar. You can also opt to enable or disable cursor's blink property.
--   To enable or disable the display of terminal scrollbar.
+-   Change the shape of the cursor from Block, to Underscore or to Vertical bar. You can also opt to enable or disable the cursor's blink property.
+-   To enable or disable the display of the terminal scrollbar.
 
 The _Terminal_ tab gives less frequently used options:
 
 -   To either enable System beep, or use Visual bell or disable bell mode altogether.
--   To change Terminal's exit behavior
+-   To change Terminal's exit behavior.
 
 Clicking on the _Apply_ button will cause the currently selected options to take effect immediately.
 
@@ -38,8 +46,8 @@ You can toggle Fullscreen mode by pressing F11.
 
 -   `--help`: Display help message and exit
 -   `--version`: Print version
--   `-e`: Execute this command inside the terminal
--   `-k`: Keep the terminal open after the command has finished executing
+-   `-e <command>`: Execute this command inside the terminal
+-   `-k`: Keep the terminal open after the command has finished executing (only valid with `-e`)
 
 ## Examples
 

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -81,11 +81,6 @@ BrowserWindow::BrowserWindow(WebView::CookieJar& cookie_jar, Vector<URL::URL> co
         update_displayed_zoom_level();
     };
 
-    m_tab_widget->on_middle_click = [](auto& clicked_widget) {
-        auto& tab = static_cast<Browser::Tab&>(clicked_widget);
-        tab.on_tab_close_request(tab);
-    };
-
     m_tab_widget->on_tab_close_click = [](auto& clicked_widget) {
         auto& tab = static_cast<Browser::Tab&>(clicked_widget);
         tab.on_tab_close_request(tab);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -91,6 +91,11 @@ BrowserWindow::BrowserWindow(WebView::CookieJar& cookie_jar, Vector<URL::URL> co
         tab.context_menu_requested(context_menu_event.screen_position());
     };
 
+    m_tab_widget->set_add_tab_button_enabled(true);
+    m_tab_widget->on_add_tab_button_click = [this] {
+        create_new_tab(Browser::g_new_tab_url, Web::HTML::ActivateTab::Yes);
+    };
+
     m_window_actions.on_create_new_tab = [this] {
         create_new_tab(Browser::g_new_tab_url, Web::HTML::ActivateTab::Yes);
     };

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -70,10 +70,6 @@ MainWidget::MainWidget()
         }
     };
 
-    m_tab_widget->on_middle_click = [&](auto& widget) {
-        m_tab_widget->on_tab_close_click(widget);
-    };
-
     m_tab_widget->on_tab_close_click = [&](auto& widget) {
         auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
         if (image_editor.request_close()) {

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -184,6 +184,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             }
         });
 
+    m_tab_widget->set_add_tab_button_enabled(true);
+    m_tab_widget->on_add_tab_button_click = [this, &window] {
+        m_new_image_action->activate(&window);
+    };
+
     m_new_image_from_clipboard_action = GUI::Action::create(
         "&New Image from Clipboard", { Mod_Ctrl | Mod_Shift, Key_V }, g_icon_bag.new_clipboard, [&](auto&) {
             auto result = create_image_from_clipboard();

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -119,6 +119,9 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
 
     setup_tabs(m_workbook->sheets());
 
+    m_tab_widget->set_add_tab_button_enabled(true);
+    m_tab_widget->on_add_tab_button_click = [&] { add_sheet(); };
+
     m_new_action = GUI::Action::create("Add New Sheet", Gfx::Bitmap::load_from_file("/res/icons/16x16/new-tab.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         add_sheet();
     });
@@ -344,6 +347,7 @@ void SpreadsheetWidget::clipboard_content_did_change(ByteString const& mime_type
 
 void SpreadsheetWidget::setup_tabs(Vector<NonnullRefPtr<Sheet>> new_sheets)
 {
+    RefPtr<GUI::Widget> last_view;
     for (auto& sheet : new_sheets) {
         auto& new_view = m_tab_widget->add_tab<SpreadsheetView>(String::from_byte_string(sheet->name()).release_value_but_fixme_should_propagate_errors(), sheet);
         new_view.model()->on_cell_data_change = [&](auto& cell, auto& previous_data) {
@@ -439,7 +443,10 @@ void SpreadsheetWidget::setup_tabs(Vector<NonnullRefPtr<Sheet>> new_sheets)
 
             static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(nullptr);
         };
+        last_view = new_view;
     }
+    if (last_view)
+        m_tab_widget->set_active_widget(last_view.ptr());
 }
 
 void SpreadsheetWidget::try_generate_tip_for_input_expression(StringView source, size_t cursor_offset)

--- a/Userland/Applications/Terminal/CMakeLists.txt
+++ b/Userland/Applications/Terminal/CMakeLists.txt
@@ -6,6 +6,7 @@ serenity_component(
 
 set(SOURCES
     main.cpp
+    TerminalWindow.cpp
 )
 
 serenity_app(Terminal ICON app-terminal)

--- a/Userland/Applications/Terminal/TerminalWindow.cpp
+++ b/Userland/Applications/Terminal/TerminalWindow.cpp
@@ -13,8 +13,10 @@
 #include <LibCore/Directory.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
+#include <LibCore/Timer.h>
 #include <LibDesktop/Launcher.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -105,6 +107,24 @@ static int shell_child_process_count(pid_t shell_pid)
     return count;
 }
 
+static void kill_shell_processes(pid_t shell_pid)
+{
+    // Kill the shell's process group (PGID == shell_pid after forkpty) and the shell itself.
+    (void)Core::System::kill(-shell_pid, SIGHUP);
+    (void)Core::System::kill(shell_pid, SIGHUP);
+    // Kill background children that may have their own process groups.
+    (void)Core::Directory::for_each_entry(
+        String::formatted("/proc/{}/children", shell_pid).release_value_but_fixme_should_propagate_errors(),
+        Core::DirIterator::Flags::SkipParentAndBaseDir,
+        [&](auto& entry, auto&) {
+            if (auto child_pid = entry.name.template to_number<pid_t>(); child_pid.has_value()) {
+                (void)Core::System::kill(-child_pid.value(), SIGHUP);
+                (void)Core::System::kill(child_pid.value(), SIGHUP);
+            }
+            return IterationDecision::Continue;
+        });
+}
+
 static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget& terminal)
 {
     auto window = GUI::Window::construct(&terminal);
@@ -181,6 +201,43 @@ TerminalWindow::TerminalWindow()
     m_show_scroll_bar = Config::read_bool("Terminal"sv, "Terminal"sv, "ShowScrollBar"sv, Terminal::Defaults::SHOW_SCROLLBAR);
     set_has_alpha_channel(m_opacity < 255);
 
+    auto main_widget = set_main_widget<GUI::Widget>();
+    main_widget->set_layout<GUI::VerticalBoxLayout>(0);
+    main_widget->set_fill_with_background_color(true);
+
+    m_top_line = main_widget->add<GUI::HorizontalSeparator>();
+    m_top_line->set_fixed_height(2);
+    m_top_line->set_visible(false);
+
+    m_tab_widget = main_widget->add<GUI::TabWidget>();
+    m_tab_widget->set_container_margins(GUI::Margins { 0 });
+    m_tab_widget->set_reorder_allowed(true);
+    m_tab_widget->set_close_button_enabled(true);
+    m_tab_widget->on_tab_count_change = [this](size_t count) {
+        m_top_line->set_visible(count > 1);
+        m_tab_widget->set_bar_visible(!is_fullscreen() && count > 1);
+        if (count == 0)
+            GUI::Application::the()->quit(0);
+    };
+    m_tab_widget->on_change = [this](auto& widget) {
+        auto& terminal = verify_cast<VT::TerminalWidget>(widget);
+        terminal.apply_size_increments_to_window(*this);
+        for (auto& data : m_tab_data_list) {
+            if (data.terminal.ptr() == &terminal) {
+                set_title(data.title.is_empty() ? "Terminal" : data.title);
+                break;
+            }
+        }
+    };
+    m_tab_widget->on_tab_close_click = [this](auto& widget) {
+        auto& terminal = verify_cast<VT::TerminalWidget>(widget);
+        if (check_tab_quit(terminal) == GUI::MessageBox::ExecResult::OK) {
+            close_terminal_tab(terminal);
+        }
+    };
+    m_tab_widget->set_add_tab_button_enabled(true);
+    m_tab_widget->on_add_tab_button_click = [this] { (void)open_new_terminal_tab(); };
+
     on_close_request = [this]() -> GUI::Window::CloseRequestDecision {
         if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
             return GUI::Window::CloseRequestDecision::Close;
@@ -188,66 +245,37 @@ TerminalWindow::TerminalWindow()
     };
 
     on_input_preemption_change = [this](bool is_preempted) {
-        if (m_terminal)
-            m_terminal->set_logical_focus(!is_preempted);
+        active_terminal().set_logical_focus(!is_preempted);
     };
 
     m_modified_state_check_timer = Core::Timer::create_repeating(500, [this] {
-        set_modified(tty_has_foreground_process(m_ptm_fd, m_shell_pid) || shell_child_process_count(m_shell_pid) > 0);
+        for (auto& data : m_tab_data_list) {
+            bool modified = tty_has_foreground_process(data.ptm_fd, data.shell_pid)
+                || shell_child_process_count(data.shell_pid) > 0;
+            m_tab_widget->set_tab_modified(*data.terminal, modified);
+        }
+        set_modified(m_tab_widget->is_any_tab_modified());
     });
 }
 
 ErrorOr<void> TerminalWindow::initialize(StringView initial_command, bool keep_open)
 {
-    int ptm_fd;
-    pid_t shell_pid = forkpty(&ptm_fd, nullptr, nullptr, nullptr);
-    if (shell_pid < 0)
-        return Error::from_errno(errno);
-    if (shell_pid == 0) {
-        auto startup_command = Config::read_string("Terminal"sv, "Startup"sv, "Command"sv, ""sv);
-        if (run_command(initial_command.is_empty() ? startup_command.view() : initial_command, keep_open).is_error())
-            _exit(1);
-        VERIFY_NOT_REACHED();
-    }
-
-    m_ptm_fd = ptm_fd;
-    m_shell_pid = shell_pid;
-    m_ptsname = TRY(Core::System::ptsname(ptm_fd));
-    TRY(utmp_update(m_ptsname, shell_pid, true));
-
     auto app_icon = GUI::Icon::default_icon("app-terminal"sv);
-    auto terminal = set_main_widget<VT::TerminalWidget>(ptm_fd, true);
-    m_terminal = terminal;
-    terminal->set_startup_process_id(shell_pid);
-    terminal->on_command_exit = [] {
-        GUI::Application::the()->quit(0);
-    };
-    terminal->on_title_change = [this](auto title) {
-        set_title(title);
-    };
-    terminal->on_terminal_size_change = [this](auto size) {
-        resize(size);
-    };
-    terminal->apply_size_increments_to_window(*this);
-    set_icon(app_icon.bitmap_for_size(16));
-
-    terminal->set_bell_mode(m_bell);
-    terminal->set_auto_mark_mode(m_automark);
-    terminal->set_cursor_shape(m_cursor_shape);
-    terminal->set_cursor_blinking(m_cursor_blinking);
-    terminal->set_opacity(m_opacity);
-    terminal->set_max_history_size(Config::read_i32("Terminal"sv, "Terminal"sv, "MaxHistorySize"sv, terminal->max_history_size()));
-    terminal->set_show_scrollbar(m_show_scroll_bar);
-
-    m_find_window = TRY(create_find_window(*terminal));
-
     m_open_settings_action = GUI::Action::create("Terminal &Settings",
         TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/settings.png"sv)),
         [this](auto&) { GUI::Process::spawn_or_show_error(this, "/bin/TerminalSettings"sv); });
-    terminal->context_menu().add_separator();
-    terminal->context_menu().add_action(*m_open_settings_action);
-
     TRY(build_menus(app_icon));
+
+    TRY(open_new_terminal_tab(initial_command, keep_open));
+
+    Optional<Gfx::IntSize> fallback_size;
+    auto increment = size_increment();
+    if (increment.width() > 0 && increment.height() > 0) {
+        auto base = base_size();
+        fallback_size = Gfx::IntSize { base.width() + 80 * increment.width(), base.height() + 25 * increment.height() };
+    }
+    restore_size_and_position("Terminal"sv, "Geometry"sv, fallback_size);
+    save_size_and_position_on_close("Terminal"sv, "Geometry"sv);
 
     if (m_should_confirm_close)
         m_modified_state_check_timer->start();
@@ -257,10 +285,11 @@ ErrorOr<void> TerminalWindow::initialize(StringView initial_command, bool keep_o
 
 ErrorOr<void> TerminalWindow::build_menus(GUI::Icon const& app_icon)
 {
-    VERIFY(m_terminal);
-
     auto file_menu = add_menu("&File"_string);
-    file_menu->add_action(GUI::Action::create("Open New &Terminal", { Mod_Ctrl | Mod_Shift, Key_N },
+    file_menu->add_action(GUI::Action::create("New &Tab", { Mod_Ctrl | Mod_Shift, Key_T },
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/new-tab.png"sv)),
+        [this](auto&) { (void)open_new_terminal_tab(); }));
+    file_menu->add_action(GUI::Action::create("Open New &Window", { Mod_Ctrl | Mod_Shift, Key_N },
         TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"sv)),
         [this](auto&) { GUI::Process::spawn_or_show_error(this, "/bin/Terminal"sv); }));
     file_menu->add_action(*m_open_settings_action);
@@ -274,23 +303,36 @@ ErrorOr<void> TerminalWindow::build_menus(GUI::Icon const& app_icon)
         GUI::CommonActions::QuitAltShortcut::None));
 
     auto edit_menu = add_menu("&Edit"_string);
-    edit_menu->add_action(m_terminal->copy_action());
-    edit_menu->add_action(m_terminal->paste_action());
+    edit_menu->add_action(GUI::Action::create("&Copy", { Mod_Ctrl | Mod_Shift, Key_C },
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"sv)),
+        [this](auto&) { active_terminal().copy(); }));
+    edit_menu->add_action(GUI::Action::create("&Paste", { Mod_Ctrl | Mod_Shift, Key_V },
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/paste.png"sv)),
+        [this](auto&) { active_terminal().paste(); }));
     edit_menu->add_separator();
     edit_menu->add_action(GUI::Action::create("&Find...", { Mod_Ctrl | Mod_Shift, Key_F },
         TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)),
         [this](auto&) {
-            VERIFY(m_find_window);
-            m_find_window->show();
-            m_find_window->move_to_front();
+            auto& terminal = active_terminal();
+            for (auto& data : m_tab_data_list) {
+                if (data.terminal.ptr() == &terminal) {
+                    if (!data.find_window)
+                        data.find_window = create_find_window(terminal).release_value_but_fixme_should_propagate_errors();
+                    data.find_window->show();
+                    data.find_window->move_to_front();
+                    return;
+                }
+            }
         }));
 
     auto view_menu = add_menu("&View"_string);
     view_menu->add_action(GUI::CommonActions::make_fullscreen_action([this](auto&) {
         set_fullscreen(!is_fullscreen());
     }));
-    view_menu->add_action(m_terminal->clear_including_history_action());
-    view_menu->add_action(m_terminal->clear_to_previous_mark_action());
+    view_menu->add_action(GUI::Action::create("Clear Including &History", { Mod_Ctrl | Mod_Shift, Key_K },
+        [this](auto&) { active_terminal().clear_including_history(); }));
+    view_menu->add_action(GUI::Action::create("Clear &Previous Command", { Mod_Ctrl | Mod_Shift, Key_U },
+        [this](auto&) { active_terminal().clear_to_previous_mark(); }));
     view_menu->add_separator();
     view_menu->add_action(GUI::CommonActions::make_zoom_in_action([this](auto&) {
         adjust_font_size(1, Gfx::Font::AllowInexactSizeMatch::Larger);
@@ -308,58 +350,171 @@ ErrorOr<void> TerminalWindow::build_menus(GUI::Icon const& app_icon)
     return {};
 }
 
+VT::TerminalWidget& TerminalWindow::active_terminal()
+{
+    return verify_cast<VT::TerminalWidget>(*m_tab_widget->active_widget());
+}
+
+ErrorOr<void> TerminalWindow::create_terminal_tab(int ptm_fd, pid_t shell_pid, ByteString ptsname)
+{
+    auto& terminal = m_tab_widget->add_tab<VT::TerminalWidget>("Terminal"_string, ptm_fd, false);
+    terminal.set_startup_process_id(shell_pid);
+
+    terminal.set_max_history_size(Config::read_i32("Terminal"sv, "Terminal"sv, "MaxHistorySize"sv, Terminal::Defaults::MAX_HISTORY_SIZE));
+    terminal.set_show_scrollbar(m_show_scroll_bar);
+    terminal.set_opacity(m_opacity);
+    terminal.set_cursor_shape(m_cursor_shape);
+    terminal.set_cursor_blinking(m_cursor_blinking);
+    terminal.set_bell_mode(m_bell);
+    terminal.set_auto_mark_mode(m_automark);
+    terminal.apply_size_increments_to_window(*this);
+    terminal.on_terminal_size_change = [this](auto size) {
+        resize(size);
+    };
+    terminal.context_menu().add_separator();
+    terminal.context_menu().add_action(*m_open_settings_action);
+
+    m_tab_data_list.append({ ptm_fd, shell_pid, move(ptsname), {}, terminal, nullptr });
+
+    auto* terminal_ptr = &terminal;
+
+    terminal.on_command_exit = [this, terminal_ptr] {
+        m_tab_widget->deferred_invoke([this, terminal_ptr] {
+            close_terminal_tab(*terminal_ptr);
+        });
+    };
+
+    terminal.on_title_change = [this, terminal_ptr](auto title) {
+        m_tab_widget->set_tab_title(*terminal_ptr, String::from_utf8(title).release_value_but_fixme_should_propagate_errors());
+        for (auto& data : m_tab_data_list) {
+            if (data.terminal.ptr() == terminal_ptr) {
+                data.title = title;
+                break;
+            }
+        }
+        if (m_tab_widget->active_widget() == terminal_ptr)
+            set_title(title);
+    };
+
+    m_tab_widget->set_active_widget(&terminal);
+    return {};
+}
+
+void TerminalWindow::close_terminal_tab(VT::TerminalWidget& terminal)
+{
+    for (size_t i = 0; i < m_tab_data_list.size(); ++i) {
+        if (m_tab_data_list[i].terminal == &terminal) {
+            kill_shell_processes(m_tab_data_list[i].shell_pid);
+            (void)utmp_update(m_tab_data_list[i].ptsname, 0, false);
+            m_tab_data_list.remove(i);
+            break;
+        }
+    }
+    m_tab_widget->remove_tab(terminal);
+}
+
+ErrorOr<void> TerminalWindow::open_new_terminal_tab(StringView cmd, bool keep_open)
+{
+    int ptm_fd;
+    pid_t shell_pid = forkpty(&ptm_fd, nullptr, nullptr, nullptr);
+    if (shell_pid < 0)
+        return Error::from_errno(errno);
+    if (shell_pid == 0) {
+        auto startup_command = Config::read_string("Terminal"sv, "Startup"sv, "Command"sv, ""sv);
+        if (run_command(cmd.is_empty() ? startup_command.view() : cmd, keep_open).is_error())
+            _exit(1);
+        VERIFY_NOT_REACHED();
+    }
+    auto ptsname = TRY(Core::System::ptsname(ptm_fd));
+    TRY(utmp_update(ptsname, shell_pid, true));
+    return create_terminal_tab(ptm_fd, shell_pid, ptsname);
+}
+
 ErrorOr<void> TerminalWindow::cleanup()
 {
     dbgln("Terminal: Exiting, updating utmp");
-    return utmp_update(m_ptsname, 0, false);
+    for (auto& data : m_tab_data_list) {
+        kill_shell_processes(data.shell_pid);
+        TRY(utmp_update(data.ptsname, 0, false));
+    }
+    return {};
 }
 
 GUI::Dialog::ExecResult TerminalWindow::check_terminal_quit()
 {
     if (!m_should_confirm_close)
         return GUI::MessageBox::ExecResult::OK;
-
+    bool has_foreground = false;
+    int total_children = 0;
+    for (auto& data : m_tab_data_list) {
+        if (tty_has_foreground_process(data.ptm_fd, data.shell_pid))
+            has_foreground = true;
+        total_children += shell_child_process_count(data.shell_pid);
+    }
     Optional<String> close_message;
     auto title = "Running Process"sv;
-    if (tty_has_foreground_process(m_ptm_fd, m_shell_pid)) {
+    if (has_foreground) {
         close_message = "Close Terminal and kill its foreground process?"_string;
     } else {
-        auto child_process_count = shell_child_process_count(m_shell_pid);
-        if (child_process_count > 1) {
+        if (total_children > 1) {
             title = "Running Processes"sv;
-            close_message = String::formatted("Close Terminal and kill its {} background processes?", child_process_count).release_value_but_fixme_should_propagate_errors();
-        } else if (child_process_count == 1) {
+            close_message = String::formatted("Close Terminal and kill its {} background processes?", total_children).release_value_but_fixme_should_propagate_errors();
+        } else if (total_children == 1) {
             close_message = "Close Terminal and kill its background process?"_string;
         }
     }
-
     if (close_message.has_value())
         return GUI::MessageBox::show(this, *close_message, title, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
     return GUI::MessageBox::ExecResult::OK;
 }
 
+GUI::Dialog::ExecResult TerminalWindow::check_tab_quit(VT::TerminalWidget& terminal)
+{
+    if (!m_should_confirm_close)
+        return GUI::MessageBox::ExecResult::OK;
+    for (auto& data : m_tab_data_list) {
+        if (data.terminal.ptr() != &terminal)
+            continue;
+        bool has_foreground = tty_has_foreground_process(data.ptm_fd, data.shell_pid);
+        int children = shell_child_process_count(data.shell_pid);
+        Optional<String> close_message;
+        auto title = "Running Process"sv;
+        if (has_foreground) {
+            close_message = "Close tab and kill its foreground process?"_string;
+        } else if (children > 1) {
+            title = "Running Processes"sv;
+            close_message = String::formatted("Close tab and kill its {} background processes?", children).release_value_but_fixme_should_propagate_errors();
+        } else if (children == 1) {
+            close_message = "Close tab and kill its background process?"_string;
+        }
+        if (close_message.has_value())
+            return GUI::MessageBox::show(this, *close_message, title, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
+        return GUI::MessageBox::ExecResult::OK;
+    }
+    return GUI::MessageBox::ExecResult::OK;
+}
+
 void TerminalWindow::adjust_font_size(float adjustment, Gfx::Font::AllowInexactSizeMatch preference)
 {
-    VERIFY(m_terminal);
-
-    auto& font = m_terminal->font();
+    auto& terminal = active_terminal();
+    auto& font = terminal.font();
     auto new_size = max(5, font.presentation_size() + adjustment);
     if (auto new_font = Gfx::FontDatabase::the().get(font.family(), new_size, font.weight(), font.width(), font.slope(), preference)) {
-        m_terminal->set_font_and_resize_to_fit(*new_font);
-        m_terminal->apply_size_increments_to_window(*this);
-        resize(m_terminal->size());
+        terminal.set_font_and_resize_to_fit(*new_font);
+        terminal.apply_size_increments_to_window(*this);
+        resize(terminal.size());
     }
 }
 
 void TerminalWindow::config_bool_did_change(StringView domain, StringView group, StringView key, bool value)
 {
     VERIFY(domain == "Terminal");
-    VERIFY(m_terminal);
 
     if (group == "Terminal") {
         if (key == "ShowScrollBar") {
             m_show_scroll_bar = value;
-            m_terminal->set_show_scrollbar(value);
+            for (auto& data : m_tab_data_list)
+                data.terminal->set_show_scrollbar(value);
         } else if (key == "ConfirmClose") {
             m_should_confirm_close = value;
             if (value) {
@@ -371,44 +526,50 @@ void TerminalWindow::config_bool_did_change(StringView domain, StringView group,
         }
     } else if (group == "Cursor" && key == "Blinking") {
         m_cursor_blinking = value;
-        m_terminal->set_cursor_blinking(value);
+        for (auto& data : m_tab_data_list)
+            data.terminal->set_cursor_blinking(value);
     }
 }
 
 void TerminalWindow::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     VERIFY(domain == "Terminal");
-    VERIFY(m_terminal);
 
     if (group == "Window" && key == "Bell") {
         m_bell = VT::TerminalWidget::parse_bell(value).value_or(VT::TerminalWidget::BellMode::Visible);
-        m_terminal->set_bell_mode(m_bell);
+        for (auto& data : m_tab_data_list)
+            data.terminal->set_bell_mode(m_bell);
     } else if (group == "Text" && key == "Font") {
         auto font = Gfx::FontDatabase::the().get_by_name(value);
         if (font.is_null())
             font = Gfx::FontDatabase::default_fixed_width_font();
-        m_terminal->set_font_and_resize_to_fit(*font);
-        m_terminal->apply_size_increments_to_window(*this);
-        resize(m_terminal->size());
+        for (auto& data : m_tab_data_list) {
+            data.terminal->set_font_and_resize_to_fit(*font);
+            data.terminal->apply_size_increments_to_window(*data.terminal->window());
+            data.terminal->window()->resize(data.terminal->size());
+        }
     } else if (group == "Cursor" && key == "Shape") {
         m_cursor_shape = VT::TerminalWidget::parse_cursor_shape(value).value_or(VT::CursorShape::Block);
-        m_terminal->set_cursor_shape(m_cursor_shape);
+        for (auto& data : m_tab_data_list)
+            data.terminal->set_cursor_shape(m_cursor_shape);
     } else if (group == "Terminal" && key == "AutoMark") {
         m_automark = VT::TerminalWidget::parse_automark_mode(value).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
-        m_terminal->set_auto_mark_mode(m_automark);
+        for (auto& data : m_tab_data_list)
+            data.terminal->set_auto_mark_mode(m_automark);
     }
 }
 
 void TerminalWindow::config_i32_did_change(StringView domain, StringView group, StringView key, i32 value)
 {
     VERIFY(domain == "Terminal");
-    VERIFY(m_terminal);
 
     if (group == "Terminal" && key == "MaxHistorySize") {
-        m_terminal->set_max_history_size(value);
+        for (auto& data : m_tab_data_list)
+            data.terminal->set_max_history_size(value);
     } else if (group == "Window" && key == "Opacity") {
         m_opacity = value;
         set_has_alpha_channel(value < 255);
-        m_terminal->set_opacity(value);
+        for (auto& data : m_tab_data_list)
+            data.terminal->set_opacity(value);
     }
 }

--- a/Userland/Applications/Terminal/TerminalWindow.cpp
+++ b/Userland/Applications/Terminal/TerminalWindow.cpp
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TerminalWindow.h"
+#include <AK/FixedArray.h>
+#include <Applications/TerminalSettings/Defaults.h>
+#include <LibConfig/Client.h>
+#include <LibCore/Account.h>
+#include <LibCore/Directory.h>
+#include <LibCore/Process.h>
+#include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibGUI/Application.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/Icon.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
+#include <LibGUI/Process.h>
+#include <LibGUI/TextBox.h>
+#include <LibGUI/Widget.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/SystemTheme.h>
+#include <LibURL/URL.h>
+#include <errno.h>
+#include <pty.h>
+#include <termios.h>
+#include <unistd.h>
+
+static ErrorOr<void> utmp_update(StringView tty, pid_t pid, bool create)
+{
+    auto pid_string = String::number(pid);
+    Array utmp_update_command {
+        "-f"sv,
+        "Terminal"sv,
+        "-p"sv,
+        pid_string.bytes_as_string_view(),
+        (create ? "-c"sv : "-d"sv),
+        tty,
+    };
+
+    auto utmpupdate_pid = TRY(Core::Process::spawn("/bin/utmpupdate"sv, utmp_update_command, {}, Core::Process::KeepAsChild::Yes));
+
+    Core::System::WaitPidResult status;
+    auto wait_successful = false;
+    while (!wait_successful) {
+        auto result = Core::System::waitpid(utmpupdate_pid, 0);
+        if (result.is_error() && result.error().code() != EINTR) {
+            return result.release_error();
+        } else if (!result.is_error()) {
+            status = result.release_value();
+            wait_successful = true;
+        }
+    }
+
+    if (WIFEXITED(status.status) && WEXITSTATUS(status.status) != 0)
+        dbgln("Terminal: utmpupdate exited with status {}", WEXITSTATUS(status.status));
+    else if (WIFSIGNALED(status.status))
+        dbgln("Terminal: utmpupdate exited due to unhandled signal {}", WTERMSIG(status.status));
+
+    return {};
+}
+
+static ErrorOr<void> run_command(StringView command, bool keep_open)
+{
+    auto shell = TRY(String::from_byte_string(TRY(Core::Account::self(Core::Account::Read::PasswdOnly)).shell()));
+    if (shell.is_empty())
+        shell = "/bin/Shell"_string;
+
+    Vector<StringView> arguments;
+    arguments.append(shell);
+    if (!command.is_empty()) {
+        if (keep_open)
+            arguments.append("--keep-open"sv);
+        arguments.append("-c"sv);
+        arguments.append(command);
+    }
+    auto env = TRY(FixedArray<StringView>::create({ "TERM=xterm"sv, "COLORTERM=truecolor"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
+    TRY(Core::System::exec(shell, arguments, Core::System::SearchInPath::No, env.span()));
+    VERIFY_NOT_REACHED();
+}
+
+static bool tty_has_foreground_process(int ptm_fd, pid_t shell_pid)
+{
+    pid_t fg_pid = tcgetpgrp(ptm_fd);
+    return fg_pid != -1 && fg_pid != shell_pid;
+}
+
+static int shell_child_process_count(pid_t shell_pid)
+{
+    int count = 0;
+    Core::Directory::for_each_entry(String::formatted("/proc/{}/children", shell_pid).release_value_but_fixme_should_propagate_errors(),
+        Core::DirIterator::Flags::SkipParentAndBaseDir, [&](auto&, auto&) {
+            ++count;
+            return IterationDecision::Continue;
+        })
+        .release_value_but_fixme_should_propagate_errors();
+    return count;
+}
+
+static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget& terminal)
+{
+    auto window = GUI::Window::construct(&terminal);
+    window->set_window_mode(GUI::WindowMode::RenderAbove);
+    window->set_title("Find in Terminal");
+    window->set_resizable(false);
+    window->resize(300, 90);
+
+    auto main_widget = window->set_main_widget<GUI::Widget>();
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_background_role(Gfx::ColorRole::Button);
+    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
+
+    auto& find = main_widget->add<GUI::Widget>();
+    find.set_layout<GUI::HorizontalBoxLayout>(4);
+    find.set_fixed_height(30);
+
+    auto& find_textbox = find.add<GUI::TextBox>();
+    find_textbox.set_fixed_width(230);
+    find_textbox.set_focus(true);
+    if (terminal.has_selection())
+        find_textbox.set_text(terminal.selected_text().replace("\n"sv, " "sv, ReplaceMode::All));
+    auto& find_backwards = find.add<GUI::Button>();
+    find_backwards.set_fixed_width(25);
+    find_backwards.set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/upward-triangle.png"sv)));
+    auto& find_forwards = find.add<GUI::Button>();
+    find_forwards.set_fixed_width(25);
+    find_forwards.set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/downward-triangle.png"sv)));
+
+    find_textbox.on_return_pressed = [&find_backwards] { find_backwards.click(); };
+    find_textbox.on_shift_return_pressed = [&find_forwards] { find_forwards.click(); };
+
+    auto& match_case = main_widget->add<GUI::CheckBox>("Case sensitive"_string);
+    auto& wrap_around = main_widget->add<GUI::CheckBox>("Wrap around"_string);
+
+    find_backwards.on_click = [&terminal, &find_textbox, &match_case, &wrap_around](auto) {
+        auto needle = find_textbox.text();
+        if (needle.is_empty())
+            return;
+        auto found_range = terminal.find_previous(needle, terminal.normalized_selection().start(), match_case.is_checked(), wrap_around.is_checked());
+        if (found_range.is_valid()) {
+            terminal.scroll_to_row(found_range.start().row());
+            terminal.set_selection(found_range);
+        }
+    };
+    find_forwards.on_click = [&terminal, &find_textbox, &match_case, &wrap_around](auto) {
+        auto needle = find_textbox.text();
+        if (needle.is_empty())
+            return;
+        auto found_range = terminal.find_next(needle, terminal.normalized_selection().end(), match_case.is_checked(), wrap_around.is_checked());
+        if (found_range.is_valid()) {
+            terminal.scroll_to_row(found_range.start().row());
+            terminal.set_selection(found_range);
+        }
+    };
+
+    return window;
+}
+
+TerminalWindow::TerminalWindow()
+{
+    auto app_icon = GUI::Icon::default_icon("app-terminal"sv);
+    set_title("Terminal");
+    set_obey_widget_min_size(false);
+    set_icon(app_icon.bitmap_for_size(16));
+
+    Config::monitor_domain("Terminal");
+    m_should_confirm_close = Config::read_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, Terminal::Defaults::CONFIRM_CLOSE);
+    m_bell = VT::TerminalWidget::parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv)).value_or(Terminal::Defaults::BELL_MODE);
+    m_automark = VT::TerminalWidget::parse_automark_mode(Config::read_string("Terminal"sv, "Terminal"sv, "AutoMark"sv)).value_or(Terminal::Defaults::AUTOMARK_MODE);
+    m_cursor_shape = VT::TerminalWidget::parse_cursor_shape(Config::read_string("Terminal"sv, "Cursor"sv, "Shape"sv)).value_or(Terminal::Defaults::CURSOR_SHAPE);
+    m_cursor_blinking = Config::read_bool("Terminal"sv, "Cursor"sv, "Blinking"sv, Terminal::Defaults::CURSOR_BLINKING);
+    m_opacity = Config::read_i32("Terminal"sv, "Window"sv, "Opacity"sv, Terminal::Defaults::OPACITY);
+    m_show_scroll_bar = Config::read_bool("Terminal"sv, "Terminal"sv, "ShowScrollBar"sv, Terminal::Defaults::SHOW_SCROLLBAR);
+    set_has_alpha_channel(m_opacity < 255);
+
+    on_close_request = [this]() -> GUI::Window::CloseRequestDecision {
+        if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
+            return GUI::Window::CloseRequestDecision::Close;
+        return GUI::Window::CloseRequestDecision::StayOpen;
+    };
+
+    on_input_preemption_change = [this](bool is_preempted) {
+        if (m_terminal)
+            m_terminal->set_logical_focus(!is_preempted);
+    };
+
+    m_modified_state_check_timer = Core::Timer::create_repeating(500, [this] {
+        set_modified(tty_has_foreground_process(m_ptm_fd, m_shell_pid) || shell_child_process_count(m_shell_pid) > 0);
+    });
+}
+
+ErrorOr<void> TerminalWindow::initialize(StringView initial_command, bool keep_open)
+{
+    int ptm_fd;
+    pid_t shell_pid = forkpty(&ptm_fd, nullptr, nullptr, nullptr);
+    if (shell_pid < 0)
+        return Error::from_errno(errno);
+    if (shell_pid == 0) {
+        auto startup_command = Config::read_string("Terminal"sv, "Startup"sv, "Command"sv, ""sv);
+        if (run_command(initial_command.is_empty() ? startup_command.view() : initial_command, keep_open).is_error())
+            _exit(1);
+        VERIFY_NOT_REACHED();
+    }
+
+    m_ptm_fd = ptm_fd;
+    m_shell_pid = shell_pid;
+    m_ptsname = TRY(Core::System::ptsname(ptm_fd));
+    TRY(utmp_update(m_ptsname, shell_pid, true));
+
+    auto app_icon = GUI::Icon::default_icon("app-terminal"sv);
+    auto terminal = set_main_widget<VT::TerminalWidget>(ptm_fd, true);
+    m_terminal = terminal;
+    terminal->set_startup_process_id(shell_pid);
+    terminal->on_command_exit = [] {
+        GUI::Application::the()->quit(0);
+    };
+    terminal->on_title_change = [this](auto title) {
+        set_title(title);
+    };
+    terminal->on_terminal_size_change = [this](auto size) {
+        resize(size);
+    };
+    terminal->apply_size_increments_to_window(*this);
+    set_icon(app_icon.bitmap_for_size(16));
+
+    terminal->set_bell_mode(m_bell);
+    terminal->set_auto_mark_mode(m_automark);
+    terminal->set_cursor_shape(m_cursor_shape);
+    terminal->set_cursor_blinking(m_cursor_blinking);
+    terminal->set_opacity(m_opacity);
+    terminal->set_max_history_size(Config::read_i32("Terminal"sv, "Terminal"sv, "MaxHistorySize"sv, terminal->max_history_size()));
+    terminal->set_show_scrollbar(m_show_scroll_bar);
+
+    m_find_window = TRY(create_find_window(*terminal));
+
+    m_open_settings_action = GUI::Action::create("Terminal &Settings",
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/settings.png"sv)),
+        [this](auto&) { GUI::Process::spawn_or_show_error(this, "/bin/TerminalSettings"sv); });
+    terminal->context_menu().add_separator();
+    terminal->context_menu().add_action(*m_open_settings_action);
+
+    TRY(build_menus(app_icon));
+
+    if (m_should_confirm_close)
+        m_modified_state_check_timer->start();
+
+    return {};
+}
+
+ErrorOr<void> TerminalWindow::build_menus(GUI::Icon const& app_icon)
+{
+    VERIFY(m_terminal);
+
+    auto file_menu = add_menu("&File"_string);
+    file_menu->add_action(GUI::Action::create("Open New &Terminal", { Mod_Ctrl | Mod_Shift, Key_N },
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"sv)),
+        [this](auto&) { GUI::Process::spawn_or_show_error(this, "/bin/Terminal"sv); }));
+    file_menu->add_action(*m_open_settings_action);
+    file_menu->add_separator();
+    file_menu->add_action(GUI::CommonActions::make_quit_action(
+        [this](auto&) {
+            dbgln("Terminal: Quit menu activated!");
+            if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
+                GUI::Application::the()->quit();
+        },
+        GUI::CommonActions::QuitAltShortcut::None));
+
+    auto edit_menu = add_menu("&Edit"_string);
+    edit_menu->add_action(m_terminal->copy_action());
+    edit_menu->add_action(m_terminal->paste_action());
+    edit_menu->add_separator();
+    edit_menu->add_action(GUI::Action::create("&Find...", { Mod_Ctrl | Mod_Shift, Key_F },
+        TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)),
+        [this](auto&) {
+            VERIFY(m_find_window);
+            m_find_window->show();
+            m_find_window->move_to_front();
+        }));
+
+    auto view_menu = add_menu("&View"_string);
+    view_menu->add_action(GUI::CommonActions::make_fullscreen_action([this](auto&) {
+        set_fullscreen(!is_fullscreen());
+    }));
+    view_menu->add_action(m_terminal->clear_including_history_action());
+    view_menu->add_action(m_terminal->clear_to_previous_mark_action());
+    view_menu->add_separator();
+    view_menu->add_action(GUI::CommonActions::make_zoom_in_action([this](auto&) {
+        adjust_font_size(1, Gfx::Font::AllowInexactSizeMatch::Larger);
+    }));
+    view_menu->add_action(GUI::CommonActions::make_zoom_out_action([this](auto&) {
+        adjust_font_size(-1, Gfx::Font::AllowInexactSizeMatch::Smaller);
+    }));
+
+    auto help_menu = add_menu("&Help"_string);
+    help_menu->add_action(GUI::CommonActions::make_command_palette_action(this));
+    help_menu->add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Applications/Terminal.md"), "/bin/Help");
+    }));
+    help_menu->add_action(GUI::CommonActions::make_about_action("Terminal"_string, app_icon, this));
+    return {};
+}
+
+ErrorOr<void> TerminalWindow::cleanup()
+{
+    dbgln("Terminal: Exiting, updating utmp");
+    return utmp_update(m_ptsname, 0, false);
+}
+
+GUI::Dialog::ExecResult TerminalWindow::check_terminal_quit()
+{
+    if (!m_should_confirm_close)
+        return GUI::MessageBox::ExecResult::OK;
+
+    Optional<String> close_message;
+    auto title = "Running Process"sv;
+    if (tty_has_foreground_process(m_ptm_fd, m_shell_pid)) {
+        close_message = "Close Terminal and kill its foreground process?"_string;
+    } else {
+        auto child_process_count = shell_child_process_count(m_shell_pid);
+        if (child_process_count > 1) {
+            title = "Running Processes"sv;
+            close_message = String::formatted("Close Terminal and kill its {} background processes?", child_process_count).release_value_but_fixme_should_propagate_errors();
+        } else if (child_process_count == 1) {
+            close_message = "Close Terminal and kill its background process?"_string;
+        }
+    }
+
+    if (close_message.has_value())
+        return GUI::MessageBox::show(this, *close_message, title, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
+    return GUI::MessageBox::ExecResult::OK;
+}
+
+void TerminalWindow::adjust_font_size(float adjustment, Gfx::Font::AllowInexactSizeMatch preference)
+{
+    VERIFY(m_terminal);
+
+    auto& font = m_terminal->font();
+    auto new_size = max(5, font.presentation_size() + adjustment);
+    if (auto new_font = Gfx::FontDatabase::the().get(font.family(), new_size, font.weight(), font.width(), font.slope(), preference)) {
+        m_terminal->set_font_and_resize_to_fit(*new_font);
+        m_terminal->apply_size_increments_to_window(*this);
+        resize(m_terminal->size());
+    }
+}
+
+void TerminalWindow::config_bool_did_change(StringView domain, StringView group, StringView key, bool value)
+{
+    VERIFY(domain == "Terminal");
+    VERIFY(m_terminal);
+
+    if (group == "Terminal") {
+        if (key == "ShowScrollBar") {
+            m_show_scroll_bar = value;
+            m_terminal->set_show_scrollbar(value);
+        } else if (key == "ConfirmClose") {
+            m_should_confirm_close = value;
+            if (value) {
+                m_modified_state_check_timer->start();
+            } else {
+                m_modified_state_check_timer->stop();
+                set_modified(false);
+            }
+        }
+    } else if (group == "Cursor" && key == "Blinking") {
+        m_cursor_blinking = value;
+        m_terminal->set_cursor_blinking(value);
+    }
+}
+
+void TerminalWindow::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
+{
+    VERIFY(domain == "Terminal");
+    VERIFY(m_terminal);
+
+    if (group == "Window" && key == "Bell") {
+        m_bell = VT::TerminalWidget::parse_bell(value).value_or(VT::TerminalWidget::BellMode::Visible);
+        m_terminal->set_bell_mode(m_bell);
+    } else if (group == "Text" && key == "Font") {
+        auto font = Gfx::FontDatabase::the().get_by_name(value);
+        if (font.is_null())
+            font = Gfx::FontDatabase::default_fixed_width_font();
+        m_terminal->set_font_and_resize_to_fit(*font);
+        m_terminal->apply_size_increments_to_window(*this);
+        resize(m_terminal->size());
+    } else if (group == "Cursor" && key == "Shape") {
+        m_cursor_shape = VT::TerminalWidget::parse_cursor_shape(value).value_or(VT::CursorShape::Block);
+        m_terminal->set_cursor_shape(m_cursor_shape);
+    } else if (group == "Terminal" && key == "AutoMark") {
+        m_automark = VT::TerminalWidget::parse_automark_mode(value).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
+        m_terminal->set_auto_mark_mode(m_automark);
+    }
+}
+
+void TerminalWindow::config_i32_did_change(StringView domain, StringView group, StringView key, i32 value)
+{
+    VERIFY(domain == "Terminal");
+    VERIFY(m_terminal);
+
+    if (group == "Terminal" && key == "MaxHistorySize") {
+        m_terminal->set_max_history_size(value);
+    } else if (group == "Window" && key == "Opacity") {
+        m_opacity = value;
+        set_has_alpha_channel(value < 255);
+        m_terminal->set_opacity(value);
+    }
+}

--- a/Userland/Applications/Terminal/TerminalWindow.h
+++ b/Userland/Applications/Terminal/TerminalWindow.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <LibConfig/Listener.h>
+#include <LibCore/Timer.h>
+#include <LibGUI/Action.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/Icon.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Font/Font.h>
+#include <LibVT/TerminalWidget.h>
+
+class TerminalWindow final : public GUI::Window
+    , public Config::Listener {
+    C_OBJECT(TerminalWindow);
+
+public:
+    virtual ~TerminalWindow() override = default;
+
+    ErrorOr<void> initialize(StringView initial_command, bool keep_open);
+    ErrorOr<void> cleanup();
+
+private:
+    TerminalWindow();
+
+    ErrorOr<void> build_menus(GUI::Icon const& app_icon);
+    GUI::Dialog::ExecResult check_terminal_quit();
+    void adjust_font_size(float adjustment, Gfx::Font::AllowInexactSizeMatch);
+
+    // ^Config::Listener
+    virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
+    virtual void config_i32_did_change(StringView domain, StringView group, StringView key, i32 value) override;
+
+    RefPtr<VT::TerminalWidget> m_terminal;
+    RefPtr<GUI::Window> m_find_window;
+    RefPtr<GUI::Action> m_open_settings_action;
+    RefPtr<Core::Timer> m_modified_state_check_timer;
+    int m_ptm_fd { -1 };
+    pid_t m_shell_pid { -1 };
+    ByteString m_ptsname;
+    bool m_should_confirm_close { true };
+
+    // Cached config values
+    VT::TerminalWidget::BellMode m_bell;
+    VT::TerminalWidget::AutoMarkMode m_automark;
+    VT::CursorShape m_cursor_shape { VT::CursorShape::Block };
+    bool m_cursor_blinking { true };
+    i32 m_opacity { 255 };
+    bool m_show_scroll_bar { true };
+};

--- a/Userland/Applications/Terminal/TerminalWindow.h
+++ b/Userland/Applications/Terminal/TerminalWindow.h
@@ -8,11 +8,13 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/Vector.h>
 #include <LibConfig/Listener.h>
 #include <LibCore/Timer.h>
-#include <LibGUI/Action.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Icon.h>
+#include <LibGUI/SeparatorWidget.h>
+#include <LibGUI/TabWidget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Font/Font.h>
 #include <LibVT/TerminalWidget.h>
@@ -30,8 +32,22 @@ public:
 private:
     TerminalWindow();
 
+    struct TabData {
+        int ptm_fd;
+        pid_t shell_pid;
+        ByteString ptsname;
+        ByteString title;
+        RefPtr<VT::TerminalWidget> terminal;
+        RefPtr<GUI::Window> find_window;
+    };
+
     ErrorOr<void> build_menus(GUI::Icon const& app_icon);
+    VT::TerminalWidget& active_terminal();
+    ErrorOr<void> create_terminal_tab(int ptm_fd, pid_t shell_pid, ByteString ptsname);
+    void close_terminal_tab(VT::TerminalWidget&);
+    ErrorOr<void> open_new_terminal_tab(StringView cmd = {}, bool keep_open = false);
     GUI::Dialog::ExecResult check_terminal_quit();
+    GUI::Dialog::ExecResult check_tab_quit(VT::TerminalWidget&);
     void adjust_font_size(float adjustment, Gfx::Font::AllowInexactSizeMatch);
 
     // ^Config::Listener
@@ -39,14 +55,12 @@ private:
     virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
     virtual void config_i32_did_change(StringView domain, StringView group, StringView key, i32 value) override;
 
-    RefPtr<VT::TerminalWidget> m_terminal;
-    RefPtr<GUI::Window> m_find_window;
+    RefPtr<GUI::TabWidget> m_tab_widget;
+    RefPtr<GUI::HorizontalSeparator> m_top_line;
     RefPtr<GUI::Action> m_open_settings_action;
-    RefPtr<Core::Timer> m_modified_state_check_timer;
-    int m_ptm_fd { -1 };
-    pid_t m_shell_pid { -1 };
-    ByteString m_ptsname;
+    Vector<TabData> m_tab_data_list;
     bool m_should_confirm_close { true };
+    RefPtr<Core::Timer> m_modified_state_check_timer;
 
     // Cached config values
     VT::TerminalWidget::BellMode m_bell;

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -1,228 +1,18 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/FixedArray.h>
-#include <AK/QuickSort.h>
-#include <AK/TypedTransfer.h>
-#include <Applications/TerminalSettings/Defaults.h>
+#include "TerminalWindow.h"
 #include <LibConfig/Client.h>
-#include <LibConfig/Listener.h>
 #include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/Directory.h>
 #include <LibCore/System.h>
-#include <LibDesktop/Launcher.h>
-#include <LibFileSystem/FileSystem.h>
-#include <LibGUI/Action.h>
-#include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/BoxLayout.h>
-#include <LibGUI/Button.h>
-#include <LibGUI/CheckBox.h>
-#include <LibGUI/ComboBox.h>
-#include <LibGUI/Event.h>
-#include <LibGUI/Icon.h>
-#include <LibGUI/ItemListModel.h>
-#include <LibGUI/Menu.h>
-#include <LibGUI/Menubar.h>
-#include <LibGUI/MessageBox.h>
-#include <LibGUI/Process.h>
-#include <LibGUI/TextBox.h>
-#include <LibGUI/Widget.h>
-#include <LibGUI/Window.h>
-#include <LibGfx/Font/FontDatabase.h>
-#include <LibGfx/Palette.h>
 #include <LibMain/Main.h>
-#include <LibURL/URL.h>
-#include <LibVT/TerminalWidget.h>
-#include <pty.h>
-
-class TerminalChangeListener : public Config::Listener {
-public:
-    TerminalChangeListener(VT::TerminalWidget& parent_terminal)
-        : m_parent_terminal(parent_terminal)
-    {
-    }
-
-    virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value) override
-    {
-        VERIFY(domain == "Terminal");
-
-        if (group == "Terminal") {
-            if (key == "ShowScrollBar")
-                m_parent_terminal.set_show_scrollbar(value);
-            else if (key == "ConfirmClose" && on_confirm_close_changed)
-                on_confirm_close_changed(value);
-        } else if (group == "Cursor" && key == "Blinking") {
-            m_parent_terminal.set_cursor_blinking(value);
-        }
-    }
-
-    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override
-    {
-        VERIFY(domain == "Terminal");
-
-        if (group == "Window" && key == "Bell") {
-            auto bell_mode = VT::TerminalWidget::parse_bell(value).value_or(VT::TerminalWidget::BellMode::Visible);
-            m_parent_terminal.set_bell_mode(bell_mode);
-        } else if (group == "Text" && key == "Font") {
-            auto font = Gfx::FontDatabase::the().get_by_name(value);
-            if (font.is_null())
-                font = Gfx::FontDatabase::default_fixed_width_font();
-            m_parent_terminal.set_font_and_resize_to_fit(*font);
-            m_parent_terminal.apply_size_increments_to_window(*m_parent_terminal.window());
-            m_parent_terminal.window()->resize(m_parent_terminal.size());
-        } else if (group == "Cursor" && key == "Shape") {
-            auto cursor_shape = VT::TerminalWidget::parse_cursor_shape(value).value_or(VT::CursorShape::Block);
-            m_parent_terminal.set_cursor_shape(cursor_shape);
-        } else if (group == "Terminal" && key == "AutoMark") {
-            auto automark_mode = VT::TerminalWidget::parse_automark_mode(value).value_or(VT::TerminalWidget::AutoMarkMode::MarkInteractiveShellPrompt);
-            m_parent_terminal.set_auto_mark_mode(automark_mode);
-        }
-    }
-
-    virtual void config_i32_did_change(StringView domain, StringView group, StringView key, i32 value) override
-    {
-        VERIFY(domain == "Terminal");
-
-        if (group == "Terminal" && key == "MaxHistorySize") {
-            m_parent_terminal.set_max_history_size(value);
-        } else if (group == "Window" && key == "Opacity") {
-            m_parent_terminal.set_opacity(value);
-        }
-    }
-
-    Function<void(bool)> on_confirm_close_changed;
-
-private:
-    VT::TerminalWidget& m_parent_terminal;
-};
-
-static ErrorOr<void> utmp_update(StringView tty, pid_t pid, bool create)
-{
-    auto pid_string = String::number(pid);
-    Array utmp_update_command {
-        "-f"sv,
-        "Terminal"sv,
-        "-p"sv,
-        pid_string.bytes_as_string_view(),
-        (create ? "-c"sv : "-d"sv),
-        tty,
-    };
-
-    auto utmpupdate_pid = TRY(Core::Process::spawn("/bin/utmpupdate"sv, utmp_update_command, {}, Core::Process::KeepAsChild::Yes));
-
-    Core::System::WaitPidResult status;
-    auto wait_successful = false;
-    while (!wait_successful) {
-        auto result = Core::System::waitpid(utmpupdate_pid, 0);
-        if (result.is_error() && result.error().code() != EINTR) {
-            return result.release_error();
-        } else if (!result.is_error()) {
-            status = result.release_value();
-            wait_successful = true;
-        }
-    }
-
-    if (WIFEXITED(status.status) && WEXITSTATUS(status.status) != 0)
-        dbgln("Terminal: utmpupdate exited with status {}", WEXITSTATUS(status.status));
-    else if (WIFSIGNALED(status.status))
-        dbgln("Terminal: utmpupdate exited due to unhandled signal {}", WTERMSIG(status.status));
-
-    return {};
-}
-
-static ErrorOr<void> run_command(StringView command, bool keep_open)
-{
-    auto shell = TRY(String::from_byte_string(TRY(Core::Account::self(Core::Account::Read::PasswdOnly)).shell()));
-    if (shell.is_empty())
-        shell = "/bin/Shell"_string;
-
-    Vector<StringView> arguments;
-    arguments.append(shell);
-    if (!command.is_empty()) {
-        if (keep_open)
-            arguments.append("--keep-open"sv);
-        arguments.append("-c"sv);
-        arguments.append(command);
-    }
-    auto env = TRY(FixedArray<StringView>::create({ "TERM=xterm"sv, "COLORTERM=truecolor"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
-    TRY(Core::System::exec(shell, arguments, Core::System::SearchInPath::No, env.span()));
-    VERIFY_NOT_REACHED();
-}
-
-static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget& terminal)
-{
-    auto window = GUI::Window::construct(&terminal);
-    window->set_window_mode(GUI::WindowMode::RenderAbove);
-    window->set_title("Find in Terminal");
-    window->set_resizable(false);
-    window->resize(300, 90);
-
-    auto main_widget = window->set_main_widget<GUI::Widget>();
-    main_widget->set_fill_with_background_color(true);
-    main_widget->set_background_role(ColorRole::Button);
-    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
-
-    auto& find = main_widget->add<GUI::Widget>();
-    find.set_layout<GUI::HorizontalBoxLayout>(4);
-    find.set_fixed_height(30);
-
-    auto& find_textbox = find.add<GUI::TextBox>();
-    find_textbox.set_fixed_width(230);
-    find_textbox.set_focus(true);
-    if (terminal.has_selection())
-        find_textbox.set_text(terminal.selected_text().replace("\n"sv, " "sv, ReplaceMode::All));
-    auto& find_backwards = find.add<GUI::Button>();
-    find_backwards.set_fixed_width(25);
-    find_backwards.set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/upward-triangle.png"sv)));
-    auto& find_forwards = find.add<GUI::Button>();
-    find_forwards.set_fixed_width(25);
-    find_forwards.set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/downward-triangle.png"sv)));
-
-    find_textbox.on_return_pressed = [&find_backwards] {
-        find_backwards.click();
-    };
-
-    find_textbox.on_shift_return_pressed = [&find_forwards] {
-        find_forwards.click();
-    };
-
-    auto& match_case = main_widget->add<GUI::CheckBox>("Case sensitive"_string);
-    auto& wrap_around = main_widget->add<GUI::CheckBox>("Wrap around"_string);
-
-    find_backwards.on_click = [&terminal, &find_textbox, &match_case, &wrap_around](auto) {
-        auto needle = find_textbox.text();
-        if (needle.is_empty()) {
-            return;
-        }
-
-        auto found_range = terminal.find_previous(needle, terminal.normalized_selection().start(), match_case.is_checked(), wrap_around.is_checked());
-
-        if (found_range.is_valid()) {
-            terminal.scroll_to_row(found_range.start().row());
-            terminal.set_selection(found_range);
-        }
-    };
-    find_forwards.on_click = [&terminal, &find_textbox, &match_case, &wrap_around](auto) {
-        auto needle = find_textbox.text();
-        if (needle.is_empty()) {
-            return;
-        }
-
-        auto found_range = terminal.find_next(needle, terminal.normalized_selection().end(), match_case.is_checked(), wrap_around.is_checked());
-
-        if (found_range.is_valid()) {
-            terminal.scroll_to_row(found_range.start().row());
-            terminal.set_selection(found_range);
-        }
-    };
-
-    return window;
-}
+#include <signal.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -232,10 +22,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     act.sa_mask = 0;
     // Do not trust that both function pointers overlap.
     act.sa_sigaction = nullptr;
-
     act.sa_flags = SA_NOCLDWAIT;
     act.sa_handler = SIG_IGN;
-
     TRY(Core::System::sigaction(SIGCHLD, &act, nullptr));
 
     auto app = TRY(GUI::Application::create(arguments));
@@ -250,7 +38,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Core::ArgsParser args_parser;
     args_parser.add_option(command_to_execute, "Execute this command inside the terminal", nullptr, 'e', "command");
     args_parser.add_option(keep_open, "Keep the terminal open after the command has finished executing", nullptr, 'k');
-
     args_parser.parse(arguments);
 
     if (keep_open && command_to_execute.is_empty()) {
@@ -258,211 +45,31 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    int ptm_fd;
-    pid_t shell_pid = forkpty(&ptm_fd, nullptr, nullptr, nullptr);
-    if (shell_pid < 0)
-        return Error::from_errno(errno);
-
-    // We're the child process; run the startup command.
-    if (shell_pid == 0) {
-        if (!command_to_execute.is_empty())
-            TRY(run_command(command_to_execute, keep_open));
-        else
-            TRY(run_command(Config::read_string("Terminal"sv, "Startup"sv, "Command"sv, ""sv), false));
-        VERIFY_NOT_REACHED();
-    }
-
-    auto ptsname = TRY(Core::System::ptsname(ptm_fd));
-    TRY(utmp_update(ptsname, shell_pid, true));
-
-    auto app_icon = GUI::Icon::default_icon("app-terminal"sv);
-
-    auto window = GUI::Window::construct();
-    window->set_title("Terminal");
-    window->set_obey_widget_min_size(false);
-
-    auto terminal = window->set_main_widget<VT::TerminalWidget>(ptm_fd, true);
-    terminal->set_startup_process_id(shell_pid);
-
-    terminal->on_command_exit = [&] {
-        app->quit(0);
-    };
-    terminal->on_title_change = [&](auto title) {
-        window->set_title(title);
-    };
-    terminal->on_terminal_size_change = [&](auto size) {
-        window->resize(size);
-    };
-    terminal->apply_size_increments_to_window(*window);
-    window->set_icon(app_icon.bitmap_for_size(16));
-
-    Config::monitor_domain("Terminal");
-    auto should_confirm_close = Config::read_bool("Terminal"sv, "Terminal"sv, "ConfirmClose"sv, Terminal::Defaults::CONFIRM_CLOSE);
-    TerminalChangeListener listener { terminal };
-
-    terminal->set_bell_mode(VT::TerminalWidget::parse_bell(Config::read_string("Terminal"sv, "Window"sv, "Bell"sv)).value_or(Terminal::Defaults::BELL_MODE));
-
-    terminal->set_auto_mark_mode(VT::TerminalWidget::parse_automark_mode(Config::read_string("Terminal"sv, "Terminal"sv, "AutoMark"sv)).value_or(Terminal::Defaults::AUTOMARK_MODE));
-
-    auto cursor_shape = VT::TerminalWidget::parse_cursor_shape(Config::read_string("Terminal"sv, "Cursor"sv, "Shape"sv)).value_or(Terminal::Defaults::CURSOR_SHAPE);
-    terminal->set_cursor_shape(cursor_shape);
-
-    auto cursor_blinking = Config::read_bool("Terminal"sv, "Cursor"sv, "Blinking"sv, Terminal::Defaults::CURSOR_BLINKING);
-    terminal->set_cursor_blinking(cursor_blinking);
-
-    auto find_window = TRY(create_find_window(terminal));
-
-    auto new_opacity = Config::read_i32("Terminal"sv, "Window"sv, "Opacity"sv, Terminal::Defaults::OPACITY);
-    terminal->set_opacity(new_opacity);
-    window->set_has_alpha_channel(new_opacity < 255);
-
-    auto new_scrollback_size = Config::read_i32("Terminal"sv, "Terminal"sv, "MaxHistorySize"sv, Terminal::Defaults::MAX_HISTORY_SIZE);
-    terminal->set_max_history_size(new_scrollback_size);
-
-    auto show_scroll_bar = Config::read_bool("Terminal"sv, "Terminal"sv, "ShowScrollBar"sv, Terminal::Defaults::SHOW_SCROLLBAR);
-    terminal->set_show_scrollbar(show_scroll_bar);
-
-    auto open_settings_action = GUI::Action::create("Terminal &Settings", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/settings.png"sv)),
-        [&](auto&) {
-            GUI::Process::spawn_or_show_error(window, "/bin/TerminalSettings"sv);
-        });
-
-    terminal->context_menu().add_separator();
-    terminal->context_menu().add_action(open_settings_action);
-
-    auto file_menu = window->add_menu("&File"_string);
-    file_menu->add_action(GUI::Action::create("Open New &Terminal", { Mod_Ctrl | Mod_Shift, Key_N }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"sv)), [&](auto&) {
-        GUI::Process::spawn_or_show_error(window, "/bin/Terminal"sv);
-    }));
-
-    file_menu->add_action(open_settings_action);
-    file_menu->add_separator();
-
-    auto tty_has_foreground_process = [&] {
-        pid_t fg_pid = tcgetpgrp(ptm_fd);
-        return fg_pid != -1 && fg_pid != shell_pid;
-    };
-
-    auto shell_child_process_count = [&] {
-        int background_process_count = 0;
-        Core::Directory::for_each_entry(String::formatted("/proc/{}/children", shell_pid).release_value_but_fixme_should_propagate_errors(), Core::DirIterator::Flags::SkipParentAndBaseDir, [&](auto&, auto&) {
-            ++background_process_count;
-            return IterationDecision::Continue;
-        }).release_value_but_fixme_should_propagate_errors();
-        return background_process_count;
-    };
-
-    auto check_terminal_quit = [&]() -> GUI::Dialog::ExecResult {
-        if (!should_confirm_close)
-            return GUI::MessageBox::ExecResult::OK;
-        Optional<String> close_message;
-        auto title = "Running Process"sv;
-        if (tty_has_foreground_process()) {
-            close_message = "Close Terminal and kill its foreground process?"_string;
-        } else {
-            auto child_process_count = shell_child_process_count();
-            if (child_process_count > 1) {
-                title = "Running Processes"sv;
-                close_message = String::formatted("Close Terminal and kill its {} background processes?", child_process_count).release_value_but_fixme_should_propagate_errors();
-            } else if (child_process_count == 1) {
-                close_message = "Close Terminal and kill its background process?"_string;
-            }
-        }
-        if (close_message.has_value())
-            return GUI::MessageBox::show(window, *close_message, title, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
-        return GUI::MessageBox::ExecResult::OK;
-    };
-
-    file_menu->add_action(GUI::CommonActions::make_quit_action(
-        [&](auto&) {
-            dbgln("Terminal: Quit menu activated!");
-            if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
-                GUI::Application::the()->quit();
-        },
-        GUI::CommonActions::QuitAltShortcut::None));
-
-    auto edit_menu = window->add_menu("&Edit"_string);
-    edit_menu->add_action(terminal->copy_action());
-    edit_menu->add_action(terminal->paste_action());
-    edit_menu->add_separator();
-    edit_menu->add_action(GUI::Action::create("&Find...", { Mod_Ctrl | Mod_Shift, Key_F }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)),
-        [&](auto&) {
-            find_window->show();
-            find_window->move_to_front();
-        }));
-
-    auto view_menu = window->add_menu("&View"_string);
-    view_menu->add_action(GUI::CommonActions::make_fullscreen_action([&](auto&) {
-        window->set_fullscreen(!window->is_fullscreen());
-    }));
-    view_menu->add_action(terminal->clear_including_history_action());
-    view_menu->add_action(terminal->clear_to_previous_mark_action());
-
-    auto adjust_font_size = [&](float adjustment, Gfx::Font::AllowInexactSizeMatch preference) {
-        auto& font = terminal->font();
-        auto new_size = max(5, font.presentation_size() + adjustment);
-        if (auto new_font = Gfx::FontDatabase::the().get(font.family(), new_size, font.weight(), font.width(), font.slope(), preference)) {
-            terminal->set_font_and_resize_to_fit(*new_font);
-            terminal->apply_size_increments_to_window(*window);
-            window->resize(terminal->size());
-        }
-    };
-
-    view_menu->add_separator();
-    view_menu->add_action(GUI::CommonActions::make_zoom_in_action([&](auto&) {
-        adjust_font_size(1, Gfx::Font::AllowInexactSizeMatch::Larger);
-    }));
-    view_menu->add_action(GUI::CommonActions::make_zoom_out_action([&](auto&) {
-        adjust_font_size(-1, Gfx::Font::AllowInexactSizeMatch::Smaller);
-    }));
-
-    auto help_menu = window->add_menu("&Help"_string);
-    help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
-    help_menu->add_action(GUI::CommonActions::make_help_action([](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Applications/Terminal.md"), "/bin/Help");
-    }));
-    help_menu->add_action(GUI::CommonActions::make_about_action("Terminal"_string, app_icon, window));
-
-    window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
-        if (check_terminal_quit() == GUI::MessageBox::ExecResult::OK)
-            return GUI::Window::CloseRequestDecision::Close;
-        return GUI::Window::CloseRequestDecision::StayOpen;
-    };
-
-    window->on_input_preemption_change = [&](bool is_preempted) {
-        terminal->set_logical_focus(!is_preempted);
-    };
+    // Read the user's shell before locking unveil so we can unveil the correct executable.
+    auto user_shell = TRY(String::from_byte_string(TRY(Core::Account::self(Core::Account::Read::PasswdOnly)).shell()));
+    if (user_shell.is_empty())
+        user_shell = "/bin/Shell"_string;
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin", "r"));
     TRY(Core::System::unveil("/proc", "r"));
+    TRY(Core::System::unveil("/dev/pts", "rw"));
+    TRY(Core::System::unveil("/dev/ptmx", "rw"));
+    TRY(Core::System::unveil(user_shell.bytes_as_string_view(), "x"sv));
     TRY(Core::System::unveil("/bin/Terminal", "x"));
     TRY(Core::System::unveil("/bin/TerminalSettings", "x"));
     TRY(Core::System::unveil("/bin/utmpupdate", "x"));
+    TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/launch", "rw"));
     TRY(Core::System::unveil("/dev/beep", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto modified_state_check_timer = Core::Timer::create_repeating(500, [&] {
-        window->set_modified(tty_has_foreground_process() || shell_child_process_count() > 0);
-    });
-
-    listener.on_confirm_close_changed = [&](bool confirm_close) {
-        if (confirm_close) {
-            modified_state_check_timer->start();
-        } else {
-            modified_state_check_timer->stop();
-            window->set_modified(false);
-        }
-        should_confirm_close = confirm_close;
-    };
-
+    auto window = TerminalWindow::construct();
+    TRY(window->initialize(command_to_execute, keep_open));
     window->show();
-    if (should_confirm_close)
-        modified_state_check_timer->start();
+
     int result = app->exec();
-    dbgln("Exiting terminal, updating utmp");
-    TRY(utmp_update(ptsname, 0, false));
+    TRY(window->cleanup());
     return result;
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -756,11 +756,6 @@ void HackStudioWidget::add_new_editor_tab_widget(GUI::Widget& parent)
         current_editor().set_focus(true);
     };
 
-    tab_widget->on_middle_click = [](auto& widget) {
-        auto& wrapper = static_cast<EditorWrapper&>(widget);
-        wrapper.on_tab_close_request(wrapper);
-    };
-
     tab_widget->on_tab_close_click = [](auto& widget) {
         auto& wrapper = static_cast<EditorWrapper&>(widget);
         wrapper.on_tab_close_request(wrapper);

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -222,6 +222,9 @@ ErrorOr<void> MainWidget::initialize()
         on_editor_change();
     };
 
+    m_tab_widget->set_add_tab_button_enabled(true);
+    m_tab_widget->on_add_tab_button_click = [&] { open_new_script(); };
+
     m_action_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("action_tab_widget"sv);
 
     m_query_results_widget = m_action_tab_widget->add_tab<GUI::Widget>("Results"_string);

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -488,8 +488,8 @@ void TabWidget::mousedown_event(MouseEvent& event)
         } else if (event.button() == MouseButton::Middle) {
             auto* widget = m_tabs[i].widget;
             deferred_invoke([this, widget] {
-                if (on_middle_click && widget)
-                    on_middle_click(*widget);
+                if (on_tab_close_click && widget)
+                    on_tab_close_click(*widget);
             });
         }
         return;

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -30,6 +30,7 @@ TabWidget::TabWidget()
 
     REGISTER_MARGINS_PROPERTY("container_margins", container_margins, set_container_margins);
     REGISTER_BOOL_PROPERTY("show_close_buttons", close_button_enabled, set_close_button_enabled);
+    REGISTER_BOOL_PROPERTY("show_add_tab_button", add_tab_button_enabled, set_add_tab_button_enabled);
     REGISTER_BOOL_PROPERTY("show_tab_bar", is_bar_visible, set_bar_visible);
     REGISTER_BOOL_PROPERTY("reorder_allowed", reorder_allowed, set_reorder_allowed);
     REGISTER_BOOL_PROPERTY("uniform_tabs", uniform_tabs, set_uniform_tabs);
@@ -298,6 +299,15 @@ void TabWidget::paint_event(PaintEvent& event)
         }
     }
 
+    if (m_add_tab_button_enabled) {
+        auto add_rect = add_button_rect();
+        if (m_hovered_add_button)
+            Gfx::StylePainter::paint_frame(painter, add_rect, palette(), m_pressed_add_button ? Gfx::FrameStyle::SunkenPanel : Gfx::FrameStyle::RaisedPanel);
+        auto center = add_rect.center().translated(-1, -1);
+        painter.draw_line({ center.x() - 3, center.y() }, { center.x() + 3, center.y() }, palette().button_text());
+        painter.draw_line({ center.x(), center.y() - 3 }, { center.x(), center.y() + 3 }, palette().button_text());
+    }
+
     for (size_t i = 0; i < m_tabs.size(); ++i) {
         if (m_tabs[i].widget != m_active_widget)
             continue;
@@ -384,7 +394,13 @@ int TabWidget::uniform_tab_width() const
         return tab_width;
 
     int available_width = width() - bar_margin() * 2;
-    if (total_tab_width > available_width)
+    if (m_add_tab_button_enabled) {
+        int gap = m_tabs.is_empty() ? 0 : bar_margin();
+        // The active last tab is drawn 2 px past its logical right edge
+        int trailing_overhang = !m_tabs.is_empty() && m_tabs.last().widget == m_active_widget ? 2 : 0;
+        available_width -= gap + (bar_height() - bar_margin() * 2) + trailing_overhang;
+    }
+    if (total_tab_width > available_width && !m_tabs.is_empty())
         tab_width = available_width / m_tabs.size();
     return max(tab_width, m_min_tab_width);
 }
@@ -395,6 +411,35 @@ void TabWidget::set_bar_visible(bool bar_visible)
     if (m_active_widget)
         m_active_widget->set_relative_rect(child_rect_for_size(size()));
     update_bar();
+}
+
+void TabWidget::set_add_tab_button_enabled(bool enabled)
+{
+    m_add_tab_button_enabled = enabled;
+    update_bar();
+}
+
+int TabWidget::compute_tab_width(size_t index) const
+{
+    int close_button_offset = m_close_button_enabled ? 16 : 0;
+    if (m_uniform_tabs)
+        return uniform_tab_width();
+    if (has_vertical_tabs())
+        return m_tabs[index].width(font()) + close_button_offset;
+    // Auto-shrink all tabs evenly when total natural width overflows available bar space.
+    int total = 0;
+    for (auto& tab : m_tabs)
+        total += tab.width(font()) + close_button_offset;
+    int available = width() - bar_margin() * 2;
+    if (m_add_tab_button_enabled) {
+        int gap = m_tabs.is_empty() ? 0 : bar_margin();
+        // The active last tab is drawn 2 px past its logical right edge
+        int trailing_overhang = !m_tabs.is_empty() && m_tabs.last().widget == m_active_widget ? 2 : 0;
+        available -= gap + (bar_height() - bar_margin() * 2) + trailing_overhang;
+    }
+    if (total > available && !m_tabs.is_empty())
+        return max(available / (int)m_tabs.size(), m_min_tab_width);
+    return m_tabs[index].width(font()) + close_button_offset;
 }
 
 Gfx::IntRect TabWidget::button_rect(size_t index) const
@@ -424,13 +469,10 @@ Gfx::IntRect TabWidget::vertical_button_rect(size_t index) const
 Gfx::IntRect TabWidget::horizontal_button_rect(size_t index) const
 {
     int x_offset = bar_margin();
-    int close_button_offset = m_close_button_enabled ? 16 : 0;
-
     for (size_t i = 0; i < index; ++i) {
-        auto tab_width = m_uniform_tabs ? uniform_tab_width() : m_tabs[i].width(font()) + close_button_offset;
-        x_offset += tab_width;
+        x_offset += compute_tab_width(i);
     }
-    Gfx::IntRect rect { x_offset, 0, m_uniform_tabs ? uniform_tab_width() : m_tabs[index].width(font()) + close_button_offset, bar_height() };
+    Gfx::IntRect rect { x_offset, 0, compute_tab_width(index), bar_height() };
     if (m_tabs[index].widget != m_active_widget) {
         rect.translate_by(0, m_tab_position == TabPosition::Top ? 2 : 0);
         rect.set_height(rect.height() - 2);
@@ -453,6 +495,62 @@ Gfx::IntRect TabWidget::close_button_rect(size_t index) const
     return close_button_rect;
 }
 
+Gfx::IntRect TabWidget::add_button_rect() const
+{
+    auto bar = bar_rect();
+    int size = bar_height() - bar_margin() * 2;
+    bool vertical_tabs = has_vertical_tabs();
+    int button_width = vertical_tabs ? bar.width() - 1 : size;
+
+    // Vertical tabs use a full-width add button to match the tab column. Horizontal tabs keep the square button.
+    int button_x = vertical_tabs ? 0 : bar_margin();
+    int button_y = bar_margin();
+    if (!m_tabs.is_empty()) {
+        if (vertical_tabs) {
+            int total_tab_height = m_tabs.size() * bar_height();
+            int gap = bar_margin();
+            // Place the button after the last tab when there is room, otherwise pin it to the bottom of the bar.
+            int trailing_overhang = m_tabs.last().widget == m_active_widget ? 2 : 0;
+            int aligned_button_y = bar.height() - bar_margin() - size;
+            int available_height = bar.height() - bar_margin() * 2 - gap - size - trailing_overhang;
+            if (total_tab_height > available_height) {
+                button_y = aligned_button_y;
+            } else {
+                auto last_tab_rect = button_rect(m_tabs.size() - 1);
+                int desired_button_y = last_tab_rect.bottom() - bar.y() + 1 + bar_margin();
+                button_y = min(desired_button_y, aligned_button_y);
+            }
+        } else {
+            // Place the button after the last tab when there is room, otherwise pin it to the end of the bar.
+            int aligned_button_x = bar.width() - bar_margin() - size;
+            int close_button_offset = m_close_button_enabled ? 16 : 0;
+            int total_tab_width = 0;
+            if (m_uniform_tabs) {
+                total_tab_width = m_tabs.size() * uniform_tab_width();
+            } else {
+                for (auto& tab : m_tabs)
+                    total_tab_width += tab.width(font()) + close_button_offset;
+            }
+
+            int gap = bar_margin();
+            // The active last tab is drawn 2 px past its logical right edge
+            int trailing_overhang = m_tabs.last().widget == m_active_widget ? 2 : 0;
+            int available_width = width() - bar_margin() * 2 - gap - size - trailing_overhang;
+            if (total_tab_width > available_width) {
+                button_x = aligned_button_x;
+            } else {
+                auto last_tab_rect = button_rect(m_tabs.size() - 1);
+                int desired_button_x = last_tab_rect.right() - bar.x() + 1 + bar_margin();
+                button_x = min(desired_button_x, aligned_button_x);
+            }
+        }
+    }
+
+    Gfx::IntRect rect { button_x, button_y, button_width, size };
+    rect.translate_by(bar.location());
+    return rect;
+}
+
 int TabWidget::TabData::width(Gfx::Font const& font) const
 {
     auto width = 16 + font.width_rounded_up(title) + (icon ? (16 + 4) : 0);
@@ -470,6 +568,14 @@ int TabWidget::TabData::width(Gfx::Font const& font) const
 
 void TabWidget::mousedown_event(MouseEvent& event)
 {
+    if (m_add_tab_button_enabled && event.button() == MouseButton::Primary) {
+        if (add_button_rect().contains(event.position())) {
+            m_pressed_add_button = true;
+            update_bar();
+            return;
+        }
+    }
+
     for (size_t i = 0; i < m_tabs.size(); ++i) {
         auto button_rect = this->button_rect(i);
         auto close_button_rect = this->close_button_rect(i);
@@ -500,6 +606,14 @@ void TabWidget::mouseup_event(MouseEvent& event)
 {
     if (event.button() != MouseButton::Primary)
         return;
+
+    if (m_pressed_add_button) {
+        m_pressed_add_button = false;
+        update_bar();
+        if (add_button_rect().contains(event.position()) && on_add_tab_button_click)
+            on_add_tab_button_click();
+        return;
+    }
 
     if (m_dragging_active_tab) {
         m_dragging_active_tab = false;
@@ -532,6 +646,14 @@ void TabWidget::mousemove_event(MouseEvent& event)
         recalculate_tab_order();
         update_bar();
         return;
+    }
+
+    if (m_add_tab_button_enabled) {
+        bool hovered = add_button_rect().contains(event.position());
+        if (hovered != m_hovered_add_button) {
+            m_hovered_add_button = hovered;
+            update_bar();
+        }
     }
 
     for (size_t i = 0; i < m_tabs.size(); ++i) {
@@ -568,9 +690,10 @@ void TabWidget::mousewheel_event(MouseEvent& event)
 
 void TabWidget::leave_event(Core::Event&)
 {
-    if (m_hovered_tab_index.has_value() || m_hovered_close_button_index.has_value()) {
+    if (m_hovered_tab_index.has_value() || m_hovered_close_button_index.has_value() || m_hovered_add_button) {
         m_hovered_tab_index = {};
         m_hovered_close_button_index = {};
+        m_hovered_add_button = false;
         update_bar();
     }
 }

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -97,7 +97,6 @@ public:
 
     Function<void(size_t)> on_tab_count_change;
     Function<void(Widget&)> on_change;
-    Function<void(Widget&)> on_middle_click;
     Function<void(Widget&)> on_tab_close_click;
     Function<void(Widget&, ContextMenuEvent const&)> on_context_menu_request;
     Function<void(Widget&)> on_double_click;

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -92,6 +92,9 @@ public:
     void set_close_button_enabled(bool close_button_enabled) { m_close_button_enabled = close_button_enabled; }
     bool close_button_enabled() const { return m_close_button_enabled; }
 
+    void set_add_tab_button_enabled(bool add_tab_button_enabled);
+    bool add_tab_button_enabled() const { return m_add_tab_button_enabled; }
+
     void set_reorder_allowed(bool reorder_allowed) { m_reorder_allowed = reorder_allowed; }
     bool reorder_allowed() const { return m_reorder_allowed; }
 
@@ -100,6 +103,7 @@ public:
     Function<void(Widget&)> on_tab_close_click;
     Function<void(Widget&, ContextMenuEvent const&)> on_context_menu_request;
     Function<void(Widget&)> on_double_click;
+    Function<void()> on_add_tab_button_click;
 
 protected:
     TabWidget();
@@ -122,8 +126,10 @@ private:
     Gfx::IntRect vertical_button_rect(size_t index) const;
     Gfx::IntRect horizontal_button_rect(size_t index) const;
     Gfx::IntRect close_button_rect(size_t index) const;
+    Gfx::IntRect add_button_rect() const;
     Gfx::IntRect bar_rect() const;
     Gfx::IntRect container_rect() const;
+    int compute_tab_width(size_t index) const;
     void update_bar();
     void update_focus_policy();
     int bar_margin() const { return 2; }
@@ -148,7 +154,9 @@ private:
     bool m_uniform_tabs { false };
     bool m_bar_visible { true };
     bool m_close_button_enabled { false };
-
+    bool m_add_tab_button_enabled { false };
+    bool m_hovered_add_button { false };
+    bool m_pressed_add_button { false };
     int m_max_tab_width { 160 };
     int m_min_tab_width { 24 };
 

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -88,7 +88,8 @@ void ClassicStylePainter::paint_tab_button(Painter& painter, IntRect const& rect
         // If the tab is active, draw the accent line
         if (active && accented) {
             painter.fill_rect_with_gradient({ 1, 1, 2, rect.height() - 2 }, accent, accent.lightened(1.5f));
-            painter.draw_line({ 0, 2 }, { 0, rect.height() - 3 }, accent.darkened());
+            painter.draw_line({ 0, 3 }, { 0, rect.height() - 3 }, accent.darkened());
+            painter.set_pixel({ 0, 2 }, highlight_color2);
         } else {
             painter.draw_line({ 0, 2 }, { 0, rect.height() - 3 }, highlight_color2);
             painter.draw_line({ rect.width(), 1 }, { rect.width(), rect.height() - 1 }, shadow_color1);
@@ -107,7 +108,8 @@ void ClassicStylePainter::paint_tab_button(Painter& painter, IntRect const& rect
         // If the tab is active, draw the accent line
         if (active && accented) {
             painter.fill_rect_with_gradient({ rect.width() - 2, 1, 2, rect.height() - 2 }, accent.lightened(1.5f), accent);
-            painter.draw_line({ rect.width(), 2 }, { rect.width(), rect.height() - 3 }, accent.darkened());
+            painter.draw_line({ rect.width(), 3 }, { rect.width(), rect.height() - 3 }, accent.darkened());
+            painter.set_pixel({ rect.width() - 1, 2 }, shadow_color1);
         } else {
             painter.draw_line({ rect.width(), 2 }, { rect.width(), rect.height() - 3 }, shadow_color2);
             painter.draw_line({ 0, 0 }, { 0, rect.height() - 1 }, shadow_color1);

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -85,6 +85,15 @@ void TerminalWidget::set_pty_master_fd(int fd)
     };
 }
 
+TerminalWidget::~TerminalWidget()
+{
+    if (m_ptm_fd != -1) {
+        m_notifier = nullptr;
+        close(m_ptm_fd);
+        m_ptm_fd = -1;
+    }
+}
+
 TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy)
     : m_terminal(*this)
     , m_automatic_size_policy(automatic_size_policy)

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -28,7 +28,7 @@ class TerminalWidget final
     C_OBJECT(TerminalWidget);
 
 public:
-    virtual ~TerminalWidget() override = default;
+    virtual ~TerminalWidget() override;
 
     void set_pty_master_fd(int fd);
     void inject_string(StringView string)


### PR DESCRIPTION
This PR adds tab support to the Terminal application. It also includes several commits that improve the `TabWidget` system across the application. Additionally, it adds an "Add Tab" button and implements automatic tab resizing when there is a width overflow. The Terminal `main.cpp` file was one big main function so I refactored that completely into the `TerminalWindow` class.

Hope you like it :^)

## Demo

https://github.com/user-attachments/assets/c37484a3-6e7e-45de-b236-587b361b8540

