### PR TITLE
WebWorker: Pledge map_fixed

### DIFF
--- a/Userland/Services/WebWorker/main.cpp
+++ b/Userland/Services/WebWorker/main.cpp
@@ -23,7 +23,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath thread proc"));
+    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath thread proc map_fixed"));
 
     Core::EventLoop event_loop;
     TRY(Core::System::unveil("/res", "r"));


### PR DESCRIPTION
~The first commit is a cherry-pick of https://github.com/LadybirdBrowser/ladybird/pull/5636. This fixes the common "VERIFICATION FAILED: is_monotonically_increasing()" browser crash, which happens on a lot of websites. This crash seems to be significantly easier to trigger in serenity itself, e.g. by just waiting on e.g. duckduckgo.com.
I had to apply one small fixup (`GC::RootVector<GC::Ref<Animation>>(vm().heap())` -> `JS::MarkedVector<JS::NonnullGCPtr<Animation>>(vm().heap())`) to make it compile without having cherry-picked the LibGC changes from upstream Ladybird.~

The second commit fixes the Google Search reCAPTCHA crash from #26548, but we still hang with 100% CPU usage, so this issue isn't fixed yet.