### PR TITLE
LibSSH+SSHServer: Add basic support for sftp

### DIFF
--- a/Tests/LibSSH/CMakeLists.txt
+++ b/Tests/LibSSH/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     SFTP/TestSFTPPeer.cpp
     SFTP/TestSFTPServerBasic.cpp
+    SFTP/TestSFTPStat.cpp
     TestSSHCipher.cpp
     TestSSHEncodeDecode.cpp
     TestSSHIdentificationString.cpp

--- a/Tests/LibSSH/CMakeLists.txt
+++ b/Tests/LibSSH/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     SFTP/TestSFTPPeer.cpp
     SFTP/TestSFTPServerBasic.cpp
     SFTP/TestSFTPStat.cpp
+    SFTP/TestSFTPRead.cpp
     TestSSHCipher.cpp
     TestSSHEncodeDecode.cpp
     TestSSHIdentificationString.cpp

--- a/Tests/LibSSH/CMakeLists.txt
+++ b/Tests/LibSSH/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(TEST_SOURCES
+    SFTP/TestSFTPPeer.cpp
+    SFTP/TestSFTPServerBasic.cpp
     TestSSHCipher.cpp
     TestSSHEncodeDecode.cpp
     TestSSHIdentificationString.cpp

--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -32,3 +32,29 @@ inline ErrorOr<void> server_process_data(SSH::SFTP::Server& server, ReadonlyByte
 
     return Core::run_async_in_new_event_loop([&]() { return server.handle_channel_data(session); });
 }
+
+struct Message {
+    SSH::SFTP::FXPMessageID type;
+    ReadonlyBytes payload;
+};
+
+inline SSH::SFTP::Server make_initialized_server(Function<ErrorOr<void>(Message)> callback)
+{
+    bool was_called { false };
+    SSH::SFTP::Server server([=, callback = move(callback)](ReadonlyBytes bytes) mutable -> ErrorOr<void> {
+        if (was_called) {
+            PeerMock peer { [](ReadonlyBytes) -> ErrorOr<void> { VERIFY_NOT_REACHED(); } };
+            FixedMemoryStream stream { bytes };
+            auto type = TRY(peer.read_header(stream));
+            return callback({ type, bytes.slice(bytes.size() - stream.remaining()) });
+        }
+        EXPECT_EQ(bytes, g_version_packet.bytes());
+        was_called = true;
+        return {};
+    });
+
+    if (server_process_data(server, g_initialization_packet.bytes()).is_error())
+        FAIL("Unable to perform handshake with server");
+
+    return server;
+}

--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/EventLoop.h>
+#include <LibSSH/SFTP/Peer.h>
+#include <LibSSH/SFTP/Server.h>
+#include <LibSSH/Session.h>
+
+class PeerMock : public SSH::SFTP::Peer {
+public:
+    PeerMock(Function<ErrorOr<void>(ReadonlyBytes)> send_packet)
+        : SSH::SFTP::Peer(move(send_packet))
+    {
+    }
+
+    using SSH::SFTP::Peer::read_header;
+    using SSH::SFTP::Peer::write_packet;
+};
+
+inline constexpr auto g_initialization_packet = "\x00\x00\x00\x05\x01\x00\x00\x00\x03"sv;
+inline constexpr auto g_version_packet = "\x00\x00\x00\x05\x02\x00\x00\x00\x03"sv;
+
+inline ErrorOr<void> server_process_data(SSH::SFTP::Server& server, ReadonlyBytes bytes)
+{
+    auto session = MUST(SSH::Session::create(0, 0, 0));
+    session->channel_data.append(bytes);
+
+    return Core::run_async_in_new_event_loop([&]() { return server.handle_channel_data(session); });
+}

--- a/Tests/LibSSH/SFTP/TestSFTPPeer.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPPeer.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibTest/TestCase.h>
+#include <Tests/LibSSH/SFTP/Shared.h>
+
+TEST_CASE(read_header)
+{
+    auto send_packet = [&](ReadonlyBytes) -> ErrorOr<void> {
+        FAIL("This shouldn't be called"sv);
+        return {};
+    };
+    PeerMock peer { move(send_packet) };
+
+    // Valid packet
+    auto stream = FixedMemoryStream { g_initialization_packet.bytes() };
+    TRY_OR_FAIL(peer.read_header(stream));
+    EXPECT_EQ(stream.remaining(), 4u);
+
+    // Invalid packets
+    auto message_copy = TRY_OR_FAIL(ByteBuffer::copy(g_initialization_packet.bytes()));
+
+    // We modify the packet content to change the signaled size.
+    auto altered_content = message_copy;
+    EXPECT_EQ(altered_content[3], 5);
+    altered_content[3] = 4;
+    stream = FixedMemoryStream { altered_content.bytes() };
+    EXPECT(peer.read_header(stream).is_error());
+
+    // We append bytes to the packet to change the actual size.
+    auto altered_length = message_copy;
+    altered_length.append(0);
+    stream = FixedMemoryStream { altered_length.bytes() };
+    EXPECT(peer.read_header(stream).is_error());
+}
+
+TEST_CASE(write_packet)
+{
+    static constexpr auto payload = "Random Payload"sv;
+
+    Optional<ByteBuffer> written_packet;
+    auto send_packet = [&](ReadonlyBytes bytes) -> ErrorOr<void> {
+        written_packet = TRY(ByteBuffer::copy(bytes));
+        return {};
+    };
+    PeerMock peer { move(send_packet) };
+
+    TRY_OR_FAIL(peer.write_packet(payload.bytes()));
+    EXPECT(written_packet.has_value());
+
+    auto expected_size = to_array<u8>({
+        0x00,
+        0x00,
+        0x00,
+        payload.length(),
+    });
+
+    EXPECT_EQ(written_packet->bytes().trim(4), expected_size);
+    EXPECT_EQ(written_packet->bytes().slice(4), payload.bytes());
+}

--- a/Tests/LibSSH/SFTP/TestSFTPRead.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPRead.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/TempFile.h>
+#include <LibSSH/DataTypes.h>
+#include <LibTest/TestCase.h>
+#include <Tests/LibSSH/SFTP/Shared.h>
+
+namespace {
+
+ErrorOr<ByteBuffer> make_open_packet(StringView path, u32 request_id)
+{
+    AllocatingMemoryStream inner;
+
+    TRY(inner.write_value(SSH::SFTP::FXPMessageID::OPEN));
+    TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
+    TRY(SSH::encode_string(inner, path));
+    TRY(inner.write_value<NetworkOrdered<u32>>(1)); // SSH_FXF_READ
+    TRY(inner.write_value<NetworkOrdered<u32>>(0)); // No attributes.
+
+    auto payload = TRY(inner.read_until_eof());
+
+    AllocatingMemoryStream packet;
+    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
+    TRY(packet.write_until_depleted(payload));
+
+    return TRY(packet.read_until_eof());
+}
+
+ErrorOr<ByteBuffer> make_read_packet(ByteBuffer const& handle, u32 request_id, u64 offset, u32 length)
+{
+    AllocatingMemoryStream inner;
+
+    TRY(inner.write_value(SSH::SFTP::FXPMessageID::READ));
+    TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
+    TRY(SSH::encode_string(inner, handle));
+    TRY(inner.write_value<NetworkOrdered<u64>>(offset));
+    TRY(inner.write_value<NetworkOrdered<u32>>(length));
+
+    auto payload = TRY(inner.read_until_eof());
+
+    AllocatingMemoryStream packet;
+    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
+    TRY(packet.write_until_depleted(payload));
+
+    return TRY(packet.read_until_eof());
+}
+
+ErrorOr<void> run_read_test(StringView path, u64 offset, u64 size, bool expect_eof = false)
+{
+    Optional<ByteBuffer> handle;
+    u32 request_id = get_random<u32>();
+    auto callback = [&](Message message) -> ErrorOr<void> {
+        FixedMemoryStream stream { message.payload };
+        if (!handle.has_value()) {
+
+            EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::HANDLE);
+            EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
+
+            handle = TRY(SSH::decode_string(stream));
+            return {};
+        }
+
+        if (expect_eof) {
+            EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
+            EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
+            EXPECT_EQ(to_underlying(SSH::SFTP::FXStatus::FX_EOF), TRY(stream.read_value<NetworkOrdered<u32>>()));
+
+            return {};
+        }
+
+        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::DATA);
+        EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
+
+        auto remote_data = TRY(SSH::decode_string(stream));
+
+        auto local_buffer = TRY(ByteBuffer::create_uninitialized(remote_data.size()));
+        local_buffer.resize(remote_data.size());
+
+        auto fd = TRY(Core::System::open(path, O_RDONLY));
+        ssize_t nread = TRY(Core::System::pread(fd, local_buffer, offset));
+        EXPECT_EQ(static_cast<unsigned long>(nread), local_buffer.size());
+
+        EXPECT_EQ(remote_data, local_buffer);
+
+        return {};
+    };
+    auto server = make_initialized_server(move(callback));
+
+    auto open_packet = TRY(make_open_packet(path, request_id));
+    TRY(server_process_data(server, open_packet));
+
+    if (!handle.has_value())
+        return Error::from_string_literal("The handle should have been received");
+
+    request_id = get_random<u32>();
+    auto read_packet = TRY(make_read_packet(*handle, request_id, offset, size));
+    TRY(server_process_data(server, read_packet));
+
+    return {};
+}
+
+}
+
+TEST_CASE(basic)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(file->write_until_depleted("hello world"sv));
+
+    TRY_OR_FAIL(run_read_test(temp_file->path(), 0, 5)); // "hello"
+    TRY_OR_FAIL(run_read_test(temp_file->path(), 6, 5)); // "world"
+}
+
+TEST_CASE(read_past_eof)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(file->write_until_depleted("abc"sv));
+
+    TRY_OR_FAIL(run_read_test(temp_file->path(), 1000, 1000, true));
+}
+
+TEST_CASE(read_includes_eof)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(file->write_until_depleted("abc"sv));
+
+    TRY_OR_FAIL(run_read_test(temp_file->path(), 1, 10));
+}
+
+TEST_CASE(read_zero_length)
+{
+    auto file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    TRY_OR_FAIL(run_read_test(file->path(), 0, 0));
+}

--- a/Tests/LibSSH/SFTP/TestSFTPServerBasic.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPServerBasic.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibTest/TestCase.h>
+#include <Tests/LibSSH/SFTP/Shared.h>
+
+TEST_CASE(handshake)
+{
+    bool already_called { false };
+    auto send_packet = [&](ReadonlyBytes bytes) -> ErrorOr<void> {
+        EXPECT_EQ(already_called, false);
+        already_called = true;
+        EXPECT_EQ(bytes, g_version_packet.bytes());
+        return {};
+    };
+
+    SSH::SFTP::Server server { move(send_packet) };
+
+    // We should handle one initialization packet and answer it.
+    TRY_OR_FAIL(server_process_data(server, g_initialization_packet.bytes()));
+
+    // We should fail when receiving a second initialization packet.
+    EXPECT(server_process_data(server, g_initialization_packet.bytes()).is_error());
+}

--- a/Tests/LibSSH/SFTP/TestSFTPStat.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPStat.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/TempFile.h>
+#include <LibSSH/DataTypes.h>
+#include <LibTest/TestCase.h>
+#include <Tests/LibSSH/SFTP/Shared.h>
+
+namespace {
+
+struct Attributes {
+    Optional<u64> size;
+    Optional<u32> uid;
+    Optional<u32> gid;
+    Optional<u32> mode;
+    Optional<u32> atim;
+    Optional<u32> mtim;
+
+    static Attributes from_stat(struct ::stat const& s)
+    {
+        return {
+            .size = s.st_size,
+            .uid = s.st_uid,
+            .gid = s.st_gid,
+            .mode = s.st_mode,
+            .atim = s.st_atime,
+            .mtim = s.st_mtime,
+        };
+    }
+
+    bool operator==(Attributes const&) const = default;
+};
+
+ErrorOr<Attributes> decode_attribute_message(FixedMemoryStream& stream)
+{
+    u32 flags = TRY(stream.read_value<NetworkOrdered<u32>>());
+    // All flags, but EXTENDED set.
+    EXPECT_EQ(flags, 0b1111u);
+    Attributes attributes;
+    attributes.size = TRY(stream.read_value<NetworkOrdered<u64>>());
+    attributes.uid = TRY(stream.read_value<NetworkOrdered<u32>>());
+    attributes.gid = TRY(stream.read_value<NetworkOrdered<u32>>());
+    attributes.mode = TRY(stream.read_value<NetworkOrdered<u32>>());
+    attributes.atim = TRY(stream.read_value<NetworkOrdered<u32>>());
+    attributes.mtim = TRY(stream.read_value<NetworkOrdered<u32>>());
+
+    return attributes;
+}
+
+ErrorOr<ByteBuffer> make_stat_packet(StringView path, bool use_lstat = false)
+{
+    AllocatingMemoryStream inner;
+    TRY(inner.write_value(use_lstat ? SSH::SFTP::FXPMessageID::LSTAT : SSH::SFTP::FXPMessageID::STAT));
+    TRY(inner.write_value<NetworkOrdered<u32>>(42));
+    TRY(SSH::encode_string(inner, path));
+    auto payload = TRY(inner.read_until_eof());
+
+    AllocatingMemoryStream packet;
+    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
+    TRY(packet.write_until_depleted(payload));
+    return TRY(packet.read_until_eof());
+}
+
+ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, Attributes const& expected)
+{
+    auto callback = [=](Message message) -> ErrorOr<void> {
+        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::ATTRS);
+        FixedMemoryStream stream { message.payload };
+        EXPECT_EQ(TRY(stream.read_value<NetworkOrdered<u32>>()), 42u);
+        auto attributes = TRY(decode_attribute_message(stream));
+        EXPECT_EQ(attributes, expected);
+        return {};
+    };
+    auto server = make_initialized_server(move(callback));
+
+    auto request = TRY(make_stat_packet(path, use_lstat));
+    return server_process_data(server, request);
+}
+
+ErrorOr<void> run_for_path(StringView path)
+{
+    TRY(run_for_path_impl(path, false, Attributes::from_stat(TRY(Core::System::stat(path)))));
+    TRY(run_for_path_impl(path, true, Attributes::from_stat(TRY(Core::System::lstat(path)))));
+    return {};
+}
+
+ErrorOr<void> run_for_path_with_expected_stat_failure(StringView path)
+{
+    EXPECT(Core::System::stat(path).is_error());
+    TRY(run_for_path_impl(path, true, Attributes::from_stat(TRY(Core::System::lstat(path)))));
+    return {};
+}
+
+}
+
+TEST_CASE(basic)
+{
+    auto file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    TRY_OR_FAIL(run_for_path(file->path()));
+
+    {
+        auto stream = TRY_OR_FAIL(Core::File::open(file->path(), Core::File::OpenMode::Write));
+        TRY_OR_FAIL(stream->write_until_depleted("Some content to make the file have a size"sv));
+    }
+    TRY_OR_FAIL(run_for_path(file->path()));
+
+    auto directory = TRY_OR_FAIL(FileSystem::TempFile::create_temp_directory());
+    TRY_OR_FAIL(run_for_path(directory->path()));
+
+    TRY_OR_FAIL(run_for_path("/dev/null"sv));
+
+    // Different set of attributes.
+    TRY_OR_FAIL(run_for_path("/etc/passwd"sv));
+}
+
+TEST_CASE(symlink)
+{
+    auto file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    unlink("/tmp/a");
+    TRY_OR_FAIL(Core::System::symlink(file->path(), "/tmp/a"sv));
+    TRY_OR_FAIL(run_for_path(file->path()));
+    TRY_OR_FAIL(run_for_path("/tmp/a"sv));
+
+    unlink("/tmp/b");
+    TRY_OR_FAIL(Core::System::symlink("/tmp/b"sv, "/tmp/b"sv));
+    TRY_OR_FAIL(run_for_path_with_expected_stat_failure("/tmp/b"sv));
+
+    unlink("/tmp/c");
+    TRY_OR_FAIL(Core::System::symlink("/i/dont/exist"sv, "/tmp/c"sv));
+    TRY_OR_FAIL(run_for_path_with_expected_stat_failure("/tmp/c"sv));
+}

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -674,6 +674,17 @@ ErrorOr<ssize_t> read(int fd, Bytes buffer)
     return rc;
 }
 
+ErrorOr<ssize_t> pread(int fd, Bytes buffer, off_t offset)
+{
+    ssize_t rc;
+    do {
+        rc = ::pread(fd, buffer.data(), buffer.size(), offset);
+    } while (rc < 0 && errno == EINTR);
+    if (rc < 0)
+        return Error::from_syscall("pread"sv, -errno);
+    return rc;
+}
+
 ErrorOr<ssize_t> write(int fd, ReadonlyBytes buffer)
 {
     ssize_t rc;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -134,6 +134,7 @@ ErrorOr<void> fsync(int fd);
 ErrorOr<struct stat> stat(StringView path);
 ErrorOr<struct stat> lstat(StringView path);
 ErrorOr<ssize_t> read(int fd, Bytes buffer);
+ErrorOr<ssize_t> pread(int fd, Bytes buffer, off_t offset);
 ErrorOr<ssize_t> write(int fd, ReadonlyBytes buffer);
 ErrorOr<void> kill(pid_t, int signal);
 ErrorOr<void> killpg(int pgrp, int signal);

--- a/Userland/Libraries/LibSSH/CMakeLists.txt
+++ b/Userland/Libraries/LibSSH/CMakeLists.txt
@@ -5,6 +5,8 @@ set(SOURCES
     KeyExchangeData.cpp
     Peer.cpp
     Session.cpp
+    SFTP/Peer.cpp
+    SFTP/Server.cpp
 )
 
 serenity_lib(LibSSH ssh)

--- a/Userland/Libraries/LibSSH/Forward.h
+++ b/Userland/Libraries/LibSSH/Forward.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace SSH {
+
+struct Session;
+
+}

--- a/Userland/Libraries/LibSSH/SFTP/Peer.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Peer.h"
+#include <AK/Debug.h>
+#include <AK/Endian.h>
+
+namespace SSH::SFTP {
+
+// 3. General Packet Format
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-3
+ErrorOr<FXPMessageID> Peer::read_header(FixedMemoryStream& stream)
+{
+    u32 length = TRY(stream.read_value<NetworkOrdered<u32>>());
+    if (length != stream.remaining())
+        return Error::from_string_literal("Invalid packet size");
+
+    auto type = TRY(stream.read_value<FXPMessageID>());
+    return type;
+}
+
+// 3. General Packet Format
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-3
+ErrorOr<void> Peer::write_packet(ReadonlyBytes bytes)
+{
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value<NetworkOrdered<u32>>(bytes.size()));
+    TRY(stream.write_until_depleted(bytes));
+    auto packet = TRY(stream.read_until_eof());
+    TRY(m_send_packet(packet));
+    return {};
+}
+
+} // SSH::SFTP

--- a/Userland/Libraries/LibSSH/SFTP/Peer.h
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/MemoryStream.h>
+
+namespace SSH::SFTP {
+
+// 3. General Packet Format
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-3
+enum class FXPMessageID : u8 {
+    INIT = 1,
+    VERSION = 2,
+    OPEN = 3,
+    CLOSE = 4,
+    READ = 5,
+    WRITE = 6,
+    LSTAT = 7,
+    FSTAT = 8,
+    SETSTAT = 9,
+    FSETSTAT = 10,
+    OPENDIR = 11,
+    READDIR = 12,
+    REMOVE = 13,
+    MKDIR = 14,
+    RMDIR = 15,
+    REALPATH = 16,
+    STAT = 17,
+    RENAME = 18,
+    READLINK = 19,
+    SYMLINK = 20,
+    STATUS = 101,
+    HANDLE = 102,
+    DATA = 103,
+    NAME = 104,
+    ATTRS = 105,
+    EXTENDED = 200,
+    EXTENDED_REPLY = 201,
+};
+
+// This class implement the SFTP protocol v3. Newer version exist, but they
+// never really took off, this is the same version that openssh implements.
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
+class Peer {
+public:
+    Peer(Function<ErrorOr<void>(ReadonlyBytes)> send_packet)
+        : m_send_packet(move(send_packet))
+    {
+    }
+
+protected:
+    ErrorOr<FXPMessageID> read_header(FixedMemoryStream& stream);
+    ErrorOr<void> write_packet(ReadonlyBytes bytes);
+
+private:
+    Function<ErrorOr<void>(ReadonlyBytes)> m_send_packet;
+};
+
+} // SFTP::SSH

--- a/Userland/Libraries/LibSSH/SFTP/Peer.h
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.h
@@ -43,6 +43,20 @@ enum class FXPMessageID : u8 {
     EXTENDED_REPLY = 201,
 };
 
+// 7. Responses from the Server to the Client
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
+enum class FXStatus : u8 {
+    OK = 0,
+    FX_EOF = 1, // Renamed EOF => FX_EOF to avoid collision with the EOF macro.
+    NO_SUCH_FILE = 2,
+    PERMISSION_DENIED = 3,
+    FAILURE = 4,
+    BAD_MESSAGE = 5,
+    NO_CONNECTION = 6,
+    CONNECTION_LOST = 7,
+    OP_UNSUPPORTED = 8,
+};
+
 // This class implement the SFTP protocol v3. Newer version exist, but they
 // never really took off, this is the same version that openssh implements.
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -7,6 +7,8 @@
 #include "Server.h"
 #include <AK/Debug.h>
 #include <AK/Endian.h>
+#include <LibCore/System.h>
+#include <LibSSH/DataTypes.h>
 #include <LibSSH/Session.h>
 
 namespace SSH::SFTP {
@@ -71,10 +73,86 @@ ErrorOr<void> Server::handle_packet(FixedMemoryStream& stream)
     auto type = TRY(read_header(stream));
 
     switch (type) {
+    case FXPMessageID::STAT:
+        return handle_stat(stream, StatType::Normal);
+    case FXPMessageID::LSTAT:
+        return handle_stat(stream, StatType::LStat);
     default:
         dbgln_if(SSH_DEBUG, "Received packet with type: {}", to_underlying(type));
         return Error::from_string_literal("Unknown packet type");
     }
+}
+
+// 6.8 Retrieving File Attributes
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.8
+ErrorOr<void> Server::handle_stat(FixedMemoryStream& stream, StatType type)
+{
+    u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto path = TRY(decode_string(stream));
+
+    // "The server responds to this request with either SSH_FXP_ATTRS or SSH_FXP_STATUS."
+    auto maybe_stat = [&]() {
+        switch (type) {
+        case StatType::LStat:
+            return Core::System::lstat(path);
+        case StatType::Normal:
+            return Core::System::stat(path);
+        }
+        VERIFY_NOT_REACHED();
+    }();
+
+    if (maybe_stat.is_error()) {
+        // FIXME: Send SSH_FXP_STATUS.
+        return maybe_stat.release_error();
+    }
+
+    auto stat = maybe_stat.release_value();
+    TRY(send_file_attribute_message(id, stat));
+    return {};
+}
+
+// 5. File Attributes
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-5
+
+#define SSH_FILEXFER_ATTR_SIZE 0x00000001
+#define SSH_FILEXFER_ATTR_UIDGID 0x00000002
+#define SSH_FILEXFER_ATTR_PERMISSIONS 0x00000004
+#define SSH_FILEXFER_ATTR_ACMODTIME 0x00000008
+#define SSH_FILEXFER_ATTR_EXTENDED 0x80000000
+
+static ErrorOr<void> encode_file_attributes(AllocatingMemoryStream& stream, struct ::stat const& s)
+{
+    TRY(stream.write_value<NetworkOrdered<u32>>(
+        SSH_FILEXFER_ATTR_SIZE
+        | SSH_FILEXFER_ATTR_UIDGID
+        | SSH_FILEXFER_ATTR_PERMISSIONS
+        | SSH_FILEXFER_ATTR_ACMODTIME));
+
+    TRY(stream.write_value<NetworkOrdered<u64>>(s.st_size));
+
+    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_uid));
+    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_gid));
+
+    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_mode));
+
+    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_atime));
+    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_mtime));
+
+    return {};
+}
+
+// 7. Responses from the Server to the Client
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
+ErrorOr<void> Server::send_file_attribute_message(u32 id, struct stat const& s)
+{
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(FXPMessageID::ATTRS));
+    TRY(stream.write_value<NetworkOrdered<u32>>(id));
+    TRY(encode_file_attributes(stream, s));
+
+    auto packet = TRY(stream.read_until_eof());
+    TRY(write_packet(packet));
+    return {};
 }
 
 } // SSH::SFTP

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Server.h"
+#include <AK/Debug.h>
 #include <AK/Endian.h>
 #include <LibSSH/Session.h>
 
@@ -21,7 +22,7 @@ Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
     case State::Constructed:
         co_return handle_init_message(stream);
     case State::Initialized:
-        co_return Error::from_string_literal("Draw the rest of the owl");
+        co_return handle_packet(stream);
     }
     VERIFY_NOT_REACHED();
 }
@@ -63,6 +64,17 @@ ErrorOr<void> Server::send_version_message()
 
     TRY(write_packet(packet));
     return {};
+}
+
+ErrorOr<void> Server::handle_packet(FixedMemoryStream& stream)
+{
+    auto type = TRY(read_header(stream));
+
+    switch (type) {
+    default:
+        dbgln_if(SSH_DEBUG, "Received packet with type: {}", to_underlying(type));
+        return Error::from_string_literal("Unknown packet type");
+    }
 }
 
 } // SSH::SFTP

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -75,6 +75,8 @@ ErrorOr<void> Server::handle_packet(FixedMemoryStream& stream)
     switch (type) {
     case FXPMessageID::OPEN:
         return handle_open(stream);
+    case FXPMessageID::READ:
+        return handle_read(stream);
     case FXPMessageID::STAT:
         return handle_stat(stream, StatType::Normal);
     case FXPMessageID::LSTAT:
@@ -222,6 +224,100 @@ ErrorOr<void> Server::send_file_handle(u32 id, File const& file)
     TRY(stream.write_value(FXPMessageID::HANDLE));
     TRY(stream.write_value<NetworkOrdered<u32>>(id));
     TRY(encode_string(stream, file.handle.bytes()));
+
+    auto packet = TRY(stream.read_until_eof());
+    TRY(write_packet(packet));
+    return {};
+}
+
+ErrorOr<Server::File*> Server::find_file(ReadonlyBytes handle)
+{
+    auto maybe_file = m_open_files.first_matching([&](auto const& file) {
+        return file.handle.bytes() == handle;
+    });
+
+    if (maybe_file.has_value())
+        return &maybe_file.value();
+
+    return Error::from_string_literal("Unable to find file for given handle");
+}
+
+// 6.4 Reading and Writing
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.4
+ErrorOr<void> Server::handle_read(FixedMemoryStream& stream)
+{
+    u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto handle = TRY(decode_string(stream));
+    u64 offset = TRY(stream.read_value<NetworkOrdered<u64>>());
+    u32 len = TRY(stream.read_value<NetworkOrdered<u32>>());
+
+    auto& file = *TRY(find_file(handle));
+
+    // "If an error occurs or EOF is encountered before reading any
+    //   data, the server will respond with SSH_FXP_STATUS."
+    // FIXME: Send FXP_STATUS
+    ByteBuffer buffer;
+    bool should_send_eof { false };
+    auto operation_result = [&]() -> ErrorOr<void> {
+        // FIXME: Ensure len is somewhat reasonable.
+        TRY(buffer.try_resize(len));
+
+        Optional<u64> last_read;
+        u64 read {};
+        while (!last_read.has_value() || last_read.value() != 0) {
+            if (read == buffer.size())
+                break;
+            last_read = TRY(Core::System::pread(file.file->fd(), buffer.bytes().slice(read), offset + read));
+            read += *last_read;
+        }
+
+        if (last_read == 0u) {
+            buffer.trim(read, false);
+            if (buffer.size() == 0)
+                should_send_eof = true;
+        }
+
+        return {};
+    }();
+
+    if (operation_result.is_error()) {
+        // FIXME: Send SSH_FXP_STATUS
+        return operation_result.release_error();
+    }
+
+    if (should_send_eof)
+        TRY(send_eof(id));
+    else
+        TRY(send_data(id, buffer));
+
+    return {};
+}
+
+ErrorOr<void> Server::send_data(u32 id, ReadonlyBytes data)
+{
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(FXPMessageID::DATA));
+    TRY(stream.write_value<NetworkOrdered<u32>>(id));
+    TRY(encode_string(stream, data));
+
+    auto packet = TRY(stream.read_until_eof());
+    TRY(write_packet(packet));
+    return {};
+}
+
+// 7. Responses from the Server to the Client
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
+
+ErrorOr<void> Server::send_eof(u32 id)
+{
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(FXPMessageID::STATUS));
+    TRY(stream.write_value<NetworkOrdered<u32>>(id));
+    TRY(stream.write_value<NetworkOrdered<u32>>(to_underlying(FXStatus::FX_EOF)));
+
+    // error message and language tag
+    TRY(encode_string(stream, ""sv));
+    TRY(encode_string(stream, ""sv));
 
     auto packet = TRY(stream.read_until_eof());
     TRY(write_packet(packet));

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Server.h"
+#include <AK/Endian.h>
+#include <LibSSH/Session.h>
+
+namespace SSH::SFTP {
+
+Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
+{
+    // FIXME: For the moment everything is done sequentially, but we should
+    //        probably make most IO related syscall asynchronous.
+
+    FixedMemoryStream stream { session.channel_data.data() };
+    ScopeGuard commit_read_bytes { [&] { session.channel_data.dequeue(stream.offset()); } };
+    switch (m_state) {
+    case State::Constructed:
+        co_return handle_init_message(stream);
+    case State::Initialized:
+        co_return Error::from_string_literal("Draw the rest of the owl");
+    }
+    VERIFY_NOT_REACHED();
+}
+
+void Server::handle_channel_eof(Session const&)
+{
+    // There is nothing to do here.
+}
+
+// 4. Protocol Initialization
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-4
+ErrorOr<void> Server::handle_init_message(FixedMemoryStream& stream)
+{
+    TRY(read_header(stream));
+    u32 version = TRY(stream.read_value<NetworkOrdered<u32>>());
+
+    if (version != 3)
+        return Error::from_string_literal("Invalid SFTP version");
+
+    // FIXME: Read extension data.
+
+    TRY(send_version_message());
+
+    m_state = State::Initialized;
+
+    return {};
+}
+
+// 4. Protocol Initialization
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-4
+ErrorOr<void> Server::send_version_message()
+{
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(FXPMessageID::VERSION));
+    // Protocol version
+    TRY(stream.write_value<NetworkOrdered<u32>>(3));
+
+    auto packet = TRY(stream.read_until_eof());
+
+    TRY(write_packet(packet));
+    return {};
+}
+
+} // SSH::SFTP

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -73,6 +73,8 @@ ErrorOr<void> Server::handle_packet(FixedMemoryStream& stream)
     auto type = TRY(read_header(stream));
 
     switch (type) {
+    case FXPMessageID::OPEN:
+        return handle_open(stream);
     case FXPMessageID::STAT:
         return handle_stat(stream, StatType::Normal);
     case FXPMessageID::LSTAT:
@@ -113,6 +115,7 @@ ErrorOr<void> Server::handle_stat(FixedMemoryStream& stream, StatType type)
 
 // 5. File Attributes
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-5
+namespace {
 
 #define SSH_FILEXFER_ATTR_SIZE 0x00000001
 #define SSH_FILEXFER_ATTR_UIDGID 0x00000002
@@ -120,7 +123,7 @@ ErrorOr<void> Server::handle_stat(FixedMemoryStream& stream, StatType type)
 #define SSH_FILEXFER_ATTR_ACMODTIME 0x00000008
 #define SSH_FILEXFER_ATTR_EXTENDED 0x80000000
 
-static ErrorOr<void> encode_file_attributes(AllocatingMemoryStream& stream, struct ::stat const& s)
+ErrorOr<void> encode_file_attributes(AllocatingMemoryStream& stream, struct ::stat const& s)
 {
     TRY(stream.write_value<NetworkOrdered<u32>>(
         SSH_FILEXFER_ATTR_SIZE
@@ -141,6 +144,20 @@ static ErrorOr<void> encode_file_attributes(AllocatingMemoryStream& stream, stru
     return {};
 }
 
+struct Attributes { };
+
+ErrorOr<Attributes> read_attributes(FixedMemoryStream& stream)
+{
+    u32 flags = TRY(stream.read_value<NetworkOrdered<u32>>());
+
+    if (flags != 0)
+        return Error::from_string_literal("Unsupported file attributes");
+
+    return Attributes {};
+}
+
+}
+
 // 7. Responses from the Server to the Client
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
 ErrorOr<void> Server::send_file_attribute_message(u32 id, struct stat const& s)
@@ -149,6 +166,62 @@ ErrorOr<void> Server::send_file_attribute_message(u32 id, struct stat const& s)
     TRY(stream.write_value(FXPMessageID::ATTRS));
     TRY(stream.write_value<NetworkOrdered<u32>>(id));
     TRY(encode_file_attributes(stream, s));
+
+    auto packet = TRY(stream.read_until_eof());
+    TRY(write_packet(packet));
+    return {};
+}
+
+// 6.3 Opening, Creating, and Closing Files
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.3
+
+#define SSH_FXF_READ 0x00000001
+#define SSH_FXF_WRITE 0x00000002
+#define SSH_FXF_APPEND 0x00000004
+#define SSH_FXF_CREAT 0x00000008
+#define SSH_FXF_TRUNC 0x00000010
+#define SSH_FXF_EXCL 0x00000020
+
+ErrorOr<void> Server::handle_open(FixedMemoryStream& stream)
+{
+    u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto filename = TRY(decode_string(stream));
+    u32 pflags = TRY(stream.read_value<NetworkOrdered<u32>>());
+    [[maybe_unused]] auto attrs = TRY(read_attributes(stream));
+
+    // FIXME: Support relative path.
+    if (filename.is_empty() || filename[0] != '/')
+        return Error::from_string_literal("Relative paths are unsupported");
+
+    // FIXME: Support other pflags.
+    if (pflags != SSH_FXF_READ)
+        return Error::from_string_literal("Unsupported pflags");
+
+    auto maybe_file = Core::File::open(StringView { filename.bytes() }, Core::File::OpenMode::Read);
+
+    // "The response to this message will be either SSH_FXP_HANDLE (if the
+    //   operation is successful) or SSH_FXP_STATUS (if the operation fails)."
+    if (maybe_file.is_error()) {
+        // FIXME: Send SSH_FXP_STATUS.
+        return maybe_file.release_error();
+    }
+
+    m_open_files.empend(maybe_file.release_value(),
+        Crypto::Hash::MD5::hash(filename));
+
+    TRY(send_file_handle(id, m_open_files.last()));
+
+    return {};
+}
+
+// 7. Responses from the Server to the Client
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
+ErrorOr<void> Server::send_file_handle(u32 id, File const& file)
+{
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(FXPMessageID::HANDLE));
+    TRY(stream.write_value<NetworkOrdered<u32>>(id));
+    TRY(encode_string(stream, file.handle.bytes()));
 
     auto packet = TRY(stream.read_until_eof());
     TRY(write_packet(packet));

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibSSH/Forward.h>
+#include <LibSSH/SFTP/Peer.h>
+
+namespace SSH::SFTP {
+
+class Server : public Peer {
+public:
+    Server(Function<ErrorOr<void>(ReadonlyBytes)> send_packet)
+        : Peer(move(send_packet))
+    {
+    }
+
+    Coroutine<ErrorOr<void>> handle_channel_data(Session&);
+    void handle_channel_eof(Session const&);
+
+private:
+    enum class State : u8 {
+        Constructed,
+        Initialized,
+    };
+
+    ErrorOr<void> handle_init_message(FixedMemoryStream& stream);
+    ErrorOr<void> send_version_message();
+
+    State m_state { State::Constructed };
+};
+
+} // SSH::SFTP

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -30,6 +30,8 @@ private:
     ErrorOr<void> handle_init_message(FixedMemoryStream& stream);
     ErrorOr<void> send_version_message();
 
+    ErrorOr<void> handle_packet(FixedMemoryStream& stream);
+
     State m_state { State::Constructed };
 };
 

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -8,6 +8,7 @@
 
 #include <LibSSH/Forward.h>
 #include <LibSSH/SFTP/Peer.h>
+#include <sys/stat.h>
 
 namespace SSH::SFTP {
 
@@ -31,6 +32,13 @@ private:
     ErrorOr<void> send_version_message();
 
     ErrorOr<void> handle_packet(FixedMemoryStream& stream);
+
+    enum class StatType : u8 {
+        Normal,
+        LStat,
+    };
+    ErrorOr<void> handle_stat(FixedMemoryStream& stream, StatType);
+    ErrorOr<void> send_file_attribute_message(u32 id, struct ::stat const&);
 
     State m_state { State::Constructed };
 };

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/Vector.h>
+#include <LibCore/File.h>
+#include <LibCrypto/Hash/MD5.h>
 #include <LibSSH/Forward.h>
 #include <LibSSH/SFTP/Peer.h>
 #include <sys/stat.h>
@@ -28,6 +31,11 @@ private:
         Initialized,
     };
 
+    struct File {
+        NonnullOwnPtr<Core::File> file;
+        Crypto::Hash::Digest<128> handle;
+    };
+
     ErrorOr<void> handle_init_message(FixedMemoryStream& stream);
     ErrorOr<void> send_version_message();
 
@@ -40,7 +48,12 @@ private:
     ErrorOr<void> handle_stat(FixedMemoryStream& stream, StatType);
     ErrorOr<void> send_file_attribute_message(u32 id, struct ::stat const&);
 
+    ErrorOr<void> handle_open(FixedMemoryStream& stream);
+    ErrorOr<void> send_file_handle(u32, File const&);
+
     State m_state { State::Constructed };
+
+    Vector<File> m_open_files {};
 };
 
 } // SSH::SFTP

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -51,6 +51,12 @@ private:
     ErrorOr<void> handle_open(FixedMemoryStream& stream);
     ErrorOr<void> send_file_handle(u32, File const&);
 
+    ErrorOr<void> handle_read(FixedMemoryStream& stream);
+    ErrorOr<void> send_data(u32, ReadonlyBytes);
+    ErrorOr<void> send_eof(u32);
+
+    ErrorOr<File*> find_file(ReadonlyBytes handle);
+
     State m_state { State::Constructed };
 
     Vector<File> m_open_files {};

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -14,6 +14,7 @@
 #include <AK/Variant.h>
 #include <LibCore/File.h>
 #include <LibCore/Process.h>
+#include <LibSSH/SFTP/Server.h>
 
 namespace SSH {
 
@@ -47,7 +48,7 @@ struct Session : public RefCounted<Session> {
     StreamBuffer channel_data {};
     bool has_streaming_coroutine { false };
 
-    Variant<Empty, ExecData> system {};
+    Variant<Empty, ExecData, SFTP::Server> system {};
 
     bool is_closed { false };
     bool has_received_eof { false };

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -617,10 +617,9 @@ Coroutine<void> SSHClient::async_stream_data_to_subsystem(NonnullRefPtr<Session>
         co_return {};
     }();
 
-    if (maybe_error.is_error()) {
-        dbgln("Unable to process incoming channel data: {}", maybe_error.error());
-        // FIXME: Think about what we should do with this error.
-    }
+    if (maybe_error.is_error())
+        disconnect(maybe_error.release_error());
+
     co_return;
 }
 
@@ -848,6 +847,12 @@ ErrorOr<void> SSHClient::send_exit_status(Session const& session, int status)
 
     TRY(write_packet(TRY(stream.read_until_eof())));
     return {};
+}
+
+void SSHClient::disconnect(Error error)
+{
+    dbgln("Disconnecting: {}", error);
+    m_disconnect();
 }
 
 } // SSHServer

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -569,6 +569,11 @@ ErrorOr<void> SSHClient::handle_channel_request(GenericMessage& message)
         return {};
     }
 
+    if (request_type == "subsystem"sv.bytes()) {
+        TRY(handle_channel_subsystem(session, message));
+        return {};
+    }
+
     return Error::from_string_literal("Unsupported channel request");
 }
 
@@ -721,6 +726,26 @@ Coroutine<void> SSHClient::async_wait_for_child(NonnullRefPtr<Session> session)
         // FIXME: Think about what we should do with this error.
     }
     co_return;
+}
+
+// 6.5.  Starting a Shell or a Command
+// https://datatracker.ietf.org/doc/html/rfc4254#section-6.5
+ErrorOr<void> SSHClient::handle_channel_subsystem(Session& session, GenericMessage& message)
+{
+    auto subsystem = TRY(decode_string(message.payload));
+    dbgln_if(SSH_DEBUG, "Subsystem requested: {:s}", subsystem.bytes());
+
+    if (subsystem == "sftp"sv.bytes()) {
+        // 2. Use with the SSH Connection Protocol
+        // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-2
+
+        session.system = SFTP::Server { [this, &session](ReadonlyBytes bytes) -> ErrorOr<void> {
+            return send_channel_data(session, bytes);
+        } };
+        return TRY(send_channel_success_message(session));
+    }
+
+    return Error::from_string_literal("Unsupported subsystem");
 }
 
 ErrorOr<void> SSHClient::send_channel_success_message(Session const& session)

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -90,6 +90,7 @@ private:
     ErrorOr<void> send_channel_open_confirmation(Session const&);
     ErrorOr<void> handle_channel_request(GenericMessage&);
     ErrorOr<void> handle_channel_data(GenericMessage&);
+    ErrorOr<void> handle_channel_subsystem(Session&, GenericMessage&);
     ErrorOr<void> handle_channel_exec(NonnullRefPtr<Session> const&, GenericMessage&);
     ErrorOr<void> send_channel_success_message(Session const&);
     ErrorOr<void> send_channel_data(Session const&, ReadonlyBytes);

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -41,9 +41,10 @@ public:
 
 class SSHClient : public Peer {
 public:
-    explicit SSHClient(Core::TCPSocket& tcp_socket)
+    explicit SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect)
         : Peer(tcp_socket)
-        , m_tcp_socket { tcp_socket }
+        , m_tcp_socket(tcp_socket)
+        , m_disconnect(move(disconnect))
     {
     }
 
@@ -106,8 +107,12 @@ private:
     Coroutine<void> async_stream_data_to_subsystem(NonnullRefPtr<Session>);
     Coroutine<void> async_wait_for_child(NonnullRefPtr<Session>);
 
+    void disconnect(Error);
+
     State m_state { State::Constructed };
     Core::TCPSocket& m_tcp_socket;
+
+    Function<void()> m_disconnect;
 
     KeyExchangeData m_key_exchange_data {};
     ByteBuffer m_cookie {};

--- a/Userland/Services/SSHServer/TCPClient.cpp
+++ b/Userland/Services/SSHServer/TCPClient.cpp
@@ -14,7 +14,9 @@ namespace SSH::Server {
 TCPClient::TCPClient(NonnullOwnPtr<Core::TCPSocket>&& socket, Function<void()>&& on_quit)
     : m_on_quit(move(on_quit))
     , m_socket(move(socket))
-    , m_ssh_client(*m_socket)
+    , m_ssh_client(*m_socket, [this]() {
+        Core::EventLoop::current().deferred_invoke([this]() { die(); });
+    })
 {
 }
 


### PR DESCRIPTION
<img width="1027" height="833" alt="Screenshot From 2026-04-08 14-06-17" src="https://github.com/user-attachments/assets/8c93cf02-f2ed-4373-8726-25ce33ea40f5" />

---

There is quite a lot of boilerplate in the test code to generate the packets, but most of it could eventually land in a `Client` class in the future :^)