### PR TITLE
LibVT+Userland+Kernel: Use the ConEmu OSC sequence for progress bars

### DIFF
--- a/Kernel/Devices/TTY/VirtualConsole.cpp
+++ b/Kernel/Devices/TTY/VirtualConsole.cpp
@@ -456,7 +456,7 @@ void VirtualConsole::set_window_title(StringView)
     // Do nothing.
 }
 
-void VirtualConsole::set_window_progress(int, int)
+void VirtualConsole::set_window_progress(VT::ProgressState, u8)
 {
     // Do nothing.
 }

--- a/Kernel/Devices/TTY/VirtualConsole.h
+++ b/Kernel/Devices/TTY/VirtualConsole.h
@@ -100,7 +100,7 @@ private:
     // ^TerminalClient
     virtual void beep() override;
     virtual void set_window_title(StringView) override;
-    virtual void set_window_progress(int, int) override;
+    virtual void set_window_progress(VT::ProgressState, u8) override;
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
     virtual void terminal_history_changed(int) override;
     virtual void terminal_did_perform_possibly_partial_clear() override;

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -257,8 +257,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto print_progress = [&] {
         if (!dont_print_progress) {
-            warn("\033]9;{};{};\033\\", index, paths.size());
             double percentage_done = (100. * index) / paths.size();
+            warn("\033]9;4;1;{}\033\\", static_cast<int>(percentage_done));
             warn("{:04.2f}% {:3.1f}s ", percentage_done, (Test::get_time_in_ms() - start_time) / 1000.);
             for (size_t i = 0; i < result_counts.size(); ++i) {
                 auto result_type = static_cast<TestResult>(i);
@@ -286,7 +286,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     print_progress();
     if (!dont_print_progress)
-        warn("\n\033]9;-1;\033\\");
+        warn("\n\033]9;4;0\033\\");
 
     outln("Took {} seconds", time_taken_in_ms / 1000.);
     outln("{}: {}", total_test_emoji, paths.size());

--- a/Userland/Libraries/LibTest/TestRunner.h
+++ b/Userland/Libraries/LibTest/TestRunner.h
@@ -83,7 +83,7 @@ inline void cleanup()
 {
     // Clear the taskbar progress.
     if (TestRunner::the() && TestRunner::the()->is_printing_progress())
-        warn("\033]9;-1;\033\\");
+        warn("\033]9;4;0\033\\");
 }
 
 [[noreturn]] inline void cleanup_and_exit()
@@ -102,11 +102,11 @@ inline void TestRunner::run(ByteString test_glob)
         ++progress_counter;
         do_run_single_test(path, progress_counter, test_paths.size());
         if (m_print_progress)
-            warn("\033]9;{};{};\033\\", progress_counter, test_paths.size());
+            warn("\033]9;4;1;{}\033\\", static_cast<int>((100. * progress_counter) / test_paths.size()));
     }
 
     if (m_print_progress)
-        warn("\033]9;-1;\033\\");
+        warn("\033]9;4;0\033\\");
 
     if (!m_print_json)
         print_test_results();

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -1360,14 +1360,50 @@ void Terminal::execute_osc_sequence(OscParameters parameters, u8 last_byte)
         }
 #endif
         break;
-    case 9:
-        if (parameters.size() < 2)
-            dbgln("Atttempted to set window progress but gave too few parameters");
-        else if (parameters.size() == 2)
-            m_client.set_window_progress(stringview_ify(1).to_number<int>().value_or(-1), 0);
-        else
-            m_client.set_window_progress(stringview_ify(1).to_number<int>().value_or(-1), stringview_ify(2).to_number<int>().value_or(0));
+    case 9: {
+        if (parameters.size() < 2) {
+            unimplemented_osc_sequence(parameters, last_byte);
+            return;
+        }
+
+        if (stringview_ify(1) != "4"sv) {
+            unimplemented_osc_sequence(parameters, last_byte);
+            return;
+        }
+
+        if (parameters.size() != 3 && parameters.size() != 4) {
+            dbgln("Atttempted to set window progress but gave incorrect number of parameters");
+            return;
+        }
+
+        auto maybe_new_state = stringview_ify(2).to_number<int>();
+        if (!maybe_new_state.has_value()
+            || maybe_new_state.value() < 0
+            || maybe_new_state.value() > to_underlying(ProgressState::Paused)) {
+            dbgln("Atttempted to set window progress but gave invalid state");
+            return;
+        }
+
+        auto new_state = static_cast<ProgressState>(maybe_new_state.value());
+
+        if (parameters.size() == 4) {
+            auto maybe_new_value = stringview_ify(3).to_number<int>();
+            if (!maybe_new_value.has_value()
+                || maybe_new_value.value() < 0
+                || maybe_new_value.value() > 100) {
+                dbgln("Atttempted to set window progress but gave invalid value");
+                return;
+            }
+
+            m_current_progress = maybe_new_value.value();
+        }
+
+        if (new_state == ProgressState::Inactive)
+            m_current_progress = 0;
+
+        m_client.set_window_progress(new_state, m_current_progress);
         break;
+    }
     default:
         unimplemented_osc_sequence(parameters, last_byte);
     }

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -41,13 +41,21 @@ enum CursorKeysMode {
     Cursor,
 };
 
+enum class ProgressState {
+    Inactive = 0,
+    InProgress = 1,
+    Error = 2,
+    Indeterminate = 3,
+    Paused = 4,
+};
+
 class TerminalClient {
 public:
     virtual ~TerminalClient() = default;
 
     virtual void beep() = 0;
     virtual void set_window_title(StringView) = 0;
-    virtual void set_window_progress(int value, int max) = 0;
+    virtual void set_window_progress(ProgressState, u8 percentage) = 0;
     virtual void terminal_did_resize(u16 columns, u16 rows) = 0;
     virtual void terminal_history_changed(int delta) = 0;
     virtual void terminal_did_perform_possibly_partial_clear() = 0;
@@ -450,6 +458,8 @@ protected:
 #ifndef KERNEL
     u32 m_next_href_id { 0 };
 #endif
+
+    u8 m_current_progress { 0 };
 
     Vector<bool> m_horizontal_tabs;
     u32 m_last_code_point { 0 };

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -477,17 +477,15 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
     }
 }
 
-void TerminalWidget::set_window_progress(int value, int max)
+void TerminalWidget::set_window_progress(VT::ProgressState state, u8 value)
 {
-    if (max == 0) {
+    // FIXME: What should we do for ProgressState::{Error,Indeterminate,Paused}?
+    if (state != VT::ProgressState::InProgress) {
         window()->set_progress(OptionalNone {});
         return;
     }
 
-    float float_value = value;
-    float float_max = max;
-    float progress = (float_value / float_max) * 100.0f;
-    window()->set_progress((int)roundf(progress));
+    window()->set_progress(value);
 }
 
 void TerminalWidget::set_window_title(StringView title)

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -146,7 +146,7 @@ private:
     // ^TerminalClient
     virtual void beep() override;
     virtual void set_window_title(StringView) override;
-    virtual void set_window_progress(int value, int max) override;
+    virtual void set_window_progress(VT::ProgressState state, u8) override;
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
     virtual void terminal_history_changed(int delta) override;
     virtual void terminal_did_perform_possibly_partial_clear() override;

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -269,7 +269,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         previous_report_time = current_time;
         warn("\r\033[2K");
         if (maybe_total_size.has_value()) {
-            warn("\033]9;{};{};\033\\", downloaded_size, maybe_total_size.value());
+            warn("\033]9;4;1;{}\033\\", static_cast<int>((100. * downloaded_size) / maybe_total_size.value()));
             warn("Download progress: {} / {}", human_readable_size(downloaded_size), human_readable_size(maybe_total_size.value()));
         } else {
             warn("Download progress: {} / ???", human_readable_size(downloaded_size));
@@ -401,7 +401,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (success)
                 update_progress(total_size, total_size, true);
 
-            warn("\033]9;-1;\033\\");
+            warn("\033]9;4;0\033\\");
             warnln();
             if (!success)
                 warnln("Request failed :(");


### PR DESCRIPTION
Instead of having our own incompatible OSC 9 sequence for showing a progress bar in the task bar, switch to using the more commonly used OSC 9;4 sequence, introduced by ConEmu [1].
Other terminal emulators, like iTerm2 [2], Ghostty [3], and the Windows Terminal [4] also use this OSC sequence.

This makes progress bar updates sent by Neovim work properly in our terminal. Previously, it was always stuck at 100%.
<img width="317" height="94" alt="image" src="https://github.com/user-attachments/assets/fb56800a-6ab7-427d-8715-ed70e55a295a" />

[1] https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
[2] https://iterm2.com/documentation-escape-codes.html
[3] https://ghostty.org/docs/vt/osc/conemu#change-progress-state-(osc-94)
[4] https://learn.microsoft.com/en-us/windows/terminal/tutorials/progress-bar-sequences