### PR TITLE
Ports/neovim: Add better SerenityOS integration

### DIFF
--- a/Ports/neovim/patches/0001-feat-vim.ui.open-support-serenity-open-tool.patch
+++ b/Ports/neovim/patches/0001-feat-vim.ui.open-support-serenity-open-tool.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6nke=20Holz?= <soenke.holz@serenityos.org>
+Date: Thu, 2 Apr 2026 18:26:15 +0200
+Subject: [PATCH] feat(vim.ui.open): support serenity "open" tool
+
+---
+ runtime/lua/vim/ui.lua | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/runtime/lua/vim/ui.lua b/runtime/lua/vim/ui.lua
+index 28ae4bfee08a0f556eaf27d78b3a3fe0c55eb1d9..af5a338f58cd47d7e50cd087a755a8a6aa65be02 100644
+--- a/runtime/lua/vim/ui.lua
++++ b/runtime/lua/vim/ui.lua
+@@ -196,8 +196,10 @@ function M._get_open_cmd()
+     return { 'explorer.exe' }, nil
+   elseif vim.fn.executable('lemonade') == 1 then
+     return { 'lemonade', 'open' }, nil
++  elseif vim.fn.executable('open') == 1 then
++    return { 'open' }, nil
+   else
+-    return nil, 'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open, lemonade)'
++    return nil, 'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open, lemonade, open)'
+   end
+ end
+ 

--- a/Ports/neovim/patches/0002-feat-has-serenity.patch
+++ b/Ports/neovim/patches/0002-feat-has-serenity.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6nke=20Holz?= <soenke.holz@serenityos.org>
+Date: Thu, 9 Apr 2026 18:42:09 +0200
+Subject: [PATCH] feat: has('serenity')
+
+---
+ runtime/doc/vimfn.txt               | 1 +
+ runtime/lua/vim/_meta/vimfn.lua     | 1 +
+ src/nvim/eval.lua                   | 1 +
+ src/nvim/eval/funcs.c               | 3 +++
+ test/old/testdir/test_functions.vim | 2 ++
+ 5 files changed, 8 insertions(+)
+
+diff --git a/runtime/doc/vimfn.txt b/runtime/doc/vimfn.txt
+index afb253a4f3be78a174151c74fe4efbd968218005..68b3425ca37ab3a5d2f1ce10af72f94e09658f20 100644
+--- a/runtime/doc/vimfn.txt
++++ b/runtime/doc/vimfn.txt
+@@ -4702,6 +4702,7 @@ has({feature})                                                           *has()*
+ 			nvim		This is Nvim.
+ 			python3		Legacy Vim |python3| interface. |has-python|
+ 			pythonx		Legacy Vim |python_x| interface. |has-pythonx|
++			serenity	SerenityOS system.
+ 			sun		SunOS system.
+ 			*termux*	Termux, an |android| terminal app and packaging environment.
+ 			ttyin		input is a terminal (tty).
+diff --git a/runtime/lua/vim/_meta/vimfn.lua b/runtime/lua/vim/_meta/vimfn.lua
+index 347862e865ded433cbbe63060e69c010a17cbe71..b2b00825667b17fa11863e2405bc7838727e68c1 100644
+--- a/runtime/lua/vim/_meta/vimfn.lua
++++ b/runtime/lua/vim/_meta/vimfn.lua
+@@ -4249,6 +4249,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
+ ---   nvim    This is Nvim.
+ ---   python3    Legacy Vim |python3| interface. |has-python|
+ ---   pythonx    Legacy Vim |python_x| interface. |has-pythonx|
++---   serenity    SerenityOS system.
+ ---   sun    SunOS system.
+ ---   *termux*  Termux, an |android| terminal app and packaging environment.
+ ---   ttyin    input is a terminal (tty).
+diff --git a/src/nvim/eval.lua b/src/nvim/eval.lua
+index a52b0660214d5030aa5266687ec2fea19fe18e94..7e8cc65b2ffa0b4bc5b43278bc0875ba1ea29ff3 100644
+--- a/src/nvim/eval.lua
++++ b/src/nvim/eval.lua
+@@ -5234,6 +5234,7 @@ M.funcs = {
+       	nvim		This is Nvim.
+       	python3		Legacy Vim |python3| interface. |has-python|
+       	pythonx		Legacy Vim |python_x| interface. |has-pythonx|
++      	serenity	SerenityOS system.
+       	sun		SunOS system.
+       	*termux*	Termux, an |android| terminal app and packaging environment.
+       	ttyin		input is a terminal (tty).
+diff --git a/src/nvim/eval/funcs.c b/src/nvim/eval/funcs.c
+index 07361d820cb46af42608c836112027152565c413..8e2043f46906a080f1ceaf97cf81f67f1552804f 100644
+--- a/src/nvim/eval/funcs.c
++++ b/src/nvim/eval/funcs.c
+@@ -2666,6 +2666,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+ #ifdef __linux__
+     "linux",
+ #endif
++#ifdef __serenity__
++    "serenity",
++#endif
+ #ifdef SUN_SYSTEM
+     "sun",
+ #endif
+diff --git a/test/old/testdir/test_functions.vim b/test/old/testdir/test_functions.vim
+index cfb15b488915bcd270fe2e91ada54e4af8f11684..9e5db303e939954a5c65c5fbb5ad0aeb0295eb27 100644
+--- a/test/old/testdir/test_functions.vim
++++ b/test/old/testdir/test_functions.vim
+@@ -2743,6 +2743,7 @@ func Test_platform_name()
+   call assert_equal(has('linux'), has('linux') && has('unix'))
+   call assert_equal(has('mac'), has('mac') && has('unix'))
+   call assert_equal(has('qnx'), has('qnx') && has('unix'))
++  call assert_equal(has('serenity'), has('serenity') && has('unix'))
+   call assert_equal(has('sun'), has('sun') && has('unix'))
+   call assert_equal(has('win32'), has('win32') && !has('unix'))
+   call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
+@@ -2758,6 +2759,7 @@ func Test_platform_name()
+     call assert_equal(uname =~? 'SunOS', has('sun'))
+     call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
+     call assert_equal(uname =~? 'GNU', has('hurd'))
++    call assert_equal(uname =~? 'SerenityOS', has('serenity'))
+   endif
+ endfunc
+ 

--- a/Ports/neovim/patches/0003-feat-provider-support-serenity-clipboard.patch
+++ b/Ports/neovim/patches/0003-feat-provider-support-serenity-clipboard.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6nke=20Holz?= <soenke.holz@serenityos.org>
+Date: Thu, 2 Apr 2026 18:26:43 +0200
+Subject: [PATCH] feat(provider): support serenity clipboard
+
+---
+ runtime/autoload/provider/clipboard.vim | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/runtime/autoload/provider/clipboard.vim b/runtime/autoload/provider/clipboard.vim
+index fbd692ce4a557e17682a4c6d63657b18ebea89cb..2acb997115ecd78648c3bba673744d8f38123c62 100644
+--- a/runtime/autoload/provider/clipboard.vim
++++ b/runtime/autoload/provider/clipboard.vim
+@@ -174,6 +174,14 @@ function! s:set_tmux() abort
+   return 'tmux'
+ endfunction
+ 
++function! s:set_serenity() abort
++  let s:copy['+'] = ['copy', '--type', 'text/plain']
++  let s:paste['+'] = ['paste', '--no-newline']
++  let s:copy['*'] = s:copy['+']
++  let s:paste['*'] = s:paste['+']
++  return 'serenity'
++endfunction
++
+ let s:cache_enabled = 1
+ let s:err = ''
+ 
+@@ -191,6 +199,8 @@ function! provider#clipboard#Executable() abort
+         return s:set_osc52()
+       elseif 'pbcopy' == g:clipboard
+         return s:set_pbcopy()
++      elseif 'serenity' == g:clipboard
++        return s:set_serenity()
+       elseif 'wl-copy' == g:clipboard
+         return s:set_wayland()
+       elseif 'wayclip' == g:clipboard
+@@ -235,6 +245,8 @@ function! provider#clipboard#Executable() abort
+     return get(g:clipboard, 'name', 'g:clipboard')
+   elseif has('mac')
+     return s:set_pbcopy()
++  elseif has('serenity')
++    return s:set_serenity()
+   elseif !empty($WAYLAND_DISPLAY) && executable('wl-copy') && executable('wl-paste')
+     return s:set_wayland()
+   elseif !empty($WAYLAND_DISPLAY) && executable('waycopy') && executable('waypaste')

--- a/Ports/neovim/patches/ReadMe.md
+++ b/Ports/neovim/patches/ReadMe.md
@@ -10,3 +10,8 @@ feat(vim.ui.open): support serenity "open" tool
 feat: has('serenity')
 
 
+## `0003-feat-provider-support-serenity-clipboard.patch`
+
+feat(provider): support serenity clipboard
+
+

--- a/Ports/neovim/patches/ReadMe.md
+++ b/Ports/neovim/patches/ReadMe.md
@@ -5,3 +5,8 @@
 feat(vim.ui.open): support serenity "open" tool
 
 
+## `0002-feat-has-serenity.patch`
+
+feat: has('serenity')
+
+

--- a/Ports/neovim/patches/ReadMe.md
+++ b/Ports/neovim/patches/ReadMe.md
@@ -1,0 +1,7 @@
+# Patches for neovim on SerenityOS
+
+## `0001-feat-vim.ui.open-support-serenity-open-tool.patch`
+
+feat(vim.ui.open): support serenity "open" tool
+
+


### PR DESCRIPTION
This makes [`gx`](https://neovim.io/doc/user/various/#gx) and the [`"+`](https://neovim.io/doc/user/provider/#quote%2B) system clipboard register work in SerenityOS.

This also makes the corresponding health checks pass:
<img width="340" height="71" alt="image" src="https://github.com/user-attachments/assets/fb6ffda8-e8fa-406a-8e56-4ddff6af34f8" />
<img width="274" height="29" alt="image" src="https://github.com/user-attachments/assets/322770a2-4513-4d60-abb8-ac7ad81cc815" />