### PR TITLE
LibVT+Userland+Kernel: Make DECTCEM not reset the cursor shape

### DIFF
--- a/Kernel/Devices/TTY/VirtualConsole.cpp
+++ b/Kernel/Devices/TTY/VirtualConsole.cpp
@@ -493,6 +493,11 @@ void VirtualConsole::set_cursor_blinking(bool)
     // Do nothing
 }
 
+void VirtualConsole::set_cursor_hidden(bool)
+{
+    // Do nothing
+}
+
 void VirtualConsole::echo(u8 ch)
 {
     m_console_impl.on_input(ch);

--- a/Kernel/Devices/TTY/VirtualConsole.h
+++ b/Kernel/Devices/TTY/VirtualConsole.h
@@ -107,6 +107,7 @@ private:
     virtual void emit(u8 const*, size_t) override;
     virtual void set_cursor_shape(VT::CursorShape) override;
     virtual void set_cursor_blinking(bool) override;
+    virtual void set_cursor_hidden(bool) override;
 
     // ^CharacterDevice
     virtual StringView class_name() const override { return "VirtualConsole"sv; }

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -153,13 +153,10 @@ void Terminal::alter_private_mode(bool should_set, Parameters params)
         case 25:
             if (should_set) {
                 // Show cursor
-                m_cursor_shape = m_saved_cursor_shape;
-                m_client.set_cursor_shape(m_cursor_shape);
+                m_client.set_cursor_hidden(false);
             } else {
                 // Hide cursor
-                m_saved_cursor_shape = m_cursor_shape;
-                m_cursor_shape = VT::CursorShape::None;
-                m_client.set_cursor_shape(VT::CursorShape::None);
+                m_client.set_cursor_hidden(true);
             }
             break;
         case 1047:

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -54,6 +54,7 @@ public:
     virtual void emit(u8 const*, size_t) = 0;
     virtual void set_cursor_shape(CursorShape) = 0;
     virtual void set_cursor_blinking(bool) = 0;
+    virtual void set_cursor_hidden(bool) = 0;
 };
 
 class Terminal : public EscapeSequenceExecutor {
@@ -432,8 +433,6 @@ protected:
     bool m_stomp { false };
     bool m_in_application_keypad_mode { false };
 
-    CursorShape m_cursor_shape { VT::CursorShape::Block };
-    CursorShape m_saved_cursor_shape { VT::CursorShape::Block };
     bool m_cursor_is_blinking_set { true };
 
     bool m_needs_bracketed_paste { false };

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -343,6 +343,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
 
         for (size_t column = 0; column < line.length(); ++column) {
             bool should_reverse_fill_for_cursor_or_selection = m_cursor_blink_state
+                && !m_cursor_is_hidden
                 && m_cursor_shape == VT::CursorShape::Block
                 && m_has_logical_focus
                 && visual_row == row_with_cursor
@@ -417,6 +418,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
         for (size_t column = 0; column < line.length(); ++column) {
             auto attribute = line.attribute_at(column);
             bool should_reverse_fill_for_cursor_or_selection = m_cursor_blink_state
+                && !m_cursor_is_hidden
                 && m_cursor_shape == VT::CursorShape::Block
                 && m_has_logical_focus
                 && visual_row == row_with_cursor
@@ -448,7 +450,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
     }
 
     // Draw cursor.
-    if (m_cursor_blink_state && row_with_cursor < m_terminal.rows()) {
+    if (m_cursor_blink_state && !m_cursor_is_hidden && row_with_cursor < m_terminal.rows()) {
         auto& cursor_line = m_terminal.line(first_row_from_history + row_with_cursor);
         if (m_terminal.cursor_row() >= (m_terminal.rows() - rows_from_history))
             return;
@@ -1140,6 +1142,12 @@ void TerminalWidget::set_cursor_blinking(bool blinking)
         m_cursor_blink_state = true;
         m_cursor_is_blinking_set = false;
     }
+    invalidate_cursor();
+}
+
+void TerminalWidget::set_cursor_hidden(bool hidden)
+{
+    m_cursor_is_hidden = hidden;
     invalidate_cursor();
 }
 

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -112,6 +112,7 @@ public:
 
     VT::CursorShape cursor_shape() { return m_cursor_shape; }
     virtual void set_cursor_blinking(bool) override;
+    virtual void set_cursor_hidden(bool) override;
     virtual void set_cursor_shape(CursorShape) override;
 
     static Optional<VT::CursorShape> parse_cursor_shape(StringView);
@@ -230,6 +231,8 @@ private:
 
     VT::CursorShape m_cursor_shape { VT::CursorShape::Block };
     bool m_cursor_is_blinking_set { true };
+
+    bool m_cursor_is_hidden { false };
 
     enum class AutoScrollDirection {
         None,


### PR DESCRIPTION
Previously, making the cursor visible with DECTCEM caused the cursor to reset its appearance to the shape that was set before the last DECTCEM command making it invisible.
However, the cursor shape could have been changed between those two commands (or the cursor could have never been made invisible before), causing us to display an incorrect cursor shape.

Instead of (incorrectly) keeping track of the old cursor shape in `m_saved_cursor_shape`, let's simplify this code by introducing a `set_cursor_hidden` function, which is used by `TerminalWidget` to set its `m_cursor_is_hidden` variable to enable/disable drawing of the cursor.

This causes neovim to display the bar cursor shape in insert mode. Previously, it displayed the block shape since it always issues a "set cursor visible" command after setting the cursor shape, therefore we incorrectly reset the shape to a block cursor.

Before:
<img width="239" height="124" alt="image" src="https://github.com/user-attachments/assets/f77351f8-fec3-4c8c-9a11-b83823c650d1" />

After:
<img width="251" height="123" alt="image" src="https://github.com/user-attachments/assets/05904dab-533f-4beb-b42a-4585146c8539" />
