### PR TITLE
Meta: Don't write .pcap USB traffic dump for UAS drives

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -694,7 +694,7 @@ def set_up_boot_drive(config: Configuration):
         config.kernel_cmdline.append("root=block3:0")
     elif config.boot_drive_type == BootDriveType.USB_UAS:
         config.add_device("qemu-xhci,id=boot-drive-xhci,p3=0")
-        config.add_device("usb-uas,bus=boot-drive-xhci.0,id=boot-drive-uas,pcap=log.pcap")
+        config.add_device("usb-uas,bus=boot-drive-xhci.0,id=boot-drive-uas")
         config.add_device("scsi-hd,bus=boot-drive-uas.0,scsi-id=0,lun=0,drive=boot-drive")
         # FIXME: Find a better way to address the usb drive
         config.kernel_cmdline.append("root=block3:0")


### PR DESCRIPTION
This appears to be leftover debugging code.