### PR TITLE
Terminal: Advertise 24-bit "true color" support

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -148,7 +148,7 @@ static ErrorOr<void> run_command(StringView command, bool keep_open)
         arguments.append("-c"sv);
         arguments.append(command);
     }
-    auto env = TRY(FixedArray<StringView>::create({ "TERM=xterm"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
+    auto env = TRY(FixedArray<StringView>::create({ "TERM=xterm"sv, "COLORTERM=truecolor"sv, "PAGER=more"sv, "PATH="sv DEFAULT_PATH_SV }));
     TRY(Core::System::exec(shell, arguments, Core::System::SearchInPath::No, env.span()));
     VERIFY_NOT_REACHED();
 }


### PR DESCRIPTION
According to https://github.com/termstandard/colors?tab=readme-ov-file#checking-for-colorterm, a widespread method for advertising 24-bit color support is by defining the "COLORTERM" environment variable to either "truecolor" or "24bit".

The other suggested truecolor detection method of querying the terminal doesn't work, since we don't support DECRQSS yet (or any other DCS sequence).

This causes neovim to detect that our terminal emulator supports 24-bit color.

This PR will cause a conflict with #26673.

Before:
<img width="604" height="418" alt="image" src="https://github.com/user-attachments/assets/0a961d98-12af-4244-9043-9c5ebdd3823d" />

After:
<img width="604" height="418" alt="image" src="https://github.com/user-attachments/assets/2313806d-6883-4ec1-9e03-87bb2d1d084b" />
