### PR TITLE
Kernel: Add GoldfishRTC driver for RISC-V

### DIFF
--- a/Kernel/Arch/riscv64/GoldfishRTC.cpp
+++ b/Kernel/Arch/riscv64/GoldfishRTC.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, miridav
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/riscv64/GoldfishRTC.h>
+#include <Kernel/Memory/MemoryManager.h>
+
+
+
+
+namespace Kernel {
+
+static NeverDestroyed<Optional<GoldfishRTC>> s_rtc;
+
+GoldfishRTC& GoldfishRTC::the()
+{
+    VERIFY(s_rtc->has_value());
+    return s_rtc->value();
+}
+
+ErrorOr<void> GoldfishRTC::initialize(PhysicalAddress paddr)
+{
+    if (s_rtc->has_value())
+        return {};
+
+    auto mapping = TRY(Memory::map_typed<Registers volatile>(paddr, sizeof(Registers)));
+
+    s_rtc->emplace(move(mapping));
+
+    return {};
+}
+
+
+GoldfishRTC::GoldfishRTC(Memory::TypedMapping<Registers volatile> mapping)
+    : m_regs(move(mapping))        
+{
+    m_boot_time = now();
+}
+
+UnixDateTime GoldfishRTC::now() const
+{
+    SpinlockLocker lock(m_lock);
+    u32 high, low;
+    do {
+        high = m_regs->time_high;
+        low  = m_regs->time_low;
+    } while (m_regs->time_high != high);
+
+    u64 time = (static_cast<u64>(high) << 32) | low;
+    return UnixDateTime::from_nanoseconds_since_epoch(time);
+}
+
+UnixDateTime GoldfishRTC::boot_time() const
+{
+    return m_boot_time;
+}
+
+bool GoldfishRTC::is_initialized(){
+    return s_rtc->has_value();
+}
+
+} // namespace Kernel

--- a/Kernel/Arch/riscv64/GoldfishRTC.h
+++ b/Kernel/Arch/riscv64/GoldfishRTC.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, miridav
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NeverDestroyed.h>
+#include <AK/Optional.h>
+#include <AK/Time.h>
+#include <Kernel/Locking/LockRank.h>
+#include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Memory/TypedMapping.h>
+
+namespace Kernel {
+
+class GoldfishRTC final {
+
+    public:
+    struct Registers {
+        u32 time_low;
+        u32 time_high;
+    };
+
+    // Public only for NeverDestroyed; do not construct directly.
+    explicit GoldfishRTC(Memory::TypedMapping<Registers volatile>);
+
+    static ErrorOr<void> initialize(PhysicalAddress);
+    static GoldfishRTC& the();
+    static bool is_initialized();
+
+    UnixDateTime now() const;
+    UnixDateTime boot_time() const;
+
+private:
+    Memory::TypedMapping<Registers volatile> m_regs;
+    UnixDateTime m_boot_time;
+    mutable Spinlock<LockRank::None> m_lock;
+
+};
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -592,6 +592,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/SBI.cpp
         Arch/riscv64/SmapDisabler.cpp
         Arch/riscv64/Timer.cpp
+        Arch/riscv64/GoldfishRTC.cpp
         Arch/riscv64/trap_handler.S
 
         Bus/PCI/Controller/GenericECAMHostController.cpp

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -23,6 +23,7 @@
 #    include <Kernel/Arch/aarch64/Time/PL031.h>
 #elif ARCH(RISCV64)
 #    include <Kernel/Arch/riscv64/Timer.h>
+#    include <Kernel/Arch/riscv64/GoldfishRTC.h>
 #else
 #    error Unknown architecture
 #endif
@@ -38,6 +39,7 @@
 #include <Kernel/Time/HardwareTimer.h>
 #include <Kernel/Time/TimeManagement.h>
 #include <Kernel/Time/TimerQueue.h>
+
 
 namespace Kernel {
 
@@ -232,7 +234,13 @@ UNMAP_AFTER_INIT void TimeManagement::initialize([[maybe_unused]] u32 cpu)
     }
 #elif ARCH(RISCV64)
     if (cpu == 0) {
-        VERIFY(!s_the.is_initialized());
+        auto rtc_or_error = GoldfishRTC::initialize(PhysicalAddress(0x101000));
+        if (rtc_or_error.is_error()) {
+            dmesgln("GoldfishRTC: Failed to initialize at 0x101000: {}", rtc_or_error.error());
+        } else {
+            dmesgln("GoldfishRTC: Successfully initialized!");
+        }
+
         s_the.ensure_instance();
     }
 #else
@@ -269,8 +277,7 @@ UnixDateTime TimeManagement::boot_time()
         return UnixDateTime::epoch();
     return rtc->boot_time();
 #elif ARCH(RISCV64)
-    // FIXME: Return correct boot time
-    return UnixDateTime::epoch();
+    return GoldfishRTC::the().boot_time();
 #else
 #    error Unknown architecture
 #endif
@@ -312,6 +319,7 @@ UNMAP_AFTER_INIT TimeManagement::TimeManagement()
         m_epoch_time += boot_time().offset_to_epoch();
     probe_and_set_aarch64_hardware_timers();
 #elif ARCH(RISCV64)
+    m_epoch_time += boot_time().offset_to_epoch();
     probe_and_set_riscv64_hardware_timers();
 #else
 #    error Unknown architecture


### PR DESCRIPTION
This PR adds support for the Goldfish RTC device on RISC-V.

The QEMU virt machine exposes a Goldfish RTC for timekeeping, which was previously unsupported in SerenityOS. This change introduces a minimal driver that reads the current time from the device via MMIO and makes it available to the kernel.

The implementation follows the QEMU hardware specification and is loosely based on existing RTC drivers in the tree.

Tested by confirming successful initialization and valid time readings in the kernel log during boot.