### PR TITLE
NetworkServer: Make "IPv4Address" Network.ini entry work again

### DIFF
--- a/Userland/Services/NetworkServer/main.cpp
+++ b/Userland/Services/NetworkServer/main.cpp
@@ -75,7 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
                 // FIXME: Propagate errors
                 // FIXME: Do this asynchronously
                 dbgln("Setting up interface {} statically ({}/{})", ifname, config.ipv4_address, config.ipv4_netmask);
-                MUST(Core::command("ifconfig"sv, { "-a", ifname.characters(), "-i", config.ipv4_address.characters(), "-m", config.ipv4_netmask.characters() }, {}));
+                MUST(Core::command("ifconfig"sv, { "-a", ifname.characters(), "--ipv4", config.ipv4_address.characters(), "-m", config.ipv4_netmask.characters() }, {}));
                 if (config.ipv4_gateway != "0.0.0.0") {
                     MUST(Core::command("route"sv, { "del", "-n", "0.0.0.0", "-m", "0.0.0.0", "-i", ifname }, {}));
                     MUST(Core::command("route"sv, { "add", "-n", "0.0.0.0", "-m", "0.0.0.0", "-g", config.ipv4_gateway, "-i", ifname }, {}));
@@ -85,7 +85,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
             // FIXME: Propagate errors
             dbgln("Disabling interface {}", ifname);
             MUST(Core::command("route"sv, { "del", "-n", "0.0.0.0", "-m", "0.0.0.0", "-i", ifname }, {}));
-            MUST(Core::command("ifconfig"sv, { "-a", ifname.characters(), "-i", "0.0.0.0", "-m", "0.0.0.0" }, {}));
+            MUST(Core::command("ifconfig"sv, { "-a", ifname.characters(), "--ipv4", "0.0.0.0", "-m", "0.0.0.0" }, {}));
         }
     });
 


### PR DESCRIPTION
ac44ec5ebc7 removed the short "-i" flag from ifconfig, breaking this code.

<hr>

I noticed this while attempting to configure a static IP for my Pi 5.