### PR TITLE
Kernel/PS2: Add keyboard LED support for lock keys

### DIFF
--- a/Kernel/Arch/x86_64/ISABus/I8042Controller.cpp
+++ b/Kernel/Arch/x86_64/ISABus/I8042Controller.cpp
@@ -298,6 +298,10 @@ ErrorOr<void> I8042Controller::send_command(PortIndex port_index, DeviceCommand 
         SpinlockLocker lock(m_lock);
         return do_send_command(port_index, I8042Command::SetSampleRate, data);
     }
+    case DeviceCommand::SetLeds: {
+        SpinlockLocker lock(m_lock);
+        return do_send_command(port_index, I8042Command::KeyboardSetLEDs, data);
+    }
 
     case DeviceCommand::GetDeviceID:
         return EOPNOTSUPP;

--- a/Kernel/Arch/x86_64/ISABus/I8042Controller.h
+++ b/Kernel/Arch/x86_64/ISABus/I8042Controller.h
@@ -32,6 +32,7 @@ enum I8042Command : u8 {
     DisableFirstPS2Port = 0xAD,
     EnableFirstPS2Port = 0xAE,
     WriteSecondPS2PortInputBuffer = 0xD4,
+    KeyboardSetLEDs = 0xED,
     SetScanCodeSet = 0xF0,
     GetDeviceID = 0xF2,
     SetSampleRate = 0xF3,

--- a/Kernel/Bus/SerialIO/Controller.h
+++ b/Kernel/Bus/SerialIO/Controller.h
@@ -27,6 +27,7 @@ public:
         EnablePacketStreaming,
         DisablePacketStreaming,
         SetDefaults,
+        SetLeds,
     };
 
     AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, PortIndex);

--- a/Kernel/Devices/Input/KeyboardDevice.h
+++ b/Kernel/Devices/Input/KeyboardDevice.h
@@ -49,6 +49,8 @@ public:
 
     void handle_input_event(KeyEvent);
     bool num_lock_on() const { return m_num_lock_on; }
+    bool caps_lock_on() const { return m_caps_lock_on; }
+    bool scroll_lock_on() const { return m_scroll_lock_on; }
 
 protected:
     KeyboardDevice();
@@ -61,6 +63,7 @@ protected:
     bool m_caps_lock_to_ctrl_pressed { false };
     bool m_caps_lock_on { false };
     bool m_num_lock_on { false };
+    bool m_scroll_lock_on { false };
 
     void key_state_changed(u8 raw, bool pressed);
 };

--- a/Kernel/Devices/Input/PS2/KeyboardDevice.cpp
+++ b/Kernel/Devices/Input/PS2/KeyboardDevice.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Types.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/Bus/SerialIO/PS2Definitions.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/Device.h>
@@ -17,6 +18,10 @@
 #include <Kernel/Tasks/WorkQueue.h>
 
 namespace Kernel {
+
+constexpr u8 LED_SCROLL_LOCK = 1 << 0;
+constexpr u8 LED_NUM_LOCK = 1 << 1;
+constexpr u8 LED_CAPS_LOCK = 1 << 2;
 
 // clang-format off
 static constexpr KeyCodeEntry unshifted_scan_code_set1_key_map[0x80] = {
@@ -546,6 +551,26 @@ void PS2KeyboardDevice::handle_scan_code_input_event(ScanCodeEvent event)
     }
 
     m_keyboard_device->handle_input_event(queued_event);
+
+    if (raw_event.is_press()) {
+        if (queued_event.key == Key_CapsLock || queued_event.key == Key_NumLock || queued_event.key == Key_ScrollLock) {
+            bool caps_lock = m_keyboard_device->caps_lock_on();
+            bool num_lock = m_keyboard_device->num_lock_on();
+            bool scroll_lock = m_keyboard_device->scroll_lock_on();
+            u8 leds = 0;
+
+            if (caps_lock)
+                leds |= LED_CAPS_LOCK;
+            if (num_lock)
+                leds |= LED_NUM_LOCK;
+            if (scroll_lock)
+                leds |= LED_SCROLL_LOCK;
+
+            (void)g_io_work->try_queue([this, leds] {
+                (void)update_leds(leds);
+            });
+        }
+    }
 }
 
 void PS2KeyboardDevice::handle_byte_read_for_scan_code_set1(u8 byte)
@@ -750,8 +775,12 @@ UNMAP_AFTER_INIT ErrorOr<void> PS2KeyboardDevice::initialize()
             // NMB SGI keyboard, raw and translated
         case 0x60:
         case 0x47:
+            (void)update_leds(0);
             return {};
         }
+    } else {
+        // Clear all LEDs on startup to ensure a known state.
+        (void)update_leds(0);
     }
 
     return err;
@@ -769,5 +798,12 @@ UNMAP_AFTER_INIT PS2KeyboardDevice::PS2KeyboardDevice(SerialIOController const& 
 // FIXME: UNMAP_AFTER_INIT might not be correct, because in practice PS/2 devices
 // are hot pluggable.
 UNMAP_AFTER_INIT PS2KeyboardDevice::~PS2KeyboardDevice() = default;
+
+ErrorOr<void> PS2KeyboardDevice::update_leds(u8 led_mask)
+{
+    led_mask &= (LED_SCROLL_LOCK | LED_NUM_LOCK | LED_CAPS_LOCK);
+    TRY(attached_controller().send_command(attached_port_index(), SerialIOController::DeviceCommand::SetLeds, led_mask));
+    return {};
+}
 
 }

--- a/Kernel/Devices/Input/PS2/KeyboardDevice.h
+++ b/Kernel/Devices/Input/PS2/KeyboardDevice.h
@@ -13,6 +13,7 @@
 #include <Kernel/Devices/Input/Definitions.h>
 #include <Kernel/Devices/Input/KeyboardDevice.h>
 #include <Kernel/Security/Random.h>
+#include <Kernel/Tasks/WorkQueue.h>
 
 namespace Kernel {
 
@@ -26,8 +27,11 @@ public:
 
     // ^SerialIODevice
     virtual void handle_byte_read_from_serial_input(u8 byte) override;
+    ErrorOr<void> update_leds(u8 led_mask);
 
 private:
+    u8 m_keyboard_leds { 0 };
+
     PS2KeyboardDevice(SerialIOController const&, SerialIOController::PortIndex port_index, ScanCodeSet scan_code_set, KeyboardDevice const&);
 
     RawKeyEvent generate_raw_key_event_input_from_set1(ScanCodeEvent);


### PR DESCRIPTION
Adds support for updating keyboard LEDs (Caps Lock, Num Lock, Scroll Lock) for PS/2 keyboards.

The driver sends the appropriate command (0xED) to the controller when the LED state changes.

LED updates are performed outside of interrupt context to avoid blocking in IRQ handlers.

Tested by verifying correct LED behavior in QEMU.