### PR TITLE
Meta: Fix building disk image on macOS with macFUSE

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -148,12 +148,12 @@ fi
 
 cleanup() {
     if [ -d mnt ]; then
-        if [ $use_genext2fs = 0 ] ; then
+        if [ $use_genext2fs = 0 ]; then
             printf "unmounting filesystem... "
-            if [ $USE_FUSE2FS -eq 1 ]; then
+            if [ $USE_FUSE2FS -eq 1 ] && command -v fusermount >/dev/null 2>&1; then
                 fusermount -u mnt || (sleep 1 && sync && fusermount -u mnt)
             else
-                umount mnt || ( sleep 1 && sync && umount mnt )
+                umount mnt || (sleep 1 && sync && umount mnt)
             fi
         fi
         rm -rf mnt

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -169,7 +169,7 @@ cleanup() {
 trap cleanup EXIT
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-"$script_path/build-root-filesystem.sh"
+SERENITY_USE_GENEXT2FS=$use_genext2fs "$script_path/build-root-filesystem.sh"
 
 if [ $use_genext2fs = 1 ]; then
     genext2fs -B 4096 -b $((DISK_SIZE_BYTES / 4096)) -i "${BYTES_PER_INODE}" -d mnt _disk_image || die "try increasing image size (genext2fs -b)"

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -23,14 +23,30 @@ if ! command -v rsync >/dev/null; then
     die "Please install rsync."
 fi
 
+# On macOS, APFS returns filenames as NFC bytes, but fuse2fs via macFUSE only
+# accepts file creation with NFD-encoded names. Use --iconv=UTF-8,UTF-8-MAC to
+# convert sender filenames from NFC (UTF-8) to NFD (UTF-8-MAC) so that
+# non-ASCII filenames can be written to the ext2 disk image.
+# This is not needed when using genext2fs, which operates on a directory directly.
+RSYNC_ICONV=""
+if [ "${SERENITY_USE_GENEXT2FS:-0}" = "0" ] && [ "$(uname -s)" = "Darwin" ] && rsync --help 2>&1 | grep -q iconv; then
+    RSYNC_ICONV="--iconv=UTF-8,UTF-8-MAC"
+fi
+
 if rsync --chown 2>&1 | grep "missing argument" >/dev/null; then
-    rsync -aH --chown=0:0 --inplace --update "$SERENITY_SOURCE_DIR"/Base/ mnt/
-    rsync -aH --chown=0:0 --exclude="/usr/include" --inplace --update Root/ mnt/
-    rsync -aHL --chown=0:0 --inplace --update Root/usr/include/ mnt/usr/include/
+    # shellcheck disable=SC2086
+    rsync -aH $RSYNC_ICONV --chown=0:0 --inplace --update "$SERENITY_SOURCE_DIR"/Base/ mnt/
+    # shellcheck disable=SC2086
+    rsync -aH $RSYNC_ICONV --chown=0:0 --exclude="/usr/include" --inplace --update Root/ mnt/
+    # shellcheck disable=SC2086
+    rsync -aHL $RSYNC_ICONV --chown=0:0 --inplace --update Root/usr/include/ mnt/usr/include/
 else
-    rsync -aH --inplace --update "$SERENITY_SOURCE_DIR"/Base/ mnt/
-    rsync -aH --inplace --exclude="/usr/include" --update Root/ mnt/
-    rsync -aHL --inplace --update Root/usr/include/ mnt/usr/include/
+    # shellcheck disable=SC2086
+    rsync -aH $RSYNC_ICONV --inplace --update "$SERENITY_SOURCE_DIR"/Base/ mnt/
+    # shellcheck disable=SC2086
+    rsync -aH $RSYNC_ICONV --inplace --exclude="/usr/include" --update Root/ mnt/
+    # shellcheck disable=SC2086
+    rsync -aHL $RSYNC_ICONV --inplace --update Root/usr/include/ mnt/usr/include/
     chown -R 0:0 mnt/
 fi
 

--- a/Toolchain/BuildFuseExt2.sh
+++ b/Toolchain/BuildFuseExt2.sh
@@ -8,27 +8,75 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 exit_if_running_as_root "Do not run BuildFuseExt2.sh as root, parts of your Toolchain directory will become root-owned"
 
-export PATH="/usr/local/opt/m4/bin:$PATH"
-
 die() {
     echo "die: $*"
     exit 1
 }
 
-if [[ "$OSTYPE" != "darwin"* ]]; then
-    die "This script makes sense to be run only on macOS"
+SOURCE_DIR="$DIR/Tarballs/fuse-ext2"
+PATCH_DIR="$DIR/Patches/fuse-ext2/macos"
+
+EXTRA_CFLAGS=""
+EXTRA_LDFLAGS=""
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if command -v brew &>/dev/null; then
+        m4_prefix="$(brew --prefix m4 2>/dev/null)"
+        [ -n "$m4_prefix" ] && export PATH="${m4_prefix}/bin:$PATH"
+        E2FSPROGS_PREFIX="$(brew --prefix e2fsprogs 2>/dev/null)"
+        EXTRA_CFLAGS="-I${E2FSPROGS_PREFIX}/include"
+        EXTRA_LDFLAGS="-L${E2FSPROGS_PREFIX}/lib"
+    elif command -v pkg-config &>/dev/null && pkg-config --exists ext2fs; then
+        EXTRA_CFLAGS="$(pkg-config --cflags ext2fs)"
+        EXTRA_LDFLAGS="$(pkg-config --libs ext2fs)"
+    else
+        die "Could not find e2fsprogs. Install it via Homebrew (brew install e2fsprogs) or ensure pkg-config can find ext2fs."
+    fi
+    # Support older osxfuse installs that put headers in /usr/local/include/osxfuse
+    if [ -d "/usr/local/include/osxfuse" ]; then
+        EXTRA_CFLAGS="-I/usr/local/include/osxfuse ${EXTRA_CFLAGS}"
+    fi
+    MACFUSE_FRAMEWORK_DIR="/Library/Filesystems/macfuse.fs/Contents/Frameworks"
+    if [ -d "${MACFUSE_FRAMEWORK_DIR}/MFMount.framework" ]; then
+        EXTRA_LDFLAGS="${EXTRA_LDFLAGS} -F${MACFUSE_FRAMEWORK_DIR}"
+    fi
+    MACOS_PATCHES=true
+else
+    if command -v pkg-config &>/dev/null && pkg-config --exists ext2fs; then
+        EXTRA_CFLAGS="$(pkg-config --cflags ext2fs)"
+        EXTRA_LDFLAGS="$(pkg-config --libs ext2fs)"
+    else
+        EXTRA_LDFLAGS="-lext2fs"
+    fi
+    MACOS_PATCHES=false
 fi
 
 mkdir -p "$DIR"/Tarballs
 pushd "$DIR"/Tarballs
 
-if [ ! -d fuse-ext2 ]; then
-    git clone https://github.com/alperakcan/fuse-ext2.git	
+if [ -d "$SOURCE_DIR" ]; then
+    rm -rf "$SOURCE_DIR"
 fi
 
-cd fuse-ext2
+git clone --depth 1 https://github.com/alperakcan/fuse-ext2.git "$SOURCE_DIR"
+
+cd "$SOURCE_DIR"
+if [ "$MACOS_PATCHES" = true ]; then
+    for patch in "$PATCH_DIR"/*.patch; do
+        [ -f "$patch" ] || continue
+        patch -p1 < "$patch" > /dev/null
+    done
+fi
+
 ./autogen.sh
-CFLAGS="-I/usr/local/include/osxfuse/ -I/$(brew --prefix e2fsprogs)/include" LDFLAGS="-L$(brew --prefix e2fsprogs)/lib" ./configure
-make
+CFLAGS="${EXTRA_CFLAGS}" LDFLAGS="${EXTRA_LDFLAGS}" ./configure
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    make \
+        "fuse_ext2_wait_LINK=\$(OBJC) \$(OBJCFLAGS) \$(AM_OBJCFLAGS) \$(AM_LDFLAGS) \$(LDFLAGS) \$(fuse_ext2_wait_LDFLAGS) -o \$@" \
+        "fuse_ext2_install_LINK=\$(OBJC) \$(OBJCFLAGS) \$(AM_OBJCFLAGS) \$(AM_LDFLAGS) \$(LDFLAGS) \$(fuse_ext2_install_LDFLAGS) -o \$@" \
+        "OBJCLINK=\$(OBJC) \$(OBJCFLAGS) \$(AM_OBJCFLAGS) \$(AM_LDFLAGS) \$(LDFLAGS) -o \$@"
+else
+    make
+fi
 sudo make install
 popd

--- a/Toolchain/Patches/fuse-ext2/macos/0001-Build-with-latest-macFUSE-on-macOS.patch
+++ b/Toolchain/Patches/fuse-ext2/macos/0001-Build-with-latest-macFUSE-on-macOS.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+Date: Tue, 5 May 2026 20:56:42 +0200
+Subject: [PATCH] Build with latest macFUSE on macOS
+
+Adjust the macOS build for current macFUSE headers and skip installing the
+legacy preference pane.
+
+Link: https://github.com/alperakcan/fuse-ext2/issues/149
+---
+ fuse-ext2/fuse-ext2.h    | 2 +-
+ fuse-ext2/op_getxattr.c  | 3 ++-
+ tools/macosx/Makefile.am | 2 --
+ 3 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/fuse-ext2/fuse-ext2.h b/fuse-ext2/fuse-ext2.h
+index 07fd1db..09399ed 100644
+--- a/fuse-ext2/fuse-ext2.h
++++ b/fuse-ext2/fuse-ext2.h
+@@ -178,7 +178,7 @@ int op_fgetattr (const char *path, struct stat *stbuf, struct fuse_file_info *fi
+ 
+ int op_getattr (const char *path, struct stat *stbuf);
+ 
+-int op_getxattr(const char *path, const char *name, char *value, size_t size);
++int op_getxattr(const char *path, const char *name, char *value, size_t size, uint32_t position);
+ 
+ ext2_file_t do_open (ext2_filsys e2fs, const char *path, int flags);
+ 
+diff --git a/fuse-ext2/op_getxattr.c b/fuse-ext2/op_getxattr.c
+index 27f95c3..eea5ae3 100644
+--- a/fuse-ext2/op_getxattr.c
++++ b/fuse-ext2/op_getxattr.c
+@@ -15,7 +15,8 @@
+ static int do_getxattr(ext2_filsys e2fs, struct ext2_inode *node, const char *name,
+ 		char *value, size_t size);
+ 
+-int op_getxattr(const char *path, const char *name, char *value, size_t size) {
++int op_getxattr(const char *path, const char *name, char *value, size_t size, uint32_t position) {
++	(void)position;
+ 	int rt;
+ 	ext2_ino_t ino;
+ 	struct ext2_inode inode;
+diff --git a/tools/macosx/Makefile.am b/tools/macosx/Makefile.am
+index 5afaaa4..533d09f 100644
+--- a/tools/macosx/Makefile.am
++++ b/tools/macosx/Makefile.am
+@@ -26,7 +26,5 @@ install-exec-local:
+ 	$(INSTALL) -m 644 $(top_srcdir)/tools/macosx/fuse-ext2.fs/Contents/Info.plist $(DESTDIR)/Library/Filesystems/fuse-ext2.fs/Contents/Info.plist
+ 	$(INSTALL) -m 644 $(top_srcdir)/tools/macosx/fuse-ext2.fs/Contents/PkgInfo $(DESTDIR)/Library/Filesystems/fuse-ext2.fs/Contents/PkgInfo
+ 	$(INSTALL) -m 644 $(top_srcdir)/tools/macosx/fuse-ext2.fs/Contents/Resources/English.lproj/InfoPlist.strings $(DESTDIR)/Library/Filesystems/fuse-ext2.fs/Contents/Resources/English.lproj/InfoPlist.strings
+-	$(INSTALL) -d $(DESTDIR)/Library/PreferencePanes
+-	cp -R $(top_srcdir)/tools/macosx/prefpane/build/Release/fuse-ext2.prefPane $(DESTDIR)/Library/PreferencePanes/fuse-ext2.prefPane
+ 
+ endif
+-- 
+2.49.0

--- a/Toolchain/Patches/fuse-ext2/macos/ReadMe.md
+++ b/Toolchain/Patches/fuse-ext2/macos/ReadMe.md
@@ -1,0 +1,14 @@
+# Patches for fuse-ext2 on macOS
+
+## `0001-Build-with-latest-macFUSE-on-macOS.patch`
+
+Build with latest macFUSE on macOS
+
+Adjusts the macOS build for current macFUSE headers and skips installing
+the legacy preference pane.
+
+The `op_getxattr` signature gains a `position` parameter required by the
+macFUSE 4.x FUSE API. The preference pane install step is removed because
+the prebuilt `.prefPane` bundle is no longer shipped in the source tree.
+
+https://github.com/alperakcan/fuse-ext2/issues/149


### PR DESCRIPTION
This pr contains 3 fixes that fixes building a disk image on macOS with macFUSE.

There is still an issue that files with non ascii characters will be written to the ext2 disk as non-normalized unicode utf-8. This will currently not render correctly in SerenityOS.

Fixes #25884

I've used AI coding tools to debug these issues.