### PR TITLE
MacVideoPlayer: Call finishLaunching just once

### DIFF
--- a/Meta/Lagom/Contrib/MacVideoPlayer/main.mm
+++ b/Meta/Lagom/Contrib/MacVideoPlayer/main.mm
@@ -18,7 +18,6 @@ int main()
     @autoreleasepool {
         NSArray* top_level_objects;
         [[NSBundle mainBundle] loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication] topLevelObjects:&top_level_objects];
-        [NSApp finishLaunching];
     }
 
     return event_loop.exec();


### PR DESCRIPTION
event_loop.exec() calls [NSApp run] which already calls finishLaunching internally, according to the finishLaunching docs.

When passing a file as a command-line arg, this would cause the file to be processed twice. For files that open successfully, that's not visible as the NSDocument infrastructure just activates the document's window the second time round. But for files that fail to open, we used to get two error dialogs. Now we get just one.