### PR TITLE
MacPDF+MacVideoPlayer: Remove duplicate .xib extension in ninja output

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/CMakeLists.txt
+++ b/Meta/Lagom/Contrib/MacPDF/CMakeLists.txt
@@ -58,5 +58,5 @@ foreach(xib ${RESOURCES})
         COMMAND ${IBTOOL} --errors --warnings --notices --output-format human-readable-text
                 --compile "$<TARGET_BUNDLE_DIR:MacPDF>/Contents/Resources/${nib}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/${xib}"
-        COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/${xib}.xib")
+        COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/${xib}")
 endforeach()

--- a/Meta/Lagom/Contrib/MacVideoPlayer/CMakeLists.txt
+++ b/Meta/Lagom/Contrib/MacVideoPlayer/CMakeLists.txt
@@ -58,5 +58,5 @@ foreach(xib ${RESOURCES})
         COMMAND ${IBTOOL} --errors --warnings --notices --output-format human-readable-text
                 --compile "$<TARGET_BUNDLE_DIR:MacVideoPlayer>/Contents/Resources/${nib}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/${xib}"
-        COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/${xib}.xib")
+        COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/${xib}")
 endforeach()


### PR DESCRIPTION
${xib} already ended in .xib, but we were adding a second .xib in the ninja build command description.

No behavior change, outside of `ninja` output to the console while building.