### PR TITLE
Ports/oniguruma: Upgrade to 6.9.10

### DIFF
--- a/Ports/oniguruma/package.sh
+++ b/Ports/oniguruma/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='oniguruma'
-version='6.9.9'
+version='6.9.10'
 useconfigure='true'
 use_fresh_config_sub='true'
 files=(
-    "https://github.com/kkos/oniguruma/releases/download/v${version}/onig-${version}.tar.gz#60162bd3b9fc6f4886d4c7a07925ffd374167732f55dce8c491bfd9cd818a6cf"
+    "https://github.com/kkos/oniguruma/releases/download/v${version}/onig-${version}.tar.gz#2a5cfc5ae259e4e97f86b68dfffc152cdaffe94e2060b770cb827238d769fc05"
 )
 workdir="onig-${version}"


### PR DESCRIPTION
This also fixes a build failure with LLVM/clang: the `alloca.h` include was guarded with `!defined(__GNUC__)`, which clang also defines for GCC compatibility, so the header was never included. Upstream fixed this in 6.9.10.