### PR TITLE
Ports/git: Use the correct strip program

### DIFF
--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -18,7 +18,7 @@ build() {
     run make \
         "${makeopts[@]}" \
         CURL_LDFLAGS='-lcurl -lssl -lcrypto -lz'
-    run make strip
+    run make strip STRIP="${STRIP}"
 }
 
 post_install() {


### PR DESCRIPTION
The host strip program will only work for the host architecture and throws an error during cross compilation.