### PR TITLE
Meta: Don't use virtio-net

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -732,8 +732,6 @@ def set_up_network_hardware(config: Configuration):
     provided_ethernet_device_type = environ.get("SERENITY_ETHERNET_DEVICE_TYPE")
     if provided_ethernet_device_type is not None:
         config.ethernet_device_type = provided_ethernet_device_type
-    elif config.architecture in [Arch.Aarch64, Arch.RISCV64] and not config.machine_type.is_raspberry_pi():
-        config.ethernet_device_type = "virtio-net-pci"
 
     if config.machine_type.is_raspberry_pi():
         config.network_backend = None


### PR DESCRIPTION
Our virtio-net driver is unstable and causes kernel panics, see issue #26477. Instead, use the e1000 device, like we already do on x86. (`ethernet_device_type` defaults to "e1000")