### PR TITLE
GMLCompiler+Userland: Make initialize a virtual function of GUI::Widget

### DIFF
--- a/Base/usr/share/man/man5/GML/Usage.md
+++ b/Base/usr/share/man/man5/GML/Usage.md
@@ -57,9 +57,10 @@ Initialization, like adding models, attaching callbacks, etc., should be done in
 
 ```cpp
 // MyApp::Widget
-ErrorOr<void> initialize();
+private:
+    virtual ErrorOr<void> initialize() override;
 ```
 
-This initializer function, if it exists, will automatically be called after the structure of your widget was set up by the auto-generated GML code.
+This initializer function will automatically be called after the structure of your widget was set up by the auto-generated GML code.
 
 The only case where this function cannot be used is when your initialization requires additional parameters, like a GUI window. You may still consider moving as much initialization to the canonical function as possible.

--- a/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/GMLCompiler/main.cpp
@@ -373,7 +373,9 @@ static ErrorOr<void> generate_loader_for_object(GUI::GML::Object const& gml_obje
         return {};
     }));
 
-    TRY(append(generator, "TRY(::GUI::initialize(*@object_name@));"));
+    if (gml_object.layout_object() != nullptr) {
+        TRY(append(generator, "TRY(@object_name@->initialize());"));
+    }
 
     generator.append(TRY(String::repeated(' ', (indentation - 1) * 4)));
     generator.appendln("}");

--- a/Toolchain/BuildJakt.sh
+++ b/Toolchain/BuildJakt.sh
@@ -82,7 +82,7 @@ buildstep_ninja() {
 
 mkdir -p "$DIR/Tarballs"
 
-JAKT_COMMIT_HASH="6f6c9e9005683b0c1cf59f6282a1bb15770e1c92"
+JAKT_COMMIT_HASH="ec3f4d3a1e2cd392d87116d6e5198221dd65c1bc"
 JAKT_NAME="jakt-${JAKT_COMMIT_HASH}"
 JAKT_TARBALL="${JAKT_NAME}.tar.gz"
 JAKT_GIT_URL="https://github.com/serenityos/jakt"

--- a/Userland/Applications/Browser/FindInPageWidget.h
+++ b/Userland/Applications/Browser/FindInPageWidget.h
@@ -24,6 +24,7 @@ class FindInPageWidget final
 public:
     virtual ~FindInPageWidget() override = default;
 
+    using GUI::Widget::initialize;
     void initialize(WebView::OutOfProcessWebView& web_view);
     void show(String const& global_term);
 

--- a/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.h
@@ -28,13 +28,13 @@ class AutoplaySettingsWidget : public GUI::SettingsWindow::Tab {
 
 public:
     static ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     AutoplaySettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     void set_allowlist_model(NonnullRefPtr<AutoplayAllowlistModel> model);
 

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
@@ -23,9 +23,9 @@ public:
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
-    ErrorOr<void> initialize();
-
 private:
+    virtual ErrorOr<void> initialize() override;
+
     RefPtr<GUI::TextBox> m_homepage_url_textbox;
     RefPtr<GUI::TextBox> m_new_tab_url_textbox;
     void set_color_scheme(StringView);

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.h
@@ -38,13 +38,13 @@ class ContentFilterSettingsWidget : public GUI::SettingsWindow::Tab {
 
 public:
     static ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     ContentFilterSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     void set_domain_list_model(NonnullRefPtr<DomainListModel>);
 

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -21,7 +21,6 @@ class CalculatorWidget final : public GUI::Widget {
     C_OBJECT(CalculatorWidget)
 public:
     static ErrorOr<NonnullRefPtr<CalculatorWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual ~CalculatorWidget() override = default;
     String get_entry();
@@ -36,6 +35,7 @@ public:
 
 private:
     CalculatorWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     void add_operation_button(GUI::Button&, Calculator::Operation);
     void add_digit_button(GUI::Button&, int digit);

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.h
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.h
@@ -16,13 +16,13 @@ class CalendarSettingsWidget final : public GUI::SettingsWindow::Tab {
 
 public:
     static ErrorOr<NonnullRefPtr<CalendarSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     CalendarSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     static constexpr Array<StringView, 2> const m_view_modes = { "Month"sv, "Year"sv };
 

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
@@ -61,11 +61,11 @@ class CertificateStoreWidget : public GUI::SettingsWindow::Tab {
 public:
     virtual ~CertificateStoreWidget() override = default;
     static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> try_create();
-    ErrorOr<void> initialize();
     virtual void apply_settings() override { }
 
 private:
     CertificateStoreWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     ErrorOr<void> import_pem();
     ErrorOr<void> export_pem();

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.h
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.h
@@ -33,6 +33,7 @@ public:
     int preferred_width() const;
     int preferred_height() const;
 
+    using GUI::Frame::initialize;
     void initialize(Gfx::BitmapFont*);
 
     int scale() const { return m_scale; }

--- a/Userland/Applications/FontEditor/MainWidget.h
+++ b/Userland/Applications/FontEditor/MainWidget.h
@@ -32,6 +32,7 @@ public:
     void show_error(Error, StringView action, StringView filename = {});
     void reset();
 
+    using GUI::Widget::initialize;
     ErrorOr<void> initialize(StringView path, RefPtr<Gfx::BitmapFont>&&);
     ErrorOr<void> initialize_menubar(GUI::Window&);
 

--- a/Userland/Applications/GamesSettings/CardSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/CardSettingsWidget.h
@@ -21,7 +21,6 @@ class CardSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(CardSettingsWidget)
 public:
     static ErrorOr<NonnullRefPtr<CardSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
     virtual ~CardSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -29,6 +28,7 @@ public:
 
 private:
     CardSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     bool set_card_back_image_path(StringView);
     String card_back_image_path() const;

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.h
@@ -18,7 +18,6 @@ class ChessSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(ChessSettingsWidget)
 public:
     static ErrorOr<NonnullRefPtr<ChessSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
     virtual ~ChessSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -26,6 +25,7 @@ public:
 
 private:
     ChessSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     Vector<ByteString> m_piece_sets;
 

--- a/Userland/Applications/Help/MainWidget.h
+++ b/Userland/Applications/Help/MainWidget.h
@@ -21,6 +21,7 @@ public:
 
     static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
 
+    using GUI::Widget::initialize;
     ErrorOr<void> initialize(GUI::Window&);
     ErrorOr<void> set_start_page(Vector<StringView, 2> query_parameters);
 

--- a/Userland/Applications/MailSettings/MailSettingsWidget.h
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.h
@@ -17,13 +17,13 @@ class MailSettingsWidget final : public GUI::SettingsWindow::Tab {
 
 public:
     static ErrorOr<NonnullRefPtr<MailSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     MailSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     ByteString m_server;
     ByteString m_port;

--- a/Userland/Applications/Maps/FavoritesPanel.h
+++ b/Userland/Applications/Maps/FavoritesPanel.h
@@ -17,7 +17,6 @@ class FavoritesPanel final : public GUI::StackWidget {
 
 public:
     static ErrorOr<NonnullRefPtr<FavoritesPanel>> try_create();
-    ErrorOr<void> initialize();
 
     void load_favorites();
     void reset();
@@ -29,6 +28,7 @@ public:
 
 private:
     FavoritesPanel() = default;
+    virtual ErrorOr<void> initialize() override;
 
     ErrorOr<void> edit_favorite(GUI::ModelIndex const& index);
     void favorites_changed();

--- a/Userland/Applications/Maps/SearchPanel.h
+++ b/Userland/Applications/Maps/SearchPanel.h
@@ -23,7 +23,6 @@ class SearchPanel final : public GUI::Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<SearchPanel>> try_create();
-    ErrorOr<void> initialize();
 
     void search(StringView query);
     void reset();
@@ -38,6 +37,7 @@ public:
 
 private:
     SearchPanel() = default;
+    virtual ErrorOr<void> initialize() override;
 
     RefPtr<Protocol::RequestClient> m_request_client;
     RefPtr<Protocol::Request> m_request;

--- a/Userland/Applications/MapsSettings/MapsSettingsWidget.h
+++ b/Userland/Applications/MapsSettings/MapsSettingsWidget.h
@@ -15,13 +15,13 @@ class MapsSettingsWidget final : public GUI::SettingsWindow::Tab {
 
 public:
     static ErrorOr<NonnullRefPtr<MapsSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
 private:
     MapsSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     void set_tile_provider(StringView tile_provider_url_format);
 

--- a/Userland/Applications/MouseSettings/HighlightWidget.h
+++ b/Userland/Applications/MouseSettings/HighlightWidget.h
@@ -17,7 +17,6 @@ class HighlightWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(HighlightWidget)
 public:
     static ErrorOr<NonnullRefPtr<HighlightWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual ~HighlightWidget() override = default;
 
@@ -26,6 +25,7 @@ public:
 
 private:
     HighlightWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     Gfx::Color highlight_color();
 

--- a/Userland/Applications/MouseSettings/MouseWidget.h
+++ b/Userland/Applications/MouseSettings/MouseWidget.h
@@ -16,7 +16,6 @@ class MouseWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(MouseWidget)
 public:
     static ErrorOr<NonnullRefPtr<MouseWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual ~MouseWidget() override = default;
 
@@ -25,6 +24,7 @@ public:
 
 private:
     MouseWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     void update_speed_label();
     void update_double_click_speed_label();

--- a/Userland/Applications/MouseSettings/ThemeWidget.h
+++ b/Userland/Applications/MouseSettings/ThemeWidget.h
@@ -68,7 +68,6 @@ class ThemeWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT_ABSTRACT(ThemeWidget)
 public:
     static ErrorOr<NonnullRefPtr<ThemeWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual ~ThemeWidget() override = default;
 
@@ -77,6 +76,7 @@ public:
 
 private:
     ThemeWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     RefPtr<GUI::TableView> m_cursors_tableview;
     RefPtr<GUI::ComboBox> m_theme_name_box;

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
@@ -17,13 +17,13 @@ class NetworkSettingsWidget : public GUI::SettingsWindow::Tab {
 
 public:
     static ErrorOr<NonnullRefPtr<NetworkSettingsWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual void apply_settings() override;
     void switch_adapter(ByteString const& adapter);
 
 private:
     NetworkSettingsWidget() = default;
+    virtual ErrorOr<void> initialize() override;
 
     struct NetworkAdapterData {
         bool enabled = false;

--- a/Userland/Applications/Piano/MainWidget.h
+++ b/Userland/Applications/Piano/MainWidget.h
@@ -39,7 +39,7 @@ public:
 private:
     explicit MainWidget(TrackManager&, AudioPlayerLoop&);
 
-    ErrorOr<void> initialize();
+    virtual ErrorOr<void> initialize() override;
 
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void keyup_event(GUI::KeyEvent&) override;

--- a/Userland/Applications/Piano/PlayerWidget.h
+++ b/Userland/Applications/Piano/PlayerWidget.h
@@ -26,7 +26,7 @@ public:
 private:
     explicit PlayerWidget(TrackManager&, MainWidget&, AudioPlayerLoop&);
 
-    ErrorOr<void> initialize();
+    virtual ErrorOr<void> initialize() override;
 
     TrackManager& m_track_manager;
     MainWidget& m_main_widget;

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -25,7 +25,6 @@ class MainWidget final : public GUI::Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
-    ErrorOr<void> initialize();
 
     virtual ~MainWidget() override = default;
     ErrorOr<void> read_file(ByteString const& filename, Core::File&);
@@ -50,6 +49,8 @@ public:
 
 private:
     MainWidget() = default;
+    virtual ErrorOr<void> initialize() override;
+
     void set_path(StringView);
     void update_preview();
     void update_markdown_preview();

--- a/Userland/Applications/UsersSettings/UserAddDialog.h
+++ b/Userland/Applications/UsersSettings/UserAddDialog.h
@@ -18,13 +18,12 @@ namespace UsersSettings {
 class UserAddDialog final : public GUI::Widget {
     C_OBJECT(UserAddDialog)
 public:
-    static ErrorOr<NonnullRefPtr<UserAddDialog>> try_create();
-    ErrorOr<void> initialize();
-
     static ErrorOr<Optional<String>> show(GUI::Window* parent_window);
 
 private:
     UserAddDialog() = default;
+    static ErrorOr<NonnullRefPtr<UserAddDialog>> try_create();
+    virtual ErrorOr<void> initialize() override;
 
     ErrorOr<void> add_user();
 

--- a/Userland/Applications/UsersSettings/UserDetailsWidget.h
+++ b/Userland/Applications/UsersSettings/UserDetailsWidget.h
@@ -30,6 +30,7 @@ public:
 private:
     UserDetailsWidget() = default;
 
+    using GUI::Widget::initialize;
     ErrorOr<void> initialize(Core::Account const& account);
     ErrorOr<void> change_password();
 

--- a/Userland/Applications/UsersSettings/UsersTab.h
+++ b/Userland/Applications/UsersSettings/UsersTab.h
@@ -27,7 +27,7 @@ public:
 
 private:
     UsersTab() = default;
-    ErrorOr<void> initialize();
+    virtual ErrorOr<void> initialize() override;
 
     ErrorOr<void> refresh_users();
     ErrorOr<void> add_user();

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -25,7 +25,6 @@ class VideoPlayerWidget final : public GUI::Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<VideoPlayerWidget>> try_create();
-    ErrorOr<void> initialize();
     virtual ~VideoPlayerWidget() override = default;
     void close_file();
     void open_file(FileSystemAccessClient::File filename);
@@ -43,6 +42,8 @@ public:
 
 private:
     VideoPlayerWidget() = default;
+    virtual ErrorOr<void> initialize() override;
+
     void update_play_pause_icon();
     void update_seek_slider_max();
     void set_current_timestamp(Duration);

--- a/Userland/Applications/Weather/view.jakt
+++ b/Userland/Applications/Weather/view.jakt
@@ -50,7 +50,7 @@ namespace Weather {
         public extern fn try_create() throws -> SearchView
         public fn construct() => must try_create()
 
-        public fn initialize(mut this) throws {
+        public override fn initialize(mut this) throws {
             .content = must_be<GUI::Widget>("content", .find_descendant_of_type_named<UnderlyingClassTypeOf<GUI::Widget>>("content"))
         }
     }
@@ -68,7 +68,7 @@ namespace Weather {
 
         public extern fn try_create() throws -> View
         public fn construct() =>  must try_create()
-        public fn initialize(mut this) throws {
+        public override fn initialize(mut this) throws {
             .content = must_be<GUI::Widget>("content", .find_descendant_of_type_named<UnderlyingClassTypeOf<GUI::Widget>>("content"))
             .searchbox = must_be<GUI::TextBox>("searchbox", .find_descendant_of_type_named<UnderlyingClassTypeOf<GUI::TextBox>>("searchbox"))
         }
@@ -114,7 +114,7 @@ namespace Weather {
 
         public fn construct() -> IndividualEntryWidget => must try_create()
         public extern fn try_create() throws -> IndividualEntryWidget
-        public fn initialize(mut this) throws {
+        public override fn initialize(mut this) throws {
             .description = must_be<GUI::Label>(
                 "description"
                 .find_descendant_of_type_named<UnderlyingClassTypeOf<GUI::Label>>("description")

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -75,7 +75,7 @@ GitWidget::GitWidget()
     m_staged_files->set_foreground_role(Gfx::ColorRole::Green);
 }
 
-bool GitWidget::initialize()
+bool GitWidget::initialize_impl()
 {
     auto result = GitRepo::try_to_create(m_repo_root);
     switch (result.type) {
@@ -102,7 +102,7 @@ bool GitWidget::initialize_if_needed()
     if (initialized())
         return true;
 
-    return initialize();
+    return initialize_impl();
 }
 
 void GitWidget::refresh()

--- a/Userland/DevTools/HackStudio/Git/GitWidget.h
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.h
@@ -29,7 +29,7 @@ public:
 private:
     explicit GitWidget();
 
-    bool initialize();
+    bool initialize_impl();
     bool initialize_if_needed();
     void stage_file(ByteString const&);
     void unstage_file(ByteString const&);

--- a/Userland/DevTools/SQLStudio/MainWidget.h
+++ b/Userland/DevTools/SQLStudio/MainWidget.h
@@ -24,7 +24,6 @@ class MainWidget : public GUI::Widget {
 public:
     virtual ~MainWidget() = default;
     static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
-    ErrorOr<void> initialize();
 
     ErrorOr<void> initialize_menu(GUI::Window*);
     void open_new_script();
@@ -33,6 +32,8 @@ public:
     bool request_close();
 
 private:
+    virtual ErrorOr<void> initialize() override;
+
     ScriptEditor* active_editor();
 
     void update_title();

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -121,7 +121,7 @@ ErrorOr<NonnullRefPtr<Field>> Field::create(GUI::Label& flag_label, GUI::Label& 
     field->m_bad_face_bitmap = TRY(Gfx::Bitmap::load_from_file("/res/graphics/minesweeper/face-bad.png"sv));
     for (int i = 0; i < 8; ++i)
         field->m_number_bitmap[i] = TRY(Gfx::Bitmap::load_from_file(ByteString::formatted("/res/graphics/minesweeper/{}.png", i + 1)));
-    field->initialize();
+    MUST(field->initialize());
     return field;
 }
 
@@ -133,7 +133,7 @@ Field::Field(GUI::Label& flag_label, GUI::Label& time_label, GUI::Button& face_b
 {
 }
 
-void Field::initialize()
+ErrorOr<void> Field::initialize()
 {
     m_timer = Core::Timer::create_repeating(
         1000, [this] {
@@ -168,6 +168,8 @@ void Field::initialize()
 
         set_single_chording(single_chording);
     }
+
+    return {};
 }
 
 void Field::set_face(Face face)

--- a/Userland/Games/Minesweeper/Field.h
+++ b/Userland/Games/Minesweeper/Field.h
@@ -111,7 +111,7 @@ public:
 private:
     Field(GUI::Label& flag_label, GUI::Label& time_label, GUI::Button& face_button);
 
-    void initialize();
+    virtual ErrorOr<void> initialize() override;
 
     virtual void paint_event(GUI::PaintEvent&) override;
 

--- a/Userland/Libraries/LibGUI/GlyphMapWidget.h
+++ b/Userland/Libraries/LibGUI/GlyphMapWidget.h
@@ -20,6 +20,7 @@ class GlyphMapWidget final : public AbstractScrollableWidget {
 public:
     virtual ~GlyphMapWidget() override = default;
 
+    using AbstractScrollableWidget::initialize;
     ErrorOr<void> initialize(Gfx::Font const*);
 
     class Selection {

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.h
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.h
@@ -16,7 +16,7 @@ class IncrementalSearchBanner final : public Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<IncrementalSearchBanner>> try_create(TextEditor& editor);
-    ErrorOr<void> initialize();
+    virtual ErrorOr<void> initialize() override;
 
     virtual ~IncrementalSearchBanner() override = default;
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -71,19 +71,13 @@ enum class AllowCallback {
     Yes
 };
 
-template<typename T>
-ALWAYS_INLINE ErrorOr<void> initialize(T& object)
-{
-    if constexpr (requires { { object.initialize() } -> SameAs<ErrorOr<void>>; })
-        return object.initialize();
-    else
-        return {};
-}
-
 class Widget : public GUI::Object {
     C_OBJECT(Widget)
 public:
     virtual ~Widget() override;
+
+    // This is intended to be used for custom initialization of GML-compiled Widgets.
+    virtual ErrorOr<void> initialize() { return {}; }
 
     Layout* layout() { return m_layout.ptr(); }
     Layout const* layout() const { return m_layout.ptr(); }


### PR DESCRIPTION
This allows us to unconditionally call `widget->initialize()` in the
GMLCompiler instead of having to use `GUI::initialize(widget)`, allowing
us to retire the helper.

The role of `GUI::initialize` was to call `widget.initialize()` if the
method existed on the widget or otherwise return silently. It is however
bounded to the visibility of the function itself, meaning that if a
widget defined a private `initialize()`, it would not be considered.

Visibility being a compile-time property, I expect a compiler error if I
incorrectly restrict the visibility of a method. `GUI::initialize` had
the surprising behavior of silencing these errors leaving you with a
broken half-initialized GUI.

Now that initialize is a virtual method, widgets can implement the
override as private without issues.

This fixes UsersSettings (which has a widget with a private initialize).

Also, this commit makes most initialization methods private as they
don't need to be public anymore.

---

Before:
<img width="411" height="510" alt="Screenshot From 2026-05-02 16-13-51-1" src="https://github.com/user-attachments/assets/ef21b597-b706-4177-9eae-e3761c492849" />

After:
<img width="411" height="510" alt="Screenshot From 2026-05-02 16-15-41" src="https://github.com/user-attachments/assets/5770bdfb-619f-49bb-84e4-123a75f24b18" />

Alternative title for the PR is "watch me going down a rabbit hole and blaming GUI::initialize while this could have been a one line fix :clown_face:".