### PR TITLE
UsersSettings+Utilities/groupmod: Add groups management

### DIFF
--- a/Base/usr/share/man/man1/Applications/UsersSettings.md
+++ b/Base/usr/share/man/man1/Applications/UsersSettings.md
@@ -12,7 +12,7 @@ $ UsersSettings
 
 ## Description
 
-`Users Settings` is an application for managing user accounts on the system.
+`Users Settings` is an application for managing user accounts and groups on the system.
 
 ### User List
 
@@ -46,3 +46,26 @@ Click the **Change Password...** button in the user details panel to open the _C
 ### Deleting a User
 
 Select a user from the list and click the **Delete** button. A confirmation dialog will appear before the account and its home directory are permanently removed.
+
+### Group List
+
+The **Groups** tab lists all groups present on the system. Selecting a group shows its name, GID, and members.
+
+The members list includes both:
+
+-   users explicitly listed in `/etc/group`
+-   users whose primary GID matches the selected group
+
+Primary-group members are shown for visibility, but they cannot be removed from the group from this dialog because that membership is controlled by the user account itself.
+
+### Adding a Group
+
+Click the **Add** button below the group list to open the _Add Group_ dialog, then enter the new group name.
+
+### Editing a Group
+
+Select a group to edit its name or manage explicit group members, then click **Apply Changes** to save the modifications.
+
+### Deleting a Group
+
+Select a group and click the **Delete** button to remove it. System groups cannot be deleted, and a group cannot be removed while it is still the primary group of any user.

--- a/Base/usr/share/man/man8/groupadd.md
+++ b/Base/usr/share/man/man8/groupadd.md
@@ -33,5 +33,6 @@ This program must be run as root.
 ## See Also
 
 -   [`useradd`(8)](help://man/8/useradd)
+-   [`groupmod`(8)](help://man/8/groupmod)
 -   [`groupdel`(8)](help://man/8/groupdel)
 -   [`groups`(1)](help://man/1/groups)

--- a/Base/usr/share/man/man8/groupdel.md
+++ b/Base/usr/share/man/man8/groupdel.md
@@ -10,7 +10,7 @@ groupdel - delete a group
 
 ## Description
 
-This program deletes a group in the system.
+This program deletes a group from the system.
 
 This program must be run as root.
 
@@ -43,4 +43,5 @@ You should manually check all users to ensure that no user remain in this group.
 
 -   [`userdel`(8)](help://man/8/userdel)
 -   [`groupadd`(8)](help://man/8/groupadd)
+-   [`groupmod`(8)](help://man/8/groupmod)
 -   [`groups`(1)](help://man/1/groups)

--- a/Base/usr/share/man/man8/groupmod.md
+++ b/Base/usr/share/man/man8/groupmod.md
@@ -1,0 +1,42 @@
+## Name
+
+groupmod - modify an existing group
+
+## Synopsis
+
+```**sh
+# groupmod [options] <group>
+```
+
+## Description
+
+This program modifies an existing group in the system.
+
+This program must be run as root.
+
+## Options
+
+-   `-n`, `--new-name` _new-name_: Rename the group to _new-name_.
+
+## Exit Values
+
+-   0 - Success
+-   6 - Specified group doesn't exist
+-   9 - Group with the requested new name already exists
+
+## Files
+
+-   `/etc/group` - group information is updated in this file.
+
+## Examples
+
+```sh
+# groupmod -n developers contributors
+```
+
+## See Also
+
+-   [`usermod`(8)](help://man/8/usermod)
+-   [`groupadd`(8)](help://man/8/groupadd)
+-   [`groupdel`(8)](help://man/8/groupdel)
+-   [`groups`(1)](help://man/1/groups)

--- a/Userland/Applications/UsersSettings/AddMemberDialog.cpp
+++ b/Userland/Applications/UsersSettings/AddMemberDialog.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "AddMemberDialog.h"
+#include <LibGUI/Button.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/ItemListModel.h>
+
+namespace UsersSettings {
+
+ErrorOr<void> AddMemberDialog::initialize()
+{
+    m_user_combobox = find_descendant_of_type_named<GUI::ComboBox>("user_combobox");
+    return {};
+}
+
+ErrorOr<Optional<String>> AddMemberDialog::show(GUI::Window* parent_window, Vector<String> const& available_usernames)
+{
+    auto dialog = TRY(GUI::Dialog::try_create(parent_window));
+    dialog->set_title("Add Member");
+    dialog->resize(260, 64);
+    dialog->set_resizable(false);
+
+    auto widget = TRY(AddMemberDialog::try_create());
+    widget->m_user_combobox->set_model(*GUI::ItemListModel<String>::create(available_usernames));
+    widget->m_user_combobox->set_only_allow_values_from_model(true);
+    widget->m_user_combobox->set_selected_index(0);
+    dialog->set_main_widget(widget);
+
+    auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
+    ok_button.on_click = [&dialog](auto) { dialog->done(GUI::Dialog::ExecResult::OK); };
+    ok_button.set_default(true);
+
+    auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+    cancel_button.on_click = [&dialog](auto) { dialog->done(GUI::Dialog::ExecResult::Cancel); };
+
+    if (dialog->exec() != GUI::Dialog::ExecResult::OK)
+        return OptionalNone {};
+
+    return available_usernames[widget->m_user_combobox->selected_index()];
+}
+
+}

--- a/Userland/Applications/UsersSettings/AddMemberDialog.gml
+++ b/Userland/Applications/UsersSettings/AddMemberDialog.gml
@@ -1,0 +1,45 @@
+@UsersSettings::AddMemberDialog {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [4]
+        spacing: 4
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {
+            spacing: 4
+        }
+
+        @GUI::Label {
+            text: "User:"
+            text_alignment: "CenterLeft"
+            fixed_width: 50
+        }
+
+        @GUI::ComboBox {
+            name: "user_combobox"
+        }
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {
+            spacing: 4
+        }
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::DialogButton {
+            name: "ok_button"
+            text: "Add"
+            fixed_width: 75
+        }
+
+        @GUI::DialogButton {
+            name: "cancel_button"
+            text: "Cancel"
+            fixed_width: 75
+        }
+    }
+}

--- a/Userland/Applications/UsersSettings/AddMemberDialog.h
+++ b/Userland/Applications/UsersSettings/AddMemberDialog.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+
+namespace UsersSettings {
+
+class AddMemberDialog final : public GUI::Widget {
+    C_OBJECT(AddMemberDialog)
+public:
+    static ErrorOr<NonnullRefPtr<AddMemberDialog>> try_create();
+    ErrorOr<void> initialize();
+
+    static ErrorOr<Optional<String>> show(GUI::Window* parent_window, Vector<String> const& available_usernames);
+
+private:
+    AddMemberDialog() = default;
+
+    RefPtr<GUI::ComboBox> m_user_combobox;
+};
+
+}

--- a/Userland/Applications/UsersSettings/CMakeLists.txt
+++ b/Userland/Applications/UsersSettings/CMakeLists.txt
@@ -8,6 +8,10 @@ compile_gml(UsersTab.gml UsersTabGML.cpp)
 compile_gml(UserAddDialog.gml UserAddDialogGML.cpp)
 compile_gml(UserDetailsWidget.gml UserDetailsWidgetGML.cpp)
 compile_gml(ChangePasswordDialog.gml ChangePasswordDialogGML.cpp)
+compile_gml(GroupsTab.gml GroupsTabGML.cpp)
+compile_gml(GroupAddDialog.gml GroupAddDialogGML.cpp)
+compile_gml(GroupDetailsWidget.gml GroupDetailsWidgetGML.cpp)
+compile_gml(AddMemberDialog.gml AddMemberDialogGML.cpp)
 
 set(SOURCES
     main.cpp
@@ -18,6 +22,14 @@ set(SOURCES
     UserDetailsWidget.cpp
     UserDetailsWidgetGML.cpp
     ChangePasswordDialogGML.cpp
+    GroupsTab.cpp
+    GroupsTabGML.cpp
+    GroupAddDialog.cpp
+    GroupAddDialogGML.cpp
+    GroupDetailsWidget.cpp
+    GroupDetailsWidgetGML.cpp
+    AddMemberDialog.cpp
+    AddMemberDialogGML.cpp
 )
 
 serenity_app(UsersSettings ICON app-user-settings)

--- a/Userland/Applications/UsersSettings/Constants.h
+++ b/Userland/Applications/UsersSettings/Constants.h
@@ -12,6 +12,7 @@
 namespace UsersSettings {
 
 static constexpr u32 MIN_NORMAL_UID = 100;
+static constexpr u32 MIN_NORMAL_GID = 100;
 static constexpr Array ACCOUNT_TYPE_NAMES = { "Standard"sv, "Administrator"sv };
 static constexpr StringView WHEEL_GROUP_NAME = "wheel"sv;
 static constexpr Array DEFAULT_USER_GROUPS = { "users"sv, "window"sv, "audio"sv, "lookup"sv, "phys"sv };

--- a/Userland/Applications/UsersSettings/GroupAddDialog.cpp
+++ b/Userland/Applications/UsersSettings/GroupAddDialog.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GroupAddDialog.h"
+#include <LibCore/Group.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/MessageBox.h>
+
+namespace UsersSettings {
+
+ErrorOr<void> GroupAddDialog::initialize()
+{
+    m_group_name_textbox = find_descendant_of_type_named<GUI::TextBox>("group_name_textbox");
+    return {};
+}
+
+ErrorOr<Optional<String>> GroupAddDialog::show(GUI::Window* parent_window)
+{
+    auto dialog = TRY(GUI::Dialog::try_create(parent_window));
+    dialog->set_title("Add Group");
+    dialog->resize(260, 64);
+    dialog->set_resizable(false);
+
+    auto widget = TRY(GroupAddDialog::try_create());
+    dialog->set_main_widget(widget);
+
+    Optional<String> created_group_name;
+
+    auto& ok_button = *widget->find_descendant_of_type_named<GUI::Button>("ok_button");
+    ok_button.on_click = [&](auto) {
+        auto group_name = MUST(String::from_byte_string(widget->m_group_name_textbox->text()));
+        if (group_name.is_empty()) {
+            GUI::MessageBox::show(dialog, "Group name must not be empty."sv, "Error"sv, GUI::MessageBox::Type::Error);
+            return;
+        }
+
+        if (auto result = widget->add_group(); result.is_error()) {
+            GUI::MessageBox::show_error(dialog, MUST(String::formatted("Failed to add group: {}", result.error())));
+            return;
+        }
+
+        created_group_name = group_name;
+        dialog->done(GUI::Dialog::ExecResult::OK);
+    };
+    ok_button.set_default(true);
+
+    auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+    cancel_button.on_click = [dialog](auto) {
+        dialog->done(GUI::Dialog::ExecResult::Cancel);
+    };
+
+    dialog->exec();
+    return created_group_name;
+}
+
+ErrorOr<void> GroupAddDialog::add_group()
+{
+    auto name = TRY(String::from_byte_string(m_group_name_textbox->text()));
+    Core::Group group { name.to_byte_string() };
+    TRY(Core::Group::add_group(group));
+    return {};
+}
+
+}

--- a/Userland/Applications/UsersSettings/GroupAddDialog.gml
+++ b/Userland/Applications/UsersSettings/GroupAddDialog.gml
@@ -1,0 +1,42 @@
+@UsersSettings::GroupAddDialog {
+    fixed_width: 260
+    fixed_height: 64
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [4]
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {}
+
+        @GUI::Label {
+            text: "Group Name:"
+            text_alignment: "CenterLeft"
+            fixed_width: 90
+        }
+
+        @GUI::TextBox {
+            name: "group_name_textbox"
+        }
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {}
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::DialogButton {
+            name: "ok_button"
+            text: "Add"
+            fixed_width: 75
+        }
+
+        @GUI::DialogButton {
+            name: "cancel_button"
+            text: "Cancel"
+            fixed_width: 75
+        }
+    }
+}

--- a/Userland/Applications/UsersSettings/GroupAddDialog.h
+++ b/Userland/Applications/UsersSettings/GroupAddDialog.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibGUI/TextBox.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+
+namespace UsersSettings {
+
+class GroupAddDialog final : public GUI::Widget {
+    C_OBJECT(GroupAddDialog)
+public:
+    static ErrorOr<NonnullRefPtr<GroupAddDialog>> try_create();
+    ErrorOr<void> initialize();
+
+    static ErrorOr<Optional<String>> show(GUI::Window* parent_window);
+
+private:
+    GroupAddDialog() = default;
+
+    ErrorOr<void> add_group();
+
+    RefPtr<GUI::TextBox> m_group_name_textbox;
+};
+
+}

--- a/Userland/Applications/UsersSettings/GroupDetailsWidget.cpp
+++ b/Userland/Applications/UsersSettings/GroupDetailsWidget.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GroupDetailsWidget.h"
+#include "AddMemberDialog.h"
+#include "Constants.h"
+#include <AK/HashTable.h>
+#include <AK/String.h>
+#include <LibCore/Account.h>
+#include <LibCore/System.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/ItemListModel.h>
+#include <LibGUI/MessageBox.h>
+
+namespace UsersSettings {
+
+ErrorOr<NonnullRefPtr<GroupDetailsWidget>> GroupDetailsWidget::create(Core::Group const& group)
+{
+    auto widget = TRY(try_create());
+    TRY(widget->initialize(group));
+    return widget;
+}
+
+ErrorOr<void> GroupDetailsWidget::initialize(Core::Group const& group)
+{
+    m_group = group;
+
+    m_group_name_textbox = find_descendant_of_type_named<GUI::TextBox>("group_name_textbox");
+    m_gid_textbox = find_descendant_of_type_named<GUI::TextBox>("gid_textbox");
+    m_members_list = find_descendant_of_type_named<GUI::ListView>("members_list");
+    m_add_member_button = find_descendant_of_type_named<GUI::Button>("add_member_button");
+    m_remove_member_button = find_descendant_of_type_named<GUI::Button>("remove_member_button");
+
+    m_group_name_textbox->set_text(group.name());
+    m_group_name_textbox->on_change = [this] {
+        if (on_modified)
+            on_modified();
+    };
+    m_gid_textbox->set_text(ByteString::formatted("{}", group.id()));
+
+    TRY(refresh_members());
+
+    m_remove_member_button->set_enabled(false);
+
+    m_members_list->on_selection_change = [this]() {
+        auto index = m_members_list->selection().first();
+        m_remove_member_button->set_enabled(index.is_valid() && index.row() < (int)m_members.size() && !m_members[index.row()].is_primary_group_member);
+    };
+
+    m_add_member_button->on_click = [this](auto) {
+        if (auto result = add_member(); result.is_error())
+            GUI::MessageBox::show_error(window(), "Failed to add member"sv);
+    };
+
+    m_remove_member_button->on_click = [this](auto) {
+        remove_member();
+    };
+
+    return {};
+}
+
+ErrorOr<void> GroupDetailsWidget::refresh_members()
+{
+    VERIFY(m_group.has_value());
+    auto accounts = TRY(Core::Account::all(Core::Account::Read::PasswdOnly));
+    HashTable<ByteString> primary_group_members;
+    for (auto const& account : accounts) {
+        if (account.gid() == m_group->id())
+            primary_group_members.set(account.username());
+    }
+
+    m_members.clear();
+    m_member_names.clear();
+    for (auto const& member : m_group->members()) {
+        auto username = TRY(String::from_byte_string(member));
+        m_members.append({ username, primary_group_members.contains(member) });
+        m_member_names.append(move(username));
+    }
+
+    for (auto const& account : accounts) {
+        if (account.gid() != m_group->id())
+            continue;
+
+        auto username = TRY(String::from_byte_string(account.username()));
+        bool already_listed = m_members.find_if([&](auto const& member) {
+            return member.username == username;
+        }) != m_members.end();
+        if (already_listed)
+            continue;
+
+        m_members.append({ username, true });
+        m_member_names.append(move(username));
+    }
+
+    if (m_members_list)
+        m_members_list->set_model(*GUI::ItemListModel<String>::create(m_member_names));
+    if (m_remove_member_button)
+        m_remove_member_button->set_enabled(false);
+    return {};
+}
+
+ErrorOr<void> GroupDetailsWidget::add_member()
+{
+    VERIFY(m_group.has_value());
+
+    auto accounts = TRY(Core::Account::all(Core::Account::Read::PasswdOnly));
+    Vector<String> available_usernames;
+    for (auto const& account : accounts) {
+        if (account.uid() < MIN_NORMAL_UID)
+            continue;
+        if (account.gid() == m_group->id())
+            continue;
+        if (!m_group->members().contains_slow(account.username()))
+            available_usernames.append(TRY(String::from_byte_string(account.username())));
+    }
+
+    if (available_usernames.is_empty()) {
+        GUI::MessageBox::show(window(), "All users are already members of this group."sv,
+            "No Users Available"sv, GUI::MessageBox::Type::Information);
+        return {};
+    }
+
+    auto selected = TRY(AddMemberDialog::show(window(), available_usernames));
+    if (!selected.has_value())
+        return {};
+
+    m_group->members().append(selected->to_byte_string());
+    TRY(refresh_members());
+    if (on_modified)
+        on_modified();
+    return {};
+}
+
+void GroupDetailsWidget::remove_member()
+{
+    VERIFY(m_group.has_value());
+
+    auto index = m_members_list->selection().first();
+    if (!index.is_valid())
+        return;
+
+    VERIFY(index.row() < (int)m_members.size());
+    auto const& member = m_members[index.row()];
+    if (member.is_primary_group_member) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Cannot remove \"{}\" from its primary group.", member.username)));
+        return;
+    }
+
+    m_group->members().remove_all_matching([&](auto const& username) {
+        return username == member.username.bytes_as_string_view();
+    });
+    MUST(refresh_members());
+    if (on_modified)
+        on_modified();
+}
+
+ErrorOr<void> GroupDetailsWidget::apply_changes()
+{
+    VERIFY(m_group.has_value());
+
+    auto new_name = m_group_name_textbox->text();
+    if (new_name != m_group->name()) {
+        TRY(Core::Group::validate_name(new_name));
+
+        if (m_group->id() < MIN_NORMAL_GID)
+            return Error::from_string_literal("Cannot rename a system group.");
+
+        auto existing = TRY(Core::System::getgrnam(new_name));
+        if (existing.has_value())
+            return Error::from_string_literal("A group with that name already exists.");
+
+        m_group->set_name(new_name);
+    }
+
+    TRY(m_group->sync());
+    return {};
+}
+
+}

--- a/Userland/Applications/UsersSettings/GroupDetailsWidget.gml
+++ b/Userland/Applications/UsersSettings/GroupDetailsWidget.gml
@@ -1,0 +1,71 @@
+@UsersSettings::GroupDetailsWidget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 4
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {}
+
+        @GUI::Label {
+            text: "Group Name:"
+            text_alignment: "CenterLeft"
+            fixed_width: 120
+        }
+
+        @GUI::TextBox {
+            name: "group_name_textbox"
+        }
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {}
+
+        @GUI::Label {
+            text: "GID:"
+            text_alignment: "CenterLeft"
+            fixed_width: 120
+        }
+
+        @GUI::TextBox {
+            name: "gid_textbox"
+            mode: "DisplayOnly"
+        }
+    }
+
+    @GUI::Label {
+        text: "Group Members:"
+        text_alignment: "CenterLeft"
+        fixed_height: 16
+    }
+
+    @GUI::ListView {
+        name: "members_list"
+        should_hide_unnecessary_scrollbars: true
+        alternating_row_colors: false
+    }
+
+    @GUI::Widget {
+        fixed_height: 24
+        layout: @GUI::HorizontalBoxLayout {
+            spacing: 4
+        }
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::Button {
+            name: "add_member_button"
+            text: "Add Member..."
+            fixed_width: 110
+        }
+
+        @GUI::Button {
+            name: "remove_member_button"
+            text: "Remove Member"
+            fixed_width: 110
+        }
+    }
+}

--- a/Userland/Applications/UsersSettings/GroupDetailsWidget.h
+++ b/Userland/Applications/UsersSettings/GroupDetailsWidget.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibCore/Group.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/ListView.h>
+#include <LibGUI/TextBox.h>
+#include <LibGUI/Widget.h>
+
+namespace UsersSettings {
+
+class GroupDetailsWidget final : public GUI::Widget {
+    C_OBJECT(GroupDetailsWidget)
+
+public:
+    static ErrorOr<NonnullRefPtr<GroupDetailsWidget>> create(Core::Group const& group);
+    static ErrorOr<NonnullRefPtr<GroupDetailsWidget>> try_create();
+
+    ErrorOr<void> apply_changes();
+
+    ByteString current_name() const { return m_group_name_textbox->text(); }
+
+    Function<void()> on_modified;
+
+private:
+    struct MemberEntry {
+        String username;
+        bool is_primary_group_member { false };
+    };
+
+    GroupDetailsWidget() = default;
+
+    ErrorOr<void> initialize(Core::Group const& group);
+    ErrorOr<void> refresh_members();
+    ErrorOr<void> add_member();
+    void remove_member();
+
+    Optional<Core::Group> m_group;
+    RefPtr<GUI::TextBox> m_group_name_textbox;
+    RefPtr<GUI::TextBox> m_gid_textbox;
+    RefPtr<GUI::ListView> m_members_list;
+    Vector<MemberEntry> m_members;
+    Vector<String> m_member_names;
+    RefPtr<GUI::Button> m_add_member_button;
+    RefPtr<GUI::Button> m_remove_member_button;
+};
+
+}

--- a/Userland/Applications/UsersSettings/GroupsTab.cpp
+++ b/Userland/Applications/UsersSettings/GroupsTab.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GroupsTab.h"
+#include "Constants.h"
+#include "GroupAddDialog.h"
+#include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
+#include <LibCore/Account.h>
+#include <LibCore/Group.h>
+#include <LibGUI/AbstractView.h>
+#include <LibGUI/ItemListModel.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
+
+namespace UsersSettings {
+
+static ErrorOr<bool> can_delete_group(Core::Group const& group)
+{
+    if (group.id() < MIN_NORMAL_GID)
+        return false;
+
+    auto accounts = TRY(Core::Account::all(Core::Account::Read::PasswdOnly));
+    for (auto const& account : accounts) {
+        if (account.gid() == group.id())
+            return false;
+    }
+
+    return true;
+}
+
+ErrorOr<void> GroupsTab::initialize()
+{
+    m_groups_list = *find_descendant_of_type_named<GUI::ListView>("groups_list");
+    m_add_button = *find_descendant_of_type_named<GUI::Button>("add_button");
+    m_delete_button = *find_descendant_of_type_named<GUI::Button>("delete_button");
+    m_details_container = *find_descendant_of_type_named<GUI::Widget>("details_container");
+
+    m_no_selection_label = TRY(GUI::Label::try_create());
+    m_no_selection_label->set_text("Select a group to view details"_string);
+    m_no_selection_label->set_text_alignment(Gfx::TextAlignment::Center);
+    m_details_container->add_child(*m_no_selection_label);
+
+    m_delete_button->set_enabled(false);
+
+    TRY(refresh_groups());
+
+    m_groups_list->on_selection_change = [this]() {
+        auto index = m_groups_list->selection().first();
+        m_delete_button->set_enabled(false);
+
+        m_details_container->remove_all_children();
+        m_group_details_widget = nullptr;
+        set_modified(false);
+        ArmedScopeGuard on_error_path = [this]() {
+            m_details_container->add_child(*m_no_selection_label);
+        };
+
+        if (!index.is_valid())
+            return;
+
+        auto groups = Core::Group::all();
+        if (groups.is_error())
+            return;
+
+        Optional<Core::Group> selected_group;
+        for (auto& group : groups.value()) {
+            if (group.name() == m_group_names[index.row()].bytes_as_string_view()) {
+                selected_group = group;
+                break;
+            }
+        }
+        if (!selected_group.has_value())
+            return;
+
+        auto can_delete = can_delete_group(selected_group.value());
+        if (can_delete.is_error())
+            return;
+        m_delete_button->set_enabled(can_delete.release_value());
+
+        auto widget = GroupDetailsWidget::create(selected_group.value());
+        if (widget.is_error()) {
+            GUI::MessageBox::show_error(window(), "Failed to load group details"sv);
+            return;
+        }
+
+        on_error_path.disarm();
+        m_group_details_widget = widget.release_value();
+        m_group_details_widget->on_modified = [this] { set_modified(true); };
+        m_details_container->add_child(*m_group_details_widget);
+    };
+
+    m_add_button->on_click = [this](auto) {
+        if (auto result = add_group(); result.is_error())
+            GUI::MessageBox::show_error(window(), "Failed to add group"sv);
+    };
+
+    m_delete_button->on_click = [this](auto) {
+        auto index = m_groups_list->selection().first();
+        if (!index.is_valid())
+            return;
+        if (auto result = delete_group(m_group_names[index.row()].bytes_as_string_view()); result.is_error())
+            GUI::MessageBox::show_error(window(), "Failed to delete group"sv);
+    };
+
+    return {};
+}
+
+ErrorOr<void> GroupsTab::refresh_groups()
+{
+    auto groups = TRY(Core::Group::all());
+    m_group_names.clear();
+    for (auto& group : groups)
+        m_group_names.append(TRY(String::from_byte_string(group.name())));
+    if (m_groups_list)
+        m_groups_list->set_model(*GUI::ItemListModel<String>::create(m_group_names));
+    return {};
+}
+
+ErrorOr<void> GroupsTab::add_group()
+{
+    auto group_name = TRY(GroupAddDialog::show(window()));
+    if (!group_name.has_value())
+        return {};
+
+    TRY(refresh_groups());
+
+    // Select the newly created group.
+    auto it = m_group_names.find_if([&group_name](auto const& name) { return name == group_name.value(); });
+    if (!it.is_end()) {
+        auto index = m_groups_list->model()->index((int)it.index());
+        m_groups_list->set_cursor(index, GUI::AbstractView::SelectionUpdate::Set);
+    }
+    return {};
+}
+
+ErrorOr<void> GroupsTab::delete_group(StringView group_name)
+{
+    auto groups = TRY(Core::Group::all());
+    Optional<Core::Group> target;
+    for (auto& group : groups) {
+        if (group.name() == group_name) {
+            target = group;
+            break;
+        }
+    }
+    if (!target.has_value() || !TRY(can_delete_group(target.value())))
+        return {};
+
+    auto result = GUI::MessageBox::show(window(),
+        TRY(String::formatted("Are you sure you want to delete group \"{}\"?", group_name)),
+        "Confirm Deletion"sv,
+        GUI::MessageBox::Type::Warning,
+        GUI::MessageBox::InputType::YesNo);
+    if (result != GUI::MessageBox::ExecResult::Yes)
+        return {};
+
+    TRY(Core::Group::delete_group(group_name));
+
+    m_details_container->remove_all_children();
+    m_group_details_widget = nullptr;
+    m_details_container->add_child(*m_no_selection_label);
+    TRY(refresh_groups());
+    return {};
+}
+
+void GroupsTab::apply_settings()
+{
+    if (!m_group_details_widget)
+        return;
+
+    auto new_name = m_group_details_widget->current_name();
+    if (auto result = m_group_details_widget->apply_changes(); result.is_error()) {
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Failed to apply settings: {}", result.error())));
+        return;
+    }
+
+    if (auto result = refresh_groups(); result.is_error())
+        return;
+
+    auto it = m_group_names.find_if([&new_name](auto const& name) { return name.bytes_as_string_view() == new_name; });
+    if (!it.is_end()) {
+        auto index = m_groups_list->model()->index((int)it.index());
+        m_groups_list->set_cursor(index, GUI::AbstractView::SelectionUpdate::Set);
+    }
+}
+
+}

--- a/Userland/Applications/UsersSettings/GroupsTab.gml
+++ b/Userland/Applications/UsersSettings/GroupsTab.gml
@@ -1,0 +1,48 @@
+@UsersSettings::GroupsTab {
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 6
+    }
+    fill_with_background_color: true
+
+    @GUI::Widget {
+        fixed_height: 120
+        layout: @GUI::VerticalBoxLayout {
+            spacing: 4
+        }
+
+        @GUI::ListView {
+            name: "groups_list"
+            should_hide_unnecessary_scrollbars: true
+            alternating_row_colors: false
+        }
+
+        @GUI::Widget {
+            fixed_height: 24
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 4
+            }
+
+            @GUI::Layout::Spacer {}
+
+            @GUI::Button {
+                name: "add_button"
+                text: "Add Group..."
+                fixed_width: 100
+            }
+
+            @GUI::Button {
+                name: "delete_button"
+                text: "Delete Group"
+                fixed_width: 100
+            }
+        }
+    }
+
+    @GUI::HorizontalSeparator {}
+
+    @GUI::Widget {
+        name: "details_container"
+        layout: @GUI::VerticalBoxLayout {}
+    }
+}

--- a/Userland/Applications/UsersSettings/GroupsTab.h
+++ b/Userland/Applications/UsersSettings/GroupsTab.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "GroupDetailsWidget.h"
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/ListView.h>
+#include <LibGUI/SettingsWindow.h>
+
+namespace UsersSettings {
+
+class GroupsTab final : public GUI::SettingsWindow::Tab {
+    C_OBJECT(GroupsTab)
+
+public:
+    static ErrorOr<NonnullRefPtr<GroupsTab>> try_create();
+
+    virtual void apply_settings() override;
+
+    ErrorOr<void> initialize();
+
+private:
+    ErrorOr<void> refresh_groups();
+    ErrorOr<void> add_group();
+    ErrorOr<void> delete_group(StringView group_name);
+
+    RefPtr<GUI::ListView> m_groups_list;
+    Vector<String> m_group_names;
+    RefPtr<GUI::Button> m_add_button;
+    RefPtr<GUI::Button> m_delete_button;
+    RefPtr<GUI::Widget> m_details_container;
+    RefPtr<GUI::Label> m_no_selection_label;
+    RefPtr<GroupDetailsWidget> m_group_details_widget;
+};
+
+}

--- a/Userland/Applications/UsersSettings/UsersTab.cpp
+++ b/Userland/Applications/UsersSettings/UsersTab.cpp
@@ -30,16 +30,21 @@ ErrorOr<void> UsersTab::initialize()
     m_no_selection_label->set_text_alignment(Gfx::TextAlignment::Center);
     m_details_container->add_child(*m_no_selection_label);
 
+    m_delete_button->set_enabled(false);
+
     TRY(refresh_users());
 
     m_users_list->on_selection_change = [this]() {
+        auto index = m_users_list->selection().first();
+        m_delete_button->set_enabled(index.is_valid());
+
         m_details_container->remove_all_children();
         m_user_details_widget = nullptr;
+        set_modified(false);
         ArmedScopeGuard on_error_path = [this]() {
             m_details_container->add_child(*m_no_selection_label);
         };
 
-        auto index = m_users_list->selection().first();
         if (!index.is_valid())
             return;
 

--- a/Userland/Applications/UsersSettings/main.cpp
+++ b/Userland/Applications/UsersSettings/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "GroupsTab.h"
 #include "UsersTab.h"
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
@@ -39,6 +40,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto users_tab = TRY(UsersSettings::UsersTab::try_create());
     TRY(window->add_tab(users_tab, "Users"_string, "users"sv));
+
+    auto groups_tab = TRY(UsersSettings::GroupsTab::try_create());
+    TRY(window->add_tab(groups_tab, "Groups"_string, "groups"sv));
 
     window->show();
     return app->exec();

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -15,6 +15,20 @@
 
 namespace Core {
 
+ErrorOr<void> Group::validate_name(StringView name)
+{
+    if (name.is_empty())
+        return Error::from_string_literal("Group name cannot be empty.");
+
+    if (name.find_any_of("\\/!@#$%^&*()~+=`:\n"sv, StringView::SearchDirection::Forward).has_value())
+        return Error::from_string_literal("Group name contains invalid characters.");
+
+    if (name.starts_with('_') || name.starts_with('-') || !is_ascii_alpha(name[0]))
+        return Error::from_string_literal("Group name must start with a letter.");
+
+    return {};
+}
+
 ErrorOr<ByteString> Group::generate_group_file() const
 {
     StringBuilder builder;
@@ -70,16 +84,7 @@ ErrorOr<void> Group::sync()
 #if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_HAIKU)
 ErrorOr<void> Group::add_group(Group& group)
 {
-    if (group.name().is_empty())
-        return Error::from_string_literal("Group name can not be empty.");
-
-    // A quick sanity check on group name
-    if (group.name().find_any_of("\\/!@#$%^&*()~+=`:\n"sv, ByteString::SearchDirection::Forward).has_value())
-        return Error::from_string_literal("Group name has invalid characters.");
-
-    // Disallow names starting with '_', '-' or other non-alpha characters.
-    if (group.name().starts_with('_') || group.name().starts_with('-') || !is_ascii_alpha(group.name().characters()[0]))
-        return Error::from_string_literal("Group name has invalid characters.");
+    TRY(validate_name(group.name()));
 
     // Verify group name does not already exist
     if (TRY(name_exists(group.name())))

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -42,7 +42,7 @@ ErrorOr<ByteString> Group::generate_group_file() const
         if (!group.has_value())
             break;
 
-        if (group->gr_name == m_name)
+        if (group->gr_name == m_original_name)
             builder.appendff("{}:x:{}:{}\n", m_name, m_id, ByteString::join(',', m_members));
         else {
             Vector<ByteString> members;
@@ -58,11 +58,9 @@ ErrorOr<ByteString> Group::generate_group_file() const
     return builder.to_byte_string();
 }
 
-ErrorOr<void> Group::sync()
+static ErrorOr<void> write_group_file(ByteString const& content)
 {
     Core::UmaskScope umask_scope(0777);
-
-    auto new_group_file_content = TRY(generate_group_file());
 
     char new_group_file[] = "/etc/group.XXXXXX";
     auto new_group_file_view = StringView { new_group_file, strlen(new_group_file) };
@@ -72,12 +70,19 @@ ErrorOr<void> Group::sync()
         ScopeGuard new_group_fd_guard([new_group_fd] { close(new_group_fd); });
         TRY(Core::System::fchmod(new_group_fd, 0664));
 
-        auto nwritten = TRY(Core::System::write(new_group_fd, new_group_file_content.bytes()));
-        VERIFY(static_cast<size_t>(nwritten) == new_group_file_content.length());
+        auto nwritten = TRY(Core::System::write(new_group_fd, content.bytes()));
+        VERIFY(static_cast<size_t>(nwritten) == content.length());
     }
 
     TRY(Core::System::rename(new_group_file_view, "/etc/group"sv));
+    return {};
+}
 
+ErrorOr<void> Group::sync()
+{
+    auto new_group_file_content = TRY(generate_group_file());
+    TRY(write_group_file(new_group_file_content));
+    m_original_name = m_name;
     return {};
 }
 
@@ -119,6 +124,40 @@ ErrorOr<void> Group::add_group(Group& group)
 
     return {};
 }
+
+ErrorOr<void> Group::delete_group(StringView name)
+{
+    StringBuilder builder;
+    char buffer[1024] = { 0 };
+    bool found_group = false;
+
+    ScopeGuard grent_guard([] { endgrent(); });
+    setgrent();
+
+    while (true) {
+        auto group = TRY(Core::System::getgrent({ buffer, sizeof(buffer) }));
+        if (!group.has_value())
+            break;
+
+        if (name == group->gr_name) {
+            found_group = true;
+            continue;
+        }
+
+        Vector<char const*> members;
+        if (group->gr_mem) {
+            for (size_t i = 0; group->gr_mem[i]; ++i)
+                members.append(group->gr_mem[i]);
+        }
+
+        builder.appendff("{}:{}:{}:{}\n", group->gr_name, group->gr_passwd, group->gr_gid, ByteString::join(","sv, members));
+    }
+
+    if (!found_group)
+        return Error::from_string_literal("Group does not exist.");
+
+    return write_group_file(builder.to_byte_string());
+}
 #endif
 
 ErrorOr<Vector<Group>> Group::all()
@@ -148,6 +187,7 @@ ErrorOr<Vector<Group>> Group::all()
 
 Group::Group(ByteString name, gid_t id, Vector<ByteString> members)
     : m_name(move(name))
+    , m_original_name(m_name)
     , m_id(id)
     , m_members(move(members))
 {

--- a/Userland/Libraries/LibCore/Group.h
+++ b/Userland/Libraries/LibCore/Group.h
@@ -15,6 +15,8 @@ namespace Core {
 
 class Group {
 public:
+    static ErrorOr<void> validate_name(StringView name);
+
 #if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_HAIKU)
     static ErrorOr<void> add_group(Group& group);
 #endif

--- a/Userland/Libraries/LibCore/Group.h
+++ b/Userland/Libraries/LibCore/Group.h
@@ -19,6 +19,7 @@ public:
 
 #if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_HAIKU)
     static ErrorOr<void> add_group(Group& group);
+    static ErrorOr<void> delete_group(StringView name);
 #endif
 
     static ErrorOr<Vector<Group>> all();
@@ -46,6 +47,7 @@ private:
     ErrorOr<ByteString> generate_group_file() const;
 
     ByteString m_name;
+    ByteString m_original_name;
     gid_t m_id { 0 };
     Vector<ByteString> m_members;
 };

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CMD_SOURCES_CPP
     gron.cpp
     groupadd.cpp
     groupdel.cpp
+    groupmod.cpp
     groups.cpp
     gzip.cpp
     head.cpp

--- a/Userland/Utilities/groupdel.cpp
+++ b/Userland/Utilities/groupdel.cpp
@@ -3,100 +3,51 @@
  * Copyright (c) 2021, Brandon Pruitt <brapru@pm.me>
  * Copyright (c) 2021, Maxime Friess <M4x1me@pm.me>
  * Copyright (c) 2022, Umut İnan Erdoğan <umutinanerdogan62@gmail.com>
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Group.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <grp.h>
-#include <pwd.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr proc exec"));
+    TRY(Core::System::pledge("stdio wpath rpath cpath fattr"));
     TRY(Core::System::unveil("/etc/", "rwc"));
-    TRY(Core::System::unveil("/bin/rm", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    ByteString groupname;
+    StringView group_name;
 
     Core::ArgsParser args_parser;
-    args_parser.add_positional_argument(groupname, "Group name", "group");
+    args_parser.set_general_help("Delete a group from the system group file");
+    args_parser.add_positional_argument(group_name, "Name of the group to delete", "group");
     args_parser.parse(arguments);
 
-    setgrent();
-    auto* g = getgrnam(groupname.characters());
-
-    // Check if the group exists
-    if (!g) {
-        warnln("group {} does not exist", groupname);
-        return 6;
-    }
-    auto gid = g->gr_gid;
-    endgrent();
-
-    // Search if the group is the primary group of an user
-    setpwent();
-    struct passwd* pw;
-    for (pw = getpwent(); pw; pw = getpwent()) {
-        if (pw->pw_gid == gid)
+    auto groups = TRY(Core::Group::all());
+    Optional<Core::Group> target;
+    for (auto& group : groups) {
+        if (group.name() == group_name) {
+            target = move(group);
             break;
-    }
-
-    // If pw is not NULL it means we ended prematurely, aka. the group was found as primary group of an user
-    if (pw) {
-        warnln("cannot remove the primary group of user '{}'", pw->pw_name);
-        endpwent();
-        return 8;
-    }
-
-    endpwent();
-    // We can now safely delete the group
-
-    // Create a temporary group file
-    char temp_group[] = "/etc/group.XXXXXX";
-    StringView temp_group_view { temp_group, strlen(temp_group) };
-
-    auto unlink_temp_files = [&] {
-        if (Core::System::unlink(temp_group_view).is_error())
-            perror("unlink");
-    };
-
-    ArmedScopeGuard unlink_temp_files_guard = [&] {
-        unlink_temp_files();
-    };
-
-    int temp_group_fd = TRY(Core::System::mkstemp(temp_group));
-
-    FILE* temp_group_file = fdopen(temp_group_fd, "w");
-    if (!temp_group_file) {
-        perror("fdopen");
-        return 1;
-    }
-
-    setgrent();
-    for (auto* gr = getgrent(); gr; gr = getgrent()) {
-        if (gr->gr_gid != gid) {
-            if (putgrent(gr, temp_group_file) != 0) {
-                perror("failed to put an entry in the temporary group file");
-                return 1;
-            }
         }
     }
-    endgrent();
-
-    if (fclose(temp_group_file)) {
-        perror("fclose");
-        return 1;
+    if (!target.has_value()) {
+        warnln("groupdel: group '{}' does not exist", group_name);
+        return 6;
     }
 
-    TRY(Core::System::chmod(temp_group_view, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH));
-    TRY(Core::System::rename(temp_group_view, "/etc/group"sv));
+    auto accounts = TRY(Core::Account::all(Core::Account::Read::PasswdOnly));
+    for (auto const& account : accounts) {
+        if (account.gid() == target->id()) {
+            warnln("groupdel: cannot remove the primary group of user '{}'", account.username());
+            return 8;
+        }
+    }
 
-    unlink_temp_files_guard.disarm();
-
+    TRY(Core::Group::delete_group(group_name));
     return 0;
 }

--- a/Userland/Utilities/groupmod.cpp
+++ b/Userland/Utilities/groupmod.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <LibCore/Group.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    TRY(Core::System::pledge("stdio wpath rpath cpath fattr"));
+    TRY(Core::System::unveil("/etc/", "rwc"));
+    TRY(Core::System::unveil(nullptr, nullptr));
+
+    StringView new_name;
+    StringView group_name;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("Modify a group definition on the system");
+    args_parser.add_option(new_name, "New name for the group", "new-name", 'n', "new-name");
+    args_parser.add_positional_argument(group_name, "Name of the group to modify", "group");
+    args_parser.parse(arguments);
+
+    auto groups = TRY(Core::Group::all());
+    Optional<Core::Group> target;
+    for (auto& group : groups) {
+        if (group.name() == group_name) {
+            target = move(group);
+            break;
+        }
+    }
+
+    if (!target.has_value()) {
+        warnln("groupmod: group '{}' does not exist", group_name);
+        return 6;
+    }
+
+    if (!new_name.is_empty()) {
+        if (auto result = Core::Group::validate_name(new_name); result.is_error()) {
+            warnln("groupmod: {}", result.error());
+            return 1;
+        }
+
+        auto existing = TRY(Core::System::getgrnam(new_name));
+        if (existing.has_value()) {
+            warnln("groupmod: group '{}' already exists", new_name);
+            return 9;
+        }
+        target->set_name(new_name);
+    }
+
+    TRY(target->sync());
+    return 0;
+}


### PR DESCRIPTION
This pr adds the following:

- Extends `LibCore::Group` API with group renaming and deleting support
- Updates `groupdel.cpp` to use LibCore like `groupadd.cpp`
- Add `groupmod.cpp` to rename groups
- Some small disabled state ux improvement for UserSettings user tab
- Add group management tab to UsersSettings

I need to rebase this pr when #26748 is merged because of the changes in visibility of `Widget::initialize()`

## Demo video

https://github.com/user-attachments/assets/41162fc0-5781-4a6c-96bf-6b2ac8d8f478
