### PR TITLE
SSHServer: Stream exec data back to the client

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -73,7 +73,7 @@ public:
 
     void wake();
 
-    void adopt_coroutine(Coroutine<void>&&);
+    static void adopt_coroutine(Coroutine<void>&&);
 
     void quit(int);
     void unquit();

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -86,6 +86,14 @@ public:
         co_return co_await GenericAwaiter([&](auto ready) { notifier->on_activation = move(ready); });
     }
 
+    // When using this API, ensure that `bytes` are still valid after the
+    // coroutine resumes.
+    Coroutine<ErrorOr<Bytes>> async_read_some(Bytes bytes)
+    {
+        CO_TRY(co_await wait_for_state(Core::Notifier::Type::Read));
+        co_return read_some(bytes);
+    }
+
     template<OneOf<::IPC::File, ::Core::MappedFile> VIP>
     int leak_fd(Badge<VIP>)
     {

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -99,6 +99,10 @@ ErrorOr<Process> Process::spawn(ProcessSpawnOptions const& options)
             [&](FileAction::CloseFile const& action) -> ErrorOr<void> {
                 CHECK(posix_spawn_file_actions_addclose(&spawn_actions, action.fd));
                 return {};
+            },
+            [&](FileAction::DuplicateFile const& action) -> ErrorOr<void> {
+                CHECK(posix_spawn_file_actions_adddup2(&spawn_actions, action.old_fd, action.new_fd));
+                return {};
             }));
     }
 

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -31,7 +31,10 @@ struct CloseFile {
     int fd { -1 };
 };
 
-// FIXME: Implement other file actions
+struct DuplicateFile {
+    int old_fd { -1 };
+    int new_fd { -1 };
+};
 
 }
 
@@ -42,7 +45,7 @@ struct ProcessSpawnOptions {
     Vector<ByteString> const& arguments {};
     Optional<ByteString> working_directory {};
 
-    using FileActionType = Variant<FileAction::OpenFile, FileAction::CloseFile>;
+    using FileActionType = Variant<FileAction::OpenFile, FileAction::CloseFile, FileAction::DuplicateFile>;
     Vector<FileActionType> file_actions {};
 };
 

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -8,11 +8,21 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Variant.h>
+#include <LibCore/File.h>
 
 namespace SSH {
 
 // 6.1.  Opening a Session
 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.1
+
+struct ExecData {
+    NonnullOwnPtr<Core::File> stdin_;
+    NonnullOwnPtr<Core::File> stdout_;
+    NonnullOwnPtr<Core::File> stderr_;
+};
+
 struct Session {
     static ErrorOr<Session> create(u32 sender_channel_id, u32 window_size, u32 maximum_packet_size);
 
@@ -20,6 +30,8 @@ struct Session {
     u32 sender_channel_id {};
     u32 maximum_packet_size {};
     ByteBuffer window {};
+
+    Variant<Empty, ExecData> system {};
 
     bool is_closed { false };
 };

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Variant.h>
 #include <LibCore/File.h>
+#include <LibCore/Process.h>
 
 namespace SSH {
 
@@ -18,6 +19,8 @@ namespace SSH {
 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.1
 
 struct ExecData {
+    Core::Process child;
+
     NonnullOwnPtr<Core::File> stdin_;
     NonnullOwnPtr<Core::File> stdout_;
     NonnullOwnPtr<Core::File> stderr_;

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -554,6 +554,8 @@ ErrorOr<void> SSHClient::handle_channel_request(GenericMessage& message)
     }
 
     if (request_type == "exec"sv.bytes()) {
+        if (!want_reply)
+            return Error::from_string_literal("Client requested exec but doesn't want a reply");
         TRY(handle_channel_exec(session, message));
         return {};
     }

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -613,25 +613,27 @@ ErrorOr<void> SSHClient::handle_channel_exec(Session& session, GenericMessage& m
     TRY(send_channel_success_message(session));
 
     // FIXME: Make sure to cancel these coroutines if anything goes wrong.
-    Core::EventLoop::adopt_coroutine(async_stream_channel_data(session.sender_channel_id));
+    Core::EventLoop::adopt_coroutine(async_stream_std_data(session.sender_channel_id, [](ExecData& exec_data) -> Core::File& { return *exec_data.stdout_; }, [this](auto&... args) { return send_channel_data(args...); }));
+    Core::EventLoop::adopt_coroutine(async_stream_std_data(session.sender_channel_id, [](ExecData& exec_data) -> Core::File& { return *exec_data.stderr_; }, [this](auto&... args) { return send_channel_extended_data(args...); }));
     Core::EventLoop::adopt_coroutine(async_wait_for_child(session.sender_channel_id));
 
     return {};
 }
 
-Coroutine<void> SSHClient::async_stream_channel_data(u32 sender_channel_id)
+template<typename F, typename F2>
+Coroutine<void> SSHClient::async_stream_std_data(u32 sender_channel_id, F&& file_extractor, F2&& sender)
 {
     auto maybe_error = co_await [&]() -> Coroutine<ErrorOr<void>> {
         while (true) {
             auto& session = *CO_TRY(find_session(sender_channel_id));
 
             auto output_buffer = CO_TRY(ByteBuffer::create_uninitialized(PAGE_SIZE));
-            auto output = CO_TRY(co_await session.system.get<ExecData>().stdout_->async_read_some(output_buffer));
+            auto output = CO_TRY(co_await file_extractor(session.system.template get<ExecData>()).async_read_some(output_buffer));
 
             if (output.is_empty())
                 break;
 
-            CO_TRY(send_channel_data(session, output));
+            CO_TRY(sender(session, output));
         }
         co_return {};
     }();
@@ -682,11 +684,35 @@ ErrorOr<void> SSHClient::send_channel_success_message(Session const& session)
     return {};
 }
 
+// 5.2. Data Transfer
+// https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
 ErrorOr<void> SSHClient::send_channel_data(Session const& session, ReadonlyBytes data)
 {
     AllocatingMemoryStream stream;
     TRY(stream.write_value(MessageID::CHANNEL_DATA));
     TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
+    TRY(encode_string(stream, data));
+    TRY(write_packet(TRY(stream.read_until_eof())));
+    return {};
+}
+
+// 5.2. Data Transfer
+// https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
+ErrorOr<void> SSHClient::send_channel_extended_data(Session const& session, ReadonlyBytes data)
+{
+    // This only supports sending stderr data.
+
+    // "Additionally, some channels can transfer several types of data.  An
+    //   example of this is stderr data from interactive sessions.  Such data
+    //   can be passed with SSH_MSG_CHANNEL_EXTENDED_DATA messages, where a
+    //   separate integer specifies the type of data."
+
+    static constexpr u32 EXTENDED_DATA_STDERR = 1;
+
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(MessageID::CHANNEL_EXTENDED_DATA));
+    TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
+    TRY(stream.write_value<NetworkOrdered<u32>>(EXTENDED_DATA_STDERR));
     TRY(encode_string(stream, data));
     TRY(write_packet(TRY(stream.read_until_eof())));
     return {};

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -12,8 +12,9 @@
 #include <AK/MemoryStream.h>
 #include <AK/Random.h>
 #include <LibCore/Account.h>
-#include <LibCore/Command.h>
+#include <LibCore/Process.h>
 #include <LibCore/Socket.h>
+#include <LibCore/System.h>
 #include <LibCrypto/Curves/Ed25519.h>
 #include <LibCrypto/Curves/X25519.h>
 #include <LibSSH/DataTypes.h>
@@ -569,10 +570,7 @@ ErrorOr<void> SSHClient::handle_channel_exec(Session& session, GenericMessage& m
 {
     auto command = TRY(decode_string(message.payload));
 
-    // FIXME: This is a naive implementation, we should stream the result back
-    //        to the user and not block the event loop during the execution of
-    //        the command.
-    //        We should also use the user's shell rather than hardcoding it.
+    // FIXME: We should use the user's shell rather than hardcoding it.
 
 #ifdef AK_OS_SERENITY
     auto shell = "/bin/Shell"sv;
@@ -581,26 +579,44 @@ ErrorOr<void> SSHClient::handle_channel_exec(Session& session, GenericMessage& m
 #endif
 
     Vector<ByteString> args;
-    args.append(shell);
     args.append("-c");
     args.append(ByteString(command.bytes()));
 
-    Vector<char const*> raw_args;
-    raw_args.ensure_capacity(args.size() + 1);
-    for (auto& arg : args)
-        raw_args.append(arg.characters());
+    // FIXME: Close pipes in every branch, probably with something nicer than 6 (Armed)ScopeGuards
+    //        (maybe introduce some new variant/api of Core::File that doesn't allocate, just returns RAII owner?).
+    auto stdin_fds = TRY(Core::System::pipe2(O_CLOEXEC));
+    auto stdout_fds = TRY(Core::System::pipe2(O_CLOEXEC));
+    auto stderr_fds = TRY(Core::System::pipe2(O_CLOEXEC));
 
-    raw_args.append(nullptr);
+    auto child = TRY(Core::Process::spawn({
+        .executable = shell,
+        .arguments = args,
+        .file_actions = {
+            Core::FileAction::DuplicateFile { stdin_fds[0], STDIN_FILENO },
+            Core::FileAction::DuplicateFile { stdout_fds[1], STDOUT_FILENO },
+            Core::FileAction::DuplicateFile { stderr_fds[1], STDERR_FILENO },
+        },
+    }));
 
-    auto child = TRY(Core::Command::create(shell, raw_args.data()));
-    auto output = TRY(child->read_all());
-    auto status = TRY(child->status());
+    TRY(Core::System::close(stdin_fds[0]));
+    TRY(Core::System::close(stdout_fds[1]));
+    TRY(Core::System::close(stderr_fds[1]));
 
-    if (status != Core::Command::ProcessResult::DoneWithZeroExitCode)
+    session.system = ExecData {
+        .stdin_ = TRY(Core::File::adopt_fd(stdin_fds[1], Core::File::OpenMode::Write)),
+        .stdout_ = TRY(Core::File::adopt_fd(stdout_fds[0], Core::File::OpenMode::Read)),
+        .stderr_ = TRY(Core::File::adopt_fd(stderr_fds[0], Core::File::OpenMode::Read)),
+    };
+
+    auto output = TRY(session.system.get<ExecData>().stdout_->read_until_eof());
+
+    auto exited_with_code_0 = TRY(child.wait_for_termination());
+
+    if (!exited_with_code_0)
         return Error::from_string_literal("Unable to run command");
 
     TRY(send_channel_success_message(session));
-    TRY(send_channel_data(session, output.standard_output));
+    TRY(send_channel_data(session, output));
     TRY(send_channel_close(session));
     return {};
 }

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -12,6 +12,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/Random.h>
 #include <LibCore/Account.h>
+#include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
@@ -603,22 +604,73 @@ ErrorOr<void> SSHClient::handle_channel_exec(Session& session, GenericMessage& m
     TRY(Core::System::close(stderr_fds[1]));
 
     session.system = ExecData {
+        .child = move(child),
         .stdin_ = TRY(Core::File::adopt_fd(stdin_fds[1], Core::File::OpenMode::Write)),
         .stdout_ = TRY(Core::File::adopt_fd(stdout_fds[0], Core::File::OpenMode::Read)),
         .stderr_ = TRY(Core::File::adopt_fd(stderr_fds[0], Core::File::OpenMode::Read)),
     };
 
-    auto output = TRY(session.system.get<ExecData>().stdout_->read_until_eof());
-
-    auto exited_with_code_0 = TRY(child.wait_for_termination());
-
-    if (!exited_with_code_0)
-        return Error::from_string_literal("Unable to run command");
-
     TRY(send_channel_success_message(session));
-    TRY(send_channel_data(session, output));
-    TRY(send_channel_close(session));
+
+    // FIXME: Make sure to cancel these coroutines if anything goes wrong.
+    Core::EventLoop::adopt_coroutine(async_stream_channel_data(session.sender_channel_id));
+    Core::EventLoop::adopt_coroutine(async_wait_for_child(session.sender_channel_id));
+
     return {};
+}
+
+Coroutine<void> SSHClient::async_stream_channel_data(u32 sender_channel_id)
+{
+    auto maybe_error = co_await [&]() -> Coroutine<ErrorOr<void>> {
+        while (true) {
+            auto& session = *CO_TRY(find_session(sender_channel_id));
+
+            auto output_buffer = CO_TRY(ByteBuffer::create_uninitialized(PAGE_SIZE));
+            auto output = CO_TRY(co_await session.system.get<ExecData>().stdout_->async_read_some(output_buffer));
+
+            if (output.is_empty())
+                break;
+
+            CO_TRY(send_channel_data(session, output));
+        }
+        co_return {};
+    }();
+
+    if (maybe_error.is_error()) {
+        dbgln("Unable to read stdout from process: {}", maybe_error.error());
+        // FIXME: Think about what we should do with this error.
+    }
+    co_return;
+}
+
+Coroutine<void> SSHClient::async_wait_for_child(u32 sender_channel_id)
+{
+    auto maybe_error = [&]() -> ErrorOr<void> {
+        auto& session = *TRY(find_session(sender_channel_id));
+
+        // FIXME: If the child closes STDOUT, we will block the server in
+        //        wait_for_termination() bellow. We should implement a way to
+        //        wake up the event loop on the child's death.
+        Core::EventLoop::current().spin_until([this, sender_channel_id]() {
+            auto& session = *MUST(find_session(sender_channel_id));
+            auto& exec_data = session.system.get<ExecData>();
+            return exec_data.stdout_->is_eof();
+        });
+
+        auto exited_with_code_0 = TRY(session.system.get<ExecData>().child.wait_for_termination());
+
+        if (!exited_with_code_0)
+            return Error::from_string_literal("Unable to run command");
+
+        TRY(send_channel_close(session));
+        return {};
+    }();
+
+    if (maybe_error.is_error()) {
+        dbgln("Error while waiting for the child: {}", maybe_error.error());
+        // FIXME: Think about what we should do with this error.
+    }
+    co_return;
 }
 
 ErrorOr<void> SSHClient::send_channel_success_message(Session const& session)

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -96,6 +96,9 @@ private:
     ErrorOr<void> send_channel_close(Session&);
     ErrorOr<Session*> find_session(u32 sender_channel_id);
 
+    Coroutine<void> async_stream_channel_data(u32 sender_channel_id);
+    Coroutine<void> async_wait_for_child(u32 sender_channel_id);
+
     State m_state { State::Constructed };
     Core::TCPSocket& m_tcp_socket;
 

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -92,11 +92,13 @@ private:
     ErrorOr<void> handle_channel_exec(Session&, GenericMessage&);
     ErrorOr<void> send_channel_success_message(Session const&);
     ErrorOr<void> send_channel_data(Session const&, ReadonlyBytes);
+    ErrorOr<void> send_channel_extended_data(Session const&, ReadonlyBytes);
     ErrorOr<void> handle_channel_close(GenericMessage&);
     ErrorOr<void> send_channel_close(Session&);
     ErrorOr<Session*> find_session(u32 sender_channel_id);
 
-    Coroutine<void> async_stream_channel_data(u32 sender_channel_id);
+    template<typename F, typename F2>
+    Coroutine<void> async_stream_std_data(u32 sender_channel_id, F&& file_extractor, F2&& sender);
     Coroutine<void> async_wait_for_child(u32 sender_channel_id);
 
     State m_state { State::Constructed };


### PR DESCRIPTION
This PR makes the following command behave normally (results appear progressively and stderr is displayed):
`ssh -p 2222 anon@127.0.0.1 "echo 0; sleep 1; echo 1 1>&2; sleep 1; echo 2;"`