### PR TITLE
SSHServer: Take functors as plain values in async_stream_std_data

### DIFF
--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -675,7 +675,7 @@ ErrorOr<void> SSHClient::handle_channel_exec(NonnullRefPtr<Session> const& sessi
 }
 
 template<typename F, typename F2>
-Coroutine<void> SSHClient::async_stream_std_data(NonnullRefPtr<Session> session, F&& file_extractor, F2&& sender)
+Coroutine<void> SSHClient::async_stream_std_data(NonnullRefPtr<Session> session, F file_extractor, F2 sender)
 {
     auto maybe_error = co_await [&]() -> Coroutine<ErrorOr<void>> {
         while (true) {

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -101,7 +101,7 @@ private:
     ErrorOr<NonnullRefPtr<Session>> find_session(u32 sender_channel_id);
 
     template<typename F, typename F2>
-    Coroutine<void> async_stream_std_data(NonnullRefPtr<Session>, F&& file_extractor, F2&& sender);
+    Coroutine<void> async_stream_std_data(NonnullRefPtr<Session>, F file_extractor, F2 sender);
     Coroutine<void> async_stream_data_to_subsystem(NonnullRefPtr<Session>);
     Coroutine<void> async_wait_for_child(NonnullRefPtr<Session>);
 


### PR DESCRIPTION
Taking a universal reference may not always lead to the functor being owned by the coroutine frame. It can cause issues, if the functor is not available anymore when the coroutine resumes.

As an example:
```
template<typename Func>
f(Func&&) {}

void g() {
    f([](){}); // The lambda is owned by g().
    auto lambda = [](){};
    f(lambda); // The lambda is owned by g().
    f(move(lambda)); // Only in this case, the lambda is owned by f.
}
```

In practice this didn't cause problems as, I suppose, the compiler was able inline these lambdas, thus circumventing the issue. It however didn't prevent ASAN from finding it.