### PR TITLE
Kernel/MM: Flush data cache after mapping non-cacheable Regions

### DIFF
--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -63,6 +63,8 @@ public:
     static void flush_tlb_local(VirtualAddress vaddr, size_t page_count);
     static void flush_tlb(Memory::PageDirectory const*, VirtualAddress, size_t);
 
+    // FIXME: Add wrappers for data cache clean or invalidate operations when necessary.
+    static void flush_data_cache(VirtualAddress vaddr, size_t byte_count);
     static void flush_instruction_cache(VirtualAddress vaddr, size_t byte_count);
 
     void early_initialize(u32 cpu);

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -94,6 +94,7 @@ public:
     {
         return current_id() == 0;
     }
+    ALWAYS_INLINE bool has_self_snooping() const;
     ALWAYS_INLINE bool has_nx() const;
     ALWAYS_INLINE bool has_feature(CPUFeature::Type const& feature) const
     {

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -9,6 +9,7 @@
 #include <AK/Vector.h>
 
 #include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/MemoryFences.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/TrapFrame.h>
 #include <Kernel/Arch/aarch64/ASM_wrapper.h>
@@ -98,6 +99,18 @@ void ProcessorBase::flush_entire_tlb_local()
 void ProcessorBase::flush_tlb(Memory::PageDirectory const*, VirtualAddress vaddr, size_t page_count)
 {
     flush_tlb_local(vaddr, page_count);
+}
+
+void ProcessorBase::flush_data_cache(VirtualAddress vaddr, size_t byte_count)
+{
+    // NOTE: This assumes that all processors have the same cache line size,
+    //       as a context switch can happen during execution of this function.
+
+    auto const cache_line_size = Aarch64::Asm::get_cache_line_size();
+    for (FlatPtr addr = align_down_to(vaddr.get(), cache_line_size); addr < vaddr.get() + byte_count; addr += cache_line_size)
+        asm volatile("dc civac, %0" ::"r"(addr) : "memory");
+
+    full_memory_fence();
 }
 
 void ProcessorBase::flush_instruction_cache(VirtualAddress vaddr, size_t byte_count)

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -125,6 +125,11 @@ ALWAYS_INLINE void ProcessorBase::set_current_in_scheduler(bool value)
     current().m_in_scheduler = value;
 }
 
+ALWAYS_INLINE bool ProcessorBase::has_self_snooping() const
+{
+    return false;
+}
+
 ALWAYS_INLINE bool ProcessorBase::has_nx() const
 {
     return true;

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -243,6 +243,28 @@ void ProcessorBase::flush_tlb(Memory::PageDirectory const*, VirtualAddress vaddr
     flush_tlb_local(vaddr, page_count);
 }
 
+void ProcessorBase::flush_data_cache(VirtualAddress vaddr, size_t byte_count)
+{
+    if (!Processor::current().has_feature(CPUFeature::Zicbom))
+        return;
+
+    // Flushing userspace memory requires sstatus.SUM=1.
+    SmapDisabler disabler;
+
+    // NOTE: This assumes that all processors have Zicbom and the same m_zicbom_block_size,
+    //       as a context switch can happen during execution of this function.
+
+    auto const block_size = current().m_zicbom_block_size;
+    for (FlatPtr addr = align_down_to(vaddr.get(), block_size); addr < vaddr.get() + byte_count; addr += block_size) {
+        asm volatile(R"(
+            .option push
+            .option arch, +zicbom
+                cbo.flush (%0)
+            .option pop
+        )" ::"r"(addr) : "memory");
+    }
+}
+
 void ProcessorBase::flush_instruction_cache(VirtualAddress, size_t)
 {
     // FIXME: Use the SBI RFENCE extension to flush the instruction cache of other harts when we support SMP on riscv64.
@@ -689,6 +711,16 @@ void Processor::find_and_parse_devicetree_node()
         store_fpu_state(s_clean_fpu_state);
 
         generate_userspace_extension_bitmask();
+
+        if (has_feature(CPUFeature::Zicbom)) {
+            auto zicbom_block_size = cpu.get_property("riscv,cbom-block-size"sv);
+            if (zicbom_block_size.has_value() && zicbom_block_size->size() == sizeof(u32))
+                m_zicbom_block_size = zicbom_block_size->as<u32>();
+            else
+                dmesgln("CPU[{}]: Supports Zicbom but its node ({}) doesn't have a valid \"riscv,cbom-block-size\" property", id(), cpu_name);
+        } else {
+            dmesgln("CPU[{}]: Doesn't support Zicbom, Processor::flush_data_cache() won't work", id());
+        }
 
         break;
     }

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -145,6 +145,11 @@ ALWAYS_INLINE void ProcessorBase::set_current_in_scheduler(bool value)
     current().m_in_scheduler = value;
 }
 
+ALWAYS_INLINE bool ProcessorBase::has_self_snooping() const
+{
+    return false;
+}
+
 ALWAYS_INLINE bool ProcessorBase::has_nx() const
 {
     return true;

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -74,6 +74,8 @@ private:
 
     Optional<ProcessorInfo> m_info;
     Array<unsigned long long, EXTENSION_BITMASK_GROUP_COUNT> m_userspace_extension_bitmask {};
+
+    u32 m_zicbom_block_size { 0 };
 };
 
 ALWAYS_INLINE bool ProcessorBase::is_initialized()

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -23,6 +23,7 @@
 #include <Kernel/Tasks/Thread.h>
 
 #include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/MemoryFences.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/SafeMem.h>
 #include <Kernel/Arch/TrapFrame.h>
@@ -228,6 +229,9 @@ UNMAP_AFTER_INIT void Processor::cpu_detect()
         m_features |= CPUFeature::IA64;
     if (processor_info.edx() & (1 << 31))
         m_features |= CPUFeature::PBE;
+
+    if (has_feature(CPUFeature::CLFLUSH))
+        m_clflush_cache_line_size = ((processor_info.ebx() >> 8) & 0xff) * 8;
 
     CPUID extended_features(0x7);
 
@@ -667,6 +671,9 @@ UNMAP_AFTER_INIT void ProcessorBase::initialize(u32 cpu)
     if (self->m_has_qemu_hvf_quirk.was_set())
         dmesgln("CPU[{}]: Applied correction for QEMU Hypervisor.framework quirk", current_id());
 
+    if (!has_feature(CPUFeature::CLFLUSH))
+        dmesgln("CPU[{}]: Doesn't support CLFUSH, Processor::flush_data_cache() won't work", current_id());
+
     if (cpu == 0)
         initialize_interrupts();
     else
@@ -805,6 +812,26 @@ void ProcessorBase::flush_tlb(Memory::PageDirectory const* page_directory, Virtu
         Processor::smp_broadcast_flush_tlb(page_directory, vaddr, page_count);
     else
         flush_tlb_local(vaddr, page_count);
+}
+
+void ProcessorBase::flush_data_cache(VirtualAddress vaddr, size_t byte_count)
+{
+    // FIXME: Implement a WBINVD fallback. WBINVD only flushes the caches for the current processor,
+    //        so we need to broadcast an SMP messsage to do that.
+    // FIXME: Maybe use CLFLUSHOPT, if supported.
+    if (!Processor::current().has_feature(CPUFeature::CLFLUSH))
+        return;
+
+    // NOTE: This assumes that all processors have CLFLUSH and the same m_clflush_cache_line_size,
+    //       as a context switch can happen during execution of this function.
+
+    full_memory_fence();
+
+    auto const cache_line_size = current().m_clflush_cache_line_size;
+    for (FlatPtr addr = align_down_to(vaddr.get(), cache_line_size); addr < vaddr.get() + byte_count; addr += cache_line_size)
+        asm volatile("clflush %0" ::"m"(addr) : "memory");
+
+    full_memory_fence();
 }
 
 void ProcessorBase::flush_instruction_cache(VirtualAddress, size_t)

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -67,6 +67,8 @@ private:
     alignas(Descriptor) Descriptor m_gdt[256];
     u32 m_gdt_length;
 
+    u16 m_clflush_cache_line_size { 0 };
+
     static Atomic<u32> s_idle_cpu_mask;
 
     TSS m_tss;

--- a/Kernel/Arch/x86_64/Processor.h
+++ b/Kernel/Arch/x86_64/Processor.h
@@ -242,6 +242,11 @@ ALWAYS_INLINE void ProcessorBase::disable_interrupts()
     cli();
 }
 
+ALWAYS_INLINE bool ProcessorBase::has_self_snooping() const
+{
+    return has_feature(CPUFeature::SS);
+}
+
 ALWAYS_INLINE bool ProcessorBase::has_nx() const
 {
     return has_feature(CPUFeature::NX);

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -221,11 +221,11 @@ bool Region::should_dirty_on_write(size_t page_index, ShouldLockVMObject should_
     return is_not_dirty(page_index);
 }
 
-bool Region::map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage> page, ShouldLockVMObject should_lock_vmobject)
+bool Region::map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage> page, ShouldLockVMObject should_lock_vmobject, bool readable, bool writeable)
 {
     if (!page)
         return map_individual_page_impl(page_index, {}, false, false, should_lock_vmobject);
-    return map_individual_page_impl(page_index, page->paddr(), is_readable(), is_writable() && !page->is_shared_zero_page() && !page->is_lazy_committed_page(), should_lock_vmobject);
+    return map_individual_page_impl(page_index, page->paddr(), readable, writeable && !page->is_shared_zero_page() && !page->is_lazy_committed_page(), should_lock_vmobject);
 }
 
 bool Region::map_individual_page_impl(size_t page_index, PhysicalAddress paddr)
@@ -266,14 +266,14 @@ bool Region::map_individual_page_impl(size_t page_index, PhysicalAddress paddr, 
     return true;
 }
 
-bool Region::map_individual_page_impl(size_t page_index, ShouldLockVMObject should_lock_vmobject)
+bool Region::map_individual_page_impl(size_t page_index, ShouldLockVMObject should_lock_vmobject, bool readable, bool writeable)
 {
     RefPtr<PhysicalRAMPage> page = nullptr;
     if (should_lock_vmobject == ShouldLockVMObject::Yes)
         page = physical_page(page_index);
     else
         page = physical_page_locked(page_index);
-    return map_individual_page_impl(page_index, page, should_lock_vmobject);
+    return map_individual_page_impl(page_index, page, should_lock_vmobject, readable, writeable);
 }
 
 bool Region::remap_vmobject_page(size_t page_index, NonnullRefPtr<PhysicalRAMPage> physical_page, ShouldLockVMObject should_lock_vmobject)
@@ -284,7 +284,7 @@ bool Region::remap_vmobject_page(size_t page_index, NonnullRefPtr<PhysicalRAMPag
     if (!translate_vmobject_page(page_index))
         return false;
 
-    bool success = map_individual_page_impl(page_index, physical_page, should_lock_vmobject);
+    bool success = map_individual_page_impl(page_index, physical_page, should_lock_vmobject, is_readable(), is_writable());
     MemoryManager::flush_tlb(m_page_directory, vaddr_from_page_index(page_index));
     return success;
 }
@@ -317,7 +317,7 @@ void Region::set_page_directory(PageDirectory& page_directory)
     m_page_directory = page_directory;
 }
 
-ErrorOr<void> Region::map_impl(PageDirectory& page_directory, ShouldLockVMObject should_lock_vmobject, ShouldFlushTLB should_flush_tlb)
+ErrorOr<void> Region::map_impl(PageDirectory& page_directory, ShouldLockVMObject should_lock_vmobject, ShouldFlushTLB should_flush_tlb, bool readable, bool writeable)
 {
     SpinlockLocker page_lock(page_directory.get_lock());
 
@@ -329,7 +329,7 @@ ErrorOr<void> Region::map_impl(PageDirectory& page_directory, ShouldLockVMObject
     set_page_directory(page_directory);
     size_t page_index = 0;
     while (page_index < page_count()) {
-        if (!map_individual_page_impl(page_index, should_lock_vmobject))
+        if (!map_individual_page_impl(page_index, should_lock_vmobject, readable, writeable))
             break;
         ++page_index;
     }
@@ -344,7 +344,7 @@ ErrorOr<void> Region::map_impl(PageDirectory& page_directory, ShouldLockVMObject
 
 ErrorOr<void> Region::map(PageDirectory& page_directory, ShouldFlushTLB should_flush_tlb)
 {
-    return map_impl(page_directory, ShouldLockVMObject::Yes, should_flush_tlb);
+    return map_impl(page_directory, ShouldLockVMObject::Yes, should_flush_tlb, is_readable(), is_writable());
 }
 
 ErrorOr<void> Region::map(PageDirectory& page_directory, PhysicalAddress paddr, ShouldFlushTLB should_flush_tlb)
@@ -374,7 +374,7 @@ void Region::remap_impl(ShouldLockVMObject should_lock_vmobject)
     if (m_vmobject->is_mmio())
         result = map(*m_page_directory, static_cast<MMIOVMObject const&>(*m_vmobject).base_address());
     else
-        result = map_impl(*m_page_directory, should_lock_vmobject, ShouldFlushTLB::Yes);
+        result = map_impl(*m_page_directory, should_lock_vmobject, ShouldFlushTLB::Yes, is_readable(), is_writable());
     if (result.is_error())
         TODO();
 }

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -344,6 +344,39 @@ ErrorOr<void> Region::map_impl(PageDirectory& page_directory, ShouldLockVMObject
 
 ErrorOr<void> Region::map(PageDirectory& page_directory, ShouldFlushTLB should_flush_tlb)
 {
+    // Flushing the data cache requires this region to be in the current address space,
+    // or in the always mapped kernel address space.
+    VERIFY(&page_directory == Memory::PageDirectory::find_current() || &page_directory == &MM.kernel_page_directory());
+
+    // NOTE: The !Processor::current().has_self_snooping() check assumes that either all or none of
+    //       the processors in an SMP system support self-snooping, since a context switch can happen
+    //       after that check.
+    if (m_memory_type != MemoryType::Normal && !Processor::current().has_self_snooping()) {
+        // The physical pages used by this region could have previously been used by a cacheable region,
+        // so some cache lines might still contain data for this region.
+        // Because non-cacheable accesses bypass the data cache, those lines could later be written back
+        // after the underlying physical memory has changed.
+        // Since we don't track whether physical pages were previously mapped as cacheable,
+        // always flush the data cache to remove any stale entries for this region.
+        // If the processor supports self-snooping, the processor will snoop its own cache and handle
+        // such memory type conflicts transparently.
+
+        if (!is_writable()) {
+            // Temporarily map it as writable, so we can flush the data cache.
+            // In this case, we always need to flush the TLB to change the permissions,
+            // both when making the mapping writable and when reverting to the original permissions.
+
+            TRY(map_impl(page_directory, ShouldLockVMObject::Yes, ShouldFlushTLB::Yes, true, true));
+            Processor::flush_data_cache(vaddr(), PAGE_SIZE * page_count());
+
+            TRY(map_impl(page_directory, ShouldLockVMObject::Yes, ShouldFlushTLB::Yes, is_readable(), is_writable()));
+        } else {
+            TRY(map_impl(page_directory, ShouldLockVMObject::Yes, should_flush_tlb, is_readable(), is_writable()));
+            Processor::flush_data_cache(vaddr(), PAGE_SIZE * page_count());
+        }
+        return {};
+    }
+
     return map_impl(page_directory, ShouldLockVMObject::Yes, should_flush_tlb, is_readable(), is_writable());
 }
 

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -237,7 +237,7 @@ private:
 
     [[nodiscard]] bool should_dirty_on_write(size_t page_index, ShouldLockVMObject should_lock_vmobject) const;
 
-    ErrorOr<void> map_impl(PageDirectory&, ShouldLockVMObject, ShouldFlushTLB);
+    ErrorOr<void> map_impl(PageDirectory&, ShouldLockVMObject, ShouldFlushTLB, bool readable, bool writeable);
 
     void set_access_bit(Access access, bool b)
     {
@@ -254,8 +254,8 @@ private:
     [[nodiscard]] PageFaultResponse handle_zero_fault(size_t page_index, PhysicalRAMPage& page_in_slot_at_time_of_fault);
     [[nodiscard]] PageFaultResponse handle_inode_write_fault(size_t page_index);
 
-    [[nodiscard]] bool map_individual_page_impl(size_t page_index, ShouldLockVMObject);
-    [[nodiscard]] bool map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage>, ShouldLockVMObject);
+    [[nodiscard]] bool map_individual_page_impl(size_t page_index, ShouldLockVMObject, bool readable, bool writeable);
+    [[nodiscard]] bool map_individual_page_impl(size_t page_index, RefPtr<PhysicalRAMPage>, ShouldLockVMObject, bool readable, bool writeable);
     [[nodiscard]] bool map_individual_page_impl(size_t page_index, PhysicalAddress);
     [[nodiscard]] bool map_individual_page_impl(size_t page_index, PhysicalAddress, bool readable, bool writeable, ShouldLockVMObject);
 

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -133,6 +133,8 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
 
     TRY(address_space().with([&](auto& parent_space) {
         return child->address_space().with([&](auto& child_space) -> ErrorOr<void> {
+            ScopedAddressSpaceSwitcher switcher(child);
+
             if (parent_space->enforces_syscall_regions())
                 child_space->set_enforces_syscall_regions();
             for (auto& region : parent_space->region_tree().regions()) {


### PR DESCRIPTION
Without this PR, the (not yet upstream) VideoCore VII 3D driver will hang after drawing a couple of frames, due to the cache writing back stale data into MemoryType::NonCacheable regions.

This PR flushes the data cache immediately after mapping non-cacheable regions to ensure that the data caches don't contain any stale data. See the commit descriptions for more details.