### PR TITLE
Nix: Add fuse2fs as a dependency

### DIFF
--- a/Toolchain/default.nix
+++ b/Toolchain/default.nix
@@ -46,8 +46,7 @@ mkShell.override { stdenv = gccStdenv; } {
     pre-commit
   ]
   ++ lib.optionals stdenv.isLinux [
-    fuse
-    fuse-ext2
+    fuse2fs
     grub2
     parted
   ]


### PR DESCRIPTION
This allows building the image on NixOS without sudo