### PR TITLE
SSHServer: Support streaming more data to the child

### DIFF
--- a/Userland/Libraries/LibSSH/Session.cpp
+++ b/Userland/Libraries/LibSSH/Session.cpp
@@ -8,6 +8,18 @@
 
 namespace SSH {
 
+ErrorOr<ExecData> ExecData::create(Core::Process&& process, int fd_stdin, int fd_stdout, int fd_stderr)
+{
+    ExecData exec_data = {
+        move(process),
+        TRY(Core::File::adopt_fd(fd_stdin, Core::File::OpenMode::Write)),
+        TRY(Core::File::adopt_fd(fd_stdout, Core::File::OpenMode::Read)),
+        TRY(Core::File::adopt_fd(fd_stderr, Core::File::OpenMode::Read)),
+    };
+
+    return exec_data;
+}
+
 Coroutine<ErrorOr<void>> ExecData::handle_channel_data(Session& session)
 {
     CO_TRY(co_await stdin_->wait_for_state(Core::Notifier::Type::Write));

--- a/Userland/Libraries/LibSSH/Session.cpp
+++ b/Userland/Libraries/LibSSH/Session.cpp
@@ -17,6 +17,10 @@ ErrorOr<ExecData> ExecData::create(Core::Process&& process, int fd_stdin, int fd
         TRY(Core::File::adopt_fd(fd_stderr, Core::File::OpenMode::Read)),
     };
 
+    TRY(exec_data.stdin_->set_blocking(false));
+    TRY(exec_data.stdout_->set_blocking(false));
+    TRY(exec_data.stderr_->set_blocking(false));
+
     return exec_data;
 }
 

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -23,6 +23,8 @@ struct Session;
 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.1
 
 struct ExecData {
+    static ErrorOr<ExecData> create(Core::Process&& process, int fd_stdin, int fd_stdout, int fd_stderr);
+
     Core::Process child;
 
     NonnullOwnPtr<Core::File> stdin_;

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -478,6 +478,9 @@ ErrorOr<SSHClient::ShouldDisconnect> SSHClient::handle_generic_packet(GenericMes
     case MessageID::CHANNEL_EOF:
         TRY(handle_channel_eof(message));
         break;
+    case MessageID::CHANNEL_WINDOW_ADJUST:
+        TRY(handle_channel_window_adjust_message(message));
+        break;
     case MessageID::CHANNEL_CLOSE:
         TRY(handle_channel_close(message));
         break;
@@ -778,6 +781,13 @@ ErrorOr<void> SSHClient::handle_channel_eof(GenericMessage& message)
         [&](auto& system) { system.handle_channel_eof(session); },
         [](Empty) {});
 
+    return {};
+}
+
+ErrorOr<void> SSHClient::handle_channel_window_adjust_message(GenericMessage&)
+{
+    // FIXME: Actually support this packet and don't spam the client without
+    //        respecting its window size.
     return {};
 }
 

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -657,12 +657,7 @@ ErrorOr<void> SSHClient::handle_channel_exec(NonnullRefPtr<Session> const& sessi
     TRY(Core::System::close(stdout_fds[1]));
     TRY(Core::System::close(stderr_fds[1]));
 
-    session->system = ExecData {
-        .child = move(child),
-        .stdin_ = TRY(Core::File::adopt_fd(stdin_fds[1], Core::File::OpenMode::Write)),
-        .stdout_ = TRY(Core::File::adopt_fd(stdout_fds[0], Core::File::OpenMode::Read)),
-        .stderr_ = TRY(Core::File::adopt_fd(stderr_fds[0], Core::File::OpenMode::Read)),
-    };
+    session->system = TRY(ExecData::create(move(child), stdin_fds[1], stdout_fds[0], stderr_fds[0]));
 
     TRY(send_channel_success_message(session));
 

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -94,6 +94,7 @@ private:
     ErrorOr<void> send_channel_success_message(Session const&);
     ErrorOr<void> send_channel_data(Session const&, ReadonlyBytes);
     ErrorOr<void> send_channel_extended_data(Session const&, ReadonlyBytes);
+    ErrorOr<void> handle_channel_window_adjust_message(GenericMessage&);
     ErrorOr<void> handle_channel_eof(GenericMessage&);
     ErrorOr<void> send_exit_status(Session const&, int);
     ErrorOr<void> handle_channel_close(GenericMessage&);


### PR DESCRIPTION
This make the following command not crash every single time :sweat_smile::

```bash
ssh -p 2222 127.0.0.1 cat - < ~/progress_file_2MB.txt
```