### PR TITLE
SSHServer: Handle partial packets

### DIFF
--- a/Tests/LibSSH/TestSSHPeer.cpp
+++ b/Tests/LibSSH/TestSSHPeer.cpp
@@ -48,8 +48,16 @@ public:
         set_shared_secret(move(shared_secret));
     }
 
+    PeerMock(SocketMock& socket, Crypto::Hash::Digest<256> hash, ByteBuffer shared_secret)
+        : SSH::Peer(socket)
+    {
+        set_hash(hash);
+        set_shared_secret(move(shared_secret));
+    }
+
     using SSH::Peer::handle_disconnect_message;
     using SSH::Peer::handle_new_keys_message;
+    using SSH::Peer::is_buffer_containing_a_full_packet;
     using SSH::Peer::read_packet;
     using SSH::Peer::send_new_keys_message;
     using SSH::Peer::session_id;
@@ -118,4 +126,60 @@ TEST_CASE(stable_session_id)
     peer.set_hash(new_hash);
 
     EXPECT_EQ(peer.session_id(), session_id);
+}
+
+TEST_CASE(is_buffer_containing_a_full_packet)
+{
+    // A session ID is stable, even after the peers rekeyed.
+    AllocatingMemoryStream stream;
+    SocketMock socket(stream);
+    auto peer = PeerMock(socket);
+
+    auto message = TRY_OR_FAIL(ByteBuffer::copy(new_keys_message.bytes()));
+    message.append("Additional data"sv.bytes());
+
+    EXPECT(peer.is_buffer_containing_a_full_packet(new_keys_message.bytes()));
+    EXPECT(peer.is_buffer_containing_a_full_packet(new_keys_message.bytes().trim(new_keys_message.length())));
+    EXPECT(!peer.is_buffer_containing_a_full_packet(new_keys_message.bytes().trim(new_keys_message.length() - 1)));
+}
+
+TEST_CASE(is_buffer_containing_a_full_packet_encrypted)
+{
+    // The data comes from ChaCha20Poly1305_decrypt.
+    auto shared_secret_raw = "\x53\x22\xc2\x28\x50\xfe\x85\xbd\xb3\x35\xcf\xb4\x67\x4a\x82\x0b\xd0\x54\xa3\xd9\x4a\xc8\x3c\x55\x91\xb4\xd5\xf7\x52\x28\xd2\x6c"sv.bytes();
+    auto hash_raw = "\xc0\x73\x95\x08\xd8\xc0\xbf\x2a\x6d\x13\x1b\xfd\x67\x88\x32\xdf\x15\xeb\x5a\x2e\x5a\xf3\xdf\x98\xa1\x1c\x41\x2b\x2a\x26\x4d\x62"sv.bytes();
+
+    auto shared_secret = TRY_OR_FAIL(ByteBuffer::copy(shared_secret_raw));
+    SSH::ChaCha20Poly1305Cipher::Digest hash;
+    hash_raw.copy_to({ &hash.data, decltype(hash)::Size });
+
+    // A session ID is stable, even after the peers rekeyed.
+    AllocatingMemoryStream stream;
+    SocketMock socket(stream);
+    auto peer = PeerMock(socket, hash, shared_secret);
+
+    auto make_message = []() {
+        return ByteBuffer::copy(new_keys_message.bytes());
+    };
+
+    // This is hackish, we call read_packet multiple times to bump Peer's private variable
+    // m_incoming_packet_sequence_number to 3. This is required to decrypt the packet below.
+    for (u32 i = 0; i < 2; ++i) {
+        auto message = TRY_OR_FAIL(make_message());
+        TRY_OR_FAIL(peer.read_packet(message));
+    }
+
+    auto message = TRY_OR_FAIL(make_message());
+    TRY_OR_FAIL(peer.handle_new_keys_message(message));
+
+    // Peer is properly initialized to decrypt messages.
+
+    auto encrypted_raw = "\x0c\x3b\x6d\x66\xb1\x72\xf3\x85\xa4\x88\x35\xf2\x0a\x6d\xa5\x9b\x29\xcf\xe6\xe8\x5f\xad\x05\x6b\x94\x89\xae\xab\x10\x37\x88\x7a\x6b\x58\x30\xb1\x9b\x6f\xc1\x8f\x6c\x89\x68\x24"sv.bytes();
+    auto packet = TRY_OR_FAIL(ByteBuffer::copy(encrypted_raw));
+    auto additional_data = "Additional data"sv.bytes();
+    packet.append(additional_data);
+
+    EXPECT(peer.is_buffer_containing_a_full_packet(packet));
+    EXPECT(peer.is_buffer_containing_a_full_packet(packet.bytes().trim(encrypted_raw.size())));
+    EXPECT(!peer.is_buffer_containing_a_full_packet(packet.bytes().trim(encrypted_raw.size() - 1)));
 }

--- a/Userland/Libraries/LibSSH/Cipher.cpp
+++ b/Userland/Libraries/LibSSH/Cipher.cpp
@@ -40,6 +40,11 @@ ErrorOr<void> Cipher::encrypt(u32 packet_sequence_number, Bytes bytes)
     return {};
 }
 
+u32 IdentityCipher::decrypt_packet_length(u32, Bytes bytes)
+{
+    return AK::convert_between_host_and_network_endian(ByteReader::load32(bytes.data()));
+}
+
 NonnullOwnPtr<ChaCha20Poly1305Cipher> ChaCha20Poly1305Cipher::create(ByteBuffer const& shared_secret, Crypto::Hash::Digest<256> hash, Crypto::Hash::Digest<256> session_id)
 {
 
@@ -109,7 +114,7 @@ NonnullOwnPtr<ChaCha20Poly1305Cipher> ChaCha20Poly1305Cipher::create(ByteBuffer 
 
 // 7. Packet Handling
 // https://datatracker.ietf.org/doc/html/draft-ietf-sshm-chacha20-poly1305-02#section-7
-void ChaCha20Poly1305Cipher::decrypt_impl(u32 packet_sequence_number, Bytes bytes)
+u32 ChaCha20Poly1305Cipher::decrypt_packet_length(u32 packet_sequence_number, Bytes bytes)
 {
     // "When receiving a packet, the length must be decrypted first. When 4 bytes o
     // ciphertext length have been received, they may be decrypted using the K_2 key,
@@ -123,14 +128,25 @@ void ChaCha20Poly1305Cipher::decrypt_impl(u32 packet_sequence_number, Bytes byte
     Crypto::Cipher::ChaCha20 length_decryptor(m_k_2_client_to_server.bytes(), nonce, 0);
     length_decryptor.decrypt(encrypted_length, encrypted_length);
 
+    u32 packet_length = AK::convert_between_host_and_network_endian(ByteReader::load32(encrypted_length.data()));
+    return packet_length;
+}
+
+// 7. Packet Handling
+// https://datatracker.ietf.org/doc/html/draft-ietf-sshm-chacha20-poly1305-02#section-7
+void ChaCha20Poly1305Cipher::decrypt_impl(u32 packet_sequence_number, Bytes bytes)
+{
+    u32 packet_length = decrypt_packet_length(packet_sequence_number, bytes);
+
     // FIXME: "Once the entire packet has been received, the MAC MUST be checked before decryption."
 
     // "the packet decrypted using ChaCha20 as described above (with K_1, the packet
     // sequence number as nonce and a starting block counter of 1)."
 
-    u32 packet_length = AK::convert_between_host_and_network_endian(ByteReader::load32(encrypted_length.data()));
     auto packet = bytes.slice(4, packet_length);
 
+    NetworkOrdered<u64> nonce_data(packet_sequence_number);
+    ReadonlyBytes nonce { &nonce_data, sizeof(nonce_data) };
     Crypto::Cipher::ChaCha20 packet_decryptor(m_k_1_client_to_server.bytes(), nonce, 1);
     packet_decryptor.decrypt(packet, packet);
 }

--- a/Userland/Libraries/LibSSH/Cipher.h
+++ b/Userland/Libraries/LibSSH/Cipher.h
@@ -18,6 +18,7 @@ public:
     Cipher(u8 block_size, u8 mac_size);
     virtual ~Cipher() = default;
 
+    virtual u32 decrypt_packet_length(u32 packet_sequence_number, Bytes bytes) = 0;
     ErrorOr<void> decrypt(u32 packet_sequence_number, Bytes);
     ErrorOr<void> encrypt(u32 packet_sequence_number, Bytes);
 
@@ -42,6 +43,7 @@ public:
     virtual ~IdentityCipher() = default;
 
 private:
+    u32 decrypt_packet_length(u32, Bytes bytes) override;
     void decrypt_impl(u32, Bytes) override { }
     void encrypt_impl(u32, Bytes) override { }
 };
@@ -64,6 +66,7 @@ private:
     {
     }
 
+    u32 decrypt_packet_length(u32, Bytes) override;
     void decrypt_impl(u32, Bytes) override;
     void encrypt_impl(u32, Bytes) override;
 

--- a/Userland/Libraries/LibSSH/Peer.cpp
+++ b/Userland/Libraries/LibSSH/Peer.cpp
@@ -12,6 +12,18 @@
 
 namespace SSH {
 
+bool Peer::is_buffer_containing_a_full_packet(ReadonlyBytes data)
+{
+    if (data.size() < sizeof(u32))
+        return false;
+
+    // We make a copy to ensure the input bytes stay unchanged.
+    auto copy = MUST(ByteBuffer::copy(data.trim(sizeof(u32))));
+
+    auto packet_length = m_cipher->decrypt_packet_length(m_incoming_packet_sequence_number, copy);
+    return sizeof(u32) + packet_length + m_cipher->mac_size() <= data.size();
+}
+
 // 6.  Binary Packet Protocol
 // https://datatracker.ietf.org/doc/html/rfc4253#section-6
 ErrorOr<ByteBuffer> Peer::read_packet(ByteBuffer& data)

--- a/Userland/Libraries/LibSSH/Peer.h
+++ b/Userland/Libraries/LibSSH/Peer.h
@@ -24,6 +24,8 @@ public:
     virtual ~Peer() = default;
 
 protected:
+    bool is_buffer_containing_a_full_packet(ReadonlyBytes);
+
     ErrorOr<ByteBuffer> read_packet(ByteBuffer&);
     ErrorOr<void> write_packet(ReadonlyBytes payload);
 

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -27,6 +27,11 @@ namespace SSH::Server {
 
 ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_data(ByteBuffer& data)
 {
+    if (m_state != State::Constructed) {
+        if (!is_buffer_containing_a_full_packet(data))
+            return BehaviorControl::WaitForMoreData;
+    }
+
     switch (m_state) {
     case State::Constructed:
         TRY(handle_protocol_version(data));

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -25,7 +25,7 @@
 
 namespace SSH::Server {
 
-ErrorOr<SSHClient::ShouldDisconnect> SSHClient::handle_data(ByteBuffer& data)
+ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_data(ByteBuffer& data)
 {
     switch (m_state) {
     case State::Constructed:
@@ -50,7 +50,7 @@ ErrorOr<SSHClient::ShouldDisconnect> SSHClient::handle_data(ByteBuffer& data)
     case State::Authentified:
         return handle_generic_packet(TRY(unpack_generic_message(data)));
     }
-    return ShouldDisconnect::No;
+    return BehaviorControl::ContinueExecution;
 }
 
 // 4.2.  Protocol Version Exchange
@@ -460,12 +460,12 @@ ErrorOr<void> SSHClient::send_user_authentication_success()
     return {};
 }
 
-ErrorOr<SSHClient::ShouldDisconnect> SSHClient::handle_generic_packet(GenericMessage&& message)
+ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_generic_packet(GenericMessage&& message)
 {
     switch (message.type) {
     case MessageID::DISCONNECT:
         TRY(handle_disconnect_message(message.data));
-        return ShouldDisconnect::Yes;
+        return BehaviorControl::Disconnect;
     case MessageID::CHANNEL_OPEN:
         TRY(handle_channel_open_message(message));
         break;
@@ -488,7 +488,7 @@ ErrorOr<SSHClient::ShouldDisconnect> SSHClient::handle_generic_packet(GenericMes
         dbgln_if(SSH_DEBUG, "Unexpected packet: {}", to_underlying(message.type));
         return Error::from_string_literal("Unexpected packet type");
     }
-    return ShouldDisconnect::No;
+    return BehaviorControl::ContinueExecution;
 }
 
 // 5.1.  Opening a Channel

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -47,12 +47,12 @@ public:
     {
     }
 
-    enum class ShouldDisconnect : u8 {
-        No,
-        Yes,
+    enum class BehaviorControl : u8 {
+        ContinueExecution,
+        Disconnect,
     };
 
-    ErrorOr<ShouldDisconnect> handle_data(ByteBuffer& data);
+    ErrorOr<BehaviorControl> handle_data(ByteBuffer& data);
 
 private:
     enum class State : u8 {
@@ -84,7 +84,7 @@ private:
     ErrorOr<void> send_publickey_ok_message(ReadonlyBytes algorithm_name, ReadonlyBytes blob);
     ErrorOr<void> send_user_authentication_success();
 
-    ErrorOr<ShouldDisconnect> handle_generic_packet(GenericMessage&&);
+    ErrorOr<BehaviorControl> handle_generic_packet(GenericMessage&&);
 
     ErrorOr<void> handle_channel_open_message(GenericMessage&);
     ErrorOr<void> send_channel_open_confirmation(Session const&);

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -49,6 +49,7 @@ public:
 
     enum class BehaviorControl : u8 {
         ContinueExecution,
+        WaitForMoreData,
         Disconnect,
     };
 

--- a/Userland/Services/SSHServer/TCPClient.cpp
+++ b/Userland/Services/SSHServer/TCPClient.cpp
@@ -51,8 +51,13 @@ ErrorOr<void> TCPClient::on_ready_to_read()
         return {};
 
     while (!m_read_buffer.is_empty()) {
-        if (TRY(m_ssh_client.handle_data(m_read_buffer)) == SSHClient::ShouldDisconnect::Yes)
+        auto next_behavior = TRY(m_ssh_client.handle_data(m_read_buffer));
+        switch (next_behavior) {
+        case SSHClient::BehaviorControl::ContinueExecution:
+            continue;
+        case SSHClient::BehaviorControl::Disconnect:
             die();
+        }
     }
     return {};
 }

--- a/Userland/Services/SSHServer/TCPClient.cpp
+++ b/Userland/Services/SSHServer/TCPClient.cpp
@@ -55,6 +55,8 @@ ErrorOr<void> TCPClient::on_ready_to_read()
         switch (next_behavior) {
         case SSHClient::BehaviorControl::ContinueExecution:
             continue;
+        case SSHClient::BehaviorControl::WaitForMoreData:
+            return {};
         case SSHClient::BehaviorControl::Disconnect:
             die();
         }


### PR DESCRIPTION
With this PR, we are now able to run this command for quite some time:
```bash
i=0;while true; do ssh -p 2222 127.0.0.1 cat - < ~/progress_file_1MB.txt && echo $i && ((i++)); done
```

It used to crash in less than 10 attempts, but now I've seen it go above 200 hundreds loops. There are unfortunately still issues as the server sometimes hangs, but at least crashes are gone!