### PR TITLE
SSHServer: Use signals to detect exec's child death

### DIFF
--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -196,6 +196,8 @@ public:
     ErrorOr<void> set_blocking(bool enabled) override { return m_helper.set_blocking(enabled); }
     ErrorOr<void> set_close_on_exec(bool enabled) override { return m_helper.set_close_on_exec(enabled); }
 
+    int fd() const { return m_helper.fd(); }
+
     virtual ~TCPSocket() override { close(); }
 
 private:

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -32,6 +32,8 @@ struct ExecData {
     NonnullOwnPtr<Core::File> stdout_;
     NonnullOwnPtr<Core::File> stderr_;
 
+    Optional<int> exit_status {};
+
     Coroutine<ErrorOr<void>> handle_channel_data(Session&);
     void handle_channel_eof(Session const&);
 

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -30,6 +30,17 @@ SSHClient::SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect)
     , m_tcp_socket(tcp_socket)
     , m_disconnect(move(disconnect))
 {
+    m_sigchld_handler_id = Core::EventLoop::register_signal(SIGCHLD, [this](int) {
+        if (auto maybe_error = manage_child_death(); maybe_error.is_error()) {
+            // FIXME: Maybe disconnect?
+            dbgln("Error while trying to manage child death: {}", maybe_error.error());
+        }
+    });
+}
+
+SSHClient::~SSHClient()
+{
+    Core::EventLoop::unregister_signal(m_sigchld_handler_id);
 }
 
 ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_data(ByteBuffer& data)
@@ -683,7 +694,6 @@ ErrorOr<void> SSHClient::handle_channel_exec(NonnullRefPtr<Session> const& sessi
     // FIXME: Make sure to cancel these coroutines if anything goes wrong.
     Core::EventLoop::adopt_coroutine(async_stream_std_data(session, [](ExecData& exec_data) -> Core::File& { return *exec_data.stdout_; }, [this](auto&... args) { return send_channel_data(args...); }));
     Core::EventLoop::adopt_coroutine(async_stream_std_data(session, [](ExecData& exec_data) -> Core::File& { return *exec_data.stderr_; }, [this](auto&... args) { return send_channel_extended_data(args...); }));
-    Core::EventLoop::adopt_coroutine(async_wait_for_child(session));
 
     return {};
 }
@@ -701,37 +711,14 @@ Coroutine<void> SSHClient::async_stream_std_data(NonnullRefPtr<Session> session,
 
             CO_TRY(sender(session, output));
         }
+
+        CO_TRY(close_exec_session_if_needed(session));
+
         co_return {};
     }();
 
     if (maybe_error.is_error()) {
         dbgln("Unable to read stdout from process: {}", maybe_error.error());
-        // FIXME: Think about what we should do with this error.
-    }
-    co_return;
-}
-
-Coroutine<void> SSHClient::async_wait_for_child(NonnullRefPtr<Session> session)
-{
-    auto maybe_error = [&]() -> ErrorOr<void> {
-        // FIXME: If the child closes STDOUT, we will block the server in
-        //        wait_for_termination() bellow. We should implement a way to
-        //        wake up the event loop on the child's death.
-        Core::EventLoop::current().spin_until([&session]() {
-            return session->system.get<ExecData>().stdout_->is_eof();
-        });
-
-        auto exited_with_code_0 = TRY(session->system.get<ExecData>().child.wait_for_termination());
-
-        // FIXME: Send the actual exit status.
-        TRY(send_exit_status(session, exited_with_code_0 ? 0 : -1));
-
-        TRY(send_channel_close(session));
-        return {};
-    }();
-
-    if (maybe_error.is_error()) {
-        dbgln("Error while waiting for the child: {}", maybe_error.error());
         // FIXME: Think about what we should do with this error.
     }
     co_return;
@@ -863,6 +850,60 @@ ErrorOr<void> SSHClient::send_exit_status(Session const& session, int status)
     TRY(stream.write_value<NetworkOrdered<u32>>(status));
 
     TRY(write_packet(TRY(stream.read_until_eof())));
+    return {};
+}
+
+ErrorOr<void> SSHClient::manage_child_death()
+{
+    while (true) {
+        auto maybe_result = Core::System::waitpid(-1, WNOHANG);
+
+        if (maybe_result.is_error()) {
+            auto error = maybe_result.release_error();
+            if (error.code() == EINTR)
+                continue;
+            if (error.code() == ECHILD)
+                return {};
+            return error;
+        }
+
+        auto result = maybe_result.value();
+
+        if (result.pid == 0)
+            return {};
+
+        for (auto& session : m_sessions) {
+            if (session->system.has<ExecData>()) {
+                auto& exec_data = session->system.get<ExecData>();
+                if (exec_data.child.pid() == result.pid) {
+                    bool exited_with_code_0 = true;
+                    if (WIFEXITED(result.status)) {
+                        exited_with_code_0 &= WEXITSTATUS(result.status) == 0;
+                    } else if (WIFSIGNALED(result.status)) {
+                        exited_with_code_0 = false;
+                    }
+
+                    // FIXME: Send the actual exit status.
+                    exec_data.exit_status = exited_with_code_0 ? 0 : -1;
+
+                    TRY(close_exec_session_if_needed(*session));
+                }
+            }
+        }
+    }
+}
+
+ErrorOr<void> SSHClient::close_exec_session_if_needed(Session& session)
+{
+    auto& exec_data = session.system.get<ExecData>();
+    if (!exec_data.exit_status.has_value()
+        || !exec_data.stdout_->is_eof()
+        || !exec_data.stderr_->is_eof())
+        return {};
+
+    TRY(send_exit_status(session, *session.system.get<ExecData>().exit_status));
+
+    TRY(send_channel_close(session));
     return {};
 }
 

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -25,6 +25,13 @@
 
 namespace SSH::Server {
 
+SSHClient::SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect)
+    : Peer(tcp_socket)
+    , m_tcp_socket(tcp_socket)
+    , m_disconnect(move(disconnect))
+{
+}
+
 ErrorOr<SSHClient::BehaviorControl> SSHClient::handle_data(ByteBuffer& data)
 {
     if (m_state != State::Constructed) {

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -42,6 +42,7 @@ public:
 class SSHClient : public Peer {
 public:
     explicit SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect);
+    ~SSHClient();
 
     enum class BehaviorControl : u8 {
         ContinueExecution,
@@ -102,7 +103,9 @@ private:
     template<typename F, typename F2>
     Coroutine<void> async_stream_std_data(NonnullRefPtr<Session>, F file_extractor, F2 sender);
     Coroutine<void> async_stream_data_to_subsystem(NonnullRefPtr<Session>);
-    Coroutine<void> async_wait_for_child(NonnullRefPtr<Session>);
+
+    ErrorOr<void> manage_child_death();
+    ErrorOr<void> close_exec_session_if_needed(Session&);
 
     void disconnect(Error);
 
@@ -115,6 +118,7 @@ private:
     ByteBuffer m_cookie {};
 
     Vector<NonnullRefPtr<Session>> m_sessions;
+    int m_sigchld_handler_id {};
 };
 
 } // SSHServer

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -41,12 +41,7 @@ public:
 
 class SSHClient : public Peer {
 public:
-    explicit SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect)
-        : Peer(tcp_socket)
-        , m_tcp_socket(tcp_socket)
-        , m_disconnect(move(disconnect))
-    {
-    }
+    explicit SSHClient(Core::TCPSocket& tcp_socket, Function<void()> disconnect);
 
     enum class BehaviorControl : u8 {
         ContinueExecution,

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -50,7 +50,7 @@ ErrorOr<void> accept_connection()
             g_client = SSH::Server::TCPClient::create(move(socket), move(on_quit));
         });
     } else {
-        // The client socket will be close when leaving this function.
+        // The client socket will be closed when leaving this function.
         // The server goes back to listening again.
     }
     return {};

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -27,16 +27,26 @@ OwnPtr<SSH::Server::TCPClient> g_client;
 ErrorOr<void> accept_connection()
 {
     auto client_socket = TRY(g_tcp_server->accept());
+    auto fd = client_socket->fd();
 
     if (auto pid = TRY(Core::System::fork()); pid == 0) {
         // Close the server listening socket. This is deferred to not close
         // the server from within itself.
-        Core::EventLoop::current().deferred_invoke([socket = move(client_socket)]() mutable {
+
+        // We need to ensure the socket survives until the deferred_invoke, but
+        // fd will be closed at the end of the scope with client_socket.
+        auto fd_copy = TRY(Core::System::dup(fd));
+
+        Core::EventLoop::current().deferred_invoke([fd_copy]() mutable {
             g_tcp_server = nullptr;
             auto on_quit = []() {
                 g_client = nullptr;
                 Core::EventLoop::current().quit(0);
             };
+
+            Core::EventLoop::notify_forked(Core::EventLoop::ForkEvent::Child);
+
+            auto socket = MUST(Core::TCPSocket::adopt_fd(fd_copy));
             g_client = SSH::Server::TCPClient::create(move(socket), move(on_quit));
         });
     } else {


### PR DESCRIPTION
This PR make this test more stable, and I didn't observe any hangs:
```bash
i=0; while ssh -p 2222 127.0.0.1 cat - < ~/progress_file_1MB.txt; do echo $i && ((i++)); done
```

There are still issues as this failure randomly appears (~1% of runs):
```
ssh_dispatch_run_fatal: Connection to [127.0.0.1 port 2222]: incorrect signature
```
