### PR TITLE
LibSSH: Support encoding numbers with leading zeroes as mpint

### DIFF
--- a/Tests/LibSSH/TestSSHEncodeDecode.cpp
+++ b/Tests/LibSSH/TestSSHEncodeDecode.cpp
@@ -83,11 +83,23 @@ TEST_CASE(mpint)
         return {};
     };
 
+    TRY_OR_FAIL(test(to_array<u8>({ 0x00 }), to_array<u8>({ 0x00, 0x00, 0x00, 0x00 })));
     TRY_OR_FAIL(test(to_array<u8>({ 0x09, 0xa3, 0x78, 0xf9, 0xb2, 0xe3, 0x32, 0xa7 }), to_array<u8>({ 0x00, 0x00, 0x00, 0x08, 0x09, 0xa3, 0x78, 0xf9, 0xb2, 0xe3, 0x32, 0xa7 })));
     TRY_OR_FAIL(test(to_array<u8>({ 0x80 }), to_array<u8>({ 0x00, 0x00, 0x00, 0x02, 0x00, 0x80 })));
 
+    // Encoding this wrong makes openssh's client return:
+    // ssh_dispatch_run_fatal: [SERVER IP]: incorrect signature
+    auto expected = "\x00\x00\x00\x1f\x5e\x34\x80\x61\xe5\x4d\xe0\xcb\xf3\x94\x1b\xee\x96\x6e\x20\x68\x1d\x83\xeb\x8b\xa2\xce\xc2\x33\x5c\xf1\xfd\x2d\xe7\x2f\x6c"sv.bytes();
+    TRY_OR_FAIL(test(
+        "\x00\x5e\x34\x80\x61\xe5\x4d\xe0\xcb\xf3\x94\x1b\xee\x96\x6e\x20\x68\x1d\x83\xeb\x8b\xa2\xce\xc2\x33\x5c\xf1\xfd\x2d\xe7\x2f\x6c"sv.bytes(),
+        expected));
+
+    // Same as above but with multiple leading zeroes.
+    TRY_OR_FAIL(test(
+        "\x00\x00\x00\x5e\x34\x80\x61\xe5\x4d\xe0\xcb\xf3\x94\x1b\xee\x96\x6e\x20\x68\x1d\x83\xeb\x8b\xa2\xce\xc2\x33\x5c\xf1\xfd\x2d\xe7\x2f\x6c"sv.bytes(),
+        expected));
+
     // FIXME: Whenever we add support for them add the corresponding tests:
-    //        - for input with leading zeros
     //        - for negative input numbers
 }
 

--- a/Userland/Libraries/LibSSH/DataTypes.cpp
+++ b/Userland/Libraries/LibSSH/DataTypes.cpp
@@ -29,12 +29,12 @@ ErrorOr<void> encode_mpint(AllocatingMemoryStream& stream, ReadonlyBytes bytes)
 {
     VERIFY(bytes.size() > 0);
 
-    // FIXME: Remove leading zeros.
-    VERIFY(bytes.size() > 0 || bytes[0] == 0);
+    auto first_non_null = find_if(bytes.begin(), bytes.end(), [](u8 byte) { return byte != 0; });
+    bool is_all_zeroes = first_non_null == bytes.end();
 
-    bool should_add_leading_zero = bytes.size() > 0 && bytes[0] & 0x80;
+    bool should_add_leading_zero = !is_all_zeroes && bytes[first_non_null.index()] & 0x80;
 
-    u32 total_length = bytes.size();
+    u32 total_length = bytes.size() - first_non_null.index();
 
     // "If the most significant bit would be set for a positive number,
     // the number MUST be preceded by a zero byte."
@@ -44,7 +44,7 @@ ErrorOr<void> encode_mpint(AllocatingMemoryStream& stream, ReadonlyBytes bytes)
     TRY(stream.write_value<NetworkOrdered<u32>>(total_length));
     if (should_add_leading_zero)
         TRY(stream.write_value<NetworkOrdered<u8>>(0));
-    TRY(stream.write_until_depleted(bytes));
+    TRY(stream.write_until_depleted(bytes.slice(first_non_null.index())));
     return {};
 }
 


### PR DESCRIPTION
As I failed to write a VERIFY that would hit this case, when the shared secret started with two null bytes, we were silently creating an invalid mpint which would make the ssh client abort the connection with this message:
ssh_dispatch_run_fatal: Connection to [Server IP]: incorrect signature

AFAICT, this patch makes the error go away.

---

After #26768,
This PR make the usual test way more stable, and I was able to reach more than 30k consecutive runs:
```bash
i=0; while ssh -p 2222 127.0.0.1 cat - < ~/progress_file_1MB.txt; do echo $i && ((i++)); done
```
```
Done!
36526
/bin/sh: 1: Cannot fork
Connection to 127.0.0.1 closed by remote host.
```
(I somehow forgot to make the main `SSHServer` process reap its children, and fork-bombed myself :facepalm:)