### PR TITLE
SSHServer: Reap children when they die

### DIFF
--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -81,6 +81,21 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     Core::EventLoop loop;
 
+    Core::EventLoop::register_signal(SIGCHLD, [&](int) {
+        while (true) {
+            auto maybe_result = Core::System::waitpid(-1, WNOHANG);
+            if (maybe_result.is_error()) {
+                auto error = maybe_result.release_error();
+                if (error.code() == EINTR)
+                    continue;
+                if (error.code() == ECHILD)
+                    return;
+                dbgln("Error while reaping child processes: {}", error);
+                loop.quit(-1);
+            }
+        }
+    });
+
     g_tcp_server = TRY(Core::TCPServer::try_create());
 
     g_tcp_server->on_ready_to_accept = [] {


### PR DESCRIPTION
Since 4c8188d6, we fork the main server on new connections, but I forgot to make the main server reap its children. This commit addresses the shortcoming.

---

With the patch applied on top of #26768 and #26769, the usual `while` loop seems to be a true infinite loop, on the one I started an hour ago it has done 60k+ iterations and is still going. 