### PR TITLE
Browser crashing fixed

### DIFF
--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -33,6 +33,7 @@
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/URL.h>
 #include <unistd.h>
+#include <errno.h>
 
 namespace Browser {
 
@@ -52,8 +53,14 @@ ByteString g_webdriver_content_ipc_path;
 
 static ErrorOr<void> load_content_filters()
 {
-    auto file = TRY(Core::File::open(TRY(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory())), Core::File::OpenMode::Read));
-    auto ad_filter_list = TRY(Core::InputBufferedFile::create(move(file)));
+    auto path = TRY(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()));
+    auto file_result = Core::File::open(path, Core::File::OpenMode::Read);
+    if (file_result.is_error()) {
+        if (file_result.error().is_errno() && file_result.error().code() == ENOENT)
+            return {};
+        return file_result.release_error();
+    }
+    auto ad_filter_list = TRY(Core::InputBufferedFile::create(file_result.release_value()));
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
 
     Browser::g_content_filters.clear_with_capacity();
@@ -72,8 +79,14 @@ static ErrorOr<void> load_content_filters()
 
 static ErrorOr<void> load_autoplay_allowlist()
 {
-    auto file = TRY(Core::File::open(TRY(String::formatted("{}/BrowserAutoplayAllowlist.txt", Core::StandardPaths::config_directory())), Core::File::OpenMode::Read));
-    auto allowlist = TRY(Core::InputBufferedFile::create(move(file)));
+    auto path = TRY(String::formatted("{}/BrowserAutoplayAllowlist.txt", Core::StandardPaths::config_directory()));
+    auto file_result = Core::File::open(path, Core::File::OpenMode::Read);
+    if (file_result.is_error()) {
+        if (file_result.error().is_errno() && file_result.error().code() == ENOENT)
+            return {};
+        return file_result.release_error();
+    }
+    auto allowlist = TRY(Core::InputBufferedFile::create(file_result.release_value()));
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
 
     Browser::g_autoplay_allowlist.clear_with_capacity();
@@ -239,7 +252,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         window->content_filters_changed();
     };
-    TRY(content_filters_watcher->add_watch(ByteString::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()), Core::FileWatcherEvent::Type::ContentModified));
+    if (!Core::File::open(TRY(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory())), Core::File::OpenMode::Read).is_error())
+        TRY(content_filters_watcher->add_watch(ByteString::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()), Core::FileWatcherEvent::Type::ContentModified));
 
     auto autoplay_allowlist_watcher = TRY(Core::FileWatcher::create());
     autoplay_allowlist_watcher->on_change = [&](Core::FileWatcherEvent const&) {
@@ -250,7 +264,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         window->autoplay_allowlist_changed();
     };
-    TRY(autoplay_allowlist_watcher->add_watch(ByteString::formatted("{}/BrowserAutoplayAllowlist.txt", Core::StandardPaths::config_directory()), Core::FileWatcherEvent::Type::ContentModified));
+    if (!Core::File::open(TRY(String::formatted("{}/BrowserAutoplayAllowlist.txt", Core::StandardPaths::config_directory())), Core::File::OpenMode::Read).is_error())
+        TRY(autoplay_allowlist_watcher->add_watch(ByteString::formatted("{}/BrowserAutoplayAllowlist.txt", Core::StandardPaths::config_directory()), Core::FileWatcherEvent::Type::ContentModified));
 
     app->on_action_enter = [&](GUI::Action& action) {
         if (auto* browser_window = dynamic_cast<Browser::BrowserWindow*>(app->active_window())) {

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -10,6 +10,7 @@
 #include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
+#include <LibCore/StandardPaths.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/SettingsWindow.h>
@@ -28,8 +29,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));
-    TRY(Core::System::unveil("/home/anon/.config/BrowserAutoplayAllowlist.txt", "rwc"));
-    TRY(Core::System::unveil("/home/anon/.config/BrowserContentFilters.txt", "rwc"));
+    TRY(Core::System::unveil(TRY(String::formatted("{}/BrowserAutoplayAllowlist.txt", Core::StandardPaths::config_directory())), "rwc"));
+    TRY(Core::System::unveil(TRY(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory())), "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-browser"sv);


### PR DESCRIPTION
## Description
Closes #26604 
(Changed main.cpp of Browser and BrowserSetting)

- Fixes Browser/Settings crash on non-anon users by removing hardcoded /home/anon assumptions and treating missing per-user config files as non-fatal.
- In [main.cpp](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) replaced hardcoded unveils with paths derived from [Core::StandardPaths::config_directory()](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- In [main.cpp](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) made [load_content_filters()](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [load_autoplay_allowlist()](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) return cleanly on [ENOENT](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of failing.
- Only add FileWatcher watches for those config files when they actually exist.

### Result
Browser and BrowserSettings start normally for other users and fall back to defaults when per-user config files are absent.
