### PR TITLE
Solitaire: Don't ignore the Play pile when solving

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -715,7 +715,7 @@ void Game::start_solving()
 void Game::step_solve()
 {
     for (auto& stack : stacks()) {
-        if (stack->type() != Cards::CardStack::Type::Normal)
+        if (stack->type() != Cards::CardStack::Type::Normal && stack->type() != Cards::CardStack::Type::Play)
             continue;
 
         if (attempt_to_move_card_to_foundations(stack))


### PR DESCRIPTION
Hard to measure if this actually fixes the issue always, but it was weird to see it get stuck when I had a card there it refused to use.