### PR TITLE
Kernel/xHCI: Properly determine the transfer size for short transfers

### DIFF
--- a/Kernel/Bus/USB/xHCI/xHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIController.cpp
@@ -917,10 +917,18 @@ ErrorOr<Vector<TransferRequestBlock>> xHCIController::prepare_normal_transfer(Tr
         transfer_request_block.normal.transfer_descriptor_size = min(transfer_request_blocks_count - i - 1, 31);
         transfer_request_block.normal.interrupter_target = 0;
 
-        if (i != (transfer_request_blocks_count - 1))
+        // 4.10.1.1.2 Short Transfers when not using Event Data TRBs
+        // If software is not using Event Data TRBs, but it wants to flag the completion of a
+        // TD that may receive a Short Packet, then:
+        // • The ISP flag shall be set (‘1’) in all Transfer TRBs of the TD except the last Transfer
+        //   TRB and may be set in the last Transfer TRB, and
+        // • The IOC flag shall be set (‘1’) in the last Transfer TRB of the TD.
+        if (i != (transfer_request_blocks_count - 1)) {
             transfer_request_block.normal.chain_bit = 1;
-        else
+            transfer_request_block.normal.interrupt_on_short_packet = 1;
+        } else {
             transfer_request_block.normal.interrupt_on_completion = 1;
+        }
 
         transfer_request_block.normal.transfer_request_block_type = TransferRequestBlock::TRBType::Normal;
     }
@@ -1345,21 +1353,77 @@ void xHCIController::handle_transfer_event(TransferRequestBlock const& transfer_
     // value of the Transfer Event TRB Pointer field.
     endpoint_ring.dequeue_index = transfer_request_block_index;
 
+    auto is_trb_in_transfer = [](size_t start_index, size_t end_index, size_t trb_index) {
+        auto transfer_wraps_around = start_index > end_index;
+
+        if (!transfer_wraps_around)
+            return trb_index >= start_index && trb_index <= end_index;
+
+        return trb_index >= start_index || trb_index <= end_index;
+    };
+
     for (auto& pending_transfer : endpoint_ring.pending_transfers) {
-        if (pending_transfer.start_index <= pending_transfer.end_index) {
-            if (pending_transfer.start_index > transfer_request_block_index || transfer_request_block_index > pending_transfer.end_index)
-                continue;
-        } else {
-            if (pending_transfer.start_index > transfer_request_block_index && transfer_request_block_index > pending_transfer.end_index)
-                continue;
-        }
+        if (!is_trb_in_transfer(pending_transfer.start_index, pending_transfer.end_index, transfer_request_block_index))
+            continue;
+
+        // NOTE: Per the xHCI spec, a Transfer Event with Completion Code = Short Packet doesn't always signal completion of a transfer:
+        //
+        // > If the Short Packet occurred while processing a Transfer TRB with only an ISP
+        // > flag set, then two events shall be generated for the transfer; one for the Transfer
+        // > TRB that the Short Packet occurred on, and a second for the last TRB with the
+        // > IOC flag set. [...]
+        // >
+        // > Software shall not interpret a Short Packet Event as indicating that the TD that it
+        // > is associated with is “complete”, unless the TRB Pointer field of the Transfer
+        // > Event references the last TRB of the TD.
+        // (4.10.1.1.2 Short Transfers when not using Event Data TRBs)
+        //
+        // However, some host controllers, like the qemu-xhci device from QEMU don't implement this behavior
+        // correctly and only send one event if the Short Packet occurred on a Transfer TRB that isn't the last one in
+        // a transfer. This means we can't use the second Transfer Event to signal completion of the transfer.
+        // Instead, we always treat a transfer as "complete" when we receive any transfer event for it.
+        //
+        // This requires that we ignore the second Short Packet Event on correctly behaving host controllers.
+        // We do this by saving the start and end transfer TRB indices of the previous transfer, if it was completed
+        // with Completion Code = Short Packet. If we receive a transfer event for an unknown transfer, we compare
+        // it with those saved indices. If it is inside this transfer, we simply ignore the Transfer Event silently.
 
         pending_transfer.endpoint_list_node.remove();
 
         if (endpoint_ring.type == Pipe::Type::Control || endpoint_ring.type == Pipe::Type::Bulk) {
             auto& sync_pending_transfer = static_cast<SyncPendingTransfer&>(pending_transfer);
             sync_pending_transfer.completion_code = transfer_request_block.transfer_event.completion_code;
-            sync_pending_transfer.remainder = transfer_request_block.transfer_event.transfer_request_block_transfer_length;
+
+            auto* ring_memory = endpoint_ring.ring_vaddr();
+
+            if (transfer_request_block.transfer_event.completion_code == TransferRequestBlock::CompletionCode::Short_Packet) {
+                // 4.10.1.1.2 Short Transfers when not using Event Data TRBs
+                // If Event Data TRBs are not used, then the total number of received bytes for a
+                // Short Packet TD is the sum of the TRB Transfer Length fields in all Transfer TRBs
+                // up to and including the one that generated the Short Packet Event, minus the
+                // residue value of the TRB Transfer Length field in the Short Packet Event.
+
+                // Instead of calculating the total number of transferred bytes, sum up the number of untransmitted bytes.
+
+                sync_pending_transfer.remainder = transfer_request_block.transfer_event.transfer_request_block_transfer_length;
+
+                if (transfer_request_block_index != sync_pending_transfer.end_index) {
+                    for (size_t i = transfer_request_block_index + 1;; i++) {
+                        if (i == endpoint_ring_size - 1) {
+                            // This assumes we don't use segmented Rings, i.e. the final Link TRB always points to the first TRB in the same Ring.
+                            i = 0;
+                        }
+
+                        sync_pending_transfer.remainder += ring_memory[i].normal.transfer_request_block_transfer_length;
+
+                        if (i == sync_pending_transfer.end_index)
+                            break;
+                    }
+                }
+            } else {
+                sync_pending_transfer.remainder = transfer_request_block.transfer_event.transfer_request_block_transfer_length;
+            }
+
             full_memory_fence();
             sync_pending_transfer.wait_queue.wake_all();
         } else {
@@ -1368,9 +1432,26 @@ void xHCIController::handle_transfer_event(TransferRequestBlock const& transfer_
             // Reschedule the periodic transfer (NOTE: We MUST() here since a re-enqueue should never fail)
             MUST(enqueue_transfer(slot, periodic_pending_transfer.original_transfer->pipe().endpoint_number(), periodic_pending_transfer.original_transfer->pipe().direction(), periodic_pending_transfer.transfer_request_blocks, periodic_pending_transfer));
         }
+
+        if (transfer_request_block.transfer_event.completion_code == TransferRequestBlock::CompletionCode::Short_Packet) {
+            endpoint_ring.last_short_transfer = EndpointRing::LastShortTransfer {
+                .start_transfer_trb_index = pending_transfer.start_index,
+                .end_transfer_trb_index = pending_transfer.end_index,
+            };
+        } else {
+            endpoint_ring.last_short_transfer.clear();
+        }
+
         return;
     }
-    dmesgln_xhci("Transfer event on slot {} endpoint {} points to unowned TRB", slot, endpoint);
+
+    bool should_ignore = endpoint_ring.last_short_transfer.has_value()
+        && is_trb_in_transfer(endpoint_ring.last_short_transfer->start_transfer_trb_index, endpoint_ring.last_short_transfer->end_transfer_trb_index, transfer_request_block_index);
+
+    if (!should_ignore)
+        dmesgln_xhci("Transfer event on slot {} endpoint {} points to unowned TRB", slot, endpoint);
+
+    endpoint_ring.last_short_transfer.clear();
 }
 
 void xHCIController::event_handling_thread()

--- a/Kernel/Bus/USB/xHCI/xHCIController.cpp
+++ b/Kernel/Bus/USB/xHCI/xHCIController.cpp
@@ -754,9 +754,9 @@ ErrorOr<void> xHCIController::enqueue_transfer(u8 slot, u8 endpoint, Pipe::Direc
 
     auto& endpoint_ring = m_slots_state[slot - 1].endpoint_rings[endpoint_index(endpoint, direction) - 1];
     VERIFY(endpoint_ring.region);
-    if (transfer_request_blocks.size() > endpoint_ring.free_transfer_request_blocks)
+
+    if (!endpoint_ring.has_space_for_trbs(transfer_request_blocks.size()))
         return ENOBUFS;
-    endpoint_ring.free_transfer_request_blocks -= transfer_request_blocks.size();
 
     dbgln_if(XHCI_VERBOSE_DEBUG, "-> enqueue_transfer slot={} endpoint={} dir={}:", slot, endpoint, to_underlying(direction));
 
@@ -995,9 +995,9 @@ ErrorOr<void> xHCIController::reset_pipe(USB::Device& device, USB::Pipe& pipe)
     TRY(set_tr_dequeue_pointer(slot, endpoint_id, 0, 0, endpoint_ring.ring_paddr(), 1));
 
     endpoint_ring.enqueue_index = 0;
+    endpoint_ring.dequeue_index = 0;
     endpoint_ring.pending_transfers.clear();
     endpoint_ring.producer_cycle_state = 1;
-    endpoint_ring.free_transfer_request_blocks = endpoint_ring_size - 1; // -1 to exclude the Link TRB
     for (size_t i = 0; i < endpoint_ring_size - 1; i++)
         endpoint_ring.ring_vaddr()[i] = {};
 
@@ -1338,19 +1338,24 @@ void xHCIController::handle_transfer_event(TransferRequestBlock const& transfer_
         return;
     }
     auto transfer_request_block_index = (transfer_request_block_pointer - endpoint_ring.ring_paddr()) / sizeof(TransferRequestBlock);
+
+    // 4.9.2 Transfer Ring Management
+    // Software uses the Dequeue Pointer to determine when a Transfer Ring is full. As
+    // it processes Transfer Events, it updates its copy of the Dequeue Pointer with the
+    // value of the Transfer Event TRB Pointer field.
+    endpoint_ring.dequeue_index = transfer_request_block_index;
+
     for (auto& pending_transfer : endpoint_ring.pending_transfers) {
-        auto freed_transfer_request_blocks = 0;
         if (pending_transfer.start_index <= pending_transfer.end_index) {
             if (pending_transfer.start_index > transfer_request_block_index || transfer_request_block_index > pending_transfer.end_index)
                 continue;
-            freed_transfer_request_blocks = pending_transfer.end_index - pending_transfer.start_index + 1;
         } else {
             if (pending_transfer.start_index > transfer_request_block_index && transfer_request_block_index > pending_transfer.end_index)
                 continue;
-            freed_transfer_request_blocks = (endpoint_ring_size - pending_transfer.start_index) + pending_transfer.end_index;
         }
-        endpoint_ring.free_transfer_request_blocks += freed_transfer_request_blocks;
+
         pending_transfer.endpoint_list_node.remove();
+
         if (endpoint_ring.type == Pipe::Type::Control || endpoint_ring.type == Pipe::Type::Bulk) {
             auto& sync_pending_transfer = static_cast<SyncPendingTransfer&>(pending_transfer);
             sync_pending_transfer.completion_code = transfer_request_block.transfer_event.completion_code;
@@ -1452,6 +1457,37 @@ void xHCIController::poll_thread()
 
     Thread::current()->exit();
     VERIFY_NOT_REACHED();
+}
+
+bool xHCIController::EndpointRing::has_space_for_trbs(size_t count)
+{
+    // 4.9.2.2 Pointer Advancement
+    // To prevent overruns, software shall determine when the Ring is full. The ring is
+    // defined as “full” if advancing the Enqueue Pointer will make it equal to the
+    // Dequeue Pointer. Software shall take Link TRBs into account when evaluating
+    // the full condition. If the Enqueue Pointer is not pointing at a Link TRB, software
+    // can determine if the Ring is full by adding the size of a TRB (16) to the Enqueue
+    // Pointer and checking if the result is equal to the value of the Dequeue Pointer. If
+    // the Enqueue Pointer is pointing at a Link TRB, then software shall compare the
+    // Ring Segment Pointer value in the Link TRB with the Dequeue Pointer.
+
+    u32 current_trb_index = enqueue_index;
+    for (size_t i = 0; i < count; i++) {
+        // The last TRB in a Ring is a Link TRB.
+        bool points_at_link_trb = current_trb_index == endpoint_ring_size - 1;
+
+        if (points_at_link_trb) {
+            // This assumes we don't use segmented Rings, i.e. Link TRBs always point to the first TRB in the same Ring.
+            current_trb_index = 0;
+        } else {
+            current_trb_index++;
+        }
+
+        if (current_trb_index == dequeue_index)
+            return false;
+    }
+
+    return true;
 }
 
 }

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -107,14 +107,22 @@ private:
 
     struct EndpointRing {
         OwnPtr<Memory::Region> region;
+
+        // Managed by us.
         u32 enqueue_index { 0 };
-        u32 free_transfer_request_blocks { endpoint_ring_size - 1 }; // One less, since we use up the last one for the link TRB
+
+        // Managed by the controller, therefore it might be behind the actual value.
+        u32 dequeue_index { 0 };
+
         u32 max_burst_payload { 0 };
         Pipe::Type type { Pipe::Type::Control };
         u8 producer_cycle_state { 1 };
         IntrusiveList<&PendingTransfer::endpoint_list_node> pending_transfers;
+
         TransferRequestBlock* ring_vaddr() const { return reinterpret_cast<TransferRequestBlock*>(region->vaddr().as_ptr()); }
         PhysicalPtr ring_paddr() const { return region->physical_page(0)->paddr().get(); }
+
+        bool has_space_for_trbs(size_t count);
     };
     static constexpr size_t max_endpoints = 31;
     static constexpr size_t endpoint_ring_size = PAGE_SIZE / sizeof(TransferRequestBlock);

--- a/Kernel/Bus/USB/xHCI/xHCIController.h
+++ b/Kernel/Bus/USB/xHCI/xHCIController.h
@@ -119,6 +119,12 @@ private:
         u8 producer_cycle_state { 1 };
         IntrusiveList<&PendingTransfer::endpoint_list_node> pending_transfers;
 
+        struct LastShortTransfer {
+            size_t start_transfer_trb_index;
+            size_t end_transfer_trb_index;
+        };
+        Optional<LastShortTransfer> last_short_transfer;
+
         TransferRequestBlock* ring_vaddr() const { return reinterpret_cast<TransferRequestBlock*>(region->vaddr().as_ptr()); }
         PhysicalPtr ring_paddr() const { return region->physical_page(0)->paddr().get(); }
 


### PR DESCRIPTION
Previously, we only set the remainder (number of untransmitted bytes) to the TRB transfer length of the Transfer Event.
(Note: this field is confusingly named. It's not actually the transfer length, but the number untransmitted bytes)
However, this field only tracks the number of untransmitted bytes for the specific TRB that the Transfer Event references, not the number of untransmitted bytes of the entire transfer.

Instead, use the method described by the xHCI spec to determine the amount of actually transmitted bytes. This requires setting the Interrupt-on Short Packet (ISP) flag on all Transfer TRBs except the last one for each transfer. This makes it possible to know on which Transfer TRB the Short Packet Event occurred, as it now will generate Short Packet Events on Transfer TRBs other than the last TRB in transfers.
Now that we know which transfer TRB the Short Packet event occurred on, we can add up the complete number of untransmitted bytes in a transfer.

On correctly behaving xHCs we will now receive two transfer events if the Short Packet happened during execution of a TRB that isn't the last in a transfer. However, QEMU doesn't seem to implement this correctly and always only generates one Short Packet Event.
This means we have to use the first transfer event to signal completion.

<hr>

Additionally, I included a commit to properly determine if a Ring is "full". This is necessary since the old calculation method assumes that we always only receive one Transfer Event on the last TRB for each transfer. Setting the ISP flag on all but the last TRB in transfers makes this assumption no longer true.

I tested this code on my (currently not upstream) AX88772 USB ethernet adapter driver. This is driver is also the reason I noticed the bug in the first place.