### PR TITLE
Meta: Install libcxx's __config_site to a known location

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -39,9 +39,8 @@ SERENITY_ARCH="${SERENITY_ARCH:-x86_64}"
 if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
     TOOLCHAIN_DIR="$SERENITY_SOURCE_DIR"/Toolchain/Local/clang/
     rsync -aH --update -t "$TOOLCHAIN_DIR"/lib/"$SERENITY_ARCH"-unknown-serenity/* mnt/usr/lib
-    mkdir -p mnt/usr/include/"$SERENITY_ARCH"-serenity
     rsync -aH --update -t -r "$TOOLCHAIN_DIR"/include/c++ mnt/usr/include
-    rsync -aH --update -t -r "$TOOLCHAIN_DIR"/include/"$SERENITY_ARCH"-unknown-serenity/c++ mnt/usr/include/"$SERENITY_ARCH"-serenity
+    rsync -aH --update -t -r "$TOOLCHAIN_DIR"/include/"$SERENITY_ARCH"-unknown-serenity/c++ mnt/usr/include/
 else
     rsync -aH --update -t -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-serenity/lib/* mnt/usr/lib
     rsync -aH --update -t -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-serenity/include/c++ mnt/usr/include


### PR DESCRIPTION
`libcxx` expects the `__config_site` file to be available in the default include folders. As far as I can tell, it is usually installed next to the `__config` file. Before this patch, the file was installed in its own folder, outside of clang's default includes paths.

As the `__config_site` file is dependent of CMake options, it is generated in its own directory for every runtime (this is controlled by LLVM's `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` flag). So, this patch makes the script that build the root filesystem copy the file from this specific location to `/usr/include/c++/v1` where `libcxx` is installed.

This makes it possible to use more features of `libcxx` on serenity, like for example this simple program:
```c++
#include <iostream>
int main() {
    std::cout << "Hello Serenity!\n";
}
```