### PR TITLE
LibSSH/SFTP: Support the write command

### DIFF
--- a/Tests/LibSSH/CMakeLists.txt
+++ b/Tests/LibSSH/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_SOURCES
     SFTP/TestSFTPServerBasic.cpp
     SFTP/TestSFTPStat.cpp
     SFTP/TestSFTPRead.cpp
+    SFTP/TestSFTPWrite.cpp
     TestSSHCipher.cpp
     TestSSHEncodeDecode.cpp
     TestSSHIdentificationString.cpp

--- a/Tests/LibSSH/CMakeLists.txt
+++ b/Tests/LibSSH/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    SFTP/TestSFTPAttributes.cpp
     SFTP/TestSFTPPeer.cpp
     SFTP/TestSFTPServerBasic.cpp
     SFTP/TestSFTPStat.cpp

--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibCore/EventLoop.h>
+#include <LibSSH/DataTypes.h>
 #include <LibSSH/SFTP/Peer.h>
 #include <LibSSH/SFTP/Server.h>
 #include <LibSSH/Session.h>
@@ -57,4 +58,23 @@ inline SSH::SFTP::Server make_initialized_server(Function<ErrorOr<void>(Message)
         FAIL("Unable to perform handshake with server");
 
     return server;
+}
+
+inline ErrorOr<ByteBuffer> make_open_packet(StringView path, u32 request_id)
+{
+    AllocatingMemoryStream inner;
+
+    TRY(inner.write_value(SSH::SFTP::FXPMessageID::OPEN));
+    TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
+    TRY(SSH::encode_string(inner, path));
+    TRY(inner.write_value<NetworkOrdered<u32>>(1)); // SSH_FXF_READ
+    TRY(inner.write_value<NetworkOrdered<u32>>(0)); // No attributes.
+
+    auto payload = TRY(inner.read_until_eof());
+
+    AllocatingMemoryStream packet;
+    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
+    TRY(packet.write_until_depleted(payload));
+
+    return TRY(packet.read_until_eof());
 }

--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -67,8 +67,8 @@ inline ErrorOr<ByteBuffer> make_open_packet(StringView path, u32 request_id)
     TRY(inner.write_value(SSH::SFTP::FXPMessageID::OPEN));
     TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
     TRY(SSH::encode_string(inner, path));
-    TRY(inner.write_value<NetworkOrdered<u32>>(1)); // SSH_FXF_READ
-    TRY(inner.write_value<NetworkOrdered<u32>>(0)); // No attributes.
+    TRY(inner.write_value<NetworkOrdered<u32>>(1 | 2)); // SSH_FXF_READ | SSH_FXF_WRITE
+    TRY(inner.write_value<NetworkOrdered<u32>>(0));     // No attributes.
 
     auto payload = TRY(inner.read_until_eof());
 

--- a/Tests/LibSSH/SFTP/TestSFTPAttributes.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPAttributes.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSSH/SFTP/Peer.h>
+#include <LibTest/TestCase.h>
+
+static void run_test(SSH::SFTP::Attributes attributes, ReadonlyBytes expected)
+{
+    AllocatingMemoryStream stream;
+    TRY_OR_FAIL(attributes.encode(stream));
+    auto encoded = TRY_OR_FAIL(stream.read_until_eof());
+
+    EXPECT_EQ(encoded.bytes(), expected);
+
+    FixedMemoryStream encoded_stream { encoded.bytes() };
+    auto roundtrip = TRY_OR_FAIL(SSH::SFTP::Attributes::from_stream(encoded_stream));
+
+    EXPECT_EQ(roundtrip, attributes);
+}
+
+TEST_CASE(attributes_empty)
+{
+    auto empty = SSH::SFTP::Attributes {};
+
+    auto expected = to_array<u8>({
+        0x00, 0x00, 0x00, 0x00, // flags (no fields present)
+    });
+
+    run_test(empty, expected);
+}
+
+TEST_CASE(attributes_size_only)
+{
+    auto input = SSH::SFTP::Attributes {
+        .size = 1024,
+    };
+
+    auto expected = to_array<u8>({
+        0x00, 0x00, 0x00, 0x01,                         // flags (SSH_FILEXFER_ATTR_SIZE)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, // size (1024)
+    });
+
+    run_test(input, expected);
+}
+
+TEST_CASE(attributes_uid_gid)
+{
+    auto input = SSH::SFTP::Attributes {
+        .uid = 1000,
+        .gid = 1000,
+    };
+
+    auto expected = to_array<u8>({
+        0x00, 0x00, 0x00, 0x02, // flags (SSH_FILEXFER_ATTR_UIDGID)
+        0x00, 0x00, 0x03, 0xe8, // uid (1000)
+        0x00, 0x00, 0x03, 0xe8, // gid (1000)
+    });
+
+    run_test(input, expected);
+}
+
+TEST_CASE(attributes_permissions)
+{
+    auto input = SSH::SFTP::Attributes {
+        .mode = 0100644,
+    };
+
+    auto expected = to_array<u8>({
+        0x00, 0x00, 0x00, 0x04, // flags (SSH_FILEXFER_ATTR_PERMISSIONS)
+        0x00, 0x00, 0x81, 0xa4, // mode (0100644)
+    });
+
+    run_test(input, expected);
+}
+
+TEST_CASE(attributes_timestamps)
+{
+    auto input = SSH::SFTP::Attributes {
+        .atim = 1700000000,
+        .mtim = 1700000001,
+    };
+
+    auto expected = to_array<u8>({
+        0x00, 0x00, 0x00, 0x08, // flags (SSH_FILEXFER_ATTR_ACMODTIME)
+        0x65, 0x53, 0xF1, 0x00, // atime (1700000000)
+        0x65, 0x53, 0xF1, 0x01, // mtime (1700000001)
+    });
+
+    run_test(input, expected);
+}
+
+TEST_CASE(attributes_all_fields)
+{
+    auto input = SSH::SFTP::Attributes {
+        .size = 4096,
+        .uid = 501,
+        .gid = 20,
+        .mode = 0100644,
+        .atim = 1700000000,
+        .mtim = 1700000001,
+    };
+
+    auto expected = to_array<u8>({
+        0x00, 0x00, 0x00, 0x0f,                         // flags (size | uidgid | permissions | acmodtime)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, // size (4096)
+        0x00, 0x00, 0x01, 0xf5,                         // uid (501)
+        0x00, 0x00, 0x00, 0x14,                         // gid (20)
+        0x00, 0x00, 0x81, 0xa4,                         // mode (0100644)
+        0x65, 0x53, 0xF1, 0x00,                         // atime (1700000000)
+        0x65, 0x53, 0xF1, 0x01,                         // mtime (1700000001)
+    });
+
+    run_test(input, expected);
+}

--- a/Tests/LibSSH/SFTP/TestSFTPRead.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPRead.cpp
@@ -13,25 +13,6 @@
 
 namespace {
 
-ErrorOr<ByteBuffer> make_open_packet(StringView path, u32 request_id)
-{
-    AllocatingMemoryStream inner;
-
-    TRY(inner.write_value(SSH::SFTP::FXPMessageID::OPEN));
-    TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
-    TRY(SSH::encode_string(inner, path));
-    TRY(inner.write_value<NetworkOrdered<u32>>(1)); // SSH_FXF_READ
-    TRY(inner.write_value<NetworkOrdered<u32>>(0)); // No attributes.
-
-    auto payload = TRY(inner.read_until_eof());
-
-    AllocatingMemoryStream packet;
-    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
-    TRY(packet.write_until_depleted(payload));
-
-    return TRY(packet.read_until_eof());
-}
-
 ErrorOr<ByteBuffer> make_read_packet(ByteBuffer const& handle, u32 request_id, u64 offset, u32 length)
 {
     AllocatingMemoryStream inner;

--- a/Tests/LibSSH/SFTP/TestSFTPStat.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPStat.cpp
@@ -14,35 +14,12 @@
 
 namespace {
 
-struct Attributes {
-    Optional<u64> size;
-    Optional<u32> uid;
-    Optional<u32> gid;
-    Optional<u32> mode;
-    Optional<u32> atim;
-    Optional<u32> mtim;
-
-    static Attributes from_stat(struct ::stat const& s)
-    {
-        return {
-            .size = s.st_size,
-            .uid = s.st_uid,
-            .gid = s.st_gid,
-            .mode = s.st_mode,
-            .atim = s.st_atime,
-            .mtim = s.st_mtime,
-        };
-    }
-
-    bool operator==(Attributes const&) const = default;
-};
-
-ErrorOr<Attributes> decode_attribute_message(FixedMemoryStream& stream)
+ErrorOr<SSH::SFTP::Attributes> decode_attribute_message(FixedMemoryStream& stream)
 {
     u32 flags = TRY(stream.read_value<NetworkOrdered<u32>>());
     // All flags, but EXTENDED set.
     EXPECT_EQ(flags, 0b1111u);
-    Attributes attributes;
+    SSH::SFTP::Attributes attributes;
     attributes.size = TRY(stream.read_value<NetworkOrdered<u64>>());
     attributes.uid = TRY(stream.read_value<NetworkOrdered<u32>>());
     attributes.gid = TRY(stream.read_value<NetworkOrdered<u32>>());
@@ -74,7 +51,7 @@ ErrorOr<void> run_server_with_callback(auto callback, StringView path, bool use_
     return server_process_data(server, request);
 }
 
-ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, Attributes const& expected)
+ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, SSH::SFTP::Attributes const& expected)
 {
     auto callback = [=](Message message) -> ErrorOr<void> {
         EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::ATTRS);
@@ -111,8 +88,8 @@ ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, SSH::SFTP::FXSt
 
 ErrorOr<void> run_for_path(StringView path)
 {
-    TRY(run_for_path_impl(path, false, Attributes::from_stat(TRY(Core::System::stat(path)))));
-    TRY(run_for_path_impl(path, true, Attributes::from_stat(TRY(Core::System::lstat(path)))));
+    TRY(run_for_path_impl(path, false, SSH::SFTP::Attributes::from_stat(TRY(Core::System::stat(path)))));
+    TRY(run_for_path_impl(path, true, SSH::SFTP::Attributes::from_stat(TRY(Core::System::lstat(path)))));
     return {};
 }
 
@@ -120,7 +97,7 @@ ErrorOr<void> run_for_path_with_expected_stat_failure(StringView path, SSH::SFTP
 {
     EXPECT(Core::System::stat(path).is_error());
     TRY(run_for_path_impl(path, false, error_status));
-    TRY(run_for_path_impl(path, true, Attributes::from_stat(TRY(Core::System::lstat(path)))));
+    TRY(run_for_path_impl(path, true, SSH::SFTP::Attributes::from_stat(TRY(Core::System::lstat(path)))));
     return {};
 }
 

--- a/Tests/LibSSH/SFTP/TestSFTPStat.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPStat.cpp
@@ -14,22 +14,6 @@
 
 namespace {
 
-ErrorOr<SSH::SFTP::Attributes> decode_attribute_message(FixedMemoryStream& stream)
-{
-    u32 flags = TRY(stream.read_value<NetworkOrdered<u32>>());
-    // All flags, but EXTENDED set.
-    EXPECT_EQ(flags, 0b1111u);
-    SSH::SFTP::Attributes attributes;
-    attributes.size = TRY(stream.read_value<NetworkOrdered<u64>>());
-    attributes.uid = TRY(stream.read_value<NetworkOrdered<u32>>());
-    attributes.gid = TRY(stream.read_value<NetworkOrdered<u32>>());
-    attributes.mode = TRY(stream.read_value<NetworkOrdered<u32>>());
-    attributes.atim = TRY(stream.read_value<NetworkOrdered<u32>>());
-    attributes.mtim = TRY(stream.read_value<NetworkOrdered<u32>>());
-
-    return attributes;
-}
-
 ErrorOr<ByteBuffer> make_stat_packet(StringView path, bool use_lstat = false)
 {
     AllocatingMemoryStream inner;
@@ -57,7 +41,7 @@ ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, SSH::SFTP::Attr
         EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::ATTRS);
         FixedMemoryStream stream { message.payload };
         EXPECT_EQ(TRY(stream.read_value<NetworkOrdered<u32>>()), 42u);
-        auto attributes = TRY(decode_attribute_message(stream));
+        auto attributes = TRY(SSH::SFTP::Attributes::from_stream(stream));
         EXPECT_EQ(attributes, expected);
         return {};
     };

--- a/Tests/LibSSH/SFTP/TestSFTPStat.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPStat.cpp
@@ -67,6 +67,13 @@ ErrorOr<ByteBuffer> make_stat_packet(StringView path, bool use_lstat = false)
     return TRY(packet.read_until_eof());
 }
 
+ErrorOr<void> run_server_with_callback(auto callback, StringView path, bool use_lstat)
+{
+    auto server = make_initialized_server(move(callback));
+    auto request = TRY(make_stat_packet(path, use_lstat));
+    return server_process_data(server, request);
+}
+
 ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, Attributes const& expected)
 {
     auto callback = [=](Message message) -> ErrorOr<void> {
@@ -77,10 +84,29 @@ ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, Attributes cons
         EXPECT_EQ(attributes, expected);
         return {};
     };
-    auto server = make_initialized_server(move(callback));
 
-    auto request = TRY(make_stat_packet(path, use_lstat));
-    return server_process_data(server, request);
+    return run_server_with_callback(move(callback), path, use_lstat);
+}
+
+ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, SSH::SFTP::FXStatus expected_status)
+{
+    auto callback = [=](Message message) -> ErrorOr<void> {
+        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
+        FixedMemoryStream stream { message.payload };
+        EXPECT_EQ(TRY(stream.read_value<NetworkOrdered<u32>>()), 42u);
+        u32 raw_status_code = TRY(stream.read_value<NetworkOrdered<u32>>());
+        auto status_code = static_cast<SSH::SFTP::FXStatus>(raw_status_code);
+        EXPECT_EQ(status_code, expected_status);
+
+        // `error message` and `language tag`
+        TRY(SSH::decode_string(stream));
+        TRY(SSH::decode_string(stream));
+
+        EXPECT(stream.remaining() == 0);
+        return {};
+    };
+
+    return run_server_with_callback(move(callback), path, use_lstat);
 }
 
 ErrorOr<void> run_for_path(StringView path)
@@ -90,9 +116,10 @@ ErrorOr<void> run_for_path(StringView path)
     return {};
 }
 
-ErrorOr<void> run_for_path_with_expected_stat_failure(StringView path)
+ErrorOr<void> run_for_path_with_expected_stat_failure(StringView path, SSH::SFTP::FXStatus error_status)
 {
     EXPECT(Core::System::stat(path).is_error());
+    TRY(run_for_path_impl(path, false, error_status));
     TRY(run_for_path_impl(path, true, Attributes::from_stat(TRY(Core::System::lstat(path)))));
     return {};
 }
@@ -129,9 +156,21 @@ TEST_CASE(symlink)
 
     unlink("/tmp/b");
     TRY_OR_FAIL(Core::System::symlink("/tmp/b"sv, "/tmp/b"sv));
-    TRY_OR_FAIL(run_for_path_with_expected_stat_failure("/tmp/b"sv));
+    TRY_OR_FAIL(run_for_path_with_expected_stat_failure("/tmp/b"sv, SSH::SFTP::FXStatus::FAILURE));
 
     unlink("/tmp/c");
     TRY_OR_FAIL(Core::System::symlink("/i/dont/exist"sv, "/tmp/c"sv));
-    TRY_OR_FAIL(run_for_path_with_expected_stat_failure("/tmp/c"sv));
+    TRY_OR_FAIL(run_for_path_with_expected_stat_failure("/tmp/c"sv, SSH::SFTP::FXStatus::NO_SUCH_FILE));
+}
+
+TEST_CASE(no_permission)
+{
+    auto tmp_dir = TRY_OR_FAIL(FileSystem::TempFile::create_temp_directory());
+    // The directory is created with 0700, remove the executable bit to make inner files inaccessible.
+    TRY_OR_FAIL(Core::System::chmod(tmp_dir->path(), 0600));
+
+    auto unauthorized_path = ByteString::formatted("{}/i/dont/exist", tmp_dir->path());
+
+    TRY_OR_FAIL(run_for_path_impl(unauthorized_path, true, SSH::SFTP::FXStatus::PERMISSION_DENIED));
+    TRY_OR_FAIL(run_for_path_impl(unauthorized_path, false, SSH::SFTP::FXStatus::PERMISSION_DENIED));
 }

--- a/Tests/LibSSH/SFTP/TestSFTPWrite.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPWrite.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibFileSystem/TempFile.h>
+#include <LibSSH/DataTypes.h>
+#include <LibTest/TestCase.h>
+#include <Tests/LibSSH/SFTP/Shared.h>
+
+namespace {
+
+ErrorOr<ByteBuffer> make_write_packet(ByteBuffer const& handle, u32 request_id, u64 offset, ReadonlyBytes data)
+{
+    AllocatingMemoryStream inner;
+
+    TRY(inner.write_value(SSH::SFTP::FXPMessageID::WRITE));
+    TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
+    TRY(SSH::encode_string(inner, handle));
+    TRY(inner.write_value<NetworkOrdered<u64>>(offset));
+    TRY(SSH::encode_string(inner, data));
+
+    auto payload = TRY(inner.read_until_eof());
+
+    AllocatingMemoryStream packet;
+    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
+    TRY(packet.write_until_depleted(payload));
+
+    return TRY(packet.read_until_eof());
+}
+
+ErrorOr<void> compare_files(StringView path1, StringView path2)
+{
+    auto file1 = TRY(Core::File::open(path1, Core::File::OpenMode::Read));
+    auto file2 = TRY(Core::File::open(path2, Core::File::OpenMode::Read));
+
+    auto data1 = TRY(file1->read_until_eof());
+    auto data2 = TRY(file2->read_until_eof());
+    EXPECT_EQ(data1.bytes(), data2.bytes());
+    return {};
+}
+
+ErrorOr<void> run_write_test(StringView path, u64 offset, ReadonlyBytes data)
+{
+    auto reference_file = TRY(FileSystem::TempFile::create_temp_file());
+    auto reference_path = reference_file->path();
+
+    Optional<ByteBuffer> handle;
+    u32 request_id = get_random<u32>();
+    auto callback = [&](Message message) -> ErrorOr<void> {
+        FixedMemoryStream stream { message.payload };
+        if (!handle.has_value()) {
+
+            EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::HANDLE);
+            EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
+
+            handle = TRY(SSH::decode_string(stream));
+            return {};
+        }
+
+        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
+        EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
+        EXPECT_EQ(to_underlying(SSH::SFTP::FXStatus::OK), TRY(stream.read_value<NetworkOrdered<u32>>()));
+        // error message and language tag
+        EXPECT(TRY(SSH::decode_string(stream)).is_empty());
+        EXPECT(TRY(SSH::decode_string(stream)).is_empty());
+
+        TRY(compare_files(reference_path, path));
+
+        return {};
+    };
+    auto server = make_initialized_server(move(callback));
+
+    auto open_packet = TRY(make_open_packet(path, request_id));
+    TRY(server_process_data(server, open_packet));
+
+    if (!handle.has_value())
+        return Error::from_string_literal("The handle should have been received");
+
+    TRY(FileSystem::copy_file_or_directory(reference_path, path, FileSystem::RecursionMode::Disallowed, FileSystem::LinkMode::Disallowed, FileSystem::AddDuplicateFileMarker::No));
+    auto fd = TRY(Core::System::open(reference_path, O_WRONLY));
+    u64 written = TRY(Core::System::pwrite(fd, data, offset));
+    EXPECT_EQ(written, data.size());
+
+    request_id = get_random<u32>();
+    auto packet = TRY(make_write_packet(*handle, request_id, offset, data));
+    TRY(server_process_data(server, packet));
+
+    return {};
+}
+
+}
+
+TEST_CASE(basic)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(file->write_until_depleted("hello world"sv));
+
+    TRY_OR_FAIL(run_write_test(temp_file->path(), 0, "hello"sv.bytes()));
+    TRY_OR_FAIL(run_write_test(temp_file->path(), 5, " world"sv.bytes()));
+}
+
+TEST_CASE(write_offset)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(file->write_until_depleted("hello world"sv));
+
+    TRY_OR_FAIL(run_write_test(temp_file->path(), 1, "hello world"sv.bytes()));
+}
+
+TEST_CASE(write_past_eof)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(run_write_test(temp_file->path(), 512, "hello world"sv.bytes()));
+}
+
+TEST_CASE(write_zero_length)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto file = TRY_OR_FAIL(Core::File::open(temp_file->path(), Core::File::OpenMode::Write));
+    TRY_OR_FAIL(run_write_test(temp_file->path(), 0, {}));
+
+    TRY_OR_FAIL(file->write_until_depleted("abc"sv));
+
+    TRY_OR_FAIL(run_write_test(temp_file->path(), 5, {}));
+}

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -696,6 +696,17 @@ ErrorOr<ssize_t> write(int fd, ReadonlyBytes buffer)
     return rc;
 }
 
+ErrorOr<ssize_t> pwrite(int fd, ReadonlyBytes buffer, off_t offset)
+{
+    ssize_t rc;
+    do {
+        rc = ::pwrite(fd, buffer.data(), buffer.size(), offset);
+    } while (rc < 0 && errno == EINTR);
+    if (rc < 0)
+        return Error::from_syscall("pwrite"sv, -errno);
+    return rc;
+}
+
 ErrorOr<void> kill(pid_t pid, int signal)
 {
     if (::kill(pid, signal) < 0)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -136,6 +136,7 @@ ErrorOr<struct stat> lstat(StringView path);
 ErrorOr<ssize_t> read(int fd, Bytes buffer);
 ErrorOr<ssize_t> pread(int fd, Bytes buffer, off_t offset);
 ErrorOr<ssize_t> write(int fd, ReadonlyBytes buffer);
+ErrorOr<ssize_t> pwrite(int fd, ReadonlyBytes buffer, off_t offset);
 ErrorOr<void> kill(pid_t, int signal);
 ErrorOr<void> killpg(int pgrp, int signal);
 ErrorOr<int> dup(int source_fd);

--- a/Userland/Libraries/LibSSH/SFTP/Peer.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.cpp
@@ -7,6 +7,7 @@
 #include "Peer.h"
 #include <AK/Debug.h>
 #include <AK/Endian.h>
+#include <AK/EnumBits.h>
 
 namespace SSH::SFTP {
 
@@ -31,6 +32,75 @@ ErrorOr<void> Peer::write_packet(ReadonlyBytes bytes)
     TRY(stream.write_until_depleted(bytes));
     auto packet = TRY(stream.read_until_eof());
     TRY(m_send_packet(packet));
+    return {};
+}
+
+enum class AttributesFlags : u32 {
+    SIZE = 0x00000001,
+    UIDGID = 0x00000002,
+    PERMISSIONS = 0x00000004,
+    ACMODTIME = 0x00000008,
+    EXTENDED = 0x80000000,
+};
+
+AK_ENUM_BITWISE_OPERATORS(AttributesFlags)
+
+ErrorOr<Attributes> Attributes::from_stream(FixedMemoryStream& stream)
+{
+    u32 raw_flags = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto flags = static_cast<AttributesFlags>(raw_flags);
+
+    SSH::SFTP::Attributes attributes;
+
+    if (has_flag(flags, AttributesFlags::SIZE))
+        attributes.size = TRY(stream.read_value<NetworkOrdered<u64>>());
+    if (has_flag(flags, AttributesFlags::UIDGID)) {
+        attributes.uid = TRY(stream.read_value<NetworkOrdered<u32>>());
+        attributes.gid = TRY(stream.read_value<NetworkOrdered<u32>>());
+    }
+    if (has_flag(flags, AttributesFlags::PERMISSIONS))
+        attributes.mode = TRY(stream.read_value<NetworkOrdered<u32>>());
+    if (has_flag(flags, AttributesFlags::ACMODTIME)) {
+        attributes.atim = TRY(stream.read_value<NetworkOrdered<u32>>());
+        attributes.mtim = TRY(stream.read_value<NetworkOrdered<u32>>());
+    }
+
+    if (has_flag(flags, AttributesFlags::EXTENDED))
+        return Error::from_string_literal("Unsupported attribute flag: extended");
+
+    return attributes;
+}
+
+ErrorOr<void> Attributes::encode(AllocatingMemoryStream& stream)
+{
+    AttributesFlags flags {};
+    if (size.has_value())
+        flags |= AttributesFlags::SIZE;
+    if (uid.has_value() && gid.has_value())
+        flags |= AttributesFlags::UIDGID;
+    if (mode.has_value())
+        flags |= AttributesFlags::PERMISSIONS;
+    if (atim.has_value() && mtim.has_value())
+        flags |= AttributesFlags::ACMODTIME;
+
+    TRY(stream.write_value<NetworkOrdered<u32>>(to_underlying(flags)));
+
+    if (size.has_value())
+        TRY(stream.write_value<NetworkOrdered<u64>>(*size));
+
+    if (uid.has_value() && gid.has_value()) {
+        TRY(stream.write_value<NetworkOrdered<u32>>(*uid));
+        TRY(stream.write_value<NetworkOrdered<u32>>(*gid));
+    }
+
+    if (mode.has_value())
+        TRY(stream.write_value<NetworkOrdered<u32>>(*mode));
+
+    if (atim.has_value() && mtim.has_value()) {
+        TRY(stream.write_value<NetworkOrdered<u32>>(*atim));
+        TRY(stream.write_value<NetworkOrdered<u32>>(*mtim));
+    }
+
     return {};
 }
 

--- a/Userland/Libraries/LibSSH/SFTP/Peer.h
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.h
@@ -61,12 +61,12 @@ enum class FXStatus : u8 {
 // 5. File Attributes
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-5
 struct Attributes {
-    Optional<u64> size;
-    Optional<u32> uid;
-    Optional<u32> gid;
-    Optional<u32> mode;
-    Optional<u32> atim;
-    Optional<u32> mtim;
+    Optional<u64> size {};
+    Optional<u32> uid {};
+    Optional<u32> gid {};
+    Optional<u32> mode {};
+    Optional<u32> atim {};
+    Optional<u32> mtim {};
 
     bool operator==(Attributes const&) const = default;
 
@@ -81,6 +81,9 @@ struct Attributes {
             .mtim = s.st_mtime,
         };
     }
+
+    static ErrorOr<Attributes> from_stream(FixedMemoryStream&);
+    ErrorOr<void> encode(AllocatingMemoryStream&);
 };
 
 // This class implement the SFTP protocol v3. Newer version exist, but they

--- a/Userland/Libraries/LibSSH/SFTP/Peer.h
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.h
@@ -8,6 +8,7 @@
 
 #include <AK/Function.h>
 #include <AK/MemoryStream.h>
+#include <sys/stat.h>
 
 namespace SSH::SFTP {
 
@@ -55,6 +56,31 @@ enum class FXStatus : u8 {
     NO_CONNECTION = 6,
     CONNECTION_LOST = 7,
     OP_UNSUPPORTED = 8,
+};
+
+// 5. File Attributes
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-5
+struct Attributes {
+    Optional<u64> size;
+    Optional<u32> uid;
+    Optional<u32> gid;
+    Optional<u32> mode;
+    Optional<u32> atim;
+    Optional<u32> mtim;
+
+    bool operator==(Attributes const&) const = default;
+
+    static Attributes from_stat(struct ::stat const& s)
+    {
+        return {
+            .size = s.st_size,
+            .uid = s.st_uid,
+            .gid = s.st_gid,
+            .mode = s.st_mode,
+            .atim = s.st_atime,
+            .mtim = s.st_mtime,
+        };
+    }
 };
 
 // This class implement the SFTP protocol v3. Newer version exist, but they

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -153,8 +153,6 @@ ErrorOr<void> encode_file_attributes(AllocatingMemoryStream& stream, struct ::st
     return {};
 }
 
-struct Attributes { };
-
 ErrorOr<Attributes> read_attributes(FixedMemoryStream& stream)
 {
     u32 flags = TRY(stream.read_value<NetworkOrdered<u32>>());

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -106,8 +106,15 @@ ErrorOr<void> Server::handle_stat(FixedMemoryStream& stream, StatType type)
     }();
 
     if (maybe_stat.is_error()) {
-        // FIXME: Send SSH_FXP_STATUS.
-        return maybe_stat.release_error();
+        auto const& error = maybe_stat.error();
+        VERIFY(error.is_errno());
+        if (error.code() == ENOENT)
+            TRY(send_status_message(id, FXStatus::NO_SUCH_FILE));
+        else if (error.code() == EACCES)
+            TRY(send_status_message(id, FXStatus::PERMISSION_DENIED));
+        else
+            TRY(send_status_message(id, FXStatus::FAILURE));
+        return {};
     }
 
     auto stat = maybe_stat.release_value();

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -197,7 +197,7 @@ ErrorOr<void> Server::handle_open(FixedMemoryStream& stream)
     auto attrs = TRY(Attributes::from_stream(stream));
 
     if (attrs.size.has_value() || attrs.uid.has_value() || attrs.gid.has_value()
-        || attrs.mode.has_value() || attrs.atim.has_value() || attrs.mtim.has_value())
+        || attrs.atim.has_value() || attrs.mtim.has_value())
         return Error::from_string_literal("Unsupported file attribute");
 
     // FIXME: Support relative path.
@@ -211,7 +211,7 @@ ErrorOr<void> Server::handle_open(FixedMemoryStream& stream)
     // matters when adopting).
     auto [open_mode, open_flags] = TRY(convert_pflags(pflags));
 
-    auto maybe_fd = Core::System::open(StringView { filename.bytes() }, open_flags);
+    auto maybe_fd = Core::System::open(StringView { filename.bytes() }, open_flags, attrs.mode.value_or(0644));
 
     // "The response to this message will be either SSH_FXP_HANDLE (if the
     //   operation is successful) or SSH_FXP_STATUS (if the operation fails)."

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -81,6 +81,8 @@ ErrorOr<void> Server::handle_packet(FixedMemoryStream& stream)
         return handle_stat(stream, StatType::Normal);
     case FXPMessageID::LSTAT:
         return handle_stat(stream, StatType::LStat);
+    case FXPMessageID::WRITE:
+        return handle_write(stream);
     default:
         dbgln_if(SSH_DEBUG, "Received packet with type: {}", to_underlying(type));
         return Error::from_string_literal("Unknown packet type");
@@ -301,6 +303,27 @@ ErrorOr<void> Server::handle_read(FixedMemoryStream& stream)
         TRY(send_status_message(id, FXStatus::FX_EOF));
     else
         TRY(send_data(id, buffer));
+
+    return {};
+}
+
+// 6.4 Reading and Writing
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.4
+ErrorOr<void> Server::handle_write(FixedMemoryStream& stream)
+{
+    u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto handle = TRY(decode_string(stream));
+    u64 offset = TRY(stream.read_value<NetworkOrdered<u64>>());
+    auto data = TRY(decode_string(stream));
+
+    auto& file = *TRY(find_file(handle));
+
+    u64 written = 0;
+    while (written < data.size()) {
+        written += TRY(Core::System::pwrite(file.file->fd(), data.bytes().slice(written), offset + written));
+    }
+
+    TRY(send_status_message(id, FXStatus::OK));
 
     return {};
 }

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -122,49 +122,6 @@ ErrorOr<void> Server::handle_stat(FixedMemoryStream& stream, StatType type)
     return {};
 }
 
-// 5. File Attributes
-// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-5
-namespace {
-
-#define SSH_FILEXFER_ATTR_SIZE 0x00000001
-#define SSH_FILEXFER_ATTR_UIDGID 0x00000002
-#define SSH_FILEXFER_ATTR_PERMISSIONS 0x00000004
-#define SSH_FILEXFER_ATTR_ACMODTIME 0x00000008
-#define SSH_FILEXFER_ATTR_EXTENDED 0x80000000
-
-ErrorOr<void> encode_file_attributes(AllocatingMemoryStream& stream, struct ::stat const& s)
-{
-    TRY(stream.write_value<NetworkOrdered<u32>>(
-        SSH_FILEXFER_ATTR_SIZE
-        | SSH_FILEXFER_ATTR_UIDGID
-        | SSH_FILEXFER_ATTR_PERMISSIONS
-        | SSH_FILEXFER_ATTR_ACMODTIME));
-
-    TRY(stream.write_value<NetworkOrdered<u64>>(s.st_size));
-
-    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_uid));
-    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_gid));
-
-    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_mode));
-
-    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_atime));
-    TRY(stream.write_value<NetworkOrdered<u32>>(s.st_mtime));
-
-    return {};
-}
-
-ErrorOr<Attributes> read_attributes(FixedMemoryStream& stream)
-{
-    u32 flags = TRY(stream.read_value<NetworkOrdered<u32>>());
-
-    if (flags != 0)
-        return Error::from_string_literal("Unsupported file attributes");
-
-    return Attributes {};
-}
-
-}
-
 // 7. Responses from the Server to the Client
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
 ErrorOr<void> Server::send_file_attribute_message(u32 id, struct stat const& s)
@@ -172,7 +129,7 @@ ErrorOr<void> Server::send_file_attribute_message(u32 id, struct stat const& s)
     AllocatingMemoryStream stream;
     TRY(stream.write_value(FXPMessageID::ATTRS));
     TRY(stream.write_value<NetworkOrdered<u32>>(id));
-    TRY(encode_file_attributes(stream, s));
+    TRY(Attributes::from_stat(s).encode(stream));
 
     auto packet = TRY(stream.read_until_eof());
     TRY(write_packet(packet));
@@ -194,7 +151,11 @@ ErrorOr<void> Server::handle_open(FixedMemoryStream& stream)
     u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
     auto filename = TRY(decode_string(stream));
     u32 pflags = TRY(stream.read_value<NetworkOrdered<u32>>());
-    [[maybe_unused]] auto attrs = TRY(read_attributes(stream));
+    auto attrs = TRY(Attributes::from_stream(stream));
+
+    if (attrs.size.has_value() || attrs.uid.has_value() || attrs.gid.has_value()
+        || attrs.mode.has_value() || attrs.atim.has_value() || attrs.mtim.has_value())
+        return Error::from_string_literal("Unsupported file attribute");
 
     // FIXME: Support relative path.
     if (filename.is_empty() || filename[0] != '/')

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -286,7 +286,7 @@ ErrorOr<void> Server::handle_read(FixedMemoryStream& stream)
     }
 
     if (should_send_eof)
-        TRY(send_eof(id));
+        TRY(send_status_message(id, FXStatus::FX_EOF));
     else
         TRY(send_data(id, buffer));
 
@@ -308,12 +308,12 @@ ErrorOr<void> Server::send_data(u32 id, ReadonlyBytes data)
 // 7. Responses from the Server to the Client
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7
 
-ErrorOr<void> Server::send_eof(u32 id)
+ErrorOr<void> Server::send_status_message(u32 id, FXStatus status)
 {
     AllocatingMemoryStream stream;
     TRY(stream.write_value(FXPMessageID::STATUS));
     TRY(stream.write_value<NetworkOrdered<u32>>(id));
-    TRY(stream.write_value<NetworkOrdered<u32>>(to_underlying(FXStatus::FX_EOF)));
+    TRY(stream.write_value<NetworkOrdered<u32>>(to_underlying(status)));
 
     // error message and language tag
     TRY(encode_string(stream, ""sv));

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -139,18 +139,61 @@ ErrorOr<void> Server::send_file_attribute_message(u32 id, struct stat const& s)
 // 6.3 Opening, Creating, and Closing Files
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.3
 
-#define SSH_FXF_READ 0x00000001
-#define SSH_FXF_WRITE 0x00000002
-#define SSH_FXF_APPEND 0x00000004
-#define SSH_FXF_CREAT 0x00000008
-#define SSH_FXF_TRUNC 0x00000010
-#define SSH_FXF_EXCL 0x00000020
+enum class PFlag : u8 {
+    None = 0, // This is AD-HOC.
+    READ = 0x01,
+    WRITE = 0x02,
+    APPEND = 0x04,
+    CREAT = 0x08,
+    TRUNC = 0x10,
+    EXCL = 0x20,
+};
+
+AK_ENUM_BITWISE_OPERATORS(PFlag)
+
+struct CoreAndPosixFlags {
+    Core::File::OpenMode open_mode {};
+    int posix_flags {};
+};
+
+static ErrorOr<CoreAndPosixFlags> convert_pflags(PFlag& pflags)
+{
+    int open_flags {};
+    Core::File::OpenMode open_mode {};
+    auto consume = [](PFlag& flags, PFlag mask) {
+        bool had_flag = has_flag(flags, mask);
+        flags &= ~mask;
+        return had_flag;
+    };
+
+    if (has_flag(pflags, PFlag::READ) && has_flag(pflags, PFlag::WRITE)) {
+        open_flags |= O_RDWR;
+        open_mode = Core::File::OpenMode::ReadWrite;
+        consume(pflags, PFlag::READ);
+        consume(pflags, PFlag::WRITE);
+    } else if (consume(pflags, PFlag::WRITE)) {
+        open_flags |= O_WRONLY;
+        open_mode = Core::File::OpenMode::Write;
+    } else if (consume(pflags, PFlag::READ)) {
+        open_flags |= O_RDONLY;
+        open_mode = Core::File::OpenMode::Read;
+    }
+    if (consume(pflags, PFlag::CREAT))
+        open_flags |= O_CREAT;
+
+    // FIXME: Support other pflags.
+    if (pflags != PFlag::None)
+        return Error::from_string_literal("Unsupported pflags");
+
+    return CoreAndPosixFlags { open_mode, open_flags };
+}
 
 ErrorOr<void> Server::handle_open(FixedMemoryStream& stream)
 {
     u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
     auto filename = TRY(decode_string(stream));
-    u32 pflags = TRY(stream.read_value<NetworkOrdered<u32>>());
+    u32 raw_pflags = TRY(stream.read_value<NetworkOrdered<u32>>());
+    PFlag pflags = static_cast<PFlag>(raw_pflags);
     auto attrs = TRY(Attributes::from_stream(stream));
 
     if (attrs.size.has_value() || attrs.uid.has_value() || attrs.gid.has_value()
@@ -161,20 +204,23 @@ ErrorOr<void> Server::handle_open(FixedMemoryStream& stream)
     if (filename.is_empty() || filename[0] != '/')
         return Error::from_string_literal("Relative paths are unsupported");
 
-    // FIXME: Support other pflags.
-    if (pflags != SSH_FXF_READ)
-        return Error::from_string_literal("Unsupported pflags");
+    // SSH flags maps one-to-one to POSIX flags, so use that and call open
+    // directly. This allows the SFTP server to be as transparent as possible.
+    // We still need to map these flags to a  Core::File::OpenMode so we can
+    // let Core::File adopt the fd later on (note that only read and write
+    // matters when adopting).
+    auto [open_mode, open_flags] = TRY(convert_pflags(pflags));
 
-    auto maybe_file = Core::File::open(StringView { filename.bytes() }, Core::File::OpenMode::Read);
+    auto maybe_fd = Core::System::open(StringView { filename.bytes() }, open_flags);
 
     // "The response to this message will be either SSH_FXP_HANDLE (if the
     //   operation is successful) or SSH_FXP_STATUS (if the operation fails)."
-    if (maybe_file.is_error()) {
+    if (maybe_fd.is_error()) {
         // FIXME: Send SSH_FXP_STATUS.
-        return maybe_file.release_error();
+        return maybe_fd.release_error();
     }
 
-    m_open_files.empend(maybe_file.release_value(),
+    m_open_files.empend(TRY(Core::File::adopt_fd(maybe_fd.value(), open_mode)),
         Crypto::Hash::MD5::hash(filename));
 
     TRY(send_file_handle(id, m_open_files.last()));

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -52,6 +52,8 @@ private:
     ErrorOr<void> send_file_handle(u32, File const&);
 
     ErrorOr<void> handle_read(FixedMemoryStream& stream);
+    ErrorOr<void> handle_write(FixedMemoryStream& stream);
+
     ErrorOr<void> send_data(u32, ReadonlyBytes);
     ErrorOr<void> send_status_message(u32, FXStatus);
 

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -53,7 +53,7 @@ private:
 
     ErrorOr<void> handle_read(FixedMemoryStream& stream);
     ErrorOr<void> send_data(u32, ReadonlyBytes);
-    ErrorOr<void> send_eof(u32);
+    ErrorOr<void> send_status_message(u32, FXStatus);
 
     ErrorOr<File*> find_file(ReadonlyBytes handle);
 

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -60,7 +60,7 @@ ErrorOr<void> accept_connection()
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio accept inet unix rpath proc exec sigaction"));
+    TRY(Core::System::pledge("stdio accept inet unix rpath wpath cpath proc exec sigaction"));
 
     // FIXME: Audit the server architecture and add veils wherever possible.
 
@@ -118,6 +118,6 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     outln("Listening on {}:{}", g_tcp_server->local_address().value(), g_tcp_server->local_port());
 
-    TRY(Core::System::pledge("stdio accept rpath proc exec sigaction"));
+    TRY(Core::System::pledge("stdio accept rpath wpath cpath proc exec sigaction"));
     return loop.exec();
 }


### PR DESCRIPTION
The diff looks bigger than it really is, the bulk of it is mainly code moves and tests while the actual code changes are quite simple.

Due to other limitations, it only works with small files and randomly fail because of a very similar reason to #26767 but applied to the SFTP layer.

<img width="1027" height="831" alt="Screenshot From 2026-05-21 16-43-09" src="https://github.com/user-attachments/assets/0e9be7c7-478b-406f-a42d-04df634281a7" />

(Don't look at the green box in the right bottom :sweat_smile:) (this has nothing to do with this pr, I think it's a kernel bug)