### PR TITLE
Kernel/aarch64: Allow userspace to use cache maintenance instructions

### DIFF
--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -822,6 +822,9 @@ struct alignas(u64) SCTLR_EL1 {
         // Allow EL0 to read CTR_EL0 (the cache type register).
         system_control_register_el1.UCT = 1;
 
+        // Allow EL0 to perform cache maintenance operations.
+        system_control_register_el1.UCI = 1;
+
         // Fields that are RES1 if no extensions are supported:
         system_control_register_el1.ITD = 1;
         system_control_register_el1.SED = 1;


### PR DESCRIPTION
This allows userspace to execute the DC CVAU, DC CIVAC, DC CVAC, and IC IVAU data/instruction cache maintenance instructions. These instructions operate on virtual addresses and are affected by the permissions specified in the page tables, so it should be safe to allow userspace to use them.

Both FreeBSD and Linux also allow userspace to use these instructions.

These instructions are typically used by JITs to clean the data cache to the point of unification and invalidate the instruction cache to the point of unification to ensure that self-modifying code works properly.

I missed this in 40a956c49cf because I only tested this by running Neovim (which uses LuaJIT) in QEMU. Neovim likely didn't crash in QEMU because QEMU's cache maintenance instructions are just NOPs (and CTR_EL0.{DIC,IDC} are both set to 1 to tell the guest that it doesn't need to do data/instruction cache cleaning/invalidation).