### PR TITLE
LibArchive: Fix fixed-width fields unbounded reads and PAX size OOM

### DIFF
--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -69,7 +69,7 @@ static ErrorOr<size_t> get_field_as_integral(char const (&field)[N])
 template<size_t N>
 static StringView get_field_as_string_view(char const (&field)[N])
 {
-    return { field, min(__builtin_strlen(field), N) };
+    return { field, strnlen(field, N) };
 }
 
 template<size_t N, class TSource>
@@ -100,7 +100,7 @@ public:
     ErrorOr<time_t> timestamp() const { return TRY(get_field_as_integral(m_timestamp)); }
     ErrorOr<unsigned> checksum() const { return TRY(get_field_as_integral(m_checksum)); }
     TarFileType type_flag() const { return TarFileType(m_type_flag); }
-    StringView link_name() const { return { m_link_name, strlen(m_link_name) }; }
+    StringView link_name() const { return get_field_as_string_view(m_link_name); }
     StringView magic() const { return get_field_as_string_view(m_magic); }
     StringView version() const { return get_field_as_string_view(m_version); }
     StringView owner_name() const { return get_field_as_string_view(m_owner_name); }

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -80,6 +80,8 @@ inline ErrorOr<void> TarInputStream::for_each_extended_header(F func)
     Archive::TarFileStream file_stream = file_contents();
 
     auto header_size = TRY(header().size());
+    if (header_size > 1024 * 1024)
+        return Error::from_string_literal("PAX extended header size exceeds maximum allowed limit");
     ByteBuffer file_contents_buffer = TRY(ByteBuffer::create_zeroed(header_size));
     TRY(file_stream.read_until_filled(file_contents_buffer));
 


### PR DESCRIPTION
### Description
This PR addresses two security-relevant findings in LibArchive's tar parser reported in #26773:

1. **Unbounded strlen() on fixed-width fields (Issue A):** Replaced `__builtin_strlen` with `strnlen` inside `get_field_as_string_view` to prevent out-of-bounds memory reads on non-NUL terminated fields (such as `m_link_name`, `m_magic`, `m_version`, and `m_prefix`).
2. **PAX memory amplification (Issue B):** Added a safety threshold checking if the declared PAX extended-header size exceeds 1 MiB before triggering `ByteBuffer::create_zeroed()`, mitigating potential Out-Of-Memory (OOM) amplification attacks.

Fixes #26773