### PR TITLE
LibTest: Flush stdout before running tests

### DIFF
--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -151,6 +151,10 @@ int TestSuite::main(ByteString const& suite_name, Span<StringView> arguments)
 
     outln("Running {} cases out of {}.", matching_tests.size(), m_cases.size());
 
+    // If a test forks, we don't want data that was buffered in stdout to
+    // be printed every time a process exits.
+    fflush(stdout);
+
     return run(matching_tests);
 }
 


### PR DESCRIPTION
This avoids data to appears multiple time when a test forks. It also makes the "Running {} cases out of {}." line to always appear before all "Running test '{}'.".

Before:
(This specific test is not on master, but all you need to know is that if `fork`s once.)

<img width="596" height="408" alt="Screenshot From 2026-05-26 12-22-05" src="https://github.com/user-attachments/assets/11ef3b9e-de5f-41e3-8179-06574d6bb770" />

After:
<img width="596" height="408" alt="Screenshot From 2026-05-26 12-22-37" src="https://github.com/user-attachments/assets/dc2daa83-ff77-48e7-bd40-a35ecef99376" />
