### PR TITLE
SSHServer: Fix two children-related issues

### DIFF
--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -106,6 +106,11 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             auto wait_result = maybe_result.value();
             if (wait_result.pid == 0)
                 return;
+
+            if (WIFSIGNALED(wait_result.status))
+                warnln("Connection process exited with: signal({})", WTERMSIG(wait_result.status));
+            else if (WIFEXITED(wait_result.status) && WEXITSTATUS(wait_result.status) > 0)
+                warnln("Connection process exited with: exit code({})", WEXITSTATUS(wait_result.status));
         }
     });
 

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -36,6 +36,7 @@ ErrorOr<void> accept_connection()
         // We need to ensure the socket survives until the deferred_invoke, but
         // fd will be closed at the end of the scope with client_socket.
         auto fd_copy = TRY(Core::System::dup(fd));
+        TRY(Core::System::fcntl(fd_copy, F_SETFD, FD_CLOEXEC));
 
         Core::EventLoop::current().deferred_invoke([fd_copy]() mutable {
             g_tcp_server = nullptr;

--- a/Userland/Services/SSHServer/main.cpp
+++ b/Userland/Services/SSHServer/main.cpp
@@ -103,6 +103,9 @@ ErrorOr<int> serenity_main(Main::Arguments args)
                 dbgln("Error while reaping child processes: {}", error);
                 loop.quit(-1);
             }
+            auto wait_result = maybe_result.value();
+            if (wait_result.pid == 0)
+                return;
         }
     });
 


### PR DESCRIPTION
See individual commits for details.

SSHServer is now able to sustain a continuous stream of sequential connections without acting weird.