### PR TITLE
SSHServer: Allow sessions to transfer more data

### DIFF
--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -134,6 +134,36 @@ ErrorOr<size_t> PosixSocketHelper::write(ReadonlyBytes buffer, int flags)
     return TRY(System::send(m_fd, buffer.data(), buffer.size(), flags));
 }
 
+ErrorOr<void> PosixSocketHelper::write_until_depleted(ReadonlyBytes bytes, int flags)
+{
+    u64 written = 0;
+    while (written < bytes.size()) {
+        auto maybe_error = write(bytes.slice(written), flags);
+        if (maybe_error.is_error()) {
+            auto& error = maybe_error.error();
+            if (error.code() == EWOULDBLOCK) {
+                struct pollfd the_fd = { .fd = m_fd, .events = POLLOUT, .revents = 0 };
+
+                ErrorOr<int> result { 0 };
+                do {
+                    result = Core::System::poll({ &the_fd, 1 }, 0);
+                } while (result.is_error() && result.error().code() == EINTR);
+
+                if (result.is_error())
+                    return result.release_error();
+
+                continue;
+            }
+
+            return move(error);
+        }
+
+        written += maybe_error.release_value();
+    }
+
+    return {};
+}
+
 void PosixSocketHelper::close()
 {
     if (!is_open()) {

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -132,6 +132,7 @@ public:
 
     ErrorOr<Bytes> read(Bytes, int flags);
     ErrorOr<size_t> write(ReadonlyBytes, int flags);
+    ErrorOr<void> write_until_depleted(ReadonlyBytes, int flags);
 
     bool is_eof() const { return !is_open() || m_last_read_was_eof; }
     void did_reach_eof_on_read();
@@ -183,6 +184,8 @@ public:
 
     virtual ErrorOr<Bytes> read_some(Bytes buffer) override { return m_helper.read(buffer, default_flags()); }
     virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
+    using Stream::write_until_depleted; // This keeps the access to the templated overload.
+    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes buffer) override { return m_helper.write_until_depleted(buffer, default_flags()); }
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.is_open(); }
     virtual void close() override { m_helper.close(); }

--- a/Userland/Libraries/LibSSH/Session.cpp
+++ b/Userland/Libraries/LibSSH/Session.cpp
@@ -53,7 +53,8 @@ ErrorOr<NonnullRefPtr<Session>> Session::create(u32 sender_channel_id, u32 windo
     session->local_channel_id = sender_channel_id;
     session->sender_channel_id = sender_channel_id;
     session->maximum_packet_size = maximum_packet_size;
-    session->window_size = window_size;
+    session->initial_window_size = window_size;
+    session->local_window_size = window_size;
     return session;
 }
 

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -47,7 +47,9 @@ struct Session : public RefCounted<Session> {
     u32 local_channel_id {};
     u32 sender_channel_id {};
     u32 maximum_packet_size {};
-    u64 window_size {};
+    u64 initial_window_size {};
+    u64 local_window_size {};
+    u64 total_received_bytes {};
 
     StreamBuffer channel_data {};
     bool has_streaming_coroutine { false };

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -807,8 +807,13 @@ ErrorOr<void> SSHClient::handle_channel_eof(GenericMessage& message)
     return {};
 }
 
-ErrorOr<void> SSHClient::handle_channel_window_adjust_message(GenericMessage&)
+// 5.2.  Data Transfer
+// https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
+ErrorOr<void> SSHClient::handle_channel_window_adjust_message(GenericMessage& message)
 {
+    [[maybe_unused]] auto recipient_channel_id = TRY(message.payload.read_value<NetworkOrdered<u32>>());
+    [[maybe_unused]] auto bytes_to_add = TRY(message.payload.read_value<NetworkOrdered<u32>>());
+
     // FIXME: Actually support this packet and don't spam the client without
     //        respecting its window size.
     return {};

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -555,7 +555,7 @@ ErrorOr<void> SSHClient::send_channel_open_confirmation(Session const& session)
     TRY(stream.write_value<NetworkOrdered<u32>>(session.sender_channel_id));
     TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
 
-    TRY(stream.write_value<NetworkOrdered<u32>>(session.window_size));
+    TRY(stream.write_value<NetworkOrdered<u32>>(session.initial_window_size));
     TRY(stream.write_value<NetworkOrdered<u32>>(session.maximum_packet_size));
 
     TRY(write_packet(TRY(stream.read_until_eof())));
@@ -619,6 +619,11 @@ ErrorOr<void> SSHClient::handle_channel_data(GenericMessage& message)
         return Error::from_string_literal("Received channel data after EOF");
 
     session.channel_data.append(data);
+    session.total_received_bytes += data.size();
+
+    // FIXME: Try to tune this logic, there is probably some performance to gain here.
+    if (session.local_window_size - session.total_received_bytes < session.initial_window_size / 2)
+        TRY(send_channel_window_adjust_message(session));
 
     // FIXME: Make sure to cancel this coroutine if anything goes wrong.
     if (!session.has_streaming_coroutine)
@@ -816,6 +821,21 @@ ErrorOr<void> SSHClient::handle_channel_window_adjust_message(GenericMessage& me
 
     // FIXME: Actually support this packet and don't spam the client without
     //        respecting its window size.
+    return {};
+}
+
+// 5.2.  Data Transfer
+// https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
+ErrorOr<void> SSHClient::send_channel_window_adjust_message(Session& session)
+{
+    session.local_window_size += session.initial_window_size;
+
+    AllocatingMemoryStream stream;
+    TRY(stream.write_value(MessageID::CHANNEL_WINDOW_ADJUST));
+    TRY(stream.write_value<NetworkOrdered<u32>>(session.sender_channel_id));
+    TRY(stream.write_value<NetworkOrdered<u32>>(session.initial_window_size));
+    TRY(write_packet(TRY(stream.read_until_eof())));
+
     return {};
 }
 

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -94,6 +94,7 @@ private:
     ErrorOr<void> send_channel_data(Session const&, ReadonlyBytes);
     ErrorOr<void> send_channel_extended_data(Session const&, ReadonlyBytes);
     ErrorOr<void> handle_channel_window_adjust_message(GenericMessage&);
+    ErrorOr<void> send_channel_window_adjust_message(Session&);
     ErrorOr<void> handle_channel_eof(GenericMessage&);
     ErrorOr<void> send_exit_status(Session const&, int);
     ErrorOr<void> handle_channel_close(GenericMessage&);


### PR DESCRIPTION
Second commit let the client know that it can send more data to us.
Third commit makes us resilient to the Kernel telling us to keep calm before sending more data.

Together, they make this work on Lagom:
```bash
ssh -p 2222 127.0.0.1 cat - < ~/progress_file_800MB.txt
```

(#26805 is required to satisfy the claim above.)