### PR TITLE
Kernel+Tests: Fix two small ptrace()-related bugs and add basic ptrace() tests

### DIFF
--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -68,7 +68,7 @@ static ErrorOr<FlatPtr> handle_ptrace(Kernel::Syscall::SC_ptrace_params const& p
     if (tracer->tracer_pid() != caller.pid())
         return EBUSY;
 
-    if (peer->state() == Thread::State::Running)
+    if (peer->state() != Thread::State::Stopped)
         return EBUSY;
 
     scheduler_lock.unlock();

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -886,7 +886,7 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
     VERIFY(process().is_user_process());
     VERIFY(this == Thread::current());
 
-    dbgln_if(SIGNAL_DEBUG, "Dispatch signal {} to {}, state: {}", signal, *this, state_string());
+    dbgln_if(SIGNAL_DEBUG, "Dispatch signal {} to {}", signal, *this);
 
     if (m_state == Thread::State::Invalid || !is_initialized()) {
         // Thread has barely been created, we need to wait until it is

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericShorthands.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
@@ -667,6 +668,23 @@ void Thread::send_signal(u8 signal, [[maybe_unused]] Process* sender)
     if (should_ignore_signal(signal)) {
         dbgln_if(SIGNAL_DEBUG, "Signal {} was ignored by {}", signal, process());
         return;
+    }
+
+    // https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html#tag_16_04_01
+    // "When any stop signal (SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU) is generated for a process or thread, all pending SIGCONT signals for that process or any of the threads within that process shall be discarded."
+    if (first_is_one_of(signal, SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU)) {
+        process().for_each_thread([](Thread& thread) {
+            thread.m_pending_signals &= ~(1 << (SIGCONT - 1));
+        });
+    }
+
+    // https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html#tag_16_04_01
+    // "Conversely, when SIGCONT is generated for a process or thread, all pending stop signals for that process or any of the threads within that process shall be discarded."
+    if (signal == SIGCONT) {
+        process().for_each_thread([](Thread& thread) {
+            static constexpr u32 STOP_SIGNAL_MASK = (1 << (SIGSTOP - 1)) | (1 << (SIGTSTP - 1)) | (1 << (SIGTTIN - 1)) | (1 << (SIGTTOU - 1));
+            thread.m_pending_signals &= ~STOP_SIGNAL_MASK;
+        });
     }
 
     if constexpr (SIGNAL_DEBUG) {

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -648,8 +648,6 @@ u32 Thread::pending_signals_for_state() const
 {
     VERIFY(g_scheduler_lock.is_locked_by_current_processor());
     constexpr u32 stopped_signal_mask = (1 << (SIGCONT - 1)) | (1 << (SIGKILL - 1)) | (1 << (SIGTRAP - 1));
-    if (is_handling_page_fault())
-        return 0;
     return m_state != State::Stopped ? m_pending_signals : m_pending_signals & stopped_signal_mask;
 }
 

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -114,6 +114,12 @@ Thread::BlockResult Thread::block_impl(BlockTimeout const& timeout, Blocker& blo
 
     SpinlockLocker scheduler_lock(g_scheduler_lock);
 
+    // Don't let signals unblock threads that are blocked inside a page fault handler.
+    // This prevents threads from EINTR'ing the inode read in an inode page fault.
+    // FIXME: There's probably a better way to solve this.
+    if (has_unmasked_pending_signals() && !is_handling_page_fault())
+        return BlockResult::InterruptedBySignal;
+
     SpinlockLocker block_lock(m_block_lock);
     // We need to hold m_block_lock so that nobody can unblock a blocker as soon
     // as it is constructed and registered elsewhere

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -673,7 +673,7 @@ void Thread::send_signal(u8 signal, [[maybe_unused]] Process* sender)
         if (sender)
             dbgln("Signal: {} sent {} to {}", *sender, signal, process());
         else
-            dbgln("Signal: Kernel send {} to {}", signal, process());
+            dbgln("Signal: Kernel sent {} to {}", signal, process());
     }
 
     m_pending_signals |= 1 << (signal - 1);

--- a/Tests/Kernel/TestPtrace.cpp
+++ b/Tests/Kernel/TestPtrace.cpp
@@ -1,14 +1,17 @@
 /*
  * Copyright (c) 2026, the SerenityOS developers.
+ * Copyright (c) 2026, Sönke Holz <soenke.holz@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/Atomic.h>
+#include <LibCore/System.h>
 #include <LibTest/TestCase.h>
 #include <errno.h>
 #include <pthread.h>
 #include <signal.h>
+#include <sys/arch/regs.h>
 #include <sys/ptrace.h>
 #include <unistd.h>
 
@@ -36,3 +39,340 @@ TEST_CASE(ptrace_self_attach_fail)
     s_exit_thread = true;
     VERIFY(pthread_join(thread, nullptr) == 0);
 }
+
+static void wait_for_child_stop(pid_t child_pid, int expected_signal)
+{
+    auto wait_result = TRY_OR_FAIL(Core::System::waitpid(child_pid, WSTOPPED));
+    EXPECT(WIFSTOPPED(wait_result.status));
+    EXPECT_EQ(WSTOPSIG(wait_result.status), expected_signal);
+}
+
+static void wait_for_child_exit(pid_t child_pid)
+{
+    auto wait_result = TRY_OR_FAIL(Core::System::waitpid(child_pid, 0));
+    EXPECT(WIFSIGNALED(wait_result.status));
+    EXPECT_EQ(WTERMSIG(wait_result.status), SIGTERM);
+}
+
+TEST_CASE(ptrace_trace_me)
+{
+    auto child_pid = TRY_OR_FAIL(Core::System::fork());
+
+    if (child_pid == 0) {
+        TRY_OR_FAIL(Core::System::ptrace(PT_TRACE_ME, 0, 0, 0));
+        raise(SIGSTOP);
+
+        for (;;)
+            pause();
+
+        VERIFY_NOT_REACHED();
+    }
+
+    wait_for_child_stop(child_pid, SIGSTOP);
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_ATTACH, child_pid, 0, 0));
+    wait_for_child_stop(child_pid, SIGSTOP);
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_DETACH, child_pid, 0, 0));
+
+    TRY_OR_FAIL(Core::System::kill(child_pid, SIGTERM));
+    wait_for_child_exit(child_pid);
+}
+
+TEST_CASE(ptrace_attach_and_detach)
+{
+    auto child_pid = TRY_OR_FAIL(Core::System::fork());
+
+    if (child_pid == 0) {
+        for (;;)
+            pause();
+
+        VERIFY_NOT_REACHED();
+    }
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_ATTACH, child_pid, 0, 0));
+    wait_for_child_stop(child_pid, SIGSTOP);
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_DETACH, child_pid, 0, 0));
+
+    TRY_OR_FAIL(Core::System::kill(child_pid, SIGTERM));
+    wait_for_child_exit(child_pid);
+}
+
+template<CallableAs<void> ChildFn, CallableAs<void, pid_t> ParentFn>
+static void run_generic_test(ChildFn child_callback, ParentFn parent_callback)
+{
+    auto child_pid = TRY_OR_FAIL(Core::System::fork());
+
+    if (child_pid == 0) {
+        TRY_OR_FAIL(Core::System::ptrace(PT_TRACE_ME, 0, 0, 0));
+        raise(SIGSTOP);
+
+        child_callback();
+
+        for (;;)
+            pause();
+
+        VERIFY_NOT_REACHED();
+    }
+
+    wait_for_child_stop(child_pid, SIGSTOP);
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_ATTACH, child_pid, 0, 0));
+    wait_for_child_stop(child_pid, SIGSTOP);
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_CONTINUE, child_pid, 0, 0));
+
+    parent_callback(child_pid);
+
+    TRY_OR_FAIL(Core::System::ptrace(PT_DETACH, child_pid, 0, 0));
+
+    TRY_OR_FAIL(Core::System::kill(child_pid, SIGTERM));
+    wait_for_child_exit(child_pid);
+}
+
+TEST_CASE(ptrace_breakpoint_instruction)
+{
+    run_generic_test(
+        [] {
+#if ARCH(X86_64)
+            asm volatile(R"(
+                int3
+            )" :);
+#elif ARCH(AARCH64)
+            asm volatile(R"(
+                brk #0
+            )" :);
+#elif ARCH(RISCV64)
+            asm volatile(R"(
+                ebreak
+            )" :);
+#else
+#    error Unknown architecture
+#endif
+        },
+        [](pid_t child_pid) {
+            wait_for_child_stop(child_pid, SIGTRAP);
+        });
+}
+
+TEST_CASE(ptrace_ebusy)
+{
+    run_generic_test(
+        [] {
+            // Do nothing.
+        },
+        [](pid_t child_pid) {
+            PtraceRegisters regs = {};
+            auto res = Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0);
+            EXPECT(res.is_error());
+            EXPECT_EQ(res.error().code(), EBUSY);
+
+            TRY_OR_FAIL(Core::System::kill(child_pid, SIGSTOP));
+            wait_for_child_stop(child_pid, SIGSTOP);
+
+            res = Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0);
+            EXPECT(!res.is_error());
+        });
+}
+
+TEST_CASE(ptrace_read_register)
+{
+    run_generic_test(
+        [] {
+#if ARCH(X86_64)
+            asm volatile(R"(
+                mov $42, %%eax
+                int3
+            )" ::: "rax");
+#elif ARCH(AARCH64)
+            asm volatile(R"(
+                mov x0, #42
+                brk #0
+            )" ::: "x0");
+#elif ARCH(RISCV64)
+            asm volatile(R"(
+                li x5, 42
+                ebreak
+            )" ::: "x5");
+#else
+#    error Unknown architecture
+#endif
+        },
+        [](pid_t child_pid) {
+            wait_for_child_stop(child_pid, SIGTRAP);
+
+            PtraceRegisters regs = {};
+            TRY_OR_FAIL(Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0));
+#if ARCH(X86_64)
+            EXPECT_EQ(regs.rax, 42u);
+#elif ARCH(AARCH64)
+            EXPECT_EQ(regs.x[0], 42u);
+#elif ARCH(RISCV64)
+            EXPECT_EQ(regs.x[4], 42u);
+#else
+#    error Unknown architecture
+#endif
+        });
+}
+
+TEST_CASE(ptrace_write_register)
+{
+    run_generic_test(
+        [] {
+#if ARCH(X86_64)
+            asm volatile(R"(
+                mov $0, %%eax
+                int3
+                mov %%eax, %%ebx
+                int3
+            )" ::: "rax", "rbx");
+#elif ARCH(AARCH64)
+            asm volatile(R"(
+                mov x0, #0
+                brk #0
+                mov x1, x0
+                brk #0
+            )" ::: "x0", "x1");
+#elif ARCH(RISCV64)
+            asm volatile(R"(
+                li x5, 0
+                ebreak
+                mv x6, x5
+                ebreak
+            )" ::: "x5", "x6");
+#else
+#    error Unknown architecture
+#endif
+        },
+        [](pid_t child_pid) {
+            wait_for_child_stop(child_pid, SIGTRAP);
+
+            PtraceRegisters regs = {};
+            TRY_OR_FAIL(Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0));
+
+#if ARCH(X86_64)
+            regs.rax = 123;
+#elif ARCH(AARCH64)
+            regs.x[0] = 123;
+#elif ARCH(RISCV64)
+            regs.x[4] = 123;
+#else
+#    error Unknown architecture
+#endif
+            TRY_OR_FAIL(Core::System::ptrace(PT_SETREGS, child_pid, &regs, 0));
+
+            TRY_OR_FAIL(Core::System::ptrace(PT_CONTINUE, child_pid, 0, 0));
+
+            wait_for_child_stop(child_pid, SIGTRAP);
+
+            TRY_OR_FAIL(Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0));
+#if ARCH(X86_64)
+            EXPECT_EQ(regs.rbx, 123u);
+#elif ARCH(AARCH64)
+            EXPECT_EQ(regs.x[1], 123u);
+#elif ARCH(RISCV64)
+            EXPECT_EQ(regs.x[5], 123u);
+#else
+#    error Unknown architecture
+#endif
+        });
+}
+
+TEST_CASE(ptrace_single_step)
+{
+#if ARCH(RISCV64)
+    dbgln("FIXME: Support PT_SINGLESTEP on RISC-V.");
+    return;
+#endif
+
+    run_generic_test(
+        [] {
+#if ARCH(X86_64)
+            asm volatile(R"(
+                mov $0, %%eax
+                int3
+                mov $42, %%eax
+                mov $123, %%eax
+            )" ::: "rax");
+#elif ARCH(AARCH64)
+            asm volatile(R"(
+                mov x0, #0
+                brk #0
+                mov x0, #42
+                mov x0, #123
+            )" ::: "x0");
+#elif ARCH(RISCV64)
+            asm volatile(R"(
+                li x5, 0
+                ebreak
+                li x5, 42
+                li x5, 123
+            )" ::: "x5");
+#else
+#    error Unknown architecture
+#endif
+        },
+        [](pid_t child_pid) {
+            wait_for_child_stop(child_pid, SIGTRAP);
+
+            PtraceRegisters regs = {};
+            TRY_OR_FAIL(Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0));
+#if ARCH(X86_64)
+            EXPECT_EQ(regs.rax, 0u);
+#elif ARCH(AARCH64)
+            EXPECT_EQ(regs.x[0], 0u);
+#elif ARCH(RISCV64)
+            EXPECT_EQ(regs.x[4], 0u);
+#else
+#    error Unknown architecture
+#endif
+
+            TRY_OR_FAIL(Core::System::ptrace(PT_SINGLESTEP, child_pid, 0, 0));
+            TRY_OR_FAIL(Core::System::ptrace(PT_CONTINUE, child_pid, 0, 0));
+
+            wait_for_child_stop(child_pid, SIGTRAP);
+
+            TRY_OR_FAIL(Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0));
+#if ARCH(X86_64)
+            EXPECT_EQ(regs.rax, 42u);
+#elif ARCH(AARCH64)
+            EXPECT_EQ(regs.x[0], 42u);
+#elif ARCH(RISCV64)
+            EXPECT_EQ(regs.x[4], 42u);
+#else
+#    error Unknown architecture
+#endif
+
+            TRY_OR_FAIL(Core::System::ptrace(PT_SINGLESTEP, child_pid, 0, 0));
+            TRY_OR_FAIL(Core::System::ptrace(PT_CONTINUE, child_pid, 0, 0));
+
+            wait_for_child_stop(child_pid, SIGTRAP);
+
+            TRY_OR_FAIL(Core::System::ptrace(PT_GETREGS, child_pid, &regs, 0));
+#if ARCH(X86_64)
+            EXPECT_EQ(regs.rax, 123u);
+#elif ARCH(AARCH64)
+            EXPECT_EQ(regs.x[0], 123u);
+#elif ARCH(RISCV64)
+            EXPECT_EQ(regs.x[4], 123u);
+#else
+#    error Unknown architecture
+#endif
+
+#if ARCH(X86_64)
+            // FIXME: This is very awkward.
+            //        The kernel should probably clear the trap flag for us, like we do on AArch64.
+            regs.rflags &= ~0x100;
+            TRY_OR_FAIL(Core::System::ptrace(PT_SETREGS, child_pid, &regs, 0));
+#endif
+        });
+}
+
+// FIXME: Add tests for:
+//        - PT_SYSCALL
+//        - PT_PEEK
+//        - PT_POKE
+//        - PT_PEEKDEBUG
+//        - PT_POKEDEBUG
+//        - ptrace_peekbuf()


### PR DESCRIPTION
Previously, we didn't have any ptrace() test cases, except one checking that attaching to your own thread fails.

See commit descriptions for details.