### PR TITLE
LibSSH/SFTP: Handle partials and consecutive packets

### DIFF
--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -78,3 +78,20 @@ inline ErrorOr<ByteBuffer> make_open_packet(StringView path, u32 request_id)
 
     return TRY(packet.read_until_eof());
 }
+
+inline ErrorOr<void> check_status_message(Message const& message, SSH::SFTP::FXStatus expected_status, u32 request_id = 42)
+{
+    EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
+    FixedMemoryStream stream { message.payload };
+    EXPECT_EQ(TRY(stream.read_value<NetworkOrdered<u32>>()), request_id);
+    u32 raw_status_code = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto status_code = static_cast<SSH::SFTP::FXStatus>(raw_status_code);
+    EXPECT_EQ(status_code, expected_status);
+
+    // `error message` and `language tag`
+    EXPECT(!SSH::decode_string(stream).is_error());
+    EXPECT(!SSH::decode_string(stream).is_error());
+
+    EXPECT(stream.remaining() == 0);
+    return {};
+}

--- a/Tests/LibSSH/SFTP/Shared.h
+++ b/Tests/LibSSH/SFTP/Shared.h
@@ -19,6 +19,7 @@ public:
     {
     }
 
+    using SSH::SFTP::Peer::is_buffer_containing_a_full_packet;
     using SSH::SFTP::Peer::read_header;
     using SSH::SFTP::Peer::write_packet;
 };

--- a/Tests/LibSSH/SFTP/TestSFTPPeer.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPPeer.cpp
@@ -27,14 +27,12 @@ TEST_CASE(read_header)
     // We modify the packet content to change the signaled size.
     auto altered_content = message_copy;
     EXPECT_EQ(altered_content[3], 5);
-    altered_content[3] = 4;
+    altered_content[3] = 6;
     stream = FixedMemoryStream { altered_content.bytes() };
     EXPECT(peer.read_header(stream).is_error());
 
-    // We append bytes to the packet to change the actual size.
-    auto altered_length = message_copy;
-    altered_length.append(0);
-    stream = FixedMemoryStream { altered_length.bytes() };
+    auto empty_packet = to_array<u8>({ 0x00, 0x00, 0x00, 0x00 });
+    stream = FixedMemoryStream { empty_packet.span() };
     EXPECT(peer.read_header(stream).is_error());
 }
 
@@ -61,4 +59,12 @@ TEST_CASE(write_packet)
 
     EXPECT_EQ(written_packet->bytes().trim(4), expected_size);
     EXPECT_EQ(written_packet->bytes().slice(4), payload.bytes());
+}
+
+TEST_CASE(is_buffer_containing_packet)
+{
+    EXPECT(!PeerMock::is_buffer_containing_a_full_packet({}));
+    EXPECT(!PeerMock::is_buffer_containing_a_full_packet(g_initialization_packet.bytes().trim(1)));
+    EXPECT(!PeerMock::is_buffer_containing_a_full_packet(g_initialization_packet.bytes().trim(g_initialization_packet.length() - 1)));
+    EXPECT(PeerMock::is_buffer_containing_a_full_packet(g_initialization_packet.bytes()));
 }

--- a/Tests/LibSSH/SFTP/TestSFTPRead.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPRead.cpp
@@ -48,11 +48,7 @@ ErrorOr<void> run_read_test(StringView path, u64 offset, u64 size, bool expect_e
         }
 
         if (expect_eof) {
-            EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
-            EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
-            EXPECT_EQ(to_underlying(SSH::SFTP::FXStatus::FX_EOF), TRY(stream.read_value<NetworkOrdered<u32>>()));
-
-            return {};
+            return check_status_message(message, SSH::SFTP::FXStatus::FX_EOF, request_id);
         }
 
         EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::DATA);

--- a/Tests/LibSSH/SFTP/TestSFTPServerBasic.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPServerBasic.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/MemoryStream.h>
+#include <LibFileSystem/TempFile.h>
 #include <LibTest/TestCase.h>
 #include <Tests/LibSSH/SFTP/Shared.h>
 
@@ -25,4 +26,50 @@ TEST_CASE(handshake)
 
     // We should fail when receiving a second initialization packet.
     EXPECT(server_process_data(server, g_initialization_packet.bytes()).is_error());
+}
+
+TEST_CASE(partial_packet)
+{
+    u32 call_count = 0;
+    auto callback = [&](Message message) -> ErrorOr<void> {
+        call_count++;
+        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::HANDLE);
+        return {};
+    };
+    auto server = make_initialized_server(move(callback));
+
+    auto tmp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto open_packet = TRY_OR_FAIL(make_open_packet(tmp_file->path(), 42));
+
+    auto session = TRY_OR_FAIL(SSH::Session::create(0, 0, 0));
+
+    // Send the packet byte per byte.
+    for (u32 i = 0; i < open_packet.size(); ++i) {
+        session->channel_data.append(open_packet[i]);
+        TRY_OR_FAIL(Core::run_async_in_new_event_loop([&]() { return server.handle_channel_data(session); }));
+    }
+
+    EXPECT_EQ(call_count, 1u);
+}
+
+TEST_CASE(consecutive_packets)
+{
+    u32 call_count = 0;
+    auto callback = [&](Message message) -> ErrorOr<void> {
+        call_count++;
+        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::HANDLE);
+        return {};
+    };
+    auto server = make_initialized_server(move(callback));
+
+    auto tmp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+    auto open_packet = TRY_OR_FAIL(make_open_packet(tmp_file->path(), 42));
+
+    auto session = TRY_OR_FAIL(SSH::Session::create(0, 0, 0));
+    session->channel_data.append(open_packet);
+    session->channel_data.append(open_packet);
+
+    TRY_OR_FAIL(Core::run_async_in_new_event_loop([&]() { return server.handle_channel_data(session); }));
+
+    EXPECT_EQ(call_count, 2u);
 }

--- a/Tests/LibSSH/SFTP/TestSFTPStat.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPStat.cpp
@@ -52,19 +52,7 @@ ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, SSH::SFTP::Attr
 ErrorOr<void> run_for_path_impl(StringView path, bool use_lstat, SSH::SFTP::FXStatus expected_status)
 {
     auto callback = [=](Message message) -> ErrorOr<void> {
-        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
-        FixedMemoryStream stream { message.payload };
-        EXPECT_EQ(TRY(stream.read_value<NetworkOrdered<u32>>()), 42u);
-        u32 raw_status_code = TRY(stream.read_value<NetworkOrdered<u32>>());
-        auto status_code = static_cast<SSH::SFTP::FXStatus>(raw_status_code);
-        EXPECT_EQ(status_code, expected_status);
-
-        // `error message` and `language tag`
-        TRY(SSH::decode_string(stream));
-        TRY(SSH::decode_string(stream));
-
-        EXPECT(stream.remaining() == 0);
-        return {};
+        return check_status_message(message, expected_status);
     };
 
     return run_server_with_callback(move(callback), path, use_lstat);

--- a/Tests/LibSSH/SFTP/TestSFTPWrite.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPWrite.cpp
@@ -62,12 +62,7 @@ ErrorOr<void> run_write_test(StringView path, u64 offset, ReadonlyBytes data)
             return {};
         }
 
-        EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::STATUS);
-        EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
-        EXPECT_EQ(to_underlying(SSH::SFTP::FXStatus::OK), TRY(stream.read_value<NetworkOrdered<u32>>()));
-        // error message and language tag
-        EXPECT(TRY(SSH::decode_string(stream)).is_empty());
-        EXPECT(TRY(SSH::decode_string(stream)).is_empty());
+        TRY(check_status_message(message, SSH::SFTP::FXStatus::OK, request_id));
 
         TRY(compare_files(reference_path, path));
 

--- a/Userland/Libraries/LibSSH/SFTP/Peer.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.cpp
@@ -13,10 +13,23 @@ namespace SSH::SFTP {
 
 // 3. General Packet Format
 // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-3
+bool Peer::is_buffer_containing_a_full_packet(ReadonlyBytes data)
+{
+    if (data.size() < sizeof(u32))
+        return false;
+
+    FixedMemoryStream stream { data };
+    u32 packet_length = MUST(stream.read_value<NetworkOrdered<u32>>());
+
+    return sizeof(u32) + packet_length <= data.size();
+}
+
+// 3. General Packet Format
+// https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-3
 ErrorOr<FXPMessageID> Peer::read_header(FixedMemoryStream& stream)
 {
     u32 length = TRY(stream.read_value<NetworkOrdered<u32>>());
-    if (length != stream.remaining())
+    if (length > stream.remaining())
         return Error::from_string_literal("Invalid packet size");
 
     auto type = TRY(stream.read_value<FXPMessageID>());

--- a/Userland/Libraries/LibSSH/SFTP/Peer.h
+++ b/Userland/Libraries/LibSSH/SFTP/Peer.h
@@ -97,6 +97,8 @@ public:
     }
 
 protected:
+    static bool is_buffer_containing_a_full_packet(ReadonlyBytes);
+
     ErrorOr<FXPMessageID> read_header(FixedMemoryStream& stream);
     ErrorOr<void> write_packet(ReadonlyBytes bytes);
 

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -20,13 +20,19 @@ Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
 
     FixedMemoryStream stream { session.channel_data.data() };
     ScopeGuard commit_read_bytes { [&] { session.channel_data.dequeue(stream.offset()); } };
-    switch (m_state) {
-    case State::Constructed:
+
+    if (m_state == State::Constructed)
         co_return handle_init_message(stream);
-    case State::Initialized:
-        co_return handle_packet(stream);
+
+    VERIFY(m_state == State::Initialized);
+    while (stream.remaining() > 0) {
+        if (!is_buffer_containing_a_full_packet(session.channel_data.data()))
+            co_return {};
+
+        CO_TRY(handle_packet(stream));
     }
-    VERIFY_NOT_REACHED();
+
+    co_return {};
 }
 
 void Server::handle_channel_eof(Session const&)


### PR DESCRIPTION
I don't have a 100% reproducible way to hit that issue on master, but I know that I've hit it at multiple occasion in the past.

A way to trigger it is to use this patch:
```diff
diff --git a/Userland/Libraries/LibSSH/SFTP/Server.cpp b/Userland/Libraries/LibSSH/SFTP/Server.cpp
index 5e6d30b4ab..40b5e76ce5 100644
--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -271,6 +271,8 @@ ErrorOr<void> Server::handle_read(FixedMemoryStream& stream)
     u64 offset = TRY(stream.read_value<NetworkOrdered<u64>>());
     u32 len = TRY(stream.read_value<NetworkOrdered<u32>>());
 
+    len = min(len, 32000);
+
     auto& file = *TRY(find_file(handle));
 
     // "If an error occurs or EOF is encountered before reading any
```

This makes the client send two consecutive packets: one for the missing data (the patch caps the answer at 32KB) and a second one for what was the next, originally scheduled, packet.