### PR TITLE
SSHServer: Honor the maximum packet size when sending channel data

### DIFF
--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -753,16 +753,31 @@ ErrorOr<void> SSHClient::send_channel_success_message(Session const& session)
     return {};
 }
 
+static ErrorOr<void> for_each_part(ReadonlyBytes data, u32 part_size, auto callback)
+{
+    do {
+        auto part = data.trim(part_size);
+
+        TRY(callback(part));
+
+        data = data.slice(part.size());
+    } while (!data.is_empty());
+
+    return {};
+}
+
 // 5.2. Data Transfer
 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
 ErrorOr<void> SSHClient::send_channel_data(Session const& session, ReadonlyBytes data)
 {
-    AllocatingMemoryStream stream;
-    TRY(stream.write_value(MessageID::CHANNEL_DATA));
-    TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
-    TRY(encode_string(stream, data));
-    TRY(write_packet(TRY(stream.read_until_eof())));
-    return {};
+    return for_each_part(data, session.maximum_packet_size, [&](ReadonlyBytes part) -> ErrorOr<void> {
+        AllocatingMemoryStream stream;
+        TRY(stream.write_value(MessageID::CHANNEL_DATA));
+        TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
+        TRY(encode_string(stream, part));
+        TRY(write_packet(TRY(stream.read_until_eof())));
+        return {};
+    });
 }
 
 // 5.2. Data Transfer
@@ -778,13 +793,15 @@ ErrorOr<void> SSHClient::send_channel_extended_data(Session const& session, Read
 
     static constexpr u32 EXTENDED_DATA_STDERR = 1;
 
-    AllocatingMemoryStream stream;
-    TRY(stream.write_value(MessageID::CHANNEL_EXTENDED_DATA));
-    TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
-    TRY(stream.write_value<NetworkOrdered<u32>>(EXTENDED_DATA_STDERR));
-    TRY(encode_string(stream, data));
-    TRY(write_packet(TRY(stream.read_until_eof())));
-    return {};
+    return for_each_part(data, session.maximum_packet_size, [&](ReadonlyBytes part) -> ErrorOr<void> {
+        AllocatingMemoryStream stream;
+        TRY(stream.write_value(MessageID::CHANNEL_EXTENDED_DATA));
+        TRY(stream.write_value<NetworkOrdered<u32>>(session.local_channel_id));
+        TRY(stream.write_value<NetworkOrdered<u32>>(EXTENDED_DATA_STDERR));
+        TRY(encode_string(stream, part));
+        TRY(write_packet(TRY(stream.read_until_eof())));
+        return {};
+    });
 }
 
 ErrorOr<void> SSHClient::handle_channel_eof(GenericMessage& message)


### PR DESCRIPTION
Otherwise, the client is free to ignore the packet which of course result in hangs.

---

Without this patch, SSHServer hangs while the client shows:
```bash
scp -vvv -P 2222 127.0.0.1:/home/lucas/progress_file_800MB.txt ./out.txt
[...]
channel 0: rcvd big packet 32781, maxpack 32768
```
`scp` asks for a chunk of file of 32KiB, with the SFTP packet header we reach 32781 bytes which is bigger that what is usually allowed for a channel's packet.