### PR TITLE
Kernel/Net: E1000 driver enhancements

### DIFF
--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -271,7 +271,8 @@ bool E1000NetworkAdapter::handle_irq()
         receive();
     }
 
-    m_wait_queue.wake_all();
+    // There is at most one waiter as the wait queue itself is behind the mutex.
+    m_wait_queue.notify_one();
 
     out32(REG_INTERRUPT_CAUSE_READ, 0xffffffff);
     return true;
@@ -353,6 +354,7 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_tx_descriptors()
         m_tx_buffers[i] = m_tx_buffer_region->vaddr().as_ptr() + tx_buffer_size * i;
         descriptor.addr = m_tx_buffer_region->physical_page(tx_buffer_page_count * i)->paddr().get();
         descriptor.cmd = 0;
+        descriptor.status = TSTA_DD;
     }
 
     out32(REG_TXDESCLO, m_tx_descriptors.paddr.get());
@@ -379,10 +381,21 @@ u32 E1000NetworkAdapter::in32(u16 address)
 
 void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
 {
-    disable_irq();
+    MutexLocker locker { m_write_lock };
+
     size_t tx_current = in32(REG_TXDESCTAIL) % number_of_tx_descriptors;
     dbgln_if(E1000_DEBUG, "E1000: Sending packet ({} bytes)", payload.size());
     auto& descriptor = m_tx_descriptors[tx_current];
+
+    if (descriptor.status == 0) {
+        // Someone is still using the descriptor, let's wait until it's free.
+        Spinlock<LockRank::None> dummy;
+        m_wait_queue.wait_until(dummy, [&descriptor]() {
+                        return descriptor.status == 0;
+                    })
+            .release_value_but_fixme_should_propagate_errors();
+    }
+
     VERIFY(payload.size() <= 8192);
     auto* vptr = (void*)m_tx_buffers[tx_current];
     memcpy(vptr, payload.data(), payload.size());
@@ -391,16 +404,8 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
     descriptor.cmd = CMD_EOP | CMD_IFCS | CMD_RS;
     dbgln_if(E1000_DEBUG, "E1000: Using tx descriptor {} (head is at {})", tx_current, in32(REG_TXDESCHEAD));
     tx_current = (tx_current + 1) % number_of_tx_descriptors;
-    Processor::disable_interrupts();
-    enable_irq();
     out32(REG_TXDESCTAIL, tx_current);
-    for (;;) {
-        if (descriptor.status) {
-            Processor::enable_interrupts();
-            break;
-        }
-        m_wait_queue.wait_forever("E1000NetworkAdapter"sv);
-    }
+
     dbgln_if(E1000_DEBUG, "E1000: Sent packet, status is now {:#02x}!", (u8)descriptor.status);
 }
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -365,34 +365,10 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_tx_descriptors()
     out32(REG_TIPG, 0x0060200A);
 }
 
-void E1000NetworkAdapter::out8(u16 address, u8 data)
-{
-    dbgln_if(E1000_DEBUG, "E1000: OUT8 {:#02x} @ {:#04x}", data, address);
-    m_registers_io_window->write8(address, data);
-}
-
-void E1000NetworkAdapter::out16(u16 address, u16 data)
-{
-    dbgln_if(E1000_DEBUG, "E1000: OUT16 {:#04x} @ {:#04x}", data, address);
-    m_registers_io_window->write16(address, data);
-}
-
 void E1000NetworkAdapter::out32(u16 address, u32 data)
 {
     dbgln_if(E1000_DEBUG, "E1000: OUT32 {:#08x} @ {:#04x}", data, address);
     m_registers_io_window->write32(address, data);
-}
-
-u8 E1000NetworkAdapter::in8(u16 address)
-{
-    dbgln_if(E1000_DEBUG, "E1000: IN8 @ {:#04x}", address);
-    return m_registers_io_window->read8(address);
-}
-
-u16 E1000NetworkAdapter::in16(u16 address)
-{
-    dbgln_if(E1000_DEBUG, "E1000: IN16 @ {:#04x}", address);
-    return m_registers_io_window->read16(address);
 }
 
 u32 E1000NetworkAdapter::in32(u16 address)

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -14,6 +14,7 @@
 #include <Kernel/Library/IOWindow.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/Security/Random.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 
@@ -97,10 +98,12 @@ protected:
     NonnullOwnPtr<Memory::Region> m_tx_buffer_region;
     Array<void*, number_of_rx_descriptors> m_rx_buffers;
     Array<void*, number_of_tx_descriptors> m_tx_buffers;
+
     SetOnce m_has_eeprom;
     bool m_link_up { false };
     EntropySource m_entropy_source;
 
-    DeprecatedWaitQueue m_wait_queue;
+    Mutex m_write_lock;
+    WaitQueue m_wait_queue;
 };
 }

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -80,11 +80,7 @@ protected:
     void initialize_rx_descriptors();
     void initialize_tx_descriptors();
 
-    void out8(u16 address, u8);
-    void out16(u16 address, u16);
     void out32(u16 address, u32);
-    u8 in8(u16 address);
-    u16 in16(u16 address);
     u32 in32(u16 address);
 
     void receive();


### PR DESCRIPTION
With all of these changes, SSHServer can now sustain parallel streams of connections. I tested with three clients on my host running the usual loop:
```bash
i=0; while ssh -p 2222 anon@127.0.0.1 cat - < ~/progress_file_1MB.txt; do echo $i && ((i++)); done
```

I stopped them after each of these loops reached more than 300 iterations. Previously, we would hang in less than 10 iterations with only two clients.

Also, it gives a nice boost on the network speed:
```bash
lucas@itxub:~$ scp -P 2222 anon@127.0.0.1:/home/anon/progress_file_800MB.txt ./copy.txt
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
progress_file_800MB.txt                                                      100%  800MB   3.7MB/s   03:38
lucas@itxub:~$ scp -P 2222 anon@127.0.0.1:/home/anon/progress_file_800MB.txt ./copy.txt
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
progress_file_800MB.txt                                                      100%  800MB   6.3MB/s   02:06
```