### PR TITLE
ResourceGraph: Show network speed in the tooltip

### DIFF
--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -74,8 +74,8 @@ private:
             break;
         }
         case GraphType::Network: {
-            u64 tx, rx, link_speed;
-            if (get_network_usage(tx, rx, link_speed)) {
+            u64 tx {}, rx {};
+            if (get_network_usage(tx, rx)) {
                 u64 recent_tx = tx - m_last_total;
                 m_last_total = tx;
                 if (recent_tx > m_current_scale) {
@@ -191,9 +191,9 @@ private:
         return true;
     }
 
-    bool get_network_usage(u64& tx, u64& rx, u64& link_speed)
+    bool get_network_usage(u64& tx, u64& rx)
     {
-        tx = rx = link_speed = 0;
+        tx = rx = 0;
 
         auto json = get_data_as_json(m_proc_net, "/sys/kernel/net/adapters"sv);
         if (json.is_error())
@@ -207,10 +207,7 @@ private:
 
             tx += adapter_obj.get_u64("bytes_in"sv).value_or(0);
             rx += adapter_obj.get_u64("bytes_out"sv).value_or(0);
-            // Link speed data is given in megabits, but we want all return values to be in bytes.
-            link_speed += adapter_obj.get_u64("link_speed"sv).value_or(0) * 8'000'000;
         }
-        link_speed /= 8;
         return tx != 0;
     }
 

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -76,16 +76,16 @@ private:
         case GraphType::Network: {
             u64 tx {}, rx {};
             if (get_network_usage(tx, rx)) {
-                u64 recent_tx = tx - m_last_total;
-                m_last_total = tx;
-                if (recent_tx > m_current_scale) {
+                u64 recent_rx = rx - m_last_total;
+                m_last_total = rx;
+                if (recent_rx > m_current_scale) {
                     u64 m_old_scale = m_current_scale;
                     // Scale in multiples of 1000 kB/s
-                    m_current_scale = (recent_tx / scale_unit) * scale_unit;
+                    m_current_scale = (recent_rx / scale_unit) * scale_unit;
                     rescale_history(m_old_scale, m_current_scale);
                 } else {
                     // Figure out if we can scale back down.
-                    float max = static_cast<float>(recent_tx) / static_cast<float>(m_current_scale);
+                    float max = static_cast<float>(recent_rx) / static_cast<float>(m_current_scale);
                     for (auto const value : m_history) {
                         if (value > max)
                             max = value;
@@ -96,8 +96,8 @@ private:
                         rescale_history(m_old_scale, m_current_scale);
                     }
                 }
-                m_history.enqueue(static_cast<float>(recent_tx) / static_cast<float>(m_current_scale));
-                m_tooltip = MUST(String::formatted("Network: TX {} / RX {} ({:.1} kbit/s)", tx, rx, static_cast<double>(recent_tx) * 8.0 / 1000.0));
+                m_history.enqueue(static_cast<float>(recent_rx) / static_cast<float>(m_current_scale));
+                m_tooltip = MUST(String::formatted("Network: TX {} / RX {} ({:.1} kbit/s)", tx, rx, static_cast<double>(recent_rx) * 8.0 / 1000.0));
             } else {
                 m_history.enqueue(-1);
                 m_tooltip = "Unable to determine network usage"_string;
@@ -205,8 +205,8 @@ private:
             if (!adapter_obj.has_string("ipv4_address"sv) || !adapter_obj.get_bool("link_up"sv).value())
                 continue;
 
-            tx += adapter_obj.get_u64("bytes_in"sv).value_or(0);
-            rx += adapter_obj.get_u64("bytes_out"sv).value_or(0);
+            rx += adapter_obj.get_u64("bytes_in"sv).value_or(0);
+            tx += adapter_obj.get_u64("bytes_out"sv).value_or(0);
         }
         return tx != 0;
     }

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/CircularQueue.h>
 #include <AK/JsonObject.h>
+#include <AK/NumberFormat.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -47,10 +48,10 @@ private:
         case GraphType::CPU: {
             u64 total, idle;
             if (get_cpu_usage(total, idle)) {
-                auto total_diff = total - m_last_total;
-                m_last_total = total;
-                auto idle_diff = idle - m_last_idle;
-                m_last_idle = idle;
+                auto total_diff = total - m_cpu_last_total;
+                m_cpu_last_total = total;
+                auto idle_diff = idle - m_cpu_last_idle;
+                m_cpu_last_idle = idle;
                 float cpu = total_diff > 0 ? (float)(total_diff - idle_diff) / (float)total_diff : 0;
                 m_history.enqueue(cpu);
                 m_tooltip = MUST(String::formatted("CPU usage: {:.1}%", 100 * cpu));
@@ -76,8 +77,10 @@ private:
         case GraphType::Network: {
             u64 tx {}, rx {};
             if (get_network_usage(tx, rx)) {
-                u64 recent_rx = rx - m_last_total;
-                m_last_total = rx;
+                u64 recent_rx = rx - m_network_last_rx;
+                m_network_last_rx = rx;
+                u64 recent_tx = tx - m_network_last_tx;
+                m_network_last_tx = tx;
                 if (recent_rx > m_current_scale) {
                     u64 m_old_scale = m_current_scale;
                     // Scale in multiples of 1000 kB/s
@@ -97,7 +100,7 @@ private:
                     }
                 }
                 m_history.enqueue(static_cast<float>(recent_rx) / static_cast<float>(m_current_scale));
-                m_tooltip = MUST(String::formatted("Network: TX {} / RX {} ({:.1} kbit/s)", tx, rx, static_cast<double>(recent_rx) * 8.0 / 1000.0));
+                m_tooltip = MUST(String::formatted("Network: Receiving {}/s - Sending {}/s", human_readable_size(recent_rx), human_readable_size(recent_tx)));
             } else {
                 m_history.enqueue(-1);
                 m_tooltip = "Unable to determine network usage"_string;
@@ -222,8 +225,13 @@ private:
     Gfx::Color m_graph_color;
     Gfx::Color m_graph_error_color;
     CircularQueue<float, history_size> m_history;
-    u64 m_last_idle { 0 };
-    u64 m_last_total { 0 };
+
+    u64 m_cpu_last_idle { 0 };
+    u64 m_cpu_last_total { 0 };
+
+    u64 m_network_last_rx { 0 };
+    u64 m_network_last_tx { 0 };
+
     static constexpr u64 const scale_unit = 8000;
     u64 m_current_scale { scale_unit };
     String m_tooltip;


### PR DESCRIPTION
Before:
<img width="1026" height="831" alt="image" src="https://github.com/user-attachments/assets/98d05afc-c16d-4c34-8273-c00dbebe8a1e" />

After:
<img width="1026" height="831" alt="Screenshot From 2026-06-08 10-26-55-1" src="https://github.com/user-attachments/assets/ce64d000-f878-42b4-90c8-02849ddf7b62" />

(The difference probably comes from the SSH protocol overhead)