### PR TITLE
Kernel/Net: Don't use TimePrecision::Precise when delaying TCP ACKs

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -396,7 +396,7 @@ bool TCPSocket::should_delay_next_ack() const
         return false;
 
     // RFC 1122 says we should not delay ACKs for more than 500 milliseconds.
-    if (TimeManagement::the().monotonic_time(TimePrecision::Precise) >= m_last_ack_sent_time + Duration::from_milliseconds(500))
+    if (TimeManagement::the().monotonic_time() >= m_last_ack_sent_time + Duration::from_milliseconds(500))
         return false;
 
     return true;


### PR DESCRIPTION
If the peer is able to wait for ~500ms before receiving the ACK, it will survive waiting the few more milliseconds that come with the imprecision of the Coarse setting.

On x86_64, during a SFTP file transfer, the time spent on fetching the precise clock can be as high as 10% of the total runtime.

---

Before:

<img width="1076" height="882" alt="Screenshot From 2026-06-10 15-09-02" src="https://github.com/user-attachments/assets/23677ee5-9acd-4a8d-8ed9-f52bb42fba09" />


```bash
$ scp -P 2222 anon@127.0.0.1:/home/anon/progress_file_800MB.txt ./copy.txt
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
progress_file_800MB.txt                                                 100%  800MB   8.9MB/s   01:30
```

After:

<img width="1076" height="882" alt="image" src="https://github.com/user-attachments/assets/fb6ff9cf-0d33-48f6-8fc0-1b84b4097fa6" />


```bash
$ scp -P 2222 anon@127.0.0.1:/home/anon/progress_file_800MB.txt ./copy.txt
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
progress_file_800MB.txt                                                 100%  800MB   9.5MB/s   01:23
```

Both measures were done on top of #26807 and a few local SSH fixes.

---

While this help with a single connection, we need to teach the Network Task to be smarter about delaying acks (fetching the time only once instead of once per socket, storing the sockets in a priority queue instead of iterating over all of them, sleeping until the next scheduled ack instead of a fixed 500ms...)