### PR TITLE
Kernel/SDHC: Use microseconds_delay

### DIFF
--- a/Kernel/Devices/Storage/SD/SDHostController.cpp
+++ b/Kernel/Devices/Storage/SD/SDHostController.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
+#include <Kernel/Arch/Delay.h>
 #include <Kernel/Arch/MemoryFences.h>
 #include <Kernel/Devices/Device.h>
 #include <Kernel/Devices/Storage/SD/Commands.h>
@@ -19,14 +20,6 @@ namespace Kernel {
 // * (SDHC): SD Host Controller Simplified Specification (https://www.sdcard.org/downloads/pls/)
 // * (PLSS) Physical Layer Simplified Specification (https://www.sdcard.org/downloads/pls/)
 // * (BCM2835) BCM2835 ARM Peripherals (https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf)
-
-static void delay(i64 nanoseconds)
-{
-    auto start = TimeManagement::the().monotonic_time();
-    auto end = start + Duration::from_nanoseconds(nanoseconds);
-    while (TimeManagement::the().monotonic_time() < end)
-        Processor::pause();
-}
 
 constexpr u32 max_supported_sdsc_frequency = 25000000;
 constexpr u32 max_supported_sdsc_frequency_high_speed = 50000000;
@@ -330,14 +323,14 @@ ErrorOr<NonnullRefPtr<SDMemoryCard>> SDHostController::try_initialize_inserted_c
         card_capacity_in_blocks, rca, ocr, cid, scr));
 }
 
-bool SDHostController::retry_with_timeout(Function<bool()> f, i64 delay_between_tries)
+bool SDHostController::retry_with_timeout(Function<bool()> f, i64 delay_between_tries_us)
 {
-    int timeout = 1000;
+    int timeout = 100;
     bool success = false;
     while (!success && timeout > 0) {
         success = f();
         if (!success)
-            delay(delay_between_tries);
+            microseconds_delay(delay_between_tries_us);
         timeout--;
     }
     return timeout > 0;

--- a/Kernel/Devices/Storage/SD/SDHostController.h
+++ b/Kernel/Devices/Storage/SD/SDHostController.h
@@ -71,7 +71,7 @@ private:
 
     bool card_status_contains_errors(SD::Command const&, u32);
 
-    bool retry_with_timeout(Function<bool()>, i64 delay_between_tries = 100);
+    bool retry_with_timeout(Function<bool()>, i64 delay_between_tries_us = 1);
 
     enum class DataTransferType {
         Read,


### PR DESCRIPTION
The old implementation used TimeManagement::monotonic_time for delays. Since this function defaults to TimePrecision::Coarse, the resulting timeouts were far too long. The default timeout caused us to wait for 4 s instead 100 µs.

As microseconds_delay expects a time delta in microseconds, change the "delay between tries" parameter to microseconds and adjust the retry count accordingly to keep the same timeout (100 * 1 us = 1000 * 100 ns).

This causes us to boot 4 seconds faster on the Raspberry Pi 5. Excluding the time spent in the firmware, we now boot in approximately 6 seconds from a USB drive.