### PR TITLE
Calendar: Allow editing of previously created events

### DIFF
--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2020, Ryan Grieb <ryan.m.grieb@gmail.com>
  * Copyright (c) 2022-2023, the SerenityOS developers.
  * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,18 +26,20 @@
 
 namespace Calendar {
 
-AddEventDialog::AddEventDialog(Core::DateTime date_time, EventManager& event_manager, Window* parent_window)
+AddEventDialog::AddEventDialog(Core::DateTime date_time, EventManager& event_manager, Window* parent_window, Event const* event_to_edit)
     : Dialog(parent_window)
     , m_event_manager(event_manager)
+    , m_event_to_edit(event_to_edit ? Optional<Event>(*event_to_edit) : Optional<Event>())
 {
     resize(360, 140);
-    set_title("Add Event");
+    set_title(event_to_edit ? "Edit Event" : "Add Event");
     set_resizable(false);
     set_icon(parent_window->icon());
 
-    auto start_date_time = Core::DateTime::create(date_time.year(), date_time.month(), date_time.day(), 12, 0);
+    auto start_date_time = event_to_edit ? event_to_edit->start : Core::DateTime::create(date_time.year(), date_time.month(), date_time.day(), 12, 0);
+    auto end_date_time = event_to_edit ? event_to_edit->end : Core::DateTime::from_timestamp(start_date_time.timestamp() + (15 * 60));
     auto main_widget = MUST(AddEventWidget::create(this,
-        start_date_time, Core::DateTime::from_timestamp(start_date_time.timestamp() + (15 * 60))));
+        start_date_time, end_date_time, event_to_edit));
 
     set_main_widget(main_widget);
 }
@@ -49,6 +52,10 @@ ErrorOr<bool> AddEventDialog::add_event_to_calendar(Core::DateTime start_date_ti
     }
 
     auto summary = find_descendant_of_type_named<GUI::TextBox>("event_title_textbox")->get_text();
+    if (m_event_to_edit.has_value()) {
+        m_event_manager.delete_event(m_event_to_edit.value());
+    }
+
     m_event_manager.add_event(Event {
         .summary = TRY(String::from_byte_string(summary)),
         .start = start_date_time,

--- a/Userland/Applications/Calendar/AddEventDialog.h
+++ b/Userland/Applications/Calendar/AddEventDialog.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2020, Ryan Grieb <ryan.m.grieb@gmail.com>
  * Copyright (c) 2022-2023, the SerenityOS developers.
  * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,7 @@
 #pragma once
 
 #include "EventManager.h"
+#include <AK/Optional.h>
 #include <LibGUI/Calendar.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Window.h>
@@ -20,18 +22,19 @@ class AddEventDialog final : public GUI::Dialog {
 public:
     virtual ~AddEventDialog() override = default;
 
-    static void show(Core::DateTime date_time, EventManager& event_manager, Window* parent_window = nullptr)
+    static void show(Core::DateTime date_time, EventManager& event_manager, Window* parent_window = nullptr, Event const* event_to_edit = nullptr)
     {
-        auto dialog = AddEventDialog::construct(date_time, event_manager, parent_window);
+        auto dialog = AddEventDialog::construct(date_time, event_manager, parent_window, event_to_edit);
         dialog->exec();
     }
 
     ErrorOr<bool> add_event_to_calendar(Core::DateTime start_date_time, Core::DateTime end_date_time);
 
 private:
-    AddEventDialog(Core::DateTime date_time, EventManager& event_manager, Window* parent_window = nullptr);
+    AddEventDialog(Core::DateTime date_time, EventManager& event_manager, Window* parent_window = nullptr, Event const* event_to_edit = nullptr);
 
     EventManager& m_event_manager;
+    Optional<Event> m_event_to_edit;
 };
 
 }

--- a/Userland/Applications/Calendar/AddEventWidget.cpp
+++ b/Userland/Applications/Calendar/AddEventWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,7 +16,7 @@ namespace Calendar {
 
 static constexpr StringView DATE_FORMAT = "%Y-%m-%d"sv;
 
-ErrorOr<NonnullRefPtr<AddEventWidget>> AddEventWidget::create(AddEventDialog* window, Core::DateTime start_time, Core::DateTime end_time)
+ErrorOr<NonnullRefPtr<AddEventWidget>> AddEventWidget::create(AddEventDialog* window, Core::DateTime start_time, Core::DateTime end_time, Event const* event_to_edit)
 {
     auto widget = TRY(try_create());
     widget->m_start_date_time = start_time;
@@ -23,6 +24,9 @@ ErrorOr<NonnullRefPtr<AddEventWidget>> AddEventWidget::create(AddEventDialog* wi
 
     auto& event_title_textbox = *widget->find_descendant_of_type_named<GUI::TextBox>("event_title_textbox");
     event_title_textbox.set_focus(true);
+    if (event_to_edit) {
+        event_title_textbox.set_text(event_to_edit->summary.to_byte_string());
+    }
 
     widget->m_start_date_box = *widget->find_descendant_of_type_named<GUI::TextBox>("start_date");
 

--- a/Userland/Applications/Calendar/AddEventWidget.h
+++ b/Userland/Applications/Calendar/AddEventWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,7 +20,7 @@ class AddEventWidget final : public GUI::Widget {
     C_OBJECT(AddEventWidget);
 
 public:
-    static ErrorOr<NonnullRefPtr<AddEventWidget>> create(AddEventDialog*, Core::DateTime start_time, Core::DateTime end_time);
+    static ErrorOr<NonnullRefPtr<AddEventWidget>> create(AddEventDialog*, Core::DateTime start_time, Core::DateTime end_time, Event const* event_to_edit = nullptr);
     virtual ~AddEventWidget() override = default;
 
 private:

--- a/Userland/Applications/Calendar/EventManager.cpp
+++ b/Userland/Applications/Calendar/EventManager.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023, the SerenityOS developers.
  * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -29,6 +30,15 @@ void EventManager::add_event(Event event)
 {
     m_events.append(move(event));
     quick_sort(m_events, [&](auto& a, auto& b) { return a.start < b.start; });
+    m_dirty = true;
+    on_events_change();
+}
+
+void EventManager::delete_event(Event const& event)
+{
+    m_events.remove_first_matching([&](auto& entry) {
+        return entry.summary == event.summary && entry.start.timestamp() == event.start.timestamp() && entry.end.timestamp() == event.end.timestamp();
+    });
     m_dirty = true;
     on_events_change();
 }

--- a/Userland/Applications/Calendar/EventManager.cpp
+++ b/Userland/Applications/Calendar/EventManager.cpp
@@ -37,7 +37,7 @@ void EventManager::add_event(Event event)
 void EventManager::delete_event(Event const& event)
 {
     m_events.remove_first_matching([&](auto& entry) {
-        return entry.summary == event.summary && entry.start.timestamp() == event.start.timestamp() && entry.end.timestamp() == event.end.timestamp();
+        return entry == event;
     });
     m_dirty = true;
     on_events_change();

--- a/Userland/Applications/Calendar/EventManager.h
+++ b/Userland/Applications/Calendar/EventManager.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023, the SerenityOS developers.
  * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -36,6 +37,7 @@ public:
     ErrorOr<void> save(FileSystemAccessClient::File& file);
     ErrorOr<void> load_file(FileSystemAccessClient::File& file);
     void add_event(Event);
+    void delete_event(Event const&);
     void set_events(Vector<Event>);
     void clear() { m_events.clear(); }
 

--- a/Userland/Applications/Calendar/EventManager.h
+++ b/Userland/Applications/Calendar/EventManager.h
@@ -22,6 +22,8 @@ struct Event {
     String summary;
     Core::DateTime start;
     Core::DateTime end;
+
+    bool operator==(Event const&) const = default;
 };
 
 class EventManager {

--- a/Userland/Applications/Calendar/ViewEventDialog.cpp
+++ b/Userland/Applications/Calendar/ViewEventDialog.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 #include "AddEventDialog.h"
 #include "ViewEventWidget.h"
 #include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
 
 namespace Calendar {
 
@@ -16,6 +18,7 @@ ViewEventDialog::ViewEventDialog(Core::DateTime date_time, EventManager& event_m
     , m_event_manager(event_manager)
     , m_date_time(date_time)
 {
+    resize(360, 200);
     set_title("Events");
     set_resizable(true);
     set_icon(parent_window->icon());
@@ -40,6 +43,21 @@ void ViewEventDialog::close_and_open_add_event_dialog()
 {
     close();
     AddEventDialog::show(m_date_time, m_event_manager, find_parent_window());
+}
+
+void ViewEventDialog::close_and_open_edit_event_dialog(Event const& event)
+{
+    close();
+    AddEventDialog::show(m_date_time, m_event_manager, find_parent_window(), &event);
+}
+
+void ViewEventDialog::delete_event(Event const& event)
+{
+    auto result = GUI::MessageBox::show(this, "Are you sure you want to delete this event?"sv, "Delete Event"sv, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNo);
+    if (result == GUI::MessageBox::ExecResult::Yes) {
+        m_event_manager.delete_event(event);
+        close();
+    }
 }
 
 }

--- a/Userland/Applications/Calendar/ViewEventDialog.h
+++ b/Userland/Applications/Calendar/ViewEventDialog.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +25,8 @@ public:
         dialog->exec();
     }
     void close_and_open_add_event_dialog();
+    void close_and_open_edit_event_dialog(Event const&);
+    void delete_event(Event const&);
 
 private:
     ViewEventDialog(Core::DateTime, EventManager&, Window*);

--- a/Userland/Applications/Calendar/ViewEventWidget.cpp
+++ b/Userland/Applications/Calendar/ViewEventWidget.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2024, Sanil Gupta <sanilg566@gmail.com>.
+ * Copyright (c) 2026, RiffPointer <riffpointer@gmail.com>.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "ViewEventWidget.h"
+#include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
 
@@ -15,12 +17,33 @@ ErrorOr<NonnullRefPtr<ViewEventWidget>> ViewEventWidget::create(ViewEventDialog*
 
     auto* events_list = widget->find_descendant_of_type_named<GUI::Widget>("events_list");
     for (auto const& event : events) {
+        auto container = GUI::Widget::construct();
+        container->set_layout<GUI::HorizontalBoxLayout>();
+        container->layout()->set_spacing(4);
+        container->set_fixed_height(22);
+
         String text = MUST(String::formatted("{} {}", event.start.to_byte_string("%H:%M"sv), event.summary));
         auto label = GUI::Label::construct(text);
         label->set_fill_with_background_color(true);
         label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
         label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
-        events_list->add_child(label);
+        container->add_child(label);
+
+        auto edit_button = GUI::Button::construct("Edit"_string);
+        edit_button->set_fixed_width(50);
+        edit_button->on_click = [parent_window, event](auto) {
+            parent_window->close_and_open_edit_event_dialog(event);
+        };
+        container->add_child(edit_button);
+
+        auto delete_button = GUI::Button::construct("Delete"_string);
+        delete_button->set_fixed_width(60);
+        delete_button->on_click = [parent_window, event](auto) {
+            parent_window->delete_event(event);
+        };
+        container->add_child(delete_button);
+
+        events_list->add_child(container);
     }
 
     auto* add_new_event_button = widget->find_descendant_of_type_named<GUI::Button>("add_event_button");


### PR DESCRIPTION
This PR fixes #22622.
Added a nice Events dialog showing a list of all events in a single day.

Screenshots:

1. Events list:
<img width="1076" height="884" alt="image" src="https://github.com/user-attachments/assets/473e8395-18bf-42b6-baac-e222c7fe9372" />

2. Editing an event:
<img width="1076" height="884" alt="image" src="https://github.com/user-attachments/assets/f1eca49a-fe88-4251-987c-b9d8c95d625f" />
