### PR TITLE
LibDebug: Don't continue the debuggee before detaching

### DIFF
--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -398,7 +398,8 @@ void DebugSession::detach()
     }
     for (auto& watchpoint : m_watchpoints.keys())
         remove_watchpoint(watchpoint);
-    continue_debuggee();
+
+    // The destructor will call ptrace(PT_DETACH).
 }
 
 Optional<DebugSession::InsertBreakpointAtSymbolResult> DebugSession::insert_breakpoint(ByteString const& symbol_name)


### PR DESCRIPTION
Since 0b7dc6869ea, all ptrace operations except PT_TRACE_ME and PT_ATTACH are forbidden unless the tracee is stopped. This includes PT_DETACH.

Before
<img width="613" height="428" alt="Screenshot_20260615_111731" src="https://github.com/user-attachments/assets/c84ea3e3-d375-4456-88fe-7a1a5bfd17ca" />

After
<img width="611" height="425" alt="Screenshot_20260615_111805" src="https://github.com/user-attachments/assets/7a79ecf7-7b38-4885-958b-cb2b04756fca" />
