### PR TITLE
Kernel: Dispatch signals in do_context_first_init

### DIFF
--- a/Kernel/Arch/Processor.cpp
+++ b/Kernel/Arch/Processor.cpp
@@ -127,6 +127,10 @@ void do_context_first_init(Thread* from_thread, Thread* to_thread)
     VERIFY(in_critical > 0);
     Processor::restore_critical(in_critical);
 
+    ScopedCritical critical;
+    if (!to_thread->should_die() && to_thread->dispatch_one_pending_signal() == DispatchSignalResult::Yield)
+        Scheduler::yield();
+
     // Since we got here and don't have Scheduler::context_switch in the
     // call stack (because this is the first time we switched into this
     // context), we need to notify the scheduler so that it can release

--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -326,6 +326,7 @@ FlatPtr ProcessorBase::init_context(Thread& thread, bool leave_crit)
     TrapFrame& trap = *reinterpret_cast<TrapFrame*>(stack_top);
     trap.regs = &eretframe;
     trap.next_trap = nullptr;
+    thread.current_trap() = &trap;
 
     if constexpr (CONTEXT_SWITCH_DEBUG) {
         dbgln("init_context {} ({}) set up to execute at ip={}, sp={}, stack_top={}",

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -513,6 +513,7 @@ FlatPtr ProcessorBase::init_context(Thread& thread, bool leave_crit)
     TrapFrame& trap = *reinterpret_cast<TrapFrame*>(stack_top);
     trap.regs = &frame;
     trap.next_trap = nullptr;
+    thread.current_trap() = &trap;
 
     if constexpr (CONTEXT_SWITCH_DEBUG) {
         dbgln("init_context {} ({}) set up to execute at ip={}, sp={}, stack_top={}",

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -1395,6 +1395,7 @@ FlatPtr ProcessorBase::init_context(Thread& thread, bool leave_crit)
     TrapFrame& trap = *reinterpret_cast<TrapFrame*>(stack_top);
     trap.regs = &iretframe;
     trap.next_trap = nullptr;
+    thread.current_trap() = &trap;
 
     stack_top -= sizeof(u64); // pointer to TrapFrame
     *reinterpret_cast<u64*>(stack_top) = stack_top + 8;
@@ -1535,8 +1536,6 @@ UNMAP_AFTER_INIT void ProcessorBase::initialize_context_switching(Thread& initia
         "pop %%rdi \n" // move argument for init_finished into place
         "call init_finished \n"
         "call post_init_finished \n"
-        "movq 24(%%rsp), %%rdi \n" // move pointer to TrapFrame into place
-        "call enter_trap_no_irq \n"
         "retq \n"
         :: [new_rsp] "g" (regs.rsp),
         [new_rip] "a" (regs.rip),


### PR DESCRIPTION
To make this possible, the initial trap frame has been made visible to the Thread class. This removes a now-unneeded call to `enter_trap_no_irq` in `ProcessorBase::init_context` on x86-64 as calling this is no longer necessary in order to give the idle thread a valid trap frame.

Fixes #26804.