### PR TITLE
LibC: Handle several special cases in internal_scalbn

### DIFF
--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -239,14 +239,15 @@ TEST_CASE(scalbn)
     EXPECT_EQ(scalbn(0, 3), 0);
     EXPECT_EQ(scalbn(15.3, 0), 15.3);
 
-    // TODO: implement denormal handling in fallback scalbn
-    //     EXPECT_EQ(scalbn(0x0.0000000000008p-1022, 16), 0x0.0000000000008p-1006);
-    static constexpr auto biggest_subnormal = DBL_MIN - DBL_TRUE_MIN;
-    auto smallest_normal = scalbn(biggest_subnormal, 1);
-    Extractor ex(smallest_normal);
-    EXPECT(ex.exponent != 0);
-
     EXPECT_EQ(scalbn(2.0, 4), 32.0);
+
+    // Denormal inputs.
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 0), 0x0.0'0000'0000'0008p-1022);
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 16), 0x0.0'0000'0008'0000p-1022);
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 48), 0x0.8'0000'0000'0000p-1022);
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 49), 0x1.0'0000'0000'0000p-1022); // Smallest non-denormal number.
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, -3), 0x0.00'000'0000'0001p-1022);
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, -4), 0);
 }
 
 TEST_CASE(gamma)

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -246,6 +246,12 @@ TEST_CASE(scalbn)
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 16), 0x0.0'0000'0008'0000p-1022);
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 48), 0x0.8'0000'0000'0000p-1022);
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 49), 0x1.0'0000'0000'0000p-1022); // Smallest non-denormal number.
+
+    EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2046), 0x1.0'0000'0000'0000p1023);
+    EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2047), __builtin_huge_val());
+    EXPECT_EQ(scalbn(-0x0.8'0000'0000'0000p-1022, 2046), -0x1.0'0000'0000'0000p1023);
+    EXPECT_EQ(scalbn(-0x0.8'0000'0000'0000p-1022, 2047), -__builtin_huge_val());
+
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, -3), 0x0.00'000'0000'0001p-1022);
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, -4), 0);
 }

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -241,11 +241,20 @@ TEST_CASE(scalbn)
 
     EXPECT_EQ(scalbn(2.0, 4), 32.0);
 
+    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, 2045), 0x1.0'0000'0000'0000p1023);
+    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, 2046), __builtin_huge_val());
+    EXPECT_EQ(scalbn(-0x1.0'0000'0000'0000p-1022, 2045), -0x1.0'0000'0000'0000p1023);
+    EXPECT_EQ(scalbn(-0x1.0'0000'0000'0000p-1022, 2046), -__builtin_huge_val());
+
+    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, -1), 0x0.8'0000'0000'0000p-1022); // Smallest non-denormal number on lhs.
+    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, -52), 0x0.0'0000'0000'0001p-1022);
+    EXPECT_EQ(scalbn(0x1.0'0000'0000'0000p-1022, -53), 0);
+
     // Denormal inputs.
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 0), 0x0.0'0000'0000'0008p-1022);
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 16), 0x0.0'0000'0008'0000p-1022);
     EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 48), 0x0.8'0000'0000'0000p-1022);
-    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 49), 0x1.0'0000'0000'0000p-1022); // Smallest non-denormal number.
+    EXPECT_EQ(scalbn(0x0.0'0000'0000'0008p-1022, 49), 0x1.0'0000'0000'0000p-1022); // Smallest non-denormal number on rhs.
 
     EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2046), 0x1.0'0000'0000'0000p1023);
     EXPECT_EQ(scalbn(0x0.8'0000'0000'0000p-1022, 2047), __builtin_huge_val());

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -252,11 +252,11 @@ static FloatT internal_scalbn(FloatT x, int exponent) NOEXCEPT
         return extractor.to_float();
     }
 
-    unsigned leading_mantissa_zeroes = extractor.mantissa == 0 ? 32 : count_leading_zeroes(extractor.mantissa);
+    // extractor.mantissa is always != 0 here.
+    unsigned leading_mantissa_zeroes = count_leading_zeroes(extractor.mantissa);
     int shift = min((int)leading_mantissa_zeroes, exponent);
     exponent = max(exponent - shift, 0);
 
-    extractor.exponent <<= shift;
     extractor.exponent = exponent + 1;
 
     return extractor.to_float();

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -248,7 +248,25 @@ static FloatT internal_scalbn(FloatT x, int exponent) NOEXCEPT
     auto extractor = Extractor::from_float(x);
 
     if (extractor.exponent != 0) {
-        extractor.exponent = clamp((int)extractor.exponent + exponent, 0, (int)Extractor::exponent_max);
+        int new_exponent = (int)extractor.exponent + exponent;
+        if (new_exponent >= (int)Extractor::exponent_max) {
+            extractor.mantissa = 0;
+            extractor.exponent = Extractor::exponent_max;
+            return extractor.to_float();
+        }
+        if (new_exponent > 0) {
+            extractor.exponent = new_exponent;
+            return extractor.to_float();
+        }
+
+        // Number became denormal (which means extractor.exponent <= -exponent, in particular exponent < 0).
+        unsigned shift = min((unsigned)(-new_exponent), Extractor::mantissa_bits) + 1;
+        typename Extractor::ComponentType new_mantissa = extractor.mantissa >> shift;
+        if (shift <= Extractor::mantissa_bits)
+            new_mantissa |= 1ull << (Extractor::mantissa_bits - shift);
+
+        extractor.mantissa = new_mantissa;
+        extractor.exponent = 0;
         return extractor.to_float();
     }
 

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -269,8 +269,15 @@ static FloatT internal_scalbn(FloatT x, int exponent) NOEXCEPT
     }
 
     // Denormal is shifted far enough to become non-denormal.
+    int new_exponent = exponent - leading_mantissa_zeroes;
+    if (new_exponent >= (int)Extractor::exponent_max) {
+        extractor.mantissa = 0;
+        extractor.exponent = Extractor::exponent_max;
+        return extractor.to_float();
+    }
+
     extractor.mantissa <<= (leading_mantissa_zeroes + 1);
-    extractor.exponent = exponent - leading_mantissa_zeroes;
+    extractor.exponent = new_exponent;
 
     return extractor.to_float();
 }

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -252,12 +252,25 @@ static FloatT internal_scalbn(FloatT x, int exponent) NOEXCEPT
         return extractor.to_float();
     }
 
-    // extractor.mantissa is always != 0 here.
-    unsigned leading_mantissa_zeroes = count_leading_zeroes(extractor.mantissa);
-    int shift = min((int)leading_mantissa_zeroes, exponent);
-    exponent = max(exponent - shift, 0);
+    // Denormal x.
+    if (exponent < 0) {
+        unsigned shift = min((unsigned)(-exponent), Extractor::mantissa_bits);
+        extractor.mantissa >>= shift;
+        return extractor.to_float();
+    }
 
-    extractor.exponent = exponent + 1;
+    // extractor.mantissa is always != 0 here.
+    // Mantissa is mantissa_bits long, count_leading_zeroes() counts in ComponentType, adjust:
+    auto const always_zero_bits = sizeof(typename FloatExtractor<FloatT>::ComponentType) * 8 - (FloatExtractor<FloatT>::mantissa_bits);
+    unsigned leading_mantissa_zeroes = count_leading_zeroes(extractor.mantissa) - always_zero_bits;
+    if ((unsigned)exponent <= leading_mantissa_zeroes) {
+        extractor.mantissa <<= exponent;
+        return extractor.to_float();
+    }
+
+    // Denormal is shifted far enough to become non-denormal.
+    extractor.mantissa <<= (leading_mantissa_zeroes + 1);
+    extractor.exponent = exponent - leading_mantissa_zeroes;
 
     return extractor.to_float();
 }


### PR DESCRIPTION
We now handle normal inputs transitioning to denormals, and denormals transitioning to normals.

---

The motivation here is that I tried running https://github.com/nico/js-math-bench/blob/main/c/bench-libm.c against serenity's math routines. That code does:

```cpp
static double ulp_of(double x) {
    if (!isfinite(x) || x == 0.0) return 0.0;
    uint64_t bits;
    memcpy(&bits, &x, sizeof(bits));
    int exp_bits = (int)((bits >> 52) & 0x7FF);
    if (exp_bits == 0) return 5e-324;
    return ldexp(1.0, exp_bits - 1075);
}
```

For an expected value of `0x1.e891f4820dee5p-1002`, exp_bits is 21, calling `ldexp(1.0, -1054)`. That is a normal -> denormal transition, which we previously didn't handle. (ldexp() internally calls internal_scalbn.)

Building the file like:

```
% cat test-ak-math.sh 
#!/bin/bash

clang -g -std=c++26 -O2 -c -o math.o Userland/Libraries/LibC/math.cpp \
  -DAK_OS_SERENITY \
  -I . \
  -I Userland/Libraries/LibC

clang -g -std=c++26 -O2 -c -o math-assertions.o math-assertions.cpp -I .

clang -g -O2 -c -o bench-libm.o ~/src/js-math-bench/c/bench-libm.c \
  -I .

clang++ -o ak-math-bench math.o bench-libm.o  math-assertions.o
```

with math-assertions.cpp being a stub:

```
% cat math-assertions.cpp 
#include <AK/Assertions.h>

#include <stdio.h>
#include <unistd.h>

extern "C" {

void ak_verification_failed(char const* message)
{
    bool colorize_output = isatty(STDERR_FILENO) == 1;

    if (colorize_output)
        fprintf(stderr, "\033[31;1mVERIFICATION FAILED\033[0m: %s", message);
    else
        fprintf(stderr, "VERIFICATION FAILED: %s", message);

    __builtin_trap();
}

}
```

…and removing all mentions of `long double` from LibC/math.cpp locally because macOS has no long double, and removing references to `FE_TOMAXMAGNITUDE` / `ToMaxMagnitude` (why do we even have that), here's before this patch:

```
% ./ak-math-bench  
Running libm benchmark...

Function         Max ULP    Mean ULP    % CR    % FR  Accuracy       Ops/sec   Perf+   Total
----------------------------------------------------------------------------------------------
acos()        184318822.002465877.8443   58.7%   82.7%       0.0        100.0M     2.0     2.0
acosh()              Inf310496642824108.3125   37.4%   55.1%       0.0        328.5M     6.6     6.6
asin()        390846002.0011969221.1695   51.3%   83.0%       0.0        116.8M     2.3     2.3
asinh()              Inf321488920585157.2500   31.2%   44.9%       0.0        325.4M     6.5     6.5
atan()            194.00      6.7815   57.0%   78.3%      12.9        218.1M     4.4    17.2
atan2()           193.00     15.4890    8.7%   12.4%       6.1         88.4M     1.8     7.8
atanh()              Inf5009209242386.5391   17.0%   31.8%       0.0        312.3M     6.2     6.2
cbrt()        3599848444635204.501566170712607.8740   79.9%   99.8%       0.0        191.5M     3.8     3.8
cos()         36699240079375282176.00687620400157763.1250    6.6%    7.0%       0.0        224.7M     4.5     4.5
cosh()               Inf15661707126084.9043   51.3%   73.1%       0.0        105.0M     2.1     2.1
exp()                Inf3004243338838.5005   35.3%   70.7%       0.0        121.2M     2.4     2.4
expm1()              Inf37827315541969.4375   10.3%   16.4%       0.0        118.2M     2.4     2.4
hypot()              Inf4421518054532.2627   78.9%   99.6%       0.0          1.5B    20.0    20.0
log()         310946340992610.00384626858457.5200   68.7%   97.3%       0.0        371.6M     7.4     7.4
log1p()              Inf209872739065279.2812   35.5%   52.6%       0.0        342.7M     6.9     6.9
log2()        258078592498945.00797357332298.7749   72.3%   94.9%       0.0        407.2M     8.1     8.1
log10()       310757590323696.00475266258517.5991   60.6%   98.1%       0.0        368.1M     7.4     7.4
pow()                Inf5193987839511.5840   62.1%   67.6%       0.0         92.3M     1.8     1.8
sin()         3673062266248464687642368278528695621376781083.0000   10.0%   16.8%       0.0        212.4M     4.2     4.2
sinh()               Inf24368273281448.2773   11.3%   32.9%       0.0        108.3M     2.2     2.2
sqrt()              0.00      0.0000  100.0%  100.0%     100.0          2.0B    20.0   120.0
tan()         5180923832023617536.00722629867753792.8750    5.9%    7.1%       0.0        129.1M     2.6     2.6
tanh()               Inf6706593009274.8486   18.0%   28.0%       0.0        114.0M     2.3     2.3
==============================================================================================
```

…and after:

```
% ./ak-math-bench    
Running libm benchmark...

Function         Max ULP    Mean ULP    % CR    % FR  Accuracy       Ops/sec   Perf+   Total
----------------------------------------------------------------------------------------------
acos()        184318822.002465877.8443   58.7%   82.7%       0.0         98.7M     2.0     2.0
acosh()              Inf310496642824108.3125   37.4%   55.1%       0.0        325.6M     6.5     6.5
asin()        390846002.0011969221.1695   51.3%   83.0%       0.0        116.6M     2.3     2.3
asinh()       12492726523409004.00321488920585157.2500   31.2%   44.9%       0.0        325.0M     6.5     6.5
atan()            194.00      6.7815   57.0%   78.3%      12.9        218.7M     4.4    17.2
atan2()           193.00     15.4890    8.7%   12.4%       6.1         85.8M     1.7     7.8
atanh()       9007199254740992.005009209242386.5391   17.0%   31.8%       0.0        306.9M     6.1     6.1
cbrt()        3599848444635204.501566170712607.8740   79.9%   99.8%       0.0        191.3M     3.8     3.8
cos()         36699240079375282176.00687620400157763.1250    6.6%    7.0%       0.0        226.4M     4.5     4.5
cosh()               Inf15661707126084.9043   51.3%   73.1%       0.0        105.3M     2.1     2.1
exp()         767616867333199.001438072626230.9326   35.3%   70.7%       0.0        123.0M     2.5     2.5
expm1()       6032057205060441.0037827315541969.4375   10.3%   16.4%       0.0        119.6M     2.4     2.4
hypot()       9007199254740992.004421518054532.2627   78.9%   99.6%       0.0          1.5B    20.0    20.0
log()         310946340992610.00384626858457.5200   68.7%   97.3%       0.0        373.3M     7.5     7.5
log1p()       12993505224675404.00209872739065279.2812   35.5%   52.6%       0.0        341.8M     6.8     6.8
log2()        258078592498945.00797357332298.7749   72.3%   94.9%       0.0        409.5M     8.2     8.2
log10()       310757590323696.00475266258517.5991   60.6%   98.1%       0.0        369.4M     7.4     7.4
pow()         2883312345810313.004457068163756.8330   62.1%   67.6%       0.0         94.6M     1.9     1.9
sin()         3673062266248464687642368278528695621376781083.0000   10.0%   16.8%       0.0        217.7M     4.4     4.4
sinh()               Inf24368273281448.2773   11.3%   32.9%       0.0        108.0M     2.2     2.2
sqrt()              0.00      0.0000  100.0%  100.0%     100.0          2.1B    20.0   120.0
tan()         5180923832023617536.00722629867753792.8750    5.9%    7.1%       0.0        129.9M     2.6     2.6
tanh()               Inf6706593009274.8486   18.0%   28.0%       0.0        113.1M     2.3     2.3
==============================================================================================
```


More importantly, when running with `-v`, the input values and actual / expected values make a bit more sense. For `hypot`, before:

```
hypot()              Inf4421518054532.2627   78.9%   99.6%       0.0          1.5B    20.0    20.0
                ^ input: -0x1p-1074, -0x1.e891f4820dee5p-1002  expected: 0x1.e891f4820dee5p-1002  got: 0x0p+0
```

and after:

```
hypot()       9007199254740992.004421518054532.2627   78.9%   99.6%       0.0          1.5B    20.0    20.0
                ^ input: 0x1.ffffffffffffep+870, 0x1.fffffffffffffp+844  expected: 0x1.fffffffffffffp+870  got: inf
```


The implementation of internal_scalbn is likely overly complicated now, but it now has fairly exhaustive tests, so we can simplify it later. And it gets more things right than the old version.