### PR TITLE
LibC: Remove FE_TOMAXMAGNITUDE

### DIFF
--- a/Tests/LibC/TestFenv.cpp
+++ b/Tests/LibC/TestFenv.cpp
@@ -11,10 +11,6 @@
 
 static constexpr auto reset_rounding_mode = [] { fesetround(FE_TONEAREST); };
 
-#if !ARCH(RISCV64)
-#    define TOMAXMAGNITUDE_DECAYS_TO_TONEAREST
-#endif
-
 TEST_CASE(float_round_up)
 {
     // Non-default rounding mode should not escape files with -frounding-math.
@@ -65,23 +61,6 @@ TEST_CASE(float_round_to_nearest)
     EXPECT_EQ(1.f + 5.9604645e-08f, 1.f);
 }
 
-TEST_CASE(float_round_to_max_magnitude)
-{
-    ScopeGuard rounding_mode_guard = reset_rounding_mode;
-
-    fesetround(FE_TOMAXMAGNITUDE);
-    EXPECT_EQ(0.1f + 0.2f, 0.3f);
-    EXPECT_EQ(0.1f + 0.3f, 0.4f);
-    EXPECT_EQ(0.1f + 0.4f, 0.5f);
-    EXPECT_EQ(-1.f + -0.1f, -1.1f);
-    EXPECT_EQ(1.f + 0.1f, 1.1f);
-#ifdef TOMAXMAGNITUDE_DECAYS_TO_TONEAREST
-    EXPECT_EQ(1.f + 5.9604645e-08f, 1.f);
-#else
-    EXPECT_EQ(1.f + 5.9604645e-08f, 1.0000001f);
-#endif
-}
-
 TEST_CASE(store_round_in_env)
 {
     ScopeGuard rounding_mode_guard = reset_rounding_mode;
@@ -110,12 +89,4 @@ TEST_CASE(save_restore_round)
     EXPECT_EQ(-1.f + -0.1f, -1.0999999f);
     fesetround(rounding_mode);
     EXPECT_EQ(-1.f + -0.1f, -1.1f);
-
-    fesetround(FE_TOMAXMAGNITUDE);
-#ifdef TOMAXMAGNITUDE_DECAYS_TO_TONEAREST
-    // Max-magnitude rounding is not supported by x86, so we expect fesetround to decay it to some other rounding mode.
-    EXPECT_EQ(fegetround(), FE_TONEAREST);
-#else
-    EXPECT_EQ(fegetround(), FE_TOMAXMAGNITUDE);
-#endif
 }

--- a/Userland/Libraries/LibC/arch/aarch64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/aarch64/fenv.cpp
@@ -133,11 +133,8 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
         return 1;
-
-    if (rounding_mode == FE_TOMAXMAGNITUDE)
-        rounding_mode = FE_TONEAREST;
 
     set_rounding_mode(rmode_from_feround(rounding_mode));
 

--- a/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
@@ -43,8 +43,6 @@ static RoundingMode frm_from_feround(int c_rounding_mode)
         return RoundingMode::RDN;
     case FE_UPWARD:
         return RoundingMode::RUP;
-    case FE_TOMAXMAGNITUDE:
-        return RoundingMode::RMM;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -62,7 +60,7 @@ static int feround_from_frm(RoundingMode frm)
     case RoundingMode::RUP:
         return FE_UPWARD;
     case RoundingMode::RMM:
-        return FE_TOMAXMAGNITUDE;
+        VERIFY_NOT_REACHED();
     default:
         // DYN is invalid in the frm register and therefore should never appear here.
     case RoundingMode::DYN:
@@ -220,7 +218,7 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
         return 1;
 
     auto frm = frm_from_feround(rounding_mode);

--- a/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
@@ -117,11 +117,8 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
         return 1;
-
-    if (rounding_mode == FE_TOMAXMAGNITUDE)
-        rounding_mode = FE_TONEAREST;
 
     auto control_word = read_control_word();
 

--- a/Userland/Libraries/LibC/fenv.h
+++ b/Userland/Libraries/LibC/fenv.h
@@ -38,8 +38,6 @@ int feraiseexcept(int exceptions);
 #define FE_DOWNWARD 1
 #define FE_UPWARD 2
 #define FE_TOWARDZERO 3
-// Only exists in RISC-V at the moment; on other architectures this is replaced with FE_TONEAREST.
-#define FE_TOMAXMAGNITUDE 4
 
 int fesetround(int round);
 int fegetround(void);

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -58,8 +58,6 @@ enum class RoundingMode {
     Up = FE_UPWARD,
     Down = FE_DOWNWARD,
     ToEven = FE_TONEAREST,
-    // Round to nearest, ties away from zero.
-    ToMaxMagnitude = FE_TOMAXMAGNITUDE,
 };
 
 // This is much branchier than it really needs to be
@@ -125,9 +123,6 @@ static FloatType internal_to_integer(FloatType x, RoundingMode rounding_mode)
             should_round = has_nonhalf_fraction || has_half_fraction;
         break;
     case RoundingMode::ToZero:
-        break;
-    case RoundingMode::ToMaxMagnitude:
-        should_round = true;
         break;
     }
 


### PR DESCRIPTION
It's non-standard (and a serenity-only extension, not something in common use), unused, and riscv-only.