### PR TITLE
Toolchain: Pass target-specific ar binary to runtime and main build

### DIFF
--- a/Meta/CMake/jakt.cmake
+++ b/Meta/CMake/jakt.cmake
@@ -112,6 +112,14 @@ message(STATUS "Using jakt compiler at ${JAKT_COMPILER}")
 message(STATUS "Using jakt target triple ${JAKT_TARGET_TRIPLE}")
 message(STATUS "Using jakt library directory ${JAKT_LIBRARY_DIR}")
 
+add_library(jakt_main_${JAKT_TARGET_TRIPLE} STATIC IMPORTED)
+set_property(TARGET jakt_main_${JAKT_TARGET_TRIPLE} PROPERTY IMPORTED_LOCATION ${JAKT_LIBRARY_DIR}/libjakt_main_${JAKT_TARGET_TRIPLE}.a)
+add_library(jakt_runtime_${JAKT_TARGET_TRIPLE} STATIC IMPORTED)
+set_property(TARGET jakt_runtime_${JAKT_TARGET_TRIPLE} PROPERTY IMPORTED_LOCATION ${JAKT_LIBRARY_DIR}/libjakt_runtime_${JAKT_TARGET_TRIPLE}.a)
+
+add_library(Jakt::Main ALIAS jakt_main_${JAKT_TARGET_TRIPLE})
+add_library(Jakt::Runtime ALIAS jakt_runtime_${JAKT_TARGET_TRIPLE})
+
 function(add_jakt_executable target source)
     cmake_parse_arguments(PARSE_ARGV 2 JAKT_EXECUTABLE "" "" "INCLUDES;CONFIGS;LINK_LIBRARIES;EXTRA_CPP_SOURCES")
     set(configs)
@@ -211,9 +219,9 @@ function(add_jakt_executable target source)
 
     target_link_libraries(${JAKT_EXECUTABLE_NAME}
         PRIVATE
-        ${JAKT_LIBRARY_DIR}/libjakt_main_${JAKT_TARGET_TRIPLE}.a
+        Jakt::Main
         ${JAKT_EXECUTABLE_NAME}.lib
-        ${JAKT_LIBRARY_DIR}/libjakt_runtime_${JAKT_TARGET_TRIPLE}.a
+        Jakt::Runtime
         ${JAKT_EXECUTABLE_LINK_LIBRARIES}
     )
 endfunction()

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -205,12 +205,7 @@ function(embed_resource target section file)
         "${asm_file}"
     )
 
-    target_link_libraries(
-        ${target} PRIVATE
-        -Wl,--whole-archive
-        ${target}-resources-${section}
-        -Wl,--no-whole-archive
-    )
+    target_link_libraries(${target} PRIVATE ${target}-resources-${section})
 endfunction()
 
 function(invoke_generator name generator primary_source header implementation)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -82,6 +82,7 @@ endif()
 include(flac_spec_tests)
 include(ca_certificates_data)
 include(lagom_compile_options)
+include(jakt)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -16,8 +16,6 @@ add_subdirectory(ConfigureComponents)
 add_subdirectory(PrekernelPEImageGenerator)
 add_subdirectory(IPCMagicLinter)
 
-include(jakt)
-
 if (APPLE)
     # FIXME: Remove this once https://openradar.appspot.com/21478051 is fixed.
     find_package(Python3 REQUIRED COMPONENTS Interpreter)

--- a/Toolchain/BuildJakt.sh
+++ b/Toolchain/BuildJakt.sh
@@ -30,6 +30,9 @@ for ARCH in "${ARCHES[@]}"; do
   eval "RANLIB_GNU_${ARCH}=\"$DIR/Local/$ARCH/bin/$TARGET-ranlib\""
   eval "RANLIB_CLANG_${ARCH}=\"$DIR/Local/clang/bin/llvm-ranlib\""
 
+  eval "AR_GNU_${ARCH}=\"$DIR/Local/$ARCH/bin/$TARGET-ar\""
+  eval "AR_CLANG_${ARCH}=\"$DIR/Local/clang/bin/llvm-ar\""
+
   VAR_CXX_GNU="CXX_GNU_${ARCH}"
   if [ -x "${!VAR_CXX_GNU}" ]; then
       VALID_TOOLCHAINS+=("GNU;${ARCH}")
@@ -194,10 +197,12 @@ build_for() {
     current_build="BUILD_${TOOLCHAIN}_${ARCH}"
     current_cxx="CXX_${TOOLCHAIN}_${ARCH}"
     current_ranlib="RANLIB_${TOOLCHAIN}_${ARCH}"
+    current_ar="AR_${TOOLCHAIN}_${ARCH}"
 
     BUILD="${!current_build}"
     TARGET_CXX="${!current_cxx}"
     TARGET_RANLIB="${!current_ranlib}"
+    TARGET_AR="${!current_ar}"
 
     if already_available "$TOOLCHAIN" "$ARCH"; then
         return 0
@@ -251,6 +256,7 @@ build_for() {
                                                             --target-triple "$JAKT_TARGET" \
                                                             --target-links-ak \
                                                             -C "$TARGET_CXX" \
+                                                            --archiver "$TARGET_AR" \
                                                             -O \
                                                             -J "$NPROC"
 


### PR DESCRIPTION
When building the runtime and main archives, we need to ensure that we
use the target-specific `ar` binary. Without this, the Clang aarch64
configuration on aarch64 macOS hosts would improperly use the host's
`ar`` binary, which assumes one is building Mach-O files and trips up
on the target's ELF files.

This fixes the ENABLE_JAKT=ON config for Clang aarch64 on macOS hosts.