### PR TITLE
AK: Make log{,2,10}(inf) return inf

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -1045,6 +1045,8 @@ constexpr T log2(T x)
         return -Infinity<T>;
     if (x <= 0 || __builtin_isnan(x))
         return NaN<T>;
+    if (__builtin_isinf(x))
+        return Infinity<T>;
 
     auto ext = FloatExtractor<T>::from_float(x);
 

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -133,6 +133,7 @@ TEST_CASE(logarithms)
     EXPECT_APPROXIMATE(log2(5), 2.321928);
     EXPECT_APPROXIMATE(log2(0x0.0'0000'0000'000cp-1022), 0.5849625007 /* == log2(1.5) */ - 1022 - 49);
     EXPECT_APPROXIMATE(log10(5), 0.698970);
+    EXPECT_EQ(log(AK::Infinity<double>), AK::Infinity<double>);
 }
 
 union Extractor {


### PR DESCRIPTION
Previously, e.g. log2(inf) = 0x1p+7, which was wrong.