### PR TITLE
AK: Make asin() more accurate and faster

### DIFF
--- a/AK/Math/Trigonometry.h
+++ b/AK/Math/Trigonometry.h
@@ -19,22 +19,6 @@ namespace AK {
 
 namespace Trigonometry {
 
-namespace Details {
-template<size_t>
-constexpr size_t product_even();
-template<>
-constexpr size_t product_even<2>() { return 2; }
-template<size_t value>
-constexpr size_t product_even() { return value * product_even<value - 2>(); }
-
-template<size_t>
-constexpr size_t product_odd();
-template<>
-constexpr size_t product_odd<1>() { return 1; }
-template<size_t value>
-constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
-}
-
 template<FloatingPoint T>
 constexpr T hypot(T x, T y)
 {
@@ -224,25 +208,37 @@ constexpr T asin(T x)
         return Pi<T> / 2 - 2 * asin(sqrt((1 - x) / 2));
     }
 
-    T squared = x * x;
-    T value = x;
-    T i = x * squared;
-    value += i * Details::product_odd<1>() / Details::product_even<2>() / 3;
-    i *= squared;
-    value += i * Details::product_odd<3>() / Details::product_even<4>() / 5;
-    i *= squared;
-    value += i * Details::product_odd<5>() / Details::product_even<6>() / 7;
-    i *= squared;
-    value += i * Details::product_odd<7>() / Details::product_even<8>() / 9;
-    i *= squared;
-    value += i * Details::product_odd<9>() / Details::product_even<10>() / 11;
-    i *= squared;
-    value += i * Details::product_odd<11>() / Details::product_even<12>() / 13;
-    i *= squared;
-    value += i * Details::product_odd<13>() / Details::product_even<14>() / 15;
-    i *= squared;
-    value += i * Details::product_odd<15>() / Details::product_even<16>() / 17;
-    return value;
+    // https://github.com/samhocevar/lolremez/wiki/Tutorial-4-of-5%3A-fixing-lower-order-parameters
+    auto f = [](T x) {
+        if constexpr (IsSame<T, f32>) {
+            // lolremez --float --degree 5 --range "1e-50:1/4" "(asin(sqrt(x))-sqrt(x))/(x*sqrt(x))" "1/(x*sqrt(x))"
+            // "Estimated max error: 8.5377476e-11"
+            f32 u = 0.039088517f;
+            u = u * x + 0.013210787f;
+            u = u * x + 0.032170232f;
+            u = u * x + 0.044467181f;
+            u = u * x + 0.075008146f;
+            return u * x + 0.16666654f;
+        } else {
+            // FIXME: Could do something custom for long double.
+            // lolremez --degree 11 --range "1e-50:1/4" "(asin(sqrt(x))-sqrt(x))/(x*sqrt(x))" "1/(x*sqrt(x))"
+            // "Estimated max error: 4.3580651842210834e-18"
+            T u = 0.033660618737294104;
+            u = u * x + -0.018930050045116921;
+            u = u * x + 0.021367266503207524;
+            u = u * x + 0.005806729168702944;
+            u = u * x + 0.012349571686866897;
+            u = u * x + 0.013855247852028872;
+            u = u * x + 0.017363058003675668;
+            u = u * x + 0.022371508713932262;
+            u = u * x + 0.03038197103721944;
+            u = u * x + 0.044642856488345831;
+            u = u * x + 0.075000000008444367;
+            return u * x + 0.16666666666662552;
+        }
+    };
+    T x2 = x * x;
+    return (x + x * x2 * f(x2));
 }
 
 template<FloatingPoint T>

--- a/AK/Math/Trigonometry.h
+++ b/AK/Math/Trigonometry.h
@@ -195,17 +195,26 @@ constexpr T asin(T x)
 {
     CONSTEXPR_STATE(asin, x);
 
-    if (x < 0)
-        return -asin(-x);
+    T sign = 1;
+
+    // asin(x) = -asin(-x)
+    // Use this to make x always >= 0.
+    if (x < 0) {
+        x = -x;
+        sign = -1;
+    }
 
     if (x > 1)
         return NaN<T>;
 
+    T offset = 0;
     if (x > (T)0.5) {
         // asin(x) = pi/2 - 2 * asin(sqrt((1 - x) / 2))
         // If 0.5 < x <= 1, then sqrt((1 - x) / 2 ) < 0.5,
         // and the recursion will go down the `<= 0.5` branch.
-        return Pi<T> / 2 - 2 * asin(sqrt((1 - x) / 2));
+        offset = sign * Pi<T> / 2;
+        x = sqrt((1 - x) / 2);
+        sign = sign * -2;
     }
 
     // https://github.com/samhocevar/lolremez/wiki/Tutorial-4-of-5%3A-fixing-lower-order-parameters
@@ -238,7 +247,7 @@ constexpr T asin(T x)
         }
     };
     T x2 = x * x;
-    return (x + x * x2 * f(x2));
+    return offset + sign * (x + x * x2 * f(x2));
 }
 
 template<FloatingPoint T>


### PR DESCRIPTION
Both commits combined, before:

float:

```
% ./bench-float-exhaustive -f acosf -f asinf                                                                                 
acosf       max ULP: 1267.00       mean ULP: 0.039223  CR: 96.1%  FR: 100.0%  AK: 223.8M/s  ref: 217.2M/s  (2.7s)
           worst: acosf(0x1.fffffep-1) = 0x1.6ap-12, expected 0x1.6a09e6p-12
asinf       max ULP: 8.00          mean ULP: 0.010256  CR: 99.1%  FR: 99.9%  AK: 235.4M/s  ref: 270.7M/s  (2.4s)
           worst: asinf(-0x1.003ccep-1) = -0x1.0c5b6cp-1, expected -0x1.0c5b5cp-1
```

double:

```
% ./ak-math-bench --format=wide -f acos -f asin
Function                     Max ULP                Mean ULP    % CR    % FR  Accuracy       Ops/sec   Perf+   Total
----------------------------------------------------------------------------------------------------------------------
acos()                  184318822.00            2465877.8443   58.7%   82.7%       0.0         96.5M     1.9     1.9
asin()                  390846002.00           11969221.1695   51.3%   83.0%       0.0        118.6M     2.4     2.4
```

After:

float:

```
% ./bench-float-exhaustive -f acosf -f asinf                                                                                 
acosf       max ULP: 1267.00       mean ULP: 0.038492  CR: 96.2%  FR: 100.0%  AK: 599.5M/s  ref: 219.6M/s  (2.0s)
           worst: acosf(0x1.fffffep-1) = 0x1.6ap-12, expected 0x1.6a09e6p-12
asinf       max ULP: 2.00          mean ULP: 0.002522  CR: 99.8%  FR: 100.0%  AK: 735.8M/s  ref: 264.6M/s  (1.6s)
           worst: asinf(0x1.000008p-1) = 0x1.0c153p-1, expected 0x1.0c152cp-1
```

double:

```
% ./ak-math-bench -f acos -f asin              
Function         Max ULP    Mean ULP    % CR    % FR  Accuracy       Ops/sec   Perf+   Total
----------------------------------------------------------------------------------------------
acos()       25216051.00  20936.4458   70.3%   98.7%       0.0        160.0M     3.2     3.2
asin()              1.00      0.0791   92.1%  100.0%      92.7        193.0M     3.9    96.5
```

For reference, macOS system libm for doubles:

```
% ~/src/js-math-bench/c/bench-libm -f acos -f asin
Function         Max ULP    Mean ULP    % CR    % FR  Accuracy       Ops/sec   Perf+   Total
----------------------------------------------------------------------------------------------
acos()              1.00      0.2600   74.0%  100.0%      79.4        147.0M     2.9    82.3
asin()              1.00      0.0318   96.8%  100.0%      96.9        236.6M     4.7   101.7
```

So our double impl is 26% slower than macOS system libm, while being roughly half as accurate.

Our float impl is 2.78x as fast as libc++'s (but libc++'s impl is fully accurate, while we're up to 2 ULP off).

Still, roughly in the same ballpark. This makes asin() the second of our math functions (after atan/atan2) that are kinda decent.