### PR TITLE
LibSSH+SSHServer: Properly close the SFTP subsystem

### DIFF
--- a/Tests/LibSSH/CMakeLists.txt
+++ b/Tests/LibSSH/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     SFTP/TestSFTPAttributes.cpp
+    SFTP/TestSFTPClose.cpp
     SFTP/TestSFTPPeer.cpp
     SFTP/TestSFTPServerBasic.cpp
     SFTP/TestSFTPStat.cpp

--- a/Tests/LibSSH/SFTP/TestSFTPClose.cpp
+++ b/Tests/LibSSH/SFTP/TestSFTPClose.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/TempFile.h>
+#include <LibSSH/DataTypes.h>
+#include <LibTest/TestCase.h>
+#include <Tests/LibSSH/SFTP/Shared.h>
+
+inline ErrorOr<ByteBuffer> make_close_packet(StringView handle, u32 request_id)
+{
+    AllocatingMemoryStream inner;
+
+    TRY(inner.write_value(SSH::SFTP::FXPMessageID::CLOSE));
+    TRY(inner.write_value<NetworkOrdered<u32>>(request_id));
+    TRY(SSH::encode_string(inner, handle));
+
+    auto payload = TRY(inner.read_until_eof());
+
+    AllocatingMemoryStream packet;
+    TRY(packet.write_value<NetworkOrdered<u32>>(payload.size()));
+    TRY(packet.write_until_depleted(payload));
+
+    return TRY(packet.read_until_eof());
+}
+
+TEST_CASE(basic)
+{
+    auto temp_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
+
+    Optional<ByteBuffer> handle;
+    u32 request_id = 42;
+
+    SSH::SFTP::FXStatus expected_status = SSH::SFTP::FXStatus::OK;
+
+    auto callback = [&](Message message) -> ErrorOr<void> {
+        FixedMemoryStream stream { message.payload };
+        if (!handle.has_value()) {
+
+            EXPECT_EQ(message.type, SSH::SFTP::FXPMessageID::HANDLE);
+            EXPECT_EQ(request_id, TRY(stream.read_value<NetworkOrdered<u32>>()));
+
+            handle = TRY(SSH::decode_string(stream));
+            return {};
+        }
+
+        return check_status_message(message, expected_status, request_id);
+    };
+    auto server = make_initialized_server(move(callback));
+
+    auto open_packet = TRY_OR_FAIL(make_open_packet(temp_file->path(), request_id));
+    TRY_OR_FAIL(server_process_data(server, open_packet));
+
+    if (!handle.has_value())
+        FAIL("The handle should have been received");
+
+    auto close_1 = TRY_OR_FAIL(make_close_packet(*handle, ++request_id));
+    expected_status = SSH::SFTP::FXStatus::OK;
+    TRY_OR_FAIL(server_process_data(server, close_1));
+
+    auto close_2 = TRY_OR_FAIL(make_close_packet(*handle, ++request_id));
+    expected_status = SSH::SFTP::FXStatus::FAILURE;
+    TRY_OR_FAIL(server_process_data(server, close_2));
+}

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -32,12 +32,16 @@ Coroutine<ErrorOr<void>> Server::handle_channel_data(Session& session)
         CO_TRY(handle_packet(stream));
     }
 
+    if (session.has_received_eof)
+        m_is_ready_to_be_closed = true;
+
     co_return {};
 }
 
-void Server::handle_channel_eof(Session const&)
+void Server::handle_channel_eof(Session const& session)
 {
-    // There is nothing to do here.
+    if (session.channel_data.is_empty())
+        m_is_ready_to_be_closed = true;
 }
 
 // 4. Protocol Initialization

--- a/Userland/Libraries/LibSSH/SFTP/Server.cpp
+++ b/Userland/Libraries/LibSSH/SFTP/Server.cpp
@@ -89,6 +89,8 @@ ErrorOr<void> Server::handle_packet(FixedMemoryStream& stream)
         return handle_stat(stream, StatType::LStat);
     case FXPMessageID::WRITE:
         return handle_write(stream);
+    case FXPMessageID::CLOSE:
+        return handle_close(stream);
     default:
         dbgln_if(SSH_DEBUG, "Received packet with type: {}", to_underlying(type));
         return Error::from_string_literal("Unknown packet type");
@@ -248,6 +250,17 @@ ErrorOr<void> Server::send_file_handle(u32 id, File const& file)
     auto packet = TRY(stream.read_until_eof());
     TRY(write_packet(packet));
     return {};
+}
+
+ErrorOr<void> Server::handle_close(FixedMemoryStream& stream)
+{
+    u32 id = TRY(stream.read_value<NetworkOrdered<u32>>());
+    auto handle = TRY(decode_string(stream));
+
+    if (m_open_files.remove_first_matching([&](auto const& file) { return file.handle.bytes() == handle; }))
+        return send_status_message(id, FXStatus::OK);
+
+    return send_status_message(id, FXStatus::FAILURE);
 }
 
 ErrorOr<Server::File*> Server::find_file(ReadonlyBytes handle)

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -25,6 +25,8 @@ public:
     Coroutine<ErrorOr<void>> handle_channel_data(Session&);
     void handle_channel_eof(Session const&);
 
+    bool is_ready_to_be_closed() const { return true; }
+
 private:
     enum class State : u8 {
         Constructed,

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -51,6 +51,8 @@ private:
     ErrorOr<void> handle_open(FixedMemoryStream& stream);
     ErrorOr<void> send_file_handle(u32, File const&);
 
+    ErrorOr<void> handle_close(FixedMemoryStream&);
+
     ErrorOr<void> handle_read(FixedMemoryStream& stream);
     ErrorOr<void> handle_write(FixedMemoryStream& stream);
 

--- a/Userland/Libraries/LibSSH/SFTP/Server.h
+++ b/Userland/Libraries/LibSSH/SFTP/Server.h
@@ -25,7 +25,7 @@ public:
     Coroutine<ErrorOr<void>> handle_channel_data(Session&);
     void handle_channel_eof(Session const&);
 
-    bool is_ready_to_be_closed() const { return true; }
+    bool is_ready_to_be_closed() const { return m_is_ready_to_be_closed; }
 
 private:
     enum class State : u8 {
@@ -66,6 +66,7 @@ private:
     State m_state { State::Constructed };
 
     Vector<File> m_open_files {};
+    bool m_is_ready_to_be_closed { false };
 };
 
 } // SSH::SFTP

--- a/Userland/Libraries/LibSSH/Session.cpp
+++ b/Userland/Libraries/LibSSH/Session.cpp
@@ -47,6 +47,11 @@ void ExecData::close_stdin_if_required(Session const& session) const
         stdin_->close();
 }
 
+bool ExecData::is_ready_to_be_closed() const
+{
+    return exit_status.has_value() && stdout_->is_eof() && stderr_->is_eof();
+}
+
 ErrorOr<NonnullRefPtr<Session>> Session::create(u32 sender_channel_id, u32 window_size, u32 maximum_packet_size)
 {
     auto session = make_ref_counted<Session>();
@@ -56,6 +61,20 @@ ErrorOr<NonnullRefPtr<Session>> Session::create(u32 sender_channel_id, u32 windo
     session->initial_window_size = window_size;
     session->local_window_size = window_size;
     return session;
+}
+
+bool Session::is_ready_to_be_closed() const
+{
+    return system.visit(
+        [](Empty) { return true; },
+        [](auto& system) { return system.is_ready_to_be_closed(); });
+}
+
+int Session::exit_status() const
+{
+    return system.visit(
+        [](auto const&) { return 0; },
+        [](ExecData const& exec_data) { return *exec_data.exit_status; });
 }
 
 }

--- a/Userland/Libraries/LibSSH/Session.h
+++ b/Userland/Libraries/LibSSH/Session.h
@@ -37,12 +37,17 @@ struct ExecData {
     Coroutine<ErrorOr<void>> handle_channel_data(Session&);
     void handle_channel_eof(Session const&);
 
+    bool is_ready_to_be_closed() const;
+
 private:
     void close_stdin_if_required(Session const&) const;
 };
 
 struct Session : public RefCounted<Session> {
     static ErrorOr<NonnullRefPtr<Session>> create(u32 sender_channel_id, u32 window_size, u32 maximum_packet_size);
+
+    bool is_ready_to_be_closed() const;
+    int exit_status() const;
 
     u32 local_channel_id {};
     u32 sender_channel_id {};

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -717,7 +717,7 @@ Coroutine<void> SSHClient::async_stream_std_data(NonnullRefPtr<Session> session,
             CO_TRY(sender(session, output));
         }
 
-        CO_TRY(close_exec_session_if_needed(session));
+        CO_TRY(close_session_if_needed(session));
 
         co_return {};
     }();
@@ -882,14 +882,14 @@ ErrorOr<void> SSHClient::send_channel_close(Session& session)
 
 // 6.10.  Returning Exit Status
 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.10
-ErrorOr<void> SSHClient::send_exit_status(Session const& session, int status)
+ErrorOr<void> SSHClient::send_exit_status(Session const& session)
 {
     AllocatingMemoryStream stream;
     TRY(stream.write_value(MessageID::CHANNEL_REQUEST));
     TRY(stream.write_value<NetworkOrdered<u32>>(session.sender_channel_id));
     TRY(encode_string(stream, "exit-status"sv));
     TRY(stream.write_value(false));
-    TRY(stream.write_value<NetworkOrdered<u32>>(status));
+    TRY(stream.write_value<NetworkOrdered<u32>>(session.exit_status()));
 
     TRY(write_packet(TRY(stream.read_until_eof())));
     return {};
@@ -928,22 +928,19 @@ ErrorOr<void> SSHClient::manage_child_death()
                     // FIXME: Send the actual exit status.
                     exec_data.exit_status = exited_with_code_0 ? 0 : -1;
 
-                    TRY(close_exec_session_if_needed(*session));
+                    TRY(close_session_if_needed(*session));
                 }
             }
         }
     }
 }
 
-ErrorOr<void> SSHClient::close_exec_session_if_needed(Session& session)
+ErrorOr<void> SSHClient::close_session_if_needed(Session& session)
 {
-    auto& exec_data = session.system.get<ExecData>();
-    if (!exec_data.exit_status.has_value()
-        || !exec_data.stdout_->is_eof()
-        || !exec_data.stderr_->is_eof())
+    if (!session.is_ready_to_be_closed())
         return {};
 
-    TRY(send_exit_status(session, *session.system.get<ExecData>().exit_status));
+    TRY(send_exit_status(session));
 
     TRY(send_channel_close(session));
     return {};

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -645,6 +645,9 @@ Coroutine<void> SSHClient::async_stream_data_to_subsystem(NonnullRefPtr<Session>
                 [&](auto& system) -> Coroutine<ErrorOr<void>> { return system.handle_channel_data(session); },
                 [](Empty) -> Coroutine<ErrorOr<void>> { VERIFY_NOT_REACHED(); }));
         }
+
+        CO_TRY(close_session_if_needed(session));
+
         co_return {};
     }();
 
@@ -825,6 +828,8 @@ ErrorOr<void> SSHClient::handle_channel_eof(GenericMessage& message)
     session.system.visit(
         [&](auto& system) { system.handle_channel_eof(session); },
         [](Empty) {});
+
+    TRY(close_session_if_needed(session));
 
     return {};
 }

--- a/Userland/Services/SSHServer/SSHClient.cpp
+++ b/Userland/Services/SSHServer/SSHClient.cpp
@@ -937,6 +937,9 @@ ErrorOr<void> SSHClient::manage_child_death()
 
 ErrorOr<void> SSHClient::close_session_if_needed(Session& session)
 {
+    if (session.is_closed)
+        return {};
+
     if (!session.is_ready_to_be_closed())
         return {};
 

--- a/Userland/Services/SSHServer/SSHClient.h
+++ b/Userland/Services/SSHServer/SSHClient.h
@@ -96,7 +96,7 @@ private:
     ErrorOr<void> handle_channel_window_adjust_message(GenericMessage&);
     ErrorOr<void> send_channel_window_adjust_message(Session&);
     ErrorOr<void> handle_channel_eof(GenericMessage&);
-    ErrorOr<void> send_exit_status(Session const&, int);
+    ErrorOr<void> send_exit_status(Session const&);
     ErrorOr<void> handle_channel_close(GenericMessage&);
     ErrorOr<void> send_channel_close(Session&);
     ErrorOr<NonnullRefPtr<Session>> find_session(u32 sender_channel_id);
@@ -106,7 +106,7 @@ private:
     Coroutine<void> async_stream_data_to_subsystem(NonnullRefPtr<Session>);
 
     ErrorOr<void> manage_child_death();
-    ErrorOr<void> close_exec_session_if_needed(Session&);
+    ErrorOr<void> close_session_if_needed(Session&);
 
     void disconnect(Error);
 


### PR DESCRIPTION
Doesn't change much functionality-wise, but makes `scp` return without an error. (This is necessary to use libcxx's test harness.)

Before:
```bash
$ scp -P 2222 127.0.0.1:/home/lucas/progress_file_1MB.txt ./copy.txt
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
progress_file_1MB.txt                                            100% 1024KB  10.9MB/s   00:00    
Connection to 127.0.0.1 closed by remote host.
scp: Connection closed
$ echo $?
255
```

After:
```bash
$ scp -P 2222 127.0.0.1:/home/lucas/progress_file_1MB.txt ./copy.txt
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
progress_file_1MB.txt                                            100% 1024KB  10.6MB/s   00:00    
$ echo $?
0
```